### PR TITLE
Fix c-style varargs accepting only single parameter

### DIFF
--- a/sandbox/Test.scala
+++ b/sandbox/Test.scala
@@ -1,5 +1,9 @@
+import scalanative.native._, stdlib._, stdio._
+
 object Test {
   def main(args: Array[String]): Unit = {
-    println("Hello, world!")
+    val W = 800
+    val H = 600
+    fprintf(stdout, c"P3\n%d %d\n%d\n", W, H, 255)
   }
 }

--- a/unit-tests/src/main/scala/scala/scalanative/native/CInteropSuite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/native/CInteropSuite.scala
@@ -1,0 +1,15 @@
+package scala.scalanative.native
+
+import stdio._
+
+object CInteropSuite extends tests.Suite {
+
+  test("varargs") {
+    val buff = stackalloc[CChar](64)
+    sprintf(buff, c"%d %d %d", 1, 2, 3)
+    for ((c, i) <- "1 2 3".zipWithIndex) {
+      assert(buff(i) == c)
+    }
+  }
+
+}

--- a/unit-tests/src/main/scala/tests/Main.scala
+++ b/unit-tests/src/main/scala/tests/Main.scala
@@ -10,6 +10,7 @@ object Main {
       java.lang.DoubleSuite,
       java.util.RandomSuite,
       scala.scalanative.native.CStringSuite,
+      scala.scalanative.native.CInteropSuite,
       scala.ArrayIntCopySuite,
       scala.ArrayDoubleCopySuite,
       scala.ArrayObjectCopySuite


### PR DESCRIPTION
Fixes bug introduced in #299 (sorry for that!), where llvm codegen ignored all vararg parameters beside the first one
