### PR TITLE
implement array.clone() and basic array.copy()

### DIFF
--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -11,7 +11,10 @@ object System {
                 srcPos: scala.Int,
                 dest: Object,
                 destPos: scala.Int,
-                length: scala.Int): Unit = ???
+                length: scala.Int): Unit = {
+    scalanative.runtime.Array.copy(src, srcPos, dest, destPos, length)
+  }
+
   def identityHashCode(x: Object): scala.Int =
     x.cast[Word].hashCode
   def getenv(name: String): String                      = ???

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -1,20 +1,30 @@
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 1)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 1)
 package scala.scalanative
 package runtime
 
 // Note 1:
-// Arrays.scala is currently implemented as textual templating that is expanded through project/gyb.py script.
+// Arrays.scala is currently implemented as textual templating that is expanded through project/gyb.py script. 
 // Update Arrays.scala.gyb and re-generate the source
+// $ ./project/gyb.py \ 
+//     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb > \
+//     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+
 
 // Note 2:
 // Array of primitiveTypes don't contain pointers, runtime.allocAtomic() is called for memory allocation
 // Array of Object do contain pointers. runtime.alloc() is called for memory allocation
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 16)
+// Note 3:
+// PrimitiveArray.helperClone can allocate memory with GC.malloc_atomic() because 
+// it will overwrite all data (no need to call llvm.memset)
+
 
 import native._
+import Intrinsics._
 
 @struct class ArrayHeader(val info: Ptr[_], val length: Int)
+
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 30)
 
 sealed abstract class Array[T]
     extends java.io.Serializable with java.lang.Cloneable {
@@ -22,7 +32,7 @@ sealed abstract class Array[T]
   def length: Int =
     // TODO: Update once we support ptr->field
     !(this.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]]
-
+    
   /** Loads element at i, throws IndexOutOfBoundsException. */
   def apply(i: Int): T
 
@@ -30,382 +40,297 @@ sealed abstract class Array[T]
   def update(i: Int, value: T): Unit
 
   /** Create a shallow of given array. */
-  protected override def clone(): Array[T] = undefined
+  protected override def clone(): Array[T] = undefined  
+}
+
+object Array {
+  def copy (from: AnyRef, fromPos: Int, to: AnyRef, toPos: Int, len: Int): Unit = {
+    if (from == null)
+      throw new NullPointerException()
+    
+    if (to == null)
+      throw new NullPointerException()
+    
+    val fromTypeId = instanceTypeId(from)
+    val toTypeId = instanceTypeId(to)
+    
+    val stride = if (fromTypeId == arrayObjectTypeId && toTypeId == arrayObjectTypeId)
+      sizeof[Object]
+    
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 63)
+
+    else if (fromTypeId == arrayBooleanTypeId && toTypeId == arrayBooleanTypeId) 
+      sizeof[Boolean]
+      
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 63)
+
+    else if (fromTypeId == arrayCharTypeId && toTypeId == arrayCharTypeId) 
+      sizeof[Char]
+      
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 63)
+
+    else if (fromTypeId == arrayByteTypeId && toTypeId == arrayByteTypeId) 
+      sizeof[Byte]
+      
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 63)
+
+    else if (fromTypeId == arrayShortTypeId && toTypeId == arrayShortTypeId) 
+      sizeof[Short]
+      
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 63)
+
+    else if (fromTypeId == arrayIntTypeId && toTypeId == arrayIntTypeId) 
+      sizeof[Int]
+      
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 63)
+
+    else if (fromTypeId == arrayLongTypeId && toTypeId == arrayLongTypeId) 
+      sizeof[Long]
+      
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 63)
+
+    else if (fromTypeId == arrayFloatTypeId && toTypeId == arrayFloatTypeId) 
+      sizeof[Float]
+      
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 63)
+
+    else if (fromTypeId == arrayDoubleTypeId && toTypeId == arrayDoubleTypeId) 
+      sizeof[Double]
+      
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 68)
+
+    else
+      throw new ArrayStoreException ("Invalid array copy.")
+      
+    validateBoundaries (from.asInstanceOf[Array[_]], fromPos, to.asInstanceOf[Array[_]], toPos, len)
+    
+    val fromPtr: Ptr[Byte] = (from.cast[Ptr[Byte]] + sizeof[ArrayHeader] + stride * fromPos).cast[Ptr[Byte]]
+    
+    val toPtr: Ptr[Byte] = (to.cast[Ptr[Byte]] + sizeof[ArrayHeader] + stride * toPos).cast[Ptr[Byte]]
+        
+    `llvm.memmove.p0i8.p0i8.i64`(toPtr, fromPtr, stride * len, 1, false)
+  }
+  
+  // the id's chosen by the compiler/linker for differents types of array
+
+  val arrayObjectTypeId = typeId (typeof[scalanative.runtime.ObjectArray])
+  
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 86)
+
+  val arrayBooleanTypeId = typeId (typeof[scalanative.runtime.BooleanArray])
+  
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 86)
+
+  val arrayCharTypeId = typeId (typeof[scalanative.runtime.CharArray])
+  
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 86)
+
+  val arrayByteTypeId = typeId (typeof[scalanative.runtime.ByteArray])
+  
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 86)
+
+  val arrayShortTypeId = typeId (typeof[scalanative.runtime.ShortArray])
+  
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 86)
+
+  val arrayIntTypeId = typeId (typeof[scalanative.runtime.IntArray])
+  
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 86)
+
+  val arrayLongTypeId = typeId (typeof[scalanative.runtime.LongArray])
+  
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 86)
+
+  val arrayFloatTypeId = typeId (typeof[scalanative.runtime.FloatArray])
+  
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 86)
+
+  val arrayDoubleTypeId = typeId (typeof[scalanative.runtime.DoubleArray])
+  
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 90)
+    
+  private def typeId (ptr : Ptr[Type]): Int = {
+    (!ptr).id    
+  }
+  
+  private def instanceTypeId (any : AnyRef): Int = {
+    typeId(runtime.getType(any))
+  }
+  
+  @inline private[runtime] def validateBoundaries (from: Array[_], fromPos: Int, to: Array[_], toPos: Int, len: Int): Unit = {
+    if (len < 0)
+      throw new IndexOutOfBoundsException("length is negative")
+
+    if (fromPos < 0 || fromPos + len > from.length)
+      throw new IndexOutOfBoundsException(fromPos.toString)
+
+    if (toPos < 0 || toPos + len > to.length)
+      throw new IndexOutOfBoundsException(toPos.toString)    
+  }
+  
+  @inline private[runtime] def pointerAt(arr: Array[_], sizeOneElement: CSize, i: Int): Ptr[_] = {
+    if (i < 0 || i >= arr.length)
+      throw new IndexOutOfBoundsException(i.toString)
+    else {
+      (arr.cast[Ptr[Byte]] + sizeof[ArrayHeader] + sizeOneElement * i).cast[Ptr[_]]
+    }
+  }
+  
+  @inline private[runtime] def helperClone(from: Array[_], length: Int, stride: CSize): Ptr[_] = {
+    val arrsize = sizeof[ArrayHeader] + stride * length
+    val arr = GC.malloc(arrsize)
+    `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]], from.cast[Ptr[Byte]], arrsize, 1, false)
+    arr        
+  }  
+  
+  def alloc(length: Int, arrinfo:  Ptr[Type], stride: CSize): Ptr[_] = {
+    val arrsize = sizeof[ArrayHeader] + stride * length
+    val arr = runtime.alloc(arrinfo, arrsize)
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr        
+  } 
+}
+
+object PrimitiveArray {
+  @inline private[runtime] def helperClone(src: Array[_], length: Int, stride: CSize): Ptr[_] = {
+    val arrsize = sizeof[ArrayHeader] + stride * length
+    val arr = GC.malloc_atomic(arrsize)
+    `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]], src.cast[Ptr[Byte]], arrsize, 1, false)
+    arr
+  }
+  
+  def alloc(length: Int, arrinfo:  Ptr[Type], stride: CSize): Ptr[_] = {
+    val arrsize = sizeof[ArrayHeader] + stride * length
+    // Primitive arrays don't contain pointers 
+    val arr = runtime.allocAtomic(arrinfo, arrsize)
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr        
+  }
 }
 
 final class ObjectArray private () extends Array[Object] {
-  def apply(i: Int): Object =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Object]]
-      headptr(i)
-    }
+  def apply(i: Int): Object = ! (Array.pointerAt(this, sizeof[Object], i).cast[Ptr[Object]])
 
