### PR TITLE
Don't tag module names

### DIFF
--- a/tools/src/main/scala/scala/scalanative/compiler/analysis/ClassHierarchy.scala
+++ b/tools/src/main/scala/scala/scalanative/compiler/analysis/ClassHierarchy.scala
@@ -277,14 +277,12 @@ object ClassHierarchy {
                         isModule = false))
 
       case defn: Defn.Module =>
-        val name = defn.name tag "module"
-        val cls = new Class(defn.attrs,
-                            name,
-                            defn.parent,
-                            defn.traits,
-                            isModule = true)
-        enter(defn.name, cls)
-        enter(name, cls)
+        enter(defn.name,
+              new Class(defn.attrs,
+                        defn.name,
+                        defn.parent,
+                        defn.traits,
+                        isModule = true))
 
       case defn: Defn.Var =>
         enter(defn.name, new Field(defn.attrs, defn.name, defn.ty))

--- a/tools/src/main/scala/scala/scalanative/compiler/pass/UnitLowering.scala
+++ b/tools/src/main/scala/scala/scalanative/compiler/pass/UnitLowering.scala
@@ -44,11 +44,10 @@ class UnitLowering(implicit fresh: Fresh) extends Pass {
 object UnitLowering extends PassCompanion {
   def apply(ctx: Ctx) = new UnitLowering()(ctx.fresh)
 
-  val unitName = Global.Top("scala.scalanative.runtime.BoxedUnit$")
-  val unit     = Val.Global(unitName, Type.Ptr)
-  val unitTy   = Type.Struct(unitName tag "module" tag "class", Seq(Type.Ptr))
-  val unitConst =
-    Val.Global(unitName tag "module" tag "class" tag "type", Type.Ptr)
+  val unitName  = Global.Top("scala.scalanative.runtime.BoxedUnit$")
+  val unit      = Val.Global(unitName, Type.Ptr)
+  val unitTy    = Type.Struct(unitName tag "class", Seq(Type.Ptr))
+  val unitConst = Val.Global(unitName tag "class" tag "type", Type.Ptr)
   val unitValue = Val.Struct(unitTy.name, Seq(unitConst))
   val unitDefn  = Defn.Const(Attrs.None, unitName, unitTy, unitValue)
 


### PR DESCRIPTION
This is an artifact of the times when we had separate namespaces for
modules and classes/traits.

Fix #330