### PR TITLE
Convert result of `FileInputStream.read()` to unsigned int

### DIFF
--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -29,7 +29,7 @@ class FileInputStream(fd: FileDescriptor) extends InputStream {
   override def read(): Int = {
     val buffer = new Array[Byte](1)
     if (read(buffer) <= 0) -1
-    else buffer(0) & 0xFF
+    else buffer(0).toUInt.toInt
   }
 
   override def read(buffer: Array[Byte]): Int = {

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -29,7 +29,7 @@ class FileInputStream(fd: FileDescriptor) extends InputStream {
   override def read(): Int = {
     val buffer = new Array[Byte](1)
     if (read(buffer) <= 0) -1
-    else buffer(0)
+    else buffer(0) & 0xFF
   }
 
   override def read(buffer: Array[Byte]): Int = {

--- a/unit-tests/src/main/scala/java/io/FileInputStreamSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileInputStreamSuite.scala
@@ -51,4 +51,15 @@ object FileInputStreamSuite extends tests.Suite {
     assert(fd.valid())
     assert(Try(fd.sync()).isSuccess)
   }
+
+  test("can read 0xFF correctly") {
+    val file = File.createTempFile("file", ".tmp")
+    val fos  = new FileOutputStream(file)
+    fos.write(0xFF)
+    fos.close()
+
+    val fis = new FileInputStream(file)
+    assert(fis.read() == 0xFF)
+    assert(fis.read() == -1)
+  }
 }


### PR DESCRIPTION
We didn't convert the return value of `FileInputStream.read()` to an
unsigned int, and thus we returned an incorrect value when encountering
`0xFF` for instance.