### PR TITLE
Cross-publish nscplugin against 2.11.8, 2.11.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import scala.util.Try
 import scalanative.tools.OptimizerReporter
 import scalanative.sbtplugin.ScalaNativePluginInternal._
 
-val toolScalaVersion = "2.10.6"
-
-val libScalaVersion = "2.11.11"
+val toolScalaVersion      = "2.10.6"
+val libScalaVersion       = "2.11.11"
+val libCrossScalaVersions = Seq("2.11.8", "2.11.11")
 
 lazy val baseSettings = Seq(
   organization := "org.scala-native",
@@ -218,10 +218,11 @@ lazy val tools =
 lazy val nscplugin =
   project
     .in(file("nscplugin"))
-    .settings(toolSettings)
+    .settings(baseSettings)
     .settings(mavenPublishSettings)
     .settings(
-      scalaVersion := "2.11.11",
+      scalaVersion := libScalaVersion,
+      crossScalaVersions := libCrossScalaVersions,
       crossVersion := CrossVersion.full,
       unmanagedSourceDirectories in Compile ++= Seq(
         (scalaSource in (nir, Compile)).value,

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -38,13 +38,13 @@ now simply run ``sbt run`` to get everything compiled and have the expected outp
 Scala versions
 --------------
 
-Scala Native uses following Scala versions for its releases:
+Scala Native supports following Scala versions for corresponding releases:
 
 ==================== ================
-Scala Native Version Scala Version(s)
+Scala Native Version Scala Versions
 ==================== ================
 0.1                  2.11.8
-0.2                  2.11.11
+0.2                  2.11.8, 2.11.11
 ==================== ================
 
 Sbt settings and tasks


### PR DESCRIPTION
This makes sure that existing builds with 2.11.8 are not affected by
version bump to 2.11.11. We're going to support 2.11.8 for some time.