### PR TITLE
	Add support for linker and optimizer reporters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,6 @@
 import scala.util.Try
+import scalanative.tools.OptimizerReporter
+import scalanative.sbtplugin.ScalaNativePluginInternal.nativeOptimizerReporter
 
 val toolScalaVersion = "2.10.6"
 
@@ -112,7 +114,6 @@ lazy val libSettings =
 lazy val projectSettings =
   ScalaNativePlugin.projectSettings ++ Seq(
     scalaVersion := libScalaVersion,
-    nativeVerbose := true,
     nativeClangOptions ++= Seq("-O0"),
     resolvers := Nil
   )
@@ -329,6 +330,10 @@ lazy val sandbox =
     .in(file("sandbox"))
     .settings(projectSettings)
     .settings(noPublishSettings)
+    .settings(
+      nativeOptimizerReporter := OptimizerReporter.toDirectory(
+        crossTarget.value)
+    )
     .enablePlugins(ScalaNativePlugin)
 
 lazy val benchmarks =

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -1,6 +1,8 @@
 package scala.scalanative
 package sbtplugin
 
+import scalanative.tools
+
 import sbt._
 
 object ScalaNativePlugin extends AutoPlugin {
@@ -14,17 +16,12 @@ object ScalaNativePlugin extends AutoPlugin {
 
     val nativeVersion = nir.Versions.current
 
-    val nativeVerbose = settingKey[Boolean]("Enable verbose tool logging.")
-
     val nativeClang = settingKey[File]("Location of the clang compiler.")
 
     val nativeClangPP = settingKey[File]("Location of the clang++ compiler.")
 
     val nativeClangOptions =
       settingKey[Seq[String]]("Additional options that are passed to clang.")
-
-    val nativeEmitDependencyGraphPath = settingKey[Option[File]](
-      "If non-empty, emit linker graph to the given file path.")
 
     val nativeLibraryLinkage = settingKey[Map[String, String]](
       "Given a native library, provide the linkage kind (static or dynamic). " +

--- a/scripted-tests/run/linker-reporter/build.sbt
+++ b/scripted-tests/run/linker-reporter/build.sbt
@@ -1,0 +1,14 @@
+import scalanative.tools.LinkerReporter
+import scalanative.sbtplugin.ScalaNativePluginInternal.nativeLinkerReporter
+
+ScalaNativePlugin.projectSettings
+
+scalaVersion := "2.11.8"
+
+nativeLinkerReporter := LinkerReporter.toFile(target.value / "out.dot")
+
+lazy val check = taskKey[Unit]("Check that dot file was created.")
+
+check := {
+  assert((target.value / "out.dot").exists)
+}

--- a/scripted-tests/run/linker-reporter/project/scala-native.sbt
+++ b/scripted-tests/run/linker-reporter/project/scala-native.sbt
@@ -1,0 +1,10 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scala-native" % "sbt-scala-native" % pluginVersion)
+}
+
+resolvers += Resolver.sonatypeRepo("snapshots")

--- a/scripted-tests/run/linker-reporter/src/main/scala/Hello.scala
+++ b/scripted-tests/run/linker-reporter/src/main/scala/Hello.scala
@@ -1,0 +1,3 @@
+object Main {
+  def main(args: Array[String]): Unit = ()
+}

--- a/scripted-tests/run/linker-reporter/test
+++ b/scripted-tests/run/linker-reporter/test
@@ -1,0 +1,2 @@
+> nativeLink
+> check

--- a/scripted-tests/run/optimizer-reporter/build.sbt
+++ b/scripted-tests/run/optimizer-reporter/build.sbt
@@ -1,0 +1,14 @@
+import scalanative.tools.OptimizerReporter
+import scalanative.sbtplugin.ScalaNativePluginInternal.nativeOptimizerReporter
+
+ScalaNativePlugin.projectSettings
+
+scalaVersion := "2.11.8"
+
+nativeOptimizerReporter := OptimizerReporter.toDirectory(crossTarget.value)
+
+lazy val check = taskKey[Unit]("Check that dot file was created.")
+
+check := {
+  assert((crossTarget.value / "out.00.hnir").exists)
+}

--- a/scripted-tests/run/optimizer-reporter/project/scala-native.sbt
+++ b/scripted-tests/run/optimizer-reporter/project/scala-native.sbt
@@ -1,0 +1,10 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scala-native" % "sbt-scala-native" % pluginVersion)
+}
+
+resolvers += Resolver.sonatypeRepo("snapshots")

--- a/scripted-tests/run/optimizer-reporter/src/main/scala/Hello.scala
+++ b/scripted-tests/run/optimizer-reporter/src/main/scala/Hello.scala
@@ -1,0 +1,3 @@
+object Main {
+  def main(args: Array[String]): Unit = ()
+}

--- a/scripted-tests/run/optimizer-reporter/test
+++ b/scripted-tests/run/optimizer-reporter/test
@@ -1,0 +1,2 @@
+> nativeLink
+> check

--- a/tools/src/main/scala/scala/scalanative/linker/Reporter.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reporter.scala
@@ -1,0 +1,78 @@
+package scala.scalanative
+package linker
+
+import java.io.{File, PrintWriter}
+import nir.Global
+import nir.Shows._
+import util.sh
+
+/** Linking reporters can override one of the corresponding methods to
+ *  get notified whenever one of the linking events happens.
+ */
+trait Reporter {
+
+  /** Gets called whenever linking starts. */
+  def onStart(): Unit = ()
+
+  /** Gets called whenever a new entry point is discovered. */
+  def onEntry(global: Global): Unit = ()
+
+  /** Gets called whenever a new definition is loaded from nir path. */
+  def onResolved(global: Global): Unit = ()
+
+  /** Gets called whenever linker fails to resolve a global. */
+  def onUnresolved(globa: Global): Unit = ()
+
+  /** Gets called whenever a new direct dependency is discovered. */
+  def onDirectDependency(from: Global, to: Global): Unit = ()
+
+  /** Gets called whenever a new conditional dependency is discovered. */
+  def onConditionalDependency(from: Global, to: Global, cond: Global): Unit =
+    ()
+
+  /** Gets called whenever linking is complete. */
+  def onComplete(): Unit = ()
+}
+
+object Reporter {
+
+  /** Default no-op reporter. */
+  val empty = new Reporter {}
+
+  /** Generate dot file for observed dependency graph. */
+  def toFile(file: File): Reporter = new Reporter {
+    private var writer: PrintWriter = _
+
+    private def writeStart(): Unit = {
+      writer = new PrintWriter(file)
+      writer.println("digraph G {")
+    }
+
+    private def writeEdge(from: Global, to: Global): Unit = {
+      def quoted(s: String) = "\"" + s + "\""
+      writer.print(quoted(sh"$from".toString))
+      writer.print("->")
+      writer.print(quoted(sh"$to".toString))
+      writer.println(";")
+    }
+
+    private def writeEnd(): Unit = {
+      writer.println("}")
+      writer.close()
+    }
+
+    override def onStart(): Unit =
+      writeStart()
+
+    override def onDirectDependency(from: Global, to: Global): Unit =
+      writeEdge(from, to)
+
+    override def onConditionalDependency(from: Global,
+                                         to: Global,
+                                         cond: Global): Unit =
+      writeEdge(from, to)
+
+    override def onComplete(): Unit =
+      writeEnd()
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/optimizer/Reporter.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Reporter.scala
@@ -1,0 +1,51 @@
+package scala.scalanative
+package optimizer
+
+import java.io.File
+import java.nio.file.Paths
+import scalanative.nir.Defn
+import scalanative.nir.serialization.serializeText
+import scalanative.io.{withScratchBuffer, VirtualDirectory}
+
+trait Reporter {
+
+  /** Gets called whenever optimizations starts. */
+  def onStart(assembly: Seq[Defn]): Unit = ()
+
+  /** Gets called right after pass transforms the assembly. */
+  def onPass(pass: Pass, assembly: Seq[nir.Defn]): Unit = ()
+
+  /** Gets called with final result of optimization. */
+  def onComplete(assembly: Seq[Defn]): Unit = ()
+}
+
+object Reporter {
+
+  /** Default no-op reporter. */
+  val empty: Reporter = new Reporter {}
+
+  /** Dump textual NIR after every pass to given directory. */
+  def toDirectory(file: File): Reporter = new Reporter {
+    private var last: Int             = _
+    private var dir: VirtualDirectory = _
+
+    private def debug(assembly: Seq[Defn], suffix: String) =
+      withScratchBuffer { buffer =>
+        serializeText(assembly, buffer)
+        buffer.flip
+        dir.write(Paths.get(s"out.$suffix.hnir"), buffer)
+      }
+
+    override def onStart(assembly: Seq[Defn]): Unit = {
+      last = 0
+      dir = VirtualDirectory.local(file)
+      debug(assembly, "00")
+    }
+
+    override def onPass(pass: Pass, assembly: Seq[nir.Defn]): Unit = {
+      last += 1
+      val padded = if (last < 10) "0" + last else "" + last
+      debug(assembly, padded + "-" + pass.getClass.getSimpleName)
+    }
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/tools/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/tools/Config.scala
@@ -10,7 +10,7 @@ sealed trait Config {
   def entry: Global
 
   /** Sequence of all NIR locations. */
-  def paths: Seq[Path]
+  def paths: Seq[LinkerPath]
 
   /** Directory to emit intermediate compilation results. */
   def targetDirectory: VirtualDirectory
@@ -18,29 +18,17 @@ sealed trait Config {
   /** Should a main method be injected? */
   def injectMain: Boolean
 
-  /** Check IR for well-formedness. */
-  def check: Boolean
-
-  /** Log extra debugging information. */
-  def verbose: Boolean
-
   /** Create new config with given entry point. */
   def withEntry(value: Global): Config
 
   /** Create a new config with given nir paths. */
-  def withPaths(value: Seq[Path]): Config
+  def withPaths(value: Seq[LinkerPath]): Config
 
   /** Create a new config with given directory. */
   def withTargetDirectory(value: VirtualDirectory): Config
 
   /** Create a new config with given inject main flag. */
   def withInjectMain(value: Boolean): Config
-
-  /** Create a new config with given check flag. */
-  def withCheck(value: Boolean): Config
-
-  /** Create a new config with given verbose flag. */
-  def withVerbose(value: Boolean): Config
 }
 
 object Config {
@@ -50,21 +38,17 @@ object Config {
     Impl(entry = Global.None,
          paths = Seq.empty,
          targetDirectory = VirtualDirectory.empty,
-         injectMain = true,
-         check = false,
-         verbose = false)
+         injectMain = true)
 
   private final case class Impl(entry: Global,
-                                paths: Seq[Path],
+                                paths: Seq[LinkerPath],
                                 targetDirectory: VirtualDirectory,
-                                injectMain: Boolean,
-                                check: Boolean,
-                                verbose: Boolean)
+                                injectMain: Boolean)
       extends Config {
     def withEntry(value: Global): Config =
       copy(entry = value)
 
-    def withPaths(value: Seq[Path]): Config =
+    def withPaths(value: Seq[LinkerPath]): Config =
       copy(paths = value)
 
     def withTargetDirectory(value: VirtualDirectory): Config =
@@ -72,11 +56,5 @@ object Config {
 
     def withInjectMain(value: Boolean): Config =
       copy(injectMain = value)
-
-    def withCheck(value: Boolean): Config =
-      copy(check = value)
-
-    def withVerbose(value: Boolean): Config =
-      copy(verbose = value)
   }
 }


### PR DESCRIPTION
Reporters supersede harcoded `nativeEmitDependencyGraph`
and `nativeVerbose` options that were used to debug the
scala native toolchain before.