### PR TITLE
Fix the resource leak of BufferedReader.close()

### DIFF
--- a/javalib/src/main/scala/java/io/BufferedReader.scala
+++ b/javalib/src/main/scala/java/io/BufferedReader.scala
@@ -21,7 +21,8 @@ class BufferedReader(in: Reader, sz: Int) extends Reader {
 
   private[this] var validMark = false
 
-  override def close(): Unit = {
+  override def close(): Unit = if (!closed) {
+    in.close()
     closed = true
   }
 

--- a/unit-tests/src/main/scala/java/io/BufferedReaderSuite.scala
+++ b/unit-tests/src/main/scala/java/io/BufferedReaderSuite.scala
@@ -1,0 +1,25 @@
+package java.io
+
+object BufferedReaderSuite extends tests.Suite {
+  class MockReader extends Reader {
+    var isClosed: Boolean = false
+
+    def close(): Unit = isClosed = true
+
+    def read(cbuf: Array[Char], off: Int, len: Int): Int = 0
+  }
+
+  test("Closing a `BufferedReader` closes its inner reader") {
+    val inner  = new MockReader
+    val reader = new BufferedReader(inner)
+    reader.close()
+    assert(inner.isClosed)
+  }
+
+  test("Closing twice is harmless") {
+    val inner  = new MockReader
+    val reader = new BufferedReader(inner)
+    reader.close()
+    reader.close()
+  }
+}


### PR DESCRIPTION
Demonstration:

```sandbox/Test.scala
import java.io._

object Test {
  def withTempFile(proc: File => Unit): Unit = {
    val file = File.createTempFile("scala-native-sandbox", null)
    try { proc(file) } finally { file.delete() }
  }

  def main(args: Array[String]): Unit = {
    withTempFile { file =>
      val freader = new InputStreamReader(new FileInputStream(file))
      val breader = new BufferedReader(freader)
      breader.close()
      freader.read()
      // JVM:
      // java.io.IOException: Stream closed
      //   at sun.nio.cs.StreamDecoder.ensureOpen(StreamDecoder.java:46)
      //   at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:148)
      //   at sun.nio.cs.StreamDecoder.read0(StreamDecoder.java:127)
      //   at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:112)
      //   at java.io.InputStreamReader.read(InputStreamReader.java:168)
      //   at Test$$anonfun$main$1.apply(Test.scala:14)
      // ...
      println(":(")
      freader.close()
      // Scala Native before fix:
      // :(
      // after fix:
      // java.io.IOException: Stream closed
      //   at java.lang.Throwable.init(Unknown Source)
      //   at java.lang.Exception.init(Unknown Source)
      //   at java.io.IOException.init(Unknown Source)
      //   at java.io.IOException.init(Unknown Source)
      //   at java.io.InputStreamReader.ensureOpen(Unknown Source)
      //   at java.io.InputStreamReader.read(Unknown Source)
      //   at Test$$anonfun$main$1.apply(Unknown Source)
      //   at Test$$anonfun$main$1.apply(Unknown Source)
      //   at Test$.withTempFile(Unknown Source)
      //   at Test$.main(Unknown Source)
      //   at <none>.main(Unknown Source)
      //   at <none>.__libc_start_main(Unknown Source)
      //   at <none>._start(Unknown Source)
    }
  }
}
```
