### PR TITLE
Cache stack trace elements

### DIFF
--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -1,15 +1,92 @@
 package java.lang
 
-final class StackTraceElement(val getClassName: String,
-                              val getMethodName: String,
-                              val getFileName: String,
-                              val getLineNumber: Int) {
+import scala.scalanative.native.{
+  fromCString,
+  stackalloc,
+  string,
+  CChar,
+  CString,
+  CUnsignedLong,
+  Ptr
+}
+import scala.scalanative.runtime.{ByteArray, unwind}
 
-  if (getClassName == null)
-    throw new NullPointerException("Declaring class is null")
+final class StackTraceElement private (_symbol: CString) {
+  var symbol: Array[Byte] = _
 
-  if (getMethodName == null)
-    throw new NullPointerException("Method name is null")
+  if (_symbol != null) {
+    symbol = new Array[Byte](256)
+    string.memcpy(symbol.asInstanceOf[ByteArray].at(0), _symbol, 256)
+  }
+
+  def this(className: String,
+           methodName: String,
+           fileName: String,
+           lineNumber: Int) = {
+    this(null)
+    if (className == null)
+      throw new NullPointerException("Declaring class is null")
+
+    if (methodName == null)
+      throw new NullPointerException("Method name is null")
+
+    initDone = true
+    _className = className
+    _methodName = methodName
+    _fileName = fileName
+    _lineNumber = lineNumber
+  }
+
+  private var initDone: Boolean   = false
+  private var _className: String  = _
+  private var _methodName: String = _
+  private var _fileName: String   = _
+  private var _lineNumber: Int    = _
+
+  def getClassName: String = {
+    if (!initDone) initMembers()
+    _className
+  }
+
+  def getMethodName: String = {
+    if (!initDone) initMembers()
+    _methodName
+  }
+
+  def getFileName: String = {
+    if (!initDone) initMembers()
+    _fileName
+  }
+
+  def getLineNumber: Int = {
+    if (!initDone) initMembers()
+    _lineNumber
+  }
+
+  // symbol is "classname::methodName_T1_..._TN"
+  // where classname doesn't include colons and method name underscores.
+  private def initMembers(): Unit = {
+    val sym = fromCString(symbol.asInstanceOf[ByteArray].at(0))
+    val (className, methodName) =
+      sym.indexOf("::") match {
+        case -1 =>
+          ("<none>", sym)
+        case sep =>
+          sym.indexOf("_", sep) match {
+            case -1 =>
+              (sym.substring(0, sep), sym.substring(sep + 2))
+            case end =>
+              (sym.substring(0, sep), sym.substring(sep + 2, end))
+          }
+      }
+
+    initDone = true
+    _className = className
+    _methodName = methodName
+    _fileName = null
+    _lineNumber = 0
+    symbol = null
+  }
 
   def isNativeMethod: scala.Boolean = false
 
@@ -37,21 +114,27 @@ final class StackTraceElement(val getClassName: String,
 }
 
 private[lang] object StackTraceElement {
-  // symbol is "classname::methodName_T1_..._TN"
-  // where classname doesn't include colons and method name underscores.
-  def fromSymbol(symbol: String): StackTraceElement = {
-    val (className, methodName) =
-      symbol.indexOf("::") match {
-        case -1 =>
-          ("<none>", symbol)
-        case sep =>
-          symbol.indexOf("_", sep) match {
-            case -1 =>
-              (symbol.substring(0, sep), symbol.substring(sep + 2))
-            case end =>
-              (symbol.substring(0, sep), symbol.substring(sep + 2, end))
-          }
-      }
-    new StackTraceElement(className, methodName, null, 0)
+  private val cache =
+    collection.mutable.HashMap.empty[CUnsignedLong, StackTraceElement]
+  private def makeStackTraceElement(
+      cursor: Ptr[scala.Byte]): StackTraceElement = {
+    val name   = stackalloc[CChar](256)
+    val offset = stackalloc[scala.Byte](8)
+
+    unwind.get_proc_name(cursor, name, 256, offset)
+    new StackTraceElement(name)
   }
+
+  /**
+   * Tries to retrieve a pre-computed `StackTraceElement`, or computes it.
+   * We use `startIp` (ie. the address of the first instruction of the function)
+   * as cache key.
+   *
+   * Computing stack traces is expensive because we need to collect names of
+   * functions, and convert those names from C strings to Scala strings.
+   */
+  private[lang] def cached(cursor: Ptr[scala.Byte],
+                           startIp: CUnsignedLong): StackTraceElement =
+    cache.getOrElseUpdate(startIp, makeStackTraceElement(cursor))
+
 }

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -29,15 +29,14 @@ class Throwable(s: String, private var e: Throwable)
   def fillInStackTrace(): Throwable = {
     val cursor  = stackalloc[scala.Byte](2048)
     val context = stackalloc[scala.Byte](2048)
-    val offset  = stackalloc[scala.Byte](8)
-    val name    = stackalloc[CChar](256)
+    val startIp = stackalloc[CUnsignedLong](1)
     var buffer  = mutable.ArrayBuffer.empty[StackTraceElement]
 
     unwind.get_context(context)
     unwind.init_local(cursor, context)
     while (unwind.step(cursor) > 0) {
-      unwind.get_proc_name(cursor, name, 256, offset)
-      buffer += StackTraceElement.fromSymbol(fromCString(name))
+      unwind.get_proc_start_ip(cursor, startIp)
+      buffer += StackTraceElement.cached(cursor, !startIp)
     }
 
     this.stackTrace = buffer.toArray

--- a/nativelib/src/main/resources/unwind.c
+++ b/nativelib/src/main/resources/unwind.c
@@ -17,3 +17,15 @@ int scalanative_unwind_get_proc_name(void *cursor, char *buffer, size_t length,
     return unw_get_proc_name((unw_cursor_t *)cursor, buffer, length,
                              (unw_word_t *)offset);
 }
+
+int scalanative_unwind_get_proc_start_ip(void *cursor, unsigned long *buffer) {
+    unw_proc_info_t pip;
+    int result = unw_get_proc_info((unw_cursor_t *)cursor, &pip);
+
+    if (result == 0) {
+        *buffer = pip.start_ip;
+        return 0;
+    } else {
+        return result;
+    }
+}

--- a/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
@@ -16,4 +16,7 @@ object unwind {
                     buffer: CString,
                     length: CSize,
                     offset: Ptr[Byte]): CInt = extern
+  @name("scalanative_unwind_get_proc_start_ip")
+  def get_proc_start_ip(cursor: Ptr[Byte], buffer: Ptr[CUnsignedLong]): CInt =
+    extern
 }


### PR DESCRIPTION
Generating stack traces is slow because we convert C strings to Scala
strings. This commits improves the situation by caching stack trace
elements and lazily converting strings.

Fixes #920