### PR TITLE
Disable Travis CI on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,6 @@ matrix:
       language: scala
       env: SCALANATIVE_GC=immix
 
-    - os: osx
-      osx_image: xcode7.3
-      env: SCALANATIVE_GC=boehm
-
-    - os: osx
-      osx_image: xcode7.3
-      env: SCALANATIVE_GC=none
-
-    - os: osx
-      osx_image: xcode7.3
-      env: SCALANATIVE_GC=immix
-
 env:
   global:
     - MAVEN_REALM="Sonatype Nexus Repository Manager"


### PR DESCRIPTION
The builds are consistently getting timed out due to travis limits.
We really need to start looking for a replacement.