### PR TITLE
rename sbt-cross to sbt-crossproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ _build/
 _build/
 bin/.coursier
 bin/.scalafmt*
-sbt-cross/
+sbt-crossproject/

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,5 @@ before_script:
     fi;
 script:
   - java -version
-  - git clone https://github.com/scala-native/sbt-cross.git
-  - pushd sbt-cross
-  - sbt publishLocal
-  - popd
-  - bin/scalafmt --test && sbt ";rebuild ;test-all ;publishSnapshot"
+  - bin/scalafmt --test
+  - sbt ";rebuild ;test-all ;publishSnapshot"

--- a/build.sbt
+++ b/build.sbt
@@ -231,7 +231,11 @@ lazy val sbtScalaNative =
     .in(file("sbt-scala-native"))
     .settings(sbtPluginSettings)
     .settings(
-      addSbtPlugin("org.scala-native" % "sbt-cross" % "0.1.0-SNAPSHOT"),
+      resolvers += Resolver.url(
+        "bintray-scala-native-sbt-plugins",
+        url("http://dl.bintray.com/scala-native/sbt-plugins"))(
+        Resolver.ivyStylePatterns),
+      addSbtPlugin("org.scala-native" % "sbt-crossproject" % "0.1.0"),
       moduleName := "sbt-scala-native",
       sbtTestDirectory := (baseDirectory in ThisBuild).value / "scripted-tests",
       // publish the other projects before running scripted tests.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN git clone https://github.com/scala-native/scala-native.git native
 
-RUN git clone https://github.com/scala-native/sbt-cross.git
+RUN git clone https://github.com/scala-native/sbt-crossproject.git
   
 WORKDIR /tmp/native
 
@@ -14,7 +14,7 @@ RUN  nix-shell bin/scala-native.nix -A clangEnv --run "clangEnv installed"
 
 RUN  nix-shell bin/scala-native.nix -A clangEnv --run "cd .. && sbt scalaVersion"
 
-RUN  nix-shell bin/scala-native.nix -A clangEnv --run "cd .. && cd sbt-cross && sbt publishLocal"
+RUN  nix-shell bin/scala-native.nix -A clangEnv --run "cd .. && cd sbt-crossproject && sbt publishLocal"
 
 RUN  nix-shell bin/scala-native.nix -A clangEnv --run "sbt ';rtlib/publishLocal ;nscplugin/publishLocal'"
 

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -37,7 +37,7 @@ now simply run ``sbt run`` to get everything compiled and have the expected outp
 Cross compilation between JS, JVM and Native
 --------------------------------------------
 
-We created `sbt-cross <https://github.com/scala-native/sbt-cross>`_ to be a
+We created `sbt-crossproject <https://github.com/scala-native/sbt-crossproject>`_ to be a
 drop-in replacement of Scala.js' crossProject. Please refer to the documentation
 in the README.
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -18,8 +18,14 @@ libraryDependencies ++= Seq(
     "org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
 )
 
-addSbtPlugin("org.scala-native" % "sbt-cross"       % "0.1.0-SNAPSHOT")
-addSbtPlugin("com.eed3si9n"     % "sbt-dirty-money" % "0.1.0")
+// until we include it sbt general plugins
+resolvers += Resolver.url(
+  "bintray-scala-native-sbt-plugins",
+  url("http://dl.bintray.com/scala-native/sbt-plugins"))(
+  Resolver.ivyStylePatterns)
+
+addSbtPlugin("org.scala-native" % "sbt-crossproject" % "0.1.0")
+addSbtPlugin("com.eed3si9n"     % "sbt-dirty-money"  % "0.1.0")
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/NativeCross.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/NativeCross.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package sbtplugin
 
 import sbt._
-import sbtcross._
+import sbtcrossproject._
 
 import scala.language.implicitConversions
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/NativePlatform.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/NativePlatform.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package sbtplugin
 
 import sbt._
-import sbtcross._
+import sbtcrossproject._
 
 case object NativePlatform extends Platform {
   def identifier: String = "native"

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package sbtplugin
 
 import util._
-import sbtcross.CrossPlugin.autoImport._
+import sbtcrossproject.CrossPlugin.autoImport._
 import ScalaNativePlugin.autoImport._
 
 import scalanative.nir


### PR DESCRIPTION
sbt-crossproject tests depends on this PR but this PR depends on sbt-crossproject :).

Let's merge sbt-crossproject first: https://github.com/scala-native/sbt-cross/pull/22 then we can rerun the test here.

When this PR is merged we can rerun the tests in sbt-crossproject.

I hope it's not too confusing :)

I'm using the published sbt-crossproject now :-).
