### PR TITLE
Verify that file descriptors are valid using `fcntl`

### DIFF
--- a/javalib/src/main/scala/java/io/FileDescriptor.scala
+++ b/javalib/src/main/scala/java/io/FileDescriptor.scala
@@ -1,6 +1,6 @@
 package java.io
 
-import scala.scalanative.posix.unistd
+import scala.scalanative.posix.{fcntl, unistd}
 
 /** Wraps a UNIX file descriptor */
 final class FileDescriptor private[io] (private[io] val fd: Int,
@@ -18,7 +18,7 @@ final class FileDescriptor private[io] (private[io] val fd: Int,
       }
     }
 
-  def valid(): Boolean = fd != -1
+  def valid(): Boolean = fcntl.fcntl(fd, fcntl.F_GETFD) != -1
 
   private def throwSyncFailed(): Unit =
     throw new SyncFailedException("sync failed")

--- a/nativelib/src/main/resources/fcntl.c
+++ b/nativelib/src/main/resources/fcntl.c
@@ -11,3 +11,23 @@ int scalanative_o_append() { return O_APPEND; }
 int scalanative_o_creat() { return O_CREAT; }
 
 int scalanative_o_trunc() { return O_TRUNC; }
+
+int scalanative_f_dupfd() { return F_DUPFD; }
+
+int scalanative_f_getfd() { return F_GETFD; }
+
+int scalanative_f_setfd() { return F_SETFD; }
+
+int scalanative_f_getfl() { return F_GETFL; }
+
+int scalanative_f_setfl() { return F_SETFL; }
+
+int scalanative_f_getown() { return F_GETOWN; }
+
+int scalanative_f_setown() { return F_SETOWN; }
+
+int scalanative_f_getlk() { return F_GETLK; }
+
+int scalanative_f_setlk() { return F_SETLK; }
+
+int scalanative_f_setlkw() { return F_SETLKW; }

--- a/nativelib/src/main/scala/scala/scalanative/posix/fcntl.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/fcntl.scala
@@ -14,6 +14,8 @@ object fcntl {
 
   def close(fd: CInt): CInt = extern
 
+  def fcntl(fd: CInt, cmd: CInt, args: CVararg*): CInt = extern
+
   @name("scalanative_o_rdonly")
   def O_RDONLY: CInt = extern
 
@@ -43,4 +45,35 @@ object fcntl {
 
   @name("scalanative_f_ok")
   def F_OK: CInt = extern
+
+  @name("scalanative_f_dupfd")
+  def F_DUPFD: CInt = extern
+
+  @name("scalanative_f_getfd")
+  def F_GETFD: CInt = extern
+
+  @name("scalanative_f_setfd")
+  def F_SETFD: CInt = extern
+
+  @name("scalanative_f_getfl")
+  def F_GETFL: CInt = extern
+
+  @name("scalanative_f_setfl")
+  def F_SETFL: CInt = extern
+
+  @name("scalanative_f_getown")
+  def F_GETOWN: CInt = extern
+
+  @name("scalanative_f_setown")
+  def F_SETOWN: CInt = extern
+
+  @name("scalanative_f_getlk")
+  def F_GETLK: CInt = extern
+
+  @name("scalanative_f_setlk")
+  def F_SETLK: CInt = extern
+
+  @name("scalanative_f_setlkw")
+  def F_SETLKW: CInt = extern
+
 }

--- a/unit-tests/src/main/scala/java/io/FileDescriptorSuite.scala
+++ b/unit-tests/src/main/scala/java/io/FileDescriptorSuite.scala
@@ -39,4 +39,13 @@ object FileDescriptorSuite extends tests.Suite {
       fd.sync()
     }
   }
+
+  test("valid should verify that file descriptor is still valid") {
+    val tmpFile = File.createTempFile("tmp", ".tmp")
+    assert(tmpFile.exists())
+    val fis = new FileInputStream(tmpFile)
+    assert(fis.getFD().valid())
+    fis.close()
+    assertNot(fis.getFD().valid())
+  }
 }


### PR DESCRIPTION
Previously we would just assume that they were valid if their ID was
greater than -1. This is not correct, as a closed FD is no longer valid.

Fixes #760