### PR TITLE
Revert #944

### DIFF
--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -19,6 +19,9 @@ class FileInputStream(fd: FileDescriptor) extends InputStream {
   override def close(): Unit =
     fcntl.close(fd.fd)
 
+  override protected def finalize(): Unit =
+    close()
+
   final def getFD: FileDescriptor =
     fd
 

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -15,6 +15,9 @@ class FileOutputStream(fd: FileDescriptor) extends OutputStream {
   override def close(): Unit =
     fcntl.close(fd.fd)
 
+  override protected def finalize(): Unit =
+    close()
+
   final def getFD(): FileDescriptor =
     fd
 


### PR DESCRIPTION
We can not remove methods in a point release, due
to binary compatibility constraints. We'll need to reapply
them when 0.4.0 happens.

Review @Duhemm 
/cc @matil019 