### PR TITLE
Cache primitive numeric boxes

### DIFF
--- a/javalib/src/main/scala/java/lang/Byte.scala
+++ b/javalib/src/main/scala/java/lang/Byte.scala
@@ -225,12 +225,27 @@ object Byte {
   @inline def toUnsignedLong(x: scala.Byte): scala.Long =
     byteToULong(x)
 
-  @inline def valueOf(byteValue: scala.Byte): Byte =
-    new Byte(byteValue)
+  import ByteCache.cache
+
+  @inline def valueOf(byteValue: scala.Byte): Byte = {
+    val idx    = byteValue - MIN_VALUE
+    val cached = cache(idx)
+    if (cached != null) {
+      cached
+    } else {
+      val newbyte = new Byte(byteValue)
+      cache(idx) = newbyte
+      newbyte
+    }
+  }
 
   @inline def valueOf(s: String): Byte =
     valueOf(parseByte(s))
 
   @inline def valueOf(s: String, radix: scala.Int): Byte =
     valueOf(parseByte(s, radix))
+}
+
+private[lang] object ByteCache {
+  private[lang] val cache = new Array[java.lang.Byte](256)
 }

--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -1111,7 +1111,23 @@ object Character {
 
   def hashCode(value: scala.Char): scala.Int = value
 
-  def valueOf(charValue: scala.Char): Character = new Character(charValue)
+  import CharacterCache.cache
+
+  def valueOf(charValue: scala.Char): Character = {
+    if (charValue > 127) {
+      new Character(charValue)
+    } else {
+      val idx    = charValue.toInt
+      val cached = cache(idx)
+      if (cached != null) {
+        cached
+      } else {
+        val newchar = new Character(charValue)
+        cache(idx) = newchar
+        newchar
+      }
+    }
+  }
 
   def getType(ch: scala.Char): Int = getType(ch.toInt)
 
@@ -2148,4 +2164,8 @@ object Character {
   // def getNumericValue(c: scala.Char): Int
   // def reverseBytes(ch: scala.Char): scala.Char
   // ...
+}
+
+private[lang] object CharacterCache {
+  private[lang] val cache = new Array[java.lang.Character](128)
 }

--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -564,8 +564,23 @@ object Integer {
   @inline def toUnsignedLong(x: scala.Int): scala.Long =
     intToULong(x)
 
-  @inline def valueOf(i: scala.Int): Integer =
-    new Integer(i)
+  import IntegerCache.cache
+
+  @inline def valueOf(intValue: scala.Int): Integer = {
+    if (intValue.toByte.toInt != intValue) {
+      new Integer(intValue)
+    } else {
+      val idx    = intValue + 128
+      val cached = cache(idx)
+      if (cached != null) {
+        cached
+      } else {
+        val newint = new Integer(intValue)
+        cache(idx) = newint
+        newint
+      }
+    }
+  }
 
   @inline def valueOf(s: String): Integer =
     valueOf(parseInt(s))
@@ -652,4 +667,8 @@ object Integer {
       new String(buffer)
     }
   }
+}
+
+private[lang] object IntegerCache {
+  private[lang] val cache = new Array[java.lang.Integer](256)
 }

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -468,8 +468,23 @@ object Long {
     }
   }
 
-  @inline def valueOf(longValue: scala.Long): Long =
-    new Long(longValue)
+  import LongCache.cache
+
+  @inline def valueOf(longValue: scala.Long): Long = {
+    if (longValue.toByte.toLong != longValue) {
+      new Long(longValue)
+    } else {
+      val idx    = (longValue + 128).toInt
+      val cached = cache(idx)
+      if (cached != null) {
+        cached
+      } else {
+        val newlong = new Long(longValue)
+        cache(idx) = newlong
+        newlong
+      }
+    }
+  }
 
   @inline def valueOf(s: String): Long =
     valueOf(parseLong(s))
@@ -557,5 +572,8 @@ object Long {
       new String(buffer)
     }
   }
+}
 
+private[lang] object LongCache {
+  private[lang] val cache = new Array[java.lang.Long](256)
 }

--- a/javalib/src/main/scala/java/lang/Short.scala
+++ b/javalib/src/main/scala/java/lang/Short.scala
@@ -228,12 +228,33 @@ object Short {
   @inline def toUnsignedLong(x: scala.Short): scala.Long =
     shortToULong(x)
 
-  @inline def valueOf(shortValue: scala.Short): Short =
-    new Short(shortValue)
+  private val cache = new Array[java.lang.Short](256)
+
+  import ShortCache.cache
+
+  @inline def valueOf(shortValue: scala.Short): Short = {
+    if (shortValue.toByte.toShort != shortValue) {
+      new Short(shortValue)
+    } else {
+      val idx    = shortValue + 128
+      val cached = cache(idx)
+      if (cached != null) {
+        cached
+      } else {
+        val newshort = new Short(shortValue)
+        cache(idx) = newshort
+        newshort
+      }
+    }
+  }
 
   @inline def valueOf(s: String): Short =
     valueOf(parseShort(s))
 
   @inline def valueOf(s: String, radix: scala.Int): Short =
     valueOf(parseShort(s, radix))
+}
+
+private[lang] object ShortCache {
+  private[lang] val cache = new Array[java.lang.Short](256)
 }


### PR DESCRIPTION
JavaDoc for valueOf specifies that primitive numeric types must
be boxed in ranges of -128 to 127 for signed primitives and up
to at least 127 for characters.

Review @sjrd