### PR TITLE
Make InetAddress a concrete class instead of abstract

### DIFF
--- a/javalib/src/main/scala/java/net/Inet4Address.scala
+++ b/javalib/src/main/scala/java/net/Inet4Address.scala
@@ -6,25 +6,25 @@ final class Inet4Address private[net] (ipAddress: Array[Byte], host: String)
 
   private[net] def this(ipAddress: Array[Byte]) = this(ipAddress, null)
 
-  def isMulticastAddress(): Boolean =
+  override def isMulticastAddress(): Boolean =
     (ipAddress(0) & 0xF0) == 0xE0
 
-  def isAnyLocalAddress(): Boolean =
+  override def isAnyLocalAddress(): Boolean =
     ipAddress.forall(_ == 0)
 
-  def isLoopbackAddress(): Boolean =
+  override def isLoopbackAddress(): Boolean =
     (ipAddress(0) & 255) == 127
 
-  def isLinkLocalAddress(): Boolean =
+  override def isLinkLocalAddress(): Boolean =
     ((ipAddress(0) & 255) == 169) && ((ipAddress(1) & 255) == 254)
 
-  def isSiteLocalAddress(): Boolean = {
+  override def isSiteLocalAddress(): Boolean = {
     ((ipAddress(0) & 255) == 10) || ((ipAddress(0) & 255) == 172) &&
     (((ipAddress(1) & 255) > 15) && (ipAddress(1) & 255) < 32) ||
     ((ipAddress(0) & 255) == 192) && ((ipAddress(1) & 255) == 168)
   }
 
-  def isMCGlobal(): Boolean = {
+  override def isMCGlobal(): Boolean = {
     if (!isMulticastAddress) return false
 
     val address = InetAddress.bytesToInt(ipAddress, 0)
@@ -36,15 +36,15 @@ final class Inet4Address private[net] (ipAddress: Array[Byte], host: String)
     true
   }
 
-  def isMCNodeLocal(): Boolean = false
+  override def isMCNodeLocal(): Boolean = false
 
-  def isMCLinkLocal(): Boolean =
+  override def isMCLinkLocal(): Boolean =
     InetAddress.bytesToInt(ipAddress, 0) >>> 8 == 0xE00000
 
-  def isMCSiteLocal(): Boolean =
+  override def isMCSiteLocal(): Boolean =
     (InetAddress.bytesToInt(ipAddress, 0) >>> 16) == 0xEFFF
 
-  def isMCOrgLocal(): Boolean = {
+  override def isMCOrgLocal(): Boolean = {
     val prefix = InetAddress.bytesToInt(ipAddress, 0) >>> 16
     prefix >= 0xEFC0 && prefix <= 0xEFC3
   }

--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -13,36 +13,36 @@ final class Inet6Address private[net] (ipAddress: Array[Byte],
 
   def getScopeId(): Int = scopeId
 
-  def isLinkLocalAddress(): Boolean =
+  override def isLinkLocalAddress(): Boolean =
     (ipAddress(0) == -2) && ((ipAddress(1) & 255) >>> 6) == 2
 
-  def isAnyLocalAddress(): Boolean = ipAddress.forall(_ == 0)
+  override def isAnyLocalAddress(): Boolean = ipAddress.forall(_ == 0)
 
-  def isLoopbackAddress(): Boolean = {
+  override def isLoopbackAddress(): Boolean = {
     if (ipAddress(15) != 1)
       return false
 
     ipAddress.dropRight(1).forall(_ == 0)
   }
 
-  def isMCGlobal(): Boolean =
+  override def isMCGlobal(): Boolean =
     (ipAddress(0) == -1) && (ipAddress(1) & 15) == 14
 
-  def isMCLinkLocal(): Boolean =
+  override def isMCLinkLocal(): Boolean =
     (ipAddress(0) == -1) && (ipAddress(1) & 15) == 2
 
-  def isMCNodeLocal(): Boolean =
+  override def isMCNodeLocal(): Boolean =
     (ipAddress(0) == -1) && (ipAddress(1) & 15) == 1
 
-  def isMCOrgLocal(): Boolean =
+  override def isMCOrgLocal(): Boolean =
     (ipAddress(0) == -1) && (ipAddress(1) & 15) == 8
 
-  def isMCSiteLocal(): Boolean =
+  override def isMCSiteLocal(): Boolean =
     (ipAddress(0) == -1) && (ipAddress(1) & 15) == 5
 
-  def isMulticastAddress(): Boolean = ipAddress(0) == -1
+  override def isMulticastAddress(): Boolean = ipAddress(0) == -1
 
-  def isSiteLocalAddress(): Boolean =
+  override def isSiteLocalAddress(): Boolean =
     (ipAddress(0) == -2) && ((ipAddress(1) & 255) >>> 6) == 3
 
   def isIPv4CompatibleAddress(): Boolean = ipAddress.take(12).forall(_ == 0)

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -553,8 +553,8 @@ private[net] trait InetAddressBase {
 
 object InetAddress extends InetAddressBase
 
-abstract class InetAddress private[net] (ipAddress: Array[Byte],
-                                         private var host: String)
+class InetAddress private[net] (ipAddress: Array[Byte],
+                                private var host: String)
     extends Serializable {
   import InetAddress._
 
@@ -604,24 +604,24 @@ abstract class InetAddress private[net] (ipAddress: Array[Byte],
     }
   }
 
-  def isLinkLocalAddress(): Boolean
+  def isLinkLocalAddress(): Boolean = false
 
-  def isAnyLocalAddress(): Boolean
+  def isAnyLocalAddress(): Boolean = false
 
-  def isLoopbackAddress(): Boolean
+  def isLoopbackAddress(): Boolean = false
 
-  def isMCGlobal(): Boolean
+  def isMCGlobal(): Boolean = false
 
-  def isMCLinkLocal(): Boolean
+  def isMCLinkLocal(): Boolean = false
 
-  def isMCNodeLocal(): Boolean
+  def isMCNodeLocal(): Boolean = false
 
-  def isMCOrgLocal(): Boolean
+  def isMCOrgLocal(): Boolean = false
 
-  def isMCSiteLocal(): Boolean
+  def isMCSiteLocal(): Boolean = false
 
-  def isMulticastAddress(): Boolean
+  def isMulticastAddress(): Boolean = false
 
-  def isSiteLocalAddress(): Boolean
+  def isSiteLocalAddress(): Boolean = false
 
 }


### PR DESCRIPTION
Although InetAdress is only intended as a base class for `Inet4Address` and `Inet6Address`, it's supposed to be a concrete class but it's abstract in Scala Native.