### PR TITLE
Fix #665: change return type of string.strtok from CChar to CString

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/native/string.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/string.scala
@@ -18,7 +18,7 @@ object string {
   def strcspn(dest: CString, src: CString): CSize                      = extern
   def strpbrk(dest: CString, breakset: CString): CString               = extern
   def strstr(str: CString, substr: CString): CString                   = extern
-  def strtok(str: CString, delim: CString): CChar                      = extern
+  def strtok(str: CString, delim: CString): CString                    = extern
   def memchr(ptr: Ptr[Byte], ch: CInt, count: CSize): Ptr[Byte]        = extern
   def memcmp(lhs: Ptr[Byte], rhs: Ptr[Byte], count: CSize): Ptr[Byte]  = extern
   def memset(dest: Ptr[Byte], ch: CInt, count: CSize): Ptr[Byte]       = extern


### PR DESCRIPTION
This is pretty straightforward, I think, but I haven't been able to compile scala-native from source locally, so totally untested as of yet.  I wanted to offer the patch first, but I'd be happy to write whatever level of tests you feel are necessary -- I'll just need a bit of time to get my environment ramped up.