### PR TITLE
Fix #147: finalizers are officially not supported

### DIFF
--- a/docs/user/lang.rst
+++ b/docs/user/lang.rst
@@ -22,6 +22,11 @@ programming and assumes single-threaded execution by default.
 It's possible to use C libraries to get access to multi-threading and
 synchronization primitives but this is not officially supported at the moment.
 
+Finalization
+------------
+
+Finalize method from ``java.lang.Object`` is never called in Scala Native.
+
 Undefined behavior
 ------------------
 


### PR DESCRIPTION
Finalize is getting deprecated in Java 9 and we are not going to support. 