### PR TITLE
Scoped resource management

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -8,6 +8,7 @@ import ScalaNativePlugin.autoImport._
 import scalanative.nir
 import scalanative.tools
 import scalanative.io.VirtualDirectory
+import scalanative.util.{Scope => ResourceScope}
 
 import sbt._, Keys._, complete.DefaultParsers._
 import xsbti.{Maybe, Reporter, Position, Severity, Problem}
@@ -199,7 +200,7 @@ object ScalaNativePluginInternal {
     artifactPath in nativeLink := {
       (crossTarget in Compile).value / (moduleName.value + "-out")
     },
-    nativeLink := {
+    nativeLink := ResourceScope { implicit in =>
       val mainClass = (selectMainClass in Compile).value.getOrElse(
         throw new MessageOnlyException("No main class detected.")
       )

--- a/tools/src/main/scala/scala/scalanative/linker/Linker.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Linker.scala
@@ -6,7 +6,7 @@ import scala.collection.mutable
 import nir._
 import nir.serialization._
 import nir.Shows._
-import util.sh
+import util.Scope
 
 sealed trait Linker {
 
@@ -84,8 +84,6 @@ object Linker {
         processDirect
         processConditional
       }
-
-      config.paths.foreach(_.close)
 
       (unresolved.toSeq, links.toSeq, defns.sortBy(_.name.toString).toSeq)
     }

--- a/tools/src/main/scala/scala/scalanative/linker/Path.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Path.scala
@@ -5,6 +5,7 @@ import nir.{Global, Dep, Attr, Defn}
 import nir.serialization.BinaryDeserializer
 import java.nio.file.FileSystems
 import scalanative.io.VirtualDirectory
+import scalanative.util.Scope
 
 sealed trait Path {
 
@@ -13,9 +14,6 @@ sealed trait Path {
 
   /** Load given global and info about its dependencies. */
   def load(name: Global): Option[(Seq[Dep], Seq[Attr.Link], Defn)]
-
-  /** Dispose of given nir path. */
-  def close(): Unit
 }
 
 object Path {
@@ -45,7 +43,5 @@ object Path {
       entries.get(name.top).flatMap { deserializer =>
         deserializer.deserialize(name)
       }
-
-    def close = directory.close()
   }
 }

--- a/util/src/main/scala/scala/scalanative/util/Scope.scala
+++ b/util/src/main/scala/scala/scalanative/util/Scope.scala
@@ -1,0 +1,59 @@
+package scala.scalanative
+package util
+
+/** Scoped implicit lifetime.
+ *
+ *  The main idea behind the Scope is to encode resource lifetimes through
+ *  a concept of an implicit scope. Scopes are necessary to acquire resources.
+ *  They are responsible for disposal of the resources once the evaluation exits
+ *  the demarkated block in the source code.
+ *
+ *  See https://www.youtube.com/watch?v=MV2eJkwarT4 for details.
+ */
+@annotation.implicitNotFound(msg = "Resource acquisition requires a scope.")
+trait Scope {
+
+  /** Push resource onto the resource stack. */
+  def acquire(res: Resource): Unit
+
+  /** Clean up all the resources in FIFO order. */
+  def close(): Unit
+}
+
+object Scope {
+
+  /** Opens an implicit scope, evaluates the function and cleans up all the
+   *  resources as soon as execution leaves the demercated block.
+   */
+  def apply[T](f: Scope => T): T = {
+    val scope = new Impl()
+    try f(scope)
+    finally scope.close()
+  }
+
+  /** Scope that never closes. Resources allocated in this scope are
+   *  going to be acquired as long as application is running.
+   */
+  val forever: Scope = new Impl {
+    override def close(): Unit =
+      throw new UnsupportedOperationException("Can't close forever Scope.")
+  }
+
+  private sealed class Impl extends Scope {
+    private[this] var resources: List[Resource] = Nil
+
+    def acquire(res: Resource): Unit = {
+      resources ::= res
+    }
+
+    def close(): Unit = resources match {
+      case Nil =>
+        ()
+
+      case first :: rest =>
+        resources = rest
+        try first.close()
+        finally close()
+    }
+  }
+}

--- a/util/src/main/scala/scala/scalanative/util/package.scala
+++ b/util/src/main/scala/scala/scalanative/util/package.scala
@@ -17,4 +17,20 @@ package object util {
   final case class UnsupportedException(msg: String) extends Exception(msg)
   def unsupported(v: Any = "") =
     throw UnsupportedException(s"$v (${v.getClass})")
+
+  /** Scope-managed resource. */
+  type Resource = java.lang.AutoCloseable
+
+  /** Acquire given resource in implicit scope. */
+  def acquire[R <: Resource](res: R)(implicit in: Scope): R = {
+    in.acquire(res)
+    res
+  }
+
+  /** Defer cleanup until the scope closes. */
+  def defer(f: => Unit)(implicit in: Scope): Unit = {
+    in.acquire(new Resource {
+      def close(): Unit = f
+    })
+  }
 }


### PR DESCRIPTION
This should make it impossible to forget to close resources in
our codebase ever again, by construction. For example we used to
forget to close directories before which caused
`java.nio.file.FileSystemAlreadyExistsException` to be thrown.