### PR TITLE
Fix #640: Implement C-like escape sequences for c"..." literals

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -3,6 +3,7 @@ package nir
 
 import java.lang.Float.floatToRawIntBits
 import java.lang.Double.doubleToRawLongBits
+import scala.annotation.tailrec
 
 sealed abstract class Val {
   final def ty: Type = this match {
@@ -36,7 +37,7 @@ sealed abstract class Val {
 
     // Subtracts from the length of the bytes for each escape sequence
     // uses String, not Seq[Byte], but should be okay since we handle ASCII only
-    def uncountEscapes(from: Int, accum: Int): Int =
+    @tailrec def uncountEscapes(from: Int, accum: Int): Int =
       s.indexOf('\\', from) match {
         case -1 => accum
         case idx if idx == s.length - 1 =>

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -19,13 +19,54 @@ sealed abstract class Val {
     case Val.Double(_)          => Type.Double
     case Val.Struct(name, vals) => Type.Struct(name, vals.map(_.ty))
     case Val.Array(ty, vals)    => Type.Array(ty, vals.length)
-    case Val.Chars(s)           => Type.Array(Type.Byte, s.getBytes.length + 1)
+    case Val.Chars(s)           => Type.Array(Type.Byte, countBytes(s))
     case Val.Local(_, ty)       => ty
     case Val.Global(_, ty)      => ty
 
     case Val.Unit      => Type.Unit
     case Val.Const(_)  => Type.Ptr
     case Val.String(_) => Rt.String
+  }
+
+  private def countBytes(s: String): Int = {
+    import Character.isDigit
+
+    // TODO: should be a compilation error, how to report?
+    def malformed() = ???
+
+    // Subtracts from the length of the bytes for each escape sequence
+    // uses String, not Seq[Byte], but should be okay since we handle ASCII only
+    def uncountEscapes(from: Int, accum: Int): Int =
+      s.indexOf('\\', from) match {
+        case -1 => accum
+        case idx if idx == s.length - 1 =>
+          malformed()
+        case idx =>
+          def isOct(c: Char): Boolean = isDigit(c) && c != '8' && c != '9'
+          def isHex(c: Char): Boolean =
+            isDigit(c) ||
+              c == 'a' || c == 'b' || c == 'c' || c == 'd' || c == 'e' || c == 'f' ||
+              c == 'A' || c == 'B' || c == 'C' || c == 'D' || c == 'E' || c == 'F'
+          s(idx + 1) match {
+            case d if isOct(d) =>
+              // octal ("\O", "\OO", "\OOO")
+              val digitNum = s.drop(idx + 1).take(3).takeWhile(isOct).length
+              uncountEscapes(idx + 1 + digitNum, accum - digitNum)
+            case 'x' =>
+              // hexademical ("\xH", "\xHH")
+              val digitNum = s.drop(idx + 2).takeWhile(isHex).length
+              // mimic clang, which reports compilation error against too many hex digits
+              if (digitNum >= 3)
+                malformed()
+              uncountEscapes(idx + 2 + digitNum, accum - 1 - digitNum)
+            // TODO: support unicode?
+            // case 'u' =>
+            // case 'U' =>
+            case _ =>
+              uncountEscapes(idx + 2, accum - 1)
+          }
+      }
+    uncountEscapes(0, s.getBytes.length + 1)
   }
 
   final def show: String = nir.Show(this)

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -31,8 +31,8 @@ sealed abstract class Val {
   private def countBytes(s: String): Int = {
     import Character.isDigit
 
-    // TODO: should be a compilation error, how to report?
-    def malformed() = ???
+    def malformed() =
+      throw new IllegalArgumentException("malformed C string: " + s)
 
     // Subtracts from the length of the bytes for each escape sequence
     // uses String, not Seq[Byte], but should be okay since we handle ASCII only

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -4,6 +4,7 @@ package codegen
 import java.{lang => jl}
 import java.nio.ByteBuffer
 import java.nio.file.Paths
+import scala.annotation.tailrec
 import scala.collection.mutable
 import scalanative.util.{Scope, ShowBuilder, unsupported}
 import scalanative.io.{VirtualDirectory, withScratchBuffer}
@@ -396,7 +397,7 @@ object CodeGen {
       // `value` should contain a content of a CString literal as is in its source file
       // malformed literals are assumed absent
       str("c\"")
-      def loop(from: Int): Unit =
+      @tailrec def loop(from: Int): Unit =
         value.indexOf('\\', from) match {
           case -1 => str(value.substring(from))
           case idx =>

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -419,7 +419,7 @@ object CodeGen {
               case 't'                   => str("\\09"); loop(idx + 2)
               case 'v'                   => str("\\0B"); loop(idx + 2)
               case d if isOct(d) =>
-                val oct = value.drop(from + 1).take(3).takeWhile(isOct)
+                val oct = value.drop(idx + 1).take(3).takeWhile(isOct)
                 val hex =
                   Integer.toHexString(Integer.parseInt(oct, 8)).toUpperCase
                 str {
@@ -428,7 +428,7 @@ object CodeGen {
                 }
                 loop(idx + 1 + oct.length)
               case 'x' =>
-                val hex = value.drop(from + 2).takeWhile(isHex).toUpperCase
+                val hex = value.drop(idx + 2).takeWhile(isHex).toUpperCase
                 str {
                   if (hex.length < 2) "\\0" + hex
                   else "\\" + hex

--- a/unit-tests/src/test/scala/scala/scalanative/CStringEscapesSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/CStringEscapesSuite.scala
@@ -1,0 +1,34 @@
+package scala.scalanative
+
+import native._
+
+object CStringEscapesSuite extends tests.Suite {
+  test("""c"..." literals with various escapes""") {
+    // note: `fromCString` is needed to trigger compilation errors against malformed literals
+    fromCString(c"")
+    fromCString(c"no escapes")
+    fromCString(c"\'"); fromCString(c"\\'")
+    fromCString(c"\?"); fromCString(c"\\?")
+    fromCString(c"\\")
+    fromCString(c"\a"); fromCString(c"\\a")
+    fromCString(c"\b"); fromCString(c"\\b")
+    fromCString(c"\f"); fromCString(c"\\f")
+    fromCString(c"\n"); fromCString(c"\\n")
+    fromCString(c"\r"); fromCString(c"\\r")
+    fromCString(c"\t"); fromCString(c"\\t")
+    fromCString(c"\v"); fromCString(c"\\v")
+    fromCString(c"\012\x6a")
+    fromCString(c"%s \\t %.2f %s/s\00")
+
+    // uncomment the following to trigger compilation errors for testing
+    // fromCString(c"\")     // error at NIR
+    // fromCString(c"\x2ae") // error at NIR
+    // fromCString(c"\"")    // error at Scala compiler
+  }
+
+  test("""the value of c"..." literals""") {
+    assertEquals("\t", fromCString(c"\t"))
+    assertEquals("\\t", fromCString(c"\\t"))
+    assertEquals("\u0020\u0020\u0061\u0062", fromCString(c"\040\40\141\x62"))
+  }
+}


### PR DESCRIPTION
Fix: #640 

This PR contains questions. Please see `TODO` in the changed file.

This PR includes two changes:
* Count bytes of CString constants when they contain escape sequences
* Format CString constants into proper LLVM IR string constants  
  e.g. `\t` -> `\09`