### PR TITLE
Clarify recommended LLVM minimum version and library dependencies

### DIFF
--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -7,7 +7,7 @@ This is what you will be doing, in a nutshell:
 
 * installation of sbt
 * installation of LLVM and Clang
-* installation of Boehm GC
+* installation of native libraries
 
 Installing sbt
 --------------
@@ -18,12 +18,26 @@ for instructions for your OS.
 Please note that you'll need Java 8 or more recent to use the Scala Native
 toolchain.
 
-Installing LLVM, Clang and Boehm GC
------------------------------------
+Installing LLVM, Clang and native libraries
+-------------------------------------------
 
-Boehm GC and LLVM (that includes Clang) are Scala Native's only external
-dependencies. Here are install instructions for a number of operating
-systems Scala Native has been used with:
+Scala Native requires Clang, which is part of the LLVM toolchain. The
+recommended LLVM version is 3.7 or newer, however, the Scala Native sbt
+plugin uses feature detection to discover the installed version of Clang
+so older versions may also work.
+
+In addition, the native Scala runtime and Java API implementation
+require the Boehm garbage collector and the RE2 regular expression
+engine. Both the native library and header files must be provided at
+build time.
+
+.. note::
+
+  Some package managers provide the library header files in separate
+  `-dev` packages.
+
+Here are install instructions for a number of operating systems Scala
+Native has been used with:
 
 Ubuntu::
 


### PR DESCRIPTION
Even though feature detection is used the sbt plugin will not try to
discover LLVM versions older than 3.7. Also update to mention that Scala
Native now also depends on RE2.

<img width="635" alt="screen shot 2017-05-06 at 8 19 52 pm" src="https://cloud.githubusercontent.com/assets/8417/25776890/7c6618b4-3299-11e7-9cb9-f06d24ba7fd2.png">

