### PR TITLE
BufferedWriter should not throw an IOException on second close()

### DIFF
--- a/javalib/src/main/scala/java/io/BufferedWriter.scala
+++ b/javalib/src/main/scala/java/io/BufferedWriter.scala
@@ -12,10 +12,10 @@ class BufferedWriter(out: Writer, sz: Int) extends Writer {
   private var pos: Int            = 0
   private var closed: Boolean     = false
 
-  def close(): Unit = {
+  def close(): Unit = if (!closed) {
     flush()
-    closed = true
     out.close()
+    closed = true
   }
 
   def flush(): Unit = {

--- a/unit-tests/src/main/scala/java/io/BufferedWriterSuite.scala
+++ b/unit-tests/src/main/scala/java/io/BufferedWriterSuite.scala
@@ -28,4 +28,11 @@ object BufferedWriterSuite extends tests.Suite {
     assert(stream.toString == string)
   }
 
+  test("Closing twice is harmless") {
+    val stream = new ByteArrayOutputStream
+    val writer = new BufferedWriter(new OutputStreamWriter(stream))
+    writer.close()
+    writer.close()
+  }
+
 }


### PR DESCRIPTION
Demonstration:

```sandbox/Test.scala
import java.io._

object Test {
  def main(args: Array[String]): Unit = {
    val writer = new OutputStreamWriter(new FileOutputStream("/dev/null"))
    writer.close()
    writer.close()
    println(":)")
    // JVM:
    // :)
    //
    // Native:
    // :)

    val bwriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream("/dev/null")))
    bwriter.close()
    bwriter.close()
    println(":)")
    // JVM:
    // :)
    //
    // Native before fix:
    // java.io.IOException: Stream closed
    //         at java.lang.Throwable.init(Unknown Source)
    //         at java.lang.Exception.init(Unknown Source)
    //         at java.io.IOException.init(Unknown Source)
    //         at java.io.IOException.init(Unknown Source)
    //         at java.io.BufferedWriter.ensureOpen(Unknown Source)
    //         at java.io.BufferedWriter.flush(Unknown Source)
    //         at java.io.BufferedWriter.close(Unknown Source)
    //         at Test$.main(Unknown Source)
    //         at <none>.main(Unknown Source)
    //         at <none>.__libc_start_main(Unknown Source)
    //         at <none>._start(Unknown Source)
  }
}
```
