### PR TITLE
Fix #867: Support `scala.util.Properties`

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -209,6 +209,8 @@ trait NirDefinitions { self: NirGlobalAddons =>
     lazy val InlineClass      = getRequiredClass("scala.inline")
     lazy val NoInlineClass    = getRequiredClass("scala.noinline")
     lazy val EnumerationClass = getRequiredClass("scala.Enumeration")
+    lazy val PropertiesTrait  = getRequiredClass("scala.util.PropertiesTrait")
+    lazy val JavaProperties   = getRequiredClass("java.util.Properties")
 
     lazy val StringConcatMethod = getMember(StringClass, TermName("concat"))
 

--- a/unit-tests/src/test/scala/scala/util/PropertiesSuite.scala
+++ b/unit-tests/src/test/scala/scala/util/PropertiesSuite.scala
@@ -1,0 +1,15 @@
+package scala.util
+
+object PropertiesSuite extends tests.Suite {
+  test("Properties.releaseVersion") {
+    assert(Properties.releaseVersion != null)
+  }
+
+  test("Properties.versionNumberString") {
+    assert(Properties.versionNumberString != null)
+  }
+
+  test("Properties.copyrightString") {
+    assert(Properties.copyrightString != null)
+  }
+}


### PR DESCRIPTION
`scala.util.Properties` works by reading the resource
`/library.properties` using `getResourceAsStream`, which we don't
support. To be able to use `scala.util.Properties`, we rewrite the lhs
of `lazy val scalaProps` (where the resource is read), so that we return
a pre-populated `java.util.Properties` instance if the resource to read
is `/library.properties`. The original implementation is used otherwise.

The content of `scala.util.Properties` that is returned is the same as
the one that was available when the `scalalib` was compiled.

Fixes #867