### PR TITLE
Add event loop callback to the runtime

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -77,7 +77,7 @@ package object runtime {
   def getMonitor(obj: Object): Monitor = Monitor.dummy
 
   /** Initialize runtime with given arguments and return the
-   * rest as Java-style array.
+   *  rest as Java-style array.
    */
   def init(argc: Int, argv: Ptr[Ptr[Byte]]): ObjectArray = {
     val args = new scala.Array[String](argc - 1)
@@ -92,4 +92,9 @@ package object runtime {
 
     args.asInstanceOf[ObjectArray]
   }
+
+  /** Run the runtime's event loop. The method is called from the
+   *  generated C-style after the application's main method terminates.
+   */
+  def loop(): Unit = ()
 }

--- a/tools/src/main/scala/scala/scalanative/optimizer/inject/Main.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/inject/Main.scala
@@ -39,6 +39,7 @@ class Main(entry: Global)(implicit fresh: Fresh) extends Inject {
                  Op.Call(RtInitSig, RtInit, Seq(rt, argc, argv), unwind)),
         Inst.Let(module.name, Op.Module(entry.top, unwind)),
         Inst.Let(Op.Call(entryMainTy, entryMain, Seq(module, arr), unwind)),
+        Inst.Let(Op.Call(RtLoopSig, RtLoop, Seq(module), unwind)),
         Inst.Ret(Val.Int(0)),
         Inst.Label(unwind.name, Seq(exc)),
         Inst.Let(
@@ -59,6 +60,10 @@ object Main extends InjectCompanion {
     Type.Function(Seq(Rt, Type.Int, Type.Ptr), ObjectArray)
   val RtInit =
     Val.Global(Rt.name member "init_i32_ptr_class.ssnr.ObjectArray", Type.Ptr)
+  val RtLoopSig =
+    Type.Function(Seq(Rt), Type.Unit)
+  val RtLoop =
+    Val.Global(Rt.name member "loop_unit", Type.Ptr)
 
   val MainName = Global.Top("main")
   val MainSig  = Type.Function(Seq(Type.Int, Type.Ptr), Type.Int)
@@ -78,7 +83,11 @@ object Main extends InjectCompanion {
   val InitDecl = Defn.Declare(Attrs.None, Init.name, InitSig)
 
   override val depends =
-    Seq(ObjectArray.name, Rt.name, RtInit.name, PrintStackTraceName)
+    Seq(ObjectArray.name,
+        Rt.name,
+        RtInit.name,
+        RtLoop.name,
+        PrintStackTraceName)
 
   override val injects =
     Seq(InitDecl)


### PR DESCRIPTION
This is preparatory to change towards #617. It adds a a new method
to the runtime's package object. This method is called after the
application's main is complete and should be later changed to
implement a custom execution context to run Scala futures.