### PR TITLE
Lock sbt.version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11


### PR DESCRIPTION
* Specified version of sbt is used to avoid trouble.
  * If there is not this file, the newest version of sbt of client is used