### PR TITLE
Fix issues handling floating point numbers

### DIFF
--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -26,9 +26,11 @@ final class Double(override val doubleValue: scala.Double)
   @inline override def equals(that: Any): scala.Boolean =
     that match {
       case that: Double =>
-        val a = doubleValue
-        val b = that.doubleValue
-        (a == b) || (Double.isNaN(a) && Double.isNaN(b))
+        // As doubles with different NaNs are considered equal,
+        // use doubleToLongBits instead of doubleToRawLongBits
+        val a = Double.doubleToLongBits(doubleValue)
+        val b = Double.doubleToLongBits(that.doubleValue)
+        a == b
 
       case _ =>
         false

--- a/javalib/src/main/scala/java/lang/Float.scala
+++ b/javalib/src/main/scala/java/lang/Float.scala
@@ -26,9 +26,11 @@ final class Float(override val floatValue: scala.Float)
   @inline override def equals(that: Any): scala.Boolean =
     that match {
       case that: Float =>
-        val a = floatValue
-        val b = that.floatValue
-        (a == b) || (Float.isNaN(a) && Float.isNaN(b))
+        // As floats with different NaNs are considered equal,
+        // use floatToIntBits instead of floatToRawIntBits
+        val a = Float.floatToIntBits(floatValue)
+        val b = Float.floatToIntBits(that.floatValue)
+        a == b
 
       case _ =>
         false

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -1,6 +1,9 @@
 package scala.scalanative
 package nir
 
+import java.lang.Float.floatToRawIntBits
+import java.lang.Double.doubleToRawLongBits
+
 sealed abstract class Val {
   final def ty: Type = this match {
     case Val.None               => Type.None
@@ -26,17 +29,33 @@ sealed abstract class Val {
 }
 object Val {
   // low-level
-  final case object None                                      extends Val
-  final case object True                                      extends Val
-  final case object False                                     extends Val
-  final case class Zero(of: nir.Type)                         extends Val
-  final case class Undef(of: nir.Type)                        extends Val
-  final case class I8(value: Byte)                            extends Val
-  final case class I16(value: Short)                          extends Val
-  final case class I32(value: Int)                            extends Val
-  final case class I64(value: Long)                           extends Val
-  final case class F32(value: Float)                          extends Val
-  final case class F64(value: Double)                         extends Val
+  final case object None               extends Val
+  final case object True               extends Val
+  final case object False              extends Val
+  final case class Zero(of: nir.Type)  extends Val
+  final case class Undef(of: nir.Type) extends Val
+  final case class I8(value: Byte)     extends Val
+  final case class I16(value: Short)   extends Val
+  final case class I32(value: Int)     extends Val
+  final case class I64(value: Long)    extends Val
+  final case class F32(value: Float) extends Val {
+    override def equals(that: Any): Boolean = that match {
+      case F32(thatValue) =>
+        val theseBits = floatToRawIntBits(value)
+        val thoseBits = floatToRawIntBits(thatValue)
+        theseBits == thoseBits
+      case _ => false
+    }
+  }
+  final case class F64(value: Double) extends Val {
+    override def equals(that: Any): Boolean = that match {
+      case F64(thatValue) =>
+        val theseBits = doubleToRawLongBits(value)
+        val thoseBits = doubleToRawLongBits(thatValue)
+        theseBits == thoseBits
+      case _ => false
+    }
+  }
   final case class Struct(name: nir.Global, values: Seq[Val]) extends Val
   final case class Array(elemty: nir.Type, values: Seq[Val])  extends Val
   final case class Chars(value: java.lang.String)             extends Val

--- a/unit-tests/src/main/scala/java/lang/DoubleSuite.scala
+++ b/unit-tests/src/main/scala/java/lang/DoubleSuite.scala
@@ -1,6 +1,191 @@
 package java.lang
 
+import java.lang.Double.{
+  doubleToLongBits,
+  doubleToRawLongBits,
+  longBitsToDouble
+}
+
 object DoubleSuite extends tests.Suite {
+  test("equals") {
+    val pzero = +0.0
+    val nzero = -0.0
+    assert(pzero equals pzero)
+    assert(nzero equals nzero)
+    assertNot(pzero equals nzero)
+    val szero = 1.0 - 1.0
+    assert(pzero equals szero)
+
+    val bpzero: java.lang.Double = pzero
+    val bnzero: java.lang.Double = nzero
+    assertNot(bpzero equals bnzero)
+    val bszero: java.lang.Double = szero
+    assert(bpzero equals bszero)
+
+    val num1 = 123.45
+    val num2 = 123.45
+    assert(num1 equals num2)
+
+    val bnum1: java.lang.Double = num1
+    val bnum2: java.lang.Double = num2
+    assert(bnum1 == bnum2)
+    val pmax1 = scala.Double.MaxValue
+    val pmax2 = scala.Double.MaxValue
+    assert(pmax1 equals pmax2)
+    val pmax3 = scala.Double.MaxValue + 1
+    assert(pmax1 equals pmax3)
+
+    val bpmax1: java.lang.Double = scala.Double.MaxValue
+    val bpmax2: java.lang.Double = scala.Double.MaxValue
+    assert(bpmax1 equals bpmax2)
+    val bpmax3: java.lang.Double = scala.Double.MaxValue + 1
+    assert(bpmax1 equals bpmax3)
+
+    val pmin1 = scala.Double.MinValue
+    val pmin2 = scala.Double.MinValue
+    assert(pmin1 equals pmin2)
+    val pmin3 = scala.Double.MinValue + 1
+    assert(pmin1 equals pmin3)
+
+    val bpmin1: java.lang.Double = scala.Double.MinValue
+    val bpmin2: java.lang.Double = scala.Double.MinValue
+    assert(bpmin1 equals bpmin2)
+    val bpmin3: java.lang.Double = scala.Double.MinValue + 1
+    assert(bpmin1 equals bpmin3)
+
+    val pinf1 = scala.Double.PositiveInfinity
+    val pinf2 = scala.Double.MaxValue + scala.Double.MaxValue
+    assert(pinf1 equals pinf2)
+
+    val bpinf1: java.lang.Double = pinf1
+    val bpinf2: java.lang.Double = pinf2
+    assert(bpinf1 equals bpinf2)
+
+    val ninf1 = scala.Double.NegativeInfinity
+    val ninf2 = scala.Double.MinValue + scala.Double.MinValue
+    assert(ninf1 equals ninf2)
+
+    val bninf1: java.lang.Double = ninf1
+    val bninf2: java.lang.Double = ninf2
+    assert(bninf1 equals bninf2)
+
+    assert(Double.NaN equals Double.NaN)
+
+    val x = Double.NaN
+    val y = longBitsToDouble(doubleToRawLongBits(x) | 1)
+    assert(x equals y)
+
+    val z = longBitsToDouble(doubleToLongBits(x) | 1)
+    assert(x equals z)
+  }
+
+  test("==") {
+    val pzero = +0.0
+    val nzero = -0.0
+    assert(pzero == pzero)
+    assert(nzero == nzero)
+    assert(pzero == nzero)
+    val szero = 1.0 - 1.0
+    assert(pzero == szero)
+
+    val bpzero: java.lang.Double = pzero
+    val bnzero: java.lang.Double = nzero
+    assertNot(bpzero == bnzero)
+    val bszero: java.lang.Double = szero
+    assert(bpzero == bszero)
+
+    val num1 = 123.45
+    val num2 = 123.45
+    assert(num1 == num2)
+
+    val bnum1: java.lang.Double = num1
+    val bnum2: java.lang.Double = num2
+    assert(bnum1 == bnum2)
+
+    val pmax1 = scala.Double.MaxValue
+    val pmax2 = scala.Double.MaxValue
+    assert(pmax1 == pmax2)
+    val pmax3 = scala.Double.MaxValue + 1
+    assert(pmax1 == pmax3)
+
+    val bpmax1: java.lang.Double = scala.Double.MaxValue
+    val bpmax2: java.lang.Double = scala.Double.MaxValue
+    assert(bpmax1 == bpmax2)
+    val bpmax3: java.lang.Double = scala.Double.MaxValue + 1
+    assert(bpmax1 == bpmax3)
+
+    val pmin1 = scala.Double.MinValue
+    val pmin2 = scala.Double.MinValue
+    assert(pmin1 == pmin2)
+    val pmin3 = scala.Double.MinValue + 1
+    assert(pmin1 == pmin3)
+
+    val bpmin1: java.lang.Double = scala.Double.MinValue
+    val bpmin2: java.lang.Double = scala.Double.MinValue
+    assert(bpmin1 == bpmin2)
+    val bpmin3: java.lang.Double = scala.Double.MinValue + 1
+    assert(bpmin1 == bpmin3)
+
+    val pinf1 = scala.Double.PositiveInfinity
+    val pinf2 = scala.Double.MaxValue + scala.Double.MaxValue
+    assert(pinf1 == pinf2)
+
+    val bpinf1: java.lang.Double = pinf1
+    val bpinf2: java.lang.Double = pinf2
+    assert(bpinf1 == bpinf2)
+
+    val ninf1 = scala.Double.NegativeInfinity
+    val ninf2 = scala.Double.MinValue + scala.Double.MinValue
+    assert(ninf1 == ninf2)
+
+    val bninf1: java.lang.Double = ninf1
+    val bninf2: java.lang.Double = ninf2
+    assert(bninf1 == bninf2)
+
+    assertNot(Double.NaN == Double.NaN)
+
+    val x = Double.NaN
+    val y = longBitsToDouble(doubleToRawLongBits(x) | 1)
+    // assertNot(x == y) // FIXME this works on the JVM, but fails on native.
+
+    val z = longBitsToDouble(doubleToLongBits(x) | 1)
+    // assertNot(x == z) // FIXME this works on the JVM, but fails on native.
+  }
+
+  test("eq") {
+    val bpzero: java.lang.Double = +0.0
+    val bnzero: java.lang.Double = -0.0
+    assert(bpzero eq bpzero)
+    assert(bnzero eq bnzero)
+    assertNot(bpzero eq bnzero)
+    val bszero: java.lang.Double = 1.0 - 1.0
+    assertNot(bpzero eq bszero)
+
+    val bnum1: java.lang.Double = 123.45
+    val bnum2: java.lang.Double = 123.45
+    assertNot(bnum1 eq bnum2)
+
+    val bpmax1: java.lang.Double = scala.Double.MaxValue
+    val bpmax2: java.lang.Double = scala.Double.MaxValue
+    assertNot(bpmax1 eq bpmax2)
+    val bpmax3: java.lang.Double = scala.Double.MaxValue + 1
+    assertNot(bpmax1 eq bpmax3)
+
+    val bpmin1: java.lang.Double = scala.Double.MinValue
+    val bpmin2: java.lang.Double = scala.Double.MinValue
+    assertNot(bpmin1 eq bpmin2)
+    val bpmin3: java.lang.Double = scala.Double.MinValue + 1
+    assertNot(bpmin1 eq bpmin3)
+
+    val bpinf1: java.lang.Double = scala.Double.PositiveInfinity
+    val bpinf2: java.lang.Double = scala.Double.MaxValue + scala.Double.MaxValue
+    assertNot(bpinf1 eq bpinf2)
+
+    val bninf1: java.lang.Double = scala.Double.NegativeInfinity
+    val bninf2: java.lang.Double = scala.Double.MinValue + scala.Double.MinValue
+    assertNot(bninf1 eq bninf2)
+  }
+
   test("parseDouble") {
     assert(Double.parseDouble("1.0") == 1.0)
     assert(Double.parseDouble("-1.0") == -1.0)

--- a/unit-tests/src/main/scala/java/lang/FloatSuite.scala
+++ b/unit-tests/src/main/scala/java/lang/FloatSuite.scala
@@ -1,6 +1,187 @@
 package java.lang
 
+import java.lang.Float.{floatToIntBits, floatToRawIntBits, intBitsToFloat}
+
 object FloatSuite extends tests.Suite {
+  test("equals") {
+    val pzero = +0.0f
+    val nzero = -0.0f
+    assert(pzero equals pzero)
+    assert(nzero equals nzero)
+    assertNot(pzero equals nzero)
+    val szero = 1.0f - 1.0f
+    assert(pzero equals szero)
+
+    val bpzero: java.lang.Float = pzero
+    val bnzero: java.lang.Float = nzero
+    assertNot(bpzero equals bnzero)
+    val bszero: java.lang.Float = szero
+    assert(bpzero equals bszero)
+
+    val num1 = 123.45f
+    val num2 = 123.45f
+    assert(num1 equals num2)
+
+    val bnum1: java.lang.Float = num1
+    val bnum2: java.lang.Float = num2
+    assert(bnum1 == bnum2)
+    val pmax1 = scala.Float.MaxValue
+    val pmax2 = scala.Float.MaxValue
+    assert(pmax1 equals pmax2)
+    val pmax3 = scala.Float.MaxValue + 1
+    assert(pmax1 equals pmax3)
+
+    val bpmax1: java.lang.Float = scala.Float.MaxValue
+    val bpmax2: java.lang.Float = scala.Float.MaxValue
+    assert(bpmax1 equals bpmax2)
+    val bpmax3: java.lang.Float = scala.Float.MaxValue + 1
+    assert(bpmax1 equals bpmax3)
+
+    val pmin1 = scala.Float.MinValue
+    val pmin2 = scala.Float.MinValue
+    assert(pmin1 equals pmin2)
+    val pmin3 = scala.Float.MinValue + 1
+    assert(pmin1 equals pmin3)
+
+    val bpmin1: java.lang.Float = scala.Float.MinValue
+    val bpmin2: java.lang.Float = scala.Float.MinValue
+    assert(bpmin1 equals bpmin2)
+    val bpmin3: java.lang.Float = scala.Float.MinValue + 1
+    assert(bpmin1 equals bpmin3)
+
+    val pinf1 = scala.Float.PositiveInfinity
+    val pinf2 = scala.Float.MaxValue + scala.Float.MaxValue
+    assert(pinf1 equals pinf2)
+
+    val bpinf1: java.lang.Float = pinf1
+    val bpinf2: java.lang.Float = pinf2
+    assert(bpinf1 equals bpinf2)
+
+    val ninf1 = scala.Float.NegativeInfinity
+    val ninf2 = scala.Float.MinValue + scala.Float.MinValue
+    assert(ninf1 equals ninf2)
+
+    val bninf1: java.lang.Float = ninf1
+    val bninf2: java.lang.Float = ninf2
+    assert(bninf1 equals bninf2)
+
+    assert(Float.NaN equals Float.NaN)
+
+    val x = Float.NaN
+    val y = intBitsToFloat(floatToRawIntBits(x) | 1)
+    assert(x equals y)
+
+    val z = intBitsToFloat(floatToIntBits(x) | 1)
+    assert(x equals z)
+  }
+
+  test("==") {
+    val pzero = +0.0f
+    val nzero = -0.0f
+    assert(pzero == pzero)
+    assert(nzero == nzero)
+    assert(pzero == nzero)
+    val szero = 1.0f - 1.0f
+    assert(pzero == szero)
+
+    val bpzero: java.lang.Float = pzero
+    val bnzero: java.lang.Float = nzero
+    assertNot(bpzero == bnzero)
+    val bszero: java.lang.Float = szero
+    assert(bpzero == bszero)
+
+    val num1 = 123.45f
+    val num2 = 123.45f
+    assert(num1 == num2)
+
+    val bnum1: java.lang.Float = num1
+    val bnum2: java.lang.Float = num2
+    assert(bnum1 == bnum2)
+
+    val pmax1 = scala.Float.MaxValue
+    val pmax2 = scala.Float.MaxValue
+    assert(pmax1 == pmax2)
+    val pmax3 = scala.Float.MaxValue + 1
+    assert(pmax1 == pmax3)
+
+    val bpmax1: java.lang.Float = scala.Float.MaxValue
+    val bpmax2: java.lang.Float = scala.Float.MaxValue
+    assert(bpmax1 == bpmax2)
+    val bpmax3: java.lang.Float = scala.Float.MaxValue + 1
+    assert(bpmax1 == bpmax3)
+
+    val pmin1 = scala.Float.MinValue
+    val pmin2 = scala.Float.MinValue
+    assert(pmin1 == pmin2)
+    val pmin3 = scala.Float.MinValue + 1
+    assert(pmin1 == pmin3)
+
+    val bpmin1: java.lang.Float = scala.Float.MinValue
+    val bpmin2: java.lang.Float = scala.Float.MinValue
+    assert(bpmin1 == bpmin2)
+    val bpmin3: java.lang.Float = scala.Float.MinValue + 1
+    assert(bpmin1 == bpmin3)
+
+    val pinf1 = scala.Float.PositiveInfinity
+    val pinf2 = scala.Float.MaxValue + scala.Float.MaxValue
+    assert(pinf1 == pinf2)
+
+    val bpinf1: java.lang.Float = pinf1
+    val bpinf2: java.lang.Float = pinf2
+    assert(bpinf1 == bpinf2)
+
+    val ninf1 = scala.Float.NegativeInfinity
+    val ninf2 = scala.Float.MinValue + scala.Float.MinValue
+    assert(ninf1 == ninf2)
+
+    val bninf1: java.lang.Float = ninf1
+    val bninf2: java.lang.Float = ninf2
+    assert(bninf1 == bninf2)
+
+    assertNot(Float.NaN == Float.NaN)
+
+    val x = Float.NaN
+    val y = intBitsToFloat(floatToRawIntBits(x) | 1)
+    // assertNot(x == y) // FIXME this works on the JVM, but fails on native.
+
+    val z = intBitsToFloat(floatToIntBits(x) | 1)
+    // assertNot(x == z) // FIXME this works on the JVM, but fails on native.
+  }
+
+  test("eq") {
+    val bpzero: java.lang.Float = +0.0f
+    val bnzero: java.lang.Float = -0.0f
+    assert(bpzero eq bpzero)
+    assert(bnzero eq bnzero)
+    assertNot(bpzero eq bnzero)
+    val bszero: java.lang.Float = 1.0f - 1.0f
+    assertNot(bpzero eq bszero)
+
+    val bnum1: java.lang.Float = 123.45f
+    val bnum2: java.lang.Float = 123.45f
+    assertNot(bnum1 eq bnum2)
+
+    val bpmax1: java.lang.Float = scala.Float.MaxValue
+    val bpmax2: java.lang.Float = scala.Float.MaxValue
+    assertNot(bpmax1 eq bpmax2)
+    val bpmax3: java.lang.Float = scala.Float.MaxValue + 1
+    assertNot(bpmax1 eq bpmax3)
+
+    val bpmin1: java.lang.Float = scala.Float.MinValue
+    val bpmin2: java.lang.Float = scala.Float.MinValue
+    assertNot(bpmin1 eq bpmin2)
+    val bpmin3: java.lang.Float = scala.Float.MinValue + 1
+    assertNot(bpmin1 eq bpmin3)
+
+    val bpinf1: java.lang.Float = scala.Float.PositiveInfinity
+    val bpinf2: java.lang.Float = scala.Float.MaxValue + scala.Float.MaxValue
+    assertNot(bpinf1 eq bpinf2)
+
+    val bninf1: java.lang.Float = scala.Float.NegativeInfinity
+    val bninf2: java.lang.Float = scala.Float.MinValue + scala.Float.MinValue
+    assertNot(bninf1 eq bninf2)
+  }
+
   test("parseFloat") {
     assert(Float.parseFloat("1.0") == 1.0f)
     assert(Float.parseFloat("-1.0") == -1.0f)


### PR DESCRIPTION
There are two issues at play here, discovered while implementing
ArrayList#contains:

- Boxing elimination replaces +0.0 values with -0.0 values that were
  defined ealier in the code (or the other way around).
  This happens because the the F32/F64 case classes synthesize the
  standard equals implementation which uses == and considers +0.0/-0.0
  equal (and identical NaNs values never equal).
  This is fixed by providing an equals method that compares the raw bits
  instead, making sure that we only deduplicate values that have the
  same bits.

- The ArrayList#contains method was still failing as Float#equals and
  Double#equals were using ==. This was fixed by comparing the processed
  bits (all NaN bit patterns are collapsed into one).

The test suite is extended with tests for both zero and NaN.