### PR TITLE
Fix #260

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -202,34 +202,30 @@ final class _String()
   def endsWith(suffix: _String): scala.Boolean =
     regionMatches(count - suffix.count, suffix, 0, suffix.count)
 
-  override def equals(obj: Any): scala.Boolean = {
-    if (obj == this) {
+  override def equals(obj: Any): scala.Boolean = obj match {
+    case s: _String if s eq this =>
       true
-    } else {
-      obj match {
-        case s: _String =>
-          val thisHash = this.hashCode()
-          val thatHash = s.hashCode()
+    case s: _String =>
+      val thisHash = this.hashCode()
+      val thatHash = s.hashCode()
 
-          if (count != s.count ||
-              (thisHash != thatHash && thisHash != 0 && thatHash != 0)) {
-            false
+      if (count != s.count ||
+          (thisHash != thatHash && thisHash != 0 && thatHash != 0)) {
+        false
+      } else {
+        var i = 0
+        while (i < count) {
+          if (value(offset + i) != s.value(s.offset + i)) {
+            return false
           } else {
-            var i = 0
-            while (i < count) {
-              if (value(offset + i) != s.value(s.offset + i)) {
-                return false
-              } else {
-                i += 1
-              }
-            }
-
-            true
+            i += 1
           }
-        case _ =>
-          false
+        }
+
+        true
       }
-    }
+    case _ =>
+      false
   }
 
   def equalsIgnoreCase(string: _String): scala.Boolean = {

--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -10,7 +10,7 @@ final class _Class[A](val ty: Ptr[Type]) {
 
   override def equals(other: Any): scala.Boolean = other match {
     case other: _Class[_] =>
-      ty.cast[Long] == other.ty.cast[Long]
+      ty == other.ty
     case _ =>
       false
   }

--- a/sandbox/Test.scala
+++ b/sandbox/Test.scala
@@ -2,8 +2,6 @@ import scalanative.native._, stdlib._, stdio._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    val W = 800
-    val H = 600
-    fprintf(stdout, c"P3\n%d %d\n%d\n", W, H, 255)
+    println("Hello, world!")
   }
 }

--- a/unit-tests/src/main/scala/scala/EqualitySuite.scala
+++ b/unit-tests/src/main/scala/scala/EqualitySuite.scala
@@ -1,0 +1,23 @@
+package scala
+
+object EqualitySuite extends tests.Suite {
+  case class O(m: Int)
+
+  test("case class equality") {
+    assert(O(5) == O(5))
+  }
+
+  test("null equals null") {
+    assert((null: Object) == (null: Object))
+  }
+
+  test("null does not equal object") {
+    val obj = new Object
+    assert((null: Object) != obj)
+  }
+
+  test("object does not equal null") {
+    val obj = new Object
+    assert(obj != (null: Object))
+  }
+}

--- a/unit-tests/src/main/scala/scala/scalanative/issues/_260.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/issues/_260.scala
@@ -1,0 +1,15 @@
+package scala.scalanative.issues
+
+object _260 extends tests.Suite {
+  test("https://github.com/scala-native/scala-native/issues/260") {
+    def getStr(): String = {
+      val bytes = Array('h'.toByte, 'o'.toByte, 'l'.toByte, 'a'.toByte)
+      new String(bytes)
+    }
+
+    val sz = getStr()
+
+    assert("hola" == sz)
+    assert("hola".equals(sz))
+  }
+}

--- a/unit-tests/src/main/scala/tests/Main.scala
+++ b/unit-tests/src/main/scala/tests/Main.scala
@@ -9,13 +9,16 @@ object Main {
       java.lang.FloatSuite,
       java.lang.DoubleSuite,
       java.util.RandomSuite,
+      scala.scalanative.issues._260,
+      scala.scalanative.issues._314,
       scala.scalanative.issues._337,
       scala.scalanative.native.CStringSuite,
       scala.scalanative.native.CInteropSuite,
       scala.scalanative.native.InstanceOfSuite,
       scala.ArrayIntCopySuite,
       scala.ArrayDoubleCopySuite,
-      scala.ArrayObjectCopySuite
+      scala.ArrayObjectCopySuite,
+      scala.EqualitySuite
   )
 
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
It turns out the original fix by @ragnr wasn't sufficient. Equality needs a bit more boilerplate to handle calling == on nulls.