### PR TITLE
Improved unit test runner

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -51,6 +51,8 @@ object ScalaNativePlugin extends AutoPlugin {
 
     val nativeGC =
       settingKey[String]("GC choice, either \"none\", \"boehm\" or \"immix\".")
+
+    val directTestCommand = InputKey[String]("direct-test-command")
   }
 
   override def globalSettings: Seq[Setting[_]] =

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -462,7 +462,20 @@ object ScalaNativePluginInternal {
     scalaNativeConfigSettings ++ Seq(
       test := (test in NativeTest).value,
       testOnly := (testOnly in NativeTest).evaluated,
-      testQuick := (testQuick in NativeTest).evaluated
+      testQuick := (testQuick in NativeTest).evaluated,
+      directTestCommand := {
+        val args: Seq[String] = spaceDelimited("<arg>").parsed
+        val tests             = (definedTests in Test).value
+        val testsToRun        = if (args.isEmpty) tests.map(_.name) else args
+        val res = nativeLink.value.getPath + " run-test " + testsToRun.mkString(
+          " ")
+        println("Command to run tests directly:")
+        println()
+        println(res)
+        println()
+
+        res
+      }
     )
 
   lazy val NativeTest = config("nativetest").extend(Test).hide

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/testinterface/ComRunner.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/testinterface/ComRunner.scala
@@ -29,7 +29,10 @@ class ComRunner(bin: File,
       import sbt.Process._
       val port = serverSocket.getLocalPort
       logger.info(s"Starting process '$bin' on port '$port'.")
-      Process(bin.toString +: port.toString +: args, None, envVars.toSeq: _*) ! logger
+      val retCode = Process(bin.toString +: port.toString +: args,
+                            None,
+                            envVars.toSeq: _*) ! logger
+      logger.info(s"Process '$bin' on port '$port' exited with code $retCode.")
     }
   }
 

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/TestMainBase.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/TestMainBase.scala
@@ -26,9 +26,47 @@ abstract class TestMainBase {
 
   /** Actual main method of the test runner. */
   def testMain(args: Array[String]): Unit = {
-    val serverPort   = args.head.toInt
-    val clientSocket = new Socket("127.0.0.1", serverPort)
-    testRunner(Array.empty, null, clientSocket)
+    args.toList match {
+      case "run-test" :: className :: Nil =>
+        runSingleTest(className)
+      case serverPort :: _ =>
+        val clientSocket = new Socket("127.0.0.1", serverPort.toInt)
+        testRunner(Array.empty, null, clientSocket)
+    }
+  }
+
+  private def runSingleTest(value: String): Unit = {
+    val runner = frameworks(0).runner(Array.empty,
+                                      Array.empty,
+                                      new PreloadedClassLoader(tests))
+    val taskDef = new TaskDef(
+      value,
+      DeserializedSubclassFingerprint(isModule = true,
+                                      "tests.Suite",
+                                      requireNoArgConstructor = false),
+      false,
+      Array(new SuiteSelector))
+    val Array(task: Task) = runner.tasks(Array(taskDef))
+    val logger = new Logger {
+      def debug(msg: String): Unit = Console.err.println("DEBUG: " + msg)
+
+      def error(msg: String): Unit = Console.err.println("ERROR: " + msg)
+
+      val ansiCodesSupported = true
+
+      def warn(msg: String): Unit = Console.err.println("WARN: " + msg)
+
+      def trace(t: Throwable): Unit = {
+        Console.err.println("TRACE:")
+        t.printStackTrace()
+      }
+
+      def info(msg: String): Unit = Console.err.println("INFO: " + msg)
+    }
+    val eventHandler = new EventHandler {
+      def handle(event: SbtEvent): Unit = {}
+    }
+    task.execute(eventHandler, Array(logger))
   }
 
   /** Test runner loop.

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/TestMainBase.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/TestMainBase.scala
@@ -196,27 +196,27 @@ abstract class TestMainBase {
 }
 
 object TestMainBase {
-  private val faultHandler = CFunctionPtr.fromFunction1(handleSegFault _)
-  private def handleSegFault(id: Int): Unit = {
+  private val faultHandler = CFunctionPtr.fromFunction1(handleFault _)
+  private def handleFault(id: Int): Unit = {
     //making ids stable i.e. vals instead fo defs
     //for use in the match
     val SIGSEGV = signal.SIGSEGV
     val SIGFPE  = signal.SIGFPE
 
-    val retCode = id match {
+    val throwable = id match {
       case `SIGSEGV` =>
-        Console.err.println("Segmentation fault")
-        139
+        val msg = "Segmentation fault"
+        Console.err.println(msg)
+        new Error(msg)
       case `SIGFPE` =>
         Console.err.println("Erroneous Arithmetic Operation")
-        136
+        new ArithmeticException()
       case _ =>
-        Console.err.println("Unknown fault")
-        -1
+        val msg = "Unknown fault"
+        Console.err.println(msg)
+        new Error(msg)
     }
-    // the handler will run on the same thread that caused the segmentation fault
-    new Throwable().printStackTrace()
-    // segfault return code
-    System.exit(retCode)
+    throwable.printStackTrace()
+    throw throwable
   }
 }


### PR DESCRIPTION
- Logging the runner's exit code
- Catching segmentation faults and dumping the relevant stack trace
- Catching arithmetic faults, like division by zero.
The catching can be disabled by specifying `--no-catch-fault`
- Added the ability to run tests directly from:
 `unit-tests/target/scala-2.11/tests-out run-test <fully qualified names>`

The function I used to reproduce segfaults:
```scala
  private def segfault: Unit = {
    val ptr: Ptr[CSignedChar] = null.asInstanceOf[Ptr[CSignedChar]]
    Console.out.println(!ptr)
  }
```

And division by zero:
```scala
  private def aritFail: Unit = {
    def x = 0
    Console.out.println(1000 / x)
  }
```