### PR TITLE
Faster BufferedReader::readLine

### DIFF
--- a/javalib/src/main/scala/java/io/BufferedReader.scala
+++ b/javalib/src/main/scala/java/io/BufferedReader.scala
@@ -72,12 +72,14 @@ class BufferedReader(in: Reader, sz: Int) extends Reader {
   def readLine(): String = {
     ensureOpen()
 
-    var res = ""
+    var sb = new java.lang.StringBuilder
 
     while (prepareRead() && buf(pos) != '\n' && buf(pos) != '\r') {
-      res += buf(pos)
+      sb.append(buf(pos))
       pos += 1
     }
+
+    val res = sb.toString
 
     if (pos >= end) {
       // We have reached the end of the stream (prepareRead() returned false)

--- a/javalib/src/main/scala/java/io/BufferedReader.scala
+++ b/javalib/src/main/scala/java/io/BufferedReader.scala
@@ -72,7 +72,7 @@ class BufferedReader(in: Reader, sz: Int) extends Reader {
   def readLine(): String = {
     ensureOpen()
 
-    var sb = new java.lang.StringBuilder
+    val sb = new java.lang.StringBuilder(80)
 
     while (prepareRead() && buf(pos) != '\n' && buf(pos) != '\r') {
       sb.append(buf(pos))


### PR DESCRIPTION
Previous implementation used String::+ in a loop which is really slow. 

According to benchmark from #752 we have:

```
// 0.2.1, nativeMode := "release", nativeGC := "boehm"

# ./perf-test.sh data_1k
data_1k native real	0m0.045s
data_1k    jvm real	0m0.854s

# ./perf-test.sh data_10k
data_10k native real	0m0.196s
data_10k    jvm real	0m0.849s

# ./perf-test.sh data_100k
data_100k native real	0m1.856s
data_100k    jvm real	0m0.849s

# ./perf-test.sh data_1000k
data_1000k native real	0m18.688s
data_1000k    jvm real	0m0.863s

// 0.3.0-SNAPSHOT, nativeMode := "release", nativeGC := "immix"

# ./perf-test.sh data_1k
data_1k native real	0m0.007s
data_1k    jvm real	0m0.839s

# ./perf-test.sh data_10k
data_10k native real	0m0.018s
data_10k    jvm real	0m0.830s

# ./perf-test.sh data_100k
data_100k native real	0m0.121s
data_100k    jvm real	0m0.837s

# ./perf-test.sh data_1000k
data_1000k native real	0m1.213s
data_1000k    jvm real	0m0.857s
```

Review @Duhemm 