-  def update(i: Int, value: Object): Unit =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Object]]
-      headptr(i) = value
-    }
+  def update(i: Int, value: Object): Unit = ! (Array.pointerAt(this, sizeof[Object], i).cast[Ptr[Object]]) = value
 
-  protected override def clone(): ObjectArray = {
-    val newarr = ObjectArray.alloc(length)
-    ObjectArray.copy(this, 0, newarr, 0, length)
-    newarr
-  }
+  protected override def clone(): ObjectArray = Array.helperClone (this, length, sizeof[Object]).cast[ObjectArray]
 }
 
 object ObjectArray {
-  def copy(from: ObjectArray, fromPos: Int,
-           to: ObjectArray, toPos: Int, length: Int): Unit = {
-    ???
-  }
-
-  def alloc(length: Int): ObjectArray = {
-    val arrty = typeof[ObjectArray]
-    val arrsize = sizeof[ArrayHeader] + sizeof[Object] * length
-    val arr = runtime.alloc(arrty, arrsize)
-    // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    arr.cast[ObjectArray]
-  }
+  def alloc(length: Int): ObjectArray = Array.alloc(length, typeof[ObjectArray], sizeof[Object]).cast[ObjectArray]
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 79)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 165)
 
 final class BooleanArray private () extends Array[Boolean] {
-  def apply(i: Int): Boolean =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Boolean]]
-      headptr(i)
-    }
+  def apply(i: Int): Boolean = ! (Array.pointerAt(this, sizeof[Boolean], i).cast[Ptr[Boolean]])
 
-  def update(i: Int, value: Boolean): Unit =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Boolean]]
-      headptr(i) = value
-    }
+  def update(i: Int, value: Boolean): Unit = ! (Array.pointerAt(this, sizeof[Boolean], i).cast[Ptr[Boolean]]) = value
 
-  protected override def clone(): BooleanArray = {
-    val newarr = BooleanArray.alloc(length)
-    BooleanArray.copy(this, 0, newarr, 0, length)
-    newarr
-  }
+  protected override def clone(): BooleanArray = PrimitiveArray.helperClone (this, length, sizeof[Boolean]).cast[BooleanArray]
 }
 
 object BooleanArray {
-  def copy(from: BooleanArray, fromPos: Int,
-           to: BooleanArray, toPos: Int, length: Int): Unit = {
-    ???
-  }
-
-  def alloc(length: Int): BooleanArray = {
-    val arrty = typeof[BooleanArray]
-    val arrsize = sizeof[ArrayHeader] + sizeof[Boolean] * length
-    val arr = runtime.allocAtomic(arrty, arrsize)
-    // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    arr.cast[BooleanArray]
-  }
+  def alloc(length: Int): BooleanArray = PrimitiveArray.alloc(length, typeof[BooleanArray], sizeof[Boolean]).cast[BooleanArray]  
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 79)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 165)
 
 final class CharArray private () extends Array[Char] {
-  def apply(i: Int): Char =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Char]]
-      headptr(i)
-    }
+  def apply(i: Int): Char = ! (Array.pointerAt(this, sizeof[Char], i).cast[Ptr[Char]])
 
-  def update(i: Int, value: Char): Unit =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Char]]
-      headptr(i) = value
-    }
+  def update(i: Int, value: Char): Unit = ! (Array.pointerAt(this, sizeof[Char], i).cast[Ptr[Char]]) = value
 
