### PR TITLE
Convert C main argc/argv to Java main args

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -74,6 +74,17 @@ package object runtime {
     */
   def init(argc: Int, argv: Ptr[Ptr[Byte]]): ObjectArray = {
     GC.init()
-    null
+
+    val args = new scala.Array[String](argc - 1)
+
+    // skip the executable name in argv(0)
+    var c = 0
+    while (c < argc-1) {
+      // use the default Charset (UTF_8 atm)
+      args(c) = fromCString(argv(c+1))
+      c += 1
+    }
+
+    args.asInstanceOf[ObjectArray]
   }
 }

--- a/tests/run/C_argc_argv-to-java_args/build.sbt
+++ b/tests/run/C_argc_argv-to-java_args/build.sbt
@@ -1,0 +1,3 @@
+ScalaNativePlugin.projectSettings
+
+scalaVersion := "2.11.8"

--- a/tests/run/C_argc_argv-to-java_args/project/scala-native.sbt
+++ b/tests/run/C_argc_argv-to-java_args/project/scala-native.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scala-native" % "sbtplugin" % pluginVersion)
+}

--- a/tests/run/C_argc_argv-to-java_args/src/main/scala/CArgcArgvToJavaArgs.scala
+++ b/tests/run/C_argc_argv-to-java_args/src/main/scala/CArgcArgvToJavaArgs.scala
@@ -1,0 +1,10 @@
+object CArgcArgvToJavaArgs {
+  def main(args: Array[String]) {
+    val len = args.length
+
+    assert(len == 3)
+    assert(args(0).equals("hello"))
+    assert(args(1).equals("hola"))
+    assert(args(2).equals("salut"))
+ }
+}

--- a/tests/run/C_argc_argv-to-java_args/test
+++ b/tests/run/C_argc_argv-to-java_args/test
@@ -1,0 +1,1 @@
+> run hello hola salut


### PR DESCRIPTION
PR for issue https://github.com/scala-native/scala-native/issues/130

C `int main (int argc char **argv)` to Java/Scala `def main (args: Array[String]): Unit`

Notes

- use the default Charset (UTF_8)
- and hopefully, without trailing blanks this time!  :)