### PR TITLE
Fix logic for opening `FileChannel`s

### DIFF
--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -153,8 +153,8 @@ private object FileChannelImpl {
       throw new FileAlreadyExistsException(path.toString)
     }
 
-    if (options.contains(WRITE) && (options.contains(CREATE_NEW) || options
-          .contains(CREATE))) {
+    if (!Files.exists(path, Array.empty) && options.contains(WRITE) && (options
+          .contains(CREATE_NEW) || options.contains(CREATE))) {
       Files.createFile(path, attrs)
     }
 

--- a/javalib/src/main/scala/java/nio/file/spi/FileSystemProvider.scala
+++ b/javalib/src/main/scala/java/nio/file/spi/FileSystemProvider.scala
@@ -58,7 +58,7 @@ abstract class FileSystemProvider protected () {
         Array[OpenOption](StandardOpenOption.CREATE,
                           StandardOpenOption.TRUNCATE_EXISTING,
                           StandardOpenOption.WRITE)
-      else _options
+      else _options :+ StandardOpenOption.WRITE
     val channel = Files.newByteChannel(path, options)
     new OutputStream {
       private val buffer = ByteBuffer.allocate(1)

--- a/unit-tests/src/main/scala/java/nio/channels/FileChannelSuite.scala
+++ b/unit-tests/src/main/scala/java/nio/channels/FileChannelSuite.scala
@@ -45,6 +45,27 @@ object FileChannelSuite extends tests.Suite {
     }
   }
 
+  test("A FileChannel can overwrite a file") {
+    withTemporaryDirectory { dir =>
+      val f = dir.resolve("file")
+      Files.write(f, "hello, world".getBytes("UTF-8"))
+
+      val bytes = "goodbye".getBytes("UTF-8")
+      val src   = ByteBuffer.wrap(bytes)
+      val channel = FileChannel.open(f,
+                                     StandardOpenOption.WRITE,
+                                     StandardOpenOption.CREATE)
+      while (src.remaining() > 0) channel.write(src)
+
+      val in = Files.newInputStream(f)
+      var i  = 0
+      while (i < bytes.length) {
+        assert(in.read() == bytes(i))
+        i += 1
+      }
+    }
+  }
+
   def withTemporaryDirectory(fn: Path => Unit) {
     val file = File.createTempFile("test", ".tmp")
     assert(file.delete())


### PR DESCRIPTION
I discovered an issue while rebasing my branch to support `java.util.zip` and `java.util.jar`. 

> If the `OpenOption`s contain `CREATE`, it would try to create the file
> again even if it existed, which would cause an error.

I also found another issue with `Files.newOutputStream`. My understanding [from the Javadoc](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#newOutputStream-java.nio.file.Path-java.nio.file.OpenOption...-) is that the `OpenOption`s should be untouched if non-empty, but it appears from experimentation with the JVM that (at least) `WRITE` should always be present. I agree it makes sense in the case of an `OutputStream`, but that's not explicitly specified.