### PR TITLE
Use FileInputStream/FileOutputStream for System.{in, out, err}

### DIFF
--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -3,7 +3,7 @@ package java.io
 import scalanative.native._, stdlib._, stdio._, string._
 import scala.scalanative.posix.{fcntl, unistd}
 import unistd._
-import scala.scalanative.runtime.GC
+import scala.scalanative.runtime
 
 class FileInputStream(fd: FileDescriptor) extends InputStream {
 
@@ -23,8 +23,6 @@ class FileInputStream(fd: FileDescriptor) extends InputStream {
   override protected def finalize(): Unit =
     close()
 
-  // def getChannel: FileChannel
-
   final def getFD: FileDescriptor =
     fd
 
@@ -34,31 +32,52 @@ class FileInputStream(fd: FileDescriptor) extends InputStream {
     else buffer(0)
   }
 
-  override def read(buffer: Array[Byte]): Int =
+  override def read(buffer: Array[Byte]): Int = {
+    if (buffer == null) {
+      throw new NullPointerException
+    }
     read(buffer, 0, buffer.length)
+  }
 
   override def read(buffer: Array[Byte], offset: Int, count: Int): Int = {
-    val buf       = GC.malloc(count)
+    if (buffer == null) {
+      throw new NullPointerException
+    }
+    if (offset < 0 || count < 0 || count > buffer.length - offset) {
+      throw new IndexOutOfBoundsException
+    }
+    if (count == 0) {
+      return 0
+    }
+
+    // we use the runtime knowledge of the array layout to avoid
+    // intermediate buffer, and write straight into the array memory
+    val buf       = buffer.asInstanceOf[runtime.ByteArray].at(offset)
     val readCount = unistd.read(fd.fd, buf, count)
 
-    if (readCount <= 0) -1
-    else {
-      var i = 0
-      while (i < readCount) {
-        buffer(offset + i) = buf(i)
-        i += 1
-      }
+    if (readCount == 0) {
+      // end of file
+      -1
+    } else if (readCount < 0) {
+      // negative value (typically -1) indicates that read failed
+      throw new IOException("couldn't read from the file")
+    } else {
+      // successfully read readCount bytes
       readCount
     }
   }
 
   override def skip(n: Long): Long =
-    if (n < 0) throw new IOException()
-    else {
+    if (n < 0) {
+      throw new IOException()
+    } else {
       val bytesToSkip = Math.min(n, available())
       lseek(fd.fd, bytesToSkip, SEEK_CUR)
       bytesToSkip
     }
+
+  // TODO:
+  // def getChannel: FileChannel
 }
 
 object FileInputStream {

--- a/unit-tests/src/main/scala/java/io/FileInputStreamSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileInputStreamSuite.scala
@@ -1,0 +1,44 @@
+package java.io
+
+object FileInputStreamSuite extends tests.Suite {
+  test("read null") {
+    val file = new File(".")
+    val fis  = new FileInputStream(file)
+    assertThrows[NullPointerException] {
+      fis.read(null)
+    }
+    assertThrows[NullPointerException] {
+      fis.read(null, 0, 0)
+    }
+  }
+
+  test("read out of bounds negative count") {
+    val file = new File(".")
+    val fis  = new FileInputStream(file)
+    val arr  = new Array[Byte](8)
+    assertThrows[IndexOutOfBoundsException] {
+      fis.read(arr, 0, -1)
+    }
+  }
+
+  test("read out of bounds negative offset") {
+    val file = new File(".")
+    val fis  = new FileInputStream(file)
+    val arr  = new Array[Byte](8)
+    assertThrows[IndexOutOfBoundsException] {
+      fis.read(arr, -1, 0)
+    }
+  }
+
+  test("read out of bounds array too small") {
+    val file = new File(".")
+    val fis  = new FileInputStream(file)
+    val arr  = new Array[Byte](8)
+    assertThrows[IndexOutOfBoundsException] {
+      fis.read(arr, 0, 16)
+    }
+    assertThrows[IndexOutOfBoundsException] {
+      fis.read(arr, 4, 8)
+    }
+  }
+}

--- a/unit-tests/src/main/scala/java/io/FileOutputStreamSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileOutputStreamSuite.scala
@@ -1,0 +1,44 @@
+package java.io
+
+object FileOutputStreamSuite extends tests.Suite {
+  test("write null") {
+    val file = new File(".")
+    val fos  = new FileOutputStream(file)
+    assertThrows[NullPointerException] {
+      fos.write(null)
+    }
+    assertThrows[NullPointerException] {
+      fos.write(null, 0, 0)
+    }
+  }
+
+  test("write out of bounds negative count") {
+    val file = new File(".")
+    val fos  = new FileOutputStream(file)
+    val arr  = new Array[Byte](8)
+    assertThrows[IndexOutOfBoundsException] {
+      fos.write(arr, 0, -1)
+    }
+  }
+
+  test("write out of bounds negative offset") {
+    val file = new File(".")
+    val fos  = new FileOutputStream(file)
+    val arr  = new Array[Byte](8)
+    assertThrows[IndexOutOfBoundsException] {
+      fos.write(arr, -1, 0)
+    }
+  }
+
+  test("write out of bounds array too small") {
+    val file = new File(".")
+    val fos  = new FileOutputStream(file)
+    val arr  = new Array[Byte](8)
+    assertThrows[IndexOutOfBoundsException] {
+      fos.write(arr, 0, 16)
+    }
+    assertThrows[IndexOutOfBoundsException] {
+      fos.write(arr, 4, 8)
+    }
+  }
+}


### PR DESCRIPTION
We've accidentally duplicated effort on implementing the same code
twice: once for File I/O and once for the standard input/output/error
streams.

Fixes #646