### PR TITLE
handle None.get in run when missing main class

### DIFF
--- a/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbtplugin/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -109,7 +109,10 @@ object ScalaNativePluginInternal {
     nativeSharedLibrary := false,
 
     nativeLink := {
-      val entry         = (selectMainClass in Compile).value.get.toString + "$"
+      val mainClass     = (selectMainClass in Compile).value.getOrElse(
+        throw new MessageOnlyException("No main class detected.")
+      )
+      val entry         = mainClass.toString + "$"
       val classpath     = cpToStrings((fullClasspath in Compile).value.map(_.data))
       val target        = (crossTarget in Compile).value
       val appll         = target / (moduleName.value + "-out.ll")


### PR DESCRIPTION
When a main class is missing, the exception is thrown: `(*:nativeLink) java.util.NoSuchElementException: None.get`, and I found myself reading the stack to figure out the issue. This gives an error message similar to default sbt when a main class is missing.