### PR TITLE
Add support for posix-based regular expressions

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -1,0 +1,162 @@
+package java.util.regex
+
+import scalanative.native._, stdlib._, stdio._
+import scalanative.runtime.struct
+
+object RegMatch {
+  @struct
+  class regmatch_t(val rm_so: Int, val rm_eo: Int)
+}
+
+class FullRegMatch(val rm_so: Int,
+                   val rm_eo: Int,
+                   input: String,
+                   val retval: Int) {
+  def length: Int               = rm_eo - rm_so
+  def get: String               = input.substring(rm_so, rm_eo)
+  override def toString: String = s"$rm_so $rm_eo $input $retval"
+}
+
+trait MatchResult {
+  def groupCount(): Int
+
+  def start(): Int
+  def end(): Int
+  def group(): String
+
+  def start(group: Int): Int
+  def end(group: Int): Int
+  def group(group: Int): String
+}
+
+final class RegexMatcher private[regex] (private var _pattern: Pattern,
+                                         private var _input: String,
+                                         private var regionStart: Int,
+                                         private var regionEnd: Int)
+    extends AnyRef
+    with MatchResult {
+
+  def pattern(): Pattern = _pattern
+
+  private var inputstr = _input.substring(regionStart, regionEnd)
+
+  private var lastMatch: FullRegMatch = new FullRegMatch(-1, -1, "", -1) // Not liking this: it creates a new struct on each instance of RegexMatcher
+  private var lastMatchIsValid        = false
+  private var canStillFind            = true
+  private var appendPos: Int          = 0
+
+  def inputstr(regionStart: Int, regionEnd: Int): String =
+    _input.substring(regionStart, regionEnd)
+
+  def matches(): Boolean = {
+    Pattern.execute(_pattern, _input).retval == 0
+  }
+
+  def groupCount(): Int = ???
+
+  def start(group: Int): Int    = ???
+  def end(group: Int): Int      = ???
+  def group(group: Int): String = ???
+
+  // The following are based on the Matcher from scala-js
+
+  def find(): Boolean =
+    if (canStillFind) {
+      lastMatchIsValid = true
+      lastMatch = Pattern.execute(_pattern, inputstr)
+      if (lastMatch.rm_so != -1) {
+        regionStart = lastMatch.rm_eo
+      } else {
+        canStillFind = false
+      }
+      lastMatch.rm_so != -1
+    } else false
+
+  def find(start: Int): Boolean = {
+    reset()
+    find()
+  }
+
+  def reset(): RegexMatcher = {
+    regionStart = 0
+    lastMatch = null
+    lastMatchIsValid = false
+    canStillFind = true
+    appendPos = 0
+    this
+  }
+
+  private def ensureLastMatch: FullRegMatch = {
+    if (lastMatch.rm_so == -1)
+      throw new IllegalStateException("No match available")
+    lastMatch
+  }
+
+  def start(): Int    = ensureLastMatch.rm_so
+  def end(): Int      = start() + group().length
+  def group(): String = ensureLastMatch.get
+
+  def replaceFirst(replacement: String): String = {
+    reset()
+
+    if (find()) {
+      val sb = new StringBuffer
+      appendReplacement(sb, replacement)
+      appendTail(sb)
+      sb.toString
+    } else {
+      inputstr
+    }
+  }
+
+  def replaceAll(replacement: String): String = {
+    reset()
+
+    val sb = new StringBuffer
+    while (find()) {
+      appendReplacement(sb, replacement)
+    }
+    appendTail(sb)
+
+    sb.toString
+  }
+
+  def appendReplacement(sb: StringBuffer, replacement: String): RegexMatcher = {
+    sb.append(inputstr.substring(appendPos, start))
+
+    @inline def isDigit(c: Char) = c >= '0' && c <= '9'
+
+    val len = replacement.length
+    var i   = 0
+    while (i < len) {
+      replacement.charAt(i) match {
+        case '$' =>
+          i += 1
+          val j = i
+          while (i < len && isDigit(replacement.charAt(i))) i += 1
+          val group = Integer.parseInt(replacement.substring(j, i))
+          sb.append(this.group(group))
+
+        case '\\' =>
+          i += 1
+          if (i < len)
+            sb.append(replacement.charAt(i))
+          i += 1
+
+        case c =>
+          sb.append(c)
+          i += 1
+      }
+    }
+
+    appendPos = end
+    this
+  }
+
+  def appendTail(sb: StringBuffer): StringBuffer = {
+    sb.append(inputstr.substring(appendPos))
+    appendPos = inputstr.length
+    sb
+  }
+
+}

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -1,0 +1,104 @@
+package java.util.regex
+
+import scalanative.native._, stdlib._, stdio._
+import scalanative.runtime.struct
+
+@extern
+object Regex {
+  def regcomp(regex: Ptr[Int], str: CString, num: Int): Int = extern
+  def regexec(regex: Ptr[Int],
+              str: CString,
+              nmatch: Int,
+              matchposition: Ptr[RegMatch.regmatch_t],
+              num2: Int): Int = extern
+}
+
+case class RegexError(error: Int)
+
+trait RegexPattern {
+  def flags(): Int
+  def pattern(): String
+  override def toString(): String
+}
+
+final class Pattern private (_compiled: Ptr[Int],
+                             _pattern: String,
+                             _flags: Int)
+    extends Serializable
+    with RegexPattern {
+  def flags(): Int                = _flags
+  def compiled(): Ptr[Int]        = _compiled
+  def pattern(): String           = _pattern
+  override def toString(): String = _pattern
+
+  def matcher(input: String): RegexMatcher =
+    new RegexMatcher(this, input, 0, input.length)
+  def split(input: CharSequence): Array[String] =
+    split(input, 0)
+
+  def split(input: CharSequence, limit: Int): Array[String] = {
+    val inputStr = input.toString
+
+    if (inputStr == "") {
+      Array("")
+    } else {
+      val lim     = if (limit > 0) limit else Int.MaxValue
+      val matcher = this.matcher(inputStr)
+      val builder = Array.newBuilder[String]
+      var prevEnd = 0
+      var size    = 0
+      while ((size < lim - 1) && matcher.find()) {
+        if (matcher.end == 0) {} else {
+          builder += inputStr.substring(prevEnd, matcher.start)
+          size += 1
+        }
+        prevEnd = matcher.end
+      }
+      builder += inputStr.substring(prevEnd)
+      val result = builder.result()
+
+      if (limit != 0) {
+        result
+      } else {
+        var actualLength = result.length
+        while (actualLength != 0 && result(actualLength - 1) == "") actualLength -= 1
+
+        if (actualLength == result.length) {
+          result
+        } else {
+          val actualResult = new Array[String](actualLength)
+          System.arraycopy(result, 0, actualResult, 0, actualLength)
+          actualResult
+        }
+      }
+    }
+  }
+}
+
+object Pattern {
+  def compile(regex: String, flags: Int): Pattern = {
+    val compiledRegex = malloc(sizeof[Int] * 100).cast[Ptr[Int]] //Dirtiest hack ever
+    val retval        = Regex.regcomp(compiledRegex, toCString(regex), 0)
+    if (retval == 0) {
+      new Pattern(compiledRegex, regex, flags)
+    } else new Pattern(null, regex, flags)
+  }
+
+  def execute(pattern: Pattern, text: String): FullRegMatch = {
+    val regmatch = malloc(sizeof[RegMatch.regmatch_t] * 1)
+      .cast[Ptr[RegMatch.regmatch_t]]
+    regmatch(0) = new RegMatch.regmatch_t(-1, -1)
+    if (pattern.compiled != null) {
+      val retval =
+        Regex.regexec(pattern.compiled, toCString(text), 1, regmatch, 0)
+      new FullRegMatch(regmatch(0).rm_so, regmatch(0).rm_eo, text, retval)
+    } else {
+      new FullRegMatch(-1, -1, text, -1)
+    }
+  }
+
+  def matches(regex: String, input: CharSequence): Boolean =
+    compile(regex).matcher(input.toString).matches()
+
+  def compile(regex: String): Pattern = compile(regex, 0)
+}

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -73,6 +73,11 @@ final class Pattern private (_compiled: Ptr[Int],
       }
     }
   }
