### PR TITLE
extends AutoCloseable in java.io.Closeable

### DIFF
--- a/javalib/src/main/scala/java/io/Closeable.scala
+++ b/javalib/src/main/scala/java/io/Closeable.scala
@@ -1,6 +1,5 @@
 package java.io
 
-/** Note that Closeable doesn't extend AutoCloseable for Java6 compat */
-trait Closeable {
+trait Closeable extends AutoCloseable {
   def close(): Unit
 }


### PR DESCRIPTION
scala-js 0.6 should keep java 6 compatibility but also scala-native no need to keep  java 6 compatibility.