### PR TITLE
Implement reader for stdin

### DIFF
--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -1,9 +1,10 @@
 package java.lang
 
-import java.io.{InputStream, PrintStream}
+import java.io.{InputStream, PrintStream, IOException}
 import java.util.{Collections, HashMap, Map, Properties}
 import scala.scalanative.native._
-import scala.scalanative.posix._
+import scala.scalanative.posix.unistd
+import scala.scalanative.posix.errno.EINTR
 import scala.scalanative.runtime.time
 import scala.scalanative.runtime.Platform
 import scala.scalanative.runtime.GC
@@ -94,7 +95,7 @@ object System {
   def getenv(): Map[String, String] = envVars
   def getenv(key: String): String   = envVars.get(key)
 
-  var in: InputStream  = _
+  var in: InputStream  = new CStdinStream()
   var out: PrintStream = new PrintStream(new CFileOutputStream(stdio.stdout))
   var err: PrintStream = new PrintStream(new CFileOutputStream(stdio.stderr))
 
@@ -138,6 +139,43 @@ object System {
     def write(b: Int): Unit = {
       !buf = b.toUByte.toByte
       stdio.fwrite(buf, 1, 1, stream)
+    }
+  }
+
+  private class CStdinStream() extends java.io.InputStream {
+    private def readAndRetry(fd: CInt,
+                             buf: Ptr[scala.Byte],
+                             count: CSize): CSize = {
+      var nread: CSize = -1
+      do {
+        nread = unistd.read(unistd.STDIN_FILENO, buf, count)
+        if (nread == -1 && errno.errno != EINTR)
+          throw new IOException("Error on reading stdin")
+      } while (nread == -1)
+      nread
+    }
+
+    def read(): CInt = {
+      val buffer = stackalloc[scala.Byte](1)
+      var nread  = readAndRetry(unistd.STDIN_FILENO, buffer, 1)
+
+      if (nread != 0) buffer(0).toInt else -1
+    }
+
+    override def read(b: Array[scala.Byte], off: Int, len: Int): Int = {
+      // Stdin is line buffered, so there is no need to reserve a too big buffer
+      val bufsize = len min 128
+      val buffer  = stackalloc[scala.Byte](bufsize)
+      val nread   = readAndRetry(unistd.STDIN_FILENO, buffer, bufsize)
+
+      if (nread != 0) {
+        var i = 0
+        while (i < nread) {
+          b(off + i) = buffer(i)
+          i += 1
+        }
+        nread.toInt
+      } else -1
     }
   }
 }

--- a/nativelib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -1,14 +1,14 @@
 package scala.scalanative.posix
 
 import scala.scalanative.native.{
-  CInt,
-  CLongLong,
   CUnsignedInt,
-  CSize,
   CString,
+  CLongLong,
   Ptr,
   extern,
-  name
+  name,
+  CSize,
+  CInt
 }
 
 @extern

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -374,7 +374,9 @@ object ScalaNativePluginInternal {
       val args   = spaceDelimited("<arg>").parsed
 
       logger.running(binary +: args)
-      val exitCode = Process(binary +: args, None, env: _*).!
+      val exitCode = Process(binary +: args, None, env: _*)
+        .run(connectInput = true)
+        .exitValue
 
       val message =
         if (exitCode == 0) None


### PR DESCRIPTION
Fix #543.

I use `read` from unistd instead of `fread` from stdio to prevent buffer issues. Stdio is line buffered, and we want the line to be available as soon as the user enter it, so we don't want `fread` to wait for the buffer to be full before returning.