### PR TITLE
Issue 475: Fix wrong array access using increments

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -507,8 +507,8 @@ object Character {
   }
 
   /* Conversions */
-  def toUpperCase(c: scala.Char): scala.Char = c.toString.toUpperCase()(0)
-  def toLowerCase(c: scala.Char): scala.Char = c.toString.toLowerCase()(0)
+  def toUpperCase(c: scala.Char): scala.Char = ???
+  def toLowerCase(c: scala.Char): scala.Char = ???
 
   def toChars(codePoint: Int): Array[Char] = {
     if (!isValidCodePoint(codePoint))

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -170,8 +170,8 @@ final class _String()
       if (count < string.count) offset + count
       else offset + string.count
     while (o1 < end) {
-      val c1: Char    = compareValue(value(o1))
-      val c2: Char    = compareValue(string.value(o2))
+      val c1: Char = compareValue(value(o1))
+      val c2: Char = compareValue(string.value(o2))
       o1 += 1
       o2 += 1
       val result: Int = c1 - c2

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -153,9 +153,9 @@ final class _String()
       if (count < string.count) offset + count
       else offset + string.count
     while (o1 < end) {
+      val result: Int = value(o1) - string.value(o2)
       o1 += 1
       o2 += 1
-      val result: Int = value(o1) - string.value(o2)
       if (result != 0) {
         return result
       }
@@ -170,10 +170,10 @@ final class _String()
       if (count < string.count) offset + count
       else offset + string.count
     while (o1 < end) {
-      o1 += 1
-      o2 += 1
       val c1: Char    = compareValue(value(o1))
       val c2: Char    = compareValue(string.value(o2))
+      o1 += 1
+      o2 += 1
       val result: Int = c1 - c2
       if (result != 0) {
         return result
@@ -237,10 +237,10 @@ final class _String()
       var o1 = offset
       var o2 = string.offset
       while (o1 < offset + count) {
-        o1 += 1
-        o2 += 1
         val c1 = value(o1)
         val c2 = string.value(o2)
+        o1 += 1
+        o2 += 1
         if (c1 != c2 && toUpperCase(c1) != toUpperCase(c2) &&
             toLowerCase(c1) != toLowerCase(c2)) {
           return false
@@ -271,8 +271,8 @@ final class _String()
         var index = _index
         var i     = offset + start
         while (i < end) {
-          index += 1
           data(index) = value(i).toByte
+          index += 1
           i += 1
         }
       } catch {
@@ -514,10 +514,10 @@ final class _String()
         val target = string.value
 
         while (thisStart < end) {
-          thisStart += 1
-          start += 1
           val c1 = value(thisStart)
           val c2 = target(start)
+          thisStart += 1
+          start += 1
           if (c1 != c2 && toUpperCase(c1) != toUpperCase(c2) &&
               toLowerCase(c1) != toLowerCase(c2)) {
             return false
@@ -540,8 +540,8 @@ final class _String()
       System.arraycopy(value, offset, buffer, 0, count)
 
       do {
-        index += 1
         buffer(index) = newChar
+        index += 1
         index = indexOf(oldChar, index)
       } while (index != -1)
 

--- a/unit-tests/src/main/scala/java/lang/StringSuite.scala
+++ b/unit-tests/src/main/scala/java/lang/StringSuite.scala
@@ -24,4 +24,44 @@ object StringSuite extends tests.Suite {
     assert("".indexOf("e", 0) == -1)       // empty
     assert("test".indexOf("e", 0) == 1)    // pos1
   }
+
+  test("String.compareTo") {
+    assert("test".compareTo("utest") < 0)
+    assert("test".compareTo("test") == 0)
+    assert("test".compareTo("stest") > 0)
+    assert("test".compareTo("tess") > 0)
+  }
+
+  //need toUpperCase and toLowerCase from Charset to be implemented for those tests to work.
+  /*test("String.compareToIgnoreCase") {
+    assert("test".compareToIgnoreCase("Utest") < 0)
+    assert("test".compareToIgnoreCase("Test") == 0)
+    assert("Test".compareToIgnoreCase("stest") > 0)
+    assert("tesT".compareToIgnoreCase("teSs") > 0)
+  }*/
+
+  //need toUpperCase and toLowerCase from Charset to be implemented for those tests to work.
+  /*test("String.equalsIgnoreCase") {
+    assert("test".equalsIgnoreCase("TEST"))
+    assert("TEst".equalsIgnoreCase("teST"))
+    assert(!("SEst".equalsIgnoreCase("TEss")))
+  }*/
+
+  test("String.regionMatches") {
+    assert("This is a test".regionMatches(10, "test", 0, 4))
+    assert(!("This is a test".regionMatches(10, "TEST", 0, 4)))
+    assert("This is a test".regionMatches(0, "This", 0, 4))
+  }
+
+  test("String.replace") {
+    assert("test".replace('t', 'p') equals "pesp")
+    assert("Test".replace('t', 'p') equals "Tesp")
+    assert("Test".replace('T', 'p') equals "pest")
+  }
+
+  test("String.getBytes") {
+    val b = new Array[scala.Byte](4)
+    "This is a test".getBytes(10, 14, b, 0)
+    assert(new String(b) equals "test")
+  }
 }


### PR DESCRIPTION
As explained on issue #475, this PR aims to correct wrong ports of the ```array[index++]``` from java to scala. I've only seen such error on String.scala, it may be possible there are other instance of this mistake elsewhere on the javalib that I haven't met yet. 