### PR TITLE
Fix #693: Can't return CUnsignedInt (UInt) from native method

### DIFF
--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -79,7 +79,7 @@ object Thread {
 
     val secs  = millis / 1000
     val usecs = (millis % 1000) * 1000 + nanos / 1000
-    if (secs > 0 && unistd.sleep(secs.toUInt) != 0) checkErrno()
+    if (secs > 0 && unistd.sleep(secs.toUInt) != 0.toUInt) checkErrno()
     if (usecs > 0 && unistd.usleep(usecs.toUInt) != 0) checkErrno()
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -9,7 +9,7 @@ object unistd {
 
   type off_t = CLongLong
 
-  def sleep(seconds: CUnsignedInt): CInt                          = extern
+  def sleep(seconds: CUnsignedInt): CUnsignedInt                  = extern
   def usleep(usecs: CUnsignedInt): CInt                           = extern
   def unlink(path: CString): CInt                                 = extern
   def access(pathname: CString, mode: CInt): CInt                 = extern


### PR DESCRIPTION
It seems, that returning `CUnsignedInt` isn't the problem. The problem is that integer literals cannot be automatically cast to `UInt`. The following line in java/lang/Thread.scala caused the compilation error mentioned in #693.
```scala
if (secs > 0 && unistd.sleep(secs.toUInt) != 0) checkErrno()
```
Explicitly casting 0 to `UInt` fixes the issue.
```scala
if (secs > 0 && unistd.sleep(secs.toUInt) != 0.toUInt) checkErrno()
```

Should literals be automatically cast to `UInt`? I could implement it, if necessary.