### PR TITLE
New c-style vararg interop

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,3 +123,13 @@ lazy val demoJVM =
       fork in run := true,
       javaOptions in run ++= Seq("-Xms64m", "-Xmx64m")
     )
+
+lazy val sandbox =
+  project.in(file("sandbox")).
+    settings(libSettings).
+    settings(
+      nativeVerbose := true,
+      nativeClangOptions := Seq("-O2")
+    ).
+    dependsOn(scalalib)
+

--- a/nativelib/src/main/scala/scala/scalanative/native/Vararg.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Vararg.scala
@@ -1,0 +1,11 @@
+package scala.scalanative
+package native
+
+import runtime.undefined
+import reflect.ClassTag
+
+final class Vararg private ()
+
+object Vararg {
+  implicit def apply[T](value: T)(implicit ct: ClassTag[T]): Vararg = undefined
+}

--- a/nativelib/src/main/scala/scala/scalanative/native/stdlib.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/stdlib.scala
@@ -5,7 +5,7 @@ package native
   var __stderrp: Ptr[_] = extern
   var __stdoutp: Ptr[_] = extern
   def fopen(filename: CString, mode: CString): Ptr[_] = extern
-  def fprintf(stream: Ptr[_], format: CString, args: Any*): CInt = extern
+  def fprintf(stream: Ptr[_], format: CString, args: Vararg*): CInt = extern
   def malloc(size: Word): Ptr[_] = extern
   def getenv(name: CString): CString = extern
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -46,12 +46,12 @@ trait NirDefinitions { self: NirGlobalAddons =>
 
     lazy val NativeModule = getRequiredModule(
         "scala.scalanative.native.package")
-    lazy val CastMethod   = getMember(NativeModule, TermName("cast"))
-    lazy val ExternMethod = getMember(NativeModule, TermName("extern"))
-    lazy val SizeofMethod = getMember(NativeModule, TermName("sizeof"))
+    lazy val CastMethod       = getMember(NativeModule, TermName("cast"))
+    lazy val ExternMethod     = getMember(NativeModule, TermName("extern"))
+    lazy val SizeofMethod     = getMember(NativeModule, TermName("sizeof"))
     lazy val StackallocMethod = getMember(NativeModule, TermName("stackalloc"))
-    lazy val ExternClass  = getRequiredClass("scala.scalanative.native.extern")
-    lazy val StructClass  = getRequiredClass("scala.scalanative.native.struct")
+    lazy val ExternClass      = getRequiredClass("scala.scalanative.native.extern")
+    lazy val StructClass      = getRequiredClass("scala.scalanative.native.struct")
 
     lazy val RuntimeModule = getRequiredModule(
         "scala.scalanative.runtime.package")

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -53,6 +53,10 @@ trait NirDefinitions { self: NirGlobalAddons =>
     lazy val ExternClass      = getRequiredClass("scala.scalanative.native.extern")
     lazy val StructClass      = getRequiredClass("scala.scalanative.native.struct")
 
+    lazy val VarargModule = getRequiredModule(
+        "scala.scalanative.native.Vararg")
+    lazy val VarargMethod = getMember(VarargModule, TermName("apply"))
+
     lazy val RuntimeModule = getRequiredModule(
         "scala.scalanative.runtime.package")
     lazy val InfoofMethod = getMember(RuntimeModule, TermName("infoof"))

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirPrimitives.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirPrimitives.scala
@@ -15,10 +15,10 @@ object NirPrimitives {
   final val PTR_APPLY  = 1 + PTR_SUB
   final val PTR_UPDATE = 1 + PTR_APPLY
 
-  final val SIZEOF = 1 + PTR_UPDATE
-  final val INFOOF = 1 + SIZEOF
-  final val CQUOTE = 1 + INFOOF
-  final val CCAST  = 1 + CQUOTE
+  final val SIZEOF     = 1 + PTR_UPDATE
+  final val INFOOF     = 1 + SIZEOF
+  final val CQUOTE     = 1 + INFOOF
+  final val CCAST      = 1 + CQUOTE
   final val STACKALLOC = 1 + CCAST
 }
 

--- a/sandbox/Test.scala
+++ b/sandbox/Test.scala
@@ -1,0 +1,9 @@
+import scalanative.native._, stdlib._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val ptr = malloc(sizeof[Int]).cast[Ptr[Int]]
+    ptr(0) = 42
+    fprintf(__stdoutp, c"%d\n", ptr(0))
+  }
+}


### PR DESCRIPTION
Previous scheme with having Any as a type did not work as we would
loose the precise type of the arguments that is necessary to undo
the boxing damage done by erasure.

Now we have a magnet-like Vararg type that is used to insert
conversions from T to Vararg with corresponding classtag information
attached.

Fixes #95, #33 

review @sjrd 