### PR TITLE
Fix #193: System.exit() fails linkage

### DIFF
--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -1,7 +1,10 @@
 package java.lang
 
+import scala.scalanative.native.stdlib
+
 class Runtime private () {
   def availableProcessors(): Int = 1
+  def exit(status: Int): Unit    = stdlib.exit(status)
   def gc(): Unit                 = ()
 }
 

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -15,6 +15,10 @@ object System {
     scalanative.runtime.Array.copy(src, srcPos, dest, destPos, length)
   }
 
+  def exit(status: Int): Unit = {
+    Runtime.getRuntime().exit(status)
+  }
+
   def identityHashCode(x: Object): scala.Int =
     x.cast[Word].hashCode
 

--- a/tests/run/system-exit/build.sbt
+++ b/tests/run/system-exit/build.sbt
@@ -1,0 +1,3 @@
+ScalaNativePlugin.projectSettings
+
+scalaVersion := "2.11.8"

--- a/tests/run/system-exit/changes/Exit-1.scala
+++ b/tests/run/system-exit/changes/Exit-1.scala
@@ -1,0 +1,5 @@
+object Exit {
+  def main(args: Array[String]): Unit = {
+    System.exit(1)
+  }
+}

--- a/tests/run/system-exit/project/scala-native.sbt
+++ b/tests/run/system-exit/project/scala-native.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scala-native" % "sbtplugin" % pluginVersion)
+}

--- a/tests/run/system-exit/src/main/scala/Exit.scala
+++ b/tests/run/system-exit/src/main/scala/Exit.scala
@@ -1,0 +1,5 @@
+object Exit {
+  def main(args: Array[String]): Unit = {
+    System.exit(0)
+  }
+}

--- a/tests/run/system-exit/test
+++ b/tests/run/system-exit/test
@@ -1,0 +1,6 @@
+> run
+
+# replace Exit.scala by a program that exits with code 1
+$ copy-file changes/Exit-1.scala src/main/scala/Exit.scala
+
+-> run


### PR DESCRIPTION
Implementation and test for `System.exit()` and `Runtime.exit()`

Fixes #193