### PR TITLE
set array length after memory allocation

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -60,7 +60,12 @@ object BooleanArray {
   def alloc(length: Int): BooleanArray = {
     val arrinfo = infoof[BooleanArray]
     val arrsize = sizeof[ArrayHeader] + sizeof[Boolean] * length
-    runtime.alloc(arrinfo, arrsize).cast[BooleanArray]
+    val arr = runtime.alloc(arrinfo, arrsize)
+    
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
+    
+    arr.cast[BooleanArray]    
   }
 }
 
@@ -99,7 +104,10 @@ object CharArray {
   def alloc(length: Int): CharArray = {
     val arrinfo = infoof[CharArray]
     val arrsize = sizeof[ArrayHeader] + sizeof[Char] * length
-    runtime.alloc(arrinfo, arrsize).cast[CharArray]
+    val arr = runtime.alloc(arrinfo, arrsize)    
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr.cast[CharArray]    
   }
 }
 
@@ -138,7 +146,10 @@ object ByteArray {
   def alloc(length: Int): ByteArray = {
     val arrinfo = infoof[ByteArray]
     val arrsize = sizeof[ArrayHeader] + sizeof[Byte] * length
-    runtime.alloc(arrinfo, arrsize).cast[ByteArray]
+    val arr = runtime.alloc(arrinfo, arrsize)    
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr.cast[ByteArray]    
   }
 }
 
@@ -177,7 +188,10 @@ object ShortArray {
   def alloc(length: Int): ShortArray = {
     val arrinfo = infoof[ShortArray]
     val arrsize = sizeof[ArrayHeader] + sizeof[Short] * length
-    runtime.alloc(arrinfo, arrsize).cast[ShortArray]
+    val arr = runtime.alloc(arrinfo, arrsize)    
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr.cast[ShortArray]    
   }
 }
 
@@ -216,7 +230,10 @@ object IntArray {
   def alloc(length: Int): IntArray = {
     val arrinfo = infoof[IntArray]
     val arrsize = sizeof[ArrayHeader] + sizeof[Int] * length
-    runtime.alloc(arrinfo, arrsize).cast[IntArray]
+    val arr = runtime.alloc(arrinfo, arrsize)    
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr.cast[IntArray]    
   }
 }
 
@@ -255,7 +272,10 @@ object LongArray {
   def alloc(length: Int): LongArray = {
     val arrinfo = infoof[LongArray]
     val arrsize = sizeof[ArrayHeader] + sizeof[Long] * length
-    runtime.alloc(arrinfo, arrsize).cast[LongArray]
+    val arr = runtime.alloc(arrinfo, arrsize)    
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr.cast[LongArray]    
   }
 }
 
@@ -294,7 +314,10 @@ object FloatArray {
   def alloc(length: Int): FloatArray = {
     val arrinfo = infoof[FloatArray]
     val arrsize = sizeof[ArrayHeader] + sizeof[Float] * length
-    runtime.alloc(arrinfo, arrsize).cast[FloatArray]
+    val arr = runtime.alloc(arrinfo, arrsize)
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr.cast[FloatArray]    
   }
 }
 
@@ -333,7 +356,10 @@ object DoubleArray {
   def alloc(length: Int): DoubleArray = {
     val arrinfo = infoof[DoubleArray]
     val arrsize = sizeof[ArrayHeader] + sizeof[Double] * length
-    runtime.alloc(arrinfo, arrsize).cast[DoubleArray]
+    val arr = runtime.alloc(arrinfo, arrsize)    
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr.cast[DoubleArray]    
   }
 }
 
@@ -372,7 +398,10 @@ object ObjectArray {
   def alloc(length: Int): ObjectArray = {
     val arrinfo = infoof[ObjectArray]
     val arrsize = sizeof[ArrayHeader] + sizeof[Object] * length
-    runtime.alloc(arrinfo, arrsize).cast[ObjectArray]
+    val arr = runtime.alloc(arrinfo, arrsize)    
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr.cast[ObjectArray]    
   }
 }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -1,8 +1,12 @@
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 1)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 1)
 package scala.scalanative
 package runtime
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 8)
+// Note:
+// Arrays.scala is currently implemented textual templating that is expanded through project/gyb.py script. 
+// Update the Arrays.scala.gyb and re-generate the source
+
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 12)
 
 import native._
 
