### PR TITLE
Fix the resource leak of InputStreamReader.close()

### DIFF
--- a/javalib/src/main/scala/java/io/InputStreamReader.scala
+++ b/javalib/src/main/scala/java/io/InputStreamReader.scala
@@ -47,7 +47,8 @@ class InputStreamReader(private[this] var in: InputStream,
   def this(in: InputStream, charsetName: String) =
     this(in, Charset.forName(charsetName))
 
-  def close(): Unit = {
+  def close(): Unit = if (!closed) {
+    in.close()
     closed = true
     in = null
     decoder = null

--- a/unit-tests/src/main/scala/java/io/InputStreamReaderSuite.scala
+++ b/unit-tests/src/main/scala/java/io/InputStreamReaderSuite.scala
@@ -1,0 +1,32 @@
+package java.io
+
+object InputStreamReaderSuite extends tests.Suite {
+  def withTempFile(proc: File => Unit): Unit = {
+    val file = File.createTempFile("scala-native-tests", null)
+    try { proc(file) } finally { file.delete() }
+  }
+
+  class MockInputStream extends InputStream {
+    private[this] var _closed: Boolean = false
+
+    def isClosed: Boolean = _closed
+
+    override def close(): Unit = _closed = true
+
+    def read(): Int = -1
+  }
+
+  test("closing closes the inner stream") {
+    val in     = new MockInputStream
+    val reader = new InputStreamReader(in)
+    reader.close()
+    assert(in.isClosed)
+  }
+
+  test("closing twice is harmless") {
+    val in     = new MockInputStream
+    val reader = new InputStreamReader(in)
+    reader.close()
+    reader.close()
+  }
+}

--- a/unit-tests/src/main/scala/java/io/InputStreamReaderSuite.scala
+++ b/unit-tests/src/main/scala/java/io/InputStreamReaderSuite.scala
@@ -1,11 +1,6 @@
 package java.io
 
 object InputStreamReaderSuite extends tests.Suite {
-  def withTempFile(proc: File => Unit): Unit = {
-    val file = File.createTempFile("scala-native-tests", null)
-    try { proc(file) } finally { file.delete() }
-  }
-
   class MockInputStream extends InputStream {
     private[this] var _closed: Boolean = false
 


### PR DESCRIPTION
Demonstration:

```sandbox/Test.scala
import java.io._

object Test {
  def withTempFile(proc: File => Unit): Unit = {
    val file = File.createTempFile("scala-native-sandbox", null)
    try { proc(file) } finally { file.delete() }
  }

  def main(args: Array[String]): Unit = {
    withTempFile { file =>
      val fin = new FileInputStream(file)
      val reader = new InputStreamReader(fin)
      reader.close()
      fin.read()
      // JVM:
      // java.io.IOException: Stream Closed
      //   at java.io.FileInputStream.read0(Native Method)
      //   at java.io.FileInputStream.read(FileInputStream.java:207)
      //   at Test$$anonfun$main$1.apply(Test.scala:14)
      // ...
      println(":(")
      fin.close()
      // Scala Native before fix:
      // :(
      // after fix:
      // java.io.IOException: couldn't read from the file
      //         at java.lang.Throwable.init(Unknown Source)
      //         at java.lang.Exception.init(Unknown Source)
      //         at java.io.IOException.init(Unknown Source)
      //         at java.io.IOException.init(Unknown Source)
      //         at java.io.FileInputStream.read(Unknown Source)
      //         at java.io.FileInputStream.read(Unknown Source)
      //         at java.io.FileInputStream.read(Unknown Source)
      //         at Test$$anonfun$main$1.apply(Unknown Source)
      //         at Test$$anonfun$main$1.apply(Unknown Source)
      //         at Test$.withTempFile(Unknown Source)
      //         at Test$.main(Unknown Source)
      //         at <none>.main(Unknown Source)
      //         at <none>.__libc_start_main(Unknown Source)
      //         at <none>._start(Unknown Source)
    }
  }
}
```

Note the difference in the error message. Indeed, even if you replace `fin.read()` by `fin.available()` it should throw `IOException` but it doesn't on Native. (`available()` is the only method which is explicitly described by JDK Javadoc to throw `IOException` if already closed.) However, it is not addressed on this PR. (Created issue #820)

The included test case utilizes a mock `InputStream` to make sure the inner stream is closed. This PR should fix the resource leak regardless of the note above.