### PR TITLE
Fix null.isInstanceOf

### DIFF
--- a/unit-tests/src/main/scala/scala/scalanative/native/InstanceOfSuite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/native/InstanceOfSuite.scala
@@ -1,0 +1,79 @@
+package scala.scalanative.native
+
+object InstanceOfSuite extends tests.Suite {
+
+  // asInstanceOf
+
+//  test("expects anyRef.asInstanceOf[String] fail") {
+//    shouldNotGetHere((new AnyRef).asInstanceOf[String])
+//  }
+
+  test("expects \"\".asInstanceOf[String] succeed") {
+    assertNotNull("".asInstanceOf[String])
+  }
+
+  test("expects null.asInstanceOf[String] should succeed") {
+    assertNull(null.asInstanceOf[String])
+  }
+
+  test("expects a.asInstanceOf[String], where a = null should succeed") {
+    castNullToString(null)
+  }
+
+  def castNullToString(x: AnyRef): Unit = {
+    if (x.isInstanceOf[String]) {
+      assertNull(x.asInstanceOf[String])
+    }
+
+  }
+
+  def assertNull(s: String): Unit = {
+    assert(s == null)
+  }
+
+  def assertNotNull(s: String): Unit = {
+    assert(s != null)
+  }
+
+  def shouldNotGetHere(s: String): Unit = {
+    assert(false)
+  }
+
+  // isInstanceOf
+
+  test("expects (new AnyRef).asInstanceOf[AnyRef] should succeeds") {
+    (new AnyRef).asInstanceOf[AnyRef]
+  }
+
+  test("expects anyRef.isInstanceOf[String] == false") {
+    val anyRef = new AnyRef
+    assert(!anyRef.isInstanceOf[String])
+  }
+
+  test("expects literal null.isInstanceOf[String] == false") {
+    assert(!null.isInstanceOf[String])
+  }
+
+  test("expects \"\".isInstanceOf[String] == true") {
+    assert("".isInstanceOf[String])
+  }
+
+  test("expects a.isInstanceOf[String] == true, where a = \"\"") {
+    assertIsInstanceOfString("", "")
+  }
+
+  test("expects a.isInstanceOf[String] == false, where a = null") {
+    assertNullIsNotInstanceOfString(null, null)
+  }
+
+  def assertNullIsNotInstanceOfString(a: AnyRef, b: AnyRef): Unit = {
+    assert(!a.isInstanceOf[String])
+    assert(!b.isInstanceOf[String])
+  }
+
+  def assertIsInstanceOfString(a: AnyRef, b: AnyRef): Unit = {
+    assert(a.isInstanceOf[String])
+    assert(b.isInstanceOf[String])
+  }
+
+}

--- a/unit-tests/src/main/scala/tests/Main.scala
+++ b/unit-tests/src/main/scala/tests/Main.scala
@@ -12,6 +12,7 @@ object Main {
       scala.scalanative.issues._337,
       scala.scalanative.native.CStringSuite,
       scala.scalanative.native.CInteropSuite,
+      scala.scalanative.native.InstanceOfSuite,
       scala.ArrayIntCopySuite,
       scala.ArrayDoubleCopySuite,
       scala.ArrayObjectCopySuite


### PR DESCRIPTION
In `preBlock` looks for `Op.Is` in a `Block` and adds runtime check if the operand is `null`.
In `preInst`, if operand is the `null` literal returns `false`, otherwise goes to proper `instanceOf` checking.

Limitations: 
- doesn't work yet - tests fail at runtime,
- is there an easier way add an `if\else` expression then splitting and creating `Block`s manually?
- static check for null literal in `preInst` is useless as `preBlock` introduces runtime check earlier.

Fixes #283
