### PR TITLE
Implement java.util.Arraylist

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractList.scala
+++ b/javalib/src/main/scala/java/util/AbstractList.scala
@@ -11,7 +11,7 @@ abstract class AbstractList[E] protected ()
     true
   }
 
-  // tests/compile:nativeLinkNIR fails without this re-declaration for some reason
+  // tests/compile:nativeLinkNIR fails without this re-declaration (issue: #375)
   // cannot link: @java.util.AbstractList::get_i32_java.lang.Object
   def get(index: Int): E
 

--- a/javalib/src/main/scala/java/util/AbstractList.scala
+++ b/javalib/src/main/scala/java/util/AbstractList.scala
@@ -11,6 +11,10 @@ abstract class AbstractList[E] protected ()
     true
   }
 
+  // tests/compile:nativeLinkNIR fails without this re-declaration for some reason
+  // cannot link: @java.util.AbstractList::get_i32_java.lang.Object
+  def get(index: Int): E
+
   def set(index: Int, element: E): E =
     throw new UnsupportedOperationException
 

--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -5,10 +5,8 @@ import java.io.Serializable
 // Added extra private constructors to handle all of the overloads.
 // To preserve method signatures, we cannot take ClassTag via implicit parameters.
 // We use an Array[AnyRef] for underlying storage and box/unbox AnyVals where needed as the JDK class would do.
-/**
- * @param inner The underlying array
- * @param _size The effective size of the underlying array. a.k.a. end index exclusive
- */
+// inner: The underlying array
+// _size: Keeps the track of the effective size of the underlying array. a.k.a. end index exclusive
 class ArrayList[E] private (private[this] var inner: Array[AnyRef],
                             private[this] var _size: Int)
     extends AbstractList[E]
