### PR TITLE
Future-proofing NIR for future changes

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Shows.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Shows.scala
@@ -260,7 +260,6 @@ object Shows {
   implicit val showType: Show[Type] = Show {
     case Type.None                => ""
     case Type.Void                => "void"
-    case Type.Label               => "label"
     case Type.Vararg              => "..."
     case Type.Ptr                 => "ptr"
     case Type.Bool                => "bool"

--- a/nir/src/main/scala/scala/scalanative/nir/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Tags.scala
@@ -1,21 +1,33 @@
 package scala.scalanative
 package nir
 
+/** Serialization tags are unique type ids used to identify
+  * types in the binary representation of NIR. There are some
+  * holes in the numbering of the types to allow for
+  * binary-compatible leeway with adding new IR nodes.
+  */
 object Tags {
-  final val MayInlineAttr    = 1
+
+  // Attibutes
+
+  final val Attr = 0
+
+  final val MayInlineAttr    = 1 + Attr
   final val InlineHintAttr   = 1 + MayInlineAttr
   final val NoInlineAttr     = 1 + InlineHintAttr
   final val AlwaysInlineAttr = 1 + NoInlineAttr
+  final val PureAttr         = 1 + AlwaysInlineAttr
+  final val ExternAttr       = 1 + PureAttr
+  final val OverrideAttr     = 1 + ExternAttr
+  final val LinkAttr         = 1 + OverrideAttr
+  final val PinAlwaysAttr    = 1 + LinkAttr
+  final val PinIfAttr        = 1 + PinAlwaysAttr
 
-  final val PureAttr     = 1 + AlwaysInlineAttr
-  final val ExternAttr   = 1 + PureAttr
-  final val OverrideAttr = 1 + ExternAttr
+  // Binary ops
 
-  final val LinkAttr      = 1 + OverrideAttr
-  final val PinAlwaysAttr = 1 + LinkAttr
-  final val PinIfAttr     = 1 + PinAlwaysAttr
+  final val Bin = Attr + 32
 
-  final val IaddBin = 1 + PinIfAttr
+  final val IaddBin = 1 + Bin
   final val FaddBin = 1 + IaddBin
   final val IsubBin = 1 + FaddBin
   final val FsubBin = 1 + IsubBin
@@ -34,7 +46,11 @@ object Tags {
   final val OrBin   = 1 + AndBin
   final val XorBin  = 1 + OrBin
 
-  final val IeqComp = 1 + XorBin
+  // Comparison ops
+
+  final val Comp = Bin + 32
+
+  final val IeqComp = 1 + Comp
   final val IneComp = 1 + IeqComp
   final val UgtComp = 1 + IneComp
   final val UgeComp = 1 + UgtComp
@@ -44,7 +60,6 @@ object Tags {
   final val SgeComp = 1 + SgtComp
   final val SltComp = 1 + SgeComp
   final val SleComp = 1 + SltComp
-
   final val FeqComp = 1 + SleComp
   final val FneComp = 1 + FeqComp
   final val FgtComp = 1 + FneComp
@@ -52,7 +67,11 @@ object Tags {
   final val FltComp = 1 + FgeComp
   final val FleComp = 1 + FltComp
 
-  final val TruncConv    = 1 + FleComp
+  // Conversion ops
+
+  final val Conv = Comp + 32
+
+  final val TruncConv    = 1 + Conv
   final val ZextConv     = 1 + TruncConv
   final val SextConv     = 1 + ZextConv
   final val FptruncConv  = 1 + SextConv
@@ -65,7 +84,11 @@ object Tags {
   final val InttoptrConv = 1 + PtrtointConv
   final val BitcastConv  = 1 + InttoptrConv
 
-  final val VarDefn     = 1 + BitcastConv
+  // Definitions
+
+  final val Defn = Conv + 32
+
+  final val VarDefn     = 1 + Defn
   final val ConstDefn   = 1 + VarDefn
   final val DeclareDefn = 1 + ConstDefn
   final val DefineDefn  = 1 + DeclareDefn
@@ -74,27 +97,42 @@ object Tags {
   final val ClassDefn   = 1 + TraitDefn
   final val ModuleDefn  = 1 + ClassDefn
 
-  final val UnreachableCf = 1 + ModuleDefn
+  // Control-flow ops
+
+  final val Cf = Defn + 32
+
+  final val UnreachableCf = 1 + Cf
   final val RetCf         = 1 + UnreachableCf
   final val JumpCf        = 1 + RetCf
   final val IfCf          = 1 + JumpCf
   final val SwitchCf      = 1 + IfCf
   final val InvokeCf      = 1 + SwitchCf
   final val ResumeCf      = 1 + InvokeCf
+  final val ThrowCf       = 1 + ResumeCf
+  final val TryCf         = 1 + ThrowCf
 
-  final val ThrowCf = 1 + ResumeCf
-  final val TryCf   = 1 + ThrowCf
+  // Globals
 
-  final val ValGlobal    = 1 + TryCf
+  final val Global = Cf + 32
+
+  final val ValGlobal    = 1 + Global
   final val TypeGlobal   = 1 + ValGlobal
   final val MemberGlobal = 1 + TypeGlobal
 
-  final val SuccNext  = 1 + MemberGlobal
+  // Nexts
+
+  final val Next = Global + 32
+
+  final val SuccNext  = 1 + Next
   final val FailNext  = 1 + SuccNext
   final val LabelNext = 1 + FailNext
   final val CaseNext  = 1 + LabelNext
 
-  final val CallOp       = 1 + CaseNext
+  // Ops
+
+  final val Op = Next + 32
+
+  final val CallOp       = 1 + Op
   final val LoadOp       = 1 + CallOp
   final val StoreOp      = 1 + LoadOp
   final val ElemOp       = 1 + StoreOp
@@ -104,7 +142,6 @@ object Tags {
   final val BinOp        = 1 + StackallocOp
   final val CompOp       = 1 + BinOp
   final val ConvOp       = 1 + CompOp
-
   final val ClassallocOp = 1 + ConvOp
   final val FieldOp      = 1 + ClassallocOp
   final val MethodOp     = 1 + FieldOp
@@ -117,7 +154,11 @@ object Tags {
   final val InfoofOp     = 1 + TypeofOp
   final val ClosureOp    = 1 + InfoofOp
 
-  final val NoneType     = 1 + ClosureOp
+  // Types
+
+  final val Type = Op + 32
+
+  final val NoneType     = 1 + Type
   final val VoidType     = 1 + NoneType
   final val VarargType   = 1 + VoidType
   final val PtrType      = 1 + VarargType
@@ -131,14 +172,17 @@ object Tags {
   final val ArrayType    = 1 + F64Type
   final val FunctionType = 1 + ArrayType
   final val StructType   = 1 + FunctionType
+  final val UnitType     = 1 + StructType
+  final val NothingType  = 1 + UnitType
+  final val ClassType    = 1 + NothingType
+  final val TraitType    = 1 + ClassType
+  final val ModuleType   = 1 + TraitType
 
-  final val UnitType    = 1 + StructType
-  final val NothingType = 1 + UnitType
-  final val ClassType   = 1 + NothingType
-  final val TraitType   = 1 + ClassType
-  final val ModuleType  = 1 + TraitType
+  // Values
 
-  final val NoneVal   = 1 + ModuleType
+  final val Val = Type + 32
+
+  final val NoneVal   = 1 + Val
   final val TrueVal   = 1 + NoneVal
   final val FalseVal  = 1 + TrueVal
   final val ZeroVal   = 1 + FalseVal

--- a/nir/src/main/scala/scala/scalanative/nir/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Tags.scala
@@ -74,19 +74,7 @@ object Tags {
   final val ClassDefn   = 1 + TraitDefn
   final val ModuleDefn  = 1 + ClassDefn
 
-  final val PrivateLink             = 1 + ModuleDefn
-  final val InternalLink            = 1 + PrivateLink
-  final val AvailableExternallyLink = 1 + InternalLink
-  final val OnceLink                = 1 + AvailableExternallyLink
-  final val WeakLink                = 1 + OnceLink
-  final val CommonLink              = 1 + WeakLink
-  final val AppendingLink           = 1 + CommonLink
-  final val ExternWeakLink          = 1 + AppendingLink
-  final val OnceODRLink             = 1 + ExternWeakLink
-  final val WeakODRLink             = 1 + OnceODRLink
-  final val ExternalLink            = 1 + WeakODRLink
-
-  final val UnreachableCf = 1 + ExternalLink
+  final val UnreachableCf = 1 + ModuleDefn
   final val RetCf         = 1 + UnreachableCf
   final val JumpCf        = 1 + RetCf
   final val IfCf          = 1 + JumpCf
@@ -131,8 +119,7 @@ object Tags {
 
   final val NoneType     = 1 + ClosureOp
   final val VoidType     = 1 + NoneType
-  final val LabelType    = 1 + VoidType
-  final val VarargType   = 1 + LabelType
+  final val VarargType   = 1 + VoidType
   final val PtrType      = 1 + VarargType
   final val BoolType     = 1 + PtrType
   final val I8Type       = 1 + BoolType

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -23,7 +23,6 @@ object Type {
   // low-level types
   final case object None   extends Type
   final case object Void   extends Type
-  final case object Label  extends Type
   final case object Vararg extends Type
   final case object Ptr    extends Type
 

--- a/nir/src/main/scala/scala/scalanative/nir/Versions.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Versions.scala
@@ -2,5 +2,27 @@ package scala.scalanative
 package nir
 
 object Versions {
-  val current: String = "0.1-SNAPSHOT"
+  /* NIR magic number */
+  final val magic: Int = 0x2e4e4952 // '.NIR' in hex
+
+  /* NIR is internally versioned by two version numbers. First one is
+   * compatibility level, and the second one is revision of the format. Both
+   * numbers are monotonically increasing. Revision is increased on any change
+   * to the format. Compatibility level is increased whenever the given change
+   * is breaking.
+   *
+   * For example here is a possible sequence of release number changes:
+   *
+   *     0.0 -> 0.1 -> 0.2 -> 1.3 -> ...
+   *
+   * NIR emitted via 0.0-compatible compiler should read without any changes
+   * in 0.2-based compiler, but not the other way around. On the other hand
+   * when 1.3-based release happens all of the code needs to recompiled with
+   * new version of the toolchain.
+   */
+  final val compat: Int   = java.lang.Integer.parseUnsignedInt("0")
+  final val revision: Int = java.lang.Integer.parseUnsignedInt("0")
+
+  /* Current public release version of Scala Native. */
+  final val current: String = "0.1-SNAPSHOT"
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -239,7 +239,6 @@ final class BinaryDeserializer(_buffer: => ByteBuffer) {
   private def getType(): Type = getInt match {
     case T.NoneType     => Type.None
     case T.VoidType     => Type.Void
-    case T.LabelType    => Type.Label
     case T.VarargType   => Type.Vararg
     case T.PtrType      => Type.Ptr
     case T.BoolType     => Type.Bool

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -364,7 +364,6 @@ final class BinarySerializer(buffer: ByteBuffer) {
   private def putType(ty: Type): Unit = ty match {
     case Type.None         => putInt(T.NoneType)
     case Type.Void         => putInt(T.VoidType)
-    case Type.Label        => putInt(T.LabelType)
     case Type.Vararg       => putInt(T.VarargType)
     case Type.Ptr          => putInt(T.PtrType)
     case Type.Bool         => putInt(T.BoolType)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -13,6 +13,10 @@ final class BinarySerializer(buffer: ByteBuffer) {
     val names     = defns.map(_.name)
     val positions = mutable.UnrolledBuffer.empty[Int]
 
+    putInt(Versions.magic)
+    putInt(Versions.compat)
+    putInt(Versions.revision)
+
     putSeq(names) { n =>
       putGlobal(n)
       positions += buffer.position
@@ -65,8 +69,8 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Attr.Extern      => putInt(T.ExternAttr)
     case Attr.Override(n) => putInt(T.OverrideAttr); putGlobal(n)
 
-    case Attr.Link(s)        => putInt(T.LinkAttr); putString(s)
-    case Attr.PinAlways(n)   => putInt(T.PinAlwaysAttr); putGlobal(n)
+    case Attr.Link(s)      => putInt(T.LinkAttr); putString(s)
+    case Attr.PinAlways(n) => putInt(T.PinAlwaysAttr); putGlobal(n)
     case Attr.PinIf(n, cond) =>
       putInt(T.PinIfAttr); putGlobal(n); putGlobal(cond)
   }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
@@ -40,7 +40,6 @@ package object serialization {
 
   def deserializeBinaryFile(path: String): BinaryDeserializer =
     new BinaryDeserializer({
-      //println(s"opened $path")
       val bytes  = Files.readAllBytes(Paths.get(path))
       val buffer = ByteBuffer.wrap(bytes)
       buffer

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -41,14 +41,14 @@ abstract class NirCodeGen
 
     def enterLabel(ld: LabelDef): Local = {
       val local = fresh()
-      enter(ld.symbol, Val.Local(local, Type.Label))
+      enter(ld.symbol, Val.Local(local, Type.Ptr))
       local
     }
 
     def resolve(sym: Symbol): Val = env(sym)
 
     def resolveLabel(ld: LabelDef): Local = {
-      val Val.Local(n, Type.Label) = resolve(ld.symbol)
+      val Val.Local(n, Type.Ptr) = resolve(ld.symbol)
       n
     }
   }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirNameEncoding.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirNameEncoding.scala
@@ -64,7 +64,6 @@ trait NirNameEncoding { self: NirCodeGen =>
     implicit lazy val showMangledType: Show[nir.Type] = Show {
       case nir.Type.None                => ""
       case nir.Type.Void                => "void"
-      case nir.Type.Label               => "label"
       case nir.Type.Vararg              => "..."
       case nir.Type.Ptr                 => "ptr"
       case nir.Type.Bool                => "bool"

--- a/tools/src/main/scala/scala/scalanative/compiler/codegen/GenTextualLLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/compiler/codegen/GenTextualLLVM.scala
@@ -128,7 +128,6 @@ class GenTextualLLVM(assembly: Seq[Defn]) extends GenShow(assembly) {
 
   implicit val showType: Show[Type] = Show {
     case Type.Void                => "void"
-    case Type.Label               => "label"
     case Type.Vararg              => "..."
     case Type.Ptr                 => "i8*"
     case Type.Bool                => "i1"


### PR DESCRIPTION
This PR adds a number of changes towards stabilization of the binary representation:

* Gets rid of the unused remnants
* Includes magic number
* Includes monotonic NIR versions