### PR TITLE
The value of environment variable CXX can be used

### DIFF
--- a/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -58,7 +58,7 @@ object ScalaNativePluginInternal {
 
     nativeVerbose := false,
 
-    nativeClang := file(Process(Seq("which", "clang++")).lines_!.head),
+    nativeClang := file(Process(Seq("which", Option(System.getenv("CXX")).getOrElse("clang++"))).lines_!.head),
 
     nativeClangOptions := Seq(),
 


### PR DESCRIPTION
By applying this patch, the following can be done:

```
~/git/scala-native $ export CXX=clang++-3.7
~/git/scala-native $ sbt
```

For CI, this patch is useful.