### PR TITLE
Add support for runtime tags

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala
@@ -2,83 +2,82 @@
 package scala.scalanative
 package native
 
-import scalanative.runtime.undefined
-import scala.reflect.ClassTag
+import scalanative.runtime.{undefined, Tag}
 
 /** C-style function pointer. */
 sealed abstract class FunctionPtr
 
 object FunctionPtr {
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction0[R](f: Function0[R]): FunctionPtr0[R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction1[T1, R](f: Function1[T1, R]): FunctionPtr1[T1, R] =
     undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction2[T1, T2, R](
       f: Function2[T1, T2, R]): FunctionPtr2[T1, T2, R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction3[T1, T2, T3, R](
       f: Function3[T1, T2, T3, R]): FunctionPtr3[T1, T2, T3, R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction4[T1, T2, T3, T4, R](
       f: Function4[T1, T2, T3, T4, R]): FunctionPtr4[T1, T2, T3, T4, R] =
     undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction5[T1, T2, T3, T4, T5, R](
       f: Function5[T1, T2, T3, T4, T5, R])
     : FunctionPtr5[T1, T2, T3, T4, T5, R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction6[T1, T2, T3, T4, T5, T6, R](
       f: Function6[T1, T2, T3, T4, T5, T6, R])
     : FunctionPtr6[T1, T2, T3, T4, T5, T6, R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction7[T1, T2, T3, T4, T5, T6, T7, R](
       f: Function7[T1, T2, T3, T4, T5, T6, T7, R])
     : FunctionPtr7[T1, T2, T3, T4, T5, T6, T7, R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](
       f: Function8[T1, T2, T3, T4, T5, T6, T7, T8, R])
     : FunctionPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](
       f: Function9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R])
     : FunctionPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](
       f: Function10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R])
     : FunctionPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](
       f: Function11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R])
     : FunctionPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] =
     undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction12[T1,
                               T2,
@@ -97,7 +96,7 @@ object FunctionPtr {
     : FunctionPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] =
     undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction13[T1,
                               T2,
@@ -141,7 +140,7 @@ object FunctionPtr {
                                                                   R] =
     undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction14[T1,
                               T2,
@@ -186,10 +185,9 @@ object FunctionPtr {
                                        T12,
                                        T13,
                                        T14,
-                                       R] =
-    undefined
+                                       R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction15[T1,
                               T2,
@@ -237,10 +235,9 @@ object FunctionPtr {
                                        T13,
                                        T14,
                                        T15,
-                                       R] =
-    undefined
+                                       R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction16[T1,
                               T2,
@@ -293,7 +290,7 @@ object FunctionPtr {
                                        T16,
                                        R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction17[T1,
                               T2,
@@ -349,7 +346,7 @@ object FunctionPtr {
                                        T17,
                                        R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction18[T1,
                               T2,
@@ -408,7 +405,7 @@ object FunctionPtr {
                                        T18,
                                        R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction19[T1,
                               T2,
@@ -470,7 +467,7 @@ object FunctionPtr {
                                        T19,
                                        R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction20[T1,
                               T2,
@@ -535,7 +532,7 @@ object FunctionPtr {
                                        T20,
                                        R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction21[T1,
                               T2,
@@ -603,7 +600,7 @@ object FunctionPtr {
                                        T21,
                                        R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 14)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction22[T1,
                               T2,
@@ -674,77 +671,76 @@ object FunctionPtr {
                                        T22,
                                        R] = undefined
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 18)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 17)
+
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr0[R] extends FunctionPtr {
-  def apply()(implicit ct1: ClassTag[R]): R = undefined
+  def apply()(implicit tag1: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr1[T1, R] extends FunctionPtr {
-  def apply(arg1: T1)(implicit ct1: ClassTag[T1], ct2: ClassTag[R]): R =
-    undefined
+  def apply(arg1: T1)(implicit tag1: Tag[T1], tag2: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr2[T1, T2, R] extends FunctionPtr {
-  def apply(arg1: T1, arg2: T2)(implicit ct1: ClassTag[T1],
-                                ct2: ClassTag[T2],
-                                ct3: ClassTag[R]): R =
+  def apply(arg1: T1,
+            arg2: T2)(implicit tag1: Tag[T1], tag2: Tag[T2], tag3: Tag[R]): R =
     undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr3[T1, T2, T3, R] extends FunctionPtr {
-  def apply(arg1: T1, arg2: T2, arg3: T3)(implicit ct1: ClassTag[T1],
-                                          ct2: ClassTag[T2],
-                                          ct3: ClassTag[T3],
-                                          ct4: ClassTag[R]): R = undefined
+  def apply(arg1: T1, arg2: T2, arg3: T3)(implicit tag1: Tag[T1],
+                                          tag2: Tag[T2],
+                                          tag3: Tag[T3],
+                                          tag4: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr4[T1, T2, T3, T4, R] extends FunctionPtr {
-  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4)(implicit ct1: ClassTag[T1],
-                                                    ct2: ClassTag[T2],
-                                                    ct3: ClassTag[T3],
-                                                    ct4: ClassTag[T4],
-                                                    ct5: ClassTag[R]): R =
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4)(implicit tag1: Tag[T1],
+                                                    tag2: Tag[T2],
+                                                    tag3: Tag[T3],
+                                                    tag4: Tag[T4],
+                                                    tag5: Tag[R]): R =
     undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr5[T1, T2, T3, T4, T5, R] extends FunctionPtr {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5)(
-      implicit ct1: ClassTag[T1],
-      ct2: ClassTag[T2],
-      ct3: ClassTag[T3],
-      ct4: ClassTag[T4],
-      ct5: ClassTag[T5],
-      ct6: ClassTag[R]): R = undefined
+      implicit tag1: Tag[T1],
+      tag2: Tag[T2],
+      tag3: Tag[T3],
+      tag4: Tag[T4],
+      tag5: Tag[T5],
+      tag6: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr6[T1, T2, T3, T4, T5, T6, R] extends FunctionPtr {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6)(
-      implicit ct1: ClassTag[T1],
-      ct2: ClassTag[T2],
-      ct3: ClassTag[T3],
-      ct4: ClassTag[T4],
-      ct5: ClassTag[T5],
-      ct6: ClassTag[T6],
-      ct7: ClassTag[R]): R = undefined
+      implicit tag1: Tag[T1],
+      tag2: Tag[T2],
+      tag3: Tag[T3],
+      tag4: Tag[T4],
+      tag5: Tag[T5],
+      tag6: Tag[T6],
+      tag7: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr7[T1, T2, T3, T4, T5, T6, T7, R] extends FunctionPtr {
   def apply(arg1: T1,
@@ -753,17 +749,17 @@ final class FunctionPtr7[T1, T2, T3, T4, T5, T6, T7, R] extends FunctionPtr {
             arg4: T4,
             arg5: T5,
             arg6: T6,
-            arg7: T7)(implicit ct1: ClassTag[T1],
-                      ct2: ClassTag[T2],
-                      ct3: ClassTag[T3],
-                      ct4: ClassTag[T4],
-                      ct5: ClassTag[T5],
-                      ct6: ClassTag[T6],
-                      ct7: ClassTag[T7],
-                      ct8: ClassTag[R]): R = undefined
+            arg7: T7)(implicit tag1: Tag[T1],
+                      tag2: Tag[T2],
+                      tag3: Tag[T3],
+                      tag4: Tag[T4],
+                      tag5: Tag[T5],
+                      tag6: Tag[T6],
+                      tag7: Tag[T7],
+                      tag8: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R]
     extends FunctionPtr {
@@ -774,18 +770,18 @@ final class FunctionPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R]
             arg5: T5,
             arg6: T6,
             arg7: T7,
-            arg8: T8)(implicit ct1: ClassTag[T1],
-                      ct2: ClassTag[T2],
-                      ct3: ClassTag[T3],
-                      ct4: ClassTag[T4],
-                      ct5: ClassTag[T5],
-                      ct6: ClassTag[T6],
-                      ct7: ClassTag[T7],
-                      ct8: ClassTag[T8],
-                      ct9: ClassTag[R]): R = undefined
+            arg8: T8)(implicit tag1: Tag[T1],
+                      tag2: Tag[T2],
+                      tag3: Tag[T3],
+                      tag4: Tag[T4],
+                      tag5: Tag[T5],
+                      tag6: Tag[T6],
+                      tag7: Tag[T7],
+                      tag8: Tag[T8],
+                      tag9: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
     extends FunctionPtr {
@@ -797,19 +793,19 @@ final class FunctionPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
             arg6: T6,
             arg7: T7,
             arg8: T8,
-            arg9: T9)(implicit ct1: ClassTag[T1],
-                      ct2: ClassTag[T2],
-                      ct3: ClassTag[T3],
-                      ct4: ClassTag[T4],
-                      ct5: ClassTag[T5],
-                      ct6: ClassTag[T6],
-                      ct7: ClassTag[T7],
-                      ct8: ClassTag[T8],
-                      ct9: ClassTag[T9],
-                      ct10: ClassTag[R]): R = undefined
+            arg9: T9)(implicit tag1: Tag[T1],
+                      tag2: Tag[T2],
+                      tag3: Tag[T3],
+                      tag4: Tag[T4],
+                      tag5: Tag[T5],
+                      tag6: Tag[T6],
+                      tag7: Tag[T7],
+                      tag8: Tag[T8],
+                      tag9: Tag[T9],
+                      tag10: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
     extends FunctionPtr {
@@ -822,20 +818,20 @@ final class FunctionPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
             arg7: T7,
             arg8: T8,
             arg9: T9,
-            arg10: T10)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[R]): R = undefined
+            arg10: T10)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
     extends FunctionPtr {
@@ -849,21 +845,21 @@ final class FunctionPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
             arg8: T8,
             arg9: T9,
             arg10: T10,
-            arg11: T11)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[R]): R = undefined
+            arg11: T11)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
     extends FunctionPtr {
@@ -878,22 +874,22 @@ final class FunctionPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
             arg9: T9,
             arg10: T10,
             arg11: T11,
-            arg12: T12)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[T12],
-                        ct13: ClassTag[R]): R = undefined
+            arg12: T12)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[T12],
+                        tag13: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr13[
     T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
@@ -910,23 +906,23 @@ final class FunctionPtr13[
             arg10: T10,
             arg11: T11,
             arg12: T12,
-            arg13: T13)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[T12],
-                        ct13: ClassTag[T13],
-                        ct14: ClassTag[R]): R = undefined
+            arg13: T13)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[T12],
+                        tag13: Tag[T13],
+                        tag14: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr14[
     T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]
@@ -944,24 +940,24 @@ final class FunctionPtr14[
             arg11: T11,
             arg12: T12,
             arg13: T13,
-            arg14: T14)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[T12],
-                        ct13: ClassTag[T13],
-                        ct14: ClassTag[T14],
-                        ct15: ClassTag[R]): R = undefined
+            arg14: T14)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[T12],
+                        tag13: Tag[T13],
+                        tag14: Tag[T14],
+                        tag15: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr15[
     T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]
@@ -980,25 +976,25 @@ final class FunctionPtr15[
             arg12: T12,
             arg13: T13,
             arg14: T14,
-            arg15: T15)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[T12],
-                        ct13: ClassTag[T13],
-                        ct14: ClassTag[T14],
-                        ct15: ClassTag[T15],
-                        ct16: ClassTag[R]): R = undefined
+            arg15: T15)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[T12],
+                        tag13: Tag[T13],
+                        tag14: Tag[T14],
+                        tag15: Tag[T15],
+                        tag16: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr16[
     T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]
@@ -1018,26 +1014,26 @@ final class FunctionPtr16[
             arg13: T13,
             arg14: T14,
             arg15: T15,
-            arg16: T16)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[T12],
-                        ct13: ClassTag[T13],
-                        ct14: ClassTag[T14],
-                        ct15: ClassTag[T15],
-                        ct16: ClassTag[T16],
-                        ct17: ClassTag[R]): R = undefined
+            arg16: T16)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[T12],
+                        tag13: Tag[T13],
+                        tag14: Tag[T14],
+                        tag15: Tag[T15],
+                        tag16: Tag[T16],
+                        tag17: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr17[T1,
                           T2,
@@ -1074,27 +1070,27 @@ final class FunctionPtr17[T1,
             arg14: T14,
             arg15: T15,
             arg16: T16,
-            arg17: T17)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[T12],
-                        ct13: ClassTag[T13],
-                        ct14: ClassTag[T14],
-                        ct15: ClassTag[T15],
-                        ct16: ClassTag[T16],
-                        ct17: ClassTag[T17],
-                        ct18: ClassTag[R]): R = undefined
+            arg17: T17)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[T12],
+                        tag13: Tag[T13],
+                        tag14: Tag[T14],
+                        tag15: Tag[T15],
+                        tag16: Tag[T16],
+                        tag17: Tag[T17],
+                        tag18: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr18[T1,
                           T2,
@@ -1133,28 +1129,28 @@ final class FunctionPtr18[T1,
             arg15: T15,
             arg16: T16,
             arg17: T17,
-            arg18: T18)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[T12],
-                        ct13: ClassTag[T13],
-                        ct14: ClassTag[T14],
-                        ct15: ClassTag[T15],
-                        ct16: ClassTag[T16],
-                        ct17: ClassTag[T17],
-                        ct18: ClassTag[T18],
-                        ct19: ClassTag[R]): R = undefined
+            arg18: T18)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[T12],
+                        tag13: Tag[T13],
+                        tag14: Tag[T14],
+                        tag15: Tag[T15],
+                        tag16: Tag[T16],
+                        tag17: Tag[T17],
+                        tag18: Tag[T18],
+                        tag19: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr19[T1,
                           T2,
@@ -1195,29 +1191,29 @@ final class FunctionPtr19[T1,
             arg16: T16,
             arg17: T17,
             arg18: T18,
-            arg19: T19)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[T12],
-                        ct13: ClassTag[T13],
-                        ct14: ClassTag[T14],
-                        ct15: ClassTag[T15],
-                        ct16: ClassTag[T16],
-                        ct17: ClassTag[T17],
-                        ct18: ClassTag[T18],
-                        ct19: ClassTag[T19],
-                        ct20: ClassTag[R]): R = undefined
+            arg19: T19)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[T12],
+                        tag13: Tag[T13],
+                        tag14: Tag[T14],
+                        tag15: Tag[T15],
+                        tag16: Tag[T16],
+                        tag17: Tag[T17],
+                        tag18: Tag[T18],
+                        tag19: Tag[T19],
+                        tag20: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr20[T1,
                           T2,
@@ -1260,30 +1256,30 @@ final class FunctionPtr20[T1,
             arg17: T17,
             arg18: T18,
             arg19: T19,
-            arg20: T20)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[T12],
-                        ct13: ClassTag[T13],
-                        ct14: ClassTag[T14],
-                        ct15: ClassTag[T15],
-                        ct16: ClassTag[T16],
-                        ct17: ClassTag[T17],
-                        ct18: ClassTag[T18],
-                        ct19: ClassTag[T19],
-                        ct20: ClassTag[T20],
-                        ct21: ClassTag[R]): R = undefined
+            arg20: T20)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[T12],
+                        tag13: Tag[T13],
+                        tag14: Tag[T14],
+                        tag15: Tag[T15],
+                        tag16: Tag[T16],
+                        tag17: Tag[T17],
+                        tag18: Tag[T18],
+                        tag19: Tag[T19],
+                        tag20: Tag[T20],
+                        tag21: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr21[T1,
                           T2,
@@ -1328,31 +1324,31 @@ final class FunctionPtr21[T1,
             arg18: T18,
             arg19: T19,
             arg20: T20,
-            arg21: T21)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[T12],
-                        ct13: ClassTag[T13],
-                        ct14: ClassTag[T14],
-                        ct15: ClassTag[T15],
-                        ct16: ClassTag[T16],
-                        ct17: ClassTag[T17],
-                        ct18: ClassTag[T18],
-                        ct19: ClassTag[T19],
-                        ct20: ClassTag[T20],
-                        ct21: ClassTag[T21],
-                        ct22: ClassTag[R]): R = undefined
+            arg21: T21)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[T12],
+                        tag13: Tag[T13],
+                        tag14: Tag[T14],
+                        tag15: Tag[T15],
+                        tag16: Tag[T16],
+                        tag17: Tag[T17],
+                        tag18: Tag[T18],
+                        tag19: Tag[T19],
+                        tag20: Tag[T20],
+                        tag21: Tag[T21],
+                        tag22: Tag[R]): R = undefined
 }
 
-// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 25)
+// ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb", line: 24)
 
 final class FunctionPtr22[T1,
                           T2,
@@ -1399,27 +1395,27 @@ final class FunctionPtr22[T1,
             arg19: T19,
             arg20: T20,
             arg21: T21,
-            arg22: T22)(implicit ct1: ClassTag[T1],
-                        ct2: ClassTag[T2],
-                        ct3: ClassTag[T3],
-                        ct4: ClassTag[T4],
-                        ct5: ClassTag[T5],
-                        ct6: ClassTag[T6],
-                        ct7: ClassTag[T7],
-                        ct8: ClassTag[T8],
-                        ct9: ClassTag[T9],
-                        ct10: ClassTag[T10],
-                        ct11: ClassTag[T11],
-                        ct12: ClassTag[T12],
-                        ct13: ClassTag[T13],
-                        ct14: ClassTag[T14],
-                        ct15: ClassTag[T15],
-                        ct16: ClassTag[T16],
-                        ct17: ClassTag[T17],
-                        ct18: ClassTag[T18],
-                        ct19: ClassTag[T19],
-                        ct20: ClassTag[T20],
-                        ct21: ClassTag[T21],
-                        ct22: ClassTag[T22],
-                        ct23: ClassTag[R]): R = undefined
+            arg22: T22)(implicit tag1: Tag[T1],
+                        tag2: Tag[T2],
+                        tag3: Tag[T3],
+                        tag4: Tag[T4],
+                        tag5: Tag[T5],
+                        tag6: Tag[T6],
+                        tag7: Tag[T7],
+                        tag8: Tag[T8],
+                        tag9: Tag[T9],
+                        tag10: Tag[T10],
+                        tag11: Tag[T11],
+                        tag12: Tag[T12],
+                        tag13: Tag[T13],
+                        tag14: Tag[T14],
+                        tag15: Tag[T15],
+                        tag16: Tag[T16],
+                        tag17: Tag[T17],
+                        tag18: Tag[T18],
+                        tag19: Tag[T19],
+                        tag20: Tag[T20],
+                        tag21: Tag[T21],
+                        tag22: Tag[T22],
+                        tag23: Tag[R]): R = undefined
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/native/FunctionPtr.scala.gyb
@@ -1,8 +1,7 @@
 package scala.scalanative
 package native
 
