### PR TITLE
Added java.util.concurrent.Callable trait.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ scalalib/src/
 target/
 *.dot
 *.ppm
+.idea

--- a/javalib/src/main/scala/java/util/concurrent/Callable.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Callable.scala
@@ -1,0 +1,5 @@
+package java.util.concurrent
+
+trait Callable[V] {
+  def call(): V
+}


### PR DESCRIPTION
Compiling against scalaz fails with missing j.u.c.Callable trait. After adding it the compilation succeeds. This patch enables scala-native plugin in scalaz to generate .nir files (https://gist.github.com/dozed/7f14d6bd820fc0e253ed8d02b98da8b2).