-  protected override def clone(): CharArray = {
-    val newarr = CharArray.alloc(length)
-    CharArray.copy(this, 0, newarr, 0, length)
-    newarr
-  }
+  protected override def clone(): CharArray = PrimitiveArray.helperClone (this, length, sizeof[Char]).cast[CharArray]
 }
 
 object CharArray {
-  def copy(from: CharArray, fromPos: Int,
-           to: CharArray, toPos: Int, length: Int): Unit = {
-    ???
-  }
-
-  def alloc(length: Int): CharArray = {
-    val arrty = typeof[CharArray]
-    val arrsize = sizeof[ArrayHeader] + sizeof[Char] * length
-    val arr = runtime.allocAtomic(arrty, arrsize)
-    // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    arr.cast[CharArray]
-  }
+  def alloc(length: Int): CharArray = PrimitiveArray.alloc(length, typeof[CharArray], sizeof[Char]).cast[CharArray]  
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 79)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 165)
 
 final class ByteArray private () extends Array[Byte] {
-  def apply(i: Int): Byte =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Byte]]
-      headptr(i)
-    }
+  def apply(i: Int): Byte = ! (Array.pointerAt(this, sizeof[Byte], i).cast[Ptr[Byte]])
 
-  def update(i: Int, value: Byte): Unit =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Byte]]
-      headptr(i) = value
-    }
+  def update(i: Int, value: Byte): Unit = ! (Array.pointerAt(this, sizeof[Byte], i).cast[Ptr[Byte]]) = value
 
-  protected override def clone(): ByteArray = {
-    val newarr = ByteArray.alloc(length)
-    ByteArray.copy(this, 0, newarr, 0, length)
-    newarr
-  }
+  protected override def clone(): ByteArray = PrimitiveArray.helperClone (this, length, sizeof[Byte]).cast[ByteArray]
 }
 
 object ByteArray {
-  def copy(from: ByteArray, fromPos: Int,
-           to: ByteArray, toPos: Int, length: Int): Unit = {
-    ???
-  }
-
-  def alloc(length: Int): ByteArray = {
-    val arrty = typeof[ByteArray]
-    val arrsize = sizeof[ArrayHeader] + sizeof[Byte] * length
-    val arr = runtime.allocAtomic(arrty, arrsize)
-    // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    arr.cast[ByteArray]
-  }
+  def alloc(length: Int): ByteArray = PrimitiveArray.alloc(length, typeof[ByteArray], sizeof[Byte]).cast[ByteArray]  
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 79)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 165)
 
 final class ShortArray private () extends Array[Short] {
-  def apply(i: Int): Short =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Short]]
-      headptr(i)
-    }
+  def apply(i: Int): Short = ! (Array.pointerAt(this, sizeof[Short], i).cast[Ptr[Short]])
 
-  def update(i: Int, value: Short): Unit =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Short]]
-      headptr(i) = value
-    }
+  def update(i: Int, value: Short): Unit = ! (Array.pointerAt(this, sizeof[Short], i).cast[Ptr[Short]]) = value
 
-  protected override def clone(): ShortArray = {
-    val newarr = ShortArray.alloc(length)
-    ShortArray.copy(this, 0, newarr, 0, length)
-    newarr
-  }
+  protected override def clone(): ShortArray = PrimitiveArray.helperClone (this, length, sizeof[Short]).cast[ShortArray]
 }
 
 object ShortArray {
-  def copy(from: ShortArray, fromPos: Int,
-           to: ShortArray, toPos: Int, length: Int): Unit = {
-    ???
-  }
-
-  def alloc(length: Int): ShortArray = {
-    val arrty = typeof[ShortArray]
-    val arrsize = sizeof[ArrayHeader] + sizeof[Short] * length
-    val arr = runtime.allocAtomic(arrty, arrsize)
-    // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    arr.cast[ShortArray]
-  }
+  def alloc(length: Int): ShortArray = PrimitiveArray.alloc(length, typeof[ShortArray], sizeof[Short]).cast[ShortArray]  
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 79)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 165)
 
 final class IntArray private () extends Array[Int] {
-  def apply(i: Int): Int =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Int]]
-      headptr(i)
-    }
+  def apply(i: Int): Int = ! (Array.pointerAt(this, sizeof[Int], i).cast[Ptr[Int]])
 
-  def update(i: Int, value: Int): Unit =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Int]]
-      headptr(i) = value
-    }
+  def update(i: Int, value: Int): Unit = ! (Array.pointerAt(this, sizeof[Int], i).cast[Ptr[Int]]) = value
 
-  protected override def clone(): IntArray = {
-    val newarr = IntArray.alloc(length)
-    IntArray.copy(this, 0, newarr, 0, length)
-    newarr
-  }
+  protected override def clone(): IntArray = PrimitiveArray.helperClone (this, length, sizeof[Int]).cast[IntArray]
 }
 
 object IntArray {
-  def copy(from: IntArray, fromPos: Int,
-           to: IntArray, toPos: Int, length: Int): Unit = {
-    ???
-  }
-
-  def alloc(length: Int): IntArray = {
-    val arrty = typeof[IntArray]
-    val arrsize = sizeof[ArrayHeader] + sizeof[Int] * length
-    val arr = runtime.allocAtomic(arrty, arrsize)
-    // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    arr.cast[IntArray]
-  }
+  def alloc(length: Int): IntArray = PrimitiveArray.alloc(length, typeof[IntArray], sizeof[Int]).cast[IntArray]  
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 79)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 165)
 
 final class LongArray private () extends Array[Long] {
-  def apply(i: Int): Long =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Long]]
-      headptr(i)
-    }
+  def apply(i: Int): Long = ! (Array.pointerAt(this, sizeof[Long], i).cast[Ptr[Long]])
 
-  def update(i: Int, value: Long): Unit =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Long]]
-      headptr(i) = value
-    }
+  def update(i: Int, value: Long): Unit = ! (Array.pointerAt(this, sizeof[Long], i).cast[Ptr[Long]]) = value
 
