### PR TITLE
Cleanup memory management in RegEx and File I/O

### DIFF
--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -5,7 +5,7 @@ import java.nio.file.{FileSystems, Path}
 import scala.collection.mutable.UnrolledBuffer
 
 import scala.annotation.tailrec
-import scalanative.runtime.{GC, Platform}
+import scalanative.runtime.Platform
 import scala.scalanative.posix.{dirent, fcntl, limits, stat, unistd, utime}
 import scala.scalanative.native._, stdlib._, stdio._, string._
 import dirent._
@@ -35,13 +35,19 @@ class File(_path: String) extends Serializable with Comparable[File] {
   }
 
   def canExecute(): Boolean =
-    access(toCString(path), fcntl.X_OK) == 0
+    Zone { implicit z =>
+      access(toCString(path), fcntl.X_OK) == 0
+    }
 
   def canRead(): Boolean =
-    access(toCString(path), fcntl.R_OK) == 0
+    Zone { implicit z =>
+      access(toCString(path), fcntl.R_OK) == 0
+    }
 
   def canWrite(): Boolean =
-    access(toCString(path), fcntl.W_OK) == 0
+    Zone { implicit z =>
+      access(toCString(path), fcntl.W_OK) == 0
+    }
 
   def setExecutable(executable: Boolean): Boolean =
     setExecutable(executable, ownerOnly = true)
@@ -71,11 +77,18 @@ class File(_path: String) extends Serializable with Comparable[File] {
   }
 
   private def updatePermissions(mask: stat.mode_t, grant: Boolean): Boolean =
-    if (grant) stat.chmod(toCString(path), accessMode() | mask) == 0
-    else stat.chmod(toCString(path), accessMode() & (~mask)) == 0
+    Zone { implicit z =>
+      if (grant) {
+        stat.chmod(toCString(path), accessMode() | mask) == 0
+      } else {
+        stat.chmod(toCString(path), accessMode() & (~mask)) == 0
+      }
+    }
 
   def exists(): Boolean =
-    access(toCString(path), fcntl.F_OK) == 0
+    Zone { implicit z =>
+      access(toCString(path), fcntl.F_OK) == 0
+    }
 
   def toPath(): Path =
     FileSystems.getDefault().getPath(this.getPath(), Array.empty)
