### PR TITLE
Fix indirect trait method dispatch

### DIFF
--- a/nativelib/src/main/resources/gc/none/gc.c
+++ b/nativelib/src/main/resources/gc/none/gc.c
@@ -25,7 +25,6 @@ void scalanative_init() {
     current = mmap(NULL, CHUNK, DUMMY_GC_PROT, DUMMY_GC_FLAGS, DUMMY_GC_FD,
                    DUMMY_GC_FD_OFFSET);
     end = current + CHUNK;
-    scalanative_safepoint_init();
 }
 
 void *scalanative_alloc(void *info, size_t size) {

--- a/sandbox/Test.scala
+++ b/sandbox/Test.scala
@@ -1,4 +1,5 @@
 object Test {
-  def main(args: Array[String]): Unit =
-    println("Hello, world!")
+  def main(args: Array[String]): Unit = {
+    println("Hello, World!")
+  }
 }

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/MethodLowering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/MethodLowering.scala
@@ -35,13 +35,14 @@ class MethodLowering(implicit fresh: Fresh, top: Top) extends Pass {
         let(n, Op.Copy(Val.Global(meth.name, Type.Ptr)))
 
       case Let(n, Op.Method(obj, MethodRef(trt: Trait, meth))) =>
+        val sigid   = top.tables.traitMethodSigs(meth.name.id)
         val typeptr = let(Op.Load(Type.Ptr, obj))
         val idptr   = let(Op.Elem(Rt.Type, typeptr, Seq(Val.Int(0), Val.Int(0))))
         val id      = let(Op.Load(Type.Int, idptr))
         val rowptr = let(
           Op.Elem(Type.Ptr,
                   top.tables.dispatchVal,
-                  Seq(Val.Int(top.tables.dispatchOffset(meth.id)))))
+                  Seq(Val.Int(top.tables.dispatchOffset(sigid)))))
         val methptrptr =
           let(Op.Elem(Type.Ptr, rowptr, Seq(id)))
         let(n, Op.Load(Type.Ptr, methptrptr))

--- a/tools/src/main/scala/scala/scalanative/tools/package.scala
+++ b/tools/src/main/scala/scala/scalanative/tools/package.scala
@@ -1,5 +1,7 @@
 package scala.scalanative
 
+import scalanative.nir.Global
+
 // API use-cases
 //
 // sbt plugin:
