### PR TITLE
Add `@stub` annotation to mark stubs

### DIFF
--- a/docs/contrib/nir.rst
+++ b/docs/contrib/nir.rst
@@ -699,6 +699,16 @@ pin-weak
 
 Require ``$name`` to be reachable if there is a reachable dynmethod with matching signature.
 
+stub
+****
+.. code-block:: text
+
+    stub
+
+Indicates that the annotated method is only a stub without implementation. If the linker is
+configured with ``linkStubs = false``, then these methods will be ignored and a linking error
+will be reported. If ``linkStubs = true``, these methods will be linked.
+
 Misc
 ````
 

--- a/docs/contrib/nir.rst
+++ b/docs/contrib/nir.rst
@@ -705,9 +705,10 @@ stub
 
     stub
 
-Indicates that the annotated method is only a stub without implementation. If the linker is
-configured with ``linkStubs = false``, then these methods will be ignored and a linking error
-will be reported. If ``linkStubs = true``, these methods will be linked.
+Indicates that the annotated method, class or module is only a stub without implementation.
+If the linker is configured with ``linkStubs = false``, then these definitions will be
+ignored and a linking error will be reported. If ``linkStubs = true``, these definitions
+will be linked.
 
 Misc
 ````

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -68,7 +68,7 @@ Since Name                     Type            Description
 0.1   ``nativeLinkingOptions`` ``Seq[String]`` Extra options passed to clang verbatim during linking
 0.1   ``nativeMode``           ``String``      Either ``"debug"`` or ``"release"`` (2)
 0.2   ``nativeGC``             ``String``      Either ``"none"``, ``"boehm"`` or ``"immix"`` (3)
-0.3.3 ``nativeLinkStubs``      ``Boolean``     Whether to link ``@stub`` methods, or to ignore them
+0.3.3 ``nativeLinkStubs``      ``Boolean``     Whether to link ``@stub`` definitions, or to ignore them
 ===== ======================== =============== =========================================================
 
 1. See `Publishing`_ and `Cross compilation`_ for details.

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -68,6 +68,7 @@ Since Name                     Type            Description
 0.1   ``nativeLinkingOptions`` ``Seq[String]`` Extra options passed to clang verbatim during linking
 0.1   ``nativeMode``           ``String``      Either ``"debug"`` or ``"release"`` (2)
 0.2   ``nativeGC``             ``String``      Either ``"none"``, ``"boehm"`` or ``"immix"`` (3)
+0.3.3 ``nativeLinkStubs``      ``Boolean``     Whether to link ``@stub`` methods, or to ignore them
 ===== ======================== =============== =========================================================
 
 1. See `Publishing`_ and `Cross compilation`_ for details.

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -353,8 +353,11 @@ class File(_path: String) extends Serializable with Comparable[File] {
 
   override def toString(): String = path
 
-  def deleteOnExit(): Unit  = ???
+  @stub
+  def deleteOnExit(): Unit = ???
+  @stub
   def toURL(): java.net.URL = ???
+  @stub
   def toURI(): java.net.URI = ???
 }
 

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -75,5 +75,6 @@ class FileInputStream(fd: FileDescriptor) extends InputStream {
       bytesToSkip
     }
 
+  @stub
   def getChannel: java.nio.channels.FileChannel = ???
 }

--- a/javalib/src/main/scala/java/lang/ClassLoader.scala
+++ b/javalib/src/main/scala/java/lang/ClassLoader.scala
@@ -1,9 +1,15 @@
 package java.lang
 
+import scala.scalanative.native.stub
+
 class ClassLoader protected (parent: ClassLoader) {
   def this() = this(null)
-  def loadClass(name: String): Class[_]                      = ???
-  def getParent(): ClassLoader                               = ???
+  @stub
+  def loadClass(name: String): Class[_] = ???
+  @stub
+  def getParent(): ClassLoader = ???
+  @stub
   def getResourceAsStream(name: String): java.io.InputStream = ???
-  def getResources(name: String): java.util.Enumeration[_]   = ???
+  @stub
+  def getResources(name: String): java.util.Enumeration[_] = ???
 }

--- a/javalib/src/main/scala/java/lang/ClassLoader.scala
+++ b/javalib/src/main/scala/java/lang/ClassLoader.scala
@@ -1,6 +1,6 @@
 package java.lang
 
