### PR TITLE
Put `assert`s in test `run/java-lang-integer`

### DIFF
--- a/tests/run/java-lang-integer/src/main/scala/IntegerTest.scala
+++ b/tests/run/java-lang-integer/src/main/scala/IntegerTest.scala
@@ -7,12 +7,12 @@ object IntegerTest {
 
   def testIntegerToString() = {
     // issue #270
-    println(Integer.toString(1).equals("1"))
-    println(Integer.toString(-1).equals("1"))
-    println(Integer.toString(123).equals("123"))
-    println(Integer.toString(-123).equals("-123"))
-    println(Integer.toString(1234).equals("1234"))
-    println(Integer.toString(-1234).equals("-1234"))
+    assert(Integer.toString(1).equals("1"))
+    assert(Integer.toString(-1).equals("-1"))
+    assert(Integer.toString(123).equals("123"))
+    assert(Integer.toString(-123).equals("-123"))
+    assert(Integer.toString(1234).equals("1234"))
+    assert(Integer.toString(-1234).equals("-1234"))
   }
 }
 


### PR DESCRIPTION
The scripted tests won't fail unless the execution is actually stopped
by a failed assertion.

Also, fix a typo in the test.