### PR TITLE
Avoid virtual dispatch in default == and ##

### DIFF
--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -32,18 +32,18 @@ class _Object {
   @inline def __wait(timeout: scala.Long, nanos: Int): Unit =
     runtime.getMonitor(this)._wait(timeout, nanos)
 
-  @inline def __scala_==(other: _Object): scala.Boolean = {
-    // This implementation is never called as we short-circuit
-    // the virtual dispatch to go directly to the equals implementation
-    // for the reference types in the optimizer. We provide it here for clarity.
-    __equals(other)
+  @inline def __scala_==(that: _Object): scala.Boolean = {
+    // This implementation is only called for classes that don't override
+    // equals. Otherwise, whenever equals is overriden, we also update the
+    // vtable entry for scala_== to point to the override directly.
+    this eq that
   }
 
   @inline def __scala_## : scala.Int = {
-    // This implementation is never called as we short-circuit
-    // the virtual dispatch to go directly to the hashCode implementation
-    // for the reference types in the optimizer. We provide it here for clarity.
-    __hashCode
+    // This implementation is only called for classes that don't override
+    // hashCode. Otherwise, whenever hashCode is overriden, we also update the
+    // vtable entry for scala_## to point to the override directly.
+    this.cast[Word].hashCode
   }
 
   protected def __clone(): _Object = {

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -42,7 +42,7 @@ class _Object {
   }
 
   @inline def __scala_## : scala.Int = {
-    // This implementation is only called for lasses that don't override
+    // This implementation is only called for classes that don't override
     // hashCode. Otherwise, whenever hashCode is overriden, we also update the
     // vtable entry for scala_## to point to the override directly.
     val addr = this.cast[Word]

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -8,8 +8,10 @@ class _Object {
   @inline def __equals(that: _Object): scala.Boolean =
     this eq that
 
-  @inline def __hashCode(): scala.Int =
-    this.cast[Word].hashCode
+  @inline def __hashCode(): scala.Int = {
+    val addr = this.cast[Word]
+    addr.toInt ^ (addr >> 32).toInt
+  }
 
   @inline def __toString(): String =
     getClass.getName + "@" + Integer.toHexString(hashCode)
@@ -40,10 +42,11 @@ class _Object {
   }
 
   @inline def __scala_## : scala.Int = {
-    // This implementation is only called for classes that don't override
+    // This implementation is only called for lasses that don't override
     // hashCode. Otherwise, whenever hashCode is overriden, we also update the
     // vtable entry for scala_## to point to the override directly.
-    this.cast[Word].hashCode
+    val addr = this.cast[Word]
+    addr.toInt ^ (addr >> 32).toInt
   }
 
   protected def __clone(): _Object = {


### PR DESCRIPTION
Previously, we introduced a peephole optimization to short-circuit the
lookup of scala_== and scala_## to point to the overriden equals and
hashCode directly.

The default implementation, on the other hand still has had a problem of
performing double virtual dispatch. This change addresses the problem by
manually inlining the identity-based equality and hash code.

Additionally we also inline hashCode for longs to avoid box allocation.

Review @Duhemm 