### PR TITLE
Implement j.l.a.RetentionPolicy to fix javalib incremental compilation

### DIFF
--- a/javalib/src/main/scala/java/lang/annotation/RetentionPolicy.scala
+++ b/javalib/src/main/scala/java/lang/annotation/RetentionPolicy.scala
@@ -1,4 +1,19 @@
 package java.lang.annotation
 
-class RetentionPolicy
-    extends java.lang.Enum[RetentionPolicy]("RetentionPolicy", 0)
+final class RetentionPolicy private (name: String, ordinal: Int)
+    extends java.lang.Enum[RetentionPolicy](name, ordinal)
+
+object RetentionPolicy {
+  final val SOURCE  = new RetentionPolicy("SOURCE", 0)
+  final val CLASS   = new RetentionPolicy("CLASS", 1)
+  final val RUNTIME = new RetentionPolicy("RUNTIME", 2)
+
+  def valueOf(name: String): RetentionPolicy =
+    values.find(_.name() == name).getOrElse {
+      throw new IllegalArgumentException(
+        s"No enum constant java.lang.annotation.RetentionPolicy.$name")
+    }
+
+  def values(): Array[RetentionPolicy] =
+    Array(SOURCE, CLASS, RUNTIME)
+}


### PR DESCRIPTION
javalib/compile on sbt caused an error when incrementally compiling.
It seems java.lang.annotation.RetentionPolicy must be absent or have all the enum constants.