### PR TITLE
Test Thread.sleep(...) and Object.wait(...)

### DIFF
--- a/unit-tests/src/test/scala/java/lang/ThreadSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/ThreadSuite.scala
@@ -73,4 +73,35 @@ object ThreadSuite extends tests.Suite {
     }
   }
 
+  test("wait suspends execution by at least the requested amount") {
+    val mutex            = new Object()
+    val millisecondTests = Seq(0, 1, 5, 100)
+    millisecondTests.foreach { ms =>
+      mutex.synchronized {
+        mutex.wait(ms)
+      }
+    }
+    millisecondTests.foreach { ms =>
+      mutex.synchronized {
+        mutex.wait(ms, 0)
+      }
+    }
+
+    val tests = Seq(0 -> 0,
+                    0   -> 1,
+                    0   -> 999999,
+                    1   -> 0,
+                    1   -> 1,
+                    5   -> 0,
+                    100 -> 0,
+                    100 -> 50)
+
+    tests.foreach {
+      case (ms, nanos) =>
+        mutex.synchronized {
+          mutex.wait(ms, nanos)
+        }
+    }
+  }
+
 }

--- a/unit-tests/src/test/scala/java/lang/ThreadSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/ThreadSuite.scala
@@ -45,14 +45,16 @@ object ThreadSuite extends tests.Suite {
 
   test("sleep suspends execution by at least the requested amount") {
     val millisecondTests = Seq(0, 1, 5, 100)
-    millisecondTests.foreach(ms =>
+    millisecondTests.foreach { ms =>
       takesAtLeast(ms) {
         Thread.sleep(ms)
-    })
-    millisecondTests.foreach(ms =>
+      }
+    }
+    millisecondTests.foreach { ms =>
       takesAtLeast(ms) {
         Thread.sleep(ms, 0)
-    })
+      }
+    }
 
     val tests = Seq(0 -> 0,
                     0   -> 1,

--- a/unit-tests/src/test/scala/java/lang/ThreadSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/ThreadSuite.scala
@@ -21,4 +21,54 @@ object ThreadSuite extends tests.Suite {
 
   }
 
+  def takesAtLeast[R](expectedDelayMs: scala.Long)(f: => R): R = {
+    val start  = System.currentTimeMillis()
+    val result = f
+    val end    = System.currentTimeMillis()
+
+    assert(end - start >= expectedDelayMs)
+
+    result
+  }
+
+  def takesAtLeast[R](expectedDelayMs: scala.Long,
+                      expectedDelayNanos: scala.Int)(f: => R): R = {
+    val expectedDelay = expectedDelayMs * 1000000 + expectedDelayMs
+    val start         = System.nanoTime()
+    val result        = f
+    val end           = System.nanoTime()
+
+    assert(end - start >= expectedDelay)
+
+    result
+  }
+
+  test("sleep suspends execution by at least the requested amount") {
+    val millisecondTests = Seq(0, 1, 5, 100)
+    millisecondTests.foreach(ms =>
+      takesAtLeast(ms) {
+        Thread.sleep(ms)
+    })
+    millisecondTests.foreach(ms =>
+      takesAtLeast(ms) {
+        Thread.sleep(ms, 0)
+    })
+
+    val tests = Seq(0 -> 0,
+                    0   -> 1,
+                    0   -> 999999,
+                    1   -> 0,
+                    1   -> 1,
+                    5   -> 0,
+                    100 -> 0,
+                    100 -> 50)
+
+    tests.foreach {
+      case (ms, nanos) =>
+        takesAtLeast(ms, nanos) {
+          Thread.sleep(ms, nanos)
+        }
+    }
+  }
+
 }


### PR DESCRIPTION
Making sure `Thread.sleep(ms)`,`Thread.sleep(ms,ns)`,`Object.wait(ms)` and `Object.wait(ms,ns)` actually create a delay. 

Note that I am only checking the lower bound, i.e. it takes **at least** x ms. This what calling theses functions actually guarantees for the programmer. The delay may be greater if, for example, some other process is scheduled or it is waiting on disk. Also it wouldn't be good if the test suite could "randomly" fail.

Testing these first as then I can safely use them to test other things.