### PR TITLE
Add overrides to make scala.Symbol work

### DIFF
--- a/sandbox/Test.scala
+++ b/sandbox/Test.scala
@@ -2,6 +2,6 @@ import scalanative.native._, stdlib._, stdio._
 
 object Test {
   def main(args: Array[String]): Unit = {
-    println("Hello, world!")
+    println('foo)
   }
 }

--- a/scalalib/overrides-2.11/scala/Symbol.scala
+++ b/scalalib/overrides-2.11/scala/Symbol.scala
@@ -1,0 +1,31 @@
+package scala
+
+// Ported from Scala.js.
+// Modified to use collection.mutable.Map instead of java.util.WeakHashMap.
+
+final class Symbol private (val name: String) extends Serializable {
+  override def toString(): String = "'" + name
+
+  @throws(classOf[java.io.ObjectStreamException])
+  private def readResolve(): Any = Symbol.apply(name)
+  override def hashCode = name.hashCode()
+  override def equals(other: Any) = this eq other.asInstanceOf[AnyRef]
+}
+
+object Symbol extends UniquenessCache[Symbol] {
+  override def apply(name: String): Symbol = super.apply(name)
+  protected def valueFromKey(name: String): Symbol = new Symbol(name)
+  protected def keyFromValue(sym: Symbol): Option[String] = Some(sym.name)
+}
+
+private[scala] abstract class UniquenessCache[V] {
+  private val cache = collection.mutable.Map.empty[String, V]
+
+  protected def valueFromKey(k: String): V
+  protected def keyFromValue(v: V): Option[String]
+
+  def apply(name: String): V =
+    cache.getOrElseUpdate(name, valueFromKey(name))
+
+  def unapply(other: V): Option[String] = keyFromValue(other)
+}

--- a/unit-tests/src/main/scala/scala/SymbolSuite.scala
+++ b/unit-tests/src/main/scala/scala/SymbolSuite.scala
@@ -1,0 +1,40 @@
+package scala
+
+object SymbolSuite extends tests.Suite {
+  def foo1: scala.Symbol = 'foo
+  def foo2: scala.Symbol = scala.Symbol("foo")
+  def bar: scala.Symbol  = 'bar
+
+  test("symbols are interned") {
+    assert(foo1 eq foo2)
+  }
+
+  test("symbols have names") {
+    assert(foo1.name == "foo")
+    assert(foo2.name == "foo")
+    assert(bar.name == "bar")
+  }
+
+  test("symbol hash code is name hash code") {
+    assert(foo1.hashCode == "foo".hashCode)
+    assert(foo2.hashCode == "foo".hashCode)
+    assert(bar.hashCode == "bar".hashCode)
+  }
+
+  test("symbol equality") {
+    assert(foo1 == foo1)
+    assert(foo2 == foo2)
+    assert(foo1 == foo2)
+    assert(foo2 == foo1)
+    assert(foo1 != bar)
+    assert(foo2 != bar)
+    assert(bar != foo1)
+    assert(bar != foo2)
+    assert(bar == bar)
+  }
+
+  test("symbol unapply") {
+    val scala.Symbol(name) = foo1
+    assert(name == "foo")
+  }
+}


### PR DESCRIPTION
The original implementation relies on WeakHashMap which we don't support yet.

Fixes #430.