### PR TITLE
Remove `finalize` from File{Input,Output}Stream

### DIFF
--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -19,9 +19,6 @@ class FileInputStream(fd: FileDescriptor) extends InputStream {
   override def close(): Unit =
     fcntl.close(fd.fd)
 
-  override protected def finalize(): Unit =
-    close()
-
   final def getFD: FileDescriptor =
     fd
 

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -15,9 +15,6 @@ class FileOutputStream(fd: FileDescriptor) extends OutputStream {
   override def close(): Unit =
     fcntl.close(fd.fd)
 
-  override protected def finalize(): Unit =
-    close()
-
   final def getFD(): FileDescriptor =
     fd
 


### PR DESCRIPTION
 (mentioned in #817)

They are just failsafes, which call `close()` and do nothing else.

Since finalize hasn't been and will never be supported, it should be safe to remove them.