### PR TITLE
GC Compiler changes

### DIFF
--- a/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
@@ -20,7 +20,7 @@ object Driver {
     inject.HasTrait,
     inject.RuntimeTypeInformation,
     inject.ClassStruct,
-    inject.GCexternals
+    inject.GCExternals
   )
 
   private val fastOptPasses = Seq(

--- a/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
@@ -19,7 +19,8 @@ object Driver {
     inject.TraitDispatchTables,
     inject.HasTrait,
     inject.RuntimeTypeInformation,
-    inject.ClassStruct
+    inject.ClassStruct,
+    inject.GCexternals
   )
 
   private val fastOptPasses = Seq(

--- a/tools/src/main/scala/scala/scalanative/optimizer/analysis/ClassHierarchy.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/analysis/ClassHierarchy.scala
@@ -94,8 +94,13 @@ object ClassHierarchy {
       Val.Struct(Global.None, vtable)
     def dynDispatchTableStruct =
       Type.Struct(Global.None, Seq(Type.Int, Type.Ptr, Type.Ptr, Type.Ptr))
-    def size: Long =
-      MemoryLayout(Type.Ptr +: allfields.map(_.ty)).size
+
+    def refMapStruct = Type.Struct(Global.None, Seq(Type.Ptr))
+    def memoryLayout = MemoryLayout(Type.Ptr +: allfields.map(_.ty))
+
+    def refMap = Val.Const(Val.Array(Type.Long, memoryLayout.offsetArray))
+    def size   = memoryLayout.size
+
     def classStruct: Type.Struct = {
       val data            = allfields.map(_.ty)
       val classStructName = name member "layout"
@@ -111,16 +116,21 @@ object ClassHierarchy {
             Type.Long, // size
             Type.Struct(Global.None, Seq(Type.Int, Type.Int)), // range
             dynDispatchTableStruct,
-            vtableStruct))
+            refMapStruct,
+            vtableStruct)
+      )
     override def typeValue: Val.Struct =
       Val.Struct(
         Global.None,
-        Seq(super.typeValue,
-            Val.Long(size),
-            Val.Struct(Global.None,
-                       Seq(Val.Int(range.head), Val.Int(range.last))),
-            dynDispatchTableValue,
-            vtableValue)
+        Seq(
+          super.typeValue,
+          Val.Long(size),
+          Val.Struct(Global.None,
+                     Seq(Val.Int(range.head), Val.Int(range.last))),
+          dynDispatchTableValue,
+          Val.Struct(Global.None, Seq(refMap)),
+          vtableValue
+        )
       )
   }
 

--- a/tools/src/main/scala/scala/scalanative/optimizer/analysis/MemoryLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/analysis/MemoryLayout.scala
@@ -1,10 +1,20 @@
 package scala.scalanative.optimizer.analysis
 
-import scala.scalanative.nir.Type
+import scala.scalanative.nir.Type.RefKind
+import scala.scalanative.nir.{Type, Val}
 import scala.scalanative.optimizer.analysis.MemoryLayout.PositionedType
 import scala.scalanative.util.unsupported
 
