### PR TITLE
Add ability to set env vars where Java can see the changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -439,14 +439,7 @@ lazy val tests =
       // nativeOptimizerReporter := OptimizerReporter.toDirectory(
       //   crossTarget.value),
       libraryDependencies += "org.scala-native" %%% "test-interface" % nativeVersion,
-      testFrameworks += new TestFramework("tests.NativeFramework"),
-      envVars in (Test, test) ++= Map(
-        "USER"                           -> "scala-native",
-        "HOME"                           -> baseDirectory.value.getAbsolutePath,
-        "SCALA_NATIVE_ENV_WITH_EQUALS"   -> "1+1=2",
-        "SCALA_NATIVE_ENV_WITHOUT_VALUE" -> "",
-        "SCALA_NATIVE_ENV_WITH_UNICODE"  -> 0x2192.toChar.toString
-      )
+      testFrameworks += new TestFramework("tests.NativeFramework")
     )
     .enablePlugins(ScalaNativePlugin)
 

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -104,7 +104,7 @@ object System {
 
   def gc(): Unit = GC.collect()
 
-  private lazy val envVars: Map[String, String] = {
+  private def envVars(): Map[String, String] = {
     // workaround since `while(ptr(0) != null)` causes segfault
     def isDefined(ptr: Ptr[CString]): Boolean = {
       val s: CString = ptr(0)

--- a/nativelib/src/main/scala/scala/scalanative/native/errno.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/errno.scala
@@ -13,4 +13,9 @@ object errno {
   def EILSEQ: CInt = extern
   @name("scalanative_erange")
   def ERANGE: CInt = extern
+  // added for setenv/unsetenv
+  @name("scalanative_einval")
+  def EINVAL: CInt = extern
+  @name("scalanative_enomen")
+  def ENOMEM: CInt = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/stdlib.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/stdlib.scala
@@ -23,8 +23,9 @@ object stdlib {
 
   // Communicating with the environment
 
-  def system(command: CString): CInt = extern
-  def getenv(name: CString): CString = extern
+  def system(command: CString): CInt                               = extern
+  def getenv(name: CString): CString                               = extern
+  def setenv(name: CString, value: CString, overwrite: CInt): CInt = extern
 
   // Pseudo-random number generation
 

--- a/nativelib/src/main/scala/scala/scalanative/native/stdlib.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/stdlib.scala
@@ -26,6 +26,7 @@ object stdlib {
   def system(command: CString): CInt                               = extern
   def getenv(name: CString): CString                               = extern
   def setenv(name: CString, value: CString, overwrite: CInt): CInt = extern
+  def unsetenv(name: CString): CInt                                = extern
 
   // Pseudo-random number generation
 

--- a/nativelib/src/main/scala/scala/scalanative/native/system.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/system.scala
@@ -1,0 +1,39 @@
+package scala.scalanative.native
+
+object system {
+
+  /**
+   * Sets an environment variable.
+   * @param name of the variable - must not be null, empty, or contain the = character
+   * @param value of the variable
+   * @param overwrite if overwriting the existing value is desired
+   * @return true if successful, false if not enough memory in the environment
+   */
+  def setenv(name: String,
+             value: String,
+             overwrite: Boolean = true): Boolean = {
+    checkName(name)
+    val ow = if (overwrite) 1 else 0
+    Zone { implicit z =>
+      val res = stdlib.setenv(toCString(name), toCString(value), ow)
+      if (res == 0) true else false
+    }
+  }
+
+  /**
+   * Unset the environment variable.
+   * @param name of the variable - must not be null, empty, or contain the = character
+   */
+  def unsetenv(name: String): Unit = {
+    checkName(name)
+    Zone { implicit z =>
+      stdlib.unsetenv(toCString(name))
+    }
+  }
+
+  private[system] def checkName(name: String): Unit = {
+    if (name == null || name.isEmpty || name.contains('='))
+      throw new IllegalArgumentException(s"name is invalid '$name'")
+  }
+
+}

--- a/unit-tests/src/test/scala/java/lang/SystemSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/SystemSuite.scala
@@ -1,6 +1,7 @@
 package java.lang
 
 object SystemSuite extends tests.Suite {
+
   test("System.nanoTime is monotonically increasing") {
     var t0 = 0L
     var t1 = 0L
@@ -19,23 +20,48 @@ object SystemSuite extends tests.Suite {
     assert(startTime - endTime < 0L)
   }
 
+  // don't override possible known env vars
+  val k = Array[String]("USERZ",
+                        "HOMEZ",
+                        "SCALA_NATIVE_ENV_WITH_EQUALS",
+                        "SCALA_NATIVE_ENV_WITHOUT_VALUE",
+                        "SCALA_NATIVE_ENV_WITH_UNICODE",
+                        "SCALA_NATIVE_ENV_THAT_DOESNT_EXIST")
+  val v = Array[String]("scala-native",
+                        "/home/scala-native",
+                        "1+1=2",
+                        "",
+                        0x2192.toChar.toString,
+                        null)
+
+  test("System.setenv") {
+    import scalanative.native._
+    Zone { implicit z =>
+      stdlib.setenv(toCString(k(0)), toCString(v(0)), 0)
+      stdlib.setenv(toCString(k(1)), toCString(v(1)), 0)
+      stdlib.setenv(toCString(k(2)), toCString(v(2)), 0)
+      stdlib.setenv(toCString(k(3)), toCString(v(3)), 0)
+      stdlib.setenv(toCString(k(4)), toCString(v(4)), 0)
+    }
+  }
+
   test("System.getenv should contain known env variables") {
-    assert(System.getenv().containsKey("HOME"))
-    assert(System.getenv().get("USER") == "scala-native")
-    assert(System.getenv().get("SCALA_NATIVE_ENV_WITH_EQUALS") == "1+1=2")
-    assert(System.getenv().get("SCALA_NATIVE_ENV_WITHOUT_VALUE") == "")
-    assert(System.getenv().get("SCALA_NATIVE_ENV_THAT_DOESNT_EXIST") == null)
-    assert(
-      System
-        .getenv()
-        .get("SCALA_NATIVE_ENV_WITH_UNICODE") == 0x2192.toChar.toString)
+    val env = System.getenv()
+    assert(env.get(k(0)) == v(0))
+    assert(env.containsKey(k(1)))
+    assert(env.get(k(2)) == v(2))
+    assert(env.get(k(3)) == v(3))
+    assert(env.get(k(4)) == v(4))
+    assert(env.get(k(5)) == v(5))
   }
 
   test("System.getenv(key) should read known env variables") {
-    assert(System.getenv("USER") == "scala-native")
-    assert(System.getenv("SCALA_NATIVE_ENV_WITH_EQUALS") == "1+1=2")
-    assert(System.getenv("SCALA_NATIVE_ENV_WITHOUT_VALUE") == "")
-    assert(System.getenv("SCALA_NATIVE_ENV_THAT_DOESNT_EXIST") == null)
+    assert(System.getenv(k(0)) == v(0))
+    assert(System.getenv(k(1)) == v(1))
+    assert(System.getenv(k(2)) == v(2))
+    assert(System.getenv(k(3)) == v(3))
+    assert(System.getenv(k(4)) == v(4))
+    assert(System.getenv(k(5)) == v(5))
   }
 
   test("Property user.home should be set") {

--- a/unit-tests/src/test/scala/java/lang/SystemSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/SystemSuite.scala
@@ -34,15 +34,13 @@ object SystemSuite extends tests.Suite {
                         0x2192.toChar.toString,
                         null)
 
-  test("System.setenv") {
+  test("scalanative.native.system.setenv") {
     import scalanative.native._
-    Zone { implicit z =>
-      stdlib.setenv(toCString(k(0)), toCString(v(0)), 0)
-      stdlib.setenv(toCString(k(1)), toCString(v(1)), 0)
-      stdlib.setenv(toCString(k(2)), toCString(v(2)), 0)
-      stdlib.setenv(toCString(k(3)), toCString(v(3)), 0)
-      stdlib.setenv(toCString(k(4)), toCString(v(4)), 0)
-    }
+    assert(system.setenv(k(0), v(0)))
+    assert(system.setenv(k(1), v(1)))
+    assert(system.setenv(k(2), v(2)))
+    assert(system.setenv(k(3), v(3)))
+    assert(system.setenv(k(4), v(4)))
   }
 
   test("System.getenv should contain known env variables") {

--- a/unit-tests/src/test/scala/scala/scalanative/native/NativeSystemSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/native/NativeSystemSuite.scala
@@ -1,0 +1,25 @@
+package scala.scalanative.native
+
+import java.lang.System._
+
+object NativeSystemSuite extends tests.Suite {
+  val name  = "FOO"
+  val value = "foobar"
+
+  test("setenv") {
+    val res = system.setenv(name, value)
+    assert(res == true)
+  }
+
+  test("getenv matches") {
+    val foobar = getenv(name)
+    assertEquals(value, foobar)
+  }
+
+  test("setenv name check") {
+    assertThrows[IllegalArgumentException](system.setenv(null, value))
+    assertThrows[IllegalArgumentException](system.setenv("", value))
+    assertThrows[IllegalArgumentException](system.setenv("foo=bar", value))
+  }
+
+}


### PR DESCRIPTION
This is the result so far of trying to remove the setting of env vars in the build file. This allows the Test to become DRY as well. The disadvantage here is that in order to see changes in the env created in the `C` realm, we have to refresh the `java.lang.System` env vars before use.

There are all sorts of hacky code out there in the JVM world to change environment variables out in the wild. Ideally it would be nice to add `System.setenv` methods if that is possible but that would mean that if people used this in Scala Native, to support JVM they would have to use something like the following.

``` scala
if (System.getProperty("java.vm.name").equals("Scala Native") System.setenv ...
else doJvmHackyStuff

```
If we could add the `setenv` methods then we could update the `envVar` map when the method succeeded to avoid always refreshing the environment.

Edit: Couldn't we provide a shim for JVM compilation so the above code would compile on both platforms?