### PR TITLE
Fix LLVM target probe compilation

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -18,7 +18,7 @@ import KeyRanks.DTask
 import scala.util.Try
 
 import System.{lineSeparator => nl}
-import java.io.File
+import java.io.{File, ByteArrayInputStream}
 
 object ScalaNativePluginInternal {
 
@@ -149,20 +149,18 @@ object ScalaNativePluginInternal {
       libs
     },
     nativeTarget := {
-      val logger       = nativeLogger.value
-      val cwd          = nativeWorkdir.value
-      val clang        = nativeClang.value
-      val targetcfile  = cwd / "target.c"
-      val targetllfile = cwd / "target.ll"
-      val compilec     = Seq(abs(clang), "-S", "-emit-llvm", abs(targetcfile))
+      val logger = nativeLogger.value
+      val cwd    = nativeWorkdir.value
+      val clang  = nativeClang.value
+      val compilec =
+        Seq(abs(clang), "-S", "-emit-llvm", "-x", "c", "-o", "-", "-")
+      val probe = new ByteArrayInputStream("int probe;".getBytes("UTF-8"))
       def fail =
         throw new MessageOnlyException("Failed to detect native target.")
 
-      IO.write(targetcfile, "int probe;")
       logger.running(compilec)
-      val exit = Process(compilec, cwd) ! logger
-      if (exit != 0) fail
-      IO.readLines(targetllfile)
+      val lines = Process(compilec, cwd) #< probe lines_! logger
+      lines
         .collectFirst {
           case line if line.startsWith("target triple") =>
             line.split("\"").apply(1)


### PR DESCRIPTION
The refactoring of the sbt plugin in commit 036de7e68bb8801 broke the
compilation to native code with clang-4.0/macOS 10.10.5 because the
compilation of the probe code was changed to use the common work
directory.

    [error] /opt/scala-native/sandbox/target/scala-2.11/native/target.ll:2:1: error: expected top-level entity
    [error] source_filename = "/opt/scala-native/sandbox/target/scala-2.11/native/target.c"
    [error] ^
    [error] 1 error generated.

---
This is half a bug report / half an attempt at providing a fix by extract the target triple without writing to disk.