### PR TITLE
Extracting logic for opening file descriptors for read to one place

### DIFF
--- a/javalib/src/main/scala/java/io/FileDescriptor.scala
+++ b/javalib/src/main/scala/java/io/FileDescriptor.scala
@@ -1,6 +1,7 @@
 package java.io
 
-import scala.scalanative.posix.unistd
+import scala.scalanative.posix.{fcntl, unistd}
+import scala.scalanative.native.{toCString, Zone}
 
 /** Wraps a UNIX file descriptor */
 final class FileDescriptor private[io] (private[io] val fd: Int,
@@ -30,5 +31,14 @@ object FileDescriptor {
   val in: FileDescriptor  = new FileDescriptor(unistd.STDIN_FILENO)
   val out: FileDescriptor = new FileDescriptor(unistd.STDOUT_FILENO)
   val err: FileDescriptor = new FileDescriptor(unistd.STDERR_FILENO)
+
+  private[io] def open(file: File): FileDescriptor =
+    Zone { implicit z =>
+      val fd = fcntl.open(toCString(file.getPath), fcntl.O_RDONLY)
+      if (fd == -1) {
+        throw new FileNotFoundException("No such file " + file.getPath)
+      }
+      new FileDescriptor(fd, true)
+    }
 
 }

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -7,7 +7,7 @@ import scala.scalanative.runtime
 
 class FileInputStream(fd: FileDescriptor) extends InputStream {
 
-  def this(file: File) = this(FileInputStream.fileDescriptor(file))
+  def this(file: File) = this(FileDescriptor.open(file))
   def this(str: String) = this(new File(str))
 
   override def available(): Int = {
@@ -78,12 +78,4 @@ class FileInputStream(fd: FileDescriptor) extends InputStream {
 
   // TODO:
   // def getChannel: FileChannel
-}
-
-object FileInputStream {
-  private def fileDescriptor(file: File): FileDescriptor =
-    Zone { implicit z =>
-      val fd = fcntl.open(toCString(file.getPath), fcntl.O_RDONLY)
-      new FileDescriptor(fd, true)
-    }
 }

--- a/javalib/src/main/scala/java/io/FileReader.scala
+++ b/javalib/src/main/scala/java/io/FileReader.scala
@@ -1,20 +1,9 @@
 package java.io
 
-import scala.scalanative.native.{toCString, Zone}
-import scala.scalanative.posix.fcntl
-
 class FileReader(fd: FileDescriptor)
     extends InputStreamReader(new FileInputStream(fd)) {
 
-  def this(file: File) = this(FileReader.fileDescriptor(file))
+  def this(file: File) = this(FileDescriptor.open(file))
   def this(fileName: String) = this(new File(fileName))
 
-}
-
-object FileReader {
-  private def fileDescriptor(file: File): FileDescriptor =
-    Zone { implicit z =>
-      val fd = fcntl.open(toCString(file.getPath), fcntl.O_RDONLY)
-      new FileDescriptor(fd, true)
-    }
 }

--- a/unit-tests/src/main/scala/java/io/FileReaderSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileReaderSuite.scala
@@ -1,0 +1,12 @@
+package java.io
+
+import scala.util.Try
+
+object FileReaderSuite extends tests.Suite {
+
+  test("throws FileNotFoundException when creating new FileReader with non-existing file path") {
+    assertThrows[FileNotFoundException] {
+      new FileReader("/the/path/does/not/exist/for/sure")
+    }
+  }
+}

--- a/unit-tests/src/main/scala/java/io/FileReaderSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileReaderSuite.scala
@@ -4,7 +4,8 @@ import scala.util.Try
 
 object FileReaderSuite extends tests.Suite {
 
-  test("throws FileNotFoundException when creating new FileReader with non-existing file path") {
+  test(
+    "throws FileNotFoundException when creating new FileReader with non-existing file path") {
     assertThrows[FileNotFoundException] {
       new FileReader("/the/path/does/not/exist/for/sure")
     }


### PR DESCRIPTION
When opening file descriptors for reading, now:
- done in one place (companion object of `FileDescriptor`)
- honors `-1` special value returned from the native `open` call and throws `FileNotFoundException` then

Fixes #765 