### PR TITLE
Fix #1029: java.lang.String.toCase should consider String's offset

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -648,12 +648,12 @@ final class _String()
   private[this] def toCase(locale: Locale, convert: Int => Int): _String = {
     if (count == 0) return this
     val buf = new StringBuilder(count)
-    var i   = 0
-    while (i < count) {
+    var i   = offset
+    while (i < offset + count) {
       val high = value(i)
       i += 1
       if (Character.isHighSurrogate(high)) {
-        if (i < count) {
+        if (i < offset + count) {
           val low = value(i)
           i += 1
           if (Character.isLowSurrogate(low)) {

--- a/unit-tests/src/test/scala/java/lang/StringSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/StringSuite.scala
@@ -168,6 +168,12 @@ object StringSuite extends tests.Suite {
     assert(Character.isHighSurrogate(hChar) equals true)
     assert(hStr.length equals 1)
     assert(hStr.toUpperCase equals hStr)
+    // toUpperCase should consider String's offset
+    assert(
+      "Hi, Scala Native!"
+        .subSequence(4, 16)
+        .toString
+        .toUpperCase equals "SCALA NATIVE")
   }
 
   test("toLowerCase") {
@@ -177,5 +183,11 @@ object StringSuite extends tests.Suite {
     assert("𐐀AAAA".toLowerCase equals "𐐨aaaa")
     assert("AAAA𐐀".toLowerCase equals "aaaa𐐨")
     assert("AA𐐀AA".toLowerCase equals "aa𐐨aa")
+    // toLowerCase should consider String's offset
+    assert(
+      "Hi, Scala Native!"
+        .subSequence(4, 16)
+        .toString
+        .toLowerCase equals "scala native")
   }
 }


### PR DESCRIPTION
The issue #1029 has nothing to do with `Regex` and can be reproduced with the following code.
```scala
/* Expected output:
 *   scala native
 *   SCALA NATIVE
 * Actual output:
 *   hi, scala na
 *   HI, SCALA NA
 */
println("Hi, Scala Native!".subSequence(4, 16).toString.toLowerCase)
println("Hi, Scala Native!".subSequence(4, 16).toString.toUpperCase)
```

I've fixed it and added appropriate tests.