### PR TITLE
Allow configuring scala/scala repo location

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -349,9 +349,13 @@ lazy val scalalib =
 
         val s      = streams.value
         val trgDir = target.value / "scalaSources" / scalaVersion.value
+        val scalaRepo = sys.env
+          .get("SCALANATIVE_SCALAREPO")
+          .getOrElse("https://github.com/scala/scala.git")
 
         if (!trgDir.exists) {
-          s.log.info(s"Fetching Scala source version ${scalaVersion.value}")
+          s.log.info(
+            s"Fetching Scala source version ${scalaVersion.value} from $scalaRepo")
 
           // Make parent dirs and stuff
           IO.createDirectory(trgDir)
@@ -359,7 +363,7 @@ lazy val scalalib =
           // Clone scala source code
           new CloneCommand()
             .setDirectory(trgDir)
-            .setURI("https://github.com/scala/scala.git")
+            .setURI(scalaRepo)
             .call()
         }
 


### PR DESCRIPTION
Currently we always clone the repo from https://github.com/scala/scala.
Being able to configure the location of the scala repository is useful
for when GitHub is down, or working without Internet access for
instance.

Example:

    SCALAREPO="file:///home/martin/scala/scala" sbt rebuild shell