### PR TITLE
Add a pass to simplify unit

### DIFF
--- a/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
@@ -22,6 +22,7 @@ object Driver {
   def apply(config: tools.Config): Driver =
     new Impl(
       Seq(pass.GlobalBoxingElimination,
+          pass.UnitSimplification,
           pass.DeadCodeElimination,
           pass.GlobalValueNumbering,
           pass.MainInjection,

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/DeadCodeElimination.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/DeadCodeElimination.scala
@@ -4,26 +4,34 @@ package pass
 
 import scala.collection.mutable
 import analysis.ClassHierarchy.Top
+import analysis.UseDef
+import analysis.ControlFlow
 import nir._, Shows._
 import util.sh
 
-/** Eliminates pure computations that are not being used. */
+/** Eliminates pure computations that are not being used, as well as unused block parameters. */
 class DeadCodeElimination(implicit top: Top) extends Pass {
+  import DeadCodeElimination._
+
   override def preDefn = {
     case defn: Defn.Define =>
-      val insts    = defn.insts
-      val cfg      = analysis.ControlFlow.Graph(insts)
-      val usedef   = analysis.UseDef(cfg)
-      val newinsts = mutable.UnrolledBuffer.empty[Inst]
+      val insts      = defn.insts
+      val cfg        = ControlFlow.Graph(insts)
+      val usedef     = UseDef(cfg)
+      val newinsts   = mutable.UnrolledBuffer.empty[Inst]
+      val removeArgs = new ArgRemover(usedef, cfg.entry.name)
 
       cfg.all.foreach { block =>
         if (usedef(block.name).alive) {
-          newinsts += block.label
+          val newParams = block.params.filter { p =>
+            (block.name == cfg.entry.name) || usedef(p.name).alive
+          }
+          newinsts += block.label.copy(params = newParams)
           block.insts.foreach {
             case inst @ Inst.Let(n, op) =>
               if (usedef(n).alive) newinsts += inst
             case inst: Inst.Cf =>
-              newinsts += inst
+              newinsts ++= removeArgs(inst)
             case _ =>
               ()
           }
@@ -37,4 +45,22 @@ class DeadCodeElimination(implicit top: Top) extends Pass {
 object DeadCodeElimination extends PassCompanion {
   override def apply(config: tools.Config, top: Top) =
     new DeadCodeElimination()(top)
+
+  class ArgRemover(usedef: Map[Local, UseDef.Def], entryName: Local)
+      extends Pass {
+    override def preNext = {
+      case Next.Label(name, args) if (name != entryName) =>
+        usedef(name) match {
+          case UseDef.BlockDef(_, _, _, params) =>
+            val newArgs = args.zip(params).collect {
+              case (arg, param) if param.alive => arg
+            }
+            Next.Label(name, newArgs)
+
+          case _ =>
+            throw new IllegalStateException(
+              s"Expected a BlockDef in usedef for ${showLocal(name)}")
+        }
+    }
+  }
 }

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/UnitSimplification.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/UnitSimplification.scala
@@ -1,0 +1,20 @@
+package scala.scalanative
+package optimizer
+package pass
+
+import nir.Val
+import nir.Type
+import analysis.ClassHierarchy.Top
+
+class UnitSimplification extends Pass {
+
+  override def preVal = {
+    case v if (v.ty == Type.Unit) => Val.Unit
+  }
+
+}
+
+object UnitSimplification extends PassCompanion {
+  override def apply(config: tools.Config, top: Top) =
+    new UnitSimplification
+}


### PR DESCRIPTION
Add a pass to simplify the unit usage, especially the ones created for the control flow.
Also improve the DCE to remove unused block parameters.

I am not particularly convinced by the solution used for the latter, suggestions are welcome.