### PR TITLE
Short-circuit virtual dispatch for == and ##

### DIFF
--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -32,11 +32,19 @@ class _Object {
   @inline def __wait(timeout: scala.Long, nanos: Int): Unit =
     runtime.getMonitor(this)._wait(timeout, nanos)
 
-  @inline def __scala_==(other: _Object): scala.Boolean =
+  @inline def __scala_==(other: _Object): scala.Boolean = {
+    // This implementation is never called as we short-circuit
+    // the virtual dispatch to go directly to the equals implementation
+    // for the reference types in the optimizer. We provide it here for clarity.
     __equals(other)
+  }
 
-  @inline def __scala_## : scala.Int =
+  @inline def __scala_## : scala.Int = {
+    // This implementation is never called as we short-circuit
+    // the virtual dispatch to go directly to the hashCode implementation
+    // for the reference types in the optimizer. We provide it here for clarity.
     __hashCode
+  }
 
   protected def __clone(): _Object = {
     val ty    = runtime.getType(this)

--- a/tools/src/main/scala/scala/scalanative/optimizer/analysis/ClassHierarchy.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/analysis/ClassHierarchy.scala
@@ -200,6 +200,11 @@ object ClassHierarchy {
                       dyns = dyns)
     top.members ++= nodes.values
 
+    val javaEquals    = nodes(javaEqualsName).asInstanceOf[Method]
+    val javaHashCode  = nodes(javaHashCodeName).asInstanceOf[Method]
+    val scalaEquals   = nodes(scalaEqualsName).asInstanceOf[Method]
+    val scalaHashCode = nodes(scalaHashCodeName).asInstanceOf[Method]
+
     def assignMethodIds(): Unit = {
       var id = 0
       traits.foreach { trt =>
@@ -282,7 +287,11 @@ object ClassHierarchy {
     }
 
     def completeClassMembers(): Unit = top.classes.foreach { cls =>
-      cls.vtable = new VirtualTable(cls)
+      cls.vtable = new VirtualTable(cls,
+                                    javaEquals,
+                                    javaHashCode,
+                                    scalaEquals,
+                                    scalaHashCode)
       cls.layout = new FieldLayout(cls)
       cls.dynmap = new DynamicHashMap(cls, dyns)
       cls.rtti = new RuntimeTypeInformation(cls)
@@ -305,4 +314,17 @@ object ClassHierarchy {
 
     top
   }
+
+  val javaEqualsName =
+    Global.Member(Global.Top("java.lang.Object"),
+                  "equals_java.lang.Object_bool")
+  val javaHashCodeName =
+    Global.Member(Global.Top("java.lang.Object"), "hashCode_i32")
+  val scalaEqualsName =
+    Global.Member(Global.Top("java.lang.Object"),
+                  "scala$underscore$==_java.lang.Object_bool")
+  val scalaHashCodeName =
+    Global.Member(Global.Top("java.lang.Object"), "scala$underscore$##_i32")
+  def depends =
+    Seq(javaEqualsName, javaHashCodeName, scalaEqualsName, scalaHashCodeName)
 }

--- a/tools/src/main/scala/scala/scalanative/optimizer/analysis/VirtualTable.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/analysis/VirtualTable.scala
@@ -6,32 +6,66 @@ import scala.collection.mutable
 import ClassHierarchy._
 import nir._
 
-class VirtualTable(cls: Class) {
-  val entries: mutable.UnrolledBuffer[Method] =
+class VirtualTable(cls: Class,
+                   javaEquals: Method,
+                   javaHashCode: Method,
+                   scalaEquals: Method,
+                   scalaHashCode: Method) {
+  private val entries: mutable.UnrolledBuffer[Method] =
     cls.parent.fold {
       mutable.UnrolledBuffer.empty[Method]
     } { parent =>
       parent.vtable.entries.clone
     }
-  val values: mutable.UnrolledBuffer[Val] =
+  private val values: mutable.UnrolledBuffer[Val] =
     cls.parent.fold {
       mutable.UnrolledBuffer.empty[Val]
     } { parent =>
       parent.vtable.values.clone
     }
-  cls.methods.foreach { meth =>
-    meth.overrides
-      .collect {
-        case ovmeth if ovmeth.inClass =>
-          values(index(ovmeth)) = meth.value
-      }
-      .headOption
-      .getOrElse {
-        if (meth.isVirtual) {
-          entries += meth
-          values += meth.value
+  locally {
+    // Go through all methods and update vtable entries and values
+    // according to override annotations. Additionally, discover
+    // if Java's hashCode/equals and Scala's ==/## are overriden.
+    var javaEqualsOverride: Option[Val]    = None
+    var javaHashCodeOverride: Option[Val]  = None
+    var scalaEqualsOverride: Option[Val]   = None
+    var scalaHashCodeOverride: Option[Val] = None
+    cls.methods.foreach { meth =>
+      meth.overrides
+        .collect {
+          case ovmeth if ovmeth.inClass =>
+            values(index(ovmeth)) = meth.value
+            if (ovmeth eq javaEquals) {
+              javaEqualsOverride = Some(meth.value)
+            }
+            if (ovmeth eq javaHashCode) {
+              javaHashCodeOverride = Some(meth.value)
+            }
+            if (ovmeth eq scalaEquals) {
+              scalaEqualsOverride = Some(meth.value)
+            }
+            if (ovmeth eq scalaHashCode) {
+              scalaHashCodeOverride = Some(meth.value)
+            }
         }
-      }
+        .headOption
+        .getOrElse {
+          if (meth.isVirtual) {
+            entries += meth
+            values += meth.value
+          }
+        }
+    }
+    // We short-circuit scala_== and scala_## to immeditately point to the
+    // equals and hashCode implementation for the reference types to avoid
+    // double virtual dispatch overhead.
+    if (javaEqualsOverride.nonEmpty && scalaEqualsOverride.isEmpty) {
+      values(index(scalaEquals)) = javaEqualsOverride.get
+    }
+    if (javaHashCodeOverride.nonEmpty && scalaHashCodeOverride.isEmpty) {
+      values(index(scalaHashCode)) = javaHashCodeOverride.get
+    }
   }
   val ty: Type =
     Type.Array(Type.Ptr, values.length)

--- a/tools/src/main/scala/scala/scalanative/tools/package.scala
+++ b/tools/src/main/scala/scala/scalanative/tools/package.scala
@@ -35,12 +35,16 @@ package object tools {
   type OptimizerReporter = optimizer.Reporter
   val OptimizerReporter = optimizer.Reporter
 
-  /** Given the classpath and main entry point, link under closed-world assumption. */
+  /** Given the classpath and main entry point, link under closed-world
+   *  assumption.
+   */
   def link(config: Config,
            driver: OptimizerDriver,
            reporter: LinkerReporter = LinkerReporter.empty): LinkerResult = {
-    val deps    = driver.passes.flatMap(_.depends).distinct
-    val injects = driver.passes.flatMap(_.injects).distinct
+    val chaDeps  = optimizer.analysis.ClassHierarchy.depends
+    val passDeps = driver.passes.flatMap(_.depends).distinct
+    val deps     = (chaDeps ++ passDeps).distinct
+    val injects  = driver.passes.flatMap(_.injects)
     val entry =
       nir.Global
         .Member(config.entry, "main_scala.scalanative.runtime.ObjectArray_unit")
@@ -50,6 +54,9 @@ package object tools {
     result.withDefns(result.defns ++ injects)
   }
 
+  /** Link just the given entries, disregarding the extra ones that are
+   *  needed for the optimizer and/or codegen.
+   */
   def linkRaw(config: Config,
               entries: Seq[Global],
               reporter: LinkerReporter = LinkerReporter.empty): LinkerResult =


### PR DESCRIPTION
Previously we would do two virtual calls to perform ==/##
on reference types: one to dispatch to scala_==/scala_##
method on java.lang.Object and second one to find concrete
equals/hashCode implementation.

Instead, we short-circuit the scala_== and scala_## to immediately
pick the implementation for the equals and hashCode.