### PR TITLE
Disable linux/nogc pair on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,6 @@ matrix:
       dist: trusty
       jdk: oraclejdk8
       language: scala
-      env: SCALANATIVE_GC=none
-
-    - os: linux
-      dist: trusty
-      jdk: oraclejdk8
-      language: scala
       env: SCALANATIVE_GC=immix
 
     - os: osx


### PR DESCRIPTION
Travis kills it due memory consumption being too high.