### PR TITLE
fix #562: nativeClang and nativeClangPP are now task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -273,8 +273,8 @@ lazy val nativelib =
     .settings(libSettings)
     .settings(mavenPublishSettings)
     .settings(compile in Compile := {
-      val clang   = nativeFindClang.value
-      val clangpp = nativeFindClangPP.value
+      val clang   = findClang(nativeClang.value)
+      val clangpp = findClangPP(nativeClangPP.value)
 
       val source = baseDirectory.value
       val compileSuccess =

--- a/build.sbt
+++ b/build.sbt
@@ -273,9 +273,10 @@ lazy val nativelib =
     .settings(libSettings)
     .settings(mavenPublishSettings)
     .settings(compile in Compile := {
-      val clang   = nativeClang.value
-      val clangpp = nativeClangPP.value
-      val source  = baseDirectory.value
+      val clang   = nativeFindClang.value
+      val clangpp = nativeFindClangPP.value
+
+      val source = baseDirectory.value
       val compileSuccess =
         IO.withTemporaryDirectory { tmp =>
           IO.copyDirectory(baseDirectory.value, tmp)

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -58,8 +58,6 @@ Since Name                     Type         Description
 0.1   ``package``              ``File``     Similar to standard package with addition of NIR
 0.1   ``publish``              ``Unit``     Similar to standard publish with addition of NIR (1)
 0.1   ``nativeLink``           ``File``     Link NIR and generate native binary
-0.2   ``nativeFindClang``      ``File``     Path to ``clang`` command
-0.2   ``nativeFindClangPP``    ``File``     Path to ``clang++`` command
 ===== ======================== ============ ====================================================
 
 

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -33,24 +33,35 @@ and now you can write your first application in ``./src/main/scala/HelloWorld.sc
 
 now simply run ``sbt run`` to get everything compiled and have the expected output!
 
-Sbt settings and tasks
+Sbt settings
 ----------------------
 
-===== ======================== =============== =========================================================
-Since Name                     Type            Description
-===== ======================== =============== =========================================================
-0.1   ``compile``              ``Analysis``    Compile Scala code to NIR
-0.1   ``run``                  ``Unit``        Compile, link and run the generated binary
-0.1   ``package``              ``File``        Similar to standard package with addition of NIR
-0.1   ``publish``              ``Unit``        Similar to standard publish with addition of NIR (1)
-0.1   ``nativeLink``           ``File``        Link NIR and generate native binary
-0.1   ``nativeClang``          ``File``        Path to ``clang`` command
-0.1   ``nativeClangPP``        ``File``        Path to ``clang++`` command
-0.1   ``nativeCompileOptions`` ``Seq[String]`` Extra options passed to clang verbatim during compilation
-0.1   ``nativeLinkingOptions`` ``Seq[String]`` Extra options passed to clang verbatim during linking
-0.1   ``nativeMode``           ``String``      Either ``"debug"`` or ``"release"`` (2)
-0.2   ``nativeGC``             ``String``      Either ``"none"`` or ``"boehm"`` (3)
-===== ======================== =============== =========================================================
+===== ======================== ================ =================================================== =========================================================
+Since Name                     Type             Default Value                                       Description
+===== ======================== ================ =================================================== =========================================================
+0.1   ``nativeClang``          ``Option[File]`` ``None``                                            Path to ``clang`` command
+0.1   ``nativeClangPP``        ``Option[File]`` ``None``                                            Path to ``clang++`` command
+0.1   ``nativeCompileOptions`` ``Seq[String]``  ``Seq("-O0")``                                      Extra options passed to clang verbatim during compilation
+0.1   ``nativeLinkingOptions`` ``Seq[String]``  ``Seq("-I/usr/local/include", "-L/usr/local/lib")`` Extra options passed to clang verbatim during linking
+0.1   ``nativeMode``           ``String``       ``"debug"``                                         Either ``"debug"`` or ``"release"`` (2)
+0.2   ``nativeGC``             ``String``       ``"boehm"``                                         Either ``"none"`` or ``"boehm"`` (3)
+===== ======================== ================ =================================================== =========================================================
+
+Sbt tasks
+----------------------
+
+===== ======================== ============ ====================================================
+Since Name                     Type         Description
+===== ======================== ============ ====================================================
+0.1   ``compile``              ``Analysis`` Compile Scala code to NIR
+0.1   ``run``                  ``Unit``     Compile, link and run the generated binary
+0.1   ``package``              ``File``     Similar to standard package with addition of NIR
+0.1   ``publish``              ``Unit``     Similar to standard publish with addition of NIR (1)
+0.1   ``nativeLink``           ``File``     Link NIR and generate native binary
+0.2   ``nativeFindClang``      ``File``     Path to ``clang`` command
+0.2   ``nativeFindClangPP``    ``File``     Path to ``clang++`` command
+===== ======================== ============ ====================================================
+
 
 1. See `Publishing`_ and `Cross compilation`_ for details.
 2. See `Compilation modes`_ for details.

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -16,9 +16,17 @@ object ScalaNativePlugin extends AutoPlugin {
 
     val nativeVersion = nir.Versions.current
 
-    val nativeClang = settingKey[File]("Location of the clang compiler.")
+    val nativeClang =
+      settingKey[Option[File]]("Location of the clang compiler.")
 
-    val nativeClangPP = settingKey[File]("Location of the clang++ compiler.")
+    val nativeClangPP =
+      settingKey[Option[File]]("Location of the clang++ compiler.")
+
+    val nativeFindClang =
+      taskKey[File]("Find the location of the clang compiler.")
+
+    val nativeFindClangPP =
+      taskKey[File]("Find the location of the clang++ compiler.")
 
     val nativeCompileOptions =
       settingKey[Seq[String]](
@@ -38,7 +46,7 @@ object ScalaNativePlugin extends AutoPlugin {
       settingKey[String]("Compilation mode, either \"debug\" or \"release\".")
 
     val nativeGC =
-      taskKey[String]("GC choice, either \"none\" or \"boehm\".")
+      settingKey[String]("GC choice, either \"none\" or \"boehm\".")
   }
 
   override def projectSettings: Seq[Setting[_]] = (

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -2,6 +2,7 @@ package scala.scalanative
 package sbtplugin
 
 import scalanative.tools
+import ScalaNativePluginInternal._
 
 import sbt._
 
@@ -12,6 +13,16 @@ object ScalaNativePlugin extends AutoPlugin {
 
   object AutoImport extends NativeCross {
 
+    def findClang(default: Option[File]): File =
+      default.getOrElse(
+        discover("clang", clangVersions)
+      )
+
+    def findClangPP(default: Option[File]): File =
+      default.getOrElse(
+        discover("clang++", clangVersions)
+      )
+
     val ScalaNativeCrossVersion = sbtplugin.ScalaNativeCrossVersion
 
     val nativeVersion = nir.Versions.current
@@ -21,12 +32,6 @@ object ScalaNativePlugin extends AutoPlugin {
 
     val nativeClangPP =
       settingKey[Option[File]]("Location of the clang++ compiler.")
-
-    val nativeFindClang =
-      taskKey[File]("Find the location of the clang compiler.")
-
-    val nativeFindClangPP =
-      taskKey[File]("Find the location of the clang++ compiler.")
 
     val nativeCompileOptions =
       settingKey[Seq[String]](
@@ -51,6 +56,6 @@ object ScalaNativePlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Setting[_]] = (
     ScalaNativePluginInternal.projectSettings ++
-      ScalaNativePluginInternal.scalaNativeEcosystemSettings
+      scalaNativeEcosystemSettings
   )
 }


### PR DESCRIPTION
A task is run everytime you require it's value. it will delay it's execution to a command that requires them.