### PR TITLE
Build fails if there are no sources in src/main/scala Fixes #911

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -179,7 +179,7 @@ object ScalaNativePluginInternal {
       val mainClass = selectMainClass.value.getOrElse(
         throw new MessageOnlyException("No main class detected.")
       )
-      val classpath = fullClasspath.value.map(_.data)
+      val classpath = fullClasspath.value.map(_.data).filter(_.exists)
       val entry     = nir.Global.Top(mainClass.toString + "$")
       val cwd       = nativeWorkdir.value
 
@@ -424,7 +424,7 @@ object ScalaNativePluginInternal {
         if (exitCode == 0) None
         else Some("Nonzero exit code: " + exitCode)
 
-      Defaults.toError(message)
+      message.foreach(sys.error)
     },
     nativeMissingDependencies := {
       (nativeExternalDependencies.value.toSet --


### PR DESCRIPTION
**sbt** automatically adds `target/scala-2.11/classes` to the classpath so this fix filters out classpath files that don't exist like when source is empty. Otherwise, the classpath goes into `Config` which goes to `Linker` and ends up in `VirtualDirectory` where it errors. Then the link fails and thus any tests. There is an `EmptyDirectory` but it is not used in this case when constructing a `VirtualDirectory`. That could be an alternative perhaps but it is a much more intrusive change.

The second change is removing a deprecation.