### PR TITLE
(WIP) Add partial support for finally blocks in the frontend

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirNameEncoding.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirNameEncoding.scala
@@ -64,7 +64,7 @@ trait NirNameEncoding { self: NirCodeGen =>
   }
 
   private def mangledType(tpe: Type, retty: Boolean): String =
-    mangledTypeInternal(genType(tpe, retty))
+    mangledTypeInternal(genType(tpe))
 
   private def mangledTypeInternal(ty: nir.Type): String = {
     implicit lazy val showMangledType: Show[nir.Type] = Show {

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirTypeEncoding.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirTypeEncoding.scala
@@ -31,15 +31,14 @@ trait NirTypeEncoding { self: NirCodeGen =>
     case tpe: ErasedValueType     => (tpe.valueClazz, Seq())
   }
 
-  def genType(t: Type, retty: Boolean = false): nir.Type = {
+  def genType(t: Type): nir.Type = {
     val (sym, args) = decomposeType(t)
 
-    genTypeSym(sym, args, retty)
+    genTypeSym(sym, args)
   }
 
   def genTypeSym(sym: Symbol,
                  targs: Seq[Type] = Seq(),
-                 retty: Boolean = false,
                  boxUnsigned: Boolean = true): nir.Type = sym match {
     case ArrayClass                  => genTypeSym(RuntimeArrayClass(genPrimCode(targs.head)))
     case UnitClass | BoxedUnitClass  => nir.Type.Unit

--- a/unit-tests/src/main/scala/scala/scalanative/native/FinallySuite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/native/FinallySuite.scala
@@ -1,0 +1,246 @@
+package scala.scalanative.native
+
+import collection.mutable
+
+object FinallySuite extends tests.Suite {
+
+  private val events = new mutable.ArrayBuffer[String]()
+
+  private val Try = "Try"
+  private val Catch = "Catch"
+  private val Finally = "Finally"
+
+  test("try throw catch throw finally") {
+    withExpectedEvents(Seq(Try, Catch, Finally)) {
+      expectException {
+        try {
+          event(Try)
+          throw new Exception
+        } catch {
+          case e: Exception =>
+            event(Catch)
+            throw e
+        } finally {
+          event(Finally)
+        }
+      }
+    }
+  }
+
+  test("try throw finally") {
+    withExpectedEvents(Seq(Try, Finally)) {
+      expectException {
+        try {
+          event(Try)
+          throw new Exception
+        } finally {
+          event(Finally)
+        }
+      }
+    }
+  }
+
+  test("try finally") {
+    withExpectedEvents(Seq(Try, Finally)) {
+      try {
+        event(Try)
+      } finally {
+        event(Finally)
+      }
+    }
+  }
+
+  test("try throw catch finally") {
+    withExpectedEvents(Seq(Try, Catch, Finally)) {
+      try {
+        event(Try)
+        throw new Exception
+      } catch {
+        case e: Exception =>
+          event(Catch)
+      } finally {
+        event(Finally)
+      }
+    }
+  }
+
+  test("try (return) finally (return)") {
+    // error: constant expression type mismatch
+    // %src.12 = phi i32 [bitcast (%"class.scala.scalanative.runtime.BoxedUnit$"* @"scala.scalanative.runtime.BoxedUnit$" to i8*), %src.6]
+    // assert(1() == 1, "tryFinally_1")
+
+    assertInt(tryFinally_2(), 1, "tryFinally_2")
+    assertInt(tryFinally_3(), 2, "tryFinally_3")
+    assertInt(tryFinally_4(), 2, "tryFinally_4")
+  }
+
+  test("try throw catch (return) finally (return)") {
+    // error: constant expression type mismatch
+    // %src.20 = phi i32 [bitcast (%"class.scala.scalanative.runtime.BoxedUnit$"* @"scala.scalanative.runtime.BoxedUnit$" to i8*), %src.15]
+    // assert(catchFinally_1() == 1, "catchFinally_1")
+
+    assertInt(catchFinally_2(), 1, "catchFinally_2")
+    assertInt(catchFinally_3(), 2, "catchFinally_3")
+    assertInt(catchFinally_4(), 2, "catchFinally_4")
+  }
+
+  test("should execute finally only once when throw in finally 1") {
+    withExpectedEvents(Seq(Try, Catch, Finally)) {
+      expectException {
+        try {
+          event(Try)
+          throw new Exception
+        } catch {
+          case e: Exception =>
+            event(Catch)
+        } finally {
+          event(Finally)
+          throw new Exception
+        }
+      }
+    }
+  }
+
+  test("should execute finally only once when throw in finally 2") {
+    withExpectedEvents(Seq(Try, Finally)) {
+      expectException {
+        try {
+          event(Try)
+          throw new Exception
+        } finally {
+          event(Finally)
+          throw new RuntimeException
+        }
+      }
+    }
+  }
+
+  test("should execute finally only once when throw in finally 3") {
+    withExpectedEvents(Seq(Try, Finally)) {
+      expectException {
+        try {
+          event(Try)
+        } finally {
+          event(Finally)
+          throw new Exception
+        }
+      }
+    }
+  }
+
+  test("throwing finally should shadow previous exception") {
+    withExpectedEvents(Seq(Try, Finally)) {
+      assertThrows[IllegalArgumentException] {
+        try {
+          event(Try)
+          throw new IllegalStateException()
+        } finally {
+          event(Finally)
+          throw new IllegalArgumentException
+        }
+      }
+    }
+  }
+
+  def tryFinally_1(): Int =
+    try {
+      1
+    } finally {
+      2
+    }
+
+  def tryFinally_2(): Int =
+    try {
+      return 1
+    } finally {
+      2
+    }
+
+  def tryFinally_3(): Int =
+    try {
+      1
+    } finally {
+      return 2
+    }
+
+  def tryFinally_4(): Int =
+    try {
+      return 1
+    } finally {
+      return 2
+    }
+
+  def catchFinally_1(): Int = try {
+    try {
+      throw new Exception
+    } catch {
+      case e: Exception => 1
+    } finally {
+      2
+    }
+  }
+
+  def catchFinally_2(): Int = try {
+    try {
+      throw new Exception
+    } catch {
+      case e: Exception => return 1
+    } finally {
+      2
+    }
+  }
+
+  def catchFinally_3(): Int = try {
+    try {
+      throw new Exception
+    } catch {
+      case e: Exception => 1
+    } finally {
+      return 2
+    }
+  }
+
+  def catchFinally_4(): Int = try {
+    try {
+      throw new Exception
+    } catch {
+      case e: Exception => return 1
+    } finally {
+      return 2
+    }
+  }
+
+  private def event(s: String): Unit = events += s
+
+  private def reset(): Unit = events.clear()
+
+  private def assertEvents(expectedEvents: Seq[String]): Unit = {
+    def sameElements(): Boolean = {
+      events.zip(expectedEvents).forall { case (a, e) => a == e }
+    }
+    val sameLen = events.size == expectedEvents.size
+
+    if (!(sameLen && sameElements())) {
+      val e = expectedEvents.mkString("[", ", ", "]")
+      val a = events.mkString("[", ", ", "]")
+      assert(false, s"[Failed] Expected: $e, actual: $a")
+    }
+  }
+
+  private def withExpectedEvents(expectedEvents: Seq[String])(
+      f: => Unit): Unit = {
+    reset()
+    f
+    assertEvents(expectedEvents)
+  }
+
+  private def expectException(fun: => Unit): Unit = {
+    assertThrows[Exception](fun)
+  }
+
+  private def assertInt(actual: Int, expected: Int, msg: String): Unit =
+    if (actual != expected) {
+      assert(false, s"[Failed] $msg: expected: $expected, actual: $actual")
+    }
+
+}

--- a/unit-tests/src/main/scala/tests/Main.scala
+++ b/unit-tests/src/main/scala/tests/Main.scala
@@ -16,6 +16,7 @@ object Main {
     scala.scalanative.issues._350,
     scala.scalanative.native.CStringSuite,
     scala.scalanative.native.CInteropSuite,
+    scala.scalanative.native.FinallySuite,
     scala.scalanative.native.InstanceOfSuite,
     scala.scalanative.native.UnsignedSizeOfSuite,
     scala.ArrayIntCopySuite,

--- a/unit-tests/src/main/scala/tests/Suite.scala
+++ b/unit-tests/src/main/scala/tests/Suite.scala
@@ -13,6 +13,12 @@ abstract class Suite {
   def assert(cond: Boolean): Unit =
     if (!cond) throw AssertionFailed else ()
 
+  def assert(cond: Boolean, msg: String): Unit =
+    if (!cond) {
+      println(msg)
+      throw AssertionFailed
+    } else ()
+
   def assertNot(cond: Boolean): Unit =
     if (cond) throw AssertionFailed else ()
 
@@ -51,10 +57,12 @@ abstract class Suite {
 
   def run(): Boolean = {
     println("* " + this.getClass.getName)
-    tests.forall { test =>
+    var allPassed = true
+    tests.foreach { test =>
       val res = test.run()
       println((if (res) "  [ok] " else "  [fail] ") + test.name)
-      res
+      allPassed = allPassed && res
     }
+    allPassed
   }
 }


### PR DESCRIPTION
For each `case` in the `catch` block I do the following

```
try {
  case_body
} catch { _ => finally_body }
finally_body
```

That handles exceptional exits from the `try`'s body.

Problems:
1.
For the normal exit from the`try`'s body I need to execute finally block outside the original `try/catch/finally` so that an exception thrown in the `finally`'s body won't cause `finally` block to be executed again. I'm not sure how do this. I tried jumping out of `try/catch` but it's confusing to tell which block have which exception handler assigned and which block won't have eh assigned anymore. 

2.
In the example above, if `case_body` returns with `ret` then `finally_body` won't be executed.
To handle this I think it's needed to insert the `finally_block` before the last instruction of `case_body`.

3.
Maybe `Try` should handle finally explicitly and have a lowering pass instead.

4.
Maybe `Try` should contain complete information about the range of the block for which it defines exception handlers, not just the initial block.

See #157
