### PR TITLE
Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,24 @@
+pipeline:
+  sftp_cache_restore:
+    image: plugins/sftp-cache
+    restore: true
+    mount:
+      - /drone/.ivy2
+      - /drone/.sbt
+      - /drone/.git
+
+  test:
+    image: scalanative/scalanative-drone:0.2.4
+    commands:
+      - export SBT_OPTS="-Xmx8G -Dsbt.log.noformat=true"
+      - sbt rebuild
+      - sbt test-all
+
+  # Save folders in distributed cache
+  sftp_cache_rebuild:
+    image: plugins/sftp-cache
+    rebuild: true
+    mount:
+      - /drone/.ivy2
+      - /drone/.sbt
+      - /drone/.git

--- a/build.sbt
+++ b/build.sbt
@@ -240,9 +240,12 @@ lazy val sbtPluginSettings =
     Seq(
       sbtPlugin := true,
       scriptedLaunchOpts ++=
-        Seq("-Xmx1024M",
-            "-XX:MaxPermSize=256M",
-            "-Dplugin.version=" + version.value)
+        Seq(
+          "-Djline.terminal=jline.UnsupportedTerminal",
+          "-Dsbt.log.noformat=true",
+          "-Xmx2G",
+          "-Dplugin.version=" + version.value
+        )
     )
 
 lazy val sbtScalaNative =
@@ -306,6 +309,8 @@ lazy val scalalib =
       assembleScalaLibrary := {
         import org.eclipse.jgit.api._
 
+        val base = (baseDirectory in ThisBuild).value
+
         val s      = streams.value
         val trgDir = target.value / "scalaSources" / scalaVersion.value
 
@@ -328,19 +333,29 @@ lazy val scalalib =
         s.log.info(s"Checking out Scala source version ${scalaVersion.value}")
         git.checkout().setName(s"v${scalaVersion.value}").call()
 
-        IO.delete(file("scalalib/src/main/scala"))
-        IO.copyDirectory(trgDir / "src" / "library" / "scala",
-                         file("scalalib/src/main/scala/scala"))
+        val scalalibDir = base / "scalalib" / "src" / "main" / "scala"
+
+        IO.delete(scalalibDir)
+        IO.copyDirectory(trgDir / "src" / "library" / "scala", scalalibDir)
 
         val epoch :: major :: _ = scalaVersion.value.split("\\.").toList
-        IO.copyDirectory(file(s"scalalib/overrides-$epoch.$major/scala"),
-                         file("scalalib/src/main/scala/scala"),
-                         overwrite = true)
+
+        val scalalibOverideDir =
+          base / "scalalib" / s"overrides-$epoch.$major" / "scala"
+
+        val destDir =
+          base /  "scalalib" / "src" / "main" / "scala"
+
+        IO.copyDirectory(
+          scalalibOverideDir,
+          destDir / "scala",
+          overwrite = true
+        )
 
         // Remove all java code, as it's not going to be available
         // in the NIR anyway. This also resolves issues wrt overrides
         // of code that was previously in Java but is in Scala now.
-        (file("scalalib/src/main/scala") ** "*.java").get.foreach(IO.delete)
+        (destDir ** "*.java").get.foreach(IO.delete)
       },
       compile in Compile := (compile in Compile)
         .dependsOn(assembleScalaLibrary)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,65 @@
-FROM nixos/nix
- 
-RUN nix-channel --update
+FROM ubuntu:16.04
 
-RUN nix-env -i git
+RUN apt-get -qq update
+RUN apt-get install -y wget
+RUN sh -c "echo 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main' >> /etc/apt/sources.list"
+RUN sh -c "echo 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main' >> /etc/apt/sources.list"
 
-WORKDIR /tmp
+# use storage driver devicemapper or it fails on renaming
+# https://github.com/docker/docker/issues/26317#issuecomment-244895700
+RUN wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+RUN apt-get -qq update
+RUN apt-get install -y wget
+RUN apt-get install -y tar
+RUN apt-get install -y curl
+RUN apt-get install -y git
+RUN apt-get install -y openjdk-8-jdk
+RUN apt-get install -y clang++-3.7
+RUN apt-get install -y llvm-3.7
+RUN apt-get install -y llvm-3.7-dev
+RUN apt-get install -y llvm-3.7-runtime
+RUN apt-get install -y llvm-3.7-tool
+RUN apt-get install -y libgc-dev
+RUN apt-get install -y libunwind-dev
 
-RUN git clone https://github.com/scala-native/scala-native.git native
-  
-WORKDIR /tmp/native
+# Install SBT
+ENV SBT_VERSION 0.13.13
+RUN curl -L -o sbt-$SBT_VERSION.deb http://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb
+RUN dpkg -i sbt-$SBT_VERSION.deb
+RUN rm sbt-$SBT_VERSION.deb
+RUN apt-get update
+RUN apt-get install sbt
 
-RUN  nix-shell bin/scala-native.nix -A clangEnv --run "echo 'clangEnv installed'"
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
+ENV SBT_OPTS -Xms512M -Xmx1536M
 
-RUN  nix-shell bin/scala-native.nix -A clangEnv --run "cd .. && sbt scalaVersion"
+WORKDIR /root
 
-RUN  nix-shell bin/scala-native.nix -A clangEnv --run "sbt rebuild"
+# Run a dummy scala project
+RUN mkdir scala-211
+RUN mkdir scala-211/project
+RUN echo 'sbt.version = 0.13.13' > scala-211/project/build.properties
+RUN echo 'scalaVersion := "2.11.8"' > scala-211/build.sbt
+RUN mkdir scala-211/src
+RUN mkdir scala-211/src/main
+RUN mkdir scala-211/src/main/scala
+RUN echo 'object Main { def main(args: Array[String]): Unit = println("Hello, World!") }' > scala-211/src/main/scala/Main.scala
+RUN cd scala-211; sbt run
+
+# Run a dummy scala project
+RUN mkdir scala-210
+RUN mkdir scala-210/project
+RUN echo 'sbt.version = 0.13.13' > scala-210/project/build.properties
+RUN echo 'scalaVersion := "2.10.6"' > scala-210/build.sbt
+RUN mkdir scala-210/src
+RUN mkdir scala-210/src/main
+RUN mkdir scala-210/src/main/scala
+RUN echo 'object Main { def main(args: Array[String]): Unit = println("Hello, World!") }' > scala-210/src/main/scala/Main.scala
+RUN cd scala-210; sbt run
+
+# git clone git://github.com/scala-native/scala-native.git
 
 CMD ["/bin/bash"]
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,16 +1,12 @@
-# Run the raytracing demo in the docker image (932MB)
+```
+docker run -i -t scalanative/scalanative-drone:0.2.4
+```
 
-```
-docker run -i -t scalacenter/scala-native:0.1.0
-bin/nix-run
-sbt
-demoNative/run
-```
 
 # Publish docker image
 
 ```
-docker build -t scalacenter/scala-native:0.1.0 .
+docker build -t scalanative/scalanative-drone:0.2.4 .
 docker login
-docker push scalacenter/scala-native:0.1.0
+docker push scalanative/scalanative-drone:0.2.4
 ```


### PR DESCRIPTION
solves #528

platform-ci.scala-lang.org is a server with a large amount of cpu/memory that runs at epfl. It uses a ci software called Drone http://readme.drone.io/. We can run test inside a docker container.

example: https://platform-ci.scala-lang.org/scala-native/scala-native/5