@@ -56,7 +54,7 @@ class ArrayList[E] private (private[this] var inner: Array[AnyRef],
 
   def size(): Int = _size
 
-  // tests/compile:nativeLinkNIR fails without this override for some reason
+  // tests/compile:nativeLinkNIR fails without this override (issue: #375)
   // cannot link: @java.util.ArrayList::isEmpty_bool
   override def isEmpty(): Boolean = _size == 0
 
@@ -143,7 +141,7 @@ class ArrayList[E] private (private[this] var inner: Array[AnyRef],
     _size = 0
   }
 
-  // define for better performance
+  // TODO: define for better performance
   //override def contains(o: Any): Boolean =
   //override def addAll(c: Collection[_ <: E]): Boolean =
   //override def addAll(index: Index, c: Collection[_ <: E]): Boolean =
@@ -155,7 +153,7 @@ class ArrayList[E] private (private[this] var inner: Array[AnyRef],
   //override def iterator(): Iterator[E] =
   //override def subList(fromIndex: Int, toIndex: Int): List[E] =
 
-  // JDK 1.8
+  // TODO: JDK 1.8
   // def forEach(action: Consumer[_ >: E]): Unit =
   // def spliterator(): Spliterator[E] =
   // def removeIf(filter: Predicate[_ >: E]): Boolean =

--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -1,0 +1,162 @@
+package java.util
+
+import java.io.Serializable
+
+// Added extra private constructors to handle all of the overloads.
+// To preserve method signatures, we cannot take ClassTag via implicit parameters.
+// We use an Array[AnyRef] for underlying storage and box/unbox AnyVals where needed as the JDK class would do.
+class ArrayList[E] private (private[this] var inner: Array[AnyRef])
+    extends AbstractList[E]
+    with List[E]
+    with RandomAccess
+    with Cloneable
+    with Serializable {
+  // keeps a track of the effective size of the underlying array.
+  // a.k.a. end index exclusive
+  private[this] var _size: Int = inner.length
+
+  private def this(initialCollection: Collection[E], initialCapacity: Int) = {
+    this {
+      val initialArr =
+        Array.ofDim[AnyRef](initialCollection.size() max initialCapacity)
+      import scala.collection.JavaConverters._
+      initialCollection.asScala
+        .map(_.asInstanceOf[AnyRef])
+        .copyToArray(initialArr)
+      initialArr
+    }
+    _size = initialCollection.size()
+  }
+
+  def this(c: Collection[E]) = this(c, c.size())
+
+  def this(initialCapacity: Int) =
+    this(Collections.emptyList(), initialCapacity)
+
+  def this() = this(10)
+
+  // by default, doubles the capacity. this mimicks C++ <vector> compiled by clang++-4.0.0
+  private[this] def expand(): Unit = expand(inner.length * 2 max 1)
+
+  private[this] def expand(newCapacity: Int): Unit = {
+    val newArr = Array.ofDim[AnyRef](newCapacity)
+    inner.copyToArray(newArr, 0, size())
+    inner = newArr
+  }
+
+  private[this] def capacity(): Int = inner.length
+
+  def trimToSize(): Unit = expand(size())
+
+  def ensureCapacity(minCapacity: Int): Unit =
+    if (capacity() < minCapacity)
+      expand(minCapacity)
+
+  def size(): Int = _size
+
+  // tests/compile:nativeLinkNIR fails without this override for some reason
+  // cannot link: @java.util.ArrayList::isEmpty_bool
+  override def isEmpty(): Boolean = _size == 0
+
+  override def indexOf(o: Any): Int = inner.indexOf(o)
+
+  override def lastIndexOf(o: Any): Int = inner.lastIndexOf(o)
+
+  // shallow-copy
+  override def clone(): AnyRef = new ArrayList(inner)
+
+  override def toArray(): Array[AnyRef] = {
+    val result = Array.ofDim[AnyRef](size())
+    inner.copyToArray(result, 0, size())
+    result
+  }
+
+  override def toArray[T <: AnyRef](a: Array[T]): Array[T] =
+    if (a.length < size())
+      toArray().asInstanceOf[Array[T]]
+    else {
+      inner.asInstanceOf[Array[T]].copyToArray(a, 0, size())
+      // fill the rest of the elements in a by null as explained in JDK Javadoc
+      for (i <- size() until a.length) {
+        a(i) = null.asInstanceOf[T]
+      }
+      a
+    }
+
+  def get(index: Int): E = {
+    checkIndexInBounds(index)
+    inner(index).asInstanceOf[E]
+  }
+
+  override def set(index: Int, element: E): E = {
+    val original = get(index)
+    inner(index) = element.asInstanceOf[AnyRef]
+    original
+  }
+
+  override def add(element: E): Boolean = {
+    add(size(), element)
+    true
+  }
+
+  override def add(index: Int, element: E): Unit = {
+    checkIndexOnBounds(index)
+
+    if (size() >= capacity())
+      expand()
+    // shift each element
+    for (i <- _size to (index + 1) by -1) {
+      inner(i) = inner(i - 1)
+    }
+    inner(index) = element.asInstanceOf[AnyRef]
+    _size += 1
+  }
+
+  override def remove(index: Int): E = {
+    val removed = get(index)
+
+    // shift each element, overwriting inner(index)
+    for (i <- index until (_size - 1)) {
+      inner(i) = inner(i + 1)
+    }
+    inner(_size - 1) = null
+    _size -= 1
+
+    removed
+  }
+
+  override def remove(o: Any): Boolean =
+    inner.indexOf(o) match {
+      case -1 => false
+      case idx =>
+        remove(idx)
+        true
+    }
+
+  override def clear(): Unit = {
+    // fill the content of inner by null so that the elements can be garbage collected
+    for (i <- (0 until _size)) {
+      inner(i) = null
+    }
+    _size = 0
+  }
+
+  // define for better performance
+  //override def contains(o: Any): Boolean =
+  //override def addAll(c: Collection[_ <: E]): Boolean =
+  //override def addAll(index: Index, c: Collection[_ <: E]): Boolean =
+  //override def removeRange(fromIndex: Int, toIndex: Int): Boolean =
+  //override def removeAll(c: Collection[_ <: AnyRef]): Boolean =
+  //override def retainAll(c: Collection[_ <: AnyRef]): Boolean =
+  //override def listIterator(index: Int): ListIterator[E] =
+  //override def listIterator(): ListIterator[E] =
+  //override def iterator(): Iterator[E] =
+  //override def subList(fromIndex: Int, toIndex: Int): List[E] =
+
+  // JDK 1.8
+  // def forEach(action: Consumer[_ >: E]): Unit =
+  // def spliterator(): Spliterator[E] =
+  // def removeIf(filter: Predicate[_ >: E]): Boolean =
+  // def replaceAll(operator: UnaryOperator[E]): Unit =
+  // def sort(c: Comparator[_ >: E]): Unit =
+}

--- a/unit-tests/src/main/scala/java/util/ArrayListSuite.scala
+++ b/unit-tests/src/main/scala/java/util/ArrayListSuite.scala
@@ -135,6 +135,17 @@ object ArrayListSuite extends tests.Suite {
     assert(al1 == al2)
   }
 
+  test("clone() with size() != capacity()") {
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    al1.ensureCapacity(20)
+    val al2 = al1.clone().asInstanceOf[ArrayList[Int]]
+    assert(al1 == al2)
+    al1.add(1)
+    assert(al1 != al2)
+    al2.add(1)
+    assert(al1 == al2)
+  }
+
   test("toArray()") {
     val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
     // Array.== doesn't work for some reason

--- a/unit-tests/src/main/scala/java/util/ArrayListSuite.scala
+++ b/unit-tests/src/main/scala/java/util/ArrayListSuite.scala
@@ -1,0 +1,237 @@
+package java.util
+
+import scala.collection.JavaConverters._
+
+object ArrayListSuite extends tests.Suite {
+  test("Constructor()") {
+    val al = new ArrayList()
+    assert(al.size() == 0)
+    assert(al.isEmpty())
+  }
+
+  test("Constructor(Int)") {
+    val al = new ArrayList(10)
+    assert(al.size() == 0)
+    assert(al.isEmpty())
+    // the capacity is opaque. exposing it just for testing is avoided
+  }
+
+  test("Constructor(Collection[java.lang.Integer])") { // for AnyVal
+    val is = Seq(1, 2, 3)
+    val al = new ArrayList(is.asJava)
+    assert(al.size() == 3)
+    assert(!al.isEmpty())
+    assert(al.get(0) == 1)
+    assert(al.get(1) == 2)
+    assert(al.get(2) == 3)
+    assert(al.asScala == Seq(1, 2, 3))
+  }
+
+  test("Constructor(Collection[String])") { // for AnyRef
+    val is = Seq(1, 2, 3).map(_.toString)
+    import scala.collection.JavaConverters._
+    val al = new ArrayList(is.asJava)
+    assert(al.size() == 3)
+    assert(!al.isEmpty())
+    assert(al.get(0) == "1")
+    assert(al.get(1) == "2")
+    assert(al.get(2) == "3")
+    assert(al.asScala == Seq("1", "2", "3"))
+  }
+
+  test("equals() for empty lists") {
+    val e1  = new ArrayList()
+    val e2  = new ArrayList()
+    val ne1 = new ArrayList(Seq(1).asJava)
+    assert(e1 == e2)
+    assert(e2 == e1)
+    assert(e1 != ne1)
+    assert(ne1 != e1)
+  }
+
+  test("equals() for nonempty lists") {
+    val ne1a = new ArrayList(Seq(1, 2, 3).asJava)
+    val ne1b = new ArrayList(Seq(1, 2, 3).asJava)
+    val ne2  = new ArrayList(Seq(1).asJava)
+    assert(ne1a == ne1b)
+    assert(ne1b == ne1a)
+    assert(ne1a != ne2)
+    assert(ne2 != ne1a)
+    assert(ne1b != ne2)
+    assert(ne2 != ne1b)
+  }
+
+  test("trimToSize() for non-empty lists with different capacities") {
+    val al1 = new ArrayList(Seq(1, 2, 3).asJava)
+    val al2 = new ArrayList(Seq(1, 2, 3).asJava)
+    al2.ensureCapacity(100)
+    val al3 = new ArrayList[Int](50)
+    al3.add(1)
+    al3.add(2)
+    al3.add(3)
+    assert(al1 == al2)
+    assert(al2 == al3)
+  }
+
+  test("trimToSize() for empty lists") {
+    val al1 = new ArrayList()
+    al1.trimToSize()
+    val al2 = new ArrayList()
+    assert(al1 == al2)
+  }
+
+  test("trimToSize() for non-empty lists") {
+    val al1 = new ArrayList(Seq(1, 2, 3).asJava)
+    val al2 = new ArrayList(Seq(1, 2, 3).asJava)
+    al2.ensureCapacity(100)
+    val al3 = new ArrayList[Int](50)
+    al3.add(1)
+    al3.add(2)
+    al3.add(3)
+    al1.trimToSize()
+    al2.trimToSize()
+    al3.trimToSize()
+    assert(al1 == al2)
+    assert(al2 == al3)
+  }
+
+  test("size()") {
+    val al1 = new ArrayList[Int]()
+    assert(al1.size() == 0)
+    val al2 = new ArrayList[Int](Seq(1, 2, 3).asJava)
+    assert(al2.size() == 3)
+    val al3 = new ArrayList[Int](10)
+    // not to be confused with its capacity.
+    assert(al3.size() == 0)
+  }
+
+  test("isEmpty()") {
+    val al1 = new ArrayList[Int]()
+    assert(al1.isEmpty())
+    val al2 = new ArrayList[Int](Seq(1, 2, 3).asJava)
+    assert(!al2.isEmpty())
+    val al3 = new ArrayList[Int](10)
+    // not to be confused with its capacity.
+    assert(al3.isEmpty())
+  }
+
+  test("indexOf(Any)") {
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    assert(al1.indexOf(2) == 1)
+  }
+
+  test("lastIndexOf(Any)") {
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    assert(al1.lastIndexOf(2) == 3)
+  }
+
+  test("clone()") {
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al2 = al1.clone().asInstanceOf[ArrayList[Int]]
+    assert(al1 == al2)
+    al1.add(1)
+    assert(al1 != al2)
+    al2.add(1)
+    assert(al1 == al2)
+  }
+
+  test("toArray()") {
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    // Array.== doesn't work for some reason
+    // assert(Array(1, 2, 3, 2).map(_.asInstanceOf[AnyRef]) = al1.toArray())
+    assert(
+      Array(1, 2, 3, 2).map(_.asInstanceOf[AnyRef]).iterator sameElements al1
+        .toArray()
+        .iterator)
+  }
+
+  test("toArray[T](arr: Array[T]) when arr is shorter") {
+    val al1  = new ArrayList[String](Seq("apple", "banana", "cherry").asJava)
+    val ain  = Array.empty[String]
+    val aout = al1.toArray(ain)
+    assert(ain ne aout)
+    // Array.== doesn't work for some reason
+    // assert(Array("apple", "banana", "cherry") == aout)
+    assert(
+      Array("apple", "banana", "cherry").iterator sameElements aout.iterator)
+  }
+
+  test("toArray[T](arr: Array[T]) when arr is with the same length or longer") {
+    val al1  = new ArrayList[String](Seq("apple", "banana", "cherry").asJava)
+    val ain  = Array.fill(4)("foo")
+    val aout = al1.toArray(ain)
+    assert(ain eq aout)
+    // Array.== doesn't work for some reason
+    // assert(Array("apple", "banana", "cherry", null) == aout)
+    assert(
+      Array("apple", "banana", "cherry", null).iterator sameElements aout.iterator)
+  }
+
+  test("get(Int)") {
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    assert(al1.get(0) == 1)
+    assert(al1.get(1) == 2)
+    assert(al1.get(2) == 3)
+    assert(al1.get(3) == 2)
+    assertThrows[IndexOutOfBoundsException] { al1.get(-1); () }
+    assertThrows[IndexOutOfBoundsException] { al1.get(4); () }
+  }
+
+  test("set(Int, E)") {
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    assert(al1.set(1, 4) == 2)
+    assert(Seq(1, 4, 3, 2) == al1.asScala)
+  }
+
+  test("add(E)") {
+    val al1 = new ArrayList[Int]()
+    al1.add(1)
+    assert(al1.asScala == Seq(1))
+    al1.add(2)
+    assert(al1.asScala == Seq(1, 2))
+  }
+
+  test("add(Int, E)") {
+    val al1 = new ArrayList[Int]()
+    al1.add(0, 1)
+    assert(al1.asScala == Seq(1))
+    al1.add(0, 2)
+    assert(al1.asScala == Seq(2, 1))
+  }
+
+  test("add(Int, E) when the capacity has to be expanded") {
+    val al1 = new ArrayList[Int](0)
+    al1.add(0, 1)
+    assert(al1.asScala == Seq(1))
+    al1.add(0, 2)
+    assert(al1.asScala == Seq(2, 1))
+  }
+
+  test("remove(Int)") {
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2, 3).asJava)
+    // remove last
+    assert(al1.remove(4) == 3)
+    // remove head
+    assert(al1.remove(0) == 1)
+    // remove middle
+    assert(al1.remove(1) == 3)
+    assertThrows[IndexOutOfBoundsException](al1.remove(4))
+    assert(Seq(2, 2) == al1.asScala)
+  }
+
+  test("remove(Any)") {
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    assert(al1.remove(2: Any) == true)
+    assert(Seq(1, 3, 2) == al1.asScala)
+    assert(al1.remove(4: Any) == false)
+    assert(Seq(1, 3, 2) == al1.asScala)
+  }
+
+  test("clear()") {
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    al1.clear()
+    assert(al1.isEmpty())
+    // makes sure that clear()ing an already empty list is safe
+    al1.clear()
+  }
+}

--- a/unit-tests/src/main/scala/java/util/ArrayListSuite.scala
+++ b/unit-tests/src/main/scala/java/util/ArrayListSuite.scala
@@ -148,12 +148,9 @@ object ArrayListSuite extends tests.Suite {
 
   test("toArray()") {
     val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
-    // Array.== doesn't work for some reason
-    // assert(Array(1, 2, 3, 2).map(_.asInstanceOf[AnyRef]) = al1.toArray())
     assert(
-      Array(1, 2, 3, 2).map(_.asInstanceOf[AnyRef]).iterator sameElements al1
-        .toArray()
-        .iterator)
+      (Array(1, 2, 3, 2).map(_.asInstanceOf[AnyRef])) sameElements
+        (al1.toArray()))
   }
 
   test("toArray[T](arr: Array[T]) when arr is shorter") {
@@ -161,10 +158,7 @@ object ArrayListSuite extends tests.Suite {
     val ain  = Array.empty[String]
     val aout = al1.toArray(ain)
     assert(ain ne aout)
-    // Array.== doesn't work for some reason
-    // assert(Array("apple", "banana", "cherry") == aout)
-    assert(
-      Array("apple", "banana", "cherry").iterator sameElements aout.iterator)
+    assert(Array("apple", "banana", "cherry") sameElements aout)
   }
 
   test("toArray[T](arr: Array[T]) when arr is with the same length or longer") {
@@ -172,10 +166,7 @@ object ArrayListSuite extends tests.Suite {
     val ain  = Array.fill(4)("foo")
     val aout = al1.toArray(ain)
     assert(ain eq aout)
-    // Array.== doesn't work for some reason
-    // assert(Array("apple", "banana", "cherry", null) == aout)
-    assert(
-      Array("apple", "banana", "cherry", null).iterator sameElements aout.iterator)
+    assert(Array("apple", "banana", "cherry", null) sameElements aout)
   }
 
   test("get(Int)") {


### PR DESCRIPTION
Implemented the essential methods using Array[AnyRef] as its underlying storage.

Methods which would only contribute to performance boost or are introduced by Java 8 are left unimplemented.

All of the code was written from scratch, and then compared with that of scala.js to tidy up.
Signed Scala CLA.

Related to: #761