### PR TITLE
Fix #404

### DIFF
--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -6,7 +6,7 @@ import scala.scalanative.runtime.Type
 final class _Class[A](val ty: Ptr[Type]) {
   def getName(): String = (!ty).name
 
-  override def hashCode: Int = ty.cast[Long].##
+  override def hashCode: Int = ty.cast[scala.Long].##
 
   override def equals(other: Any): scala.Boolean = other match {
     case other: _Class[_] =>

--- a/unit-tests/src/main/scala/scala/scalanative/issues/_404Suite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/issues/_404Suite.scala
@@ -1,0 +1,8 @@
+package scala.scalanative.issues
+
+object _404Suite extends tests.Suite {
+  test("#404") {
+    // this must not throw an exception
+    this.getClass.##
+  }
+}


### PR DESCRIPTION
Hash code on `java.lang.Class` used to throw due incorrect cast
to `jave.lang.Long` instead of intended `scala.Long`.