### PR TITLE
Run DeadBlockElimination before GlobalBoxingElimination

### DIFF
--- a/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
@@ -26,6 +26,7 @@ object Driver {
   )
 
   private val fastOptPasses = Seq(
+    pass.DeadBlockElimination,
     pass.GlobalBoxingElimination,
     pass.UnitSimplification,
     pass.DeadCodeElimination


### PR DESCRIPTION
GlobalBoxingElimination relies on control-flow graph and
dominatinator tree. Both ignore basic blocks that are not
reachable from the entry point of the cfg. This causes
problems when GBE tries to optimize dead code as there is
no information about domination available for it.

Given that the code is dead and doesn't need to be optimized
in the first place we run DeadBlockElimination before it to
ensure that this kind of condition doesn't happen.

Fixes #1009, #1057

/cc @shadaj @lihaoyi