### PR TITLE
Using == to compare with null must not call equals

### DIFF
--- a/unit-tests/src/test/scala/scala/EqualitySuite.scala
+++ b/unit-tests/src/test/scala/scala/EqualitySuite.scala
@@ -20,4 +20,19 @@ object EqualitySuite extends tests.Suite {
     val obj = new Object
     assert(obj != (null: Object))
   }
+
+  test("== null doesn't call equals") {
+    var equalsCalled = false
+    val obj = new Object {
+      override def equals(other: Any) = {
+        equalsCalled = true
+        other.asInstanceOf[AnyRef] eq this
+      }
+    }
+    assert(obj != null)
+    assert(!equalsCalled)
+    val iamnull: Any = null
+    assert(obj != iamnull)
+    assert(equalsCalled)
+  }
 }


### PR DESCRIPTION
This a semantics-affecting "optimization" that's done by scalac, we must
also replicate it for correctness.

Review @sjrd