### PR TITLE
Bugfix & Test java.lang.Integer.parseInt

### DIFF
--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -26,7 +26,7 @@ final class Integer(override val intValue: scala.Int)
   @inline override def equals(that: Any): scala.Boolean =
     that match {
       case that: Integer =>
-        byteValue == that.intValue
+        intValue == that.intValue
       case _ =>
         false
     }
@@ -206,12 +206,14 @@ object Integer {
       throw new NumberFormatException(s)
     }
 
+    val positive = s.charAt(0) == '+'
     val negative = s.charAt(0) == '-'
-    if (negative && length == 1) {
+    val offset   = if (positive || negative) 1 else 0
+    if (offset > 0 && length == 1) {
       throw new NumberFormatException(s)
     }
 
-    parse(s, 1, radix, negative)
+    parse(s, offset, radix, negative)
   }
 
   private def parse(s: String,

--- a/unit-tests/src/main/scala/java/lang/IntegerSuite.scala
+++ b/unit-tests/src/main/scala/java/lang/IntegerSuite.scala
@@ -1,0 +1,59 @@
+package java.lang
+
+object IntegerSuite extends tests.Suite {
+  test("parseInt") {
+    assert(Integer.parseInt("-1").equals(-1))
+    assert(Integer.parseInt("+1").equals(1))
+    assert(Integer.parseInt("1").equals(1))
+
+    assert(Integer.parseInt("-123").equals(-123))
+    assert(Integer.parseInt("+123").equals(123))
+    assert(Integer.parseInt("123").equals(123))
+
+    assert(Integer.parseInt("-100", 2).equals(-4))
+    assert(Integer.parseInt("+100", 2).equals(4))
+    assert(Integer.parseInt("100", 2).equals(4))
+
+    assert(Integer.parseInt("-0").equals(0))
+    assert(Integer.parseInt("+0").equals(0))
+    assert(Integer.parseInt("00").equals(0))
+
+    assert(
+        Integer.parseInt(Integer.MAX_VALUE.toString).equals(Integer.MAX_VALUE))
+    assert(
+        Integer.parseInt(Integer.MIN_VALUE.toString).equals(Integer.MIN_VALUE))
+
+    assertThrows[NumberFormatException](Integer.parseInt(null))
+    assertThrows[NumberFormatException](Integer.parseInt(""))
+    assertThrows[NumberFormatException](
+        Integer.parseInt("123", Character.MIN_RADIX - 1))
+    assertThrows[NumberFormatException](
+        Integer.parseInt("123", Character.MAX_RADIX + 1))
+    assertThrows[NumberFormatException](Integer.parseInt("123a", 10))
+    assertThrows[NumberFormatException](
+        Integer.parseInt((Integer.MAX_VALUE.toLong + 1).toString))
+    assertThrows[NumberFormatException](
+        Integer.parseInt((Integer.MIN_VALUE.toLong - 1).toString))
+
+  }
+
+  test("toString") {
+    assert(Integer.toString(1).equals("1"))
+    assert(Integer.toString(-1).equals("-1"))
+    assert(Integer.toString(123).equals("123"))
+    assert(Integer.toString(-123).equals("-123"))
+    assert(Integer.toString(1234).equals("1234"))
+    assert(Integer.toString(-1234).equals("-1234"))
+  }
+
+  test("equals") {
+    assert(new Integer(0).equals(new Integer(0)))
+    assert(new Integer(1).equals(new Integer(1)))
+    assert(new Integer(-1).equals(new Integer(-1)))
+    assert(new Integer(123).equals(new Integer(123)))
+    assert(
+        new Integer(Integer.MAX_VALUE) equals new Integer(Integer.MAX_VALUE))
+    assert(
+        new Integer(Integer.MIN_VALUE) equals new Integer(Integer.MIN_VALUE))
+  }
+}

--- a/unit-tests/src/main/scala/tests/Main.scala
+++ b/unit-tests/src/main/scala/tests/Main.scala
@@ -5,6 +5,7 @@ import java.lang.System.exit
 object Main {
   val suites = Seq[Suite](
       tests.SuiteSuite,
+      java.lang.IntegerSuite,
       java.lang.FloatSuite,
       java.lang.DoubleSuite,
       java.util.RandomSuite,


### PR DESCRIPTION
Hi, I ran into this while working on https://github.com/scala-native/scala-native/issues/242. I think parseInt will ignore the first digit if theres no negative sign.