### PR TITLE
fix UnsupportedOperationException

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -251,8 +251,9 @@ object ScalaNativePluginInternal {
     nativeAvailableDependencies := ResourceScope { implicit scope =>
       val forceCompile = compileTask.value
 
-      val globals = fullClasspath.value.flatMap(p =>
-        tools.LinkerPath(VirtualDirectory.real(p.data)).globals.toSeq)
+      val globals = fullClasspath.value
+        .collect { case p if p.data.exists => p.data }
+        .flatMap(p => tools.LinkerPath(VirtualDirectory.real(p)).globals.toSeq)
 
       globals.map(_.show).sorted
     }

--- a/scripted-tests/run/unsupported-operation-exception/build.sbt
+++ b/scripted-tests/run/unsupported-operation-exception/build.sbt
@@ -1,0 +1,3 @@
+ScalaNativePlugin.projectSettings
+
+scalaVersion := "2.11.8"

--- a/scripted-tests/run/unsupported-operation-exception/project/scala-native.sbt
+++ b/scripted-tests/run/unsupported-operation-exception/project/scala-native.sbt
@@ -1,0 +1,8 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scala-native" % "sbt-scala-native" % pluginVersion)
+}

--- a/scripted-tests/run/unsupported-operation-exception/test
+++ b/scripted-tests/run/unsupported-operation-exception/test
@@ -1,0 +1,1 @@
+> test:nativeAvailableDependencies


### PR DESCRIPTION
https://travis-ci.org/xuwei-k/scala-native/jobs/212620521#L4766

```
[info] java.lang.UnsupportedOperationException: Neither a jar, nor a directory: /private/var/folders/my/m6ynh3bn6tq06h7xr3js0z7r0000gn/T/sbt_fb371f18/unsupported-operation-exception/target/scala-2.11/test-classes
[info] 	at scala.scalanative.io.VirtualDirectory$.real(VirtualDirectory.scala:67)
[info] 	at scala.scalanative.sbtplugin.ScalaNativePluginInternal$$anonfun$availableDependenciesTask$1$$anonfun$apply$4$$anonfun$17.apply(ScalaNativePluginInternal.scala:255)
[info] 	at scala.scalanative.sbtplugin.ScalaNativePluginInternal$$anonfun$availableDependenciesTask$1$$anonfun$apply$4$$anonfun$17.apply(ScalaNativePluginInternal.scala:254)
[info] 	at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
[info] 	at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
[info] 	at scala.collection.immutable.List.foreach(List.scala:318)
[info] 	at scala.collection.TraversableLike$class.flatMap(TraversableLike.scala:251)
[info] 	at scala.collection.AbstractTraversable.flatMap(Traversable.scala:105)
[info] 	at scala.scalanative.sbtplugin.ScalaNativePluginInternal$$anonfun$availableDependenciesTask$1$$anonfun$apply$4.apply(ScalaNativePluginInternal.scala:254)
[info] 	at scala.scalanative.sbtplugin.ScalaNativePluginInternal$$anonfun$availableDependenciesTask$1$$anonfun$apply$4.apply(ScalaNativePluginInternal.scala:251)
[info] 	at scala.scalanative.util.Scope$.apply(Scope.scala:30)
[info] 	at scala.scalanative.sbtplugin.ScalaNativePluginInternal$$anonfun$availableDependenciesTask$1.apply(ScalaNativePluginInternal.scala:251)
[info] 	at scala.scalanative.sbtplugin.ScalaNativePluginInternal$$anonfun$availableDependenciesTask$1.apply(ScalaNativePluginInternal.scala:251)
[info] 	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
[info] 	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
[info] 	at sbt.std.Transform$$anon$4.work(System.scala:63)
[info] 	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
[info] 	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
[info] 	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
[info] 	at sbt.Execute.work(Execute.scala:237)
[info] 	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
[info] 	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
[info] 	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
[info] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
[info] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[info] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
[info] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
[info] 	at java.lang.Thread.run(Thread.java:745)
[info] [error] (test:nativeAvailableDependencies) java.lang.UnsupportedOperationException: Neither a jar, nor a directory: /private/var/folders/my/m6ynh3bn6tq06h7xr3js0z7r0000gn/T/sbt_fb371f18/unsupported-operation-exception/target/scala-2.11/test-classes
```