### PR TITLE
Interpreting the -1 result from fcntl.open as failure (#765)

### DIFF
--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -84,6 +84,9 @@ object FileInputStream {
   private def fileDescriptor(file: File): FileDescriptor =
     Zone { implicit z =>
       val fd = fcntl.open(toCString(file.getPath), fcntl.O_RDONLY)
+      if (fd == -1) {
+        throw new FileNotFoundException("No such file " + file.getPath)
+      }
       new FileDescriptor(fd, true)
     }
 }

--- a/unit-tests/src/main/scala/java/io/FileInputStreamSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileInputStreamSuite.scala
@@ -63,11 +63,9 @@ object FileInputStreamSuite extends tests.Suite {
     assert(fis.read() == -1)
   }
 
-  testFails("throws proper FileNotFoundException on invalid file names", 765) {
-    assertThrows[FileNotFoundException] { 
-      val fis = new FileInputStream("/the/path/does/not/exist/for/sure")
-      fis.read
+  test("throws FileNotFoundException when creating new FileInputStream with non-existing file path") {
+    assertThrows[FileNotFoundException] {
+      new FileInputStream("/the/path/does/not/exist/for/sure")
     }
   }
- 
 }

--- a/unit-tests/src/main/scala/java/io/FileInputStreamSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileInputStreamSuite.scala
@@ -62,4 +62,12 @@ object FileInputStreamSuite extends tests.Suite {
     assert(fis.read() == 0xFF)
     assert(fis.read() == -1)
   }
+
+  testFails("throws proper FileNotFoundException on invalid file names", 765) {
+    assertThrows[FileNotFoundException] { 
+      val fis = new FileInputStream("/the/path/does/not/exist/for/sure")
+      fis.read
+    }
+  }
+ 
 }


### PR DESCRIPTION
Fixes #765 
Previously, the code ignored special value `-1` returned from `fcntl.open`. 
Now, it throws the `FileNotFoundException` error there.

The [Javadoc specifies the `FNFE` should be thrown for different kind of problems](https://docs.oracle.com/javase/7/docs/api/java/io/FileInputStream.html#FileInputStream(java.lang.String)) - not only file not existing, but also it being a directory or lack of permissions.