### PR TITLE
FileOutputStream must throw FileNotFoundException if open() fails

### DIFF
--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -64,6 +64,10 @@ object FileOutputStream {
       val flags = O_CREAT | O_WRONLY | (if (append) O_APPEND else 0)
       val mode  = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
       val fd    = open(toCString(file.getPath), flags, mode)
-      new FileDescriptor(fd)
+      if (fd == -1)
+        throw new FileNotFoundException(
+          s"$file (${fromCString(string.strerror(errno.errno))})")
+      else
+        new FileDescriptor(fd)
     }
 }

--- a/unit-tests/src/main/scala/java/io/FileOutputStreamSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileOutputStreamSuite.scala
@@ -1,44 +1,105 @@
 package java.io
 
 object FileOutputStreamSuite extends tests.Suite {
-  test("write null") {
-    val file = new File(".")
-    val fos  = new FileOutputStream(file)
-    assertThrows[NullPointerException] {
-      fos.write(null)
+  def withTempFile(f: File => Unit): Unit = {
+    val tmpfile = File.createTempFile("scala-native-test", null)
+    try {
+      f(tmpfile)
+    } finally {
+      tmpfile.delete()
     }
-    assertThrows[NullPointerException] {
-      fos.write(null, 0, 0)
+  }
+
+  def withTempDirectory(f: File => Unit): Unit = {
+    import java.nio.file._
+    import attribute._
+    val tmpdir = Files.createTempDirectory("scala-native-test")
+    try {
+      f(tmpdir.toFile())
+    } finally {
+      Files.walkFileTree(
+        tmpdir,
+        new SimpleFileVisitor[Path]() {
+          override def visitFile(
+              file: Path,
+              attrs: BasicFileAttributes): FileVisitResult = {
+            Files.delete(file)
+            FileVisitResult.CONTINUE
+          }
+          override def postVisitDirectory(
+              dir: Path,
+              exc: IOException): FileVisitResult = {
+            Files.delete(dir)
+            FileVisitResult.CONTINUE
+          }
+        }
+      )
+    }
+  }
+
+  test("write null") {
+    withTempFile { file =>
+      val fos = new FileOutputStream(file)
+      assertThrows[NullPointerException] {
+        fos.write(null)
+      }
+      assertThrows[NullPointerException] {
+        fos.write(null, 0, 0)
+      }
     }
   }
 
   test("write out of bounds negative count") {
-    val file = new File(".")
-    val fos  = new FileOutputStream(file)
-    val arr  = new Array[Byte](8)
-    assertThrows[IndexOutOfBoundsException] {
-      fos.write(arr, 0, -1)
+    withTempFile { file =>
+      val fos = new FileOutputStream(file)
+      val arr = new Array[Byte](8)
+      assertThrows[IndexOutOfBoundsException] {
+        fos.write(arr, 0, -1)
+      }
     }
   }
 
   test("write out of bounds negative offset") {
-    val file = new File(".")
-    val fos  = new FileOutputStream(file)
-    val arr  = new Array[Byte](8)
-    assertThrows[IndexOutOfBoundsException] {
-      fos.write(arr, -1, 0)
+    withTempFile { file =>
+      val fos = new FileOutputStream(file)
+      val arr = new Array[Byte](8)
+      assertThrows[IndexOutOfBoundsException] {
+        fos.write(arr, -1, 0)
+      }
     }
   }
 
   test("write out of bounds array too small") {
-    val file = new File(".")
-    val fos  = new FileOutputStream(file)
-    val arr  = new Array[Byte](8)
-    assertThrows[IndexOutOfBoundsException] {
-      fos.write(arr, 0, 16)
+    withTempFile { file =>
+      val fos = new FileOutputStream(file)
+      val arr = new Array[Byte](8)
+      assertThrows[IndexOutOfBoundsException] {
+        fos.write(arr, 0, 16)
+      }
+      assertThrows[IndexOutOfBoundsException] {
+        fos.write(arr, 4, 8)
+      }
     }
-    assertThrows[IndexOutOfBoundsException] {
-      fos.write(arr, 4, 8)
+  }
+
+  test("attempt to open a readonly regular file") {
+    withTempFile { ro =>
+      ro.setReadOnly()
+      assertThrows[FileNotFoundException](new FileOutputStream(ro))
+    }
+  }
+
+  test("attempt to open a directory") {
+    withTempDirectory { dir =>
+      assertThrows[FileNotFoundException](new FileOutputStream(dir))
+    }
+  }
+
+  test("attempt to create a file in a readonly directory") {
+    withTempDirectory { ro =>
+      ro.setReadOnly()
+      assertThrows[FileNotFoundException](
+        new FileOutputStream(new File(ro, "child")))
     }
   }
 }


### PR DESCRIPTION
Discovered while porting test cases for `java.util.Formatter` from Harmony. (#804)