### PR TITLE
Thread.start() basic thread support

### DIFF
--- a/unit-tests/src/test/scala/java/lang/ThreadSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/ThreadSuite.scala
@@ -21,4 +21,48 @@ object ThreadSuite extends tests.Suite {
 
   }
 
+  test("Thread should be able to change a shared var") {
+    var shared: Int = 0
+    new Thread(new Runnable {
+      def run(): Unit = {
+        shared = 1
+      }
+    }).start()
+    Thread.sleep(100)
+    assertEquals(shared, 1)
+  }
+
+  test("Thread should be able to change runnable's internal state") {
+    class StatefulRunnable extends Runnable {
+      var internal = 0
+      def run(): Unit = {
+        internal = 1
+      }
+    }
+    val runnable = new StatefulRunnable
+    new Thread(runnable).start()
+    Thread.sleep(100)
+    assertEquals(runnable.internal, 1)
+  }
+
+  test("Thread should be able to call a method") {
+    object hasTwoArgMethod {
+      var timesCalled = 0
+      def call(arg: String, arg2: Int): Unit = {
+        assertEquals("abc", arg)
+        assertEquals(123, arg2)
+        synchronized {
+          timesCalled += 1
+        }
+      }
+    }
+    new Thread(new Runnable {
+      def run(): Unit = {
+        hasTwoArgMethod.call("abc", 123)
+        hasTwoArgMethod.call("abc", 123)
+      }
+    }).start()
+    Thread.sleep(100)
+    assertEquals(hasTwoArgMethod.timesCalled, 2)
+  }
 }


### PR DESCRIPTION
Calling `pthread_create` with a generic function(`callRun`) and provide the `Thread` object as the argument.

I had to use seemingly unsafe casts between `Ptr[scala.Byte]` and `Ptr[Thread]`. However, `pthread_create` definition has pointers to void and it works fine. 

```c
int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
                  void *(*start_routine) (void *), void *arg);
```