### PR TITLE
Fix #817: Maintain a fixed-size cache of compiled RE2 patterns to replace the finalize method

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -141,7 +141,7 @@ final class Matcher private[regex] (var _pattern: Pattern,
       toRE2String(inputSequence.toString, textAndTarget)
       toRE2String(replacement, rewrite)
 
-      withRE2Regex{ re2 =>
+      withRE2Regex { re2 =>
         val regex = re2.ptr
         if (global) cre2.globalReplace(regex, textAndTarget, rewrite)
         else cre2.replace(regex, textAndTarget, rewrite)

--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -30,14 +30,17 @@ final class Matcher private[regex] (var _pattern: Pattern,
                                     var inputSequence: CharSequence)
     extends MatchResult {
 
-  private val regex = _pattern.regex
+  private def withRE2Regex[A](f: RE2RegExpOps => A): A =
+    _pattern.withRE2Regex(f)
 
   private var hasMatch  = false
   private var hasGroups = false
   private var appendPos = 0
 
-  private var groups =
+  private var groups = withRE2Regex { re2op =>
+    val regex = re2op.ptr
     Array.ofDim[(Int, Int)](cre2.numCapturingGroups(regex) + 1)
+  }
 
   private var lastAnchor: Option[cre2.anchor_t] = None
 
@@ -75,16 +78,19 @@ final class Matcher private[regex] (var _pattern: Pattern,
       val startpos = instr.take(start).getBytes().length
       val endpos   = instr.take(end).getBytes().length
 
-      val ok = cre2.matches(
-        regex = regex,
-        text = inre2.data,
-        textlen = inre2.length,
-        startpos = startpos,
-        endpos = endpos,
-        anchor = anchor,
-        matches = matches,
-        nMatches = nMatches
-      ) == 1
+      val ok = withRE2Regex { re2 =>
+        val regex = re2.ptr
+        cre2.matches(
+          regex = regex,
+          text = inre2.data,
+          textlen = inre2.length,
+          startpos = startpos,
+          endpos = endpos,
+          anchor = anchor,
+          matches = matches,
+          nMatches = nMatches
+        ) == 1
+      }
 
       if (ok) {
         var i = 0
@@ -135,8 +141,11 @@ final class Matcher private[regex] (var _pattern: Pattern,
       toRE2String(inputSequence.toString, textAndTarget)
       toRE2String(replacement, rewrite)
 
-      if (global) cre2.globalReplace(regex, textAndTarget, rewrite)
-      else cre2.replace(regex, textAndTarget, rewrite)
+      withRE2Regex{ re2 =>
+        val regex = re2.ptr
+        if (global) cre2.globalReplace(regex, textAndTarget, rewrite)
+        else cre2.replace(regex, textAndTarget, rewrite)
+      }
 
       val res = fromRE2String(textAndTarget)
 
@@ -160,7 +169,10 @@ final class Matcher private[regex] (var _pattern: Pattern,
 
   private def groupIndex(name: String): Int =
     Zone { implicit z =>
-      val pos = cre2.findNamedCapturingGroups(regex, toCString(name))
+      val pos = withRE2Regex { re2 =>
+        val regex = re2.ptr
+        cre2.findNamedCapturingGroups(regex, toCString(name))
+      }
       if (pos == -1) {
         throw new IllegalArgumentException(s"No group with name <$name>")
       }

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -19,10 +19,7 @@ object Pattern {
 
   def compile(regex: String): Pattern = compile(regex, 0)
 
-  def compile(regex: String, flags: Int): Pattern =
-    compile(regex, 0, adapt = true)
-
-  def compile(regex: String, flags: Int, adapt: Boolean): Pattern = Zone {
+  def compile(regex: String, flags: Int): Pattern = Zone {
     implicit z =>
       def notSupported(flag: Int, flagName: String): Unit = {
         if ((flags & flag) == flag) {
@@ -117,10 +114,6 @@ object Pattern {
       val res = fromRE2String(quoted)
       res
     }
-
-  def adaptPatternToRe2(regex: String): String = {
-    regex
-  }
 }
 
 final class Pattern private[regex] (

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -19,88 +19,14 @@ object Pattern {
 
   def compile(regex: String): Pattern = compile(regex, 0)
 
-  def compile(regex: String, flags: Int): Pattern = Zone {
-    implicit z =>
-      def notSupported(flag: Int, flagName: String): Unit = {
-        if ((flags & flag) == flag) {
-          assert(false, s"regex flag $flagName is not supported")
-        }
-      }
+  def compile(regex: String, flags: Int): Pattern = {
+    // make sure the provided regex is compiled
+    CompiledPatternStore.get(regex, flags)
 
-      notSupported(CANON_EQ, "CANON_EQ(canonical equivalences)")
-      notSupported(COMMENTS, "COMMENTS")
-      notSupported(UNICODE_CASE, "UNICODE_CASE")
-      notSupported(UNICODE_CHARACTER_CLASS, "UNICODE_CHARACTER_CLASS")
-      notSupported(UNIX_LINES, "UNIX_LINES")
-
-      val options = cre2.optNew()
-      cre2.setCaseSensitive(options, flags & CASE_INSENSITIVE)
-      cre2.setDotNl(options, flags & DOTALL)
-      cre2.setLiteral(options, flags & LITERAL)
-      cre2.setLogErrors(options, 0)
-
-      // setOneLine(false) is only available when limiting ourself to posix_syntax
-      // https://github.com/google/re2/blob/2017-03-01/re2/re2.h#L548
-      // regex flag MULTILINE cannot be disabled
-
-      val re2 = {
-        val regexre2 = alloc[cre2.string_t]
-        toRE2String(regex, regexre2)
-        cre2.compile(regexre2.data, regexre2.length, options)
-      }
-
-      val code = cre2.errorCode(re2)
-
-      if (code != ERROR_NO_ERROR) {
-        val errorPattern = {
-          val arg = stackalloc[cre2.string_t]
-          cre2.errorArg(re2, arg)
-          fromRE2String(arg)
-        }
-
-        // we try to find the index of the parsing error
-        // this could return the wrong index it only finds the first match
-        // see https://groups.google.com/forum/#!topic/re2-dev/rnvFZ9Ki8nk
-        val index =
-          if (code == ERROR_TRAILING_BACKSLASH) regex.size - 1
-          else regex.indexOfSlice(errorPattern)
-
-        val reText = fromCString(cre2.errorString(re2))
-
-        val description =
-          code match {
-            case ERROR_INTERNAL           => "Internal Error"
-            case ERROR_BAD_ESCAPE         => "Illegal/unsupported escape sequence"
-            case ERROR_BAD_CHAR_CLASS     => "Illegal/unsupported character class"
-            case ERROR_BAD_CHAR_RANGE     => "Illegal character range"
-            case ERROR_MISSING_BRACKET    => "Unclosed character class"
-            case ERROR_MISSING_PAREN      => "Missing parenthesis"
-            case ERROR_TRAILING_BACKSLASH => "Trailing Backslash"
-            case ERROR_REPEAT_ARGUMENT    => "Dangling meta character '*'"
-            case ERROR_REPEAT_SIZE        => "Bad repetition argument"
-            case ERROR_REPEAT_OP          => "Bad repetition operator"
-            case ERROR_BAD_PERL_OP        => "Bad perl operator"
-            case ERROR_BAD_UTF8           => "Invalid UTF-8 in regexp"
-            case ERROR_BAD_NAMED_CAPTURE  => "Bad named capture group"
-            case ERROR_PATTERN_TOO_LARGE =>
-              "Pattern too large (compilation failed)"
-            case _ => reText
-          }
-
-        throw new PatternSyntaxException(
-          description,
-          regex,
-          index
-        )
-      }
-
-      cre2.optDelete(options)
-
-      new Pattern(
-        _pattern = regex,
-        _flags = flags,
-        _regex = re2
-      )
+    new Pattern(
+      _pattern = regex,
+      _flags = flags
+    )
   }
 
   def matches(regex: String, input: CharSequence): Boolean =
@@ -143,20 +69,98 @@ object Pattern {
       next = if (next + 1 >= cache.size) 0 else next + 1
     }
 
-    private def doCompile(regex: String, flags: Int): Ptr[cre2.regexp_t] = {
-      // TODO move Pattern$.compile here
-      ???
+    private def doCompile(regex: String, flags: Int): Ptr[cre2.regexp_t] = Zone { implicit z =>
+      def notSupported(flag: Int, flagName: String): Unit = {
+        if ((flags & flag) == flag) {
+          assert(false, s"regex flag $flagName is not supported")
+        }
+      }
+
+      notSupported(CANON_EQ, "CANON_EQ(canonical equivalences)")
+      notSupported(COMMENTS, "COMMENTS")
+      notSupported(UNICODE_CASE, "UNICODE_CASE")
+      notSupported(UNICODE_CHARACTER_CLASS, "UNICODE_CHARACTER_CLASS")
+      notSupported(UNIX_LINES, "UNIX_LINES")
+
+      val options = cre2.optNew()
+      try {
+        cre2.setCaseSensitive(options, flags & CASE_INSENSITIVE)
+        cre2.setDotNl(options, flags & DOTALL)
+        cre2.setLiteral(options, flags & LITERAL)
+        cre2.setLogErrors(options, 0)
+
+        // setOneLine(false) is only available when limiting ourself to posix_syntax
+        // https://github.com/google/re2/blob/2017-03-01/re2/re2.h#L548
+        // regex flag MULTILINE cannot be disabled
+
+        val re2 = {
+          val regexre2 = alloc[cre2.string_t]
+          toRE2String(regex, regexre2)
+          cre2.compile(regexre2.data, regexre2.length, options)
+        }
+
+        val code = cre2.errorCode(re2)
+
+        if (code != ERROR_NO_ERROR) {
+          val errorPattern = {
+            val arg = alloc[cre2.string_t]
+            cre2.errorArg(re2, arg)
+            fromRE2String(arg)
+          }
+
+          // we try to find the index of the parsing error
+          // this could return the wrong index it only finds the first match
+          // see https://groups.google.com/forum/#!topic/re2-dev/rnvFZ9Ki8nk
+          val index =
+            if (code == ERROR_TRAILING_BACKSLASH) regex.size - 1
+            else regex.indexOfSlice(errorPattern)
+
+          val reText = fromCString(cre2.errorString(re2))
+
+          val description =
+            code match {
+              case ERROR_INTERNAL           => "Internal Error"
+              case ERROR_BAD_ESCAPE         => "Illegal/unsupported escape sequence"
+              case ERROR_BAD_CHAR_CLASS     => "Illegal/unsupported character class"
+              case ERROR_BAD_CHAR_RANGE     => "Illegal character range"
+              case ERROR_MISSING_BRACKET    => "Unclosed character class"
+              case ERROR_MISSING_PAREN      => "Missing parenthesis"
+              case ERROR_TRAILING_BACKSLASH => "Trailing Backslash"
+              case ERROR_REPEAT_ARGUMENT    => "Dangling meta character '*'"
+              case ERROR_REPEAT_SIZE        => "Bad repetition argument"
+              case ERROR_REPEAT_OP          => "Bad repetition operator"
+              case ERROR_BAD_PERL_OP        => "Bad perl operator"
+              case ERROR_BAD_UTF8           => "Invalid UTF-8 in regexp"
+              case ERROR_BAD_NAMED_CAPTURE  => "Bad named capture group"
+              case ERROR_PATTERN_TOO_LARGE =>
+                "Pattern too large (compilation failed)"
+              case _ => reText
+            }
+
+          cre2.delete(re2)
+          throw new PatternSyntaxException(
+            description,
+            regex,
+            index
+          )
+        }
+
+        re2
+      } finally {
+        cre2.optDelete(options)
+      }
     }
   }
 }
 
 final class Pattern private[regex] (
     _pattern: String,
-    _flags: Int,
-    _regex: Ptr[cre2.regexp_t]
+    _flags: Int
 ) {
 
-  private[regex] def regex: Ptr[cre2.regexp_t] = _regex
+  // TODO make this function a loan pattern so that a Ptr is kept alive while in use
+  private[regex] def regex: Ptr[cre2.regexp_t] =
+    Pattern.CompiledPatternStore.get(_pattern, _flags)
 
   def split(input: CharSequence): Array[String] =
     split(input, 0)
@@ -206,10 +210,4 @@ final class Pattern private[regex] (
   def flags: Int                = _flags
   def pattern: String           = _pattern
   override def toString: String = _pattern
-
-  override protected def finalize(): Unit = {
-    // TODO remove
-    super.finalize()
-    cre2.delete(_regex)
-  }
 }

--- a/javalib/src/main/scala/java/util/regex/cre2h.scala
+++ b/javalib/src/main/scala/java/util/regex/cre2h.scala
@@ -59,6 +59,6 @@ object cre2h {
   final val ERROR_PATTERN_TOO_LARGE  = 14
 
   // this trivial wrapper class is needed to avoid compiler crash at nativeOptimizeNIR
-  // a possible instance of #367 or #939
+  // a possible instance of #367
   implicit class RE2RegExpOps(val ptr: Ptr[cre2.regexp_t]) extends AnyVal
 }

--- a/javalib/src/main/scala/java/util/regex/cre2h.scala
+++ b/javalib/src/main/scala/java/util/regex/cre2h.scala
@@ -57,4 +57,8 @@ object cre2h {
   final val ERROR_BAD_UTF8           = 12
   final val ERROR_BAD_NAMED_CAPTURE  = 13
   final val ERROR_PATTERN_TOO_LARGE  = 14
+
+  // this trivial wrapper class is needed to avoid compiler crash at nativeOptimizeNIR
+  // a possible instance of #367 or #939
+  implicit class RE2RegExpOps(val ptr: Ptr[cre2.regexp_t]) extends AnyVal
 }

--- a/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
+++ b/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
@@ -351,6 +351,22 @@ object PatternSuite extends tests.Suite {
     assertEquals(m.group(), input)
   }
 
+  test("compiling a lot of patterns") {
+    val pats = (0 until 200).map(i => Pattern.compile(i.toString))
+    // pick a newer pattern (likely in cache).
+    locally {
+      val pat = pats(198)
+      val m   = pat.matcher("198")
+      assert(m.matches())
+    }
+    // pick an older pattern (likely out of cache).
+    locally {
+      val pat = pats(1)
+      val m   = pat.matcher("1")
+      assert(m.matches())
+    }
+  }
+
   test("syntax exceptions") {
     assertThrowsAnd[PatternSyntaxException](Pattern.compile("foo\\L"))(
       e => {

--- a/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
+++ b/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
@@ -372,6 +372,18 @@ object PatternSuite extends tests.Suite {
     syntax("foo(foo)bar)baz", "Missing parenthesis", 0)
   }
 
+  private val runStressTests = false
+  if (runStressTests) {
+    test("compile should not leak memory") {
+      println("===== AN ENDLESS STRESS TEST INVOKED =====")
+      while (true) {
+        for {
+          pattern <- (1 to 500).map(_.toString)
+        } Pattern.compile(pattern)
+      }
+    }
+  }
+
   private def syntax(pattern: String, description: String, index: Int): Unit = {
     assertThrowsAnd[PatternSyntaxException](Pattern.compile(pattern))(
       e => {

--- a/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
+++ b/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
@@ -372,18 +372,6 @@ object PatternSuite extends tests.Suite {
     syntax("foo(foo)bar)baz", "Missing parenthesis", 0)
   }
 
-  private val runStressTests = false
-  if (runStressTests) {
-    test("compile should not leak memory") {
-      println("===== AN ENDLESS STRESS TEST INVOKED =====")
-      while (true) {
-        for {
-          pattern <- (1 to 500).map(_.toString)
-        } Pattern.compile(pattern)
-      }
-    }
-  }
-
   private def syntax(pattern: String, description: String, index: Int): Unit = {
     assertThrowsAnd[PatternSyntaxException](Pattern.compile(pattern))(
       e => {


### PR DESCRIPTION
Fix: #817 

The singleton object `java.util.regex.Pattern` gets a new "Store" which keeps a fixed-size, FIFO circular storage to cache compiled RE2 patterns. The Store automatically deletes older patterns when needed, eliminating the need for `Pattern.finalize`.