### PR TITLE
Fix #695: Fix handling of this in loops generated by tailrec

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -39,8 +39,9 @@ abstract class NirCodeGen
   class MethodEnv(val fresh: Fresh) {
     private val env = mutable.Map.empty[Symbol, Val]
 
-    def enter(sym: Symbol, value: Val): Unit =
+    def enter(sym: Symbol, value: Val): Unit = {
       env += ((sym, value))
+    }
 
     def enterLabel(ld: LabelDef): Local = {
       val local = fresh()
@@ -48,7 +49,9 @@ abstract class NirCodeGen
       local
     }
 
-    def resolve(sym: Symbol): Val = env(sym)
+    def resolve(sym: Symbol): Val = {
+      env(sym)
+    }
 
     def resolveLabel(ld: LabelDef): Local = {
       val Val.Local(n, Type.Ptr) = resolve(ld.symbol)
@@ -280,7 +283,7 @@ abstract class NirCodeGen
         val name     = genMethodName(sym)
         val isStatic = owner.isExternModule || owner.isImplClass
         val sig      = genMethodSig(sym, isStatic)
-        val params   = genParams(owner, dd, isStatic)
+        val params   = genParams(dd, isStatic)
 
         dd.rhs match {
           case EmptyTree =>
@@ -298,7 +301,7 @@ abstract class NirCodeGen
             genExternMethod(attrs, name, sig, params, rhs)
 
           case rhs =>
-            val body = genNormalMethodBody(params, rhs, isStatic)
+            val body = genNormalMethodBody(dd, params, rhs, isStatic)
             curClassDefns += Defn.Define(attrs, name, sig, body)
         }
       }
@@ -450,27 +453,26 @@ abstract class NirCodeGen
       Type.Function(selfty ++: paramtys, retty)
     }
 
-    def genParams(
-        owner: Symbol, dd: DefDef, isStatic: Boolean): Seq[Val.Local] = {
-      val paramSyms = {
-        val vp = dd.vparamss
-        if (vp.isEmpty) Nil else vp.head.map(_.symbol)
-      }
-      val self =
-        if (isStatic) None
-        else Some(Val.Local(fresh(), genType(curClassSym.tpe, box = true)))
-      val params = paramSyms.map { sym =>
-        val name  = fresh()
-        val ty    = genType(sym.tpe, box = false)
-        val param = Val.Local(name, ty)
-        curMethodEnv.enter(sym, param)
-        param
-      }
-
-      self ++: params
+    def genParamSyms(dd: DefDef, isStatic: Boolean): Seq[Option[Symbol]] = {
+      val vp = dd.vparamss
+      val params = if (vp.isEmpty) Nil else vp.head.map(p => Some(p.symbol))
+      if (isStatic) params else None +: params
     }
 
-    def genNormalMethodBody(params: Seq[Val.Local],
+    def genParams(dd: DefDef, isStatic: Boolean): Seq[Val.Local] =
+      genParamSyms(dd, isStatic).map {
+        case None =>
+          Val.Local(fresh(), genType(curClassSym.tpe, box = true))
+        case Some(sym) =>
+          val name  = fresh()
+          val ty    = genType(sym.tpe, box = false)
+          val param = Val.Local(name, ty)
+          curMethodEnv.enter(sym, param)
+          param
+      }
+
+    def genNormalMethodBody(dd: DefDef,
+                            params: Seq[Val.Local],
                             bodyp: Tree,
                             isStatic: Boolean): Seq[nir.Inst] = {
       val entry = {
@@ -485,6 +487,7 @@ abstract class NirCodeGen
             alloc
         }
       }
+
       val body = bodyp match {
         // Tailrec emits magical labeldefs that can hijack this reference is
         // current method. This requires special treatment on our side.
@@ -494,7 +497,7 @@ abstract class NirCodeGen
           val values = params.take(label.params.length)
           val jump   = entry.withJump(local, values: _*)
 
-          genLabel(label, jump, hijackThis = true)
+          genTailRecLabel(dd, isStatic, label, jump)
 
         case _ if curMethodSym.get == NObjectInitMethod =>
           return Seq(
@@ -930,9 +933,7 @@ abstract class NirCodeGen
       resfocus
     }
 
-    def genLabel(label: LabelDef,
-                 focus: Focus,
-                 hijackThis: Boolean = false) = {
+    def genLabel(label: LabelDef, focus: Focus) = {
       val local = curMethodEnv.resolveLabel(label)
       val params = label.params.map { id =>
         val local = Val.Local(fresh(), genType(id.tpe, box = false))
@@ -940,10 +941,28 @@ abstract class NirCodeGen
         local
       }
       val entry = focus.withLabel(local, params: _*)
-      val newThis = if (hijackThis) Some(params.head) else curMethodThis.get
 
-      scoped(curMethodThis := newThis) {
-        genExpr(label.rhs, entry)
+      genExpr(label.rhs, entry)
+    }
+
+    def genTailRecLabel(dd: DefDef, isStatic: Boolean, label: LabelDef, focus: Focus) = {
+      val local = curMethodEnv.resolveLabel(label)
+      val params = label.params.zip(genParamSyms(dd, isStatic)).map {
+        case (lparam, mparamopt) =>
+          val local = Val.Local(fresh(), genType(lparam.tpe, box = false))
+          curMethodEnv.enter(lparam.symbol, local)
+          mparamopt.foreach(curMethodEnv.enter(_, local))
+          local
+      }
+      val entry = focus.withLabel(local, params: _*)
+      def genRhs = genExpr(label.rhs, entry)
+
+      if (isStatic) {
+        genRhs
+      } else {
+        scoped(curMethodThis := Some(params.head)) {
+          genRhs
+        }
       }
     }
 
@@ -1704,9 +1723,8 @@ abstract class NirCodeGen
               val attrs  = Attrs(isExtern = true)
               val name   = genAnonName(curClassSym, anondef.symbol)
               val sig    = genMethodSig(apply.symbol, forceStatic = true)
-              val params = genParams(curClassSym, apply, isStatic = true)
-              val body = genNormalMethodBody(
-                  params, apply.rhs, isStatic = true)
+              val params = genParams(apply, isStatic = true)
+              val body   = genNormalMethodBody(apply, params, apply.rhs, isStatic = true)
 
               curClassDefns += Defn.Define(attrs, name, sig, body)
 

--- a/unit-tests/src/main/scala/scala/scalanative/IssuesSuite.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/IssuesSuite.scala
@@ -278,6 +278,18 @@ object IssuesSuite extends tests.Suite {
     assert(s"double-quotes ${`"`}" == "double-quotes 42")
   }
 
+  test("#695") {
+    val a   = List(1, 2, 3)
+    var eff = List.empty[(Int, Int)]
+
+    val result = a.corresponds(a) { (x, y) =>
+      eff ::= ((x, y))
+      true
+    }
+
+    assert(eff == List((3, 3), (2, 2), (1, 1)))
+  }
+
   test("#762") {
     val byte         = 1.toByte
     val negbyte: Any = -byte


### PR DESCRIPTION
Previously, front-end would incorrectly resolve symbols to SSA names for
methods that were transformed by tailrec phase. Instead of using the internal
loop's version of this variable, it always uses the original this, never
advancing to the tail.