-final case class MemoryLayout(size: Long, tys: List[PositionedType])
+final case class MemoryLayout(size: Long, tys: List[PositionedType]) {
+  lazy val offsetArray: Seq[Val] = {
+    val ptrOffsets =
+      tys.collect {
+        case MemoryLayout.Tpe(_, offset, _: RefKind) => Val.Long(offset)
+      }
+
+    ptrOffsets :+ Val.Long(-1)
+  }
+}
 
 object MemoryLayout {
 

--- a/tools/src/main/scala/scala/scalanative/optimizer/inject/GCExternals.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/inject/GCExternals.scala
@@ -6,36 +6,28 @@ import scala.scalanative.optimizer.analysis.ClassHierarchy.Top
 import scala.scalanative.optimizer.{Inject, InjectCompanion}
 import scala.scalanative.tools.Config
 
-/**
- * Created by lukaskellenberger on 08.03.17.
- */
-class GCexternals(top: Top) extends Inject {
+class GCExternals(top: Top) extends Inject {
   override def apply(buffer: mutable.Buffer[Defn]) = {
     buffer ++= genModuleArray(buffer)
     buffer += genObjectArrayId()
   }
 
   def genModuleArray(defns: mutable.Buffer[Defn]): Seq[Defn] = {
-    val modules = defns.filter {
-      case _: Defn.Module => true
-      case _              => false
-    }
+    val modules = defns.filter(_.isInstanceOf[Defn.Module])
 
-    val moduleArrayName     = Global.Top("__modules")
-    val moduleArraySizeName = Global.Top("__modules_size")
     val moduleArray = Val.Array(Type.Ptr, modules.map {
       case Defn.Module(_, clsName, _, _) =>
         Val.Global(clsName member "value", Type.Ptr)
     })
     val moduleArrayVar =
       Defn.Var(Attrs.None,
-               moduleArrayName,
+               GCExternals.moduleArrayName,
                Type.Array(Type.Ptr, modules.size),
                moduleArray)
 
     val moduleArraySizeVar =
       Defn.Var(Attrs.None,
-               moduleArraySizeName,
+               GCExternals.moduleArraySizeName,
                Type.Int,
                Val.Int(modules.size))
 
@@ -45,13 +37,19 @@ class GCexternals(top: Top) extends Inject {
   def genObjectArrayId(): Defn.Var = {
     val objectArray =
       top.nodes(Global.Top("scala.scalanative.runtime.ObjectArray"))
-    val objectArrayIdName = Global.Top("__object_array_id")
 
-    Defn.Var(Attrs.None, objectArrayIdName, Type.Int, Val.Int(objectArray.id))
+    Defn.Var(Attrs.None,
+             GCExternals.objectArrayIdName,
+             Type.Int,
+             Val.Int(objectArray.id))
   }
 }
 
-object GCexternals extends InjectCompanion {
+object GCExternals extends InjectCompanion {
+  val moduleArrayName     = Global.Top("__modules")
+  val moduleArraySizeName = Global.Top("__modules_size")
 
-  override def apply(config: Config, top: Top) = new GCexternals(top)
+  val objectArrayIdName = Global.Top("__object_array_id")
+
+  override def apply(config: Config, top: Top) = new GCExternals(top)
 }

--- a/tools/src/main/scala/scala/scalanative/optimizer/inject/GCexternals.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/inject/GCexternals.scala
@@ -1,0 +1,57 @@
+package scala.scalanative.optimizer.inject
+
+import scala.collection.mutable
+import scala.scalanative.nir._
+import scala.scalanative.optimizer.analysis.ClassHierarchy.Top
+import scala.scalanative.optimizer.{Inject, InjectCompanion}
+import scala.scalanative.tools.Config
+
+/**
+ * Created by lukaskellenberger on 08.03.17.
+ */
+class GCexternals(top: Top) extends Inject {
+  override def apply(buffer: mutable.Buffer[Defn]) = {
+    buffer ++= genModuleArray(buffer)
+    buffer += genObjectArrayId()
+  }
+
+  def genModuleArray(defns: mutable.Buffer[Defn]): Seq[Defn] = {
+    val modules = defns.filter {
+      case _: Defn.Module => true
+      case _              => false
+    }
+
+    val moduleArrayName     = Global.Top("__MODULES__")
+    val moduleArraySizeName = Global.Top("__MODULES_SIZE__")
+    val moduleArray = Val.Array(Type.Ptr, modules.map {
+      case Defn.Module(_, clsName, _, _) =>
+        Val.Global(clsName member "value", Type.Ptr)
+    })
+    val moduleArrayVar =
+      Defn.Var(Attrs.None,
+               moduleArrayName,
+               Type.Array(Type.Ptr, modules.size),
+               moduleArray)
+
+    val moduleArraySizeVar =
+      Defn.Var(Attrs.None,
+               moduleArraySizeName,
+               Type.Int,
+               Val.Int(modules.size))
+
+    Seq(moduleArrayVar, moduleArraySizeVar)
+  }
+
+  def genObjectArrayId(): Defn.Var = {
+    val objectArray =
+      top.nodes(Global.Top("scala.scalanative.runtime.ObjectArray"))
+    val objectArrayIdName = Global.Top("__OBJECT_ARRAY_ID__")
+
+    Defn.Var(Attrs.None, objectArrayIdName, Type.Int, Val.Int(objectArray.id))
+  }
+}
+
+object GCexternals extends InjectCompanion {
+
+  override def apply(config: Config, top: Top) = new GCexternals(top)
+}

--- a/tools/src/main/scala/scala/scalanative/optimizer/inject/GCexternals.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/inject/GCexternals.scala
@@ -21,8 +21,8 @@ class GCexternals(top: Top) extends Inject {
       case _              => false
     }
 
-    val moduleArrayName     = Global.Top("__MODULES__")
-    val moduleArraySizeName = Global.Top("__MODULES_SIZE__")
+    val moduleArrayName     = Global.Top("__modules")
+    val moduleArraySizeName = Global.Top("__modules_size")
     val moduleArray = Val.Array(Type.Ptr, modules.map {
       case Defn.Module(_, clsName, _, _) =>
         Val.Global(clsName member "value", Type.Ptr)
@@ -45,7 +45,7 @@ class GCexternals(top: Top) extends Inject {
   def genObjectArrayId(): Defn.Var = {
     val objectArray =
       top.nodes(Global.Top("scala.scalanative.runtime.ObjectArray"))
-    val objectArrayIdName = Global.Top("__OBJECT_ARRAY_ID__")
+    val objectArrayIdName = Global.Top("__object_array_id")
 
     Defn.Var(Attrs.None, objectArrayIdName, Type.Int, Val.Int(objectArray.id))
   }

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/MethodLowering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/MethodLowering.scala
@@ -24,7 +24,7 @@ class MethodLowering(implicit fresh: Fresh, top: Top) extends Pass {
           Op.Elem(cls.typeStruct,
                   typeptr,
                   Seq(Val.Int(0),
-                      Val.Int(4), // index of vtable in type struct
+                      Val.Int(5), // index of vtable in type struct
                       Val.Int(meth.vindex))))
 
         let(n, Op.Load(Type.Ptr, methptrptr))


### PR DESCRIPTION
- Adds a pass that injects global variables needed by the garbage collector
  - array of modules `__modules `
  - size of the array `__modules_size`
  - id of the `ObjectArray` class `__object_array_id`
- Adds a new field to the Runtime type information which represents the ref map of a class' fields. In the form of an array of offsets terminated by `-1`.
