### PR TITLE
change the type of constructor parameter 'aliases' in CharSet class (issue #98)

### DIFF
--- a/javalib/src/main/scala/java/nio/charset/Charset.scala
+++ b/javalib/src/main/scala/java/nio/charset/Charset.scala
@@ -3,8 +3,7 @@ package java.nio.charset
 import scala.collection.mutable
 import java.nio.{ByteBuffer, CharBuffer}
 
-abstract class Charset protected (
-    canonicalName: String, aliases: Array[String])
+abstract class Charset protected (canonicalName: String, aliases: Seq[String])
     extends AnyRef
     with Comparable[Charset] {
   final def name(): String = canonicalName

--- a/javalib/src/main/scala/niocharset/ISO_8859_1.scala
+++ b/javalib/src/main/scala/niocharset/ISO_8859_1.scala
@@ -13,18 +13,18 @@ import java.nio.charset._
 private[niocharset] object ISO_8859_1
     extends ISO_8859_1_And_US_ASCII_Common( // scalastyle:ignore
                                            "ISO-8859-1",
-                                           Array("csISOLatin1",
-                                                 "IBM-819",
-                                                 "iso-ir-100",
-                                                 "8859_1",
-                                                 "ISO_8859-1",
-                                                 "l1",
-                                                 "ISO8859-1",
-                                                 "ISO_8859_1",
-                                                 "cp819",
-                                                 "ISO8859_1",
-                                                 "latin1",
-                                                 "ISO_8859-1:1987",
-                                                 "819",
-                                                 "IBM819"),
+                                           "csISOLatin1" ::
+                                           "IBM-819" ::
+                                           "iso-ir-100" ::
+                                           "8859_1" ::
+                                           "ISO_8859-1" ::
+                                           "l1" ::
+                                           "ISO8859-1" ::
+                                           "ISO_8859_1" ::
+                                           "cp819" ::
+                                           "ISO8859_1" ::
+                                           "latin1" ::
+                                           "ISO_8859-1:1987" ::
+                                           "819" ::
+                                           "IBM819" :: Nil,
                                            maxValue = 0xff)

--- a/javalib/src/main/scala/niocharset/ISO_8859_1_And_US_ASCII_Common.scala
+++ b/javalib/src/main/scala/niocharset/ISO_8859_1_And_US_ASCII_Common.scala
@@ -22,7 +22,7 @@ import java.nio.charset._
 private[niocharset] abstract class ISO_8859_1_And_US_ASCII_Common protected (
     // scalastyle:ignore
     name: String,
-    aliases: Array[String],
+    aliases: List[String],
     private val maxValue: Int)
     extends Charset(name, aliases) {
 

--- a/javalib/src/main/scala/niocharset/US_ASCII.scala
+++ b/javalib/src/main/scala/niocharset/US_ASCII.scala
@@ -13,18 +13,18 @@ import java.nio.charset._
 private[niocharset] object US_ASCII
     extends ISO_8859_1_And_US_ASCII_Common( // scalastyle:ignore
                                            "US-ASCII",
-                                           Array("cp367",
-                                                 "ascii7",
-                                                 "ISO646-US",
-                                                 "646",
-                                                 "csASCII",
-                                                 "us",
-                                                 "iso_646.irv:1983",
-                                                 "ISO_646.irv:1991",
-                                                 "IBM367",
-                                                 "ASCII",
-                                                 "default",
-                                                 "ANSI_X3.4-1986",
-                                                 "ANSI_X3.4-1968",
-                                                 "iso-ir-6"),
+                                           "cp367" ::
+                                           "ascii7" ::
+                                           "ISO646-US" ::
+                                           "646" ::
+                                           "csASCII" ::
+                                           "us" ::
+                                           "iso_646.irv:1983" ::
+                                           "ISO_646.irv:1991" ::
+                                           "IBM367" ::
+                                           "ASCII" ::
+                                           "default" ::
+                                           "ANSI_X3.4-1986" ::
+                                           "ANSI_X3.4-1968" ::
+                                           "iso-ir-6" :: Nil,
                                            maxValue = 0x7f)

--- a/javalib/src/main/scala/niocharset/UTF_16.scala
+++ b/javalib/src/main/scala/niocharset/UTF_16.scala
@@ -11,7 +11,8 @@ package niocharset
 import java.nio.charset._
 
 private[niocharset] object UTF_16
-    extends UTF_16_Common( // scalastyle:ignore
-                          "UTF-16",
-                          Array("utf16", "UTF_16", "UnicodeBig", "unicode"),
-                          endianness = UTF_16_Common.AutoEndian)
+    extends UTF_16_Common(
+        // scalastyle:ignore
+        "UTF-16",
+        "utf16" :: "UTF_16" :: "UnicodeBig" :: "unicode" :: Nil,
+        endianness = UTF_16_Common.AutoEndian)

--- a/javalib/src/main/scala/niocharset/UTF_16BE.scala
+++ b/javalib/src/main/scala/niocharset/UTF_16BE.scala
@@ -14,6 +14,5 @@ private[niocharset] object UTF_16BE
     extends UTF_16_Common(
         // scalastyle:ignore
         "UTF-16BE",
-        Array(
-            "X-UTF-16BE", "UTF_16BE", "ISO-10646-UCS-2", "UnicodeBigUnmarked"),
+        "X-UTF-16BE" :: "UTF_16BE" :: "ISO-10646-UCS-2" :: "UnicodeBigUnmarked" :: Nil,
         endianness = UTF_16_Common.BigEndian)

--- a/javalib/src/main/scala/niocharset/UTF_16LE.scala
+++ b/javalib/src/main/scala/niocharset/UTF_16LE.scala
@@ -14,5 +14,5 @@ private[niocharset] object UTF_16LE
     extends UTF_16_Common(
         // scalastyle:ignore
         "UTF-16LE",
-        Array("UnicodeLittleUnmarked", "UTF_16LE", "X-UTF-16LE"),
+        "UnicodeLittleUnmarked" :: "UTF_16LE" :: "X-UTF-16LE" :: Nil,
         endianness = UTF_16_Common.LittleEndian)

--- a/javalib/src/main/scala/niocharset/UTF_16_Common.scala
+++ b/javalib/src/main/scala/niocharset/UTF_16_Common.scala
@@ -18,7 +18,7 @@ import java.nio.charset._
 private[niocharset] abstract class UTF_16_Common protected (
     // scalastyle:ignore
     name: String,
-    aliases: Array[String],
+    aliases: List[String],
     private val endianness: Int)
     extends Charset(name, aliases) {
 

--- a/javalib/src/main/scala/niocharset/UTF_8.scala
+++ b/javalib/src/main/scala/niocharset/UTF_8.scala
@@ -14,10 +14,7 @@ import java.nio._
 import java.nio.charset._
 
 private[niocharset] object UTF_8
-    extends Charset("UTF-8",
-                    Array( // scalastyle:ignore
-                          "UTF8",
-                          "unicode-1-1-utf-8")) {
+    extends Charset("UTF-8", "UTF8" :: "unicode-1-1-utf-8" :: Nil) {
 
   import java.lang.Character._
 


### PR DESCRIPTION
Pass the following test case and unblock issue #98

```scala
import` java.nio._
import java.nio.charset._

object Test {
  def main(args: Array[String]): Unit = {
    val s = "A java string"
    val ca = s.toCharArray()
    val cb = CharBuffer.wrap(ca, 0, s.length())
    val buffer = Charset.defaultCharset().encode(cb)
  }
}
```

The main change is:

Original:

```scala
abstract class Charset protected (
    canonicalName: String, aliases: Array[String])
```

New in this PR

```scala
abstract class Charset protected (
    canonicalName: String, aliases: Seq[String])
```

The original version throws an exception in `WrapperArray`.

As mentioned by @sjrd in issue #98, it isn't  binary compatible with the JDK API.  But:

- it affects only custom charset implementation (the constructor `aliases` is visible only to subclasses of `Charset)`
- the change is source file compatible with any custom charset implemented in Scala for the JVM,
- custom charset implemented in Java for the JVM need to be migrated to Scala anyway,
- only future custom charset implemented for Scala-Native could be incompatible with the JVM version if the programmer choose a non `Array` sequence
- the probabilty that someone will implement a custom charset for Scala-Native is rather small.
- the `aliases` constructor parameter is currently unused.  The chance that someone would need it in the future is small.

Alternatives to this PR:

- avoid wrapping the constructor parameter `aliases` to an `WrapperArray`.  

I don't see any reason why the implicit conversion from `Array` to `WrapperArray` fires, so I believe this is something internal to the compiler.

- solve the exception inside `WrapperArray`