### PR TITLE
Preliminary support for segfault-based safepoints

### DIFF
--- a/nativelib/src/main/resources/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/gc/boehm/gc.c
@@ -1,26 +1,24 @@
 #include <gc.h>
+#include <stdlib.h>
+#include <stdio.h>
 
 // At the moment we rely on the conservative
 // mode of Boehm GC as our garbage collector.
 
-void scalanative_init() {
-    GC_init();
-}
+void scalanative_init() { GC_init(); }
 
-void* scalanative_alloc(void* info, size_t size) {
-    void** alloc = (void**) GC_malloc(size);
+void *scalanative_alloc(void *info, size_t size) {
+    void **alloc = (void **)GC_malloc(size);
     *alloc = info;
-    return (void*) alloc;
+    return (void *)alloc;
 }
 
-void* scalanative_alloc_raw(size_t size) {
-    return GC_malloc(size);
-}
+void *scalanative_alloc_raw(size_t size) { return GC_malloc(size); }
 
-void* scalanative_alloc_raw_atomic(size_t size) {
+void *scalanative_alloc_raw_atomic(size_t size) {
     return GC_malloc_atomic(size);
 }
 
-void scalanative_collect() {
-    GC_gcollect();
-}
+void scalanative_collect() { GC_gcollect(); }
+
+void scalanative_safepoint() {}

--- a/nativelib/src/main/resources/gc/none/gc.c
+++ b/nativelib/src/main/resources/gc/none/gc.c
@@ -9,7 +9,7 @@
 // Dummy GC that maps chunks of 4GB and allocates but never frees.
 
 // Map 4GB
-#define CHUNK (4*1024*1024*1024L)
+#define CHUNK (4 * 1024 * 1024 * 1024L)
 // Allow read and write
 #define DUMMY_GC_PROT (PROT_READ | PROT_WRITE)
 // Map private anonymous memory, and prevent from reserving swap
@@ -18,20 +18,22 @@
 #define DUMMY_GC_FD -1
 #define DUMMY_GC_FD_OFFSET 0
 
+void *current = 0;
+void *end = 0;
 
-void* current = 0;
-void* end = 0;
-
+void scalanative_safepoint_init();
 
 void scalanative_init() {
-    current = mmap(NULL, CHUNK, DUMMY_GC_PROT, DUMMY_GC_FLAGS, DUMMY_GC_FD, DUMMY_GC_FD_OFFSET);
+    current = mmap(NULL, CHUNK, DUMMY_GC_PROT, DUMMY_GC_FLAGS, DUMMY_GC_FD,
+                   DUMMY_GC_FD_OFFSET);
     end = current + CHUNK;
+    scalanative_safepoint_init();
 }
 
-void* scalanative_alloc_raw(size_t size) {
+void *scalanative_alloc_raw(size_t size) {
     size = size + (8 - size % 8);
     if (current != 0 && current + size < end) {
-        void* alloc = current;
+        void *alloc = current;
         current += size;
         return alloc;
     } else {
@@ -40,14 +42,16 @@ void* scalanative_alloc_raw(size_t size) {
     }
 }
 
-void* scalanative_alloc_raw_atomic(size_t size) {
+void *scalanative_alloc_raw_atomic(size_t size) {
     return scalanative_alloc_raw(size);
 }
 
-void* scalanative_alloc(void* info, size_t size) {
-    void** alloc = (void**) scalanative_alloc_raw(size);
+void *scalanative_alloc(void *info, size_t size) {
+    void **alloc = (void **)scalanative_alloc_raw(size);
     *alloc = info;
-    return (void*) alloc;
+    return (void *)alloc;
 }
 
 void scalanative_collect() {}
+
+void scalanative_safepoint() {}

--- a/nativelib/src/main/resources/safepoint.c
+++ b/nativelib/src/main/resources/safepoint.c
@@ -1,0 +1,34 @@
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+
+extern unsigned char scalanative_safepoint_trigger[4096] __attribute__((aligned(4096)));
+
+void scalanative_safepoint();
+
+void scalanative_safepoint_on() {
+    mprotect((void*) &scalanative_safepoint_trigger, 4096, PROT_NONE);
+}
+
+void scalanative_safepoint_off() {
+    mprotect((void*) &scalanative_safepoint_trigger, 4096, PROT_READ);
+}
+
+void scalanative_safepoint_handler(int sig, siginfo_t *info, void *ucontext) {
+    if (info->si_addr == (void*) &scalanative_safepoint_trigger) {
+        scalanative_safepoint();
+    } else {
+        printf("Segfault %d at %p", sig, info->si_addr);
+        exit(1);
+    }
+}
+
+void scalanative_safepoint_init() {
+    struct sigaction action;
+    action.sa_sigaction = scalanative_safepoint_handler;
+    action.sa_flags = SA_RESTART | SA_SIGINFO;
+    sigemptyset(&action.sa_mask);
+    sigaction(SIGSEGV, &action, NULL);
+    sigaction(SIGBUS, &action, NULL);
+}

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -21,6 +21,8 @@ object Attr {
   final case object Extern                extends Attr
   final case class Override(name: Global) extends Attr
 
+  final case class Align(value: Int) extends Attr
+
   // Linker attributes
   final case class Link(name: String)               extends Attr
   sealed abstract class Pin                         extends Attr
@@ -35,7 +37,8 @@ final case class Attrs(inline: Inline = MayInline,
                        isDyn: Boolean = false,
                        overrides: Seq[Global] = Seq(),
                        pins: Seq[Pin] = Seq(),
-                       links: Seq[Attr.Link] = Seq()) {
+                       links: Seq[Attr.Link] = Seq(),
+                       align: Option[Int] = scala.None) {
   def toSeq: Seq[Attr] = {
     val out = mutable.UnrolledBuffer.empty[Attr]
 
@@ -46,6 +49,7 @@ final case class Attrs(inline: Inline = MayInline,
     overrides.foreach { out += Override(_) }
     out ++= pins
     out ++= links
+    align.foreach { out += Align(_) }
 
     out
   }
@@ -58,6 +62,7 @@ object Attrs {
     var isPure    = false
     var isExtern  = false
     var isDyn     = false
+    var align     = Option.empty[Int]
     val overrides = mutable.UnrolledBuffer.empty[Global]
     val pins      = mutable.UnrolledBuffer.empty[Pin]
     val links     = mutable.UnrolledBuffer.empty[Attr.Link]
@@ -67,11 +72,12 @@ object Attrs {
       case Pure            => isPure = true
       case Extern          => isExtern = true
       case Dyn             => isDyn = true
+      case Align(value)    => align = Some(value)
       case Override(name)  => overrides += name
       case attr: Pin       => pins += attr
       case link: Attr.Link => links += link
     }
 
-    new Attrs(inline, isPure, isExtern, isDyn, overrides, pins, links)
+    new Attrs(inline, isPure, isExtern, isDyn, overrides, pins, links, align)
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -55,6 +55,10 @@ object Show {
         str("alwaysinline")
       case Attr.Dyn =>
         str("dyn")
+      case Attr.Align(value) =>
+        str("align(")
+        str(value)
+        str(")")
       case Attr.Pure =>
         str("pure")
       case Attr.Extern =>

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -177,13 +177,13 @@ object Show {
           str(" ")
           next_(unwind)
         }
-      case Op.Load(ty, ptr) =>
-        str("load[")
+      case Op.Load(ty, ptr, isVolatile) =>
+        str(if (isVolatile) "volatile load[" else "load[")
         type_(ty)
         str("] ")
         val_(ptr)
-      case Op.Store(ty, ptr, value) =>
-        str("store[")
+      case Op.Store(ty, ptr, value, isVolatile) =>
+        str(if (isVolatile) "volatile store[" else "store[")
         type_(ty)
         str("] ")
         val_(ptr)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -228,8 +228,8 @@ final class BinaryDeserializer(_buffer: => ByteBuffer) {
 
   private def getOp(): Op = getInt match {
     case T.CallOp       => Op.Call(getType, getVal, getVals, getNext)
-    case T.LoadOp       => Op.Load(getType, getVal)
-    case T.StoreOp      => Op.Store(getType, getVal, getVal)
+    case T.LoadOp       => Op.Load(getType, getVal, isVolatile = false)
+    case T.StoreOp      => Op.Store(getType, getVal, getVal, isVolatile = false)
     case T.ElemOp       => Op.Elem(getType, getVal, getVals)
     case T.ExtractOp    => Op.Extract(getVal, getInts)
     case T.InsertOp     => Op.Insert(getVal, getVal, getInts)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -9,6 +9,11 @@ import nir.serialization.{Tags => T}
 final class BinarySerializer(buffer: ByteBuffer) {
   import buffer._
 
+  // Things to change in next binary-breaking release:
+  // 1. Val.Null should have its own tag, not encoded via Val.Zero(Type.Ptr).
+  // 2. Volatile Op.{Load, Store} should become serializable.
+  // 3. Attr.Align should become serializable;
+
   final def serialize(defns: Seq[Defn]): Unit = {
     val names     = defns.map(_.name)
     val positions = mutable.UnrolledBuffer.empty[Int]
@@ -66,6 +71,9 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Attr.AlwaysInline => putInt(T.AlwaysInlineAttr)
 
     case Attr.Dyn => putInt(T.DynAttr)
+
+    case Attr.Align(_) =>
+      assert(false, "alignment attribute is not serializable")
 
     case Attr.Pure        => putInt(T.PureAttr)
     case Attr.Extern      => putInt(T.ExternAttr)
@@ -265,13 +273,13 @@ final class BinarySerializer(buffer: ByteBuffer) {
       putNext(unwind)
 
     case Op.Load(ty, ptr, isVolatile) =>
-      assert(!isVolatile, "nir binary format doesn't support volatile loads")
+      assert(!isVolatile, "volatile loads are not serializable")
       putInt(T.LoadOp)
       putType(ty)
       putVal(ptr)
 
     case Op.Store(ty, value, ptr, isVolatile) =>
-      assert(!isVolatile, "nir binary format doesn't support volatile stores")
+      assert(!isVolatile, "volatile stores are not serializable")
       putInt(T.StoreOp)
       putType(ty)
       putVal(value)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -264,12 +264,14 @@ final class BinarySerializer(buffer: ByteBuffer) {
       putVals(args)
       putNext(unwind)
 
-    case Op.Load(ty, ptr) =>
+    case Op.Load(ty, ptr, isVolatile) =>
+      assert(!isVolatile, "nir binary format doesn't support volatile loads")
       putInt(T.LoadOp)
       putType(ty)
       putVal(ptr)
 
-    case Op.Store(ty, value, ptr) =>
+    case Op.Store(ty, value, ptr, isVolatile) =>
+      assert(!isVolatile, "nir binary format doesn't support volatile stores")
       putInt(T.StoreOp)
       putType(ty)
       putVal(value)

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -501,7 +501,7 @@ object CodeGen {
         case call: Op.Call =>
           genCall(genBind, call)
 
-        case Op.Load(ty, ptr) =>
+        case Op.Load(ty, ptr, isVolatile) =>
           val pointee = fresh()
 
           newline()
@@ -516,13 +516,16 @@ object CodeGen {
           newline()
           genBind()
           str("load ")
+          if (isVolatile) {
+            str("volatile ")
+          }
           genType(ty)
           str(", ")
           genType(ty)
           str("* %")
           genLocal(pointee)
 
-        case Op.Store(ty, ptr, value) =>
+        case Op.Store(ty, ptr, value, isVolatile) =>
           val pointee = fresh()
 
           newline()
@@ -537,6 +540,9 @@ object CodeGen {
           newline()
           genBind()
           str("store ")
+          if (isVolatile) {
+            str("volatile ")
+          }
           genVal(value)
           str(", ")
           genType(ty)

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -154,9 +154,9 @@ object CodeGen {
         case Defn.Struct(attrs, name, tys) =>
           genStruct(attrs, name, tys)
         case Defn.Var(attrs, name, ty, rhs) =>
-          genGlobalDefn(name, attrs.isExtern, isConst = false, ty, rhs)
+          genGlobalDefn(attrs, name, isConst = false, ty, rhs)
         case Defn.Const(attrs, name, ty, rhs) =>
-          genGlobalDefn(name, attrs.isExtern, isConst = true, ty, rhs)
+          genGlobalDefn(attrs, name, isConst = true, ty, rhs)
         case Defn.Declare(attrs, name, sig) =>
           genFunctionDefn(attrs, name, sig, Seq())
         case Defn.Define(attrs, name, sig, blocks) =>
@@ -175,20 +175,24 @@ object CodeGen {
       str("}")
     }
 
-    def genGlobalDefn(name: nir.Global,
-                      isExtern: Boolean,
+    def genGlobalDefn(attrs: Attrs,
+                      name: nir.Global,
                       isConst: Boolean,
                       ty: nir.Type,
                       rhs: nir.Val): Unit = {
       str("@")
       genGlobal(name)
       str(" = ")
-      str(if (isExtern) "external " else "")
+      str(if (attrs.isExtern) "external " else "")
       str(if (isConst) "constant" else "global")
       str(" ")
       rhs match {
         case Val.None => genType(ty)
         case rhs      => genVal(rhs)
+      }
+      attrs.align.foreach { value =>
+        str(", align ")
+        str(value)
       }
     }
 

--- a/tools/src/main/scala/scala/scalanative/nir/parser/Attr.scala
+++ b/tools/src/main/scala/scala/scalanative/nir/parser/Attr.scala
@@ -13,6 +13,8 @@ object Attr extends Base[nir.Attr] {
   val InlineHint   = P("inlinehint".! map (_ => nir.Attr.InlineHint))
   val NoInline     = P("noinline".! map (_ => nir.Attr.NoInline))
   val AlwaysInline = P("alwaysinline".! map (_ => nir.Attr.AlwaysInline))
+  val Dyn          = P("dyn".! map (_ => nir.Attr.Dyn))
+  val Align        = P(("align(" ~ int ~ ")") map (nir.Attr.Align(_)))
   val Pure         = P("pure".! map (_ => nir.Attr.Pure))
   val Extern       = P("extern".! map (_ => nir.Attr.Extern))
   val Override =
@@ -23,8 +25,9 @@ object Attr extends Base[nir.Attr] {
     P("pin-if(" ~ Global.parser ~ "," ~ Global.parser ~ ")" map {
       case (name, cond) => nir.Attr.PinIf(name, cond)
     })
+  val PinWeak = P("pin-weak(" ~ Global.parser ~ ")" map (nir.Attr.PinWeak(_)))
 
   override val parser: P[nir.Attr] =
-    MayInline | InlineHint | NoInline | AlwaysInline | Pure | Extern | Override | Link | PinAlways | PinIf
+    MayInline | InlineHint | NoInline | AlwaysInline | Dyn | Align | Pure | Extern | Override | Link | PinAlways | PinIf | PinWeak
 
 }

--- a/tools/src/main/scala/scala/scalanative/nir/parser/Op.scala
+++ b/tools/src/main/scala/scala/scalanative/nir/parser/Op.scala
@@ -19,12 +19,14 @@ object Op extends Base[nir.Op] {
       case (ty, f, args, unwind) => nir.Op.Call(ty, f, args, unwind)
     }
   val Load =
-    P("load[" ~ Type.parser ~ "]" ~ Val.parser map {
-      case (ty, ptr) => nir.Op.Load(ty, ptr)
+    P("volatile".!.? ~ "load[" ~ Type.parser ~ "]" ~ Val.parser map {
+      case (volatile, ty, ptr) =>
+        nir.Op.Load(ty, ptr, isVolatile = volatile.nonEmpty)
     })
   val Store =
-    P("store[" ~ Type.parser ~ "]" ~ Val.parser ~ "," ~ Val.parser map {
-      case (ty, ptr, value) => nir.Op.Store(ty, ptr, value)
+    P("volatile".!.? ~ "store[" ~ Type.parser ~ "]" ~ Val.parser ~ "," ~ Val.parser map {
+      case (volatile, ty, ptr, value) =>
+        nir.Op.Store(ty, ptr, value, isVolatile = volatile.nonEmpty)
     })
   val Elem =
     P(

--- a/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
@@ -21,7 +21,8 @@ object Driver {
     inject.RuntimeTypeInformation,
     inject.ClassStruct,
     inject.ObjectArrayId,
-    inject.ModuleArray
+    inject.ModuleArray,
+    inject.SafepointTrigger
   )
 
   private val fastOptPasses = Seq(
@@ -60,7 +61,8 @@ object Driver {
     pass.AllocLowering,
     pass.SizeofLowering,
     pass.CopyPropagation,
-    pass.DeadCodeElimination
+    pass.DeadCodeElimination,
+    pass.SafepointInsertion
   )
 
   /** Create driver with default pipeline for this configuration. */

--- a/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
@@ -61,8 +61,8 @@ object Driver {
     pass.AllocLowering,
     pass.SizeofLowering,
     pass.CopyPropagation,
-    pass.DeadCodeElimination,
-    pass.SafepointInsertion
+    pass.DeadCodeElimination
+    // pass.SafepointInsertion
   )
 
   /** Create driver with default pipeline for this configuration. */

--- a/tools/src/main/scala/scala/scalanative/optimizer/Pass.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Pass.scala
@@ -68,10 +68,10 @@ trait Pass extends AnyPass {
   def onOp(op: Op): Op = op match {
     case Op.Call(ty, ptrv, argvs, unwind) =>
       Op.Call(onType(ty), onVal(ptrv), argvs.map(onVal), onNext(unwind))
-    case Op.Load(ty, ptrv) =>
-      Op.Load(onType(ty), onVal(ptrv))
-    case Op.Store(ty, ptrv, v) =>
-      Op.Store(onType(ty), onVal(ptrv), onVal(v))
+    case Op.Load(ty, ptrv, isVolatile) =>
+      Op.Load(onType(ty), onVal(ptrv), isVolatile)
+    case Op.Store(ty, ptrv, v, isVolatile) =>
+      Op.Store(onType(ty), onVal(ptrv), onVal(v), isVolatile)
     case Op.Elem(ty, ptrv, indexvs) =>
       Op.Elem(onType(ty), onVal(ptrv), indexvs.map(onVal))
     case Op.Extract(aggrv, indexvs) =>

--- a/tools/src/main/scala/scala/scalanative/optimizer/inject/SafepointTrigger.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/inject/SafepointTrigger.scala
@@ -1,0 +1,27 @@
+package scala.scalanative.optimizer.inject
+
+import scala.collection.mutable
+import scala.scalanative.nir._
+import scala.scalanative.optimizer.analysis.ClassHierarchy.Top
+import scala.scalanative.optimizer.{Inject, InjectCompanion}
+import scala.scalanative.tools.Config
+
+class SafepointTrigger(top: Top) extends Inject {
+  import SafepointTrigger._
+
+  override def apply(buf: mutable.Buffer[Defn]) =
+    buf += safepointTriggerDefn
+}
+
+object SafepointTrigger extends InjectCompanion {
+  val safepointTriggerName = Global.Top("scalanative_safepoint_trigger")
+  val safepointTriggerTy   = Type.Array(Type.Byte, 4096)
+  val safepointTriggerInit = Val.Zero(safepointTriggerTy)
+  val safepointTriggerDefn =
+    Defn.Var(Attrs(align = Some(4096)),
+             safepointTriggerName,
+             safepointTriggerTy,
+             safepointTriggerInit)
+
+  override def apply(config: Config, top: Top) = new SafepointTrigger(top)
+}

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/GlobalValueNumbering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/GlobalValueNumbering.scala
@@ -278,9 +278,10 @@ object GlobalValueNumbering extends PassCompanion {
     def hashOp(op: Op): Hash = {
       import Op._
       val opFields: Seq[Any] = op match {
-        case Call(ty, ptr, args, _) => "Call" +: ty +: ptr +: args
-        case Load(ty, ptr)          => Seq("Load", ty, ptr)
-        case Store(ty, ptr, value)  => Seq("Store", ty, ptr, value)
+        case Call(ty, ptr, args, _)    => "Call" +: ty +: ptr +: args
+        case Load(ty, ptr, isVolatile) => Seq("Load", ty, ptr, isVolatile)
+        case Store(ty, ptr, value, isVolatile) =>
+          Seq("Store", ty, ptr, value, isVolatile)
         case Elem(ty, ptr, indexes) => "Elem" +: ty +: ptr +: indexes
         case Extract(aggr, indexes) => "Extract" +: aggr +: indexes
         case Insert(aggr, value, indexes) =>

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/SafepointInsertion.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/SafepointInsertion.scala
@@ -1,0 +1,50 @@
+package scala.scalanative
+package optimizer
+package pass
+
+import scala.collection.mutable
+import analysis.ClassHierarchy.Top
+import nir._
+
+/** Inserts safepoint probes before every return. */
+class SafepointInsertion(implicit fresh: Fresh) extends Pass {
+  import SafepointInsertion._
+
+  override def onDefns(defns: Seq[Defn]): Seq[Defn] = {
+    val buf = mutable.UnrolledBuffer.empty[Defn]
+
+    defns.foreach {
+      case defn: Defn.Define if defn.attrs.inline ne Attr.AlwaysInline =>
+        buf += defn.copy(insts = onInsts(defn.insts))
+
+      case defn =>
+        buf += defn
+    }
+
+    buf
+  }
+
+  override def onInsts(insts: Seq[Inst]): Seq[Inst] = {
+    val buf = new nir.Buffer
+    import buf._
+
+    insts.foreach {
+      case inst: Inst.Ret =>
+        let(Op.Load(Type.Byte, safepointTriggerVal, isVolatile = true))
+        buf += inst
+
+      case inst =>
+        buf += inst
+    }
+
+    buf.toSeq
+  }
+}
+
+object SafepointInsertion extends PassCompanion {
+  val safepointTriggerName = Global.Top("scalanative_safepoint_trigger")
+  val safepointTriggerVal  = Val.Global(safepointTriggerName, Type.Ptr)
+
+  override def apply(config: tools.Config, top: Top) =
+    new SafepointInsertion()(top.fresh)
+}

--- a/tools/src/test/scala/scala/scalanative/nir/AttrParserTest.scala
+++ b/tools/src/test/scala/scala/scalanative/nir/AttrParserTest.scala
@@ -10,16 +10,21 @@ class AttrParserTest extends FlatSpec with Matchers {
 
   "The NIR parser" should "parse attributes" in {
     import Attr._
-    val attrs: Seq[Attr] = Seq(MayInline,
-                               InlineHint,
-                               NoInline,
-                               AlwaysInline,
-                               Pure,
-                               Extern,
-                               Override(global),
-                               Link("test"),
-                               PinAlways(global),
-                               PinIf(global, global))
+    val attrs: Seq[Attr] = Seq(
+      MayInline,
+      InlineHint,
+      NoInline,
+      AlwaysInline,
+      Dyn,
+      Align(1024),
+      Pure,
+      Extern,
+      Override(global),
+      Link("test"),
+      PinAlways(global),
+      PinIf(global, global),
+      PinWeak(global)
+    )
 
     attrs foreach { attr =>
       val Parsed.Success(result, _) = parser.Attr.parser.parse(attr.show)

--- a/tools/src/test/scala/scala/scalanative/nir/OpParserTest.scala
+++ b/tools/src/test/scala/scala/scalanative/nir/OpParserTest.scala
@@ -22,14 +22,26 @@ class OpParserTest extends FlatSpec with Matchers {
     result should be(call)
   }
 
-  it should "parse `Op.Load`" in {
+  it should "parse non-volatile `Op.Load`" in {
     val load: Op                  = Op.Load(noTpe, Val.None)
     val Parsed.Success(result, _) = parser.Op.Load.parse(load.show)
     result should be(load)
   }
 
-  it should "parse `Op.Store`" in {
+  it should "parse volatile `Op.Load`" in {
+    val load: Op                  = Op.Load(noTpe, Val.None, isVolatile = true)
+    val Parsed.Success(result, _) = parser.Op.Load.parse(load.show)
+    result should be(load)
+  }
+
+  it should "parse non-volatile `Op.Store`" in {
     val store: Op                 = Op.Store(noTpe, Val.None, Val.None)
+    val Parsed.Success(result, _) = parser.Op.Store.parse(store.show)
+    result should be(store)
+  }
+
+  it should "parse volatile `Op.Store`" in {
+    val store: Op                 = Op.Store(noTpe, Val.None, Val.None, isVolatile = true)
     val Parsed.Success(result, _) = parser.Op.Store.parse(store.show)
     result should be(store)
   }


### PR DESCRIPTION
Safepoints provide a cheap way to suspend application code and transfer control to the runtime. They are necessary for an upcoming concurrent garbage collector.