### PR TITLE
Easier dependencies management.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,4 @@
 import scala.util.Try
-import scala.scalanative.sbtplugin.{ScalaNativePlugin, ScalaNativePluginInternal}
-import ScalaNativePlugin.autoImport._
 
 val toolScalaVersion = "2.10.6"
 

--- a/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -31,4 +31,7 @@ object ScalaNativePlugin extends AutoPlugin {
 
   override def projectSettings =
     ScalaNativePluginInternal.projectSettings
+
+  lazy val runtimeDependencies =
+    ScalaNativePluginInternal.runtimeDependencies
 }

--- a/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -58,10 +58,21 @@ object ScalaNativePluginInternal {
     Process(compile, target).!
   }
 
-  lazy val projectSettings = Seq(
-    addCompilerPlugin("org.scala-native" % "nscplugin" % "0.1-SNAPSHOT" cross CrossVersion.full),
+  lazy val runtimeDependencies = Seq(
+    "org.scala-native" %% "javalib"    % nativeVersion,
+    "org.scala-native" %% "scalalib"   % nativeVersion,
+    "org.scala-native" %% "nativelib"  % nativeVersion
+  )
 
-    libraryDependencies += "org.scala-native" %% "rtlib" % nir.Versions.current,
+  lazy val projectSettings = Seq(
+    addCompilerPlugin("org.scala-native" % "nscplugin" % nativeVersion cross CrossVersion.full),
+
+    libraryDependencies ++= Seq(
+      "org.scala-native" %% "rtlib" % nativeVersion,
+      compilerPlugin("org.scala-native" %  "tools_2.10" % nativeVersion),
+      compilerPlugin("org.scala-native" %  "nir_2.10"   % nativeVersion),
+      compilerPlugin("org.scala-native" %  "util_2.10"  % nativeVersion)
+    ),
 
     nativeVerbose := false,
 


### PR DESCRIPTION
As suggested on gitter by @siriux 

This result in:
https://github.com/scala-native/example/pull/2

That looks really reasonable, at least to me :-)