-import scala.scalanative.native.stub
+import scalanative.native.stub
 
 class ClassLoader protected (parent: ClassLoader) {
   def this() = this(null)

--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -1,12 +1,13 @@
 package java.lang
 
-import scala.scalanative.native.stdlib
+import scala.scalanative.native.{stdlib, stub}
 
 class Runtime private () {
   def availableProcessors(): Int = 1
   def exit(status: Int): Unit    = stdlib.exit(status)
   def gc(): Unit                 = ()
 
+  @stub
   def addShutdownHook(thread: java.lang.Thread): Unit = ???
 }
 

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -1,5 +1,7 @@
 package java.lang
 
+import scala.scalanative.native.stub
+
 class Thread private (runnable: Runnable) extends Runnable {
   if (runnable ne Thread.MainRunnable) ???
 
@@ -20,19 +22,25 @@ class Thread private (runnable: Runnable) extends Runnable {
   final def getName(): String =
     this.name
 
+  @stub
   def getStackTrace(): Array[StackTraceElement] = ???
 
   def getId(): scala.Long = 1
 
+  @stub
   def getUncaughtExceptionHandler(): UncaughtExceptionHandler = ???
 
+  @stub
   def setUncaughtExceptionHandler(handler: UncaughtExceptionHandler): Unit =
     ???
 
+  @stub
   def setDaemon(on: scala.Boolean): Unit = ???
 
+  @stub
   def this(name: String) = this(??? : Runnable)
 
+  @stub
   def getContextClassLoader(): java.lang.ClassLoader = ???
 
   trait UncaughtExceptionHandler {
@@ -77,5 +85,6 @@ object Thread {
 
   def sleep(millis: scala.Long): Unit = sleep(millis, 0)
 
+  @stub
   def dumpStack(): Unit = ???
 }

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -1,6 +1,6 @@
 package java.lang
 
-import scala.scalanative.native.stub
+import scalanative.native.stub
 
 class Thread private (runnable: Runnable) extends Runnable {
   if (runnable ne Thread.MainRunnable) ???

--- a/javalib/src/main/scala/java/lang/ref/ReferenceQueue.scala
+++ b/javalib/src/main/scala/java/lang/ref/ReferenceQueue.scala
@@ -1,5 +1,6 @@
 package java.lang.ref
 
 class ReferenceQueue[T >: Null <: AnyRef] {
+  @scala.scalanative.native.stub
   def poll(): java.lang.ref.Reference[_] = null
 }

--- a/javalib/src/main/scala/java/lang/ref/ReferenceQueue.scala
+++ b/javalib/src/main/scala/java/lang/ref/ReferenceQueue.scala
@@ -1,6 +1,6 @@
 package java.lang.ref
 
 class ReferenceQueue[T >: Null <: AnyRef] {
-  @scala.scalanative.native.stub
+  @scalanative.native.stub
   def poll(): java.lang.ref.Reference[_] = null
 }

--- a/javalib/src/main/scala/java/lang/reflect/Constructor.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Constructor.scala
@@ -1,7 +1,7 @@
 package java.lang
 package reflect
 
-import scala.scalanative.native.stub
+import scalanative.native.stub
 
 class Constructor[T] extends Executable {
   @stub

--- a/javalib/src/main/scala/java/lang/reflect/Constructor.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Constructor.scala
@@ -1,8 +1,12 @@
 package java.lang
 package reflect
 
+import scala.scalanative.native.stub
+
 class Constructor[T] extends Executable {
+  @stub
   def getParameterTypes(): scala.Array[Object] = ???
+  @stub
   def newInstance(
       args: scala.scalanative.runtime.ObjectArray): java.lang.Object = ???
 }

--- a/javalib/src/main/scala/java/lang/reflect/Field.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Field.scala
@@ -1,12 +1,7 @@
 package java.lang.reflect
 
-import scala.scalanative.native.stub
-
 class Field {
-  @stub
   def get(obj: Object): Object = ???
-  @stub
-  def getName(): String = ???
-  @stub
-  def getType(): Class[_] = ???
+  def getName(): String        = ???
+  def getType(): Class[_]      = ???
 }

--- a/javalib/src/main/scala/java/lang/reflect/Field.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Field.scala
@@ -1,7 +1,12 @@
 package java.lang.reflect
 
+import scala.scalanative.native.stub
+
 class Field {
+  @stub
   def get(obj: Object): Object = ???
-  def getName(): String        = ???
-  def getType(): Class[_]      = ???
+  @stub
+  def getName(): String = ???
+  @stub
+  def getType(): Class[_] = ???
 }

--- a/javalib/src/main/scala/java/lang/reflect/Method.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Method.scala
@@ -1,10 +1,17 @@
 package java.lang.reflect
 
+import scala.scalanative.native.stub
+
 class Method {
-  def getDeclaringClass(): java.lang.Class[_]  = ???
-  def getName(): java.lang.String              = ???
+  @stub
+  def getDeclaringClass(): java.lang.Class[_] = ???
+  @stub
+  def getName(): java.lang.String = ???
+  @stub
   def getParameterTypes(): scala.Array[Object] = ???
-  def getReturnType(): java.lang.Class[_]      = ???
+  @stub
+  def getReturnType(): java.lang.Class[_] = ???
+  @stub
   def invoke(obj: java.lang.Object,
              args: scala.Array[Object]): java.lang.Object = ???
 }

--- a/javalib/src/main/scala/java/lang/reflect/Method.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Method.scala
@@ -1,17 +1,10 @@
 package java.lang.reflect
 
-import scala.scalanative.native.stub
-
 class Method {
-  @stub
-  def getDeclaringClass(): java.lang.Class[_] = ???
-  @stub
-  def getName(): java.lang.String = ???
-  @stub
+  def getDeclaringClass(): java.lang.Class[_]  = ???
+  def getName(): java.lang.String              = ???
   def getParameterTypes(): scala.Array[Object] = ???
-  @stub
-  def getReturnType(): java.lang.Class[_] = ???
-  @stub
+  def getReturnType(): java.lang.Class[_]      = ???
   def invoke(obj: java.lang.Object,
              args: scala.Array[Object]): java.lang.Object = ???
 }

--- a/javalib/src/main/scala/java/net/URI.scala
+++ b/javalib/src/main/scala/java/net/URI.scala
@@ -1163,6 +1163,6 @@ final class URI private () extends Comparable[URI] with Serializable {
     convertHexToLowerCase(result.toString)
   }
 
-  @scala.scalanative.native.stub
+  @scalanative.native.stub
   def toURL(): java.net.URL = ???
 }

--- a/javalib/src/main/scala/java/net/URI.scala
+++ b/javalib/src/main/scala/java/net/URI.scala
@@ -1163,5 +1163,6 @@ final class URI private () extends Comparable[URI] with Serializable {
     convertHexToLowerCase(result.toString)
   }
 
+  @scala.scalanative.native.stub
   def toURL(): java.net.URL = ???
 }

--- a/javalib/src/main/scala/java/net/URL.scala
+++ b/javalib/src/main/scala/java/net/URL.scala
@@ -1,6 +1,6 @@
 package java.net
 
-import scala.scalanative.native.stub
+import scalanative.native.stub
 
 class URL(from: String) {
   @stub

--- a/javalib/src/main/scala/java/net/URL.scala
+++ b/javalib/src/main/scala/java/net/URL.scala
@@ -1,9 +1,16 @@
 package java.net
 
+import scala.scalanative.native.stub
+
 class URL(from: String) {
-  def getPath(): java.lang.String              = ???
-  def getProtocol(): java.lang.String          = ???
+  @stub
+  def getPath(): java.lang.String = ???
+  @stub
+  def getProtocol(): java.lang.String = ???
+  @stub
   def openConnection(): java.net.URLConnection = ???
-  def openStream(): java.io.InputStream        = ???
-  override def hashCode: Int                   = ???
+  @stub
+  def openStream(): java.io.InputStream = ???
+  @stub
+  override def hashCode: Int = ???
 }

--- a/javalib/src/main/scala/java/net/URLClassLoader.scala
+++ b/javalib/src/main/scala/java/net/URLClassLoader.scala
@@ -1,7 +1,11 @@
 package java.net
 
+import scala.scalanative.native.stub
+
 class URLClassLoader(args: Array[Object], parent: ClassLoader)
     extends ClassLoader(parent) {
+  @stub
   def getURLs(): Array[Object] = ???
-  def close(): Unit            = ???
+  @stub
+  def close(): Unit = ???
 }

--- a/javalib/src/main/scala/java/net/URLClassLoader.scala
+++ b/javalib/src/main/scala/java/net/URLClassLoader.scala
@@ -1,6 +1,6 @@
 package java.net
 
-import scala.scalanative.native.stub
+import scalanative.native.stub
 
 class URLClassLoader(args: Array[Object], parent: ClassLoader)
     extends ClassLoader(parent) {

--- a/javalib/src/main/scala/java/net/URLConnection.scala
+++ b/javalib/src/main/scala/java/net/URLConnection.scala
@@ -1,6 +1,6 @@
 package java.net
 
 class URLConnection {
-  @scala.scalanative.native.stub
+  @scalanative.native.stub
   def getLastModified(): scala.Long = ???
 }

--- a/javalib/src/main/scala/java/net/URLConnection.scala
+++ b/javalib/src/main/scala/java/net/URLConnection.scala
@@ -1,5 +1,6 @@
 package java.net
 
 class URLConnection {
+  @scala.scalanative.native.stub
   def getLastModified(): scala.Long = ???
 }

--- a/javalib/src/main/scala/java/nio/channels/Channels.scala
+++ b/javalib/src/main/scala/java/nio/channels/Channels.scala
@@ -2,6 +2,7 @@ package java.nio
 package channels
 
 object Channels {
+  @scala.scalanative.native.stub
   def newChannel(
       is: java.io.InputStream): java.nio.channels.ReadableByteChannel = ???
 }

--- a/javalib/src/main/scala/java/nio/channels/Channels.scala
+++ b/javalib/src/main/scala/java/nio/channels/Channels.scala
@@ -2,7 +2,7 @@ package java.nio
 package channels
 
 object Channels {
-  @scala.scalanative.native.stub
+  @scalanative.native.stub
   def newChannel(
       is: java.io.InputStream): java.nio.channels.ReadableByteChannel = ???
 }

--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -145,15 +145,11 @@ final class _Class[A](val ty: Ptr[Type]) {
   def getConstructor(args: Array[Object]): java.lang.reflect.Constructor[_] =
     ???
   @stub
-  def getConstructors(): Array[Object] = ???
-  @stub
+  def getConstructors(): Array[Object]   = ???
   def getDeclaredFields(): Array[Object] = ???
-  @stub
   def getMethod(name: java.lang.String,
-                args: Array[Object]): java.lang.reflect.Method = ???
-  @stub
-  def getMethods(): Array[Object] = ???
-  @stub
+                args: Array[Object]): java.lang.reflect.Method         = ???
+  def getMethods(): Array[Object]                                      = ???
   def getResourceAsStream(name: java.lang.String): java.io.InputStream = ???
 }
 

--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -45,6 +45,7 @@ final class _Class[A](val ty: Ptr[Type]) {
   def getSuperclass(): Class[_ >: A] =
     ???
 
+  @stub
   def getField(name: String): Field =
     ???
 
@@ -138,14 +139,21 @@ final class _Class[A](val ty: Ptr[Type]) {
     prefix + name
   }
 
+  @stub
   def getClassLoader(): java.lang.ClassLoader = ???
+  @stub
   def getConstructor(args: Array[Object]): java.lang.reflect.Constructor[_] =
     ???
-  def getConstructors(): Array[Object]   = ???
+  @stub
+  def getConstructors(): Array[Object] = ???
+  @stub
   def getDeclaredFields(): Array[Object] = ???
+  @stub
   def getMethod(name: java.lang.String,
-                args: Array[Object]): java.lang.reflect.Method         = ???
-  def getMethods(): Array[Object]                                      = ???
+                args: Array[Object]): java.lang.reflect.Method = ???
+  @stub
+  def getMethods(): Array[Object] = ???
+  @stub
   def getResourceAsStream(name: java.lang.String): java.io.InputStream = ???
 }
 
@@ -155,7 +163,9 @@ object _Class {
   private[java] implicit def class2_class[A](cls: Class[A]): _Class[A] =
     cls.asInstanceOf[_Class[A]]
 
+  @stub
   def forName(name: String): Class[_] = ???
+  @stub
   def forName(name: String,
               init: scala.Boolean,
               loader: ClassLoader): Class[_] = ???

--- a/nativelib/src/main/scala/scala/scalanative/native/stub.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/stub.scala
@@ -1,0 +1,11 @@
+package scala.scalanative
+package native
+
+import scala.annotation.StaticAnnotation
+
+/** An annotation that is used to indicate that a given method
+ *  is provided as a stub, but is not currently supported. These
+ *  methods are not discovered by the linker by default, but will
+ *  be discovered only if a special flag is enabled.
+ */
+final class stub extends StaticAnnotation

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -15,7 +15,8 @@ object Attr {
   final case object NoInline     extends Inline // should never inline
   final case object AlwaysInline extends Inline // should always inline
 
-  final case object Dyn extends Attr
+  final case object Dyn  extends Attr
+  final case object Stub extends Attr
 
   final case object Pure                  extends Attr
   final case object Extern                extends Attr
@@ -29,7 +30,6 @@ object Attr {
   final case class PinAlways(dep: Global)           extends Pin
   final case class PinIf(dep: Global, cond: Global) extends Pin
   final case class PinWeak(dep: Global)             extends Pin
-  final case object Stub                            extends Attr
 }
 
 final case class Attrs(inline: Inline = MayInline,

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -29,12 +29,14 @@ object Attr {
   final case class PinAlways(dep: Global)           extends Pin
   final case class PinIf(dep: Global, cond: Global) extends Pin
   final case class PinWeak(dep: Global)             extends Pin
+  final case object Stub                            extends Attr
 }
 
 final case class Attrs(inline: Inline = MayInline,
                        isPure: Boolean = false,
                        isExtern: Boolean = false,
                        isDyn: Boolean = false,
+                       isStub: Boolean = false,
                        overrides: Seq[Global] = Seq(),
                        pins: Seq[Pin] = Seq(),
                        links: Seq[Attr.Link] = Seq(),
@@ -46,6 +48,7 @@ final case class Attrs(inline: Inline = MayInline,
     if (isPure) out += Pure
     if (isExtern) out += Extern
     if (isDyn) out += Dyn
+    if (isStub) out += Stub
     overrides.foreach { out += Override(_) }
     out ++= pins
     out ++= links
@@ -62,6 +65,7 @@ object Attrs {
     var isPure    = false
     var isExtern  = false
     var isDyn     = false
+    var isStub    = false
     var align     = Option.empty[Int]
     val overrides = mutable.UnrolledBuffer.empty[Global]
     val pins      = mutable.UnrolledBuffer.empty[Pin]
@@ -72,12 +76,21 @@ object Attrs {
       case Pure            => isPure = true
       case Extern          => isExtern = true
       case Dyn             => isDyn = true
+      case Stub            => isStub = true
       case Align(value)    => align = Some(value)
       case Override(name)  => overrides += name
       case attr: Pin       => pins += attr
       case link: Attr.Link => links += link
     }
 
-    new Attrs(inline, isPure, isExtern, isDyn, overrides, pins, links, align)
+    new Attrs(inline,
+              isPure,
+              isExtern,
+              isDyn,
+              isStub,
+              overrides,
+              pins,
+              links,
+              align)
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -55,6 +55,8 @@ object Show {
         str("alwaysinline")
       case Attr.Dyn =>
         str("dyn")
+      case Attr.Stub =>
+        str("stub")
       case Attr.Align(value) =>
         str("align(")
         str(value)

--- a/nir/src/main/scala/scala/scalanative/nir/Versions.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Versions.scala
@@ -22,7 +22,7 @@ object Versions {
    * new version of the toolchain.
    */
   final val compat: Int   = 3
-  final val revision: Int = 3
+  final val revision: Int = 4
 
   /* Current public release version of Scala Native. */
   final val current: String = "0.4.0-SNAPSHOT"

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -87,8 +87,7 @@ final class BinaryDeserializer(_buffer: => ByteBuffer) {
         case T.NoInlineAttr     => buf += Attr.NoInline
         case T.AlwaysInlineAttr => buf += Attr.AlwaysInline
 
-        case T.DynAttr => buf += Attr.Dyn
-
+        case T.DynAttr  => buf += Attr.Dyn
         case T.StubAttr => buf += Attr.Stub
 
         case T.PureAttr     => buf += Attr.Pure

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -89,6 +89,8 @@ final class BinaryDeserializer(_buffer: => ByteBuffer) {
 
         case T.DynAttr => buf += Attr.Dyn
 
+        case T.StubAttr => buf += Attr.Stub
+
         case T.PureAttr     => buf += Attr.Pure
         case T.ExternAttr   => buf += Attr.Extern
         case T.OverrideAttr => buf += Attr.Override(getGlobal)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -72,6 +72,8 @@ final class BinarySerializer(buffer: ByteBuffer) {
 
     case Attr.Dyn => putInt(T.DynAttr)
 
+    case Attr.Stub => putInt(T.StubAttr)
+
     case Attr.Align(_) =>
       assert(false, "alignment attribute is not serializable")
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -70,8 +70,7 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Attr.NoInline     => putInt(T.NoInlineAttr)
     case Attr.AlwaysInline => putInt(T.AlwaysInlineAttr)
 
-    case Attr.Dyn => putInt(T.DynAttr)
-
+    case Attr.Dyn  => putInt(T.DynAttr)
     case Attr.Stub => putInt(T.StubAttr)
 
     case Attr.Align(_) =>

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -25,6 +25,7 @@ object Tags {
   final val PinIfAttr        = 1 + PinAlwaysAttr
   final val PinWeakAttr      = 1 + PinIfAttr
   final val DynAttr          = 1 + PinWeakAttr
+  final val StubAttr         = 1 + DynAttr
 
   // Binary ops
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -32,6 +32,7 @@ trait NirDefinitions { self: NirGlobalAddons =>
     lazy val LinkClass   = getRequiredClass("scala.scalanative.native.link")
     lazy val ExternClass = getRequiredClass("scala.scalanative.native.extern")
     lazy val PinClass    = getRequiredClass("scala.scalanative.native.pin")
+    lazy val StubClass   = getRequiredClass("scala.scalanative.native.stub")
 
     lazy val InlineHintClass = getRequiredClass(
       "scala.scalanative.native.inlinehint")

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -132,6 +132,8 @@ trait NirGenStat { self: NirGenPhase =>
         case ann if ann.symbol == LinkClass =>
           val Apply(_, Seq(Literal(Constant(name: String)))) = ann.tree
           Attr.Link(name)
+        case ann if ann.symbol == StubClass =>
+          Attr.Stub
       }
       val pure = if (PureModules.contains(sym)) Seq(Attr.Pure) else Seq()
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -258,6 +258,7 @@ trait NirGenStat { self: NirGenPhase =>
             case ann if ann.symbol == NoInlineClass   => Attr.NoInline
             case ann if ann.symbol == InlineHintClass => Attr.InlineHint
             case ann if ann.symbol == InlineClass     => Attr.AlwaysInline
+            case ann if ann.symbol == StubClass       => Attr.Stub
           }
         }
       }

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -31,6 +31,9 @@ object ScalaNativePlugin extends AutoPlugin {
       taskKey[Seq[String]](
         "Additional options that are passed to clang during linking.")
 
+    val nativeLinkStubs =
+      settingKey[Boolean]("Whether to link `@stub` methods, or ignore them.")
+
     val nativeLink =
       taskKey[File]("Generates native binary without running it.")
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -114,6 +114,8 @@ object ScalaNativePluginInternal {
     },
     nativeLinkingOptions in NativeTest := (nativeLinkingOptions in Test).value,
     nativeMode := "debug",
+    nativeLinkStubs := false,
+    nativeLinkStubs in NativeTest := (nativeLinkStubs in Test).value,
     nativeMode in NativeTest := (nativeMode in Test).value,
     nativeLinkerReporter := tools.LinkerReporter.empty,
     nativeLinkerReporter in NativeTest := (nativeLinkerReporter in Test).value,
@@ -189,6 +191,7 @@ object ScalaNativePluginInternal {
         .withWorkdir(cwd)
         .withTarget(nativeTarget.value)
         .withMode(mode(nativeMode.value))
+        .withLinkStubs(nativeLinkStubs.value)
     },
     nativeUnpackLib := {
       val cwd       = nativeWorkdir.value

--- a/scripted-tests/run/link-stubs/Main.scala
+++ b/scripted-tests/run/link-stubs/Main.scala
@@ -1,0 +1,9 @@
+object Main {
+  def main(args: Array[String]): Unit =
+    Foo.bar
+}
+
+object Foo {
+  @scala.scalanative.native.stub
+  def bar = ???
+}

--- a/scripted-tests/run/link-stubs/Main.scala
+++ b/scripted-tests/run/link-stubs/Main.scala
@@ -4,6 +4,6 @@ object Main {
 }
 
 object Foo {
-  @scala.scalanative.native.stub
+  @scalanative.native.stub
   def bar = ???
 }

--- a/scripted-tests/run/link-stubs/build.sbt
+++ b/scripted-tests/run/link-stubs/build.sbt
@@ -1,0 +1,3 @@
+enablePlugins(ScalaNativePlugin)
+
+scalaVersion := "2.11.11"

--- a/scripted-tests/run/link-stubs/project/scala-native.sbt
+++ b/scripted-tests/run/link-stubs/project/scala-native.sbt
@@ -1,0 +1,8 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scala-native" % "sbt-scala-native" % pluginVersion)
+}

--- a/scripted-tests/run/link-stubs/test
+++ b/scripted-tests/run/link-stubs/test
@@ -1,0 +1,3 @@
+-> nativeLink
+> set nativeLinkStubs := true
+> nativeLink

--- a/tools/src/main/scala/scala/scalanative/linker/Linker.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Linker.scala
@@ -50,11 +50,17 @@ object Linker {
               !unresolved.contains(workitem)) {
 
             load(workitem)
-              .filter(config.linkStubs || !_._4.attrs.isStub)
               .fold[Unit] {
                 unresolved += workitem
                 onUnresolved(workitem)
               } {
+                // If this definition is a stub, and linking stubs is disabled,
+                // then add this element to the `unresolved` items.
+                case (_, _, _, defn)
+                    if defn.attrs.isStub && !config.linkStubs =>
+                  unresolved += workitem
+                  onUnresolved(workitem)
+
                 case (deps, newlinks, newsignatures, defn) =>
                   resolved += workitem
                   defns += defn

--- a/tools/src/main/scala/scala/scalanative/nir/parser/Attr.scala
+++ b/tools/src/main/scala/scala/scalanative/nir/parser/Attr.scala
@@ -14,6 +14,7 @@ object Attr extends Base[nir.Attr] {
   val NoInline     = P("noinline".! map (_ => nir.Attr.NoInline))
   val AlwaysInline = P("alwaysinline".! map (_ => nir.Attr.AlwaysInline))
   val Dyn          = P("dyn".! map (_ => nir.Attr.Dyn))
+  val Stub         = P("stub".! map (_ => nir.Attr.Stub))
   val Align        = P(("align(" ~ int ~ ")") map (nir.Attr.Align(_)))
   val Pure         = P("pure".! map (_ => nir.Attr.Pure))
   val Extern       = P("extern".! map (_ => nir.Attr.Extern))
@@ -28,6 +29,6 @@ object Attr extends Base[nir.Attr] {
   val PinWeak = P("pin-weak(" ~ Global.parser ~ ")" map (nir.Attr.PinWeak(_)))
 
   override val parser: P[nir.Attr] =
-    MayInline | InlineHint | NoInline | AlwaysInline | Dyn | Align | Pure | Extern | Override | Link | PinAlways | PinIf | PinWeak
+    MayInline | InlineHint | NoInline | AlwaysInline | Dyn | Stub | Align | Pure | Extern | Override | Link | PinAlways | PinIf | PinWeak
 
 }

--- a/tools/src/main/scala/scala/scalanative/tools/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/tools/Config.scala
@@ -21,6 +21,9 @@ sealed trait Config {
   /** Compilation mode. */
   def mode: Mode
 
+  /** Should stubs be linked? */
+  def linkStubs: Boolean
+
   /** Create new config with given entry point. */
   def withEntry(value: Global): Config
 
@@ -35,6 +38,9 @@ sealed trait Config {
 
   /** Create a new config with given compilation mode. */
   def withMode(value: Mode): Config
+
+  /** Create a new config with given behavior for stubs. */
+  def withLinkStubs(value: Boolean): Config
 }
 
 object Config {
@@ -45,13 +51,15 @@ object Config {
          paths = Seq.empty,
          workdir = new File(""),
          target = "",
-         mode = Mode.Debug)
+         mode = Mode.Debug,
+         linkStubs = false)
 
   private final case class Impl(entry: Global,
                                 paths: Seq[File],
                                 workdir: File,
                                 target: String,
-                                mode: Mode)
+                                mode: Mode,
+                                linkStubs: Boolean)
       extends Config {
     def withEntry(value: Global): Config =
       copy(entry = value)
@@ -67,5 +75,8 @@ object Config {
 
     def withMode(value: Mode): Config =
       copy(mode = value)
+
+    def withLinkStubs(value: Boolean): Config =
+      copy(linkStubs = value)
   }
 }

--- a/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
@@ -21,7 +21,7 @@ abstract class OptimizerSpec extends LinkerSpec {
                   sources: Map[String, String],
                   driver: Option[Driver] = None)(
       fn: (Config, Seq[nir.Attr.Link], Seq[nir.Defn]) => T): T =
-    link(entry, sources, driver) {
+    link(entry, sources, driver = driver) {
       case (config, res) =>
         val driver_ = driver.fold(Driver(config))(identity)
         fn(config,

--- a/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
@@ -5,16 +5,26 @@ import nir.Global.Top
 
 class StubSpec extends LinkerSpec {
 
-  val entry  = "Main$"
-  val source = """object Main {
-                 |  def main(args: Array[String]): Unit =
-                 |    stubMethod
-                 |  @scala.scalanative.native.stub
-                 |  def stubMethod: Int = ???
-                 |}""".stripMargin
+  val entry            = "Main$"
+  val stubMethodSource = """object Main {
+                           |  def main(args: Array[String]): Unit =
+                           |    stubMethod
+                           |  @scala.scalanative.native.stub
+                           |  def stubMethod: Int = ???
+                           |}""".stripMargin
+  val stubClassSource  = """@scalanative.native.stub class StubClass
+                          |object Main {
+                          |  def main(args: Array[String]): Unit =
+                          |    new StubClass
+                          |}""".stripMargin
+  val stubModuleSource = """@scalanative.native.stub object StubModule
+                           |object Main {
+                           |  def main(args: Array[String]): Unit =
+                           |    StubModule
+                           |}""".stripMargin
 
-  "Stubs" should "be ignored by the linker when `linkStubs = false`" in {
-    link(entry, source, linkStubs = false) { (cfg, result) =>
+  "Stub methods" should "be ignored by the linker when `linkStubs = false`" in {
+    link(entry, stubMethodSource, linkStubs = false) { (cfg, result) =>
       assert(!cfg.linkStubs)
       assert(result.unresolved.length == 1)
       assert(result.unresolved.head == Top("Main$").member("stubMethod_i32"))
@@ -22,7 +32,37 @@ class StubSpec extends LinkerSpec {
   }
 
   it should "be included when `linkStubs = true`" in {
-    link(entry, source, linkStubs = true) { (cfg, result) =>
+    link(entry, stubMethodSource, linkStubs = true) { (cfg, result) =>
+      assert(cfg.linkStubs)
+      assert(result.unresolved.isEmpty)
+    }
+  }
+
+  "Stub classes" should "be ignored by the linker when `linkStubs = false`" in {
+    link(entry, stubClassSource, linkStubs = false) { (cfg, result) =>
+      assert(!cfg.linkStubs)
+      assert(result.unresolved.length == 1)
+      assert(result.unresolved.head == Top("StubClass"))
+    }
+  }
+
+  it should "be included when `linkStubs = true`" in {
+    link(entry, stubClassSource, linkStubs = true) { (cfg, result) =>
+      assert(cfg.linkStubs)
+      assert(result.unresolved.isEmpty)
+    }
+  }
+
+  "Stub modules" should "be ignored by the linker when `linkStubs = false`" in {
+    link(entry, stubModuleSource, linkStubs = false) { (cfg, result) =>
+      assert(!cfg.linkStubs)
+      assert(result.unresolved.length == 1)
+      assert(result.unresolved.head == Top("StubModule$"))
+    }
+  }
+
+  it should "be included when `linkStubs = true`" in {
+    link(entry, stubModuleSource, linkStubs = true) { (cfg, result) =>
       assert(cfg.linkStubs)
       assert(result.unresolved.isEmpty)
     }

--- a/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
@@ -1,0 +1,31 @@
+package scala.scalanative
+package linker
+
+import nir.Global.Top
+
+class StubSpec extends LinkerSpec {
+
+  val entry  = "Main$"
+  val source = """object Main {
+                 |  def main(args: Array[String]): Unit =
+                 |    stubMethod
+                 |  @scala.scalanative.native.stub
+                 |  def stubMethod: Int = ???
+                 |}""".stripMargin
+
+  "Stubs" should "be ignored by the linker when `linkStubs = false`" in {
+    link(entry, source, linkStubs = false) { (cfg, result) =>
+      assert(!cfg.linkStubs)
+      assert(result.unresolved.length == 1)
+      assert(result.unresolved.head == Top("Main$").member("stubMethod_i32"))
+    }
+  }
+
+  it should "be included when `linkStubs = true`" in {
+    link(entry, source, linkStubs = true) { (cfg, result) =>
+      assert(cfg.linkStubs)
+      assert(result.unresolved.isEmpty)
+    }
+  }
+
+}

--- a/tools/src/test/scala/scala/scalanative/nir/AttrParserTest.scala
+++ b/tools/src/test/scala/scala/scalanative/nir/AttrParserTest.scala
@@ -16,6 +16,7 @@ class AttrParserTest extends FlatSpec with Matchers {
       NoInline,
       AlwaysInline,
       Dyn,
+      Stub,
       Align(1024),
       Pure,
       Extern,


### PR DESCRIPTION
By default, method marked with `@stub` will not link.

Fixes #971.