### PR TITLE
Fix #1040: Allow easy switching of GC setting at sbt command line

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -554,7 +554,10 @@ lazy val testInterface =
     .settings(
       name := "test-interface",
       libraryDependencies += "org.scala-sbt"    % "test-interface"   % "1.0",
-      libraryDependencies -= "org.scala-native" %%% "test-interface" % version.value % Test
+      libraryDependencies -= "org.scala-native" %%% "test-interface" % version.value % Test,
+      publishLocal := publishLocal
+        .dependsOn(publishLocal in testInterfaceSerialization)
+        .value
     )
     .enablePlugins(ScalaNativePlugin)
     .dependsOn(testInterfaceSerialization)
@@ -567,7 +570,10 @@ lazy val testInterfaceSerialization =
     .in(file("test-interface-serialization"))
     .settings(
       name := "test-interface-serialization",
-      libraryDependencies -= "org.scala-native" %%% "test-interface" % version.value % Test
+      libraryDependencies -= "org.scala-native" %%% "test-interface" % version.value % Test,
+      publishLocal := publishLocal
+        .dependsOn(publishLocal in testInterfaceSbtDefs)
+        .value
     )
     .dependsOn(testInterfaceSbtDefs)
     .enablePlugins(ScalaNativePlugin)

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -240,8 +240,6 @@ object ScalaNativePluginInternal {
       val cpppaths  = (cwd ** "*.cpp").get.map(_.abs)
       val paths     = cpaths ++ cpppaths
 
-      logger.info(s"Using $gc gc")
-
       // predicate to check if given file path shall be compiled
       // we only include sources of the current gc and exclude
       // all optional dependencies if they are not necessary
@@ -400,7 +398,7 @@ object ScalaNativePluginInternal {
       val paths     = apppaths.map(_.abs) ++ opaths
       val compile   = clangpp.abs +: (flags ++ paths)
 
-      logger.time("Linking native code") {
+      logger.time(s"Linking native code ($gc GC)") {
         logger.running(compile)
         Process(compile, cwd) ! logger
       }

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -125,9 +125,7 @@ object ScalaNativePluginInternal {
     nativeLinkerReporter := tools.LinkerReporter.empty,
     nativeLinkerReporter in NativeTest := (nativeLinkerReporter in Test).value,
     nativeOptimizerReporter := tools.OptimizerReporter.empty,
-    nativeOptimizerReporter in NativeTest := (nativeOptimizerReporter in Test).value,
-    nativeGC := "boehm",
-    nativeGC in NativeTest := (nativeGC in Test).value
+    nativeOptimizerReporter in NativeTest := (nativeOptimizerReporter in Test).value
   )
 
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
@@ -139,7 +137,9 @@ object ScalaNativePluginInternal {
         case Some(_) =>
           ()
       }
-    }
+    },
+    nativeGC := "boehm",
+    nativeGC in NativeTest := (nativeGC in Test).value
   )
 
   lazy val scalaNativeConfigSettings: Seq[Setting[_]] = Seq(
@@ -239,6 +239,8 @@ object ScalaNativePluginInternal {
       val cpaths    = (cwd ** "*.c").get.map(_.abs)
       val cpppaths  = (cwd ** "*.cpp").get.map(_.abs)
       val paths     = cpaths ++ cpppaths
+
+      logger.info(s"Using $gc gc")
 
       // predicate to check if given file path shall be compiled
       // we only include sources of the current gc and exclude


### PR DESCRIPTION
Allows the following at the sbt prompt. `set nativeGC in ThisBuild := "immix"`