### PR TITLE
Make `StackTraceElement` closer to Java's impl

### DIFF
--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -37,7 +37,7 @@ class Throwable(s: String, private var e: Throwable)
     unwind.init_local(cursor, context)
     while (unwind.step(cursor) > 0) {
       unwind.get_proc_name(cursor, name, 256, offset)
-      buffer += new StackTraceElement(fromCString(name))
+      buffer += StackTraceElement.fromSymbol(fromCString(name))
     }
 
     this.stackTrace = buffer.toArray

--- a/unit-tests/src/main/scala/java/lang/ExceptionSuite.scala
+++ b/unit-tests/src/main/scala/java/lang/ExceptionSuite.scala
@@ -11,8 +11,8 @@ object ExceptionSuite extends tests.Suite {
     assert(trace.startsWith("java.lang.Exception"))
     assert(
       trace.contains(
-        "\tat tests.Main$::main_scala.scalanative.runtime.ObjectArray_unit"))
-    assert(trace.contains("\tat main"))
+        "\tat tests.Main$.main(Unknown Source)"))
+    assert(trace.contains("\tat <none>.main(Unknown Source)"))
   }
 
   test("printStackTrace <no stack trace available>") {

--- a/unit-tests/src/main/scala/java/lang/ExceptionSuite.scala
+++ b/unit-tests/src/main/scala/java/lang/ExceptionSuite.scala
@@ -9,9 +9,7 @@ object ExceptionSuite extends tests.Suite {
     (new Exception).printStackTrace(pw)
     val trace = sw.toString
     assert(trace.startsWith("java.lang.Exception"))
-    assert(
-      trace.contains(
-        "\tat tests.Main$.main(Unknown Source)"))
+    assert(trace.contains("\tat tests.Main$.main(Unknown Source)"))
     assert(trace.contains("\tat <none>.main(Unknown Source)"))
   }
 


### PR DESCRIPTION
I need to be able to re-create stack trace from the test interface, but there was no accessible constructor.