### PR TITLE
Fix #979: Caching of stack trace elements on MacOS

### DIFF
--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -29,14 +29,14 @@ class Throwable(s: String, private var e: Throwable)
   def fillInStackTrace(): Throwable = {
     val cursor  = stackalloc[scala.Byte](2048)
     val context = stackalloc[scala.Byte](2048)
-    val startIp = stackalloc[CUnsignedLong](1)
+    val ip      = stackalloc[CUnsignedLongLong]
     var buffer  = mutable.ArrayBuffer.empty[StackTraceElement]
 
     unwind.get_context(context)
     unwind.init_local(cursor, context)
     while (unwind.step(cursor) > 0) {
-      unwind.get_proc_start_ip(cursor, startIp)
-      buffer += StackTraceElement.cached(cursor, !startIp)
+      unwind.get_reg(cursor, unwind.UNW_REG_IP, ip)
+      buffer += StackTraceElement.cached(cursor, !ip)
     }
 
     this.stackTrace = buffer.toArray

--- a/nativelib/src/main/resources/unwind.c
+++ b/nativelib/src/main/resources/unwind.c
@@ -18,14 +18,9 @@ int scalanative_unwind_get_proc_name(void *cursor, char *buffer, size_t length,
                              (unw_word_t *)offset);
 }
 
-int scalanative_unwind_get_proc_start_ip(void *cursor, unsigned long *buffer) {
-    unw_proc_info_t pip;
-    int result = unw_get_proc_info((unw_cursor_t *)cursor, &pip);
-
-    if (result == 0) {
-        *buffer = pip.start_ip;
-        return 0;
-    } else {
-        return result;
-    }
+int scalanative_unwind_get_reg(void *cursor, int regnum,
+                               unsigned long long *valp) {
+    return unw_get_reg((unw_cursor_t *)cursor, regnum, (unw_word_t *)valp);
 }
+
+int scalanative_UNW_REG_IP() { return UNW_REG_IP; }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
@@ -16,7 +16,11 @@ object unwind {
                     buffer: CString,
                     length: CSize,
                     offset: Ptr[Byte]): CInt = extern
-  @name("scalanative_unwind_get_proc_start_ip")
-  def get_proc_start_ip(cursor: Ptr[Byte], buffer: Ptr[CUnsignedLong]): CInt =
-    extern
+  @name("scalanative_unwind_get_reg")
+  def get_reg(cursor: Ptr[Byte],
+              reg: CInt,
+              valp: Ptr[CUnsignedLongLong]): CInt = extern
+
+  @name("scalanative_UNW_REG_IP")
+  def UNW_REG_IP: CInt = extern
 }


### PR DESCRIPTION
To avoid re-computing all stack trace elements for every exception, we
cache the stack traces. Previously, we were using the address of the
first instruction of a function as a key to retrieve the corresponding
stack trace element. It turns out, however, that retrieving this
information doesn't work as expected on MacOS, which was the cause for
issue #979.

Fortunately, we can also use the current instruction pointer inside each
stack frame as key to get the same effect. This information can be
queried using libunwind and gives consistent results on MacOS and on
Linux.

Fixes #979