### PR TITLE
Add zlib to docker image - references #829

### DIFF
--- a/bin/scala-native.nix
+++ b/bin/scala-native.nix
@@ -17,6 +17,7 @@ in rec {
       libunwind
       re2
       clang
+      zlib
     ];
   };
 } 


### PR DESCRIPTION
This adds `zlib` to NixOS in the docker setup.