### PR TITLE
Preliminary support for zone allocation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -281,6 +281,9 @@ lazy val nativelib =
     .in(file("nativelib"))
     .settings(libSettings)
     .settings(mavenPublishSettings)
+    .settings(
+      libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
+    )
 
 lazy val javalib =
   project

--- a/nativelib/src/main/scala/scala/scalanative/native/Alloc.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Alloc.scala
@@ -1,0 +1,32 @@
+package scala.scalanative
+package native
+
+/** Typeclass that abstracts away memory allocator strategy. */
+trait Alloc {
+
+  /** Allocates memory of given size. */
+  def alloc(size: CSize): Ptr[Byte]
+
+  /** Reallocates previously allocated memory to have different size.
+   *  Might not be supported by all allocators.
+   */
+  def realloc(ptr: Ptr[Byte], newSize: CSize): Ptr[Byte]
+
+  /** Frees previously allocated memory.
+   *  Might not be supported by all allocators.
+   */
+  def free(ptr: Ptr[Byte]): Unit
+}
+
+object Alloc {
+
+  /** Standard system allocator behind malloc/free. */
+  val system: Alloc = new Alloc {
+    def alloc(size: CSize) =
+      stdlib.malloc(size)
+    def realloc(ptr: Ptr[Byte], newSize: CSize): Ptr[Byte] =
+      stdlib.realloc(ptr, newSize)
+    def free(ptr: Ptr[Byte]): Unit =
+      stdlib.free(ptr)
+  }
+}

--- a/nativelib/src/main/scala/scala/scalanative/native/Zone.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Zone.scala
@@ -1,0 +1,46 @@
+package scala.scalanative
+package native
+
+/** Zone allocator that automatically frees allocations whenever
+ *  syntactic boundary of the zone is over.
+ */
+trait Zone extends Alloc
+
+object Zone {
+
+  /** Run given function with a fresh zone and destroy it afterwards. */
+  final def apply[T](f: Zone => T): T = {
+    val zone = new ZoneImpl
+    try f(zone)
+    finally zone.close()
+  }
+
+  /** Minimalistic zone allocator that uses underlying
+   *  system allocator for allocations, and frees all of
+   *  the allocations once the zone is closed.
+   */
+  private class ZoneImpl extends Zone {
+    final class Node(val head: Ptr[Byte], val tail: Node)
+
+    private var node: Node = null
+
+    final def alloc(size: CSize): Ptr[Byte] = {
+      val ptr = stdlib.malloc(size)
+      node = new Node(ptr, node)
+      ptr
+    }
+
+    final def realloc(ptr: Ptr[Byte], newSize: CSize): Ptr[Byte] =
+      throw new UnsupportedOperationException("Zones do not support realloc")
+
+    final def free(ptr: Ptr[Byte]): Unit =
+      throw new UnsupportedOperationException("Zones do not support free")
+
+    final def close(): Unit = {
+      while (node != null) {
+        stdlib.free(node.head)
+        node = node.tail
+      }
+    }
+  }
+}

--- a/unit-tests/src/main/scala/scala/scalanative/native/AllocSuite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/native/AllocSuite.scala
@@ -1,0 +1,50 @@
+package scala.scalanative.native
+
+object AllocSuite extends tests.Suite {
+  def assertAccessible(bptr: Ptr[_], n: Int) {
+    val ptr = bptr.cast[Ptr[Int]]
+    var i   = 0
+    while (i < n) {
+      ptr(i) = i
+      i += 1
+    }
+
+    i = 0
+    var sum = 0
+    while (i < n) {
+      sum += ptr(i)
+      i += 1
+    }
+
+    assert(sum == (0 until n).sum)
+  }
+
+  test("system allocator malloc/realloc/free") {
+    val alloc = Alloc.system
+    val ptr   = alloc.alloc(64 * sizeof[Int])
+
+    assertAccessible(ptr, 64)
+
+    val ptr2 = alloc.realloc(ptr, 32 * sizeof[Int])
+
+    assertAccessible(ptr, 32)
+
+    val ptr3 = alloc.realloc(ptr2, 128 * sizeof[Int])
+
+    assertAccessible(ptr3, 128)
+
+    alloc.free(ptr3)
+  }
+
+  test("zone allocator malloc") {
+    Zone { implicit z =>
+      val ptr = z.alloc(64 * sizeof[Int])
+
+      assertAccessible(ptr, 64)
+
+      val ptr2 = alloc[Int](128)
+
+      assertAccessible(ptr2, 128)
+    }
+  }
+}


### PR DESCRIPTION
Zones, also known as regions or memory contexts, are an easy way to allocate temporary memory without having to clean it up on allocation-per-allocation basis. This PR introduces a very simple zone allocator that's meant to simplify memory management in bindings for C code.