-  protected override def clone(): LongArray = {
-    val newarr = LongArray.alloc(length)
-    LongArray.copy(this, 0, newarr, 0, length)
-    newarr
-  }
+  protected override def clone(): LongArray = PrimitiveArray.helperClone (this, length, sizeof[Long]).cast[LongArray]
 }
 
 object LongArray {
-  def copy(from: LongArray, fromPos: Int,
-           to: LongArray, toPos: Int, length: Int): Unit = {
-    ???
-  }
-
-  def alloc(length: Int): LongArray = {
-    val arrty = typeof[LongArray]
-    val arrsize = sizeof[ArrayHeader] + sizeof[Long] * length
-    val arr = runtime.allocAtomic(arrty, arrsize)
-    // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    arr.cast[LongArray]
-  }
+  def alloc(length: Int): LongArray = PrimitiveArray.alloc(length, typeof[LongArray], sizeof[Long]).cast[LongArray]  
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 79)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 165)
 
 final class FloatArray private () extends Array[Float] {
-  def apply(i: Int): Float =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Float]]
-      headptr(i)
-    }
+  def apply(i: Int): Float = ! (Array.pointerAt(this, sizeof[Float], i).cast[Ptr[Float]])
 
-  def update(i: Int, value: Float): Unit =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Float]]
-      headptr(i) = value
-    }
+  def update(i: Int, value: Float): Unit = ! (Array.pointerAt(this, sizeof[Float], i).cast[Ptr[Float]]) = value
 
-  protected override def clone(): FloatArray = {
-    val newarr = FloatArray.alloc(length)
-    FloatArray.copy(this, 0, newarr, 0, length)
-    newarr
-  }
+  protected override def clone(): FloatArray = PrimitiveArray.helperClone (this, length, sizeof[Float]).cast[FloatArray]
 }
 
 object FloatArray {
-  def copy(from: FloatArray, fromPos: Int,
-           to: FloatArray, toPos: Int, length: Int): Unit = {
-    ???
-  }
-
-  def alloc(length: Int): FloatArray = {
-    val arrty = typeof[FloatArray]
-    val arrsize = sizeof[ArrayHeader] + sizeof[Float] * length
-    val arr = runtime.allocAtomic(arrty, arrsize)
-    // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    arr.cast[FloatArray]
-  }
+  def alloc(length: Int): FloatArray = PrimitiveArray.alloc(length, typeof[FloatArray], sizeof[Float]).cast[FloatArray]  
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 79)
+// ###sourceLocation(file: "/home/francois/proyectos/oss/scala-native-fbd/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 165)
 
 final class DoubleArray private () extends Array[Double] {
-  def apply(i: Int): Double =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Double]]
-      headptr(i)
-    }
+  def apply(i: Int): Double = ! (Array.pointerAt(this, sizeof[Double], i).cast[Ptr[Double]])
 
-  def update(i: Int, value: Double): Unit =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Double]]
-      headptr(i) = value
-    }
+  def update(i: Int, value: Double): Unit = ! (Array.pointerAt(this, sizeof[Double], i).cast[Ptr[Double]]) = value
 
-  protected override def clone(): DoubleArray = {
-    val newarr = DoubleArray.alloc(length)
-    DoubleArray.copy(this, 0, newarr, 0, length)
-    newarr
-  }
+  protected override def clone(): DoubleArray = PrimitiveArray.helperClone (this, length, sizeof[Double]).cast[DoubleArray]
 }
 
 object DoubleArray {
-  def copy(from: DoubleArray, fromPos: Int,
-           to: DoubleArray, toPos: Int, length: Int): Unit = {
-    ???
-  }
-
-  def alloc(length: Int): DoubleArray = {
-    val arrty = typeof[DoubleArray]
-    val arrsize = sizeof[ArrayHeader] + sizeof[Double] * length
-    val arr = runtime.allocAtomic(arrty, arrsize)
-    // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    arr.cast[DoubleArray]
-  }
+  def alloc(length: Int): DoubleArray = PrimitiveArray.alloc(length, typeof[DoubleArray], sizeof[Double]).cast[DoubleArray]  
 }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -2,21 +2,31 @@ package scala.scalanative
 package runtime
 
 // Note 1:
-// Arrays.scala is currently implemented as textual templating that is expanded through project/gyb.py script.
+// Arrays.scala is currently implemented as textual templating that is expanded through project/gyb.py script. 
 // Update Arrays.scala.gyb and re-generate the source
+// $ ./project/gyb.py \ 
+//     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb > \
+//     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+
 
 // Note 2:
 // Array of primitiveTypes don't contain pointers, runtime.allocAtomic() is called for memory allocation
 // Array of Object do contain pointers. runtime.alloc() is called for memory allocation
 
+// Note 3:
+// PrimitiveArray.helperClone can allocate memory with GC.malloc_atomic() because 
+// it will overwrite all data (no need to call llvm.memset)
+
+
+import native._
+import Intrinsics._
+
+@struct class ArrayHeader(val info: Ptr[_], val length: Int)
+
 %{
    primitiveTypes = ['Boolean', 'Char', 'Byte', 'Short',
             'Int', 'Long', 'Float', 'Double']
 }%
-
-import native._
-
-@struct class ArrayHeader(val info: Ptr[_], val length: Int)
 
 sealed abstract class Array[T]
     extends java.io.Serializable with java.lang.Cloneable {
@@ -24,7 +34,7 @@ sealed abstract class Array[T]
   def length: Int =
     // TODO: Update once we support ptr->field
     !(this.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]]
-
+    
   /** Loads element at i, throws IndexOutOfBoundsException. */
   def apply(i: Int): T
 
@@ -32,89 +42,137 @@ sealed abstract class Array[T]
   def update(i: Int, value: T): Unit
 
   /** Create a shallow of given array. */
