### PR TITLE
Add scopes to the tasks defined by the sbt plugin

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -1,8 +1,6 @@
 package scala.scalanative
 package sbtplugin
 
-import util._
-
 import sbtcrossproject.CrossPlugin.autoImport._
 import ScalaNativePlugin.autoImport._
 
@@ -12,13 +10,11 @@ import scalanative.io.VirtualDirectory
 import scalanative.util.{Scope => ResourceScope}
 
 import sbt._, Keys._, complete.DefaultParsers._
-import xsbti.{Maybe, Reporter, Position, Severity, Problem}
-import KeyRanks.DTask
 
 import scala.util.Try
 
 import System.{lineSeparator => nl}
-import java.io.File
+import java.io.ByteArrayInputStream
 
 object ScalaNativePluginInternal {
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -250,7 +250,7 @@ object ScalaNativePluginInternal {
             logger.running(compilec)
             val result = Process(compilec, cwd) ! logger
             if (result != 0) {
-              println("Failed to compile native library runtime code.")
+              sys.error("Failed to compile native library runtime code.")
             }
         }
       }

--- a/scripted-tests/run/execution-context/build.sbt
+++ b/scripted-tests/run/execution-context/build.sbt
@@ -5,7 +5,7 @@ scalaVersion := "2.11.11"
 lazy val runAndCheck = taskKey[Unit]("...")
 
 runAndCheck := {
-  val bin = nativeLink.value
+  val bin = (nativeLink in Compile).value
   val out = Process(bin.getAbsolutePath).lines_!.toList
   assert(
     out == List(

--- a/scripted-tests/run/linker-reporter/build.sbt
+++ b/scripted-tests/run/linker-reporter/build.sbt
@@ -5,7 +5,8 @@ enablePlugins(ScalaNativePlugin)
 
 scalaVersion := "2.11.11"
 
-nativeLinkerReporter := LinkerReporter.toFile(target.value / "out.dot")
+nativeLinkerReporter in Compile := LinkerReporter.toFile(
+  target.value / "out.dot")
 
 lazy val check = taskKey[Unit]("Check that dot file was created.")
 

--- a/scripted-tests/run/optimizer-reporter/build.sbt
+++ b/scripted-tests/run/optimizer-reporter/build.sbt
@@ -5,7 +5,8 @@ enablePlugins(ScalaNativePlugin)
 
 scalaVersion := "2.11.11"
 
-nativeOptimizerReporter := OptimizerReporter.toDirectory(crossTarget.value)
+nativeOptimizerReporter in Compile := OptimizerReporter.toDirectory(
+  crossTarget.value)
 
 lazy val check = taskKey[Unit]("Check that dot file was created.")
 


### PR DESCRIPTION
The changes to the scripted tests may be seen as a problem, but they are actually correct. The following build definition would fail at runtime, saying that there are undefined settings:

```scala
lazy val foo = taskKey[Unit]("...")

foo := {
  compile.value
  ()
}
```

Also, fixes #692 