### PR TITLE
Fix formatting

### DIFF
--- a/javalib/src/main/scala/java/util/zip/ZipEntry.scala
+++ b/javalib/src/main/scala/java/util/zip/ZipEntry.scala
@@ -278,8 +278,7 @@ object ZipEntry extends ZipConstants {
 
     def readIntLE(in: InputStream): Int =
       if (in.read(b, 0, 4) == 4) {
-        ((((b(0) & 0xFF) | ((b(1) & 0xFF) << 8) | ((b(2) & 0xFF) << 16) | ((b(
-          3) & 0xFF) << 24))).toLong & 0xFFFFFFFFL).toInt
+        ((((b(0) & 0xFF) | ((b(1) & 0xFF) << 8) | ((b(2) & 0xFF) << 16) | ((b(3) & 0xFF) << 24))).toLong & 0xFFFFFFFFL).toInt
       } else {
         throw new EOFException()
       }


### PR DESCRIPTION
Scalafmt version was 0.6.8 in one of the recently merged PRs.