### PR TITLE
Move stackalloc hoisting to nscplugin

### DIFF
--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/AllocLowering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/AllocLowering.scala
@@ -16,16 +16,10 @@ class AllocLowering(implicit fresh: Fresh, top: Top) extends Pass {
   import AllocLowering._
 
   override def onInsts(insts: Seq[Inst]) = {
-    val entry, buf = new nir.Buffer
+    val buf = new nir.Buffer
     import buf._
 
-    val label +: rest = insts
-    entry += label
-
-    val newinsts = rest.foreach {
-      case inst @ Let(_, alloc: Op.Stackalloc) =>
-        entry += inst
-
+    insts.foreach {
       case Let(n, Op.Classalloc(ClassRef(cls))) =>
         val size = let(Op.Sizeof(cls.classStruct))
         let(n, Op.Call(allocSig, alloc, Seq(cls.typeConst, size), Next.None))
@@ -34,8 +28,7 @@ class AllocLowering(implicit fresh: Fresh, top: Top) extends Pass {
         buf += inst
     }
 
-    entry ++= buf
-    entry.toSeq
+    buf.toSeq
   }
 }
 

--- a/unit-tests/src/main/scala/scala/scalanative/native/StackallocSuite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/native/StackallocSuite.scala
@@ -64,4 +64,38 @@ object StackallocSuite extends tests.Suite {
     assert(!ptr._3 == 30)
     assert(!ptr._4 == 40)
   }
+
+  test("stack-allocated list") {
+    import CList._
+    var i               = 0
+    var head: Ptr[Node] = null
+    while (i < 4) {
+      head = stackalloc[Node].init(i, head)
+      i += 1
+    }
+    assert(head.sum == 6)
+  }
+}
+
+object CList {
+  type Node = CStruct2[Int, Ptr[_]]
+
+  implicit class NodeOps(val self: Ptr[Node]) extends AnyVal {
+    def init(value: Int, next: Ptr[Node]) = {
+      !self._1 = value
+      !self._2 = next
+      self
+    }
+    def value = !self._1
+    def next  = (!self._2).cast[Ptr[Node]]
+    def sum: Int = {
+      var res  = 0
+      var head = self
+      while (head != null) {
+        res += head.value
+        head = head.next
+      }
+      res
+    }
+  }
 }


### PR DESCRIPTION
This makes `native.stackalloc[T]` semantics to be fully consistent
with `alloca` in C. Previously it had different semantics if used
from the inside of a loop.