-  protected override def clone(): Array[T] = undefined
+  protected override def clone(): Array[T] = undefined  
+}
+
+object Array {
+  def copy (from: AnyRef, fromPos: Int, to: AnyRef, toPos: Int, len: Int): Unit = {
+    if (from == null)
+      throw new NullPointerException()
+    
+    if (to == null)
+      throw new NullPointerException()
+    
+    val fromTypeId = instanceTypeId(from)
+    val toTypeId = instanceTypeId(to)
+    
+    val stride = if (fromTypeId == arrayObjectTypeId && toTypeId == arrayObjectTypeId)
+      sizeof[Object]
+    
+% for T in primitiveTypes:
+
+    else if (fromTypeId == array${T}TypeId && toTypeId == array${T}TypeId) 
+      sizeof[${T}]
+      
+% end
+
+    else
+      throw new ArrayStoreException ("Invalid array copy.")
+      
+    validateBoundaries (from.asInstanceOf[Array[_]], fromPos, to.asInstanceOf[Array[_]], toPos, len)
+    
+    val fromPtr: Ptr[Byte] = (from.cast[Ptr[Byte]] + sizeof[ArrayHeader] + stride * fromPos).cast[Ptr[Byte]]
+    
+    val toPtr: Ptr[Byte] = (to.cast[Ptr[Byte]] + sizeof[ArrayHeader] + stride * toPos).cast[Ptr[Byte]]
+        
+    `llvm.memmove.p0i8.p0i8.i64`(toPtr, fromPtr, stride * len, 1, false)
+  }
+  
+  // the id's chosen by the compiler/linker for differents types of array
+
+  val arrayObjectTypeId = typeId (typeof[scalanative.runtime.ObjectArray])
+  
+% for T in primitiveTypes:
+
+  val array${T}TypeId = typeId (typeof[scalanative.runtime.${T}Array])
+  
+% end  
+    
+  private def typeId (ptr : Ptr[Type]): Int = {
+    (!ptr).id    
+  }
+  
+  private def instanceTypeId (any : AnyRef): Int = {
+    typeId(runtime.getType(any))
+  }
+  
+  @inline private[runtime] def validateBoundaries (from: Array[_], fromPos: Int, to: Array[_], toPos: Int, len: Int): Unit = {
+    if (len < 0)
+      throw new IndexOutOfBoundsException("length is negative")
+
+    if (fromPos < 0 || fromPos + len > from.length)
+      throw new IndexOutOfBoundsException(fromPos.toString)
+
+    if (toPos < 0 || toPos + len > to.length)
+      throw new IndexOutOfBoundsException(toPos.toString)    
+  }
+  
+  @inline private[runtime] def pointerAt(arr: Array[_], sizeOneElement: CSize, i: Int): Ptr[_] = {
+    if (i < 0 || i >= arr.length)
+      throw new IndexOutOfBoundsException(i.toString)
+    else {
+      (arr.cast[Ptr[Byte]] + sizeof[ArrayHeader] + sizeOneElement * i).cast[Ptr[_]]
+    }
+  }
+  
+  @inline private[runtime] def helperClone(from: Array[_], length: Int, stride: CSize): Ptr[_] = {
+    val arrsize = sizeof[ArrayHeader] + stride * length
+    val arr = GC.malloc(arrsize)
+    `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]], from.cast[Ptr[Byte]], arrsize, 1, false)
+    arr        
+  }  
+  
+  def alloc(length: Int, arrinfo:  Ptr[Type], stride: CSize): Ptr[_] = {
+    val arrsize = sizeof[ArrayHeader] + stride * length
+    val arr = runtime.alloc(arrinfo, arrsize)
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr        
+  } 
+}
+
+object PrimitiveArray {
+  @inline private[runtime] def helperClone(src: Array[_], length: Int, stride: CSize): Ptr[_] = {
+    val arrsize = sizeof[ArrayHeader] + stride * length
+    val arr = GC.malloc_atomic(arrsize)
+    `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]], src.cast[Ptr[Byte]], arrsize, 1, false)
+    arr
+  }
+  
+  def alloc(length: Int, arrinfo:  Ptr[Type], stride: CSize): Ptr[_] = {
+    val arrsize = sizeof[ArrayHeader] + stride * length
+    // Primitive arrays don't contain pointers 
+    val arr = runtime.allocAtomic(arrinfo, arrsize)
+    // set the length
+    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length    
+    arr        
+  }
 }
 
 final class ObjectArray private () extends Array[Object] {
-  def apply(i: Int): Object =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Object]]
-      headptr(i)
-    }
+  def apply(i: Int): Object = ! (Array.pointerAt(this, sizeof[Object], i).cast[Ptr[Object]])
 
-  def update(i: Int, value: Object): Unit =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[Object]]
-      headptr(i) = value
-    }
+  def update(i: Int, value: Object): Unit = ! (Array.pointerAt(this, sizeof[Object], i).cast[Ptr[Object]]) = value
 
-  protected override def clone(): ObjectArray = {
-    val newarr = ObjectArray.alloc(length)
-    ObjectArray.copy(this, 0, newarr, 0, length)
-    newarr
-  }
+  protected override def clone(): ObjectArray = Array.helperClone (this, length, sizeof[Object]).cast[ObjectArray]
 }
 
 object ObjectArray {
-  def copy(from: ObjectArray, fromPos: Int,
-           to: ObjectArray, toPos: Int, length: Int): Unit = {
-    ???
-  }
-
-  def alloc(length: Int): ObjectArray = {
-    val arrty = typeof[ObjectArray]
-    val arrsize = sizeof[ArrayHeader] + sizeof[Object] * length
-    val arr = runtime.alloc(arrty, arrsize)
-    // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    arr.cast[ObjectArray]
-  }
+  def alloc(length: Int): ObjectArray = Array.alloc(length, typeof[ObjectArray], sizeof[Object]).cast[ObjectArray]
 }
 
 % for T in primitiveTypes:
 
 final class ${T}Array private () extends Array[${T}] {
-  def apply(i: Int): ${T} =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[${T}]]
-      headptr(i)
-    }
+  def apply(i: Int): ${T} = ! (Array.pointerAt(this, sizeof[${T}], i).cast[Ptr[${T}]])
 
-  def update(i: Int, value: ${T}): Unit =
-    if (i < 0 || i >= length)
-      throw new IndexOutOfBoundsException(i.toString)
-    else {
-      val headptr = (this.cast[Ptr[Byte]] + sizeof[ArrayHeader]).cast[Ptr[${T}]]
-      headptr(i) = value
-    }
+  def update(i: Int, value: ${T}): Unit = ! (Array.pointerAt(this, sizeof[${T}], i).cast[Ptr[${T}]]) = value
 
