### PR TITLE
Fix #314

### DIFF
--- a/tools/src/main/scala/scala/scalanative/compiler/Compiler.scala
+++ b/tools/src/main/scala/scala/scalanative/compiler/Compiler.scala
@@ -32,7 +32,8 @@ final class Compiler(opts: Opts) {
       pass.TryLowering,
       pass.AllocLowering,
       pass.SizeofLowering,
-      pass.CopyPropagation)
+      pass.CopyPropagation,
+      pass.DeadCodeElimination)
 
   private lazy val (links, assembly): (Seq[Attr.Link], Seq[Defn]) = {
     val deps           = passCompanions.flatMap(_.depends).distinct

--- a/unit-tests/src/main/scala/scala/scalanative/issues/_314.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/issues/_314.scala
@@ -1,0 +1,17 @@
+package scala.scalanative.issues
+
+object _314 extends tests.Suite {
+  test("github.com/scala-native/scala-native/issues/314") {
+    // Division by zero is undefined behavior in production mode.
+    // Optimizer can assume it never happens and remove unused result.
+    assert {
+      try {
+        5 / 0
+        true
+      } catch {
+        case _: Throwable =>
+          false
+      }
+    }
+  }
+}


### PR DESCRIPTION
As per @pbatko suggestion. Doing another DCE late in
the pipeline is enough to clean up unused code that
produces control-flow information that LLVM doesn't like.