### PR TITLE
Scalafmt wrapper script must account for the version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ _build/
 .idea
 _build/
 bin/.coursier
-bin/.scalafmt
+bin/.scalafmt*

--- a/bin/scalafmt
+++ b/bin/scalafmt
@@ -3,15 +3,18 @@
 # set -x
 
 HERE="`dirname $0`"
+VERSION="0.5.1"
+COURSIER="$HERE/.coursier"
+SCALAFMT="$HERE/.scalafmt-$VERSION"
 
-if [ ! -f $HERE/.coursier ]; then
-  curl -L -o $HERE/.coursier https://git.io/vgvpD
-  chmod +x $HERE/.coursier
+if [ ! -f $COURSIER ]; then
+  curl -L -o $COURSIER https://git.io/vgvpD
+  chmod +x $COURSIER
 fi
 
-if [ ! -f $HERE/.scalafmt ]; then
-  $HERE/.coursier bootstrap com.geirsson:scalafmt-cli_2.11:0.5.1 --main org.scalafmt.cli.Cli -o $HERE/.scalafmt
-  chmod +x $HERE/.scalafmt
+if [ ! -f $SCALAFMT ]; then
+  $COURSIER bootstrap com.geirsson:scalafmt-cli_2.11:$VERSION --main org.scalafmt.cli.Cli -o $SCALAFMT
+  chmod +x $SCALAFMT
 fi
 
-$HERE/.scalafmt "$@"
+$SCALAFMT "$@"


### PR DESCRIPTION
Previously it would not re-download newer binary if the version of the
scalafmt changed.