### PR TITLE
Fix System.nanoTime

### DIFF
--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -30,7 +30,7 @@ object System {
   def getProperty(key: String, default: String): String = ???
   def setProperty(key: String, value: String): String   = ???
 
-  def nanoTime(): CLong = time.scalanative_nano_time
+  def nanoTime(): CLongLong = time.scalanative_nano_time
 
   var in: InputStream  = _
   var out: PrintStream = new PrintStream(new CFileOutputStream(stdio.stdout))

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -30,7 +30,7 @@ object System {
   def getProperty(key: String, default: String): String = ???
   def setProperty(key: String, value: String): String   = ???
 
-  def nanoTime(): CLongLong = time.scalanative_nano_time
+  def nanoTime(): scala.Long = time.scalanative_nano_time
 
   var in: InputStream  = _
   var out: PrintStream = new PrintStream(new CFileOutputStream(stdio.stdout))

--- a/nativelib/src/main/resources/time.c
+++ b/nativelib/src/main/resources/time.c
@@ -8,8 +8,10 @@
 #endif
 
 // https://gist.github.com/jbenet/1087739
-long scalanative_nano_time() {
-	long nano_time;
+long long scalanative_nano_time() {
+	long long nano_time;
+
+#define NANOSECONDS_PER_SECOND 1000000000LL
 
 #ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
 	clock_serv_t cclock;
@@ -17,13 +19,14 @@ long scalanative_nano_time() {
 	host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
 	clock_get_time(cclock, &mts);
 	mach_port_deallocate(mach_task_self(), cclock);
-	nano_time = mts.tv_sec * 1e9 + mts.tv_nsec;
+	nano_time = mts.tv_sec * NANOSECONDS_PER_SECOND + mts.tv_nsec;
 #else
 	struct timespec ts;
 	clock_gettime(CLOCK_MONOTONIC, &ts);
-	nano_time = ts.tv_sec * 1e9 + ts.tv_nsec;
+	nano_time = ts.tv_sec * NANOSECONDS_PER_SECOND + ts.tv_nsec;
 #endif
 
-	return nano_time;
+#undef NANOSECONDS_PER_SECOND
 
+  return nano_time;
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/time.scala
@@ -1,9 +1,9 @@
 package scala.scalanative
 package runtime
 
-import scala.scalanative.native.{CLong, extern}
+import scala.scalanative.native.{CLongLong, extern}
 
 @extern
 object time {
-  def scalanative_nano_time: CLong = extern
+  def scalanative_nano_time: CLongLong = extern
 }


### PR DESCRIPTION
System.nanoTime now returns a 64-bit integer and all computations use integer
arithmetic. System.nanoTime was returning a CLong which is only guaranteed at
least a 32-bit wide 2's complement integer. Computation was also being done
using floating point arithmetic instead of integer arithmetic. Since the C
standard does not specify the representation of double precision floats there
were no guarantees that the correct results would be computed.

Fixes issue 544