### PR TITLE
Add EmptyPass, options in Ctx

### DIFF
--- a/tools/src/main/scala/scala/scalanative/compiler/Compiler.scala
+++ b/tools/src/main/scala/scala/scalanative/compiler/Compiler.scala
@@ -13,12 +13,10 @@ final class Compiler(opts: Opts) {
     Global.Member(Global.Top(opts.entry), "main_class.ssnr.ObjectArray_unit")
 
   private lazy val passCompanions: Seq[PassCompanion] = Seq(
-      Seq(
-          pass.LocalBoxingElimination,
-          pass.DeadCodeElimination
-      ),
-      maybeInjectMain,
-      Seq(pass.ExternHoisting,
+      Seq(pass.LocalBoxingElimination,
+          pass.DeadCodeElimination,
+          pass.MainInjection,
+          pass.ExternHoisting,
           pass.ModuleLowering,
           pass.RuntimeTypeInfoInjection,
           pass.AsLowering,
@@ -34,9 +32,6 @@ final class Compiler(opts: Opts) {
           pass.StackallocHoisting,
           pass.CopyPropagation)).flatten
 
-  private def maybeInjectMain: Seq[PassCompanion] =
-    if (!opts.sharedLibrary) Seq(pass.MainInjection) else Seq.empty
-
   private lazy val (links, assembly): (Seq[Attr.Link], Seq[Defn]) = {
     val deps           = passCompanions.flatMap(_.depends).distinct
     val injects        = passCompanions.flatMap(_.injects).distinct
@@ -49,7 +44,8 @@ final class Compiler(opts: Opts) {
   private lazy val passes = {
     val ctx = Ctx(fresh = Fresh("tx"),
                   entry = entry,
-                  top = analysis.ClassHierarchy(assembly))
+                  top = analysis.ClassHierarchy(assembly),
+                  options = opts)
 
     passCompanions.map(_.apply(ctx))
   }

--- a/tools/src/main/scala/scala/scalanative/compiler/Compiler.scala
+++ b/tools/src/main/scala/scala/scalanative/compiler/Compiler.scala
@@ -69,6 +69,9 @@ final class Compiler(opts: Opts) {
         case Seq() =>
           assembly
 
+        case (pass.EmptyPass, _) +: rest =>
+          loop(assembly, rest)
+
         case (pass, id) +: rest =>
           val nassembly = pass(assembly)
           val n         = id + 1

--- a/tools/src/main/scala/scala/scalanative/compiler/Ctx.scala
+++ b/tools/src/main/scala/scala/scalanative/compiler/Ctx.scala
@@ -4,4 +4,5 @@ package compiler
 /** Context that pass companion can uses to instantiate passes. */
 final case class Ctx(fresh: nir.Fresh,
                      entry: nir.Global,
-                     top: analysis.ClassHierarchy.Top)
+                     top: analysis.ClassHierarchy.Top,
+                     options: Opts)

--- a/tools/src/main/scala/scala/scalanative/compiler/pass/EmptyPass.scala
+++ b/tools/src/main/scala/scala/scalanative/compiler/pass/EmptyPass.scala
@@ -1,0 +1,8 @@
+package scala.scalanative
+package compiler
+package pass
+
+/**
+ * A pass that does nothing.
+ */
+object EmptyPass extends Pass

--- a/tools/src/main/scala/scala/scalanative/compiler/pass/MainInjection.scala
+++ b/tools/src/main/scala/scala/scalanative/compiler/pass/MainInjection.scala
@@ -38,7 +38,9 @@ class MainInjection(entry: Global)(implicit fresh: Fresh) extends Pass {
 }
 
 object MainInjection extends PassCompanion {
-  def apply(ctx: Ctx) = new MainInjection(ctx.entry)(ctx.fresh)
+  def apply(ctx: Ctx) =
+    if (!ctx.options.sharedLibrary) new MainInjection(ctx.entry)(ctx.fresh)
+    else EmptyPass
 
   val ObjectArray =
     Type.Class(Global.Top("scala.scalanative.runtime.ObjectArray"))


### PR DESCRIPTION
This commit introduces a new type of pass, EmptyPass, which does
nothing. This pass can be used to replace a pass that has been disabled
(eg. `MainInjection` when `nativeSharedLibrary` is true).

Also, the `Ctx` gained an `options: Opts` field that contains the
options specific to scala-native. They make it easier to export
configuration to specific phases.