### PR TITLE
Add a pass to reduce block parameters with known values

### DIFF
--- a/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
@@ -25,6 +25,7 @@ object Driver {
         pass.GlobalBoxingElimination,
         pass.UnitSimplification,
         pass.DeadCodeElimination,
+        pass.BlockParamReduction,
         pass.Canonicalization,
         pass.GlobalValueNumbering,
         pass.MainInjection,

--- a/tools/src/main/scala/scala/scalanative/optimizer/analysis/SuppliedArguments.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/analysis/SuppliedArguments.scala
@@ -1,0 +1,70 @@
+package scala.scalanative
+package optimizer
+package analysis
+
+import ControlFlow.Block
+import nir.{Local, Val, Next}
+import scala.collection.mutable
+
+class SuppliedArguments(val cfg: ControlFlow.Graph,
+                        val forBlock: Map[Local, Seq[Set[Val]]]) {
+
+  // For each block name, tells whether each of its parameters have a known value (Some(v)) or not (None)
+  lazy val paramValues: Map[Local, Seq[Option[Val]]] = {
+    cfg.all.map { b =>
+      if (b.name == cfg.entry.name)
+        (b.name -> Seq.fill(b.params.size)(None))
+      else
+        (b.name -> reduceParams(b))
+    }.toMap
+  }
+
+  private def reduceParams(block: Block): Seq[Option[Val]] = {
+    forBlock.get(block.name) match {
+      case Some(args) =>
+        block.params.zip(args).map {
+          case (param, argValues) =>
+            val noRecArgs = argValues - param
+            if (noRecArgs.size == 1)
+              Some(noRecArgs.head)
+            else
+              None
+        }
+
+      // handles block that are unreachable, or reachable only through non-Next.Label nexts (like Success or Case)
+      case None => Seq.fill(block.params.size)(None)
+    }
+  }
+}
+
+object SuppliedArguments {
+
+  def apply(cfg: ControlFlow.Graph): SuppliedArguments = {
+    val argGatherer = new ArgGatherer
+    cfg.all.foreach(b => argGatherer(b.insts.last))
+    new SuppliedArguments(cfg, argGatherer.result)
+  }
+
+  class ArgGatherer extends Pass {
+
+    private val supplied = mutable.HashMap.empty[Local, Seq[Set[Val]]]
+
+    def result = supplied.toMap
+
+    override def preNext = {
+      case next @ Next.Label(name, args) =>
+        addArgs(name, args)
+        next
+    }
+
+    private def addArgs(name: Local, args: Seq[Val]): Unit = {
+      val suppliedArgs =
+        supplied.getOrElse(name, Seq.fill(args.size)(Set.empty[Val]))
+      assert(suppliedArgs.size == args.size)
+      val newSuppliedArgs =
+        suppliedArgs.zip(args).map { case (set, v) => set + v }
+      supplied += (name -> newSuppliedArgs)
+    }
+  }
+
+}

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/BlockParamReduction.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/BlockParamReduction.scala
@@ -1,0 +1,61 @@
+package scala.scalanative
+package optimizer
+package pass
+
+import analysis.ControlFlow
+import analysis.ClassHierarchy.Top
+import analysis.SuppliedArguments
+
+import nir._
+import Inst.Let
+
+class BlockParamReduction extends Pass {
+  import BlockParamReduction._
+
+  override def preDefn = {
+    case defn: Defn.Define =>
+      val cfg = ControlFlow.Graph(defn.insts)
+
+      val suppliedArgs = SuppliedArguments(cfg)
+      val changeParams = new ParamChanger(suppliedArgs)
+
+      changeParams(defn)
+  }
+
+}
+
+object BlockParamReduction extends PassCompanion {
+  def apply(config: tools.Config, top: Top) =
+    new BlockParamReduction
+
+  class ParamChanger(val suppliedArgs: SuppliedArguments) extends Pass {
+    /* On block labels, copy the known argument values, and remove the
+     * corresponding parameters
+     */
+    override def preInst = {
+      case Inst.Label(name, params) =>
+        val paramVals = suppliedArgs.paramValues(name)
+
+        val newParams = params.zip(paramVals).collect {
+          case (param, None) => param
+        }
+        val argCopies = params.zip(paramVals).collect {
+          case (param, Some(value)) =>
+            Let(param.name, Op.Copy(value))
+        }
+
+        val newLabel = Inst.Label(name, newParams)
+        newLabel +: argCopies
+    }
+
+    // On nexts, ignore the deleted parameters of the target block
+    override def preNext = {
+      case Next.Label(name, args) =>
+        val newArgs = args.zip(suppliedArgs.paramValues(name)).collect {
+          case (arg, None) => arg
+        }
+        Next.Label(name, newArgs)
+    }
+  }
+
+}


### PR DESCRIPTION
Add a pass to reduce block parameters with known values. The parameters are then removed, and replaced with their value.
This also adds an analysis that gathers all the arguments supplied to a block parameters'.