### PR TITLE
Issue 208: Fix nested blocks pattern matching

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -1441,7 +1441,7 @@ abstract class NirCodeGen
           val Apply(Select(New(tpt), termNames.CONSTRUCTOR), ctorargs) = ctor
 
           assert(ctorargs.isEmpty,
-                 "Can't get function pointer to a closure with captures.")
+                 s"Can't get function pointer to a closure with captures: ${ctorargs} in application ${app}")
 
           val anondef = consumeLazyAnonDef(tpt.tpe.typeSymbol)
           val body    = anondef.impl.body
@@ -1922,8 +1922,8 @@ abstract class NirCodeGen
 
     object MaybeBlock {
       def unapply(tree: Tree): Some[Tree] = tree match {
-        case Block(Seq(), expr) => Some(expr)
-        case _                  => Some(tree)
+        case Block(Seq(), MaybeBlock(expr)) => Some(expr)
+        case _                              => Some(tree)
       }
     }
 

--- a/unit-tests/src/main/scala/scala/scalanative/IssuesSuite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/IssuesSuite.scala
@@ -1,6 +1,19 @@
 package scala.scalanative
+import native.CFunctionPtr1
 
 object IssuesSuite extends tests.Suite {
+
+  def foo(arg: Int): Unit                        = ()
+  def crash(arg: CFunctionPtr1[Int, Unit]): Unit = ()
+  def lifted208Test(): Unit                      = crash(foo _)
+
+  test("#208") {
+    // If we put the test directly, behind the scenes, this will
+    // create a nested closure with a pointer to the outer one
+    // and the latter is not supported in scala-native
+    lifted208Test()
+  }
+
   test("#253") {
     class Cell(val value: Int)
 


### PR DESCRIPTION
When one-parameter methods are converted to function pointers,
we eta-expand and apply the implicit conversion. At the same time
it seems that the function is then put (unnecessairly) in nested
block trees - Block(Seq(), Block(Seq(), expr)) - breaking the previous
pattern matching in the nscplugin.