### PR TITLE
added posix errno bindings (Fix #771)

### DIFF
--- a/nativelib/src/main/resources/posix.c
+++ b/nativelib/src/main/resources/posix.c
@@ -11,6 +11,159 @@ extern char **environ;
 // can not expand C macros, and that's the easiest way to
 // get the values out of those in a portable manner.
 
+// Omitting EDOM EILSEQ and ERANGE since they are duplicated in wrap.c
+int scalanative_e2big() { return E2BIG; }
+
+int scalanative_eacces() { return EACCES; }
+
+int scalanative_eaddrinuse() { return EADDRINUSE; }
+
+int scalanative_eafnosupport() { return EAFNOSUPPORT; }
+
+int scalanative_eagain() { return EAGAIN; }
+
+int scalanative_ealready() { return EALREADY; }
+
+int scalanative_ebadf() { return EBADF; }
+
+int scalanative_ebadmsg() { return EBADMSG; }
+
+int scalanative_ebusy() { return EBUSY; }
+
+int scalanative_ecanceled() { return ECANCELED; }
+
+int scalanative_echild() { return ECHILD; }
+
+int scalanative_econnaborted() { return ECONNABORTED; }
+
+int scalanative_econnrefused() { return ECONNREFUSED; }
+
+int scalanative_econnreset() { return ECONNRESET; }
+
+int scalanative_edeadlk() { return EDEADLK; }
+
+int scalanative_edestaddrreq() { return EDESTADDRREQ; }
+
+int scalanative_edquot() { return EDQUOT; }
+
+int scalanative_eexist() { return EEXIST; }
+
+int scalanative_efault() { return EFAULT; }
+
+int scalanative_efbig() { return EFBIG; }
+
+int scalanative_ehostunreach() { return EHOSTUNREACH; }
+
+int scalanative_eidrm() { return EIDRM; }
+
+int scalanative_einprogress() { return EINPROGRESS; }
+
 int scalanative_eintr() { return EINTR; }
+
+int scalanative_einval() { return EINVAL; }
+
+int scalanative_eio() { return EIO; }
+
+int scalanative_eisconn() { return EISCONN; }
+
+int scalanative_eisdir() { return EISDIR; }
+
+int scalanative_eloop() { return ELOOP; }
+
+int scalanative_emfile() { return EMFILE; }
+
+int scalanative_emlink() { return EMLINK; }
+
+int scalanative_emsgsize() { return EMSGSIZE; }
+
+int scalanative_emultihup() { return EMULTIHOP; }
+
+int scalanative_enametoolong() { return ENAMETOOLONG; }
+
+int scalanative_enetdown() { return ENETDOWN; }
+
+int scalanative_enetreset() { return ENETRESET; }
+
+int scalanative_enetunreach() { return ENETUNREACH; }
+
+int scalanative_enfile() { return ENFILE; }
+
+int scalanative_enobufs() { return ENOBUFS; }
+
+int scalanative_enodata() { return ENODATA; }
+
+int scalanative_enodev() { return ENODEV; }
+
+int scalanative_enoent() { return ENOENT; }
+
+int scalanative_enoexec() { return ENOEXEC; }
+
+int scalanative_enolck() { return ENOLCK; }
+
+int scalanative_enolink() { return ENOLINK; }
+
+int scalanative_enomem() { return ENOMEM; }
+
+int scalanative_enomsg() { return ENOMSG; }
+
+int scalanative_enoprotoopt() { return ENOPROTOOPT; }
+
+int scalanative_enospc() { return ENOSPC; }
+
+int scalanative_enosr() { return ENOSR; }
+
+int scalanative_enostr() { return ENOSTR; }
+
+int scalanative_enosys() { return ENOSYS; }
+
+int scalanative_enotconn() { return ENOTCONN; }
+
+int scalanative_enotdir() { return ENOTDIR; }
+
+int scalanative_enotempty() { return ENOTEMPTY; }
+
+int scalanative_enotrecoverable() { return ENOTRECOVERABLE; }
+
+int scalanative_enotsock() { return ENOTSOCK; }
+
+int scalanative_enotsup() { return ENOTSUP; }
+
+int scalanative_enotty() { return ENOTTY; }
+
+int scalanative_enxio() { return ENXIO; }
+
+int scalanative_eopnotsupp() { return EOPNOTSUPP; }
+
+int scalanative_eoverflow() { return EOVERFLOW; }
+
+int scalanative_eownerdead() { return EOWNERDEAD; }
+
+int scalanative_eperm() { return EPERM; }
+
+int scalanative_epipe() { return EPIPE; }
+
+int scalanative_eproto() { return EPROTO; }
+
+int scalanative_eprotonosupport() { return EPROTONOSUPPORT; }
+
+int scalanative_eprototype() { return EPROTOTYPE; }
+
+int scalanative_erofs() { return EROFS; }
+
+int scalanative_espipe() { return ESPIPE; }
+
+int scalanative_esrch() { return ESRCH; }
+
+int scalanative_estale() { return ESTALE; }
+
+int scalanative_etime() { return ETIME; }
+
+int scalanative_etimedout() { return ETIMEDOUT; }
+
+int scalanative_etxtbsy() { return ETXTBSY; }
+
+int scalanative_ewouldblock() { return EWOULDBLOCK; }
+
+int scalanative_exdev() { return EXDEV; }
 
 char **scalanative_environ() { return environ; }

--- a/nativelib/src/main/resources/wrap.c
+++ b/nativelib/src/main/resources/wrap.c
@@ -87,6 +87,4 @@ int scalanative_edom() { return EDOM; }
 
 int scalanative_eilseq() { return EILSEQ; }
 
-int scalanaitve_erange() { return ERANGE; }
-
-int scalanative_eexist() { return EEXIST; }
+int scalanative_erange() { return ERANGE; }

--- a/nativelib/src/main/scala/scala/scalanative/posix/errno.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/errno.scala
@@ -2,9 +2,166 @@ package scala.scalanative.posix
 
 import scala.scalanative.native.{CInt, extern, name}
 
+@extern
 object errno {
-  @name("scalanative_eintr")
-  def EINTR: CInt = extern
+  @name("scalanative_e2big")
+  def E2BIG: CInt = extern
+  @name("scalanative_eacces")
+  def EACCES: CInt = extern
+  @name("scalanative_eaddrinuse")
+  def EADDRINUSE: CInt = extern
+  @name("scalanative_eafnosupport")
+  def EAFNOSUPPORT: CInt = extern
+  @name("scalanative_eagain")
+  def EAGAIN: CInt = extern
+  @name("scalanative_ealready")
+  def EALREADY: CInt = extern
+  @name("scalanative_ebadf")
+  def EBADF: CInt = extern
+  @name("scalanative_ebadmsg")
+  def EBADMSG: CInt = extern
+  @name("scalanative_ebusy")
+  def EBUSY: CInt = extern
+  @name("scalanative_ecanceled")
+  def ECANCELED: CInt = extern
+  @name("scalanative_echild")
+  def ECHILD: CInt = extern
+  @name("scalanative_econnaborted")
+  def ECONNABORTED: CInt = extern
+  @name("scalanative_econnrefused")
+  def ECONNREFUSED: CInt = extern
+  @name("scalanative_econnreset")
+  def ECONNRESET: CInt = extern
+  @name("scalanative_edeadlk")
+  def EDEADLK: CInt = extern
+  @name("scalanative_edestaddrreq")
+  def EDESTADDRREQ: CInt = extern
+  @name("scalanative_edom")
+  def EDOM: CInt = extern
+  @name("scalanative_edquot")
+  def EDQUOT: CInt = extern
   @name("scalanative_eexist")
   def EEXIST: CInt = extern
+  @name("scalanative_efault")
+  def EFAULT: CInt = extern
+  @name("scalanative_efbig")
+  def EFBIG: CInt = extern
+  @name("scalanative_ehostunreach")
+  def EHOSTUNREACH: CInt = extern
+  @name("scalanative_eidrm")
+  def EIDRM: CInt = extern
+  @name("scalanative_eilseq")
+  def EILSEQ: CInt = extern
+  @name("scalanative_einprogress")
+  def EINPROGRESS: CInt = extern
+  @name("scalanative_eintr")
+  def EINTR: CInt = extern
+  @name("scalanative_einval")
+  def EINVAL: CInt = extern
+  @name("scalanative_eio")
+  def EIO: CInt = extern
+  @name("scalanative_eisconn")
+  def EISCONN: CInt = extern
+  @name("scalanative_eisdir")
+  def EISDIR: CInt = extern
+  @name("scalanative_eloop")
+  def ELOOP: CInt = extern
+  @name("scalanative_emfile")
+  def EMFILE: CInt = extern
+  @name("scalanative_emlink")
+  def EMLINK: CInt = extern
+  @name("scalanative_emsgsize")
+  def EMSGSIZE: CInt = extern
+  @name("scalanative_emultihup")
+  def EMULTIHOP: CInt = extern
+  @name("scalanative_enametoolong")
+  def ENAMETOOLONG: CInt = extern
+  @name("scalanative_enetdown")
+  def ENETDOWN: CInt = extern
+  @name("scalanative_enetreset")
+  def ENETRESET: CInt = extern
+  @name("scalanative_enetunreach")
+  def ENETUNREACH: CInt = extern
+  @name("scalanative_enfile")
+  def ENFILE: CInt = extern
+  @name("scalanative_enobufs")
+  def ENOBUFS: CInt = extern
+  @name("scalanative_enodata")
+  def ENODATA: CInt = extern
+  @name("scalanative_enodev")
+  def ENODEV: CInt = extern
+  @name("scalanative_enoent")
+  def ENOENT: CInt = extern
+  @name("scalanative_enoexec")
+  def ENOEXEC: CInt = extern
+  @name("scalanative_enolck")
+  def ENOLCK: CInt = extern
+  @name("scalanative_enolink")
+  def ENOLINK: CInt = extern
+  @name("scalanative_enomem")
+  def ENOMEM: CInt = extern
+  @name("scalanative_enomsg")
+  def ENOMSG: CInt = extern
+  @name("scalanative_enoprotoopt")
+  def ENOPROTOOPT: CInt = extern
+  @name("scalanative_enospc")
+  def ENOSPC: CInt = extern
+  @name("scalanative_enosr")
+  def ENOSR: CInt = extern
+  @name("scalanative_enostr")
+  def ENOSTR: CInt = extern
+  @name("scalanative_enosys")
+  def ENOSYS: CInt = extern
+  @name("scalanative_enotconn")
+  def ENOTCONN: CInt = extern
+  @name("scalanative_enotdir")
+  def ENOTDIR: CInt = extern
+  @name("scalanative_enotempty")
+  def ENOTEMPTY: CInt = extern
+  @name("scalanative_enotrecoverable")
+  def ENOTRECOVERABLE: CInt = extern
+  @name("scalanative_enotsock")
+  def ENOTSOCK: CInt = extern
+  @name("scalanative_enotsup")
+  def ENOTSUP: CInt = extern
+  @name("scalanative_enotty")
+  def ENOTTY: CInt = extern
+  @name("scalanative_enxio")
+  def ENXIO: CInt = extern
+  @name("scalanative_eopnotsupp")
+  def EOPNOTSUPP: CInt = extern
+  @name("scalanative_eoverflow")
+  def EOVERFLOW: CInt = extern
+  @name("scalanative_eownerdead")
+  def EOWNERDEAD: CInt = extern
+  @name("scalanative_eperm")
+  def EPERM: CInt = extern
+  @name("scalanative_epipe")
+  def EPIPE: CInt = extern
+  @name("scalanative_eproto")
+  def EPROTO: CInt = extern
+  @name("scalanative_eprotonosupport")
+  def EPROTONOSUPPORT: CInt = extern
+  @name("scalanative_eprototype")
+  def EPROTOTYPE: CInt = extern
+  @name("scalanative_erange")
+  def ERANGE: CInt = extern
+  @name("scalanative_erofs")
+  def EROFS: CInt = extern
+  @name("scalanative_espipe")
+  def ESPIPE: CInt = extern
+  @name("scalanative_esrch")
+  def ESRCH: CInt = extern
+  @name("scalanative_estale")
+  def ESTALE: CInt = extern
+  @name("scalanative_etime")
+  def ETIME: CInt = extern
+  @name("scalanative_etimedout")
+  def ETIMEDOUT: CInt = extern
+  @name("scalanative_etxtbsy")
+  def ETXTBSY: CInt = extern
+  @name("scalanative_ewouldblock")
+  def EWOULDBLOCK: CInt = extern
+  @name("scalanative_exdev")
+  def EXDEV: CInt = extern
 }


### PR DESCRIPTION
Strictly gruntwork here.  I worked from the 2016 posix spec here: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/errno.h.html

In terms of organization: the 3 ISO C errno values have helper functions in wrap.c, and all the rest in posix.c.  Since the posix spec does in fact include those 3 codes, however, I've included bindings to them in posix/errno.scala.  

I moved `scalanative_eexist` from wrap.c to posix.c according to the scheme described above.

Thought: providing a `Map[CInt,String]` of error numbers to names, or even a `Map[CInt,(String,String)]` to include standard descriptions, would be really useful.  Does that belong in user code, or is that worth adding now?