### PR TITLE
Fix #380: toLowerCase & toUpperCase implementation missing in java.la…

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -507,8 +507,37 @@ object Character {
   }
 
   /* Conversions */
-  def toUpperCase(c: scala.Char): scala.Char = ???
-  def toLowerCase(c: scala.Char): scala.Char = ???
+  def toUpperCase(c: scala.Char): scala.Char = {
+    toUpperCase(c.toInt).toChar
+  }
+
+  def toUpperCase(codePoint: Int): Int = {
+    import CaseFolding._
+    toCase(codePoint,
+           a,
+           z,
+           toUpper,
+           lowerBeta,
+           lowerRanges,
+           lowerDeltas,
+           lowerSteps)
+  }
+
+  def toLowerCase(c: scala.Char): scala.Char = {
+    toLowerCase(c.toInt).toChar
+  }
+
+  def toLowerCase(codePoint: Int): Int = {
+    import CaseFolding._
+    toCase(codePoint,
+           A,
+           Z,
+           toLower,
+           upperMu,
+           upperRanges,
+           upperDeltas,
+           upperSteps)
+  }
 
   def toChars(codePoint: Int): Array[Char] = {
     if (!isValidCodePoint(codePoint))
@@ -933,6 +962,266 @@ object Character {
     for (i <- 1 until deltas.length)
       deltas(i) += deltas(i - 1)
     deltas
+  }
+
+  // http://www.unicode.org/Public/7.0.0/ucd/CaseFolding.txt
+  //  import scala.io.Source
+  //  import java.io.InputStream
+  //  def toInt(hex: String): Int = Integer.parseInt(hex, 16)
+  //  val filename = "/CaseFolding.txt"
+  //  val stream : InputStream = getClass.getResourceAsStream(filename)
+  //  val lines = scala.io.Source.fromInputStream(stream).getLines
+  //  val records = lines.filterNot(line => line.startsWith("#") || line.isEmpty())
+  //  val arrays = records.map { x => x.split(";")  }
+  //  val tuples = arrays.map { c => (c(0), c(1).trim(), c(2).trim, c(3).trim) }
+  //  // filter for 'simple case folding C + S' and greater than FFFF? && (t._1.size == 4)
+  //  val fTuples = tuples.filter(t => (t._2 == "C" || t._2 == "S") ).toList
+  //  val upperLower = fTuples.map(t => (toInt(t._1), toInt(t._3)))
+  //  val pairs = upperLower.map { case (u, l) => (u, l, u - l) }
+  //
+  //  def printIndented(list: List[(Int,Int,Int,Int)]) = {
+  //    list.foreach(f => if (f._4 == 0) print("\n" + f) else print(f)); println
+  //  }
+  //
+  //  def addDiff(arr: List[(Int, Int, Int)]) = {
+  //    arr.foldLeft[List[(Int, Int, Int, Int)]](Nil) {
+  //      case (x :: xs, elem) if (x._3 == elem._3) => {
+  //        val diff = elem._1 - x._1
+  //        // only ranges with diff or 1 or 2 matter
+  //        // some ranges with 2 are only 2 long
+  //        if (diff <= 2) (elem._1, elem._2, elem._3, diff) :: x :: xs
+  //        else (elem._1, elem._2, elem._3, 0) :: x :: xs
+  //      }
+  //      case (list, elem) => (elem._1, elem._2, elem._3, 0) :: list
+  //    }.reverse
+  //  }
+  //
+  //  def adjustStart(arr: List[(Int, Int, Int, Int)]) = {
+  //    arr.tail.foldLeft[List[(Int, Int, Int, Int)]](List(arr.head)) {
+  //      case (x :: xs, elem) if (x._4 == 0 || x._4 == elem._4) => elem :: x :: xs
+  //      case (list, elem) => (elem._1, elem._2, elem._3, 0) :: list
+  //    }.reverse
+  //  }
+  //
+  //  def keepLast(arr: List[(Int, Int, Int, Int)]): List[(Int, Int, Int, Int)] = {
+  //    import scala.annotation.tailrec
+  //    val h = arr.head
+  //    val tail = arr.tail
+  //    @tailrec
+  //    def process(list: List[(Int, Int, Int, Int)], acc: List[(Int, Int, Int, Int)],
+  //        prev: (Int, Int, Int, Int)): List[(Int, Int, Int, Int)] = {
+  //      list match {
+  //        case Nil => acc
+  //        case x :: xs =>
+  //          if (x._4 == 0 && x._4 != prev._4) process(xs, x :: prev :: acc, x)
+  //          else if (x._4 == 0 || xs == Nil) process(xs, x :: acc, x) // Nil to get last element
+  //          else process(xs, acc, x)
+  //      }
+  //    }
+  //    process(tail, List(h), h).reverse
+  //  }
+  //
+  //  def addDiffLower(arr: List[(Int, Int, Int)]) = {
+  //    arr.foldLeft[List[(Int, Int, Int, Int)]](Nil) {
+  //      case (x :: xs, elem) if (x._3 == elem._3) => {
+  //        val diff = elem._2 - x._2
+  //        // only ranges with diff or 1 or 2 matter
+  //        // some ranges with 2 are only 2 long
+  //        if (diff <= 2) (elem._1, elem._2, elem._3, diff) :: x :: xs
+  //        else (elem._1, elem._2, elem._3, 0) :: x :: xs
+  //      }
+  //      case (list, elem) => (elem._1, elem._2, elem._3, 0) :: list
+  //    }.reverse
+  //  }
+  //
+  //  def lowerDedup(arr: List[(Int, Int, Int)]) = {
+  //    arr.tail.foldLeft[List[(Int, Int, Int)]](List(arr.head)) {
+  //      case (x :: xs, elem) if (x._2 == elem._2) => x :: xs
+  //      case (list, elem) => elem :: list
+  //    }.reverse
+  //  }
+  //
+  //  // process uppers
+  //  val u2 = addDiff(pairs)
+  //  val u3 = adjustStart(u2)
+  //  //printIndented(u3)
+  //  val u4 = keepLast(u3)
+  //
+  //  // Lower case manipulation
+  //  val lPairs = pairs.sortBy{ case ((u,l,d))  => ((l,u)) }
+  //  val l2 = lowerDedup(lPairs)
+  //  // 1104 total, 1083 in lowers with dups removed
+  //  // 244 in uppers because of upper -> lower can have more than one mapping
+  //  // 230 in lowers
+  //  // upper to lower is loss less but back is not reversible
+  //  val l3 = addDiffLower(l2)
+  //  val l4 = adjustStart(l3)
+  //  //printIndented(l4)
+  //  val l5 = keepLast(l4)
+  //
+  //  val uk = u4.unzip { case(_, _, c, d) => (c, d)}
+  //  val ul = u4.unzip { case(a, b, _, _) => (a, b)}
+  //  val lk = l5.unzip { case(_, _, c, d) => (c, d)}
+  //  val ll = l5.unzip { case(a, b, _, _) => (a, b)}
+  //  println(uk._1.mkString("private[this] lazy val upperDeltas = Array[scala.Int](", ", ", ")"))
+  //  println(uk._2.mkString("private[this] lazy val upperSteps = Array[scala.Byte](", ", ", ")"))
+  //  println(ul._1.mkString("private[this] lazy val upperRanges = Array[scala.Int](", ", ", ")"))
+  //  println(lk._1.mkString("private[this] lazy val lowerDeltas = Array[scala.Int](", ", ", ")"))
+  //  println(lk._2.mkString("private[this] lazy val lowerSteps = Array[scala.Byte](", ", ", ")"))
+  //  println(ll._2.mkString("private[this] lazy val lowerRanges = Array[scala.Int](", ", ", ")"))
+
+  private[this] lazy val upperDeltas = Array[scala.Int](32, 32, 775, 32, 32,
+    32, 32, 1, 1, 1, 1, 1, 1, 1, 1, -121, 1, 1, -268, 210, 1, 1, 206, 1, 205,
+    205, 1, 79, 202, 203, 1, 205, 207, 211, 209, 1, 211, 213, 214, 1, 1, 218,
+    1, 218, 1, 218, 1, 217, 217, 1, 1, 219, 1, 1, 2, 1, 2, 1, 2, 1, 1, 1, 1, 2,
+    1, 1, -97, -56, 1, 1, -130, 1, 1, 10795, 1, -163, 10792, 1, -195, 69, 71,
+    1, 1, 116, 1, 1, 1, 116, 38, 37, 37, 64, 63, 63, 32, 32, 32, 32, 1, 8, -30,
+    -25, -15, -22, 1, 1, -54, -48, -60, -64, 1, -7, 1, -130, -130, 80, 80, 32,
+    32, 1, 1, 1, 1, 15, 1, 1, 1, 1, 48, 48, 7264, 7264, 7264, 7264, 1, 1, -58,
+    -7615, 1, 1, -8, -8, -8, -8, -8, -8, -8, -8, -8, -8, -8, -8, -8, -8, -8,
+    -8, -8, -8, -8, -8, -8, -8, -74, -74, -9, -7173, -86, -86, -9, -8, -8,
+    -100, -100, -8, -8, -112, -112, -7, -128, -128, -126, -126, -9, -7517,
+    -8383, -8262, 28, 16, 16, 1, 26, 26, 48, 48, 1, -10743, -3814, -10727, 1,
+    1, -10780, -10749, -10783, -10782, 1, 1, -10815, -10815, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, -35332, 1, 1, 1, -42280, 1, 1, 1, 1, -42308,
+    -42319, -42315, -42305, -42258, -42282, 32, 32, 40, 40, 32, 32)
+
+  private[this] lazy val upperSteps = Array[scala.Byte](0, 1, 0, 0, 1, 0, 1, 0,
+    2, 0, 2, 0, 2, 0, 2, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 2, 0, 2, 0, 0, 2, 0, 0, 0, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+    0, 0, 2, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0,
+    0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 2, 0, 2, 0, 0, 2, 0, 2, 0, 1, 0, 1, 0,
+    0, 0, 2, 0, 0, 0, 2, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 2, 0, 1, 0, 1, 0, 1,
+    0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0,
+    0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1,
+    0, 2, 0, 2, 0, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 0, 2, 0, 0, 0, 2, 0, 2, 0,
+    0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1)
+
+  private[this] lazy val upperRanges = Array[scala.Int](65, 90, 181, 192, 214,
+    216, 222, 256, 302, 306, 310, 313, 327, 330, 374, 376, 377, 381, 383, 385,
+    386, 388, 390, 391, 393, 394, 395, 398, 399, 400, 401, 403, 404, 406, 407,
+    408, 412, 413, 415, 416, 420, 422, 423, 425, 428, 430, 431, 433, 434, 435,
+    437, 439, 440, 444, 452, 453, 455, 456, 458, 459, 475, 478, 494, 497, 498,
+    500, 502, 503, 504, 542, 544, 546, 562, 570, 571, 573, 574, 577, 579, 580,
+    581, 582, 590, 837, 880, 882, 886, 895, 902, 904, 906, 908, 910, 911, 913,
+    929, 931, 939, 962, 975, 976, 977, 981, 982, 984, 1006, 1008, 1009, 1012,
+    1013, 1015, 1017, 1018, 1021, 1023, 1024, 1039, 1040, 1071, 1120, 1152,
+    1162, 1214, 1216, 1217, 1229, 1232, 1326, 1329, 1366, 4256, 4293, 4295,
+    4301, 7680, 7828, 7835, 7838, 7840, 7934, 7944, 7951, 7960, 7965, 7976,
+    7983, 7992, 7999, 8008, 8013, 8025, 8031, 8040, 8047, 8072, 8079, 8088,
+    8095, 8104, 8111, 8120, 8121, 8122, 8123, 8124, 8126, 8136, 8139, 8140,
+    8152, 8153, 8154, 8155, 8168, 8169, 8170, 8171, 8172, 8184, 8185, 8186,
+    8187, 8188, 8486, 8490, 8491, 8498, 8544, 8559, 8579, 9398, 9423, 11264,
+    11310, 11360, 11362, 11363, 11364, 11367, 11371, 11373, 11374, 11375,
+    11376, 11378, 11381, 11390, 11391, 11392, 11490, 11499, 11501, 11506,
+    42560, 42604, 42624, 42650, 42786, 42798, 42802, 42862, 42873, 42875,
+    42877, 42878, 42886, 42891, 42893, 42896, 42898, 42902, 42920, 42922,
+    42923, 42924, 42925, 42928, 42929, 65313, 65338, 66560, 66599, 71840,
+    71871)
+
+  private[this] lazy val lowerDeltas = Array[scala.Int](32, 32, -7615, 32, 32,
+    32, 32, -121, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, -195, 1, 1, 1, 1, 1, -97, 1,
+    -163, -130, 1, 1, 1, 1, 1, 1, 1, 1, 1, -56, 2, 2, 2, 1, 1, 79, 1, 1, 2, 1,
+    1, 1, 1, 1, 1, -10815, -10815, 1, 1, 1, -10783, -10780, -10782, 210, 206,
+    205, 205, 202, 203, -42319, 205, -42315, 207, -42280, -42308, 209, 211,
+    -10743, -42305, 211, -10749, 213, 214, -10727, 218, 218, -42282, 218, 69,
+    217, 217, 71, 219, -42258, 1, 1, 1, -130, -130, 38, 37, 37, 32, 32, 116,
+    32, 32, 775, 32, 32, 32, 32, 64, 63, 63, 8, 1, 1, -7, 116, 1, 1, 32, 32,
+    80, 80, 1, 1, 1, 1, 1, 1, 15, 1, 1, 48, 48, -35332, -3814, 1, 1, 1, 1, -8,
+    -8, -8, -8, -8, -8, -8, -8, -8, -8, -8, -8, -8, -8, -74, -74, -86, -86,
+    -100, -100, -128, -128, -112, -112, -126, -126, -8, -8, -8, -8, -8, -8, -8,
+    -8, -9, -9, -8, -8, -8, -8, -7, -9, 28, 16, 16, 1, 26, 26, 48, 48, 1,
+    10795, 10792, 1, 1, 1, 1, 1, 1, 1, 1, 1, 7264, 7264, 7264, 7264, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 32, 32, 40, 40, 32, 32)
+
+  private[this] lazy val lowerSteps = Array[scala.Byte](0, 1, 0, 0, 1, 0, 1, 0,
+    0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0,
+    0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 2, 0, 0, 0, 2, 0, 2, 0, 0, 1, 0, 0, 2,
+    0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 2, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1,
+    0, 1, 0, 0, 1, 0, 0, 2, 0, 0, 0, 0, 0, 1, 0, 1, 0, 2, 0, 2, 0, 2, 0, 0, 2,
+    0, 1, 0, 0, 0, 2, 0, 2, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 2, 0, 1, 0, 1, 0,
+    1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0,
+    0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 2, 0, 0, 0, 2, 0, 2, 0, 0, 1, 0, 0, 0,
+    2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 0, 2, 0, 2, 0, 1, 0, 1, 0, 1)
+
+  private[this] lazy val lowerRanges = Array[scala.Int](97, 122, 223, 224, 246,
+    248, 254, 255, 257, 303, 307, 311, 314, 328, 331, 375, 378, 382, 384, 387,
+    389, 392, 396, 402, 405, 409, 410, 414, 417, 421, 424, 429, 432, 436, 438,
+    441, 445, 447, 454, 457, 460, 462, 476, 477, 479, 495, 499, 501, 505, 543,
+    547, 563, 572, 575, 576, 578, 583, 591, 592, 593, 594, 595, 596, 598, 599,
+    601, 603, 604, 608, 609, 611, 613, 614, 616, 617, 619, 620, 623, 625, 626,
+    629, 637, 640, 643, 647, 648, 649, 650, 651, 652, 658, 670, 881, 883, 887,
+    891, 893, 940, 941, 943, 945, 952, 953, 954, 955, 956, 957, 961, 963, 971,
+    972, 973, 974, 983, 985, 1007, 1010, 1011, 1016, 1019, 1072, 1103, 1104,
+    1119, 1121, 1153, 1163, 1215, 1218, 1230, 1231, 1233, 1327, 1377, 1414,
+    7545, 7549, 7681, 7829, 7841, 7935, 7936, 7943, 7952, 7957, 7968, 7975,
+    7984, 7991, 8000, 8005, 8017, 8023, 8032, 8039, 8048, 8049, 8050, 8053,
+    8054, 8055, 8056, 8057, 8058, 8059, 8060, 8061, 8064, 8071, 8080, 8087,
+    8096, 8103, 8112, 8113, 8115, 8131, 8144, 8145, 8160, 8161, 8165, 8179,
+    8526, 8560, 8575, 8580, 9424, 9449, 11312, 11358, 11361, 11365, 11366,
+    11368, 11372, 11379, 11382, 11393, 11491, 11500, 11502, 11507, 11520,
+    11557, 11559, 11565, 42561, 42605, 42625, 42651, 42787, 42799, 42803,
+    42863, 42874, 42876, 42879, 42887, 42892, 42897, 42899, 42903, 42921,
+    65345, 65370, 66600, 66639, 71872, 71903)
+
+  private[this] object CaseFolding {
+    lazy val a     = lowerRanges(0)
+    lazy val z     = lowerRanges(1)
+    lazy val A     = upperRanges(0)
+    lazy val Z     = upperRanges(1)
+    lazy val delta = upperDeltas(0)
+    // other low char optimization whitespace, punctuation, etc.
+    lazy val upperMu                        = upperRanges(2)
+    lazy val lowerBeta                      = lowerRanges(2)
+    def insertionPoint(idx: Int)            = (-(idx) - 1)
+    def toUpper(codePoint: Int, delta: Int) = codePoint - delta
+    def toLower(codePoint: Int, delta: Int) = codePoint + delta
+  }
+
+  private[this] def toCase(codePoint: Int,
+                           asciiLow: Int,
+                           asciiHigh: Int,
+                           convert: (Int, Int) => Int,
+                           lowFilter: Int,
+                           ranges: Array[scala.Int],
+                           deltas: Array[scala.Int],
+                           steps: Array[scala.Byte]): Int = {
+    import CaseFolding._
+    if (asciiLow <= codePoint && codePoint <= asciiHigh)
+      convert(codePoint, delta) // ascii
+    else if (codePoint < lowFilter) codePoint // whitespace, punctuation, etc.
+    else {
+      val idx = Arrays.binarySearch(ranges, codePoint)
+      if (idx >= 0) {
+        convert(codePoint, deltas(idx))
+      } else {
+        val ip = insertionPoint(idx)
+        // ip == 0 is below ranges but < lowFilter above covers that
+        if (ip == ranges.size) codePoint // above ranges
+        else {
+          val step = steps(ip)
+          if (step == 0) {
+            // no range involved
+            codePoint
+          } else {
+            val delta      = deltas(ip)
+            val upperBound = ranges(ip)
+            if (step == 1) {
+              convert(codePoint, delta)
+            } else {
+              // step == 2 so check both odd or even
+              if ((upperBound & 1) == (codePoint & 1)) {
+                convert(codePoint, delta)
+              } else {
+                codePoint
+              }
+            }
+          }
+        }
+      }
+    }
   }
 
   // TODO:

--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -964,7 +964,19 @@ object Character {
     deltas
   }
 
+  // Create tables to support toUpperCase and toLowerCase transformations
+  // using the Unicode 7.0 database. This implementation uses the
+  // CaseFolding.txt file referenced below.
+  // Ranges: the codePoints with lower and upper bound pairs or
+  //         individual codePoints.
+  // Deltas: the difference between the upper and lower case codePoints
+  //         for ranges and individual codePoints.
+  // Steps:  values of O indicate the lower bound or individual codePoint.
+  //         Steps of 1 or 2 indicate the spacing of the upper or lower case
+  //         codePoints with the same index as the upper bound of a range.
+  //
   // http://www.unicode.org/Public/7.0.0/ucd/CaseFolding.txt
+  //
   //  import scala.io.Source
   //  import java.io.InputStream
   //  def toInt(hex: String): Int = Integer.parseInt(hex, 16)
@@ -974,7 +986,7 @@ object Character {
   //  val records = lines.filterNot(line => line.startsWith("#") || line.isEmpty())
   //  val arrays = records.map { x => x.split(";")  }
   //  val tuples = arrays.map { c => (c(0), c(1).trim(), c(2).trim, c(3).trim) }
-  //  // filter for 'simple case folding C + S' and greater than FFFF? && (t._1.size == 4)
+  //  // filter for 'simple case folding C + S'
   //  val fTuples = tuples.filter(t => (t._2 == "C" || t._2 == "S") ).toList
   //  val upperLower = fTuples.map(t => (toInt(t._1), toInt(t._3)))
   //  val pairs = upperLower.map { case (u, l) => (u, l, u - l) }

--- a/unit-tests/src/main/scala/java/lang/CharacterSuite.scala
+++ b/unit-tests/src/main/scala/java/lang/CharacterSuite.scala
@@ -1,0 +1,79 @@
+package java.lang
+
+/** Test suite for [[java.lang.Character]]
+ *
+ * To be consistent the implementations should be based on
+ * Unicode 7.0.
+ * @see [[http://www.unicode.org/Public/7.0.0 Unicode 7.0]]
+ *
+ * Overall code point range U+0000 - U+D7FF and U+E000 - U+10FFF.
+ * Surrogate code points are in the gap and U+FFFF
+ * is the max value for [[scala.Char]].
+ */
+object CharacterSuite extends tests.Suite {
+  import java.lang.Character._
+
+  def toInt(hex: String): Int = Integer.parseInt(hex, 16)
+
+  /** toUpperCase/toLowerCase based on Unicode 7 case folding.
+   * @see [[http://www.unicode.org/Public/7.0.0/ucd/CaseFolding.txt]]
+   * The implementation with the Char argument forwards
+   * to the implementation with the Int argument.
+   * Most sequence ranges that step by two have alternating
+   * upper and lowercase code points.
+   */
+  test("toLowerCase") {
+    // low chars
+    assert(toLowerCase('\n') equals '\n')
+    // ascii chars
+    assert(toLowerCase('A') equals 'a')
+    assert(toLowerCase('a') equals 'a')
+    assertNot(toLowerCase('a') equals 'A')
+    assert(toLowerCase('F') equals 'f')
+    assert(toLowerCase('Z') equals 'z')
+    // compat characters don't agree with JDK
+    assert(toLowerCase('µ') equals 'μ')
+
+    /** The Int tests are below. */
+    // alternating upper and lower case
+    //(256,257,1,0)(302,303,1,2)
+    assert(toLowerCase(256) equals 257)
+    assert(toLowerCase(257) equals 257)
+    assert(toLowerCase(258) equals 259)
+    assert(toLowerCase(302) equals 303)
+    // high points
+    assert(toLowerCase(65313) equals 65345)
+    assert(toLowerCase(65338) equals 65370)
+    assert(toLowerCase(65339) equals 65339)
+    // top and above range
+    assert(toLowerCase(toInt("10FFFF")) equals toInt("10FFFF"))
+    assert(toLowerCase(toInt("110000")) equals toInt("110000"))
+  }
+  test("toUpperCase") {
+    // low chars
+    assert(toUpperCase('\n') equals '\n')
+    // ascii chars
+    assert(toUpperCase('a') equals 'A')
+    assert(toUpperCase('A') equals 'A')
+    assertNot(toUpperCase('A') equals 'a')
+    assert(toUpperCase('f') equals 'F')
+    assert(toUpperCase('z') equals 'Z')
+    // compat characters don't agree with JDK
+    assert(toUpperCase('ß') equals 'ẞ')
+
+    /** The Int tests are below. */
+    // alternating upper and lower case
+    //(256,257,1,0)(302,303,1,2)
+    assert(toUpperCase(257) equals 256)
+    assert(toUpperCase(258) equals 258)
+    assert(toUpperCase(259) equals 258)
+    assert(toUpperCase(303) equals 302)
+    // high points
+    assert(toUpperCase(65345) equals 65313)
+    assert(toUpperCase(65370) equals 65338)
+    assert(toUpperCase(65371) equals 65371)
+    // top and above range
+    assert(toUpperCase(toInt("10FFFF")) equals toInt("10FFFF"))
+    assert(toUpperCase(toInt("110000")) equals toInt("110000"))
+  }
+}

--- a/unit-tests/src/main/scala/java/lang/StringSuite.scala
+++ b/unit-tests/src/main/scala/java/lang/StringSuite.scala
@@ -23,14 +23,14 @@ object StringSuite extends tests.Suite {
     assert("test".compareTo("tess") > 0)
   }
 
-  testFails("compareToIgnoreCase", issue = 380) {
+  test("compareToIgnoreCase") {
     assert("test".compareToIgnoreCase("Utest") < 0)
     assert("test".compareToIgnoreCase("Test") == 0)
     assert("Test".compareToIgnoreCase("stest") > 0)
     assert("tesT".compareToIgnoreCase("teSs") > 0)
   }
 
-  testFails("equalsIgnoreCase", issue = 380) {
+  test("equalsIgnoreCase") {
     assert("test".equalsIgnoreCase("TEST"))
     assert("TEst".equalsIgnoreCase("teST"))
     assert(!("SEst".equalsIgnoreCase("TEss")))


### PR DESCRIPTION
Added implementations to `java.lang.Character` based on Unicode 7.0 [CaseFolding.txt](http://www.unicode.org/Public/7.0.0/ucd/CaseFolding.txt). Note that `java.lang.String` does not have implementations for `toUpperCase` and `toLowerCase`.