### PR TITLE
Use https to fetch CLA status in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
       author=$(curl -u dummy4dummy:dummy2dummy -s "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST" | jq -r ".user.login");
       if [ $? -ne 0 ] ; then exit 1; fi;
       echo "Pull request submitted by $author";
-      signed=$(curl -s http://www.lightbend.com/contribute/cla/scala/check/$author | jq -r ".signed");
+      signed=$(curl -s https://www.lightbend.com/contribute/cla/scala/check/$author | jq -r ".signed");
       if [ $? -ne 0 ] ; then exit 1; fi;
       if [ "$signed" = "true" ] ; then
         echo "CLA check for $author successful";


### PR DESCRIPTION
This fixes spurious "please sign Scala CLA" build failures
we've been getting recently.