### PR TITLE
Make sure sonatype resolver is not used

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -111,14 +111,17 @@ lazy val toolSettings =
     )
 
 lazy val libSettings =
-  (baseSettings ++ ScalaNativePlugin.projectSettings.tail) :+
-  (scalaVersion := libScalaVersion)
+  (baseSettings ++ ScalaNativePlugin.projectSettings.tail) ++ Seq(
+    scalaVersion := libScalaVersion,
+    resolvers := Nil
+  )
 
 lazy val projectSettings =
   ScalaNativePlugin.projectSettings ++ Seq(
     scalaVersion := libScalaVersion,
     nativeVerbose := true,
-    nativeClangOptions ++= Seq("-O0")
+    nativeClangOptions ++= Seq("-O0"),
+    resolvers := Nil
   )
 
 lazy val util =


### PR DESCRIPTION
Plugin injects sonatype resolver which we don't want to use when
we build the whole repo from source.

Fixes an issue discovered by @andreaTP  in #276