### PR TITLE
throw IllegalArgumentException when specified buffer size is 0

### DIFF
--- a/javalib/src/main/scala/java/io/BufferedInputStream.scala
+++ b/javalib/src/main/scala/java/io/BufferedInputStream.scala
@@ -5,7 +5,7 @@ class BufferedInputStream(in: InputStream, size: Int)
     with Closeable
     with AutoCloseable {
 
-  if (size < 0) throw new IllegalArgumentException()
+  if (size <= 0) throw new IllegalArgumentException("Buffer size <= 0")
 
   def this(in: InputStream) = this(in, 8192)
 

--- a/javalib/src/main/scala/java/io/BufferedOutputStream.scala
+++ b/javalib/src/main/scala/java/io/BufferedOutputStream.scala
@@ -6,7 +6,7 @@ class BufferedOutputStream(out: OutputStream, size: Int)
     with Closeable
     with AutoCloseable {
 
-  if (size < 0) throw new IllegalArgumentException()
+  if (size <= 0) throw new IllegalArgumentException("Buffer size <= 0")
 
   def this(in: OutputStream) = this(in, 8192)
 

--- a/javalib/src/main/scala/java/io/BufferedReader.scala
+++ b/javalib/src/main/scala/java/io/BufferedReader.scala
@@ -2,6 +2,8 @@ package java.io
 
 class BufferedReader(in: Reader, sz: Int) extends Reader {
 
+  if (sz <= 0) throw new IllegalArgumentException("Buffer size <= 0")
+
   def this(in: Reader) = this(in, 4096)
 
   private[this] var buf = new Array[Char](sz)


### PR DESCRIPTION
`Buffered{Input, Output}Stream` and `Buffered{Reader, Writer}` should throw `IllegalArgumentException` when specified buffer size is 0.

[`BufferedWriter`](https://github.com/zaneli/scala-native/blob/c6f91d66dc13f1545acc0bc70fa310eaa12bc540/javalib/src/main/scala/java/io/BufferedWriter.scala#L7) have handled 0 as an exception, but other classes have not so.