### PR TITLE
Add O_TRUNC on opening FileOutputStream if not appending

### DIFF
--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -61,7 +61,7 @@ object FileOutputStream {
     Zone { implicit z =>
       import fcntl._
       import stat._
-      val flags = O_CREAT | O_WRONLY | (if (append) O_APPEND else 0)
+      val flags = O_CREAT | O_WRONLY | (if (append) O_APPEND else O_TRUNC)
       val mode  = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
       val fd    = open(toCString(file.getPath), flags, mode)
       new FileDescriptor(fd)

--- a/nativelib/src/main/resources/fcntl.c
+++ b/nativelib/src/main/resources/fcntl.c
@@ -9,3 +9,5 @@ int scalanative_o_rdwr() { return O_RDWR; }
 int scalanative_o_append() { return O_APPEND; }
 
 int scalanative_o_creat() { return O_CREAT; }
+
+int scalanative_o_trunc() { return O_TRUNC; }

--- a/nativelib/src/main/scala/scala/scalanative/posix/fcntl.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/fcntl.scala
@@ -29,6 +29,9 @@ object fcntl {
   @name("scalanative_o_creat")
   def O_CREAT: CInt = extern
 
+  @name("scalanative_o_trunc")
+  def O_TRUNC: CInt = extern
+
   @name("scalanative_w_ok")
   def W_OK: CInt = extern
 

--- a/unit-tests/src/main/scala/java/io/FileOutputStreamSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileOutputStreamSuite.scala
@@ -41,4 +41,60 @@ object FileOutputStreamSuite extends tests.Suite {
       fos.write(arr, 4, 8)
     }
   }
+
+  test("truncate a file on initialization if append=false") {
+    val nonEmpty = File.createTempFile("scala-native-unit-test", null)
+    try {
+      // prepares a non-empty file
+      locally {
+        val fos = new FileOutputStream(nonEmpty)
+        try { fos.write(0x20) } finally { fos.close() }
+      }
+      // re-opens the file with append=false so that it is truncated
+      locally {
+        val fos = new FileOutputStream(nonEmpty)
+        fos.close()
+      }
+      // checks the content
+      locally {
+        val fin = new FileInputStream(nonEmpty)
+        try {
+          assertEquals(-1, fin.read())
+        } finally {
+          fin.close()
+        }
+      }
+    } finally {
+      nonEmpty.delete()
+    }
+  }
+
+  test("do not truncate a file on initialization if append=true") {
+    val nonEmpty = File.createTempFile("scala-native-unit-test", null)
+    try {
+      val written = 0x20
+      // prepares a non-empty file
+      locally {
+        val fos = new FileOutputStream(nonEmpty)
+        try { fos.write(written) } finally { fos.close() }
+      }
+      // re-opens the file with append=true
+      locally {
+        val fos = new FileOutputStream(nonEmpty, true)
+        fos.close()
+      }
+      // checks the content
+      locally {
+        val fin = new FileInputStream(nonEmpty)
+        try {
+          assertEquals(written, fin.read())
+          assertEquals(-1, fin.read())
+        } finally {
+          fin.close()
+        }
+      }
+    } finally {
+      nonEmpty.delete()
+    }
+  }
 }


### PR DESCRIPTION
On JVM, FileOutputStream truncates a file if append=false is specified on initialization, but before this commit it doesn't on Scala Native.

* Add new test cases for FileOutputStream to test this behavior.
* Modify FileOutputStream.fileDescriptor to pass O_TRUNC instead of 0 to
  open() when append=false.
* Modify fcntl.scala and fcntl.c to use O_TRUNC from Scala Native.