-  protected override def clone(): ${T}Array = {
-    val newarr = ${T}Array.alloc(length)
-    ${T}Array.copy(this, 0, newarr, 0, length)
-    newarr
-  }
+  protected override def clone(): ${T}Array = PrimitiveArray.helperClone (this, length, sizeof[${T}]).cast[${T}Array]
 }
 
 object ${T}Array {
-  def copy(from: ${T}Array, fromPos: Int,
-           to: ${T}Array, toPos: Int, length: Int): Unit = {
-    ???
-  }
-
-  def alloc(length: Int): ${T}Array = {
-    val arrty = typeof[${T}Array]
-    val arrsize = sizeof[ArrayHeader] + sizeof[${T}] * length
-    val arr = runtime.allocAtomic(arrty, arrsize)
-    // set the length
-    !(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length
-    arr.cast[${T}Array]
-  }
+  def alloc(length: Int): ${T}Array = PrimitiveArray.alloc(length, typeof[${T}Array], sizeof[${T}]).cast[${T}Array]  
 }
 
 % end

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -87,4 +87,14 @@ object Intrinsics {
                                   len: Long,
                                   align: Int,
                                   isvolatile: Boolean): Unit = extern
+  def `llvm.memmove.p0i8.p0i8.i32`(dest: Ptr[Byte],
+                                   src: Ptr[Byte],
+                                   len: Int,
+                                   align: Int,
+                                   isvolatile: Boolean): Unit = extern
+  def `llvm.memmove.p0i8.p0i8.i64`(dest: Ptr[Byte],
+                                   src: Ptr[Byte],
+                                   len: Long,
+                                   align: Int,
+                                   isvolatile: Boolean): Unit = extern
 }

