### PR TITLE
Make @struct a private runtime specific API

### DIFF
--- a/demo/native/smallpt.scala
+++ b/demo/native/smallpt.scala
@@ -1,6 +1,7 @@
 package demo
 
 import scalanative.native._, stdlib._, stdio._
+import scalanative.runtime.struct
 import java.lang.Math.{PI, sin, cos, abs, pow, sqrt}
 
 @struct

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -14,7 +14,9 @@ Extern objects are simple wrapper objects that demarcate scopes where methods
 and fields are treated as their native C ABI-friendly counterparts. They are
 roughly analagous to header files in C.
 
-For example to call C's ``malloc`` one might declare it as following::
+For example to call C's ``malloc`` one might declare it as following:
+
+.. code-block:: scala
 
     @extern object libc {
       def malloc(size: CSize): Ptr[Byte] = extern
@@ -28,11 +30,15 @@ of the extern function must match the signature of the original C function
 
 Apart from calling extern methods, one may also observe global state
 defined in native libraries. To access global variable ``myvariable``
-defined in C::
+defined in C:
+
+.. code-block:: c
 
     int myvariable;
 
-One can declare it as following in Scala::
+One can declare it as following in Scala:
+
+.. code-block:: scala
 
     @extern object mylib {
       var myvariable: CInt = extern
@@ -89,7 +95,9 @@ Linking with native libraries
 
 In C/C++ one has to typically pass an additional ``-l mylib`` flag to link with
 a library. In Scala Native one can annotate libraries to link with using
-``@link`` annotation::
+``@link`` annotation:
+
+.. code-block:: scala
 
    @link("mylib")
    @extern object mylib {
@@ -103,7 +111,9 @@ Variadic functions
 ``````````````````
 
 One can declare variadic functions like ``printf`` using ``CVararg`` auxiliary
-type::
+type:
+
+.. code-block:: scala
 
    @extern object stdio {
      def printf(format: CString, args: CVararg*): CInt = extern
@@ -130,11 +140,14 @@ Memory layout types are auxiliary types that let one specify memory layout of
 unmanaged memory. They are meant to be used purely in combination with pointers
 and do not have a corresponding first-class values backing them.
 
-* ``Ptr[CStructN[T1, ..., TN]]``.
+* ``Ptr[CStructN[T1, ..., TN]]``
+
   Pointer to a C struct with up to 22 fields.
   Type parameters are the types of corresponding fields.
   One may access fields of the struct using ``_N`` helper
-  methods on a pointer value::
+  methods on a pointer value:
+
+  .. code-block:: scala
 
       val ptr = stackalloc[CStruct[Int, Int]]
       !ptr._1 = 10
@@ -144,17 +157,23 @@ and do not have a corresponding first-class values backing them.
   Here ``_N`` computes a derived pointer that corresponds to memory
   occupied by field number N.
 
-* ``Ptr[CArray[T, N]]``.
+* ``Ptr[CArray[T, N]]``
+
   Pointer to a C array with statically-known length ``N``. Length is encoded as
   a type-level natural number. Natural numbers are types that are composed of
   base naturals ``Nat._0, ... Nat._9`` and an additional ``Nat.Digit``
   constructor. So for example number ``1024`` is going to be encoded as
   following:
 
+  .. code-block:: scala
+
       import scalanative.Nat._
+
       type _1024 = Digit[_1, Digit[_0, Digit[_2, _4]]]
 
   Once you have a natural for the length, it can be used as an array length:
+
+  .. code-block:: scala
 
       val ptr = stackalloc[CArray[Byte, _1024]]
 

--- a/nativelib/src/main/scala/scala/scalanative/native/math.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/math.scala
@@ -9,9 +9,6 @@ object math {
   def abs(x: CInt): CInt                                      = extern
   def labs(x: CLong): CLong                                   = extern
   def llabs(x: CLongLong): CLongLong                          = extern
-  def div(x: CInt, y: CInt): div_t                            = extern
-  def ldiv(x: CLong, y: CLong): ldiv_t                        = extern
-  def lldiv(x: CLongLong, y: CLongLong): lldiv_t              = extern
   def fabsf(arg: CFloat): CFloat                              = extern
   def fabs(arg: CDouble): CDouble                             = extern
   def fmodf(x: CFloat, y: CFloat): CFloat                     = extern
@@ -143,12 +140,6 @@ object math {
   def nextafter(from: CDouble, to: CDouble): CDouble  = extern
   def copysignf(x: CFloat, y: CFloat): CFloat         = extern
   def copysign(x: CDouble, y: CDouble): CDouble       = extern
-
-  // Types
-
-  @struct class div_t(val x: CInt, val y: CInt)
-  @struct class ldiv_t(val x: CLong, val y: CLong)
-  @struct class lldiv_t(val x: CLongLong, val y: CLongLong)
 
   // Macros
 

--- a/nativelib/src/main/scala/scala/scalanative/native/signal.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/signal.scala
@@ -11,10 +11,6 @@ object signal {
     extern
   def raise(sig: CInt): CInt = extern
 
-  // Types
-
-  @struct class sig_atomic_t private ()
-
   // Macros
 
   @name("scalanative_libc_sig_dfl")

--- a/nativelib/src/main/scala/scala/scalanative/native/stdio.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/stdio.scala
@@ -83,8 +83,8 @@ object stdio {
 
   // Types
 
-  @struct class FILE private ()
-  @struct class fpos_t private ()
+  type FILE   = CStruct0
+  type fpos_t = CStruct0
 
   // Macros
 

--- a/nativelib/src/main/scala/scala/scalanative/native/stdlib.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/stdlib.scala
@@ -49,10 +49,6 @@ object stdlib {
   def strtof(str: CString, str_end: Ptr[CString]): CFloat  = extern
   def strtod(str: CString, str_end: Ptr[CString]): CDouble = extern
 
-  // Types
-
-  @struct class jmp_buf private ()
-
   // Macros
 
   @name("scalanative_libc_exit_success")

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Type.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Type.scala
@@ -1,6 +1,4 @@
 package scala.scalanative
 package runtime
 
-import native.{struct, Ptr}
-
 @struct class Type(val id: Int, val name: String)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/struct.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/struct.scala
@@ -1,5 +1,5 @@
 package scala.scalanative
-package native
+package runtime
 
 /** An annotation that is used to mark classes to be
  *  optimized as immutable pass-by-value structures.

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -31,7 +31,6 @@ trait NirDefinitions { self: NirGlobalAddons =>
     lazy val NameClass   = getRequiredClass("scala.scalanative.native.name")
     lazy val LinkClass   = getRequiredClass("scala.scalanative.native.link")
     lazy val ExternClass = getRequiredClass("scala.scalanative.native.extern")
-    lazy val StructClass = getRequiredClass("scala.scalanative.native.struct")
     lazy val PinClass    = getRequiredClass("scala.scalanative.native.pin")
 
     lazy val InlineHintClass = getRequiredClass(
@@ -105,6 +104,8 @@ trait NirDefinitions { self: NirGlobalAddons =>
     }
 
     // Native runtime
+
+    lazy val StructClass = getRequiredClass("scala.scalanative.runtime.struct")
 
     lazy val RuntimePackage = getPackage(TermName("scala.scalanative.runtime"))
 


### PR DESCRIPTION
This is a conclusion of #378. Memory layout types are now official way to interop with C structs and arrays. `@struct` remains as an internal implementation detail that might change without further detail in the future. 