+  protected override def finalize(): Unit = {
+    // Note that a pattern does not exist without _compiled being alloc-ed, so
+    // this free should never apply to non-alloc-ed memory
+    free(_compiled.asInstanceOf[Ptr[Byte]])
+  }
 }
 
 object Pattern {

--- a/unit-tests/src/main/scala/java/util/regex/RegexPatternSuite.scala
+++ b/unit-tests/src/main/scala/java/util/regex/RegexPatternSuite.scala
@@ -1,0 +1,16 @@
+package java.util.regex
+
+object RegexPatternSuite extends tests.Suite {
+  test("Expects abc to match abc") {
+    assert(Pattern.matches("abc", "abc"))
+  }
+  test("Expects [[:digit:]] to match 123") {
+    assert(Pattern.matches("[[:digit:]]", "123"))
+  }
+  test("Expects [[:digit:]] to match 1") {
+    assert(Pattern.matches("[[:digit:]]", "1")) // This is segfaulting!
+  }
+  test("Expects Scal.-Native to match Scala-Native") {
+    assert(Pattern.matches("Scal.-Native", "Scala-Native"))
+  }
+}


### PR DESCRIPTION
Capturing groups are still not implemented (neither search flags and many other things). 

The test suite is just a placeholder for now (the one in scala-js should cover everything needed), rignt now only tests some match cases to make sure something is matched against in the most simple cases for posix regexes with character classes. 

Used code from scala-js, removing parts that were still not needed (the indexes/group counters). These will probably need to be added again once the test suite is full.