@@ -33,7 +35,7 @@ package object tools {
   type OptimizerReporter = optimizer.Reporter
   val OptimizerReporter = optimizer.Reporter
 
-  /** Given the classpath and entry point, link under closed-world assumption. */
+  /** Given the classpath and main entry point, link under closed-world assumption. */
   def link(config: Config,
            driver: OptimizerDriver,
            reporter: LinkerReporter = LinkerReporter.empty): LinkerResult = {
@@ -47,6 +49,11 @@ package object tools {
 
     result.withDefns(result.defns ++ injects)
   }
+
+  def linkRaw(config: Config,
+              entries: Seq[Global],
+              reporter: LinkerReporter = LinkerReporter.empty): LinkerResult =
+    linker.Linker(config, reporter).link(entries)
 
   /** Transform high-level closed world to its lower-level counterpart. */
   def optimize(

--- a/tools/src/test/scala/scala/scalanative/linker/ClassReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ClassReachabilitySuite.scala
@@ -1,0 +1,56 @@
+package scala.scalanative.linker
+
+import org.scalatest._
+import scalanative.nir.Global
+
+class ClassReachabilitySuite extends ReachabilitySuite {
+  val sources = Seq("""
+    class Parent {
+      def meth1: Unit = ()
+      def meth2: Unit = ()
+    }
+
+    class Child extends Parent {
+      override def meth2: Unit = ()
+    }
+  """)
+
+  val Parent      = g("Parent")
+  val ParentInit  = g("Parent", "init")
+  val ParentMeth1 = g("Parent", "meth1_unit")
+  val ParentMeth2 = g("Parent", "meth2_unit")
+  val Child       = g("Child")
+  val ChildInit   = g("Child", "init")
+  val ChildMeth2  = g("Child", "meth2_unit")
+  val Object      = g("java.lang.Object")
+  val ObjectInit  = g("java.lang.Object", "init")
+
+  testReachable("parent class")(Parent)(Parent, Object)
+  testReachable("parent meth1")(ParentMeth1)(Parent, ParentMeth1, Object)
+  testReachable("parent meth2")(ParentMeth2)(Parent, ParentMeth2, Object)
+  testReachable("parent init")(ParentInit)(Parent,
+                                           ParentInit,
+                                           Object,
+                                           ObjectInit)
+  testReachable("child class")(Child)(Child, Parent, Object)
+  testReachable("child meth2")(ChildMeth2)(Child,
+                                           ChildMeth2,
+                                           Parent,
+                                           ParentMeth2,
+                                           Object)
+  testReachable("child init")(ChildInit)(Child,
+                                         ChildInit,
+                                         Parent,
+                                         ParentInit,
+                                         Object,
+                                         ObjectInit)
+  testReachable("child init + parent meth2")(ChildInit, ParentMeth2)(
+    Child,
+    ChildInit,
+    ChildMeth2,
+    Parent,
+    ParentInit,
+    ParentMeth2,
+    Object,
+    ObjectInit)
+}

--- a/tools/src/test/scala/scala/scalanative/linker/DirectTraitReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/DirectTraitReachabilitySuite.scala
@@ -1,0 +1,41 @@
+package scala.scalanative.linker
+
+import org.scalatest._
+import scalanative.nir.Global
+
+class DirectTraitReachabilitySuite extends ReachabilitySuite {
+  val sources = Seq("""
+    trait Parent {
+      def meth: Unit
+    }
+
+    class Child extends Parent {
+      def meth: Unit = ()
+    }
+  """)
+
+  val Parent     = g("Parent")
+  val ParentMeth = g("Parent", "meth_unit")
+  val Child      = g("Child")
+  val ChildInit  = g("Child", "init")
+  val ChildMeth  = g("Child", "meth_unit")
+  val Object     = g("java.lang.Object")
+  val ObjectInit = g("java.lang.Object", "init")
+
+  testReachable("trait")(Parent)(Parent)
+  testReachable("trait method")(ParentMeth)(Parent, ParentMeth)
+  testReachable("trait method override")(ChildMeth)(Child,
+                                                    ChildMeth,
+                                                    Parent,
+                                                    ParentMeth,
+                                                    Object)
+  testReachable("trait inherited")(Child)(Child, Parent, Object)
+  testReachable("trait meth + inherited init")(ParentMeth, ChildInit)(
+    Parent,
+    ParentMeth,
+    Child,
+    ChildInit,
+    ChildMeth,
+    Object,
+    ObjectInit)
+}

--- a/tools/src/test/scala/scala/scalanative/linker/IndirectTraitReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/IndirectTraitReachabilitySuite.scala
@@ -1,0 +1,37 @@
+package scala.scalanative.linker
+
+import org.scalatest._
+import scalanative.nir.Global
+
+class IndirectTraitReachabilitySuite extends ReachabilitySuite {
+  val sources = Seq("""
+    trait Indirect {
+      def meth: Unit
+    }
+    class Parent {
+      def meth: Unit = ()
+    }
+    class Child extends Parent with Indirect
+  """)
+
+  val Parent       = g("Parent")
+  val ParentInit   = g("Parent", "init")
+  val ParentMeth   = g("Parent", "meth_unit")
+  val Child        = g("Child")
+  val ChildInit    = g("Child", "init")
+  val Object       = g("java.lang.Object")
+  val ObjectInit   = g("java.lang.Object", "init")
+  val Indirect     = g("Indirect")
+  val IndirectMeth = g("Indirect", "meth_unit")
+
+  testReachable("child init + trait meth")(ChildInit, IndirectMeth)(
+    Child,
+    ChildInit,
+    Parent,
+    ParentInit,
+    ParentMeth,
+    Object,
+    ObjectInit,
+    Indirect,
+    IndirectMeth)
+}

--- a/tools/src/test/scala/scala/scalanative/linker/ModuleReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ModuleReachabilitySuite.scala
@@ -1,0 +1,28 @@
+package scala.scalanative.linker
+
+import org.scalatest._
+import scalanative.nir.Global
+
+class ModuleReachabilitySuite extends ReachabilitySuite {
+  val sources = Seq("""
+    object Module {
+      def meth: Unit = ()
+    }
+  """)
+
+  val Module     = g("Module$")
+  val ModuleInit = g("Module$", "init")
+  val ModuleMeth = g("Module$", "meth_unit")
+  val Object     = g("java.lang.Object")
+  val ObjectInit = g("java.lang.Object", "init")
+
+  testReachable("module constructor")(Module)(Module,
+                                              ModuleInit,
+                                              Object,
+                                              ObjectInit)
+  testReachable("module member")(ModuleMeth)(Module,
+                                             ModuleInit,
+                                             ModuleMeth,
+                                             Object,
+                                             ObjectInit)
+}

--- a/tools/src/test/scala/scala/scalanative/linker/ReachibilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ReachibilitySuite.scala
@@ -1,0 +1,72 @@
+package scala.scalanative
+package linker
+
+import org.scalatest._
+import java.io.File
+import java.nio.file.Files
+import scalanative.util.Scope
+import scalanative.nir.Global
+import scalanative.tools
+import scalanative.optimizer.Driver
+
+trait ReachabilitySuite extends FunSuite {
+
+  def sources: Seq[String]
+
+  def g(top: String, members: String*): Global =
+    members.foldLeft[Global](Global.Top(top))(Global.Member(_, _))
+
+  def testReachable(label: String)(entries: Global*)(expected: Global*) =
+    test(label) {
+      link(entries, sources) { res =>
+        val left  = res.defns.map(_.name).toSet
+        val right = expected.toSet
+        assert((left -- right).isEmpty, "overapproximation")
+        assert((right -- left).isEmpty, "underapproximation")
+      }
+    }
+
+  /**
+   * Runs the linker using `driver` with `entry` as entry point on `sources`,
+   * and applies `fn` to the definitions.
+   *
+   * @param entry   The entry point for the linker.
+   * @param sources Map from file name to file content representing all the code
+   *                to compile and link.
+   * @param driver  Optional custom driver that defines the pipeline.
+   * @param fn      A function to apply to the products of the compilation.
+   * @return The result of applying `fn` to the resulting definitions.
+   */
+  def link[T](entries: Seq[Global], sources: Seq[String])(
+      f: linker.Result => T): T =
+    Scope { implicit in =>
+      val outDir   = Files.createTempDirectory("native-test-out").toFile()
+      val compiler = NIRCompiler.getCompiler(outDir)
+      val sourceMap = sources.zipWithIndex.map {
+        case (b, i) => (s"file$i.scala", b)
+      }.toMap
+      val sourcesDir = NIRCompiler.writeSources(sourceMap)
+      val files      = compiler.compile(sourcesDir)
+      val config     = makeConfig(outDir)
+      val result     = tools.linkRaw(config, entries)
+
+      f(result)
+    }
+
+  private def makePaths(outDir: File)(implicit in: Scope) = {
+    val parts: Array[File] =
+      sys
+        .props("scalanative.nativeruntime.cp")
+        .split(File.pathSeparator)
+        .map(new File(_))
+
+    parts :+ outDir
+  }
+
+  private def makeConfig(outDir: File)(implicit in: Scope): tools.Config = {
+    val paths = makePaths(outDir)
+    tools.Config.empty
+      .withWorkdir(outDir)
+      .withPaths(paths)
+  }
+}

--- a/unit-tests/src/main/scala/scala/MixinSuite.scala
+++ b/unit-tests/src/main/scala/scala/MixinSuite.scala
@@ -1,0 +1,90 @@
+package scala
+
+object MixinSuite extends tests.Suite {
+  var messages: List[String] = Nil
+  def log(msg: String)       = messages ::= msg
+  def clear(): Unit          = messages = Nil
+  def testEffects(name: String)(effects: String*)(body: => Unit): Unit =
+    test(name) {
+      clear()
+      body
+      assert(messages.reverse == effects)
+    }
+
+  // Test 1: "super" coming from mixins
+
+  object Test1 {
+    class A {
+      def f = "A::f";
+    }
+
+    class B extends A {
+      override def f = "B::f";
+    }
+
+    trait M1 extends A {
+      override def f = "M1::" + super.f;
+    }
+
+    class C extends B with M1 {
+      override def f = super[M1].f;
+    }
+
+    def test(): Unit = {
+      val c = new C;
+      log(c.f);
+    }
+  }
+
+  // Test 2: qualified "super" inside of the host class
+
+  object Test2 {
+    class M1 {
+      def f = "M1::f";
+    }
+
+    trait M2 {
+      def f = "M2::f";
+    }
+
+    trait M3 {
+      def f = "M3::f";
+    }
+
+    class Host extends M1 with M2 with M3 {
+      override def f = super[M1].f + " " + super[M2].f + " " + super[M3].f
+    }
+
+    def test(): Unit = {
+      val h = new Host;
+      log(h.f)
+    }
+  }
+
+  // Test 3: mixin evaluation order (bug 120)
+
+  object Test3 {
+
+    class A(x: Unit, y: Unit) {
+      log("A");
+    }
+
+    trait B {
+      log("B");
+    }
+
+    class C extends A({ log("one"); }, { log("two"); }) with B {
+      log("C");
+    }
+
+    def test() = {
+      val c = new C();
+    }
+  }
+
+  // Actual tests
+
+  testEffects("1")("M1::B::f") { Test1.test() }
+  testEffects("2")("M1::f M2::f M3::f") { Test2.test() }
+  testEffects("3")("one", "two", "A", "B", "C") { Test3.test() }
+}

--- a/unit-tests/src/main/scala/scala/partest/MixinSuite.scala
+++ b/unit-tests/src/main/scala/scala/partest/MixinSuite.scala
@@ -1,4 +1,5 @@
 package scala
+package partest
 
 object MixinSuite extends tests.Suite {
   var messages: List[String] = Nil

--- a/unit-tests/src/main/scala/scala/scalanative/IssuesSuite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/IssuesSuite.scala
@@ -292,4 +292,16 @@ object IssuesSuite extends tests.Suite {
     assert(neglong.isInstanceOf[Long])
     assert(neglong.toString == "-1")
   }
+
+  test("#780") {
+    import java.util.{HashMap, Collections}
+    val hashmap = new HashMap[String, String]()
+    hashmap.put("a", "b")
+    val frozen = Collections.unmodifiableMap[String, String](hashmap)
+    val iter   = frozen.entrySet().iterator()
+    val ab     = iter.next()
+    assert(ab.getKey() == "a")
+    assert(ab.getValue() == "b")
+    assert(!iter.hasNext())
+  }
 }

--- a/unit-tests/src/main/scala/scala/scalanative/IssuesSuite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/IssuesSuite.scala
@@ -265,6 +265,13 @@ object IssuesSuite extends tests.Suite {
     2.asInstanceOf[Null]
   }
 
+  test("#667") {
+    val map = new java.util.HashMap[Int, Int]
+    map.put(1, 2)
+    val ks = map.keySet()
+    assert(ks.contains(1))
+  }
+
   test("#679") {
     val `"` = 42
     assert(("double-quotes " + `"`) == "double-quotes 42")


### PR DESCRIPTION
Previously we would not discover trait method implementations in cases
when a method that implements a trait is inherited from the parent class
(see IndirectTraitReachabilitySuite for an example.)

Fixes #780, #667