### PR TITLE
Streamline gc alloc interface

### DIFF
--- a/nativelib/src/main/resources/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/gc/boehm/gc.c
@@ -22,4 +22,3 @@ void *scalanative_alloc_atomic(void *info, size_t size) {
 }
 
 void scalanative_collect() { GC_gcollect(); }
-

--- a/nativelib/src/main/resources/gc/boehm/gc.c
+++ b/nativelib/src/main/resources/gc/boehm/gc.c
@@ -1,6 +1,7 @@
 #include <gc.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 // At the moment we rely on the conservative
 // mode of Boehm GC as our garbage collector.
@@ -13,12 +14,12 @@ void *scalanative_alloc(void *info, size_t size) {
     return (void *)alloc;
 }
 
-void *scalanative_alloc_raw(size_t size) { return GC_malloc(size); }
-
-void *scalanative_alloc_raw_atomic(size_t size) {
-    return GC_malloc_atomic(size);
+void *scalanative_alloc_atomic(void *info, size_t size) {
+    void **alloc = (void **)GC_malloc_atomic(size);
+    memset(alloc, 0, size);
+    *alloc = info;
+    return (void *)alloc;
 }
 
 void scalanative_collect() { GC_gcollect(); }
 
-void scalanative_safepoint() {}

--- a/nativelib/src/main/resources/gc/none/gc.c
+++ b/nativelib/src/main/resources/gc/none/gc.c
@@ -30,10 +30,11 @@ void scalanative_init() {
     scalanative_safepoint_init();
 }
 
-void *scalanative_alloc_raw(size_t size) {
+void *scalanative_alloc(void *info, size_t size) {
     size = size + (8 - size % 8);
-    if (current != 0 && current + size < end) {
+    if (current + size < end) {
         void *alloc = current;
+        *alloc = info;
         current += size;
         return alloc;
     } else {
@@ -42,16 +43,8 @@ void *scalanative_alloc_raw(size_t size) {
     }
 }
 
-void *scalanative_alloc_raw_atomic(size_t size) {
-    return scalanative_alloc_raw(size);
-}
-
-void *scalanative_alloc(void *info, size_t size) {
-    void **alloc = (void **)scalanative_alloc_raw(size);
-    *alloc = info;
-    return (void *)alloc;
+void *scalanative_alloc_atomic(void *info, size_t size) {
+    return scalanative_alloc(info, size);
 }
 
 void scalanative_collect() {}
-
-void scalanative_safepoint() {}

--- a/nativelib/src/main/resources/safepoint.c
+++ b/nativelib/src/main/resources/safepoint.c
@@ -6,7 +6,7 @@
 extern unsigned char scalanative_safepoint_trigger[4096]
     __attribute__((aligned(4096)));
 
-void scalanative_safepoint();
+void scalanative_safepoint() {}
 
 void scalanative_safepoint_on() {
     mprotect((void *)&scalanative_safepoint_trigger, 4096, PROT_NONE);

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -39,8 +39,9 @@ class _Object {
     __hashCode
 
   protected def __clone(): _Object = {
-    val size  = runtime.getType(this).size
-    val clone = runtime.GC.malloc(size)
+    val ty    = runtime.getType(this)
+    val size  = ty.size
+    val clone = runtime.GC.alloc(ty, size)
     `llvm.memcpy.p0i8.p0i8.i64`(clone.cast[Ptr[scala.Byte]],
                                 this.cast[Ptr[scala.Byte]],
                                 size,

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -1,4 +1,4 @@
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 1)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 1)
 package scala.scalanative
 package runtime
 
@@ -88,11 +88,11 @@ object Array {
   }
 }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 82)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 82)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
 
 final class BooleanArray private () extends Array[Boolean] {
   import Array._
@@ -117,9 +117,9 @@ final class BooleanArray private () extends Array[Boolean] {
     !at(i) = value
 
   @inline protected override def clone(): BooleanArray = {
-    val arrinfo = typeof[BooleanArray]
+    val arrinfo = typeof[BooleanArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Boolean] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize)
+    val arr     = GC.alloc_atomic(arrinfo, arrsize)
     `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]],
                                 this.cast[Ptr[Byte]],
                                 arrsize,
@@ -133,17 +133,17 @@ object BooleanArray {
   import Array._
 
   @inline def alloc(length: Int): BooleanArray = {
-    val arrinfo = typeof[BooleanArray]
+    val arrinfo = typeof[BooleanArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Boolean] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize).cast[Ptr[Header]]
+    val arr     = GC.alloc_atomic(arrinfo, arrsize).cast[Ptr[Header]]
     arr.length = length
     arr.cast[BooleanArray]
   }
 }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
 
 final class CharArray private () extends Array[Char] {
   import Array._
@@ -168,9 +168,9 @@ final class CharArray private () extends Array[Char] {
     !at(i) = value
 
   @inline protected override def clone(): CharArray = {
-    val arrinfo = typeof[CharArray]
+    val arrinfo = typeof[CharArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Char] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize)
+    val arr     = GC.alloc_atomic(arrinfo, arrsize)
     `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]],
                                 this.cast[Ptr[Byte]],
                                 arrsize,
@@ -184,17 +184,17 @@ object CharArray {
   import Array._
 
   @inline def alloc(length: Int): CharArray = {
-    val arrinfo = typeof[CharArray]
+    val arrinfo = typeof[CharArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Char] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize).cast[Ptr[Header]]
+    val arr     = GC.alloc_atomic(arrinfo, arrsize).cast[Ptr[Header]]
     arr.length = length
     arr.cast[CharArray]
   }
 }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
 
 final class ByteArray private () extends Array[Byte] {
   import Array._
@@ -219,9 +219,9 @@ final class ByteArray private () extends Array[Byte] {
     !at(i) = value
 
   @inline protected override def clone(): ByteArray = {
-    val arrinfo = typeof[ByteArray]
+    val arrinfo = typeof[ByteArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Byte] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize)
+    val arr     = GC.alloc_atomic(arrinfo, arrsize)
     `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]],
                                 this.cast[Ptr[Byte]],
                                 arrsize,
@@ -235,17 +235,17 @@ object ByteArray {
   import Array._
 
   @inline def alloc(length: Int): ByteArray = {
-    val arrinfo = typeof[ByteArray]
+    val arrinfo = typeof[ByteArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Byte] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize).cast[Ptr[Header]]
+    val arr     = GC.alloc_atomic(arrinfo, arrsize).cast[Ptr[Header]]
     arr.length = length
     arr.cast[ByteArray]
   }
 }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
 
 final class ShortArray private () extends Array[Short] {
   import Array._
@@ -270,9 +270,9 @@ final class ShortArray private () extends Array[Short] {
     !at(i) = value
 
   @inline protected override def clone(): ShortArray = {
-    val arrinfo = typeof[ShortArray]
+    val arrinfo = typeof[ShortArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Short] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize)
+    val arr     = GC.alloc_atomic(arrinfo, arrsize)
     `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]],
                                 this.cast[Ptr[Byte]],
                                 arrsize,
@@ -286,17 +286,17 @@ object ShortArray {
   import Array._
 
   @inline def alloc(length: Int): ShortArray = {
-    val arrinfo = typeof[ShortArray]
+    val arrinfo = typeof[ShortArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Short] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize).cast[Ptr[Header]]
+    val arr     = GC.alloc_atomic(arrinfo, arrsize).cast[Ptr[Header]]
     arr.length = length
     arr.cast[ShortArray]
   }
 }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
 
 final class IntArray private () extends Array[Int] {
   import Array._
@@ -321,9 +321,9 @@ final class IntArray private () extends Array[Int] {
     !at(i) = value
 
   @inline protected override def clone(): IntArray = {
-    val arrinfo = typeof[IntArray]
+    val arrinfo = typeof[IntArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Int] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize)
+    val arr     = GC.alloc_atomic(arrinfo, arrsize)
     `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]],
                                 this.cast[Ptr[Byte]],
                                 arrsize,
@@ -337,17 +337,17 @@ object IntArray {
   import Array._
 
   @inline def alloc(length: Int): IntArray = {
-    val arrinfo = typeof[IntArray]
+    val arrinfo = typeof[IntArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Int] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize).cast[Ptr[Header]]
+    val arr     = GC.alloc_atomic(arrinfo, arrsize).cast[Ptr[Header]]
     arr.length = length
     arr.cast[IntArray]
   }
 }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
 
 final class LongArray private () extends Array[Long] {
   import Array._
@@ -372,9 +372,9 @@ final class LongArray private () extends Array[Long] {
     !at(i) = value
 
   @inline protected override def clone(): LongArray = {
-    val arrinfo = typeof[LongArray]
+    val arrinfo = typeof[LongArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Long] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize)
+    val arr     = GC.alloc_atomic(arrinfo, arrsize)
     `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]],
                                 this.cast[Ptr[Byte]],
                                 arrsize,
@@ -388,17 +388,17 @@ object LongArray {
   import Array._
 
   @inline def alloc(length: Int): LongArray = {
-    val arrinfo = typeof[LongArray]
+    val arrinfo = typeof[LongArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Long] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize).cast[Ptr[Header]]
+    val arr     = GC.alloc_atomic(arrinfo, arrsize).cast[Ptr[Header]]
     arr.length = length
     arr.cast[LongArray]
   }
 }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
 
 final class FloatArray private () extends Array[Float] {
   import Array._
@@ -423,9 +423,9 @@ final class FloatArray private () extends Array[Float] {
     !at(i) = value
 
   @inline protected override def clone(): FloatArray = {
-    val arrinfo = typeof[FloatArray]
+    val arrinfo = typeof[FloatArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Float] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize)
+    val arr     = GC.alloc_atomic(arrinfo, arrsize)
     `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]],
                                 this.cast[Ptr[Byte]],
                                 arrsize,
@@ -439,17 +439,17 @@ object FloatArray {
   import Array._
 
   @inline def alloc(length: Int): FloatArray = {
-    val arrinfo = typeof[FloatArray]
+    val arrinfo = typeof[FloatArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Float] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize).cast[Ptr[Header]]
+    val arr     = GC.alloc_atomic(arrinfo, arrsize).cast[Ptr[Header]]
     arr.length = length
     arr.cast[FloatArray]
   }
 }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
 
 final class DoubleArray private () extends Array[Double] {
   import Array._
@@ -474,9 +474,9 @@ final class DoubleArray private () extends Array[Double] {
     !at(i) = value
 
   @inline protected override def clone(): DoubleArray = {
-    val arrinfo = typeof[DoubleArray]
+    val arrinfo = typeof[DoubleArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Double] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize)
+    val arr     = GC.alloc_atomic(arrinfo, arrsize)
     `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]],
                                 this.cast[Ptr[Byte]],
                                 arrsize,
@@ -490,17 +490,17 @@ object DoubleArray {
   import Array._
 
   @inline def alloc(length: Int): DoubleArray = {
-    val arrinfo = typeof[DoubleArray]
+    val arrinfo = typeof[DoubleArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Double] * length
-    val arr     = runtime.allocAtomic(arrinfo, arrsize).cast[Ptr[Header]]
+    val arr     = GC.alloc_atomic(arrinfo, arrsize).cast[Ptr[Header]]
     arr.length = length
     arr.cast[DoubleArray]
   }
 }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 84)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
+// ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 88)
 
 final class ObjectArray private () extends Array[Object] {
   import Array._
@@ -525,9 +525,9 @@ final class ObjectArray private () extends Array[Object] {
     !at(i) = value
 
   @inline protected override def clone(): ObjectArray = {
-    val arrinfo = typeof[ObjectArray]
+    val arrinfo = typeof[ObjectArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Object] * length
-    val arr     = runtime.alloc(arrinfo, arrsize)
+    val arr     = GC.alloc(arrinfo, arrsize)
     `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]],
                                 this.cast[Ptr[Byte]],
                                 arrsize,
@@ -541,9 +541,9 @@ object ObjectArray {
   import Array._
 
   @inline def alloc(length: Int): ObjectArray = {
-    val arrinfo = typeof[ObjectArray]
+    val arrinfo = typeof[ObjectArray].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[Object] * length
-    val arr     = runtime.alloc(arrinfo, arrsize).cast[Ptr[Header]]
+    val arr     = GC.alloc(arrinfo, arrsize).cast[Ptr[Header]]
     arr.length = length
     arr.cast[ObjectArray]
   }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -83,7 +83,7 @@ object Array {
 % for T in types:
 
 %{
-   alloc = 'runtime.allocAtomic' if T != 'Object' else 'runtime.alloc'
+   alloc = 'GC.alloc_atomic' if T != 'Object' else 'GC.alloc'
 }%
 
 final class ${T}Array private () extends Array[${T}] {
@@ -109,7 +109,7 @@ final class ${T}Array private () extends Array[${T}] {
     !at(i) = value
 
   @inline protected override def clone(): ${T}Array = {
-    val arrinfo = typeof[${T}Array]
+    val arrinfo = typeof[${T}Array].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[${T}] * length
     val arr     = ${alloc}(arrinfo, arrsize)
     `llvm.memcpy.p0i8.p0i8.i64`(arr.cast[Ptr[Byte]], this.cast[Ptr[Byte]], arrsize, 1, false)
@@ -121,7 +121,7 @@ object ${T}Array {
   import Array._
 
   @inline def alloc(length: Int): ${T}Array = {
-    val arrinfo = typeof[${T}Array]
+    val arrinfo = typeof[${T}Array].cast[Ptr[ClassType]]
     val arrsize = sizeof[Header] + sizeof[${T}] * length
     val arr     = ${alloc}(arrinfo, arrsize).cast[Ptr[Header]]
     arr.length  = length

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -10,10 +10,10 @@ import native._
  */
 @extern
 object GC {
-  @name("scalanative_alloc_raw")
-  def malloc(size: CSize): Ptr[Byte] = extern
-  @name("scalanative_alloc_raw_atomic")
-  def malloc_atomic(size: CSize): Ptr[Byte] = extern
+  @name("scalanative_alloc")
+  def alloc(info: Ptr[ClassType], size: CSize): Ptr[Byte] = extern
+  @name("scalanative_alloc_atomic")
+  def alloc_atomic(info: Ptr[ClassType], size: CSize): Ptr[Byte] = extern
   @name("scalanative_collect")
   def collect(): Unit = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -67,25 +67,6 @@ package object runtime {
   def select[T](cond: Boolean, thenp: T, elsep: T)(implicit tag: Tag[T]): T =
     undefined
 
-  /** Allocate memory in gc heap using given info pointer. */
-  def alloc(ty: Ptr[Type], size: CSize): Ptr[Byte] = {
-    val ptr = GC.malloc(size).cast[Ptr[Ptr[Type]]]
-    !ptr = ty
-    ptr.cast[Ptr[Byte]]
-  }
-
-  /** Allocate memory in gc heap using given info pointer.
-   *
-   * The allocated memory cannot be used to store pointers.
-   */
-  def allocAtomic(ty: Ptr[Type], size: CSize): Ptr[Byte] = {
-    val ptr = GC.malloc_atomic(size).cast[Ptr[Ptr[Type]]]
-    // initialize to 0
-    `llvm.memset.p0i8.i64`(ptr.cast[Ptr[Byte]], 0, size, 1, false)
-    !ptr = ty
-    ptr.cast[Ptr[Byte]]
-  }
-
   /** Read type information of given object. */
   def getType(obj: Object): Ptr[ClassType] = !obj.cast[Ptr[Ptr[ClassType]]]
 

--- a/nir/src/main/scala/scala/scalanative/nir/Global.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Global.scala
@@ -23,6 +23,13 @@ sealed abstract class Global {
   final def isTop: Boolean = this.isInstanceOf[Global.Top]
 
   final def show: String = nir.Show(this)
+
+  final def normalize: Global = this match {
+    case Global.Member(Global.Top("__extern"), id) =>
+      Global.Top(id)
+    case _ =>
+      this
+  }
 }
 object Global {
   final case object None extends Global {

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -87,7 +87,8 @@ object CodeGen {
     }
 
     def genDeps() = deps.foreach { n =>
-      if (!generated.contains(n)) {
+      val nn = n.normalize
+      if (!generated.contains(nn)) {
         newline()
         genDefn {
           env(n) match {
@@ -103,6 +104,7 @@ object CodeGen {
               defn.copy(attrs.copy(isExtern = true), insts = Seq())
           }
         }
+        generated += nn
       }
     }
 
@@ -130,8 +132,12 @@ object CodeGen {
           case _               => -1
         }
         .foreach { defn =>
-          newline()
-          genDefn(defn)
+          val nn = defn.name.normalize
+          if (!generated.contains(nn)) {
+            newline()
+            genDefn(defn)
+            generated += nn
+          }
         }
 
     def genPrelude(): Unit = {
@@ -149,22 +155,19 @@ object CodeGen {
         "@_ZTIN11scalanative16ExceptionWrapperE = external constant { i8*, i8*, i8* }")
     }
 
-    def genDefn(defn: Defn): Unit = {
-      defn match {
-        case Defn.Struct(attrs, name, tys) =>
-          genStruct(attrs, name, tys)
-        case Defn.Var(attrs, name, ty, rhs) =>
-          genGlobalDefn(attrs, name, isConst = false, ty, rhs)
-        case Defn.Const(attrs, name, ty, rhs) =>
-          genGlobalDefn(attrs, name, isConst = true, ty, rhs)
-        case Defn.Declare(attrs, name, sig) =>
-          genFunctionDefn(attrs, name, sig, Seq())
-        case Defn.Define(attrs, name, sig, blocks) =>
-          genFunctionDefn(attrs, name, sig, blocks)
-        case defn =>
-          unsupported(defn)
-      }
-      generated += defn.name
+    def genDefn(defn: Defn): Unit = defn match {
+      case Defn.Struct(attrs, name, tys) =>
+        genStruct(attrs, name, tys)
+      case Defn.Var(attrs, name, ty, rhs) =>
+        genGlobalDefn(attrs, name, isConst = false, ty, rhs)
+      case Defn.Const(attrs, name, ty, rhs) =>
+        genGlobalDefn(attrs, name, isConst = true, ty, rhs)
+      case Defn.Declare(attrs, name, sig) =>
+        genFunctionDefn(attrs, name, sig, Seq())
+      case Defn.Define(attrs, name, sig, blocks) =>
+        genFunctionDefn(attrs, name, sig, blocks)
+      case defn =>
+        unsupported(defn)
     }
 
     def genStruct(attrs: Attrs, name: Global, tys: Seq[Type]): Unit = {
@@ -407,12 +410,10 @@ object CodeGen {
       genJustVal(value)
     }
 
-    def genJustGlobal(g: Global): Unit = g match {
+    def genJustGlobal(g: Global): Unit = g.normalize match {
       case Global.None =>
         unsupported(g)
       case Global.Top(id) =>
-        str(id)
-      case Global.Member(Global.Top("__extern"), id) =>
         str(id)
       case Global.Member(n, id) =>
         genJustGlobal(n)


### PR DESCRIPTION
This is a minor change to simplify GC interface to always require an
instance of runtime type information. This is a strict requirement to
support precise garbage collection.

Review @LukasKellenberger 