### PR TITLE
Implement time.h

### DIFF
--- a/nativelib/src/main/resources/wrap.c
+++ b/nativelib/src/main/resources/wrap.c
@@ -144,10 +144,6 @@ clock_t scalanative_libc_clocks_per_sec() {
   return CLOCKS_PER_SEC;
 }
 
-int scalanative_libc_time_utc() {
-  return TIME_UTC;
-}
-
 int scalanative_math_errno() {
     return MATH_ERRNO;
 }

--- a/nativelib/src/main/resources/wrap.c
+++ b/nativelib/src/main/resources/wrap.c
@@ -3,6 +3,7 @@
 #include <signal.h>
 #include <math.h>
 #include <errno.h>
+#include <time.h>
 
 // This file contains functions that wrap libc
 // built-in macros. We need this because Scala Native
@@ -137,6 +138,14 @@ float scanative_libc_nan() {
 
 int scalanative_libc_math_errhandling() {
     return math_errhandling;
+}
+
+clock_t scalanative_libc_clocks_per_sec() {
+  return CLOCKS_PER_SEC;
+}
+
+int scalanative_libc_time_utc() {
+  return TIME_UTC;
 }
 
 int scalanative_math_errno() {

--- a/nativelib/src/main/scala/scala/scalanative/native/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/time.scala
@@ -9,7 +9,6 @@ object time {
   def difftime(time_end: time_t, time_beg: time_t): CDouble = extern
   def time(arg: Ptr[time_t]): time_t                        = extern
   def clock(): clock_t                                      = extern
-  def timespec_get(ts: Ptr[timespec], base: CInt): CInt     = extern
 
   // Format conversions
 
@@ -26,12 +25,9 @@ object time {
   type tm       = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
   type time_t   = CStruct0
   type clock_t  = CStruct0
-  type timespec = CStruct2[time_t, CLong]
 
   // Macros
 
   @name("scalanative_libc_clocks_per_sec")
   def CLOCKS_PER_SEC: clock_t = extern
-  @name("scalanative_libc_time_utc")
-  def TIME_UTC: CInt = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/time.scala
@@ -1,0 +1,37 @@
+package scala.scalanative
+package native
+
+@extern
+object time {
+
+  // Time manipulation
+
+  def difftime(time_end: time_t, time_beg: time_t): CDouble = extern
+  def time(arg: Ptr[time_t]): time_t                        = extern
+  def clock(): clock_t                                      = extern
+  def timespec_get(ts: Ptr[timespec], base: CInt): CInt     = extern
+
+  // Format conversions
+
+  def asctime(time_ptr: Ptr[tm]): CString = extern
+  def ctime(time: Ptr[time_t]): CString   = extern
+  def strftime(str: CString, count: CSize, format: CString, time: Ptr[tm]) =
+    extern
+  def gmtime(time: Ptr[time_t]): Ptr[tm]    = extern
+  def localtime(time: Ptr[time_t]): Ptr[tm] = extern
+  def mktime(time: Ptr[tm]): time_t         = extern
+
+  // Types
+
+  type tm       = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
+  type time_t   = CStruct0
+  type clock_t  = CStruct0
+  type timespec = CStruct2[time_t, CLong]
+
+  // Macros
+
+  @name("scalanative_libc_clocks_per_sec")
+  def CLOCKS_PER_SEC: clock_t = extern
+  @name("scalanative_libc_time_utc")
+  def TIME_UTC: CInt = extern
+}

--- a/nativelib/src/main/scala/scala/scalanative/native/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/time.scala
@@ -22,9 +22,9 @@ object time {
 
   // Types
 
-  type tm       = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
-  type time_t   = CStruct0
-  type clock_t  = CStruct0
+  type tm      = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
+  type time_t  = CLong
+  type clock_t = CLong
 
   // Macros
 


### PR DESCRIPTION
Just an implementation of the time.h header.

This seems to have some overlap with #530 which implements many of these calls inside `scala.scalanative.runtime.time` which seems to be incorrect - `scalanative.native.time` fits better with the way the other nativelib headers are laid out.