### PR TITLE
Call GC_malloc_atomic to allocate memory for primitive arrays

### DIFF
--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -1,6 +1,6 @@
 package java.lang
 
-import scalanative.runtime.Math._
+import scalanative.runtime.Intrinsics._
 
 object Math {
   final val E  = 2.718281828459045

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -1,13 +1,17 @@
 package scala.scalanative
 package runtime
 
-// Note:
-// Arrays.scala is currently implemented textual templating that is expanded through project/gyb.py script. 
-// Update the Arrays.scala.gyb and re-generate the source
+// Note 1:
+// Arrays.scala is currently implemented as textual templating that is expanded through project/gyb.py script. 
+// Update Arrays.scala.gyb and re-generate the source
+
+// Note 2:
+// Array of primitiveTypes don't contain pointers, runtime.allocAtomic() is called for memory allocation   
+// Array of Object do contain pointers. runtime.alloc() is called for memory allocation
 
 %{
-   types = ['Boolean', 'Char', 'Byte', 'Short',
-            'Int', 'Long', 'Float', 'Double', 'Object']
+   primitiveTypes = ['Boolean', 'Char', 'Byte', 'Short',
+            'Int', 'Long', 'Float', 'Double']
 }%
 
 import native._
@@ -31,7 +35,47 @@ sealed abstract class Array[T]
   protected override def clone(): Array[T] = undefined
 }
 
-% for T in types:
+final class ObjectArray private () extends Array[Object] {
+  def apply(i: Int): Object =
+    if (i < 0 || i >= length)
+      throw new IndexOutOfBoundsException(i.toString)
+    else {
+      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Object]]
+      headptr(i)
+    }
+
+  def update(i: Int, value: Object): Unit =
+    if (i < 0 || i >= length)
+      throw new IndexOutOfBoundsException(i.toString)
+    else {
+      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Object]]
+      headptr(i) = value
+    }
+
+  protected override def clone(): ObjectArray = {
+    val newarr = ObjectArray.alloc(length)
+    ObjectArray.copy(this, 0, newarr, 0, length)
+    newarr
+  }
+}
+
+object ObjectArray {
+  def copy(from: ObjectArray, fromPos: Int,
+           to: ObjectArray, toPos: Int, length: Int): Unit = {
+    ???
+  }
+
+  def alloc(length: Int): ObjectArray = {
+    val arrinfo = infoof[ObjectArray]
+    val arrsize = sizeof[ArrayHeader] + sizeof[Object] * length
+    val arr = runtime.alloc(arrinfo, arrsize)    
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr.cast[ObjectArray]        
+  }
+}
+
+% for T in primitiveTypes:
 
 final class ${T}Array private () extends Array[${T}] {
   def apply(i: Int): ${T} =
@@ -66,7 +110,7 @@ object ${T}Array {
   def alloc(length: Int): ${T}Array = {
     val arrinfo = infoof[${T}Array]
     val arrsize = sizeof[ArrayHeader] + sizeof[${T}] * length
-    val arr = runtime.alloc(arrinfo, arrsize)    
+    val arr = runtime.allocAtomic(arrinfo, arrsize)    
     // set the length
     !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
     arr.cast[${T}Array]        

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -3,11 +3,18 @@ package runtime
 
 import native._
 
+/**
+ * The Boehm GC conservative garbage collector
+ *
+ * @see [[http://hboehm.info/gc/gcinterface.html C Interface]]
+ */
 @link("gc")
 @extern
 object GC {
   @name("GC_malloc")
   def malloc(size: CSize): Ptr[_] = extern
+  @name("GC_malloc_atomic")
+  def malloc_atomic(size: CSize): Ptr[_] = extern
   @name("GC_init")
   def init(): Unit = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -3,8 +3,11 @@ package runtime
 
 import native._
 
+/**
+ * @see [[http://llvm.org/releases/3.7.0/docs/LangRef.html#intrinsic-functions LLVM intrinsics functions]]
+ */
 @extern
-object Math {
+object Intrinsics {
   def `llvm.sqrt.f32`(value: Float): Float                        = extern
   def `llvm.sqrt.f64`(value: Double): Double                      = extern
   def `llvm.powi.f32`(value: Float, power: Int): Float            = extern
@@ -64,4 +67,24 @@ object Math {
   def `llvm.cttz.i16`(source: Short, iszeroundef: Boolean): Short = extern
   def `llvm.cttz.i32`(source: Int, iszeroundef: Boolean): Int     = extern
   def `llvm.cttz.i64`(source: Long, iszeroundef: Boolean): Long   = extern
+  def `llvm.memset.p0i8.i32`(dest: Ptr[Byte],
+                             value: Byte,
+                             len: Int,
+                             align: Int,
+                             isvolatile: Boolean): Unit = extern
+  def `llvm.memset.p0i8.i64`(dest: Ptr[Byte],
+                             value: Byte,
+                             len: Long,
+                             align: Int,
+                             isvolatile: Boolean): Unit = extern
+  def `llvm.memcpy.p0i8.p0i8.i32`(dest: Ptr[Byte],
+                                  src: Ptr[Byte],
+                                  len: Int,
+                                  align: Int,
+                                  isvolatile: Boolean): Unit = extern
+  def `llvm.memcpy.p0i8.p0i8.i64`(dest: Ptr[Byte],
+                                  src: Ptr[Byte],
+                                  len: Long,
+                                  align: Int,
+                                  isvolatile: Boolean): Unit = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -2,6 +2,7 @@ package scala.scalanative
 
 import scala.reflect.ClassTag
 import native._
+import runtime.Intrinsics._
 
 package object runtime {
   /** Used as a stub right hand of intrinsified methods. */
@@ -29,6 +30,18 @@ package object runtime {
     ptr
   }
 
+  /** Allocate memory in gc heap using given info pointer.
+    *
+    * The allocated memory cannot be used to store pointers.
+    */
+  def allocAtomic(info: Ptr[_], size: CSize): Ptr[_] = {
+    val ptr = GC.malloc_atomic(size).cast[Ptr[Ptr[_]]]
+    // initialize to 0
+    `llvm.memset.p0i8.i64`(ptr.cast[Ptr[Byte]], 0, size, 1, false) 
+    !ptr = info
+    ptr
+  }
+
   /** Initialize runtime with given arguments and return the
     * rest as Java-style array.
     */
@@ -37,3 +50,4 @@ package object runtime {
     null
   }
 }
+


### PR DESCRIPTION
- modified:   javalib/src/main/scala/java/lang/Math.scala
- modified:   nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
- modified:   nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
- modified:   nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
- renamed:    nativelib/src/main/scala/scala/scalanative/runtime/Math.scala -> nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
- modified:   nativelib/src/main/scala/scala/scalanative/runtime/package.scala