### PR TITLE
Add support for `testOnly`

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -175,7 +175,8 @@ object ScalaNativePluginInternal {
   )
 
   lazy val testSettings = Seq(
-    test := (test in NativeTest).value
+    test := (test in NativeTest).value,
+    testOnly := (testOnly in NativeTest).evaluated
   )
 
   lazy val nativeTestSettings =

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -176,7 +176,8 @@ object ScalaNativePluginInternal {
 
   lazy val testSettings = Seq(
     test := (test in NativeTest).value,
-    testOnly := (testOnly in NativeTest).evaluated
+    testOnly := (testOnly in NativeTest).evaluated,
+    testQuick := (testQuick in NativeTest).evaluated
   )
 
   lazy val nativeTestSettings =


### PR DESCRIPTION
It allows to run a single test with Scala Native. Currently, `testOnly` will run on the JVM. This commit fixes that.