### PR TITLE
Test interface: Start the server on the sbt side

### DIFF
--- a/nativelib/src/main/resources/posix/arpa/inet.c
+++ b/nativelib/src/main/resources/posix/arpa/inet.c
@@ -14,3 +14,5 @@ char *scalanative_inet_ntoa(struct scalanative_in_addr *in) {
     scalanative_convert_in_addr(in, &converted);
     return inet_ntoa(converted);
 }
+
+in_addr_t scalanative_inet_addr(char *in) { return inet_addr(in); }

--- a/nativelib/src/main/resources/posix/sys/socket.c
+++ b/nativelib/src/main/resources/posix/sys/socket.c
@@ -85,6 +85,25 @@ int scalanative_socket(int domain, int type, int protocol) {
     return socket(domain, type, protocol);
 }
 
+int scalanative_connect(int socket, struct scalanative_sockaddr *address,
+                        socklen_t address_len) {
+    struct sockaddr *converted_address;
+    int convert_result =
+        scalanative_convert_sockaddr(address, &converted_address, &address_len);
+
+    int result;
+
+    if (convert_result == 0) {
+        result = connect(socket, converted_address, address_len);
+    } else {
+        errno = convert_result;
+        result = -1;
+    }
+
+    free(converted_address);
+    return result;
+}
+
 int scalanative_bind(int socket, struct scalanative_sockaddr *address,
                      socklen_t address_len) {
     struct sockaddr *converted_address;

--- a/nativelib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
@@ -4,7 +4,7 @@ package arpa
 
 import scalanative.native._
 import scalanative.posix.inttypes._
-import scalanative.posix.netinet.in.in_addr
+import scalanative.posix.netinet.in.{in_addr, in_addr_t}
 
 @extern
 object inet {
@@ -23,5 +23,8 @@ object inet {
 
   @name("scalanative_inet_ntoa")
   def inet_ntoa(in: Ptr[in_addr]): CString = extern
+
+  @name("scalanative_inet_addr")
+  def inet_addr(in: CString): in_addr_t = extern
 
 }

--- a/nativelib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -136,6 +136,11 @@ object socket {
   @name("scalanative_socket")
   def socket(domain: CInt, tpe: CInt, protocol: CInt): CInt = extern
 
+  @name("scalanative_connect")
+  def connect(socket: CInt,
+              address: Ptr[sockaddr],
+              address_len: socklen_t): CInt = extern
+
   @name("scalanative_bind")
   def bind(socket: CInt,
            address: Ptr[sockaddr],

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/testinterface/ComRunner.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/testinterface/ComRunner.scala
@@ -46,7 +46,10 @@ class ComRunner(bin: File,
       case _: SocketTimeoutException =>
         throw new MessageOnlyException(
           "The test program never connected to sbt.")
-    } finally serverSocket.close()
+    } finally {
+      // We can close it immediately, since we won't receive another connection.
+      serverSocket.close()
+    }
 
   private[this] val in = new DataInputStream(
     new BufferedInputStream(socket.getInputStream))


### PR DESCRIPTION
Previously, sbt would tell the distant program to start a server on a
given port. Unfortunately, this would prevent tests from running if the
randomly allocated port was already used, and couldn't recover from this
situation.

This commit moves the server part to the sbt plugin. Given a complete
implementation of `java.net`, it's easier to select a free port and
make sure that we can listen on this port. Once we're sure everything is
fine, we can start the distant program and instruct it to connect to the
right port.