### PR TITLE
Fix #102

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
@@ -5,10 +5,10 @@ import native._
 
 @extern
 object stdlib {
-  @name("__stderrp")
-  var stderr: Ptr[_] = extern
-  @name("__stdoutp")
-  var stdout: Ptr[_] = extern
+  @name("scalanative_stderr")
+  def stderr: Ptr[_] = extern
+  @name("scalanative_stdout")
+  def stdout: Ptr[_] = extern
 
   def fopen(filename: CString, mode: CString): Ptr[_]               = extern
   def fprintf(stream: Ptr[_], format: CString, args: Vararg*): CInt = extern

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,8 +45,6 @@ RUN git clone https://github.com/scala-native/scala-native.git
 
 WORKDIR /tmp/scala-native
 
-RUN sed -i 's|__stdoutp|stdout|;s|__stderrp|stderr|' clib/src/main/scala/scala/scalanative/libc/stdlib.scala
-
 RUN sbt 'rtlib/publishLocal' && sbt 'nscplugin/publishLocal'
 
 WORKDIR /home/sources

--- a/rtlib/src/main/resources/rt.cpp
+++ b/rtlib/src/main/resources/rt.cpp
@@ -39,5 +39,13 @@ extern "C" {
     void scalanative_init() {
         GC_init();
     }
+
+    void* scalanative_stderr() {
+        return stderr;
+    }
+
+    void* scalanative_stdout() {
+        return stdout;
+    }
 }
 


### PR DESCRIPTION
Even though we still don't have conditional compilation support
there is a simpler workaround solution to the issue of having to
deal with different native symbols -- just create a thin wrappers
on C side, that are guaranteed to be portable.