### PR TITLE
Adding a failing test for new FileInputStream("nonexisting") (#765)

### DIFF
--- a/unit-tests/src/main/scala/java/io/FileInputStreamSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileInputStreamSuite.scala
@@ -62,4 +62,12 @@ object FileInputStreamSuite extends tests.Suite {
     assert(fis.read() == 0xFF)
     assert(fis.read() == -1)
   }
+
+  testFails("throws proper FileNotFoundException on invalid file names", 765) {
+    assertThrows[FileNotFoundException] { 
+      val fis = new FileInputStream("/the/path/does/not/exist/for/sure")
+      fis.read
+    }
+  }
+ 
 }


### PR DESCRIPTION
A test case for #765