### PR TITLE
Fix FileDescriptor leak and test file in the root on repo

### DIFF
--- a/unit-tests/src/test/scala/java/io/FileInputStreamSuite.scala
+++ b/unit-tests/src/test/scala/java/io/FileInputStreamSuite.scala
@@ -50,6 +50,7 @@ object FileInputStreamSuite extends tests.Suite {
     val fd   = fis.getFD
     assert(fd.valid())
     assert(Try(fd.sync()).isSuccess)
+    fis.close()
   }
 
   test("can read 0xFF correctly") {
@@ -61,6 +62,7 @@ object FileInputStreamSuite extends tests.Suite {
     val fis = new FileInputStream(file)
     assert(fis.read() == 0xFF)
     assert(fis.read() == -1)
+    fis.close()
   }
 
   test(

--- a/unit-tests/src/test/scala/java/io/FileOutputStreamSuite.scala
+++ b/unit-tests/src/test/scala/java/io/FileOutputStreamSuite.scala
@@ -46,6 +46,7 @@ object FileOutputStreamSuite extends tests.Suite {
       assertThrows[NullPointerException] {
         fos.write(null, 0, 0)
       }
+      fos.close()
     }
   }
 
@@ -56,6 +57,7 @@ object FileOutputStreamSuite extends tests.Suite {
       assertThrows[IndexOutOfBoundsException] {
         fos.write(arr, 0, -1)
       }
+      fos.close()
     }
   }
 
@@ -66,6 +68,7 @@ object FileOutputStreamSuite extends tests.Suite {
       assertThrows[IndexOutOfBoundsException] {
         fos.write(arr, -1, 0)
       }
+      fos.close()
     }
   }
 
@@ -79,6 +82,7 @@ object FileOutputStreamSuite extends tests.Suite {
       assertThrows[IndexOutOfBoundsException] {
         fos.write(arr, 4, 8)
       }
+      fos.close()
     }
   }
 

--- a/unit-tests/src/test/scala/java/util/zip/DeflaterOutputStreamSuite.scala
+++ b/unit-tests/src/test/scala/java/util/zip/DeflaterOutputStreamSuite.scala
@@ -97,7 +97,7 @@ object DeflaterOutputStreamSuite extends tests.Suite {
 
   test("constructor(OutputStream, Deflater)") {
     val byteArray = Array[Byte](1, 3, 4, 7, 8)
-    val f1        = new File("hyts_constru(OD).tst")
+    val f1        = File.createTempFile("hyts_constru(OD)", ".tst")
     val fos       = new FileOutputStream(f1)
     val defl      = new Deflater()
     val dos       = new MyDeflaterOutputStream(fos, defl)
@@ -113,7 +113,7 @@ object DeflaterOutputStreamSuite extends tests.Suite {
     val negBuf    = -5
     val zeroBuf   = 0
     val byteArray = Array[Byte](1, 3, 4, 7, 8, 3, 6)
-    val f1        = new File("gyts_Constru(ODI).tst")
+    val f1        = File.createTempFile("gyts_Constru(ODI)", ".tst")
     val fos       = new FileOutputStream(f1)
     val defl      = new Deflater()
 
@@ -138,6 +138,7 @@ object DeflaterOutputStreamSuite extends tests.Suite {
     assertThrows[EOFException] {
       iis.read()
     }
+    iis.close()
 
     val fos       = new FileOutputStream(f1)
     val dos       = new DeflaterOutputStream(fos)


### PR DESCRIPTION
* FileDescriptor for temp test file wasn't properly closed and leaked every tests/test
* Two files are leftovers from the test in the root of repo, moved it to the temp dir