### PR TITLE
Implement System.getenv()

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -410,7 +410,13 @@ lazy val tests =
           }
         """)
         Seq(file)
-      }.taskValue
+      }.taskValue,
+      envVars in run ++= Map(
+        "USER"                           -> "scala-native",
+        "HOME"                           -> baseDirectory.value.getAbsolutePath,
+        "SCALA_NATIVE_ENV_WITH_EQUALS"   -> "1+1=2",
+        "SCALA_NATIVE_ENV_WITHOUT_VALUE" -> ""
+      )
     )
     .enablePlugins(ScalaNativePlugin)
 

--- a/nativelib/src/main/resources/posix.c
+++ b/nativelib/src/main/resources/posix.c
@@ -4,6 +4,8 @@
 #include <math.h>
 #include <errno.h>
 
+extern char **environ;
+
 // This file contains functions that wrap posix
 // built-in macros. We need this because Scala Native
 // can not expand C macros, and that's the easiest way to
@@ -11,4 +13,8 @@
 
 int scalanative_eintr() {
     return EINTR;
+}
+
+char ** scalanative_environ() {
+    return environ;
 }

--- a/nativelib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -1,12 +1,14 @@
 package scala.scalanative.posix
 
-import scala.scalanative.native.{CUnsignedInt, extern}
+import scala.scalanative.native.{CUnsignedInt, CString, Ptr, extern, name}
 
-/**
- * Created by marius on 27.10.16.
- */
 @extern
 object unistd {
   def sleep(seconds: CUnsignedInt): Int = extern
   def usleep(usecs: CUnsignedInt): Int  = extern
+
+  // Macros
+
+  @name("scalanative_environ")
+  def environ: Ptr[CString] = extern
 }

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -427,12 +427,13 @@ object ScalaNativePluginInternal {
       }
     },
     run := {
+      val env    = (envVars in run).value.toSeq
       val logger = streams.value.log
       val binary = abs(nativeLink.value)
       val args   = spaceDelimited("<arg>").parsed
 
       logger.running(binary +: args)
-      val exitCode = Process(binary +: args).!
+      val exitCode = Process(binary +: args, None, env: _*).!
 
       val message =
         if (exitCode == 0) None

--- a/unit-tests/src/main/scala/java/lang/SystemSuite.scala
+++ b/unit-tests/src/main/scala/java/lang/SystemSuite.scala
@@ -11,4 +11,19 @@ object SystemSuite extends tests.Suite {
       t0 = t1
     }
   }
+
+  test("System.getenv should contain known env variables") {
+    assert(System.getenv().containsKey("HOME"))
+    assert(System.getenv().get("USER") == "scala-native")
+    assert(System.getenv().get("SCALA_NATIVE_ENV_WITH_EQUALS") == "1+1=2")
+    assert(System.getenv().get("SCALA_NATIVE_ENV_WITHOUT_VALUE") == "")
+    assert(System.getenv().get("SCALA_NATIVE_ENV_THAT_DOESNT_EXIST") == null)
+  }
+
+  test("System.getenv(key) should read known env variables") {
+    assert(System.getenv("USER") == "scala-native")
+    assert(System.getenv("SCALA_NATIVE_ENV_WITH_EQUALS") == "1+1=2")
+    assert(System.getenv("SCALA_NATIVE_ENV_WITHOUT_VALUE") == "")
+    assert(System.getenv("SCALA_NATIVE_ENV_THAT_DOESNT_EXIST") == null)
+  }
 }


### PR DESCRIPTION
Expose `char ** environ` variable as `stdlib.environ` and use it to read
all environment variables lazily when `System.getenv()` is accessed.

Also the internal sbt plugins `run` method to pass environment variables
to the process using the `envVariable in run` setting.