### PR TITLE
Fix #643

### DIFF
--- a/tools/src/main/scala/scala/scalanative/linker/ReflectiveProxy.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ReflectiveProxy.scala
@@ -85,7 +85,7 @@ object ReflectiveProxy {
       case Some(boxTy) =>
         Inst.Let(Op.Box(boxTy, Val.Local(callName, defnRetTy)))
       case None =>
-        Inst.Let(Op.As(proxyRetTy, Val.Local(callName, defnRetTy)))
+        Inst.Let(Op.Copy(Val.Local(callName, defnRetTy)))
     }
 
   private def genRet(retValBoxName: Local, proxyRetTy: Type) =

--- a/unit-tests/src/main/scala/scala/ReflectiveProxySuite.scala
+++ b/unit-tests/src/main/scala/scala/ReflectiveProxySuite.scala
@@ -390,4 +390,9 @@ object ReflectiveProxySuite extends tests.Suite {
       callFoo((new A).asInstanceOf[{ def foo(): Int }])
     }
   }
+
+  test("issue #643 - return Nothing") {
+    val foo: { def get: Int } = Some(42)
+    assert(foo.get == 42)
+  }
 }


### PR DESCRIPTION
The issue was due to casts to `Nothing` in the reflective proxy, when the return type of the method is `Nothing`.