### PR TITLE
Fix #321

### DIFF
--- a/nativelib/src/main/resources/gc.c
+++ b/nativelib/src/main/resources/gc.c
@@ -3,6 +3,10 @@
 // At the moment we rely on the conservative
 // mode of Boehm GC as our garbage collector.
 
+void scalanative_init() {
+    GC_init();
+}
+
 void* scalanative_alloc(void* info, size_t size) {
     void** alloc = (void**) GC_malloc(size);
     *alloc = info;

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -15,6 +15,4 @@ object GC {
   def malloc(size: CSize): Ptr[_] = extern
   @name("GC_malloc_atomic")
   def malloc_atomic(size: CSize): Ptr[_] = extern
-  @name("GC_init")
-  def init(): Unit = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -72,8 +72,6 @@ package object runtime {
    * rest as Java-style array.
    */
   def init(argc: Int, argv: Ptr[Ptr[Byte]]): ObjectArray = {
-    GC.init()
-
     val args = new scala.Array[String](argc - 1)
 
     // skip the executable name in argv(0)

--- a/scalafmt.tar.gz
+++ b/scalafmt.tar.gz
@@ -1,1 +1,0 @@
-{"error":"Not Found"}


### PR DESCRIPTION
Module initialization does gc allocation for the module
value, therefore we can not initialize GC in Scala code
at the moment.