### PR TITLE
Add missing `clang` dependency for Ubuntu-based systems

### DIFF
--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -24,7 +24,7 @@ systems Scala Native has been used with:
 
 Ubuntu::
 
-    $ sudo apt-get install libgc-dev
+    $ sudo apt-get install clang libgc-dev
 
 macOS::
 


### PR DESCRIPTION
I additionally had to install the `clang` package on my system though it had not been listed.  This change adds it to the list of packages to install.