--- a/scalalib/overrides-2.11/scala/Array.scala
+++ b/scalalib/overrides-2.11/scala/Array.scala
@@ -1,0 +1,531 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+
+import scala.collection.generic._
+import scala.collection.{ mutable, immutable }
+import mutable.{ ArrayBuilder, ArraySeq }
+import scala.compat.Platform.arraycopy
+import scala.reflect.ClassTag
+import scala.runtime.ScalaRunTime.{ array_apply, array_update }
+
+/** Contains a fallback builder for arrays when the element type
+ *  does not have a class tag. In that case a generic array is built.
+ */
+class FallbackArrayBuilding {
+
+  /** A builder factory that generates a generic array.
+   *  Called instead of `Array.newBuilder` if the element type of an array
+   *  does not have a class tag. Note that fallbackBuilder factory
+   *  needs an implicit parameter (otherwise it would not be dominated in
+   *  implicit search by `Array.canBuildFrom`). We make sure that
+   *  implicit search is always successful.
+   */
+  implicit def fallbackCanBuildFrom[T](implicit m: DummyImplicit): CanBuildFrom[Array[_], T, ArraySeq[T]] =
+    new CanBuildFrom[Array[_], T, ArraySeq[T]] {
+      def apply(from: Array[_]) = ArraySeq.newBuilder[T]
+      def apply() = ArraySeq.newBuilder[T]
+    }
+}
+
+/** Utility methods for operating on arrays.
+ *  For example:
+ *  {{{
+ *  val a = Array(1, 2)
+ *  val b = Array.ofDim[Int](2)
+ *  val c = Array.concat(a, b)
+ *  }}}
+ *  where the array objects `a`, `b` and `c` have respectively the values
+ *  `Array(1, 2)`, `Array(0, 0)` and `Array(1, 2, 0, 0)`.
+ *
+ *  @author Martin Odersky
+ *  @version 1.0
+ */
+object Array extends FallbackArrayBuilding {
+  val emptyBooleanArray = new Array[Boolean](0)
+  val emptyByteArray    = new Array[Byte](0)
+  val emptyCharArray    = new Array[Char](0)
+  val emptyDoubleArray  = new Array[Double](0)
+  val emptyFloatArray   = new Array[Float](0)
+  val emptyIntArray     = new Array[Int](0)
+  val emptyLongArray    = new Array[Long](0)
+  val emptyShortArray   = new Array[Short](0)
+  val emptyObjectArray  = new Array[Object](0)
+
+  implicit def canBuildFrom[T](implicit t: ClassTag[T]): CanBuildFrom[Array[_], T, Array[T]] =
+    new CanBuildFrom[Array[_], T, Array[T]] {
+      def apply(from: Array[_]) = ArrayBuilder.make[T]()(t)
+      def apply() = ArrayBuilder.make[T]()(t)
+    }
+
+  /**
+   * Returns a new [[scala.collection.mutable.ArrayBuilder]].
+   */
+  def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T]()(t)
+
+  private def slowcopy(src : AnyRef,
+                       srcPos : Int,
+                       dest : AnyRef,
+                       destPos : Int,
+                       length : Int) {
+    var i = srcPos
+    var j = destPos
+    val srcUntil = srcPos + length
+    while (i < srcUntil) {
+      array_update(dest, j, array_apply(src, i))
+      i += 1
+      j += 1
+    }
+  }
+
+  /** Copy one array to another.
+   *  Equivalent to Java's
+   *    `System.arraycopy(src, srcPos, dest, destPos, length)`,
+   *  except that this also works for polymorphic and boxed arrays.
+   *
+   *  Note that the passed-in `dest` array will be modified by this call.
+   *
+   *  @param src the source array.
+   *  @param srcPos  starting position in the source array.
+   *  @param dest destination array.
+   *  @param destPos starting position in the destination array.
+   *  @param length the number of array elements to be copied.
+   *
+   *  @see `java.lang.System#arraycopy`
+   */
+  def copy(src: AnyRef, srcPos: Int, dest: AnyRef, destPos: Int, length: Int) {
+    arraycopy(src, srcPos, dest, destPos, length)
+  }
+
+  /** Returns an array of length 0 */
+  def empty[T: ClassTag]: Array[T] = new Array[T](0)
+
+  /** Creates an array with given elements.
+   *
+   *  @param xs the elements to put in the array
+   *  @return an array containing all elements from xs.
+   */
+  // Subject to a compiler optimization in Cleanup.
+  // Array(e0, ..., en) is translated to { val a = new Array(3); a(i) = ei; a }
+  def apply[T: ClassTag](xs: T*): Array[T] = {
+    val array = new Array[T](xs.length)
+    var i = 0
+    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    array
+  }
+
+  /** Creates an array of `Boolean` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
+    val array = new Array[Boolean](xs.length + 1)
+    array(0) = x
+    var i = 1
+    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    array
+  }
+
+  /** Creates an array of `Byte` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Byte, xs: Byte*): Array[Byte] = {
+    val array = new Array[Byte](xs.length + 1)
+    array(0) = x
+    var i = 1
+    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    array
+  }
+
+  /** Creates an array of `Short` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Short, xs: Short*): Array[Short] = {
+    val array = new Array[Short](xs.length + 1)
+    array(0) = x
+    var i = 1
+    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    array
+  }
+
+  /** Creates an array of `Char` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Char, xs: Char*): Array[Char] = {
+    val array = new Array[Char](xs.length + 1)
+    array(0) = x
+    var i = 1
+    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    array
+  }
+
+  /** Creates an array of `Int` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Int, xs: Int*): Array[Int] = {
+    val array = new Array[Int](xs.length + 1)
+    array(0) = x
+    var i = 1
+    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    array
+  }
+
+  /** Creates an array of `Long` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Long, xs: Long*): Array[Long] = {
+    val array = new Array[Long](xs.length + 1)
+    array(0) = x
+    var i = 1
+    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    array
+  }
+
+  /** Creates an array of `Float` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Float, xs: Float*): Array[Float] = {
+    val array = new Array[Float](xs.length + 1)
+    array(0) = x
+    var i = 1
+    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    array
+  }
+
+  /** Creates an array of `Double` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Double, xs: Double*): Array[Double] = {
+    val array = new Array[Double](xs.length + 1)
+    array(0) = x
+    var i = 1
+    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    array
+  }
+
+  /** Creates an array of `Unit` objects */
+  def apply(x: Unit, xs: Unit*): Array[Unit] = {
+    val array = new Array[Unit](xs.length + 1)
+    array(0) = x
+    var i = 1
+    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    array
+  }
+
+  /** Creates array with given dimensions */
+  def ofDim[T: ClassTag](n1: Int): Array[T] =
+    new Array[T](n1)
+  /** Creates a 2-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
+    val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
+    for (i <- 0 until n1) arr(i) = new Array[T](n2)
+    arr
+    // tabulate(n1)(_ => ofDim[T](n2))
+  }
+  /** Creates a 3-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
+    tabulate(n1)(_ => ofDim[T](n2, n3))
+  /** Creates a 4-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
+    tabulate(n1)(_ => ofDim[T](n2, n3, n4))
+  /** Creates a 5-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
+    tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
+
+  /** Concatenates all arrays into a single array.
+   *
+   *  @param xss the given arrays
+   *  @return   the array created from concatenating `xss`
+   */
+  def concat[T: ClassTag](xss: Array[T]*): Array[T] = {
+    val b = newBuilder[T]
+    b.sizeHint(xss.map(_.length).sum)
+    for (xs <- xss) b ++= xs
+    b.result()
+  }
+
+  /** Returns an array that contains the results of some element computation a number
+   *  of times.
+   *
+   *  Note that this means that `elem` is computed a total of n times:
+   *  {{{
+   * scala> Array.fill(3){ math.random }
+   * res3: Array[Double] = Array(0.365461167592537, 1.550395944913685E-4, 0.7907242137333306)
+   *  }}}
+   *
+   *  @param   n  the number of elements desired
+   *  @param   elem the element computation
+   *  @return an Array of size n, where each element contains the result of computing
+   *  `elem`.
+   */
+  def fill[T: ClassTag](n: Int)(elem: => T): Array[T] = {
+    val b = newBuilder[T]
+    b.sizeHint(n)
+    var i = 0
+    while (i < n) {
+      b += elem
+      i += 1
+    }
+    b.result()
+  }
+
+  /** Returns a two-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int)(elem: => T): Array[Array[T]] =
+    tabulate(n1)(_ => fill(n2)(elem))
+
+  /** Returns a three-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int, n3: Int)(elem: => T): Array[Array[Array[T]]] =
+    tabulate(n1)(_ => fill(n2, n3)(elem))
+
+  /** Returns a four-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => T): Array[Array[Array[Array[T]]]] =
+    tabulate(n1)(_ => fill(n2, n3, n4)(elem))
+
+  /** Returns a five-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => T): Array[Array[Array[Array[Array[T]]]]] =
+    tabulate(n1)(_ => fill(n2, n3, n4, n5)(elem))
+
+  /** Returns an array containing values of a given function over a range of integer
+   *  values starting from 0.
+   *
+   *  @param  n   The number of elements in the array
+   *  @param  f   The function computing element values
+   *  @return A traversable consisting of elements `f(0),f(1), ..., f(n - 1)`
+   */
+  def tabulate[T: ClassTag](n: Int)(f: Int => T): Array[T] = {
+    val b = newBuilder[T]
+    b.sizeHint(n)
+    var i = 0
+    while (i < n) {
+      b += f(i)
+      i += 1
+    }
+    b.result()
+  }
+
+  /** Returns a two-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int)(f: (Int, Int) => T): Array[Array[T]] =
+    tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
+
+  /** Returns a three-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => T): Array[Array[Array[T]]] =
+    tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
+
+  /** Returns a four-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => T): Array[Array[Array[Array[T]]]] =
+    tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
+
+  /** Returns a five-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => T): Array[Array[Array[Array[Array[T]]]]] =
+    tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
+
+  /** Returns an array containing a sequence of increasing integers in a range.
+   *
+   *  @param start  the start value of the array
+   *  @param end    the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @return  the array with values in range `start, start + 1, ..., end - 1`
+   *  up to, but excluding, `end`.
+   */
+  def range(start: Int, end: Int): Array[Int] = range(start, end, 1)
+
+  /** Returns an array containing equally spaced values in some integer interval.
+   *
+   *  @param start the start value of the array
+   *  @param end   the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @param step  the increment value of the array (may not be zero)
+   *  @return      the array with values in `start, start + step, ...` up to, but excluding `end`
+   */
+  def range(start: Int, end: Int, step: Int): Array[Int] = {
+    if (step == 0) throw new IllegalArgumentException("zero step")
+    val b = newBuilder[Int]
+    b.sizeHint(immutable.Range.count(start, end, step, isInclusive = false))
+
+    var i = start
+    while (if (step < 0) end < i else i < end) {
+      b += i
+      i += step
+    }
+    b.result()
+  }
+
+  /** Returns an array containing repeated applications of a function to a start value.
+   *
+   *  @param start the start value of the array
+   *  @param len   the number of elements returned by the array
+   *  @param f     the function that is repeatedly applied
+   *  @return      the array returning `len` values in the sequence `start, f(start), f(f(start)), ...`
+   */
+  def iterate[T: ClassTag](start: T, len: Int)(f: T => T): Array[T] = {
+    val b = newBuilder[T]
+
+    if (len > 0) {
+      b.sizeHint(len)
+      var acc = start
+      var i = 1
+      b += acc
+
+      while (i < len) {
+        acc = f(acc)
+        i += 1
+        b += acc
+      }
+    }
+    b.result()
+  }
+
+  /** Called in a pattern match like `{ case Array(x,y,z) => println('3 elements')}`.
+   *
+   *  @param x the selector value
+   *  @return  sequence wrapped in a [[scala.Some]], if `x` is a Seq, otherwise `None`
+   */
+  def unapplySeq[T](x: Array[T]): Option[IndexedSeq[T]] =
+    if (x == null) None else Some(x.toIndexedSeq)
+    // !!! the null check should to be necessary, but without it 2241 fails. Seems to be a bug
+    // in pattern matcher.  @PP: I noted in #4364 I think the behavior is correct.
+}
+
+/** Arrays are mutable, indexed collections of values. `Array[T]` is Scala's representation
+ *  for Java's `T[]`.
+ *
+ *  {{{
+ *  val numbers = Array(1, 2, 3, 4)
+ *  val first = numbers(0) // read the first element
+ *  numbers(3) = 100 // replace the 4th array element with 100
+ *  val biggerNumbers = numbers.map(_ * 2) // multiply all numbers by two
+ *  }}}
+ *
+ *  Arrays make use of two common pieces of Scala syntactic sugar, shown on lines 2 and 3 of the above
+ *  example code.
+ *  Line 2 is translated into a call to `apply(Int)`, while line 3 is translated into a call to
+ *  `update(Int, T)`.
+ *
+ *  Two implicit conversions exist in [[scala.Predef]] that are frequently applied to arrays: a conversion
+ *  to [[scala.collection.mutable.ArrayOps]] (shown on line 4 of the example above) and a conversion
+ *  to [[scala.collection.mutable.WrappedArray]] (a subtype of [[scala.collection.Seq]]).
+ *  Both types make available many of the standard operations found in the Scala collections API.
+ *  The conversion to `ArrayOps` is temporary, as all operations defined on `ArrayOps` return an `Array`,
+ *  while the conversion to `WrappedArray` is permanent as all operations return a `WrappedArray`.
+ *
+ *  The conversion to `ArrayOps` takes priority over the conversion to `WrappedArray`. For instance,
+ *  consider the following code:
+ *
+ *  {{{
+ *  val arr = Array(1, 2, 3)
+ *  val arrReversed = arr.reverse
+ *  val seqReversed : Seq[Int] = arr.reverse
+ *  }}}
+ *
+ *  Value `arrReversed` will be of type `Array[Int]`, with an implicit conversion to `ArrayOps` occurring
+ *  to perform the `reverse` operation. The value of `seqReversed`, on the other hand, will be computed
+ *  by converting to `WrappedArray` first and invoking the variant of `reverse` that returns another
+ *  `WrappedArray`.
+ *
+ *  @author Martin Odersky
+ *  @version 1.0
+ *  @see [[http://www.scala-lang.org/files/archive/spec/2.11/ Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
+ *  @see [[http://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.
+ *  @see [[http://docs.scala-lang.org/overviews/collections/arrays.html "The Scala 2.8 Collections' API"]] section on `Array` by Martin Odersky for more information.
+ *  @define coll array
+ *  @define Coll `Array`
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ *  @define collectExample
+ *  @define undefinedorder
+ *  @define thatinfo the class of the returned collection. In the standard library configuration,
+ *    `That` is either `Array[B]` if an ClassTag is available for B or `ArraySeq[B]` otherwise.
+ *  @define zipthatinfo $thatinfo
+ *  @define bfinfo an implicit value of class `CanBuildFrom` which determines the result class `That` from the current
+ *    representation type `Repr` and the new element type `B`.
+ */
+final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable {
+
+  /** The length of the array */
+  def length: Int = throw new Error()
+
+  /** The element at given index.
+   *
+   *  Indices start at `0`; `xs.apply(0)` is the first element of array `xs`.
+   *  Note the indexing syntax `xs(i)` is a shorthand for `xs.apply(i)`.
+   *
+   *  @param    i   the index
+   *  @return       the element at the given index
+   *  @throws       ArrayIndexOutOfBoundsException if `i < 0` or `length <= i`
+   */
+  def apply(i: Int): T = throw new Error()
+
+  /** Update the element at given index.
+   *
+   *  Indices start at `0`; `xs.update(i, x)` replaces the i^th^ element in the array.
+   *  Note the syntax `xs(i) = x` is a shorthand for `xs.update(i, x)`.
+   *
+   *  @param    i   the index
+   *  @param    x   the value to be written at index `i`
+   *  @throws       ArrayIndexOutOfBoundsException if `i < 0` or `length <= i`
+   */
+  def update(i: Int, x: T) { throw new Error() }
+
+  /** Clone the Array.
+   *
+   *  @return A clone of the Array.
+   */
+  override def clone(): Array[T] = throw new Error()
+}


### PR DESCRIPTION
Modified files:

Main logic:
- nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
- nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb  

New methods to allocate memory for array::clone()
- nativelib/src/main/scala/scala/scalanative/runtime/package.scala

Call scalanative.runtime.Array::copy from java/scala legacy methods
- scalalib/overrides-2.11/scala/Array.scala
- javalib/src/main/scala/java/lang/System.scala