@@ -25,7 +29,7 @@ sealed abstract class Array[T]
   protected override def clone(): Array[T] = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 31)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 35)
 
 final class BooleanArray private () extends Array[Boolean] {
   def apply(i: Int): Boolean =
@@ -60,16 +64,14 @@ object BooleanArray {
   def alloc(length: Int): BooleanArray = {
     val arrinfo = infoof[BooleanArray]
     val arrsize = sizeof[ArrayHeader] + sizeof[Boolean] * length
-    val arr = runtime.alloc(arrinfo, arrsize)
-    
+    val arr = runtime.alloc(arrinfo, arrsize)    
     // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    
-    arr.cast[BooleanArray]    
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr.cast[BooleanArray]        
   }
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 31)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 35)
 
 final class CharArray private () extends Array[Char] {
   def apply(i: Int): Char =
@@ -107,11 +109,11 @@ object CharArray {
     val arr = runtime.alloc(arrinfo, arrsize)    
     // set the length
     !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
-    arr.cast[CharArray]    
+    arr.cast[CharArray]        
   }
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 31)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 35)
 
 final class ByteArray private () extends Array[Byte] {
   def apply(i: Int): Byte =
@@ -149,11 +151,11 @@ object ByteArray {
     val arr = runtime.alloc(arrinfo, arrsize)    
     // set the length
     !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
-    arr.cast[ByteArray]    
+    arr.cast[ByteArray]        
   }
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 31)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 35)
 
 final class ShortArray private () extends Array[Short] {
   def apply(i: Int): Short =
@@ -191,11 +193,11 @@ object ShortArray {
     val arr = runtime.alloc(arrinfo, arrsize)    
     // set the length
     !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
-    arr.cast[ShortArray]    
+    arr.cast[ShortArray]        
   }
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 31)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 35)
 
 final class IntArray private () extends Array[Int] {
   def apply(i: Int): Int =
@@ -233,11 +235,11 @@ object IntArray {
     val arr = runtime.alloc(arrinfo, arrsize)    
     // set the length
     !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
-    arr.cast[IntArray]    
+    arr.cast[IntArray]        
   }
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 31)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 35)
 
 final class LongArray private () extends Array[Long] {
   def apply(i: Int): Long =
@@ -275,11 +277,11 @@ object LongArray {
     val arr = runtime.alloc(arrinfo, arrsize)    
     // set the length
     !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
-    arr.cast[LongArray]    
+    arr.cast[LongArray]        
   }
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 31)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 35)
 
 final class FloatArray private () extends Array[Float] {
   def apply(i: Int): Float =
@@ -314,14 +316,14 @@ object FloatArray {
   def alloc(length: Int): FloatArray = {
     val arrinfo = infoof[FloatArray]
     val arrsize = sizeof[ArrayHeader] + sizeof[Float] * length
-    val arr = runtime.alloc(arrinfo, arrsize)
+    val arr = runtime.alloc(arrinfo, arrsize)    
     // set the length
     !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
-    arr.cast[FloatArray]    
+    arr.cast[FloatArray]        
   }
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 31)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 35)
 
 final class DoubleArray private () extends Array[Double] {
   def apply(i: Int): Double =
@@ -359,11 +361,11 @@ object DoubleArray {
     val arr = runtime.alloc(arrinfo, arrsize)    
     // set the length
     !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
-    arr.cast[DoubleArray]    
+    arr.cast[DoubleArray]        
   }
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 31)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 35)
 
 final class ObjectArray private () extends Array[Object] {
   def apply(i: Int): Object =
@@ -401,7 +403,7 @@ object ObjectArray {
     val arr = runtime.alloc(arrinfo, arrsize)    
     // set the length
     !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
-    arr.cast[ObjectArray]    
+    arr.cast[ObjectArray]        
   }
 }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -1,6 +1,10 @@
 package scala.scalanative
 package runtime
 
+// Note:
+// Arrays.scala is currently implemented textual templating that is expanded through project/gyb.py script. 
+// Update the Arrays.scala.gyb and re-generate the source
+
 %{
    types = ['Boolean', 'Char', 'Byte', 'Short',
             'Int', 'Long', 'Float', 'Double', 'Object']
@@ -62,7 +66,10 @@ object ${T}Array {
   def alloc(length: Int): ${T}Array = {
     val arrinfo = infoof[${T}Array]
     val arrsize = sizeof[ArrayHeader] + sizeof[${T}] * length
-    runtime.alloc(arrinfo, arrsize).cast[${T}Array]
+    val arr = runtime.alloc(arrinfo, arrsize)    
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr.cast[${T}Array]        
   }
 }
 


### PR DESCRIPTION
``
  (new Array [T] (len)).length ()
``

always return zero because the length of the requested array isn't stored.