### PR TITLE
Testing result from open call in FileWriter (fix #770)

### DIFF
--- a/javalib/src/main/scala/java/io/FileWriter.scala
+++ b/javalib/src/main/scala/java/io/FileWriter.scala
@@ -19,6 +19,9 @@ object FileWriter {
       val mode =
         if (append) fcntl.O_WRONLY | fcntl.O_APPEND else fcntl.O_WRONLY
       val fd = fcntl.open(toCString(file.getPath), mode)
+      if (fd == -1) {
+        throw new FileNotFoundException("Cannot write to file " + file.getPath)
+      }
       new FileDescriptor(fd)
     }
 }

--- a/unit-tests/src/main/scala/java/io/FileWriterSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileWriterSuite.scala
@@ -1,0 +1,12 @@
+package java.io
+
+import scala.util.Try
+
+object FileWriterSuite extends tests.Suite {
+
+  test("throws FileNotFoundException when writing to a directory (or non-existing path)") {
+    assertThrows[FileNotFoundException] {
+      new FileWriter("/etc")
+    }
+  }
+}

--- a/unit-tests/src/main/scala/java/io/FileWriterSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileWriterSuite.scala
@@ -4,7 +4,8 @@ import scala.util.Try
 
 object FileWriterSuite extends tests.Suite {
 
-  test("throws FileNotFoundException when writing to a directory (or non-existing path)") {
+  test(
+    "throws FileNotFoundException when writing to a directory (or non-existing path)") {
     assertThrows[FileNotFoundException] {
       new FileWriter("/etc")
     }


### PR DESCRIPTION
Similar to #769, this time for FileWriter:
- when the `open` call fails and returns -1, we throw `FileNotFoundException`
- added `FileWriterSuite` to cover this