-import scalanative.runtime.undefined
-import scala.reflect.ClassTag
+import scalanative.runtime.{undefined, Tag}
 
 /** C-style function pointer. */
 sealed abstract class FunctionPtr
@@ -20,11 +19,11 @@ object FunctionPtr {
 
 % for N in range(0, 23):
 %   args = ", ".join("arg" + str(i) + ": T" + str(i) for i in range(1, N+1))
-%   cttys = ["T" + str(i) for i in range(1, N+1)] + ["R"]
-%   ctargs = ", ".join("ct" + str(i+1) + ": ClassTag[" + ty + "]" for (i, ty) in enumerate(cttys))
+%   tagtys = ["T" + str(i) for i in range(1, N+1)] + ["R"]
+%   tagargs = ", ".join("tag" + str(i+1) + ": Tag[" + ty + "]" for (i, ty) in enumerate(tagtys))
 
 final class FunctionPtr${N}[${", ".join(["T" + str(i) for i in range(1, N+1)] + ["R"])}] extends FunctionPtr {
-  def apply(${args})(implicit ${ctargs}): R = undefined
+  def apply(${args})(implicit ${tagargs}): R = undefined
 }
 
 % end

--- a/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala
@@ -2,27 +2,26 @@ package scala.scalanative
 package native
 
 import scala.language.dynamics
-import scala.reflect.ClassTag
-import runtime.undefined
+import runtime.{undefined, Tag}
 
 /** The C `const T *` pointer. */
 final class Ptr[T] private () {
 
   /** Dereference a pointer. */
-  def unary_!(implicit ct: ClassTag[T]): T = undefined
+  def unary_!(implicit tag: Tag[T]): T = undefined
 
   /** Store a value to the address pointed at by a pointer. */
-  def `unary_!_=`(value: T)(implicit ct: ClassTag[T]): Unit = undefined
+  def `unary_!_=`(value: T)(implicit tag: Tag[T]): Unit = undefined
 
   /** Compute a derived pointer by adding given offset. */
-  def +(offset: Word)(implicit ct: ClassTag[T]): Ptr[T] = undefined
+  def +(offset: Word)(implicit tag: Tag[T]): Ptr[T] = undefined
 
-  /** Compute a derived pointer by substricting given offset. */
-  def -(offset: Word)(implicit ct: ClassTag[T]): Ptr[T] = undefined
+  /** Compute a derived pointer by subtracting given offset. */
+  def -(offset: Word)(implicit tag: Tag[T]): Ptr[T] = undefined
 
   /** Read a value at given offset. Equivalent to !(offset + word). */
-  def apply(offset: Word)(implicit ct: ClassTag[T]): T = undefined
+  def apply(offset: Word)(implicit tag: Tag[T]): T = undefined
 
   /** Store a value to given offset. Equivalent to !(offset + word) = value. */
-  def update(offset: Word, value: T)(implicit ct: ClassTag[T]): T = undefined
+  def update(offset: Word, value: T)(implicit tag: Tag[T]): T = undefined
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/Vararg.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Vararg.scala
@@ -2,12 +2,11 @@ package scala.scalanative
 package native
 
 import scala.language.implicitConversions
-import runtime.undefined
-import reflect.ClassTag
+import runtime.{undefined, Tag}
 
 /** Type of a C-style vararg in an extern method. */
 final class Vararg private ()
 
 object Vararg {
-  implicit def apply[T](value: T)(implicit ct: ClassTag[T]): Vararg = undefined
+  implicit def apply[T](value: T)(implicit tag: Tag[T]): Vararg = undefined
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/package.scala
@@ -1,9 +1,7 @@
 package scala.scalanative
 
 import java.nio.charset.Charset
-import scala.reflect.ClassTag
-import runtime.undefined
-import runtime.GC
+import runtime.{undefined, Tag, GC}
 
 package object native {
 
@@ -71,13 +69,13 @@ package object native {
   type CString = Ptr[CChar]
 
   /** The C 'sizeof' operator. */
-  def sizeof[T](implicit ct: ClassTag[T]): CSize = undefined
+  def sizeof[T](implicit tag: Tag[T]): CSize = undefined
 
   /** Stack allocate a value of given type. */
-  def stackalloc[T](implicit ct: ClassTag[T]): Ptr[T] = undefined
+  def stackalloc[T](implicit tag: Tag[T]): Ptr[T] = undefined
 
   /** Stack allocate n values of given type. */
-  def stackalloc[T](n: Int)(implicit ct: ClassTag[T]): Ptr[T] = undefined
+  def stackalloc[T](n: Int)(implicit tag: Tag[T]): Ptr[T] = undefined
 
   /** Used as right hand side of external method and field declarations. */
   def extern: Nothing = undefined
@@ -89,7 +87,7 @@ package object native {
 
   /** C-style unchecked cast. */
   implicit class CCast[From](val from: From) {
-    def cast[To](implicit fromct: ClassTag[From], toct: ClassTag[To]): To =
+    def cast[To](implicit fromtag: Tag[From], totag: Tag[To]): To =
       undefined
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Tag.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Tag.scala
@@ -1,0 +1,25 @@
+package scala.scalanative
+package runtime
+
+import scala.reflect.ClassTag
+import native._
+
+sealed trait Tag[P]
+
+object Tag {
+  implicit val Unit: Tag[Unit]                    = new Tag[Unit]    {}
+  implicit val Boolean: Tag[Boolean]              = new Tag[Boolean] {}
+  implicit val Char: Tag[Char]                    = new Tag[Char]    {}
+  implicit val Byte: Tag[Byte]                    = new Tag[Byte]    {}
+  implicit val UByte: Tag[UByte]                  = new Tag[UByte]   {}
+  implicit val Short: Tag[Short]                  = new Tag[Short]   {}
+  implicit val UShort: Tag[UShort]                = new Tag[UShort]  {}
+  implicit val Int: Tag[Int]                      = new Tag[Int]     {}
+  implicit val UInt: Tag[UInt]                    = new Tag[UInt]    {}
+  implicit val Long: Tag[Long]                    = new Tag[Long]    {}
+  implicit val ULong: Tag[ULong]                  = new Tag[ULong]   {}
+  implicit val Float: Tag[Float]                  = new Tag[Float]   {}
+  implicit val Double: Tag[Double]                = new Tag[Double]  {}
+  implicit def Ptr[T: Tag]: Tag[Ptr[T]]           = new Tag[Ptr[T]]  {}
+  implicit def Ref[T <: AnyRef: ClassTag]: Tag[T] = new Tag[T]       {}
+}

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -1,6 +1,5 @@
 package scala.scalanative
 
-import scala.reflect.ClassTag
 import native._
 import runtime.Intrinsics._
 
@@ -10,7 +9,7 @@ package object runtime {
   def undefined: Nothing = throw new UndefinedBehaviorError
 
   /** Returns info pointer for given type. */
-  def typeof[T](implicit ct: ClassTag[T]): Ptr[Type] = undefined
+  def typeof[T](implicit tag: Tag[T]): Ptr[Type] = undefined
 
   /** Intrinsified unsigned devision on ints. */
   def divUInt(l: Int, r: Int): Int = undefined
@@ -40,8 +39,8 @@ package object runtime {
   def intToULong(v: Int): Long = undefined
 
   /** Select value without branching. */
-  def select[T](cond: Boolean, thenp: T, elsep: T)(
-      implicit ct: ClassTag[T]): T = undefined
+  def select[T](cond: Boolean, thenp: T, elsep: T)(implicit tag: Tag[T]): T =
+    undefined
 
   /** Allocate memory in gc heap using given info pointer. */
   def alloc(ty: Ptr[Type], size: CSize): Ptr[_] = {

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -64,6 +64,23 @@ trait NirDefinitions { self: NirGlobalAddons =>
       getDecl(FunctionPtrModule, TermName("fromFunction" + n))
     }
 
+    lazy val TagModule        = getRequiredModule("scala.scalanative.runtime.Tag")
+    lazy val UnitTagMethod    = getDecl(TagModule, TermName("Unit"))
+    lazy val BooleanTagMethod = getDecl(TagModule, TermName("Boolean"))
+    lazy val CharTagMethod    = getDecl(TagModule, TermName("Char"))
+    lazy val ByteTagMethod    = getDecl(TagModule, TermName("Byte"))
+    lazy val UByteTagMethod   = getDecl(TagModule, TermName("UByte"))
+    lazy val ShortTagMethod   = getDecl(TagModule, TermName("Short"))
+    lazy val UShortTagMethod  = getDecl(TagModule, TermName("UShort"))
+    lazy val IntTagMethod     = getDecl(TagModule, TermName("Int"))
+    lazy val UIntTagMethod    = getDecl(TagModule, TermName("UInt"))
+    lazy val LongTagMethod    = getDecl(TagModule, TermName("Long"))
+    lazy val ULongTagMethod   = getDecl(TagModule, TermName("ULong"))
+    lazy val FloatTagMethod   = getDecl(TagModule, TermName("Float"))
+    lazy val DoubleTagMethod  = getDecl(TagModule, TermName("Double"))
+    lazy val PtrTagMethod     = getDecl(TagModule, TermName("Ptr"))
+    lazy val RefTagMethod     = getDecl(TagModule, TermName("Ref"))
+
     // Native runtime
 
     lazy val RuntimePackage = getPackage(TermName("scala.scalanative.runtime"))

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirTypeEncoding.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirTypeEncoding.scala
@@ -10,7 +10,7 @@ trait NirTypeEncoding { self: NirCodeGen =>
   import nirDefinitions._
   import SimpleType.{fromType, fromSymbol}
 
-  final case class SimpleType(sym: Symbol, targs: Seq[SimpleType]) {
+  final case class SimpleType(sym: Symbol, targs: Seq[SimpleType] = Seq.empty) {
     def isInterface: Boolean =
       sym.isInterface
 


### PR DESCRIPTION
Runtime tags is the way how we smuggle types across the erasure border.
Previously we used ClassTags for the same purpuose, the only problem
with those is that they don't scale that well to capture all the
necessary information about generic types we care about (e.g. pointers,
tuples etc.)