@@ -83,39 +96,52 @@ class File(_path: String) extends Serializable with Comparable[File] {
   def getPath(): String = path
 
   def delete(): Boolean =
-    if (path.nonEmpty && isDirectory()) deleteDirImpl()
-    else deleteFileImpl()
+    if (path.nonEmpty && isDirectory()) {
+      deleteDirImpl()
+    } else {
+      deleteFileImpl()
+    }
 
   private def deleteDirImpl(): Boolean =
-    remove(toCString(path)) == 0
+    Zone { implicit z =>
+      remove(toCString(path)) == 0
+    }
 
   private def deleteFileImpl(): Boolean =
-    unlink(toCString(path)) == 0
+    Zone { implicit z =>
+      unlink(toCString(path)) == 0
+    }
 
   override def equals(that: Any): Boolean =
     that match {
-      case that: File if caseSensitive => this.path == that.path
+      case that: File if caseSensitive =>
+        this.path == that.path
       case that: File =>
         this.path.toLowerCase == that.path.toLowerCase
-      case _ => false
+      case _ =>
+        false
     }
 
   def getAbsolutePath(): String = properPath
 
   def getAbsoluteFile(): File = new File(this.getAbsolutePath())
 
-  def getCanonicalPath(): String = {
-    if (exists) fromCString(simplifyExistingPath(toCString(properPath)))
-    else simplifyNonExistingPath(fromCString(resolve(toCString(properPath))))
-  }
+  def getCanonicalPath(): String =
+    Zone { implicit z =>
+      if (exists) {
+        fromCString(simplifyExistingPath(toCString(properPath)))
+      } else {
+        simplifyNonExistingPath(fromCString(resolve(toCString(properPath))))
+      }
+    }
 
   /**
    * Finds the canonical path for `path`, using `realpath`.
    * The file must exist, because the result of `realpath` doesn't
    * match that of Java on non-existing file.
    */
-  private def simplifyExistingPath(path: CString): CString = {
-    val resolvedName = GC.malloc_atomic(limits.PATH_MAX).cast[CString]
+  private def simplifyExistingPath(path: CString)(implicit z: Zone): CString = {
+    val resolvedName = alloc[Byte](limits.PATH_MAX)
     realpath(path, resolvedName)
     resolvedName
   }
@@ -167,25 +193,30 @@ class File(_path: String) extends Serializable with Comparable[File] {
     File.isAbsolute(path)
 
   def isDirectory(): Boolean =
-    stat.S_ISDIR(accessMode()) != 0
+    Zone { implicit z =>
+      stat.S_ISDIR(accessMode()) != 0
+    }
 
   def isFile(): Boolean =
-    stat.S_ISREG(accessMode()) != 0
+    Zone { implicit z =>
+      stat.S_ISREG(accessMode()) != 0
+    }
 
   def isHidden(): Boolean =
     getName().startsWith(".")
 
-  def lastModified(): Long = {
-    val buf = GC.malloc_atomic(sizeof[stat.stat]).cast[Ptr[stat.stat]]
-    if (stat.stat(toCString(path), buf) == 0) {
-      !(buf._8) * 1000L
-    } else {
-      0L
+  def lastModified(): Long =
+    Zone { implicit z =>
+      val buf = alloc[stat.stat]
+      if (stat.stat(toCString(path), buf) == 0) {
+        !(buf._8) * 1000L
+      } else {
+        0L
+      }
     }
-  }
 
-  private def accessMode(): stat.mode_t = {
-    val buf = GC.malloc_atomic(sizeof[stat.stat]).cast[Ptr[stat.stat]]
+  private def accessMode()(implicit z: Zone): stat.mode_t = {
+    val buf = alloc[stat.stat]
     if (stat.stat(toCString(path), buf) == 0) {
       !(buf._13)
     } else {
@@ -194,49 +225,53 @@ class File(_path: String) extends Serializable with Comparable[File] {
   }
 
   def setLastModified(time: Long): Boolean =
-    if (time < 0) throw new IllegalArgumentException("Negative time")
-    else {
-      val statbuf = GC.malloc_atomic(sizeof[stat.stat]).cast[Ptr[stat.stat]]
-      if (stat.stat(toCString(path), statbuf) == 0) {
-        val timebuf =
-          GC.malloc_atomic(sizeof[utime.utimbuf]).cast[Ptr[utime.utimbuf]]
-        !(timebuf._1) = !(statbuf._8)
-        !(timebuf._2) = time / 1000L
-        utime.utime(toCString(path), timebuf) == 0
+    if (time < 0) {
+      throw new IllegalArgumentException("Negative time")
+    } else
+      Zone { implicit z =>
+        val statbuf = alloc[stat.stat]
+        if (stat.stat(toCString(path), statbuf) == 0) {
+          val timebuf = alloc[utime.utimbuf]
+          !(timebuf._1) = !(statbuf._8)
+          !(timebuf._2) = time / 1000L
+          utime.utime(toCString(path), timebuf) == 0
+        } else {
+          false
+        }
+      }
+
+  def setReadOnly(): Boolean =
+    Zone { implicit z =>
+      import stat._
+      val mask    = S_ISUID | S_ISGID | S_ISVTX | S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH
+      val newMode = accessMode() & mask
+      chmod(toCString(path), newMode) == 0
+    }
+
+  def length(): Long =
+    Zone { implicit z =>
+      val buf = alloc[stat.stat]
+      if (stat.stat(toCString(path), buf) == 0) {
+        !(buf._6)
       } else {
-        false
+        0L
       }
     }
-
-  def setReadOnly(): Boolean = {
-    import stat._
-    val mask    = S_ISUID | S_ISGID | S_ISVTX | S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH
-    val newMode = accessMode() & mask
-    chmod(toCString(path), newMode) == 0
-  }
-
-  def length(): Long = {
-    val buf = GC.malloc_atomic(sizeof[stat.stat]).cast[Ptr[stat.stat]]
-    if (stat.stat(toCString(path), buf) == 0) {
-      !(buf._6)
-    } else {
-      0L
-    }
-  }
 
   def list(): Array[String] =
     list(FilenameFilter.allPassFilter)
 
   def list(filter: FilenameFilter): Array[String] =
-    if (!isDirectory() || !canRead())
+    if (!isDirectory() || !canRead()) {
       null
-    else {
-      val elements = listImpl(toCString(properPath))
-      if (elements == null)
-        Array.empty[String]
-      else
-        elements.filter(filter.accept(this, _))
-    }
+    } else
+      Zone { implicit z =>
+        val elements = listImpl(toCString(properPath))
+        if (elements == null)
+          Array.empty[String]
+        else
+          elements.filter(filter.accept(this, _))
+      }
 
   def listFiles(): Array[File] =
     listFiles(FilenameFilter.allPassFilter)
@@ -258,51 +293,62 @@ class File(_path: String) extends Serializable with Comparable[File] {
 
     if (dir == null) {
       null
-    } else {
-      val buffer = UnrolledBuffer.empty[String]
-      var elem: Ptr[dirent] =
-        GC.malloc_atomic(sizeof[dirent]).cast[Ptr[dirent]]
-      while (readdir(dir, elem) == 0) {
-        val name = fromCString(elem._2.asInstanceOf[CString])
+    } else
+      Zone { implicit z =>
+        val buffer = UnrolledBuffer.empty[String]
+        var elem   = alloc[dirent]
+        while (readdir(dir, elem) == 0) {
+          val name = fromCString(elem._2.asInstanceOf[CString])
 
-        // java doesn't list '.' and '..', we filter them out.
-        if (name != "." && name != "..") {
-          buffer += name
+          // java doesn't list '.' and '..', we filter them out.
+          if (name != "." && name != "..") {
+            buffer += name
+          }
         }
+        closedir(dir)
+        buffer.toArray
       }
-      closedir(dir)
-      buffer.toArray
-    }
   }
 
-  def mkdir(): Boolean = {
-    val mode = octal("0777")
-    stat.mkdir(toCString(path), mode) == 0
-  }
+  def mkdir(): Boolean =
+    Zone { implicit z =>
+      val mode = octal("0777")
+      stat.mkdir(toCString(path), mode) == 0
+    }
 
   def mkdirs(): Boolean =
-    if (exists()) false
-    else if (mkdir()) true
-    else {
+    if (exists()) {
+      false
+    } else if (mkdir()) {
+      true
+    } else {
       val parent = getParentFile()
-      if (parent == null) false
-      else parent.mkdirs() && mkdir()
+      if (parent == null) {
+        false
+      } else {
+        parent.mkdirs() && mkdir()
+      }
     }
 
   def createNewFile(): Boolean =
-    if (path.isEmpty) throw new IOException("No such file or directory")
-    else if (!Option(getParentFile).forall(_.exists))
+    if (path.isEmpty) {
       throw new IOException("No such file or directory")
-    else if (exists) false
-    else {
-      fopen(toCString(path), c"w") match {
-        case null => false
-        case fd   => fclose(fd); exists()
+    } else if (!Option(getParentFile).forall(_.exists)) {
+      throw new IOException("No such file or directory")
+    } else if (exists) {
+      false
+    } else
+      Zone { implicit z =>
+        fopen(toCString(path), c"w") match {
+          case null => false
+          case fd   => fclose(fd); exists()
+        }
       }
-    }
 
   def renameTo(dest: File): Boolean =
-    rename(toCString(properPath), toCString(dest.properPath)) == 0
+    Zone { implicit z =>
+      rename(toCString(properPath), toCString(dest.properPath)) == 0
+    }
 
   override def toString(): String = path
 
@@ -319,11 +365,12 @@ object File {
   private def octal(v: String): UInt =
     Integer.parseInt(v, 8).toUInt
 
-  private def getUserDir(): String = {
-    var buff: CString = stackalloc[CChar](4096)
-    var res: CString  = getcwd(buff, 4095)
-    fromCString(res)
-  }
+  private def getUserDir(): String =
+    Zone { implicit z =>
+      var buff: CString = alloc[CChar](4096)
+      var res: CString  = getcwd(buff, 4095)
+      fromCString(res)
+    }
 
   /** The purpose of this method is to take a path and fix the slashes up. This
    *  includes changing them all to the current platforms fileSeparator and
@@ -416,9 +463,10 @@ object File {
    * directories if resolveAbsolute is true.
    */
   // Ported from Apache Harmony
-  private def resolveLink(path: CString,
-                          resolveAbsolute: Boolean,
-                          restart: Boolean = false): CString = {
+  private def resolveLink(
+      path: CString,
+      resolveAbsolute: Boolean,
+      restart: Boolean = false)(implicit z: Zone): CString = {
     val resolved =
       readLink(path) match {
         // path is not a symlink
@@ -439,7 +487,7 @@ object File {
 
           // previous path up to last /, plus result of resolving the link.
           val newPathLength = last + linkLength + 1
-          val newPath       = GC.malloc_atomic(newPathLength).cast[CString]
+          val newPath       = alloc[Byte](newPathLength)
           strncpy(newPath, path, last)
           strncat(newPath, link, linkLength)
 
@@ -450,8 +498,9 @@ object File {
     else resolved
   }
 
-  @tailrec private def resolve(path: CString, start: Int = 0): CString = {
-    val part: CString = GC.malloc(limits.PATH_MAX).cast[CString]
+  @tailrec private def resolve(path: CString, start: Int = 0)(
+      implicit z: Zone): CString = {
+    val part: CString = alloc[Byte](limits.PATH_MAX)
 
     // Find the next separator
     var i = start
@@ -483,8 +532,8 @@ object File {
    * If `link` is a symlink, follows it and returns the path pointed to.
    * Otherwise, returns `None`.
    */
-  private def readLink(link: CString): CString = {
-    val buffer: CString = GC.malloc_atomic(limits.PATH_MAX).cast[CString]
+  private def readLink(link: CString)(implicit z: Zone): CString = {
+    val buffer: CString = alloc[Byte](limits.PATH_MAX)
     readlink(link, buffer, limits.PATH_MAX - 1) match {
       case -1 =>
         null

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -81,8 +81,9 @@ class FileInputStream(fd: FileDescriptor) extends InputStream {
 }
 
 object FileInputStream {
-  private def fileDescriptor(file: File): FileDescriptor = {
-    val fd = fcntl.open(toCString(file.getPath), fcntl.O_RDONLY)
-    new FileDescriptor(fd, true)
-  }
+  private def fileDescriptor(file: File): FileDescriptor =
+    Zone { implicit z =>
+      val fd = fcntl.open(toCString(file.getPath), fcntl.O_RDONLY)
+      new FileDescriptor(fd, true)
+    }
 }

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -57,12 +57,13 @@ class FileOutputStream(fd: FileDescriptor) extends OutputStream {
 }
 
 object FileOutputStream {
-  private def fileDescriptor(file: File, append: Boolean) = {
-    import fcntl._
-    import stat._
-    val flags = O_CREAT | O_WRONLY | (if (append) O_APPEND else 0)
-    val mode  = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
-    val fd    = open(toCString(file.getPath), flags, mode)
-    new FileDescriptor(fd)
-  }
+  private def fileDescriptor(file: File, append: Boolean) =
+    Zone { implicit z =>
+      import fcntl._
+      import stat._
+      val flags = O_CREAT | O_WRONLY | (if (append) O_APPEND else 0)
+      val mode  = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
+      val fd    = open(toCString(file.getPath), flags, mode)
+      new FileDescriptor(fd)
+    }
 }

--- a/javalib/src/main/scala/java/io/FileReader.scala
+++ b/javalib/src/main/scala/java/io/FileReader.scala
@@ -1,6 +1,6 @@
 package java.io
 
-import scala.scalanative.native.toCString
+import scala.scalanative.native.{toCString, Zone}
 import scala.scalanative.posix.fcntl
 
 class FileReader(fd: FileDescriptor)
@@ -12,8 +12,9 @@ class FileReader(fd: FileDescriptor)
 }
 
 object FileReader {
-  private def fileDescriptor(file: File): FileDescriptor = {
-    val fd = fcntl.open(toCString(file.getPath), fcntl.O_RDONLY)
-    new FileDescriptor(fd, true)
-  }
+  private def fileDescriptor(file: File): FileDescriptor =
+    Zone { implicit z =>
+      val fd = fcntl.open(toCString(file.getPath), fcntl.O_RDONLY)
+      new FileDescriptor(fd, true)
+    }
 }

--- a/javalib/src/main/scala/java/io/FileWriter.scala
+++ b/javalib/src/main/scala/java/io/FileWriter.scala
@@ -1,6 +1,6 @@
 package java.io
 
-import scala.scalanative.native.toCString
+import scala.scalanative.native.{toCString, Zone}
 import scala.scalanative.posix.fcntl
 
 class FileWriter(fd: FileDescriptor)
@@ -14,9 +14,11 @@ class FileWriter(fd: FileDescriptor)
 }
 
 object FileWriter {
-  private def fileDescriptor(file: File, append: Boolean) = {
-    val mode = if (append) fcntl.O_WRONLY | fcntl.O_APPEND else fcntl.O_WRONLY
-    val fd   = fcntl.open(toCString(file.getPath), mode)
-    new FileDescriptor(fd)
-  }
+  private def fileDescriptor(file: File, append: Boolean) =
+    Zone { implicit z =>
+      val mode =
+        if (append) fcntl.O_WRONLY | fcntl.O_APPEND else fcntl.O_WRONLY
+      val fd = fcntl.open(toCString(file.getPath), mode)
+      new FileDescriptor(fd)
+    }
 }

--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -236,16 +236,17 @@ object Double {
   @inline def min(a: scala.Double, b: scala.Double): scala.Double =
     Math.min(a, b)
 
-  def parseDouble(s: String): scala.Double = {
-    val cstr = toCString(s)
-    val end  = stackalloc[CString]
+  def parseDouble(s: String): scala.Double =
+    Zone { implicit z =>
+      val cstr = toCString(s)
+      val end  = stackalloc[CString]
 
-    errno.errno = 0
-    val res = stdlib.strtod(cstr, end)
+      errno.errno = 0
+      val res = stdlib.strtod(cstr, end)
 
-    if (errno.errno == 0) res
-    else throw new NumberFormatException(s)
-  }
+      if (errno.errno == 0) res
+      else throw new NumberFormatException(s)
+    }
 
   @inline def sum(a: scala.Double, b: scala.Double): scala.Double =
     a + b

--- a/javalib/src/main/scala/java/lang/Float.scala
+++ b/javalib/src/main/scala/java/lang/Float.scala
@@ -230,16 +230,17 @@ object Float {
   @inline def min(a: scala.Float, b: scala.Float): scala.Float =
     Math.min(a, b)
 
-  def parseFloat(s: String): scala.Float = {
-    val cstr = toCString(s)
-    val end  = stackalloc[CString]
+  def parseFloat(s: String): scala.Float =
+    Zone { implicit z =>
+      val cstr = toCString(s)
+      val end  = stackalloc[CString]
 
-    errno.errno = 0
-    val res = stdlib.strtof(cstr, end)
+      errno.errno = 0
+      val res = stdlib.strtof(cstr, end)
 
-    if (errno.errno == 0) res
-    else throw new NumberFormatException(s)
-  }
+      if (errno.errno == 0) res
+      else throw new NumberFormatException(s)
+    }
 
   @inline def sum(a: scala.Float, b: scala.Float): scala.Float =
     a + b

--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -64,38 +64,37 @@ final class Matcher private[regex] (var _pattern: Pattern,
   private def doMatch(start: Int,
                       end: Int,
                       nMatches: Int,
-                      anchor: cre2.anchor_t): Boolean = {
-    val n       = nMatches
-    val matches = malloc(sizeof[cre2.string_t] * n).cast[Ptr[cre2.string_t]]
-    val in      = toCString(inputSequence.toString)
+                      anchor: cre2.anchor_t): Boolean =
+    Zone { implicit z =>
+      val n       = nMatches
+      val matches = alloc[cre2.string_t](n)
+      val in      = toCString(inputSequence.toString)
 
-    val ok = cre2.matches(
-        regex = regex,
-        text = in,
-        textlen = inputLength,
-        startpos = start,
-        endpos = end,
-        anchor = anchor,
-        matches = matches,
-        nMatches = nMatches
-      ) == 1
+      val ok = cre2.matches(
+          regex = regex,
+          text = in,
+          textlen = inputLength,
+          startpos = start,
+          endpos = end,
+          anchor = anchor,
+          matches = matches,
+          nMatches = nMatches
+        ) == 1
 
-    if (ok) {
-      var i = 0
-      while (i < nMatches) {
-        val m     = matches + i
-        val start = (m.data - in).toInt
-        val end   = start + m.length
-        groups(i) = ((start, end))
+      if (ok) {
+        var i = 0
+        while (i < nMatches) {
+          val m     = matches + i
+          val start = (m.data - in).toInt
+          val end   = start + m.length
+          groups(i) = ((start, end))
 
-        i += 1
+          i += 1
+        }
       }
+
+      ok
     }
-
-    free(matches.cast[Ptr[Byte]])
-
-    ok
-  }
 
   private def genMatch(start: Int, anchor: cre2.anchor_t): Boolean = {
     val ok = doMatch(start, inputLength, 1, anchor)
@@ -115,22 +114,20 @@ final class Matcher private[regex] (var _pattern: Pattern,
   def replaceAll(replacement: String): String =
     replace(replacement, global = true)
 
-  private def replace(replacement: String, global: Boolean): String = {
-    val textAndTarget, rewrite = stackalloc[cre2.string_t]
+  private def replace(replacement: String, global: Boolean): String =
+    Zone { implicit z =>
+      val textAndTarget, rewrite = stackalloc[cre2.string_t]
 
-    toRE2String(inputSequence.toString, textAndTarget)
-    toRE2String(replacement, rewrite)
+      toRE2String(inputSequence.toString, textAndTarget)
+      toRE2String(replacement, rewrite)
 
-    if (global) cre2.globalReplace(regex, textAndTarget, rewrite)
-    else cre2.replace(regex, textAndTarget, rewrite)
+      if (global) cre2.globalReplace(regex, textAndTarget, rewrite)
+      else cre2.replace(regex, textAndTarget, rewrite)
 
-    val res = fromRE2String(textAndTarget)
+      val res = fromRE2String(textAndTarget)
 
-    free(textAndTarget.data.cast[Ptr[Byte]])
-    free(rewrite.data.cast[Ptr[Byte]])
-
-    res
-  }
+      res
+    }
 
   def group(): String = group(0)
 
@@ -147,13 +144,14 @@ final class Matcher private[regex] (var _pattern: Pattern,
 
   def group(name: String): String = group(groupIndex(name))
 
-  private def groupIndex(name: String): Int = {
-    val pos = cre2.findNamedCapturingGroups(regex, toCString(name))
-    if (pos == -1) {
-      throw new IllegalArgumentException(s"No group with name <$name>")
+  private def groupIndex(name: String): Int =
+    Zone { implicit z =>
+      val pos = cre2.findNamedCapturingGroups(regex, toCString(name))
+      if (pos == -1) {
+        throw new IllegalArgumentException(s"No group with name <$name>")
+      }
+      pos
     }
-    pos
-  }
 
   def groupCount: Int = groups.length - 1
 

--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -2,7 +2,6 @@ package java.util
 package regex
 
 import cre2h._
-
 import scalanative.native._, stdlib._, stdio._, string._
 
 // Inspired by: https://github.com/google/re2j/blob/master/java/com/google/re2j/Matcher.java

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -2,10 +2,9 @@ package java.util
 package regex
 
 import scalanative.native._, stdlib._, stdio._, string._
+import cre2h._
 
 // Inspired by: https://github.com/google/re2j/blob/master/java/com/google/re2j/Pattern.java
-
-import cre2h._
 
 object Pattern {
   def CANON_EQ: Int                = 128

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -22,97 +22,97 @@ object Pattern {
   def compile(regex: String, flags: Int): Pattern =
     compile(regex, 0, adapt = true)
 
-  def compile(regex: String, flags: Int, adapt: Boolean): Pattern = {
-
-    def notSupported(flag: Int, flagName: String): Unit = {
-      if ((flags & flag) == flag) {
-        assert(false, s"regex flag $flagName is not supported")
-      }
-    }
-
-    notSupported(CANON_EQ, "CANON_EQ(canonical equivalences)")
-    notSupported(COMMENTS, "COMMENTS")
-    notSupported(UNICODE_CASE, "UNICODE_CASE")
-    notSupported(UNICODE_CHARACTER_CLASS, "UNICODE_CHARACTER_CLASS")
-    notSupported(UNIX_LINES, "UNIX_LINES")
-
-    val options = cre2.optNew()
-    cre2.setCaseSensitive(options, flags & CASE_INSENSITIVE)
-    cre2.setDotNl(options, flags & DOTALL)
-    cre2.setLiteral(options, flags & LITERAL)
-    cre2.setLogErrors(options, 0)
-
-    // setOneLine(false) is only available when limiting ourself to posix_syntax
-    // https://github.com/google/re2/blob/2017-03-01/re2/re2.h#L548
-    // regex flag MULTILINE cannot be disabled
-
-    val re2 = cre2.compile(toCString(regex), regex.size, options)
-
-    val code = cre2.errorCode(re2)
-
-    if (code != ERROR_NO_ERROR) {
-      val errorPattern = {
-        val arg = stackalloc[cre2.string_t]
-        cre2.errorArg(re2, arg)
-        fromRE2String(arg)
+  def compile(regex: String, flags: Int, adapt: Boolean): Pattern = Zone {
+    implicit z =>
+      def notSupported(flag: Int, flagName: String): Unit = {
+        if ((flags & flag) == flag) {
+          assert(false, s"regex flag $flagName is not supported")
+        }
       }
 
-      // we try to find the index of the parsing error
-      // this could return the wrong index it only finds the first match
-      // see https://groups.google.com/forum/#!topic/re2-dev/rnvFZ9Ki8nk
-      val index =
-        if (code == ERROR_TRAILING_BACKSLASH) regex.size - 1
-        else regex.indexOfSlice(errorPattern)
+      notSupported(CANON_EQ, "CANON_EQ(canonical equivalences)")
+      notSupported(COMMENTS, "COMMENTS")
+      notSupported(UNICODE_CASE, "UNICODE_CASE")
+      notSupported(UNICODE_CHARACTER_CLASS, "UNICODE_CHARACTER_CLASS")
+      notSupported(UNIX_LINES, "UNIX_LINES")
 
-      val reText = fromCString(cre2.errorString(re2))
+      val options = cre2.optNew()
+      cre2.setCaseSensitive(options, flags & CASE_INSENSITIVE)
+      cre2.setDotNl(options, flags & DOTALL)
+      cre2.setLiteral(options, flags & LITERAL)
+      cre2.setLogErrors(options, 0)
 
-      val description =
-        code match {
-          case ERROR_INTERNAL           => "Internal Error"
-          case ERROR_BAD_ESCAPE         => "Illegal/unsupported escape sequence"
-          case ERROR_BAD_CHAR_CLASS     => "Illegal/unsupported character class"
-          case ERROR_BAD_CHAR_RANGE     => "Illegal character range"
-          case ERROR_MISSING_BRACKET    => "Unclosed character class"
-          case ERROR_MISSING_PAREN      => "Missing parenthesis"
-          case ERROR_TRAILING_BACKSLASH => "Trailing Backslash"
-          case ERROR_REPEAT_ARGUMENT    => "Dangling meta character '*'"
-          case ERROR_REPEAT_SIZE        => "Bad repetition argument"
-          case ERROR_REPEAT_OP          => "Bad repetition operator"
-          case ERROR_BAD_PERL_OP        => "Bad perl operator"
-          case ERROR_BAD_UTF8           => "Invalid UTF-8 in regexp"
-          case ERROR_BAD_NAMED_CAPTURE  => "Bad named capture group"
-          case ERROR_PATTERN_TOO_LARGE =>
-            "Pattern too large (compilation failed)"
-          case _ => reText
+      // setOneLine(false) is only available when limiting ourself to posix_syntax
+      // https://github.com/google/re2/blob/2017-03-01/re2/re2.h#L548
+      // regex flag MULTILINE cannot be disabled
+
+      val re2 = cre2.compile(toCString(regex), regex.size, options)
+
+      val code = cre2.errorCode(re2)
+
+      if (code != ERROR_NO_ERROR) {
+        val errorPattern = {
+          val arg = stackalloc[cre2.string_t]
+          cre2.errorArg(re2, arg)
+          fromRE2String(arg)
         }
 
-      throw new PatternSyntaxException(
-        description,
-        regex,
-        index
+        // we try to find the index of the parsing error
+        // this could return the wrong index it only finds the first match
+        // see https://groups.google.com/forum/#!topic/re2-dev/rnvFZ9Ki8nk
+        val index =
+          if (code == ERROR_TRAILING_BACKSLASH) regex.size - 1
+          else regex.indexOfSlice(errorPattern)
+
+        val reText = fromCString(cre2.errorString(re2))
+
+        val description =
+          code match {
+            case ERROR_INTERNAL           => "Internal Error"
+            case ERROR_BAD_ESCAPE         => "Illegal/unsupported escape sequence"
+            case ERROR_BAD_CHAR_CLASS     => "Illegal/unsupported character class"
+            case ERROR_BAD_CHAR_RANGE     => "Illegal character range"
+            case ERROR_MISSING_BRACKET    => "Unclosed character class"
+            case ERROR_MISSING_PAREN      => "Missing parenthesis"
+            case ERROR_TRAILING_BACKSLASH => "Trailing Backslash"
+            case ERROR_REPEAT_ARGUMENT    => "Dangling meta character '*'"
+            case ERROR_REPEAT_SIZE        => "Bad repetition argument"
+            case ERROR_REPEAT_OP          => "Bad repetition operator"
+            case ERROR_BAD_PERL_OP        => "Bad perl operator"
+            case ERROR_BAD_UTF8           => "Invalid UTF-8 in regexp"
+            case ERROR_BAD_NAMED_CAPTURE  => "Bad named capture group"
+            case ERROR_PATTERN_TOO_LARGE =>
+              "Pattern too large (compilation failed)"
+            case _ => reText
+          }
+
+        throw new PatternSyntaxException(
+          description,
+          regex,
+          index
+        )
+      }
+
+      cre2.optDelete(options)
+
+      new Pattern(
+        _pattern = regex,
+        _flags = flags,
+        _regex = re2
       )
-    }
-
-    cre2.optDelete(options)
-
-    new Pattern(
-      _pattern = regex,
-      _flags = flags,
-      _regex = re2
-    )
   }
 
   def matches(regex: String, input: CharSequence): Boolean =
     compile(regex).matcher(input).matches
 
-  def quote(s: String): String = {
-    val original, quoted = stackalloc[cre2.string_t]
-    toRE2String(s, original)
-    cre2.quoteMeta(quoted, original)
-    val res = fromRE2String(quoted)
-    free(original.data.cast[Ptr[Byte]])
-    res
-  }
+  def quote(s: String): String =
+    Zone { implicit z =>
+      val original, quoted = stackalloc[cre2.string_t]
+      toRE2String(s, original)
+      cre2.quoteMeta(quoted, original)
+      val res = fromRE2String(quoted)
+      res
+    }
 
   def adaptPatternToRe2(regex: String): String = {
     regex

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -106,10 +106,12 @@ object Pattern {
     compile(regex).matcher(input).matches
 
   def quote(s: String): String = {
-    val original = toRE2String(s)
-    val quoted   = stackalloc[cre2.string_t]
+    val original, quoted = stackalloc[cre2.string_t]
+    toRE2String(s, original)
     cre2.quoteMeta(quoted, original)
-    fromRE2String(quoted)
+    val res = fromRE2String(quoted)
+    free(original.data.cast[Ptr[Byte]])
+    res
   }
 
   def adaptPatternToRe2(regex: String): String = {

--- a/javalib/src/main/scala/java/util/regex/cre2.scala
+++ b/javalib/src/main/scala/java/util/regex/cre2.scala
@@ -11,7 +11,7 @@ import java.nio.charset.Charset
 // re2 c wrapper: https://github.com/marcomaggi/cre2
 @link("re2")
 @extern
-private[regex] object cre2 {
+object cre2 {
   import cre2h._
 
   @name("scalanative_cre2_new")

--- a/javalib/src/main/scala/java/util/regex/cre2.scala
+++ b/javalib/src/main/scala/java/util/regex/cre2.scala
@@ -12,154 +12,158 @@ import java.nio.charset.Charset
 @link("re2")
 @extern
 object cre2 {
-  import cre2h._
+  type regexp_t     = CStruct0
+  type options_t    = CStruct0
+  type string_t     = CStruct2[CString, CInt]
+  type error_code_t = CInt
+  type anchor_t     = CInt
+  type encoding_t   = CInt
 
   @name("scalanative_cre2_new")
   def compile(
       pattern: CString,
       pattern_len: CInt,
-      options: Ptr[Options]
-  ): Ptr[Regex] = extern
+      options: Ptr[options_t]
+  ): Ptr[regexp_t] = extern
 
   @name("scalanative_cre2_delete")
   def delete(
-      regex: Ptr[Regex]
+      regex: Ptr[regexp_t]
   ): Unit = extern
 
   @name("scalanative_cre2_quote_meta")
   def quoteMeta(
-      quoted: StringPart,
-      original: StringPart
+      quoted: Ptr[string_t],
+      original: Ptr[string_t]
   ): CInt = extern
 
   @name("scalanative_cre2_num_capturing_groups")
   def numCapturingGroups(
-      regex: Ptr[Regex]
+      regex: Ptr[regexp_t]
   ): CInt = extern
 
   @name("scalanative_cre2_find_named_capturing_groups")
   def findNamedCapturingGroups(
-      regex: Ptr[Regex],
+      regex: Ptr[regexp_t],
       name: CString
   ): CInt = extern
 
   @name("scalanative_cre2_match")
   def matches(
-      regex: Ptr[Regex],
+      regex: Ptr[regexp_t],
       text: CString,
       textlen: CInt,
       startpos: CInt,
       endpos: CInt,
-      anchor: Anchor,
-      matches: StringPart,
+      anchor: anchor_t,
+      matches: Ptr[string_t],
       nMatches: CInt
   ): CInt = extern
 
   @name("scalanative_cre2_replace_re")
   def replace(
-      regex: Ptr[Regex],
-      text_and_target: StringPart,
-      rewrite: StringPart
+      regex: Ptr[regexp_t],
+      text_and_target: Ptr[string_t],
+      rewrite: Ptr[string_t]
   ): CInt = extern
 
   @name("scalanative_cre2_global_replace_re")
   def globalReplace(
-      regex: Ptr[Regex],
-      text_and_target: StringPart,
-      rewrite: StringPart
+      regex: Ptr[regexp_t],
+      text_and_target: Ptr[string_t],
+      rewrite: Ptr[string_t]
   ): CInt = extern
 
   @name("scalanative_cre2_error_code")
-  def errorCode(regex: Ptr[Regex]): CInt = extern
+  def errorCode(regex: Ptr[regexp_t]): error_code_t = extern
 
   @name("scalanative_cre2_error_string")
-  def errorString(regex: Ptr[Regex]): CString = extern
+  def errorString(regex: Ptr[regexp_t]): CString = extern
 
   @name("scalanative_cre2_error_arg")
-  def errorArg(regex: Ptr[Regex], arg: StringPart): Unit = extern
+  def errorArg(regex: Ptr[regexp_t], arg: Ptr[string_t]): Unit = extern
 
-  /* Options */
   @name("scalanative_cre2_opt_new")
-  def optNew(): Ptr[Options] = extern
+  def optNew(): Ptr[options_t] = extern
 
   @name("scalanative_cre2_opt_delete")
-  def optDelete(options: Ptr[Options]): Unit = extern
+  def optDelete(options: Ptr[options_t]): Unit = extern
 
   @name("scalanative_cre2_opt_set_posix_syntax")
   def setPosixSyntax(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       flag: CInt
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_longest_match")
   def setLongestMatch(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       flag: CInt
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_log_errors")
   def setLogErrors(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       flag: CInt
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_literal")
   def setLiteral(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       flag: CInt
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_never_nl")
   def setNeverNl(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       flag: CInt
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_dot_nl")
   def setDotNl(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       flag: CInt
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_never_capture")
   def setNeverCapture(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       flag: CInt
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_never_capture")
   def setCaseSensitive(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       flag: CInt
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_never_capture")
   def setPerlClasses(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       flag: CInt
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_word_boundary")
   def setWordBoundary(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       flag: CInt
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_one_line")
   def setOneLine(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       flag: CInt
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_max_mem")
   def setMaxMem(
-      options: Ptr[Options],
+      options: Ptr[options_t],
       m: CLong
   ): Unit = extern
 
   @name("scalanative_cre2_opt_set_encoding")
   def setEncoding(
-      options: Ptr[Options],
-      enc: Encoding
+      options: Ptr[options_t],
+      enc: encoding_t
   ): Unit = extern
 }

--- a/javalib/src/main/scala/java/util/regex/cre2.scala
+++ b/javalib/src/main/scala/java/util/regex/cre2.scala
@@ -3,7 +3,6 @@ package java.util.regex
 import scala.scalanative._
 import native._
 import native.stdlib._
-import runtime.GC
 
 import java.nio.charset.Charset
 

--- a/javalib/src/main/scala/java/util/regex/cre2h.scala
+++ b/javalib/src/main/scala/java/util/regex/cre2h.scala
@@ -3,7 +3,6 @@ package java.util.regex
 import scala.scalanative._
 import native._
 import native.stdlib._
-import runtime.GC
 
 import java.nio.charset.Charset
 
@@ -29,15 +28,10 @@ object cre2h {
     new String(bytes, charset)
   }
 
-  def toRE2String(str: String): Ptr[cre2.string_t] = {
-    val ptr = GC.malloc(sizeof[cre2.string_t]).cast[Ptr[cre2.string_t]]
-    ptr.data = toCString(str)
-    ptr.length = str.length
-    ptr
+  def toRE2String(str: String, restr: Ptr[cre2.string_t]): Unit = {
+    restr.data = toCString(str)
+    restr.length = str.length
   }
-
-  def RE2StringArray(n: CInt): Ptr[cre2.string_t] =
-    GC.malloc(sizeof[cre2.string_t] * n).cast[Ptr[cre2.string_t]]
 
   final val ENCODING_UNKNOWN = 0
   final val ENCODING_UTF_8   = 1

--- a/javalib/src/main/scala/java/util/regex/cre2h.scala
+++ b/javalib/src/main/scala/java/util/regex/cre2h.scala
@@ -28,7 +28,8 @@ object cre2h {
     new String(bytes, charset)
   }
 
-  def toRE2String(str: String, restr: Ptr[cre2.string_t]): Unit = {
+  def toRE2String(str: String, restr: Ptr[cre2.string_t])(
+      implicit a: Alloc): Unit = {
     restr.data = toCString(str)
     restr.length = str.length
   }

--- a/javalib/src/main/scala/java/util/regex/cre2h.scala
+++ b/javalib/src/main/scala/java/util/regex/cre2h.scala
@@ -7,7 +7,7 @@ import runtime.GC
 
 import java.nio.charset.Charset
 
-private[regex] object cre2h {
+object cre2h {
   type Regex       = CStruct0
   type Options     = CStruct0
   type _StringPart = CStruct2[CString, CInt]

--- a/nativelib/src/main/scala/scala/scalanative/native/Alloc.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Alloc.scala
@@ -7,7 +7,7 @@ trait Alloc {
   /** Allocates memory of given size. */
   def alloc(size: CSize): Ptr[Byte]
 
-  /** Reallocates previously allocated memory to have different size.
+  /** Reallocates previously allocated memory with a different size.
    *  Might not be supported by all allocators.
    */
   def realloc(ptr: Ptr[Byte], newSize: CSize): Ptr[Byte]

--- a/nativelib/src/main/scala/scala/scalanative/native/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/package.scala
@@ -167,14 +167,17 @@ package object native {
     new String(bytes, charset)
   }
 
-  /** Convert a java.lang.String to a CString using given charset.
-   *  The resulting c-style string is allocated using malloc, and
-   *  must be freed manually.
+  /** Convert a java.lang.String to a CString using default charset and
+   *  given allocator.
    */
-  def toCString(str: String,
-                charset: Charset = Charset.defaultCharset()): CString = {
+  def toCString(str: String)(implicit a: Alloc): CString =
+    toCString(str, Charset.defaultCharset())(a)
+
+  /** Convert a java.lang.String to a CString using given charset and allocator.
+   */
+  def toCString(str: String, charset: Charset)(implicit a: Alloc): CString = {
     val bytes = str.getBytes(charset)
-    val cstr  = malloc(bytes.length + 1).cast[Ptr[Byte]]
+    val cstr  = a.alloc(bytes.length + 1)
 
     var c = 0
     while (c < bytes.length) {

--- a/nativelib/src/main/scala/scala/scalanative/native/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/package.scala
@@ -2,7 +2,8 @@ package scala.scalanative
 
 import scala.language.experimental.macros
 import java.nio.charset.Charset
-import runtime.{undefined, GC}
+import scalanative.runtime.undefined
+import scalanative.native.stdlib.malloc
 
 package object native {
 
@@ -156,11 +157,14 @@ package object native {
     new String(bytes, charset)
   }
 
-  /** Convert a java.lang.String to a CString using given charset. */
+  /** Convert a java.lang.String to a CString using given charset.
+   *  The resulting c-style string is allocated using malloc, and
+   *  must be freed manually.
+   */
   def toCString(str: String,
                 charset: Charset = Charset.defaultCharset()): CString = {
     val bytes = str.getBytes(charset)
-    val cstr  = GC.malloc_atomic(bytes.length + 1).cast[Ptr[Byte]]
+    val cstr  = malloc(bytes.length + 1).cast[Ptr[Byte]]
 
     var c = 0
     while (c < bytes.length) {

--- a/unit-tests/src/main/scala/scala/scalanative/native/CInteropSuite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/native/CInteropSuite.scala
@@ -3,6 +3,7 @@ package scala.scalanative.native
 import stdio._
 
 object CInteropSuite extends tests.Suite {
+  implicit val alloc = Alloc.system
 
   test("varargs") {
     val buff = stackalloc[CChar](64)
@@ -29,5 +30,4 @@ object CInteropSuite extends tests.Suite {
     assert(sptr - sarr == 7)
     assert(sarr - sptr == -7)
   }
-
 }

--- a/unit-tests/src/main/scala/scala/scalanative/native/CStringSuite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/native/CStringSuite.scala
@@ -4,6 +4,8 @@ import stdio._
 import string._
 
 object CStringSuite extends tests.Suite {
+  implicit val alloc = Alloc.system
+
   test("fromCString") {
     val cstrFrom = c"1234"
     val szTo     = fromCString(cstrFrom)


### PR DESCRIPTION
* Simplify cre2 bindings, don't try to hide low-level aspects under helper methods
* Make naming in cre2 to be more consistent with the original library
* Update `alloc` to zero-initialize the memory
* Make sure we don't GC allocate manually, this isn't supported on immix, use zones instead