### PR TITLE
Fix link to NixOS environment in the Setup guide

### DIFF
--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -36,7 +36,7 @@ FreeBSD::
 
 nix/nixOS::
 
-    $ wget https://github.com/scala-native/scala-native/blob/master/bin/scala-native.nix
+    $ wget https://raw.githubusercontent.com/scala-native/scala-native/master/bin/scala-native.nix
 
     $ nix-shell scala-native.nix -A clangEnv
 


### PR DESCRIPTION
When you wget `https://github.com/scala-native/scala-native/blob/master/bin/scala-native.nix` you actually download an HTML page. The link should refer to the raw file.