### PR TITLE
Fixes for the test interface

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/TestUtilities.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/TestUtilities.scala
@@ -31,8 +31,9 @@ object TestUtilities {
           case sf: SubclassFingerprint  => sf.isModule
         }
 
-        val inst = if (isModule) t.name else s"new ${t.name}"
-        s""""${t.name}" -> _root_.$inst"""
+        val inst =
+          if (isModule) s"_root_.${t.name}" else s"new _root_.${t.name}"
+        s""""${t.name}" -> $inst"""
       }
       .mkString(", ")
 }

--- a/test-interface-serialization/src/main/scala/scala/scalanative/testinterface/serialization/SerializedInputStream.scala
+++ b/test-interface-serialization/src/main/scala/scala/scalanative/testinterface/serialization/SerializedInputStream.scala
@@ -78,7 +78,10 @@ class SerializedInputStream(in: InputStream) extends DataInputStream(in) {
                 readSeq(_.readSelector).toArray)
 
   def readStackTraceElement(): StackTraceElement =
-    new StackTraceElement(readString(), readString(), readString(), readInt())
+    new StackTraceElement(readString(),
+                          readString(),
+                          readOption(_.readString()).orNull,
+                          readInt())
 
   def readThrowable(): Throwable = {
     val ex = new RemoteException(readString(),

--- a/test-interface-serialization/src/main/scala/scala/scalanative/testinterface/serialization/SerializedOutputStream.scala
+++ b/test-interface-serialization/src/main/scala/scala/scalanative/testinterface/serialization/SerializedOutputStream.scala
@@ -79,7 +79,7 @@ class SerializedOutputStream private (out: OutputStream)
   def writeStackTraceElement(v: StackTraceElement): Unit = {
     writeString(v.getClassName)
     writeString(v.getMethodName)
-    writeString(v.getFileName)
+    writeOption(Option(v.getFileName))(writeString)
     writeInt(v.getLineNumber)
   }
 


### PR DESCRIPTION
This fixes 2 issues with test interface:
 - A test framework may report a stack trace that has `null` as filename for elements of the stack trace, in which case the serialisation fails.
 - Tests contained inside a class were not instantiated correctly.

The second bullet was reported by @xuwei-k : https://github.com/rickynils/scalacheck/pull/337#issuecomment-308925196