### PR TITLE
Fix #666: discover llvm-config relative to the clang binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
         - sudo make install prefix=/usr
         - make testinstall prefix=/usr
         - popd
+      env: PATH="/usr/lib/llvm-3.7/bin:$PATH"
 
     - os: osx
       osx_image: xcode7.3


### PR DESCRIPTION
Make sure we pick the version of llvm-config which matches the
discovered clang binary. Currently Scala Native does not use LLVM
include and libraries, however, this will be important for bindgen and
other tooling.