### PR TITLE
Fix #892: Files.scala doesn't close files and so keeps files open

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -313,7 +313,7 @@ object Files {
     lines(path, StandardCharsets.UTF_8)
 
   def lines(path: Path, cs: Charset): Stream[String] =
-    newBufferedReader(path, cs).lines()
+    newBufferedReader(path, cs).lines(true)
 
   private def _list(dir: Path): SStream[Path] =
     dir.toFile().list().toStream.map(dir.resolve)

--- a/javalib/src/main/scala/java/nio/file/spi/FileSystemProvider.scala
+++ b/javalib/src/main/scala/java/nio/file/spi/FileSystemProvider.scala
@@ -49,6 +49,8 @@ abstract class FileSystemProvider protected () {
         if (read <= 0) read
         else buffer.get(0) & 0xFF
       }
+      override def close(): Unit =
+        channel.close()
     }
   }
 


### PR DESCRIPTION
Files.copy(source: Path, target: Path, options: Array[CopyOption]) didn't close the source file because the close method of the InputStream returned by FileSystemProvider.newInputStream was empty. I've fixed that issue by overriding it.

Files.lines now closes the file as soon as the end of the returned stream is reached.

I'm not sure why Files.newByteChannel was mentioned in #892. The close method of the returned FileChannel works correctly.