### PR TITLE
Fix #1046: Double.parseDouble and and Float.parseFloat throw `NumberFormatException` when given bad data

### DIFF
--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -244,7 +244,7 @@ object Double {
       errno.errno = 0
       val res = stdlib.strtod(cstr, end)
 
-      if (errno.errno == 0) res
+      if (errno.errno == 0 && cstr != !end && string.strlen(!end) == 0) res
       else throw new NumberFormatException(s)
     }
 

--- a/javalib/src/main/scala/java/lang/Float.scala
+++ b/javalib/src/main/scala/java/lang/Float.scala
@@ -238,7 +238,7 @@ object Float {
       errno.errno = 0
       val res = stdlib.strtof(cstr, end)
 
-      if (errno.errno == 0) res
+      if (errno.errno == 0 && cstr != !end && string.strlen(!end) == 0) res
       else throw new NumberFormatException(s)
     }
 

--- a/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
@@ -194,6 +194,10 @@ object DoubleSuite extends tests.Suite {
     assert(Double.parseDouble("Infinity") == Double.POSITIVE_INFINITY)
     assert(Double.parseDouble("-Infinity") == Double.NEGATIVE_INFINITY)
     assert(Double.isNaN(Double.parseDouble("NaN")))
+    assertThrows[NumberFormatException](Double.parseDouble(""))
+    assertThrows[NumberFormatException](Double.parseDouble("potato"))
+    assertThrows[NumberFormatException](Double.parseDouble("0.0potato"))
+    assertThrows[NumberFormatException](Double.parseDouble("0.potato"))
   }
 
   // Not fully JVM compliant yet

--- a/unit-tests/src/test/scala/java/lang/FloatSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/FloatSuite.scala
@@ -190,6 +190,10 @@ object FloatSuite extends tests.Suite {
     assert(Float.parseFloat("Infinity") == Float.POSITIVE_INFINITY)
     assert(Float.parseFloat("-Infinity") == Float.NEGATIVE_INFINITY)
     assert(Float.isNaN(Float.parseFloat("NaN")))
+    assertThrows[NumberFormatException](Float.parseFloat(""))
+    assertThrows[NumberFormatException](Float.parseFloat("potato"))
+    assertThrows[NumberFormatException](Float.parseFloat("0.0potato"))
+    assertThrows[NumberFormatException](Float.parseFloat("0.potato"))
   }
 
   test("toString") {


### PR DESCRIPTION
Fixes #1046 

`strtod` and `strtof` don't set `errno.errno` when given invalid data. Instead, the following behavior (quoted below) is performed. This PR adjusts the implementations accordingly so that when calling e.g. `Double.parseDouble("potato")` an exception is raised instead of the value `0.0` being returned.

> If the subject sequence is empty or does not have the expected form, no conversion shall be performed; the value of str is stored in the object pointed to by endptr, provided that endptr is not a null pointer.

Reference: http://pubs.opengroup.org/onlinepubs/009695399/functions/strtod.html

p.s. Thanks a bunch for Scala Native! We're using it on a CLI project @ Lightbend and have been impressed with it so far!