### PR TITLE
Fix linking error reporting

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -264,8 +264,8 @@ object ScalaNativePluginInternal {
       if (result.unresolved.nonEmpty) {
         result.unresolved.map(_.show).sorted.foreach { signature =>
           logger.error(s"cannot link: $signature")
-          throw new MessageOnlyException("unable to link")
         }
+        throw new MessageOnlyException("unable to link")
       }
       val classCount = result.defns.count {
         case _: nir.Defn.Class | _: nir.Defn.Module | _: nir.Defn.Trait => true


### PR DESCRIPTION
Recent refactoring of sbt plugin introduced a bug in the way linking
errors are reported. Instead of listing all the errors like in 0.1, it
would only show the first one. This pr fixes this issue.