### PR TITLE
Add a canonicalization pass

### DIFF
--- a/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
@@ -25,6 +25,7 @@ object Driver {
         pass.GlobalBoxingElimination,
         pass.UnitSimplification,
         pass.DeadCodeElimination,
+        pass.Canonicalization,
         pass.GlobalValueNumbering,
         pass.MainInjection,
         pass.ExternHoisting,

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/Canonicalization.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/Canonicalization.scala
@@ -1,0 +1,53 @@
+package scala.scalanative
+package optimizer
+package pass
+
+import analysis.ClassHierarchy._
+import nir._, Inst.Let
+
+/** Moves constant operands in Op.Bin and Op.Comp to the right. */
+class Canonicalization extends Pass {
+
+  override def preInst = {
+    case Let(n, Op.Bin(bin, ty, lhs, rhs))
+        if (commutativeBin(bin) && scalarValue(lhs)) =>
+      Seq(Let(n, Op.Bin(bin, ty, rhs, lhs)))
+
+    case Let(n, Op.Comp(comp, ty, lhs, rhs))
+        if (commutativeComp(comp) && scalarValue(lhs)) =>
+      Seq(Let(n, Op.Comp(comp, ty, rhs, lhs)))
+  }
+
+  // We DO NOT touch floating point operations at all
+  private def commutativeBin(bin: Bin): Boolean = {
+    import Bin._
+    bin match {
+      case Iadd | Imul | And | Or | Xor => true
+      case Fadd | Isub | Fsub | Fmul | Sdiv | Udiv | Fdiv | Srem | Urem |
+          Frem | Shl | Lshr | Ashr =>
+        false
+    }
+  }
+
+  private def commutativeComp(comp: Comp): Boolean = {
+    import Comp._
+    comp match {
+      case Ieq | Ine => true
+      case _         => false
+    }
+  }
+
+  private def scalarValue(value: Val): Boolean = {
+    import Val._
+    value match {
+      case _: Struct | _: Array | _: Local | _: Global | _: Const => false
+      case _                                                      => true
+    }
+  }
+
+}
+
+object Canonicalization extends PassCompanion {
+  override def apply(config: tools.Config, top: Top) =
+    new Canonicalization
+}


### PR DESCRIPTION
Add a canonicalization pass, which is very helpful for the InstCombine-like passes (coming in separate PRs).

Not sure I got all the constant and commutative ops right, comments on this are welcome.