### PR TITLE
Fix #901: Don't include classfiles for javalib

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -323,6 +323,14 @@ lazy val javalib =
         val classDir  = (classDirectory in Compile).value.getAbsolutePath()
         val separator = sys.props("path.separator")
         "-javabootclasspath" +: s"$classDir$separator$javaBootClasspath" +: previous
+      },
+      // Don't include classfiles for javalib in the packaged jar.
+      mappings in packageBin in Compile := {
+        val previous = (mappings in packageBin in Compile).value
+        previous.filter {
+          case (file, path) =>
+            !path.endsWith(".class")
+        }
       }
     )
     .dependsOn(nativelib)


### PR DESCRIPTION
Redefinition of the java library is not that well supported by either
scalac or jvm so we should not ship those classfiles. Applications are
going to link against the official JDK APIs and then our implementation
would be a drop-in replacement on Native only.