### PR TITLE
Check exit code in `run` task

### DIFF
--- a/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -124,9 +124,18 @@ object ScalaNativePluginInternal {
     },
 
     run := {
-      val binary = nativeLink.value
+      val log = streams.value.log
+      val binary = abs(nativeLink.value)
+      val args = spaceDelimited("<arg>").parsed
 
-      Process(abs(binary)).!
+      log.info("Running " + binary + " " + args.mkString(" "))
+      val exitCode = Process(binary, args).!
+
+      val message =
+        if (exitCode == 0) None
+        else Some("Nonzero exit code: " + exitCode)
+
+      Defaults.toError(message)
     }
   )
 


### PR DESCRIPTION
Scala native's sbt plugin just ran the process without checking the
process' exit code, so that sbt reported a success even if the process
crashed.

The new run task now checks the exit code and reports an error if the
code is nonzero.

Another solution may be to redefine the [`runner` `TaskKey`](https://github.com/sbt/sbt-zero-thirteen/blob/0.13/main/src/main/scala/sbt/Keys.scala#L182) to a subclass of [`ScalaRun`](https://github.com/sbt/sbt-zero-thirteen/blob/0.13/run/src/main/scala/sbt/Run.scala#L12-L14), but I think that `ScalaRun`'s API doesn't really apply to Scala Native.