### PR TITLE
Better error message by SBT if no clang++ binary was found in $PATH

### DIFF
--- a/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -58,7 +58,17 @@ object ScalaNativePluginInternal {
 
     nativeVerbose := false,
 
-    nativeClang := file(Process(Seq("which", "clang++")).lines_!.head),
+    nativeClang := {
+      val binaryName = "clang++"
+
+      Process(Seq("which", binaryName))
+        .lines_!
+        .headOption
+        .map(file(_))
+        .getOrElse{
+          throw new MessageOnlyException(s"no $binaryName found in $$PATH. Install clang")
+        }
+    },
 
     nativeClangOptions := Seq(),
 


### PR DESCRIPTION
I hadn't installed clang and got a "NoSuchElementException". With this changes the next one will get "no clang++ found, add it to $PATH or install clang" without a stack trace.