### PR TITLE
Probe target without pipes

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -154,20 +154,28 @@ object ScalaNativePluginInternal {
       libs
     },
     nativeTarget := {
-      val logger       = nativeLogger.value
-      val cwd          = nativeWorkdir.value
-      val clang        = nativeClang.value
-      val targetcfile  = cwd / "target.c"
-      val targetllfile = cwd / "target.ll"
-      val compilec     = Seq(abs(clang), "-S", "-emit-llvm", abs(targetcfile))
+      val logger = nativeLogger.value
+      val cwd    = nativeWorkdir.value
+      val clang  = nativeClang.value
+      // Use non-standard extension to not include the ll file when linking (#639)
+      val targetc  = cwd / "target" / "c.probe"
+      val targetll = cwd / "target" / "ll.probe"
+      val compilec =
+        Seq(abs(clang),
+            "-S",
+            "-xc",
+            "-emit-llvm",
+            "-o",
+            abs(targetll),
+            abs(targetc))
       def fail =
         throw new MessageOnlyException("Failed to detect native target.")
 
-      IO.write(targetcfile, "int probe;")
+      IO.write(targetc, "int probe;")
       logger.running(compilec)
       val exit = Process(compilec, cwd) ! logger
       if (exit != 0) fail
-      IO.readLines(targetllfile)
+      IO.readLines(targetll)
         .collectFirst {
           case line if line.startsWith("target triple") =>
             line.split("\"").apply(1)


### PR DESCRIPTION
Revert change from #639 and use special extensions when generating the
target files in an attempt to fix freezes on Travis as reported in #696.

---
Note I kept the revert commit assuming it would be squashed anyway if this gets merged.