### PR TITLE
[WIP] Multithreading: Threads, Synchronization, Atomics and Futures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ matrix:
       jdk: oraclejdk8
       language: scala
       env: SCALANATIVE_GC=boehm
-
-    - os: linux
-      dist: trusty
-      jdk: oraclejdk8
-      language: scala
-      env: SCALANATIVE_GC=immix
-
 env:
   global:
     - MAVEN_REALM="Sonatype Nexus Repository Manager"

--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -1,9 +1,9 @@
 package java.lang
 
-import scala.scalanative.native.{stdlib, stub}
+import scala.scalanative.native.{stdlib, stub, sysinfo}
 
 class Runtime private () {
-  def availableProcessors(): Int = 1
+  def availableProcessors(): Int = sysinfo.get_nprocs
   def exit(status: Int): Unit    = stdlib.exit(status)
   def gc(): Unit                 = ()
 

--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -135,6 +135,8 @@ private[lang] object StackTraceElement {
    */
   private[lang] def cached(cursor: Ptr[scala.Byte],
                            startIp: CUnsignedLong): StackTraceElement =
-    cache.getOrElseUpdate(startIp, makeStackTraceElement(cursor))
+    cache.synchronized {
+      cache.getOrElseUpdate(startIp, makeStackTraceElement(cursor))
+    }
 
 }

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -101,6 +101,10 @@ object System {
   var err: PrintStream =
     new PrintStream(new FileOutputStream(FileDescriptor.err))
 
+  def setIn(in: InputStream): Unit   = this.in = in
+  def setOut(out: PrintStream): Unit = this.out = out
+  def setErr(err: PrintStream): Unit = this.err = err
+
   def gc(): Unit = GC.collect()
 
   private lazy val envVars: Map[String, String] = {

--- a/javalib/src/main/scala/java/lang/ThreadLocal.scala
+++ b/javalib/src/main/scala/java/lang/ThreadLocal.scala
@@ -1,380 +1,56 @@
 package java.lang
 
-import java.lang.ref.{Reference, WeakReference}
-import java.util.concurrent.atomic.AtomicInteger
-
 // Ported from Harmony
 
 class ThreadLocal[T] {
 
   import java.lang.ThreadLocal._
 
-  private final val reference: Reference[ThreadLocal[T]] =
-    new WeakReference[ThreadLocal[T]](this)
-
-  private final val hash: Int = hashCounter.getAndAdd(0x61c88647 << 1)
-
   protected def initialValue(): T = null.asInstanceOf[T]
 
-  @SuppressWarnings(Array("unchecked"))
   def get(): T = {
-    // Optimized for the fast path
-    val currentThread: Thread = Thread.currentThread()
-    var vals: Values          = values(currentThread)
-    if (vals != null) {
-      val table: Array[Object] = vals.getTable
-      val index: Int           = hash & vals.getMask
-      if (this.reference == table(index)) {
-        table(index + 1).asInstanceOf[T]
-      }
+    val currentThread  = Thread.currentThread()
+    val values: Values = currentThread.localValues
+    if (values != null) {
+      values.map
+        .getOrElseUpdate(this, initialValue().asInstanceOf[Object])
+        .asInstanceOf[T]
     } else {
-      vals = initializeValues(currentThread)
+      currentThread.localValues = new ThreadLocal.Values()
+      initialValue()
     }
-
-    vals.getAfterMiss(this).asInstanceOf[T]
   }
 
   def set(value: T): Unit = {
-    val currentThread: Thread = Thread.currentThread()
-    var vals: Values          = values(currentThread)
-    if (vals == null) {
-      vals = initializeValues(currentThread)
+    val currentThread         = Thread.currentThread()
+    val currentValues: Values = currentThread.localValues
+    val values = if (currentValues == null) {
+      val newValues = new Values()
+      currentThread.localValues = newValues
+      newValues
+    } else {
+      currentValues
     }
 
-    vals.put(this, value.asInstanceOf[Object])
+    values.map.put(this, value.asInstanceOf[Object])
   }
 
   def remove(): Unit = {
-    val currentThread: Thread = Thread.currentThread()
-    val vals: Values          = values(currentThread)
+    val currentThread = Thread.currentThread()
+    val vals: Values  = currentThread.localValues
     if (vals != null) {
-      vals.remove(this)
+      vals.map.remove(this)
     }
   }
-
-  def initializeValues(current: Thread): Values = {
-    current.localValues = new ThreadLocal.Values()
-    current.localValues
-  }
-
-  def values(current: Thread): Values = current.localValues
 }
 
 object ThreadLocal {
-
-  private val hashCounter: AtomicInteger = new AtomicInteger(0)
-
-  class Values {
-
-    import Values._
-
-    private var table: Array[Object] = null
-
-    private var mask: Int = 0
-
-    private var size: Int = 0
-
-    private var tombstones: Int = 0
-
-    private var maximumLoad: Int = 0
-
-    private var clean: Int = 0
-
-    initializeTable(INITIAL_SIZE)
-
-    def this(fromParent: Values) {
+  class Values() {
+    private[ThreadLocal] val map =
+      scala.collection.mutable.WeakHashMap.empty[AnyRef, Object]
+    def this(values: Values) = {
       this()
-      table = fromParent.table.clone()
-      mask = fromParent.mask
-      size = fromParent.size
-      tombstones = fromParent.tombstones
-      maximumLoad = fromParent.maximumLoad
-      clean = fromParent.clean
-      inheritValues(fromParent)
+      map ++= values.map
     }
-
-    def getTable: Array[Object] = table
-
-    def getMask: Int = mask
-
-    @SuppressWarnings(Array("unchecked"))
-    private def inheritValues(fromParent: Values): Unit = {
-      val table: Array[Object]    = this.table
-      var i: Int                  = this.table.length
-      var continue: scala.Boolean = false
-      while (i >= 0) {
-        continue = false
-        val k: Object = table(i)
-
-        if (k == null || k == TOMBSTONE) {
-          continue = true
-        }
-
-        if (!continue) {
-          val reference: Reference[InheritableThreadLocal[Object]] =
-            k.asInstanceOf[Reference[InheritableThreadLocal[Object]]]
-
-          val key: InheritableThreadLocal[Object] = reference.get()
-          if (key != null) {
-            // Replace value with filtered value
-            // We should just let exceptions bubble out and tank
-            // the thread creation
-
-            table(i + 1) = key.childValue(fromParent.table(i + 1))
-          } else {
-            table(i) = TOMBSTONE
-            table(i + 1) = null
-            fromParent.table(i) = TOMBSTONE
-            fromParent.table(i + 1) = null
-
-            tombstones += 1
-            fromParent.tombstones += 1
-
-            size -= 1
-            fromParent.size -= 1
-          }
-        }
-        i -= 2
-      }
-    }
-
-    private def initializeTable(capacity: Int): Unit = {
-      this.table = new Array[Object](capacity << 1)
-      this.mask = table.length - 1
-      this.clean = 0
-      this.maximumLoad = capacity * 2 / 3
-    }
-
-    private def cleanUp(): Unit = {
-      if (rehash()) return
-      if (size == 0) return
-
-      var index: Int           = clean
-      val table: Array[Object] = this.table
-      var counter              = table.length
-
-      var continue: scala.Boolean = false
-
-      while (counter > 0) {
-        continue = false
-        val k: Object = table(index)
-
-        if (k == TOMBSTONE || k == null) continue = true
-
-        if (!continue) {
-          val reference: Reference[ThreadLocal[_]] =
-            k.asInstanceOf[Reference[ThreadLocal[_]]]
-          if (reference.get() == null) {
-            table(index) = TOMBSTONE
-            table(index + 1) = null
-            tombstones += 1
-            size -= 1
-          }
-        }
-
-        counter >>= 1
-        index = next(index)
-      }
-
-      clean = index
-    }
-
-    private def rehash(): scala.Boolean = {
-      if (tombstones + size < maximumLoad) return false
-
-      val capacity: Int = table.length >> 1
-
-      var newCapacity: Int = capacity
-
-      if (size > (capacity >> 1)) {
-        newCapacity = capacity << 1
-      }
-
-      val oldTable: Array[Object] = table
-      initializeTable(newCapacity)
-
-      tombstones = 0
-
-      if (size == 0) return true
-
-      var i: Int                  = oldTable.length - 2
-      var continue: scala.Boolean = false
-      while (i >= 0) {
-        continue = false
-        val k: Object = oldTable(i)
-        if (k == null || k == TOMBSTONE) continue = true
-
-        if (!continue) {
-          val reference: Reference[ThreadLocal[_]] =
-            k.asInstanceOf[Reference[ThreadLocal[_]]]
-
-          val key: ThreadLocal[_] = reference.get()
-          if (key != null) add(key, oldTable(i + 1))
-          else size -= 1
-        }
-        i -= 2
-      }
-
-      true
-    }
-
-    def add(key: ThreadLocal[_], value: Object): Unit = {
-      var index: Int = key.hash & mask
-      while (true) {
-        val k: Object = table(index)
-        if (k == null) {
-          table(index) = key.reference
-          table(index + 1) = value
-          return
-        }
-
-        index = next(index)
-      }
-    }
-
-    def put(key: ThreadLocal[_], value: Object): Unit = {
-      cleanUp()
-
-      var firstTombstone: Int = -1
-
-      var index: Int = key.hash & mask
-      while (true) {
-        val k: Object = table(index)
-
-        if (k == key.reference) {
-          table(index + 1) = value
-          return
-        }
-
-        if (k == null) {
-          if (firstTombstone == -1) {
-            table(index) = key.reference
-            table(index + 1) = value
-            size += 1
-            return
-          }
-
-          table(firstTombstone) = key.reference
-          table(firstTombstone + 1) = value
-          tombstones -= 1
-          size += 1
-          return
-        }
-
-        if (firstTombstone == -1 && k == TOMBSTONE) firstTombstone = index
-
-        index = next(index)
-      }
-    }
-
-    def getAfterMiss(key: ThreadLocal[_]): Object = {
-      val table: Array[Object] = this.table
-      var index: Int           = key.hash & mask
-
-      // If the first slot is empty, the search is over
-      if (table(index) == null) {
-        val value: Object = key.initialValue().asInstanceOf[Object]
-
-        // If the table is still the same and the slot is still empty...
-        if ((this.table == table) && table(index) == null) {
-          table(index) = key.reference
-          table(index + 1) = value
-          size += 1
-
-          cleanUp()
-          return value
-        }
-
-        // The table changed during initialValue().
-        put(key, value)
-        return value
-      }
-
-      // Keep track of first tombstone. That's where we want to go back
-      // and add an entry if necessary
-      var firstTombstone: Int = -1
-
-      index = next(index)
-      while (true) {
-        val reference: Object = table(index)
-        if (reference == key.reference) return table(index + 1)
-
-        // If no entry was found...
-        if (reference == null) {
-          val value: Object = key.initialValue().asInstanceOf[Object]
-
-          // If the table is still the same
-          if (this.table == table) {
-            // If we passed a tombstone and that slot still
-            // contains a tombstone
-            if (firstTombstone > -1 && table(firstTombstone) == TOMBSTONE) {
-              table(firstTombstone) = key.reference
-              table(firstTombstone + 1) = value
-              tombstones -= 1
-              size += 1
-
-              // No need to clean up here. We aren't filling
-              // in a null slot
-              return value
-            }
-
-            // If this slot is still empty...
-            if (table(index) == null) {
-              table(index) = key.reference
-              table(index + 1) = value
-              size += 1
-
-              cleanUp()
-              return value
-            }
-          }
-
-          // The table changed during initialValue().
-          put(key, value)
-          return value
-        }
-
-        if (firstTombstone == -1 && reference == TOMBSTONE)
-          // Keep track of this tombstone so we can overwrite it.
-          firstTombstone = index
-
-        index = next(index)
-      }
-      // For the compiler
-      null.asInstanceOf[Object]
-    }
-
-    def remove(key: ThreadLocal[_]): Unit = {
-      cleanUp()
-
-      var index: Int = key.hash & mask
-      while (true) {
-        val reference: Object = table(index)
-
-        if (reference == key.reference) {
-          table(index) = TOMBSTONE
-          table(index + 1) = null
-          tombstones += 1
-          size -= 1
-          return
-        }
-
-        if (reference == null) return
-
-        index = next(index)
-      }
-    }
-
-    private def next(index: Int) = (index + 2) & mask
-
   }
-
-  object Values {
-
-    private final val INITIAL_SIZE: Int = 16
-
-    private final val TOMBSTONE: Object = new Object()
-
-  }
-
 }

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
@@ -1,46 +1,38 @@
 package java.util.concurrent.atomic
 
+import scala.scalanative.native.{CCast, CLong}
 import scala.scalanative.runtime.CAtomicLong
 
 class AtomicReference[T <: AnyRef](private[this] var value: T)
     extends Serializable {
 
-  def this() = this(0L.asInstanceOf[T])
+  def this() = this(null.asInstanceOf[T])
 
-  private[this] val inner = CAtomicLong(value.asInstanceOf[Long])
+  private[this] val inner = CAtomicLong(value)
 
   final def get(): T = inner.load()
 
-  final def set(newValue: T): Unit =
-    inner.store(newValue.asInstanceOf[Long])
+  final def set(newValue: T): Unit = inner.store(newValue)
 
-  final def lazySet(newValue: T): Unit =
-    inner.store(newValue.asInstanceOf[Long])
+  final def lazySet(newValue: T): Unit = inner.store(newValue)
 
-  final def compareAndSet(expect: T, update: T): Boolean = {
-    inner
-      .compareAndSwapStrong(expect.asInstanceOf[Long],
-                            update.asInstanceOf[Long])
-      ._1
-  }
+  final def compareAndSet(expect: T, update: T): Boolean =
+    inner.compareAndSwapStrong(expect, update)._1
 
   final def weakCompareAndSet(expect: T, update: T): Boolean =
-    inner
-      .compareAndSwapWeak(expect.asInstanceOf[Long], update.asInstanceOf[Long])
-      ._1
+    inner.compareAndSwapWeak(expect, update)._1
 
   final def getAndSet(newValue: T): T = {
     val old = inner.load()
-    inner.store(newValue.asInstanceOf[Long])
+    inner.store(newValue)
     old
   }
 
   override def toString(): String =
     String.valueOf(value)
 
-  private implicit def toLong(e: T): Long = e.asInstanceOf[Long]
-
-  private implicit def toRef(l: Long): T = l.asInstanceOf[T]
+  private implicit def toLong(e: T): Long = e.asInstanceOf[AnyRef].cast[CLong]
+  private implicit def toRef(l: Long): T  = l.cast[AnyRef].asInstanceOf[T]
 }
 
 object AtomicReference {

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceArray.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceArray.scala
@@ -1,5 +1,6 @@
 package java.util.concurrent.atomic
 
+import scala.scalanative.native.{CCast, CLong}
 import scala.scalanative.runtime.CAtomicLong
 
 class AtomicReferenceArray[E <: AnyRef](length: Int) extends Serializable {
@@ -40,9 +41,8 @@ class AtomicReferenceArray[E <: AnyRef](length: Int) extends Serializable {
   override def toString(): String =
     inner.mkString("[", ", ", "]")
 
-  private implicit def toLong(e: E): Long = e.asInstanceOf[Long]
-
-  private implicit def toRef(l: Long): E = l.asInstanceOf[E]
+  private implicit def toLong(e: E): Long = e.asInstanceOf[AnyRef].cast[CLong]
+  private implicit def toRef(l: Long): E  = l.cast[AnyRef].asInstanceOf[E]
 }
 
 object AtomicReferenceArray {

--- a/nativelib/src/main/resources/atomic.cpp
+++ b/nativelib/src/main/resources/atomic.cpp
@@ -1,607 +1,817 @@
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 1)
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 1)
 #include <atomic>
 #include <stdint.h>
 #include <stdlib.h>
 
 using namespace std;
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 16)
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 16)
 
 extern "C" {
 
-	/**
-     * Init
-     * */
+/**
+* Init
+* */
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 24)
-     // byte
-     void init_byte(int8_t* atm, int8_t init_value) {
-        *atm = ATOMIC_VAR_INIT(init_value);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 24)
-     // short
-     void init_short(int16_t* atm, int16_t init_value) {
-        *atm = ATOMIC_VAR_INIT(init_value);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 24)
-     // int
-     void init_int(int32_t* atm, int32_t init_value) {
-        *atm = ATOMIC_VAR_INIT(init_value);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 24)
-     // long
-     void init_long(int64_t* atm, int64_t init_value) {
-        *atm = ATOMIC_VAR_INIT(init_value);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 24)
-     // ubyte
-     void init_ubyte(uint8_t* atm, uint8_t init_value) {
-        *atm = ATOMIC_VAR_INIT(init_value);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 24)
-     // ushort
-     void init_ushort(uint16_t* atm, uint16_t init_value) {
-        *atm = ATOMIC_VAR_INIT(init_value);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 24)
-     // uint
-     void init_uint(uint32_t* atm, uint32_t init_value) {
-        *atm = ATOMIC_VAR_INIT(init_value);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 24)
-     // ulong
-     void init_ulong(uint64_t* atm, uint64_t init_value) {
-        *atm = ATOMIC_VAR_INIT(init_value);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 24)
-     // char
-     void init_char(char* atm, char init_value) {
-        *atm = ATOMIC_VAR_INIT(init_value);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 24)
-     // uchar
-     void init_uchar(unsigned char* atm, unsigned char init_value) {
-        *atm = ATOMIC_VAR_INIT(init_value);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 24)
-     // csize
-     void init_csize(size_t* atm, size_t init_value) {
-        *atm = ATOMIC_VAR_INIT(init_value);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 29)
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 24)
+// byte
+void init_byte(int8_t *atm, int8_t init_value) {
+    *atm = ATOMIC_VAR_INIT(init_value);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 24)
+// short
+void init_short(int16_t *atm, int16_t init_value) {
+    *atm = ATOMIC_VAR_INIT(init_value);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 24)
+// int
+void init_int(int32_t *atm, int32_t init_value) {
+    *atm = ATOMIC_VAR_INIT(init_value);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 24)
+// long
+void init_long(int64_t *atm, int64_t init_value) {
+    *atm = ATOMIC_VAR_INIT(init_value);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 24)
+// ubyte
+void init_ubyte(uint8_t *atm, uint8_t init_value) {
+    *atm = ATOMIC_VAR_INIT(init_value);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 24)
+// ushort
+void init_ushort(uint16_t *atm, uint16_t init_value) {
+    *atm = ATOMIC_VAR_INIT(init_value);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 24)
+// uint
+void init_uint(uint32_t *atm, uint32_t init_value) {
+    *atm = ATOMIC_VAR_INIT(init_value);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 24)
+// ulong
+void init_ulong(uint64_t *atm, uint64_t init_value) {
+    *atm = ATOMIC_VAR_INIT(init_value);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 24)
+// char
+void init_char(char *atm, char init_value) {
+    *atm = ATOMIC_VAR_INIT(init_value);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 24)
+// uchar
+void init_uchar(unsigned char *atm, unsigned char init_value) {
+    *atm = ATOMIC_VAR_INIT(init_value);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 24)
+// csize
+void init_csize(size_t *atm, size_t init_value) {
+    *atm = ATOMIC_VAR_INIT(init_value);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 29)
 
-	/**
-     * Memory
-     * */
+/**
+* Load
+* */
 
-     void* alloc(size_t sz) {
-        return malloc(sz);
-     }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 47)
+// byte
+int8_t load_byte(atomic<int8_t> *atm) { return atm->load(); }
 
-     void free(void* ptr) {
-        free(ptr);
-     }
+void store_byte(atomic<int8_t> *atm, int8_t val) { atm->store(val); }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 47)
+// short
+int16_t load_short(atomic<int16_t> *atm) { return atm->load(); }
 
-	/**
-     * Load
-     * */
+void store_short(atomic<int16_t> *atm, int16_t val) { atm->store(val); }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 47)
+// int
+int32_t load_int(atomic<int32_t> *atm) { return atm->load(); }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 47)
-    // byte
-    int8_t load_byte(atomic<int8_t>* atm) {
-        return atm -> load();
-    }
+void store_int(atomic<int32_t> *atm, int32_t val) { atm->store(val); }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 47)
+// long
+int64_t load_long(atomic<int64_t> *atm) { return atm->load(); }
 
-    void store_byte(atomic<int8_t>* atm, int8_t val) {
-      atm -> store(val);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 47)
-    // short
-    int16_t load_short(atomic<int16_t>* atm) {
-        return atm -> load();
-    }
+void store_long(atomic<int64_t> *atm, int64_t val) { atm->store(val); }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 47)
+// ubyte
+uint8_t load_ubyte(atomic<uint8_t> *atm) { return atm->load(); }
 
-    void store_short(atomic<int16_t>* atm, int16_t val) {
-      atm -> store(val);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 47)
-    // int
-    int32_t load_int(atomic<int32_t>* atm) {
-        return atm -> load();
-    }
+void store_ubyte(atomic<uint8_t> *atm, uint8_t val) { atm->store(val); }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 47)
+// ushort
+uint16_t load_ushort(atomic<uint16_t> *atm) { return atm->load(); }
 
-    void store_int(atomic<int32_t>* atm, int32_t val) {
-      atm -> store(val);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 47)
-    // long
-    int64_t load_long(atomic<int64_t>* atm) {
-        return atm -> load();
-    }
+void store_ushort(atomic<uint16_t> *atm, uint16_t val) { atm->store(val); }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 47)
+// uint
+uint32_t load_uint(atomic<uint32_t> *atm) { return atm->load(); }
 
-    void store_long(atomic<int64_t>* atm, int64_t val) {
-      atm -> store(val);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 47)
-    // ubyte
-    uint8_t load_ubyte(atomic<uint8_t>* atm) {
-        return atm -> load();
-    }
+void store_uint(atomic<uint32_t> *atm, uint32_t val) { atm->store(val); }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 47)
+// ulong
+uint64_t load_ulong(atomic<uint64_t> *atm) { return atm->load(); }
 
-    void store_ubyte(atomic<uint8_t>* atm, uint8_t val) {
-      atm -> store(val);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 47)
-    // ushort
-    uint16_t load_ushort(atomic<uint16_t>* atm) {
-        return atm -> load();
-    }
+void store_ulong(atomic<uint64_t> *atm, uint64_t val) { atm->store(val); }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 47)
+// char
+char load_char(atomic<char> *atm) { return atm->load(); }
 
-    void store_ushort(atomic<uint16_t>* atm, uint16_t val) {
-      atm -> store(val);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 47)
-    // uint
-    uint32_t load_uint(atomic<uint32_t>* atm) {
-        return atm -> load();
-    }
+void store_char(atomic<char> *atm, char val) { atm->store(val); }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 47)
+// uchar
+unsigned char load_uchar(atomic<unsigned char> *atm) { return atm->load(); }
 
-    void store_uint(atomic<uint32_t>* atm, uint32_t val) {
-      atm -> store(val);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 47)
-    // ulong
-    uint64_t load_ulong(atomic<uint64_t>* atm) {
-        return atm -> load();
-    }
+void store_uchar(atomic<unsigned char> *atm, unsigned char val) {
+    atm->store(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 47)
+// csize
+size_t load_csize(atomic<size_t> *atm) { return atm->load(); }
 
-    void store_ulong(atomic<uint64_t>* atm, uint64_t val) {
-      atm -> store(val);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 47)
-    // char
-    char load_char(atomic<char>* atm) {
-        return atm -> load();
-    }
+void store_csize(atomic<size_t> *atm, size_t val) { atm->store(val); }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 56)
 
-    void store_char(atomic<char>* atm, char val) {
-      atm -> store(val);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 47)
-    // uchar
-    unsigned char load_uchar(atomic<unsigned char>* atm) {
-        return atm -> load();
-    }
+/**
+ * Compare and Swap
+ * */
 
-    void store_uchar(atomic<unsigned char>* atm, unsigned char val) {
-      atm -> store(val);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 47)
-    // csize
-    size_t load_csize(atomic<size_t>* atm) {
-        return atm -> load();
-    }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 62)
+// byte
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_strong_byte(atomic<int8_t> *atm, int8_t *expected,
+                                 int8_t desired) {
+    return atomic_compare_exchange_strong(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_weak_byte(atomic<int8_t> *atm, int8_t *expected,
+                               int8_t desired) {
+    return atomic_compare_exchange_weak(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 62)
+// short
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_strong_short(atomic<int16_t> *atm, int16_t *expected,
+                                  int16_t desired) {
+    return atomic_compare_exchange_strong(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_weak_short(atomic<int16_t> *atm, int16_t *expected,
+                                int16_t desired) {
+    return atomic_compare_exchange_weak(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 62)
+// int
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_strong_int(atomic<int32_t> *atm, int32_t *expected,
+                                int32_t desired) {
+    return atomic_compare_exchange_strong(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_weak_int(atomic<int32_t> *atm, int32_t *expected,
+                              int32_t desired) {
+    return atomic_compare_exchange_weak(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 62)
+// long
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_strong_long(atomic<int64_t> *atm, int64_t *expected,
+                                 int64_t desired) {
+    return atomic_compare_exchange_strong(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_weak_long(atomic<int64_t> *atm, int64_t *expected,
+                               int64_t desired) {
+    return atomic_compare_exchange_weak(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 62)
+// ubyte
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_strong_ubyte(atomic<uint8_t> *atm, uint8_t *expected,
+                                  uint8_t desired) {
+    return atomic_compare_exchange_strong(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_weak_ubyte(atomic<uint8_t> *atm, uint8_t *expected,
+                                uint8_t desired) {
+    return atomic_compare_exchange_weak(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 62)
+// ushort
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_strong_ushort(atomic<uint16_t> *atm, uint16_t *expected,
+                                   uint16_t desired) {
+    return atomic_compare_exchange_strong(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_weak_ushort(atomic<uint16_t> *atm, uint16_t *expected,
+                                 uint16_t desired) {
+    return atomic_compare_exchange_weak(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 62)
+// uint
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_strong_uint(atomic<uint32_t> *atm, uint32_t *expected,
+                                 uint32_t desired) {
+    return atomic_compare_exchange_strong(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_weak_uint(atomic<uint32_t> *atm, uint32_t *expected,
+                               uint32_t desired) {
+    return atomic_compare_exchange_weak(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 62)
+// ulong
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_strong_ulong(atomic<uint64_t> *atm, uint64_t *expected,
+                                  uint64_t desired) {
+    return atomic_compare_exchange_strong(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_weak_ulong(atomic<uint64_t> *atm, uint64_t *expected,
+                                uint64_t desired) {
+    return atomic_compare_exchange_weak(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 62)
+// char
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_strong_char(atomic<char> *atm, char *expected,
+                                 char desired) {
+    return atomic_compare_exchange_strong(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_weak_char(atomic<char> *atm, char *expected,
+                               char desired) {
+    return atomic_compare_exchange_weak(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 62)
+// uchar
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_strong_uchar(atomic<unsigned char> *atm,
+                                  unsigned char *expected,
+                                  unsigned char desired) {
+    return atomic_compare_exchange_strong(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_weak_uchar(atomic<unsigned char> *atm,
+                                unsigned char *expected,
+                                unsigned char desired) {
+    return atomic_compare_exchange_weak(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 62)
+// csize
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_strong_csize(atomic<size_t> *atm, size_t *expected,
+                                  size_t desired) {
+    return atomic_compare_exchange_strong(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 64)
+int compare_and_swap_weak_csize(atomic<size_t> *atm, size_t *expected,
+                                size_t desired) {
+    return atomic_compare_exchange_weak(atm, expected, desired);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 69)
 
-    void store_csize(atomic<size_t>* atm, size_t val) {
-      atm -> store(val);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 56)
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 71)
+/**
+* add
+* */
 
-	/**
-	 * Compare and Swap
-	 * */
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// byte
+int8_t atomic_add_byte(atomic<int8_t> *atm, int8_t val) {
+    return atm->fetch_add(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// short
+int16_t atomic_add_short(atomic<int16_t> *atm, int16_t val) {
+    return atm->fetch_add(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// int
+int32_t atomic_add_int(atomic<int32_t> *atm, int32_t val) {
+    return atm->fetch_add(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// long
+int64_t atomic_add_long(atomic<int64_t> *atm, int64_t val) {
+    return atm->fetch_add(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ubyte
+uint8_t atomic_add_ubyte(atomic<uint8_t> *atm, uint8_t val) {
+    return atm->fetch_add(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ushort
+uint16_t atomic_add_ushort(atomic<uint16_t> *atm, uint16_t val) {
+    return atm->fetch_add(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// uint
+uint32_t atomic_add_uint(atomic<uint32_t> *atm, uint32_t val) {
+    return atm->fetch_add(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ulong
+uint64_t atomic_add_ulong(atomic<uint64_t> *atm, uint64_t val) {
+    return atm->fetch_add(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// char
+char atomic_add_char(atomic<char> *atm, char val) {
+    return atm->fetch_add(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// uchar
+unsigned char atomic_add_uchar(atomic<unsigned char> *atm, unsigned char val) {
+    return atm->fetch_add(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// csize
+size_t atomic_add_csize(atomic<size_t> *atm, size_t val) {
+    return atm->fetch_add(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 71)
+/**
+* sub
+* */
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 62)
-    // byte
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_strong_byte(atomic<int8_t>* atm, int8_t* expected, int8_t desired) {
-        return atomic_compare_exchange_strong(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_weak_byte(atomic<int8_t>* atm, int8_t* expected, int8_t desired) {
-        return atomic_compare_exchange_weak(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 62)
-    // short
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_strong_short(atomic<int16_t>* atm, int16_t* expected, int16_t desired) {
-        return atomic_compare_exchange_strong(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_weak_short(atomic<int16_t>* atm, int16_t* expected, int16_t desired) {
-        return atomic_compare_exchange_weak(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 62)
-    // int
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_strong_int(atomic<int32_t>* atm, int32_t* expected, int32_t desired) {
-        return atomic_compare_exchange_strong(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_weak_int(atomic<int32_t>* atm, int32_t* expected, int32_t desired) {
-        return atomic_compare_exchange_weak(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 62)
-    // long
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_strong_long(atomic<int64_t>* atm, int64_t* expected, int64_t desired) {
-        return atomic_compare_exchange_strong(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_weak_long(atomic<int64_t>* atm, int64_t* expected, int64_t desired) {
-        return atomic_compare_exchange_weak(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 62)
-    // ubyte
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_strong_ubyte(atomic<uint8_t>* atm, uint8_t* expected, uint8_t desired) {
-        return atomic_compare_exchange_strong(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_weak_ubyte(atomic<uint8_t>* atm, uint8_t* expected, uint8_t desired) {
-        return atomic_compare_exchange_weak(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 62)
-    // ushort
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_strong_ushort(atomic<uint16_t>* atm, uint16_t* expected, uint16_t desired) {
-        return atomic_compare_exchange_strong(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_weak_ushort(atomic<uint16_t>* atm, uint16_t* expected, uint16_t desired) {
-        return atomic_compare_exchange_weak(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 62)
-    // uint
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_strong_uint(atomic<uint32_t>* atm, uint32_t* expected, uint32_t desired) {
-        return atomic_compare_exchange_strong(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_weak_uint(atomic<uint32_t>* atm, uint32_t* expected, uint32_t desired) {
-        return atomic_compare_exchange_weak(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 62)
-    // ulong
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_strong_ulong(atomic<uint64_t>* atm, uint64_t* expected, uint64_t desired) {
-        return atomic_compare_exchange_strong(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_weak_ulong(atomic<uint64_t>* atm, uint64_t* expected, uint64_t desired) {
-        return atomic_compare_exchange_weak(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 62)
-    // char
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_strong_char(atomic<char>* atm, char* expected, char desired) {
-        return atomic_compare_exchange_strong(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_weak_char(atomic<char>* atm, char* expected, char desired) {
-        return atomic_compare_exchange_weak(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 62)
-    // uchar
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_strong_uchar(atomic<unsigned char>* atm, unsigned char* expected, unsigned char desired) {
-        return atomic_compare_exchange_strong(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_weak_uchar(atomic<unsigned char>* atm, unsigned char* expected, unsigned char desired) {
-        return atomic_compare_exchange_weak(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 62)
-    // csize
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_strong_csize(atomic<size_t>* atm, size_t* expected, size_t desired) {
-        return atomic_compare_exchange_strong(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 64)
-    int compare_and_swap_weak_csize(atomic<size_t>* atm, size_t* expected, size_t desired) {
-        return atomic_compare_exchange_weak(atm, expected, desired);
-    }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 69)
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// byte
+int8_t atomic_sub_byte(atomic<int8_t> *atm, int8_t val) {
+    return atm->fetch_sub(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// short
+int16_t atomic_sub_short(atomic<int16_t> *atm, int16_t val) {
+    return atm->fetch_sub(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// int
+int32_t atomic_sub_int(atomic<int32_t> *atm, int32_t val) {
+    return atm->fetch_sub(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// long
+int64_t atomic_sub_long(atomic<int64_t> *atm, int64_t val) {
+    return atm->fetch_sub(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ubyte
+uint8_t atomic_sub_ubyte(atomic<uint8_t> *atm, uint8_t val) {
+    return atm->fetch_sub(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ushort
+uint16_t atomic_sub_ushort(atomic<uint16_t> *atm, uint16_t val) {
+    return atm->fetch_sub(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// uint
+uint32_t atomic_sub_uint(atomic<uint32_t> *atm, uint32_t val) {
+    return atm->fetch_sub(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ulong
+uint64_t atomic_sub_ulong(atomic<uint64_t> *atm, uint64_t val) {
+    return atm->fetch_sub(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// char
+char atomic_sub_char(atomic<char> *atm, char val) {
+    return atm->fetch_sub(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// uchar
+unsigned char atomic_sub_uchar(atomic<unsigned char> *atm, unsigned char val) {
+    return atm->fetch_sub(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// csize
+size_t atomic_sub_csize(atomic<size_t> *atm, size_t val) {
+    return atm->fetch_sub(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 71)
+/**
+* and
+* */
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 71)
-	/**
-     * add
-     * */
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// byte
+int8_t atomic_and_byte(atomic<int8_t> *atm, int8_t val) {
+    return atm->fetch_and(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// short
+int16_t atomic_and_short(atomic<int16_t> *atm, int16_t val) {
+    return atm->fetch_and(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// int
+int32_t atomic_and_int(atomic<int32_t> *atm, int32_t val) {
+    return atm->fetch_and(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// long
+int64_t atomic_and_long(atomic<int64_t> *atm, int64_t val) {
+    return atm->fetch_and(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ubyte
+uint8_t atomic_and_ubyte(atomic<uint8_t> *atm, uint8_t val) {
+    return atm->fetch_and(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ushort
+uint16_t atomic_and_ushort(atomic<uint16_t> *atm, uint16_t val) {
+    return atm->fetch_and(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// uint
+uint32_t atomic_and_uint(atomic<uint32_t> *atm, uint32_t val) {
+    return atm->fetch_and(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ulong
+uint64_t atomic_and_ulong(atomic<uint64_t> *atm, uint64_t val) {
+    return atm->fetch_and(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// char
+char atomic_and_char(atomic<char> *atm, char val) {
+    return atm->fetch_and(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// uchar
+unsigned char atomic_and_uchar(atomic<unsigned char> *atm, unsigned char val) {
+    return atm->fetch_and(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// csize
+size_t atomic_and_csize(atomic<size_t> *atm, size_t val) {
+    return atm->fetch_and(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 71)
+/**
+* or
+* */
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // byte
-     int8_t atomic_add_byte(atomic<int8_t>* atm, int8_t val) {
-        return atm -> fetch_add(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // short
-     int16_t atomic_add_short(atomic<int16_t>* atm, int16_t val) {
-        return atm -> fetch_add(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // int
-     int32_t atomic_add_int(atomic<int32_t>* atm, int32_t val) {
-        return atm -> fetch_add(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // long
-     int64_t atomic_add_long(atomic<int64_t>* atm, int64_t val) {
-        return atm -> fetch_add(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ubyte
-     uint8_t atomic_add_ubyte(atomic<uint8_t>* atm, uint8_t val) {
-        return atm -> fetch_add(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ushort
-     uint16_t atomic_add_ushort(atomic<uint16_t>* atm, uint16_t val) {
-        return atm -> fetch_add(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // uint
-     uint32_t atomic_add_uint(atomic<uint32_t>* atm, uint32_t val) {
-        return atm -> fetch_add(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ulong
-     uint64_t atomic_add_ulong(atomic<uint64_t>* atm, uint64_t val) {
-        return atm -> fetch_add(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // char
-     char atomic_add_char(atomic<char>* atm, char val) {
-        return atm -> fetch_add(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // uchar
-     unsigned char atomic_add_uchar(atomic<unsigned char>* atm, unsigned char val) {
-        return atm -> fetch_add(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // csize
-     size_t atomic_add_csize(atomic<size_t>* atm, size_t val) {
-        return atm -> fetch_add(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 71)
-	/**
-     * sub
-     * */
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// byte
+int8_t atomic_or_byte(atomic<int8_t> *atm, int8_t val) {
+    return atm->fetch_or(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// short
+int16_t atomic_or_short(atomic<int16_t> *atm, int16_t val) {
+    return atm->fetch_or(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// int
+int32_t atomic_or_int(atomic<int32_t> *atm, int32_t val) {
+    return atm->fetch_or(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// long
+int64_t atomic_or_long(atomic<int64_t> *atm, int64_t val) {
+    return atm->fetch_or(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ubyte
+uint8_t atomic_or_ubyte(atomic<uint8_t> *atm, uint8_t val) {
+    return atm->fetch_or(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ushort
+uint16_t atomic_or_ushort(atomic<uint16_t> *atm, uint16_t val) {
+    return atm->fetch_or(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// uint
+uint32_t atomic_or_uint(atomic<uint32_t> *atm, uint32_t val) {
+    return atm->fetch_or(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ulong
+uint64_t atomic_or_ulong(atomic<uint64_t> *atm, uint64_t val) {
+    return atm->fetch_or(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// char
+char atomic_or_char(atomic<char> *atm, char val) { return atm->fetch_or(val); }
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// uchar
+unsigned char atomic_or_uchar(atomic<unsigned char> *atm, unsigned char val) {
+    return atm->fetch_or(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// csize
+size_t atomic_or_csize(atomic<size_t> *atm, size_t val) {
+    return atm->fetch_or(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 71)
+/**
+* xor
+* */
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // byte
-     int8_t atomic_sub_byte(atomic<int8_t>* atm, int8_t val) {
-        return atm -> fetch_sub(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // short
-     int16_t atomic_sub_short(atomic<int16_t>* atm, int16_t val) {
-        return atm -> fetch_sub(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // int
-     int32_t atomic_sub_int(atomic<int32_t>* atm, int32_t val) {
-        return atm -> fetch_sub(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // long
-     int64_t atomic_sub_long(atomic<int64_t>* atm, int64_t val) {
-        return atm -> fetch_sub(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ubyte
-     uint8_t atomic_sub_ubyte(atomic<uint8_t>* atm, uint8_t val) {
-        return atm -> fetch_sub(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ushort
-     uint16_t atomic_sub_ushort(atomic<uint16_t>* atm, uint16_t val) {
-        return atm -> fetch_sub(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // uint
-     uint32_t atomic_sub_uint(atomic<uint32_t>* atm, uint32_t val) {
-        return atm -> fetch_sub(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ulong
-     uint64_t atomic_sub_ulong(atomic<uint64_t>* atm, uint64_t val) {
-        return atm -> fetch_sub(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // char
-     char atomic_sub_char(atomic<char>* atm, char val) {
-        return atm -> fetch_sub(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // uchar
-     unsigned char atomic_sub_uchar(atomic<unsigned char>* atm, unsigned char val) {
-        return atm -> fetch_sub(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // csize
-     size_t atomic_sub_csize(atomic<size_t>* atm, size_t val) {
-        return atm -> fetch_sub(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 71)
-	/**
-     * and
-     * */
-
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // byte
-     int8_t atomic_and_byte(atomic<int8_t>* atm, int8_t val) {
-        return atm -> fetch_and(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // short
-     int16_t atomic_and_short(atomic<int16_t>* atm, int16_t val) {
-        return atm -> fetch_and(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // int
-     int32_t atomic_and_int(atomic<int32_t>* atm, int32_t val) {
-        return atm -> fetch_and(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // long
-     int64_t atomic_and_long(atomic<int64_t>* atm, int64_t val) {
-        return atm -> fetch_and(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ubyte
-     uint8_t atomic_and_ubyte(atomic<uint8_t>* atm, uint8_t val) {
-        return atm -> fetch_and(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ushort
-     uint16_t atomic_and_ushort(atomic<uint16_t>* atm, uint16_t val) {
-        return atm -> fetch_and(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // uint
-     uint32_t atomic_and_uint(atomic<uint32_t>* atm, uint32_t val) {
-        return atm -> fetch_and(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ulong
-     uint64_t atomic_and_ulong(atomic<uint64_t>* atm, uint64_t val) {
-        return atm -> fetch_and(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // char
-     char atomic_and_char(atomic<char>* atm, char val) {
-        return atm -> fetch_and(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // uchar
-     unsigned char atomic_and_uchar(atomic<unsigned char>* atm, unsigned char val) {
-        return atm -> fetch_and(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // csize
-     size_t atomic_and_csize(atomic<size_t>* atm, size_t val) {
-        return atm -> fetch_and(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 71)
-	/**
-     * or
-     * */
-
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // byte
-     int8_t atomic_or_byte(atomic<int8_t>* atm, int8_t val) {
-        return atm -> fetch_or(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // short
-     int16_t atomic_or_short(atomic<int16_t>* atm, int16_t val) {
-        return atm -> fetch_or(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // int
-     int32_t atomic_or_int(atomic<int32_t>* atm, int32_t val) {
-        return atm -> fetch_or(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // long
-     int64_t atomic_or_long(atomic<int64_t>* atm, int64_t val) {
-        return atm -> fetch_or(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ubyte
-     uint8_t atomic_or_ubyte(atomic<uint8_t>* atm, uint8_t val) {
-        return atm -> fetch_or(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ushort
-     uint16_t atomic_or_ushort(atomic<uint16_t>* atm, uint16_t val) {
-        return atm -> fetch_or(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // uint
-     uint32_t atomic_or_uint(atomic<uint32_t>* atm, uint32_t val) {
-        return atm -> fetch_or(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ulong
-     uint64_t atomic_or_ulong(atomic<uint64_t>* atm, uint64_t val) {
-        return atm -> fetch_or(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // char
-     char atomic_or_char(atomic<char>* atm, char val) {
-        return atm -> fetch_or(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // uchar
-     unsigned char atomic_or_uchar(atomic<unsigned char>* atm, unsigned char val) {
-        return atm -> fetch_or(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // csize
-     size_t atomic_or_csize(atomic<size_t>* atm, size_t val) {
-        return atm -> fetch_or(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 71)
-	/**
-     * xor
-     * */
-
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // byte
-     int8_t atomic_xor_byte(atomic<int8_t>* atm, int8_t val) {
-        return atm -> fetch_xor(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // short
-     int16_t atomic_xor_short(atomic<int16_t>* atm, int16_t val) {
-        return atm -> fetch_xor(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // int
-     int32_t atomic_xor_int(atomic<int32_t>* atm, int32_t val) {
-        return atm -> fetch_xor(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // long
-     int64_t atomic_xor_long(atomic<int64_t>* atm, int64_t val) {
-        return atm -> fetch_xor(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ubyte
-     uint8_t atomic_xor_ubyte(atomic<uint8_t>* atm, uint8_t val) {
-        return atm -> fetch_xor(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ushort
-     uint16_t atomic_xor_ushort(atomic<uint16_t>* atm, uint16_t val) {
-        return atm -> fetch_xor(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // uint
-     uint32_t atomic_xor_uint(atomic<uint32_t>* atm, uint32_t val) {
-        return atm -> fetch_xor(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // ulong
-     uint64_t atomic_xor_ulong(atomic<uint64_t>* atm, uint64_t val) {
-        return atm -> fetch_xor(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // char
-     char atomic_xor_char(atomic<char>* atm, char val) {
-        return atm -> fetch_xor(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // uchar
-     unsigned char atomic_xor_uchar(atomic<unsigned char>* atm, unsigned char val) {
-        return atm -> fetch_xor(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 77)
-     // csize
-     size_t atomic_xor_csize(atomic<size_t>* atm, size_t val) {
-        return atm -> fetch_xor(val);
-     }
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb", line: 84)
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// byte
+int8_t atomic_xor_byte(atomic<int8_t> *atm, int8_t val) {
+    return atm->fetch_xor(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// short
+int16_t atomic_xor_short(atomic<int16_t> *atm, int16_t val) {
+    return atm->fetch_xor(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// int
+int32_t atomic_xor_int(atomic<int32_t> *atm, int32_t val) {
+    return atm->fetch_xor(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// long
+int64_t atomic_xor_long(atomic<int64_t> *atm, int64_t val) {
+    return atm->fetch_xor(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ubyte
+uint8_t atomic_xor_ubyte(atomic<uint8_t> *atm, uint8_t val) {
+    return atm->fetch_xor(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ushort
+uint16_t atomic_xor_ushort(atomic<uint16_t> *atm, uint16_t val) {
+    return atm->fetch_xor(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// uint
+uint32_t atomic_xor_uint(atomic<uint32_t> *atm, uint32_t val) {
+    return atm->fetch_xor(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// ulong
+uint64_t atomic_xor_ulong(atomic<uint64_t> *atm, uint64_t val) {
+    return atm->fetch_xor(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// char
+char atomic_xor_char(atomic<char> *atm, char val) {
+    return atm->fetch_xor(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// uchar
+unsigned char atomic_xor_uchar(atomic<unsigned char> *atm, unsigned char val) {
+    return atm->fetch_xor(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 77)
+// csize
+size_t atomic_xor_csize(atomic<size_t> *atm, size_t val) {
+    return atm->fetch_xor(val);
+}
+// ###sourceLocation(file:
+// "/home/remi/perso/Projects/scala-native/nativelib/src/main/resources/atomic.cpp.gyb",
+// line: 84)
 }

--- a/nativelib/src/main/resources/gc/boehm/pthread-gc.c
+++ b/nativelib/src/main/resources/gc/boehm/pthread-gc.c
@@ -1,0 +1,32 @@
+// Binds pthread_* functions to scalanative_pthread_* functions.
+// This allows GCs to hook into pthreads.
+// Every GC must include this file.
+
+#include <pthread.h>
+#define GC_THREADS // re-defines pthread functions
+#include <gc.h>
+
+int scalanative_pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                               void *(*start_routine)(void *), void *arg) {
+    return pthread_create(thread, attr, start_routine, arg);
+}
+
+int scalanative_pthread_join(pthread_t thread, void **value_ptr) {
+    return pthread_join(thread, value_ptr);
+}
+
+int scalanative_pthread_detach(pthread_t thread) {
+    return pthread_detach(thread);
+}
+
+int scalanative_pthread_cancel(pthread_t thread) {
+    return pthread_cancel(thread);
+}
+
+void scalanative_pthread_exit(void *retval) { pthread_exit(retval); }
+
+// not bound in scala-native
+/*
+int scalanative_pthread_sigmask(int how, const sigset_t *set, sigset_t *oldset){
+    return  pthread_sigmask(how, set, oldset);
+}*/

--- a/nativelib/src/main/resources/gc/immix/pthread-gc.c
+++ b/nativelib/src/main/resources/gc/immix/pthread-gc.c
@@ -1,0 +1,36 @@
+// Binds pthread_* functions to scalanative_pthread_* functions.
+// This allows GCs to hook into pthreads.
+// Every GC must include this file.
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int scalanative_pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                               void *(*start_routine)(void *), void *arg) {
+    perror("Tried to create a thread when using immix GC\n");
+    perror("This is not supported\n");
+    exit(-1);
+
+    return -1;
+}
+
+int scalanative_pthread_join(pthread_t thread, void **value_ptr) {
+    return pthread_join(thread, value_ptr);
+}
+
+int scalanative_pthread_detach(pthread_t thread) {
+    return pthread_detach(thread);
+}
+
+int scalanative_pthread_cancel(pthread_t thread) {
+    return pthread_cancel(thread);
+}
+
+void scalanative_pthread_exit(void *retval) { pthread_exit(retval); }
+
+// not bound in scala-native
+/*
+int scalanative_pthread_sigmask(int how, const sigset_t *set, sigset_t *oldset){
+    return  pthread_sigmask(how, set, oldset);
+}*/

--- a/nativelib/src/main/resources/gc/none/pthread-gc.c
+++ b/nativelib/src/main/resources/gc/none/pthread-gc.c
@@ -1,0 +1,30 @@
+// Binds pthread_* functions to scalanative_pthread_* functions.
+// This allows GCs to hook into pthreads.
+// Every GC must include this file.
+
+#include <pthread.h>
+
+int scalanative_pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                               void *(*start_routine)(void *), void *arg) {
+    return pthread_create(thread, attr, start_routine, arg);
+}
+
+int scalanative_pthread_join(pthread_t thread, void **value_ptr) {
+    return pthread_join(thread, value_ptr);
+}
+
+int scalanative_pthread_detach(pthread_t thread) {
+    return pthread_detach(thread);
+}
+
+int scalanative_pthread_cancel(pthread_t thread) {
+    return pthread_cancel(thread);
+}
+
+void scalanative_pthread_exit(void *retval) { pthread_exit(retval); }
+
+// not bound in scala-native
+/*
+int scalanative_pthread_sigmask(int how, const sigset_t *set, sigset_t *oldset){
+    return  pthread_sigmask(how, set, oldset);
+}*/

--- a/nativelib/src/main/resources/nativethread.c
+++ b/nativelib/src/main/resources/nativethread.c
@@ -2,7 +2,6 @@
 #include <stdint.h>
 #include <pthread.h>
 #include <sched.h>
-#include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -13,251 +12,55 @@ size_t PTHREAD_DEFAULT_STACK_SIZE;
 int initialized = 0;
 
 void init() {
-	pthread_attr_init(&PTHREAD_DEFAULT_ATTR);
-	pthread_attr_getschedparam(&PTHREAD_DEFAULT_ATTR, &PTHREAD_DEFAULT_SCHED_PARAM);
-	pthread_attr_getschedpolicy(&PTHREAD_DEFAULT_ATTR, &PTHREAD_DEFAULT_POLICY);
-	pthread_attr_getstacksize(&PTHREAD_DEFAULT_ATTR, &PTHREAD_DEFAULT_STACK_SIZE);
+    pthread_attr_init(&PTHREAD_DEFAULT_ATTR);
+    pthread_attr_getschedparam(&PTHREAD_DEFAULT_ATTR,
+                               &PTHREAD_DEFAULT_SCHED_PARAM);
+    pthread_attr_getschedpolicy(&PTHREAD_DEFAULT_ATTR, &PTHREAD_DEFAULT_POLICY);
+    pthread_attr_getstacksize(&PTHREAD_DEFAULT_ATTR,
+                              &PTHREAD_DEFAULT_STACK_SIZE);
 
-	initialized = 1;
+    initialized = 1;
 }
 
 int get_max_priority() {
-	if(!initialized) init();
-	return sched_get_priority_max(PTHREAD_DEFAULT_POLICY);
+    if (!initialized)
+        init();
+    return sched_get_priority_max(PTHREAD_DEFAULT_POLICY);
 }
 
 int get_min_priority() {
-	if(!initialized) init();
-	return sched_get_priority_min(PTHREAD_DEFAULT_POLICY);
+    if (!initialized)
+        init();
+    return sched_get_priority_min(PTHREAD_DEFAULT_POLICY);
 }
 
 int get_norm_priority() {
-	if(!initialized) init();
-	return PTHREAD_DEFAULT_SCHED_PARAM.sched_priority;
+    if (!initialized)
+        init();
+    return PTHREAD_DEFAULT_SCHED_PARAM.sched_priority;
 }
 
 size_t get_stack_size() {
-	if(!initialized) init();
-	return PTHREAD_DEFAULT_STACK_SIZE;
+    if (!initialized)
+        init();
+    return PTHREAD_DEFAULT_STACK_SIZE;
+}
+
+void attr_set_priority(pthread_attr_t *attr, int priority) {
+    struct sched_param param;
+
+    pthread_attr_setschedparam(attr, &param);
+    param.sched_priority = priority;
+
+    pthread_attr_setschedparam(attr, &param);
 }
 
 void set_priority(pthread_t thread, int priority) {
-	struct sched_param param;
-	int policy;
+    struct sched_param param;
+    int policy;
 
-	pthread_getschedparam(thread, &policy, &param);
-	param.sched_priority = priority;
+    pthread_getschedparam(thread, &policy, &param);
+    param.sched_priority = priority;
 
-	pthread_setschedparam(thread, policy, &param);
+    pthread_setschedparam(thread, policy, &param);
 }
-
-/*
- * Thread suspend handling
-*/
-
-// ported from http://ptgmedia.pearsoncmg.com/images/0201633922/sourcecode/susp.c
-
-pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
-volatile int sentinel = 0;
-pthread_once_t once = PTHREAD_ONCE_INIT;
-pthread_t *array = NULL, null_pthread = {0};
-int bottom = 0;
-int inited = 0;
-
-/*
- * Handle SIGUSR1 in the target thread, to suspend it until
- * receiving SIGUSR2 (resume).
- */
-void
-suspend_signal_handler (int sig)
-{
-    sigset_t signal_set;
-
-    /*
-     * Block all signals except SIGUSR2 while suspended.
-     */
-    sigfillset (&signal_set);
-    sigdelset (&signal_set, SIGUSR2);
-    sentinel = 1;
-    sigsuspend (&signal_set);
-
-    return;
-}
-
-/*
- * Handle SIGUSR2 in the target thread.
- */
-void
-resume_signal_handler (int sig)
-{
-    return;
-}
-
-/*
- * Dynamically initialize the "suspend package" when first used
- * (called by pthread_once).
- */
-void
-suspend_init_routine (void)
-{
-    int status;
-    struct sigaction sigusr1, sigusr2;
-
-    /*
-     * Allocate the suspended threads array. This array is used
-     * to guarentee idempotency
-     */
-    bottom = 10;
-    array = (pthread_t*) calloc (bottom, sizeof (pthread_t));
-
-    /*
-     * Install the signal handlers for suspend/resume.
-     */
-    sigusr1.sa_flags = 0;
-    sigusr1.sa_handler = suspend_signal_handler;
-
-    sigemptyset (&sigusr1.sa_mask);
-    sigusr2.sa_flags = 0;
-    sigusr2.sa_handler = resume_signal_handler;
-    sigusr2.sa_mask = sigusr1.sa_mask;
-
-    status = sigaction (SIGUSR1, &sigusr1, NULL);
-    if (status == -1)
-        perror("Installing suspend handler");
-
-    status = sigaction (SIGUSR2, &sigusr2, NULL);
-    if (status == -1)
-        perror("Installing resume handler");
-
-    inited = 1;
-    return;
-}
-
-/*
- * Suspend a thread by sending it a signal (SIGUSR1), which will
- * block the thread until another signal (SIGUSR2) arrives.
- *
- * Multiple calls to thd_suspend for a single thread have no
- * additional effect on the thread -- a single thd_continue
- * call will cause it to resume execution.
- */
-int
-thd_suspend (pthread_t target_thread)
-{
-    int status;
-    int i = 0;
-
-    /*
-     * The first call to thd_suspend will initialize the
-     * package.
-     */
-    status = pthread_once (&once, suspend_init_routine);
-    if (status != 0)
-        return status;
-
-    /*
-     * Serialize access to suspend, makes life easier
-     */
-    status = pthread_mutex_lock (&mut);
-    if (status != 0)
-        return status;
-
-    /*
-     * Threads that are suspended are added to the target_array;
-     * a request to suspend a thread already listed in the array
-     * is ignored. Sending a second SIGUSR1 would cause the
-     * thread to re-suspend itself as soon as it is resumed.
-     */
-    while (i < bottom)
-        if (array[i++] == target_thread) {
-            status = pthread_mutex_unlock (&mut);
-            return status;
-        }
-
-    i = 0;
-    while (array[i] != 0)
-        i++;
-
-    if (i == bottom) {
-        array = (pthread_t*) realloc (
-            array, (++bottom * sizeof (pthread_t)));
-        if (array == NULL) {
-            pthread_mutex_unlock (&mut);
-            perror("Null pointer");
-        }
-
-        array[bottom] = null_pthread;   /* Clear new entry */
-    }
-
-    /*
-     * Clear the sentinel and signal the thread to suspend.
-     */
-    sentinel = 0;
-    status = pthread_kill (target_thread, SIGUSR1);
-    if (status != 0) {
-        pthread_mutex_unlock (&mut);
-        return status;
-    }
-
-    /*
-     * Wait for the sentinel to change.
-     */
-    while (sentinel == 0)
-        sched_yield ();
-
-    array[i] = target_thread;
-
-    status = pthread_mutex_unlock (&mut);
-    return status;
-}
-
-/*
- * Resume a suspended thread by sending it SIGUSR2 to break
- * it out of the sigsuspend() in which it's waiting. If the
- * target thread isn't suspended, return with success.
- */
-int
-thd_continue (pthread_t target_thread)
-{
-    int status;
-    int i = 0;
-
-    status = pthread_mutex_lock (&mut);
-    if (status != 0)
-        return status;
-
-    if (!inited) {
-        status = pthread_mutex_unlock (&mut);
-        return status;
-    }
-
-    /*
-     * Make sure the thread is in the suspend array. If not, it
-     * hasn't been suspended (or it has already been resumed).
-     */
-    while (array[i] != target_thread && i < bottom)
-        i++;
-
-    if (i >= bottom) {
-        pthread_mutex_unlock (&mut);
-        return 0;
-    }
-
-    /*
-     * Signal the thread to continue, and remove the thread from
-     * the suspended array.
-     */
-    status = pthread_kill (target_thread, SIGUSR2);
-    if (status != 0) {
-        pthread_mutex_unlock (&mut);
-        return status;
-    }
-
-    array[i] = 0;               /* Clear array element */
-    status = pthread_mutex_unlock (&mut);
-    return status;
-}
-
-/*
- * End of Thread suspend
- */

--- a/nativelib/src/main/resources/pthread.c
+++ b/nativelib/src/main/resources/pthread.c
@@ -1,99 +1,66 @@
 #include <pthread.h>
 #include <sys/types.h>
+#include <string.h>
+
+size_t scalanative_size_of_pthread_t() { return sizeof(pthread_t); }
+
+size_t scalanative_pthread_attr_t() { return sizeof(pthread_attr_t); }
+
+size_t scalanative_size_of_pthread_cond_t() { return sizeof(pthread_cond_t); }
+
+size_t scalanative_size_of_pthread_condattr_t() {
+    return sizeof(pthread_condattr_t);
+}
+
+size_t scalanative_size_of_pthread_mutex_t() { return sizeof(pthread_mutex_t); }
+
+size_t scalanative_size_of_pthread_mutexattr_t() {
+    return sizeof(pthread_mutexattr_t);
+}
 
 int scalanative_pthread_cancel_asynchronous() {
     return PTHREAD_CANCEL_ASYNCHRONOUS;
 }
 
-int scalanative_pthread_cancel_enable() {
-    return PTHREAD_CANCEL_ENABLE;
-}
+int scalanative_pthread_cancel_enable() { return PTHREAD_CANCEL_ENABLE; }
 
-int scalanative_pthread_cancel_ered() {
-    return PTHREAD_CANCEL_DEFERRED;
-}
+int scalanative_pthread_cancel_ered() { return PTHREAD_CANCEL_DEFERRED; }
 
-int scalanative_pthread_cancel_disable() {
-    return PTHREAD_CANCEL_DISABLE;
-}
+int scalanative_pthread_cancel_disable() { return PTHREAD_CANCEL_DISABLE; }
 
-void* scalanative_pthread_canceled() {
-    return PTHREAD_CANCELED;
-}
+void *scalanative_pthread_canceled() { return PTHREAD_CANCELED; }
 
-int scalanative_pthread_create_deteached() {
-    return PTHREAD_CREATE_DETACHED;
-}
+int scalanative_pthread_create_deteached() { return PTHREAD_CREATE_DETACHED; }
 
-int scalanative_pthread_create_joinale() {
-    return PTHREAD_CREATE_JOINABLE;
-}
+int scalanative_pthread_create_joinale() { return PTHREAD_CREATE_JOINABLE; }
 
-int scalanative_pthread_explicit_sched() {
-    return PTHREAD_EXPLICIT_SCHED;
-}
+int scalanative_pthread_explicit_sched() { return PTHREAD_EXPLICIT_SCHED; }
 
-int scalanative_pthread_inherit_sched() {
-    return PTHREAD_INHERIT_SCHED;
-}
+int scalanative_pthread_inherit_sched() { return PTHREAD_INHERIT_SCHED; }
 
-int scalanative_pthread_mutex_ault() {
-    return PTHREAD_MUTEX_DEFAULT;
-}
+int scalanative_pthread_mutex_ault() { return PTHREAD_MUTEX_DEFAULT; }
 
-int scalanative_pthread_mutex_errorcheck() {
-    return PTHREAD_MUTEX_ERRORCHECK;
-}
+int scalanative_pthread_mutex_errorcheck() { return PTHREAD_MUTEX_ERRORCHECK; }
 
-int scalanative_pthread_mutex_normal() {
-    return PTHREAD_MUTEX_NORMAL;
-}
+int scalanative_pthread_mutex_normal() { return PTHREAD_MUTEX_NORMAL; }
 
-int scalanative_pthread_mutex_recursive() {
-    return PTHREAD_MUTEX_RECURSIVE;
-}
+int scalanative_pthread_mutex_recursive() { return PTHREAD_MUTEX_RECURSIVE; }
 
 pthread_once_t scalanative_pthread_once_init() {
     pthread_once_t once_block = PTHREAD_ONCE_INIT;
     return once_block;
 }
 
-int scalanative_pthread_prio_inherit() {
-    return PTHREAD_PRIO_INHERIT;
-}
+int scalanative_pthread_prio_inherit() { return PTHREAD_PRIO_INHERIT; }
 
-int scalanative_pthread_prio_none() {
-    return PTHREAD_PRIO_NONE;
-}
+int scalanative_pthread_prio_none() { return PTHREAD_PRIO_NONE; }
 
-int scalanative_pthread_prio_protect() {
-    return PTHREAD_PRIO_PROTECT;
-}
+int scalanative_pthread_prio_protect() { return PTHREAD_PRIO_PROTECT; }
 
-int scalanative_pthread_process_shared() {
-    return PTHREAD_PROCESS_SHARED;
-}
+int scalanative_pthread_process_shared() { return PTHREAD_PROCESS_SHARED; }
 
-int scalanative_pthread_process_private() {
-    return PTHREAD_PROCESS_PRIVATE;
-}
+int scalanative_pthread_process_private() { return PTHREAD_PROCESS_PRIVATE; }
 
-int scalanative_pthread_scope_process() {
-    return PTHREAD_SCOPE_PROCESS;
-}
+int scalanative_pthread_scope_process() { return PTHREAD_SCOPE_PROCESS; }
 
-int scalanative_pthread_scope_system() {
-    return PTHREAD_SCOPE_SYSTEM;
-}
-
-pthread_cond_t scalanative_pthread_cond_initializer() {
-    return (pthread_cond_t)PTHREAD_COND_INITIALIZER;
-}
-
-pthread_mutex_t scalanative_pthread_mutex_initializer() {
-    return (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
-}
-
-pthread_rwlock_t scalanative_pthread_rwlock_initializer() {
-    return (pthread_rwlock_t)PTHREAD_RWLOCK_INITIALIZER;
-}
+int scalanative_pthread_scope_system() { return PTHREAD_SCOPE_SYSTEM; }

--- a/nativelib/src/main/resources/time.c
+++ b/nativelib/src/main/resources/time.c
@@ -18,3 +18,5 @@ long long scalanative_current_time_millis() {
 
     return current_time_millis;
 }
+
+int scalanative_clock_realtime() { return CLOCK_REALTIME; }

--- a/nativelib/src/main/resources/wrap.c
+++ b/nativelib/src/main/resources/wrap.c
@@ -63,6 +63,12 @@ int scalanative_libc_sigsegv() { return SIGSEGV; }
 
 int scalanative_libc_sigterm() { return SIGTERM; }
 
+int scalanative_libc_sigusr1() { return SIGUSR1; }
+
+int scalanative_libc_sigrtmin() { return SIGRTMIN; }
+
+int scalanative_libc_sigrtmax() { return SIGRTMAX; }
+
 int scalanative_libc_rand_max() { return RAND_MAX; }
 
 float scalanative_libc_huge_valf() { return HUGE_VALF; }

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -5,6 +5,7 @@ import scala.scalanative.runtime, runtime.ClassTypeOps
 import scala.scalanative.runtime.Intrinsics._
 
 class _Object {
+  var __monitor: scala.scalanative.runtime.Monitor = _
   @inline def __equals(that: _Object): scala.Boolean =
     this eq that
 

--- a/nativelib/src/main/scala/scala/scalanative/native/signal.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/signal.scala
@@ -31,4 +31,12 @@ object signal {
   def SIGSEGV: CInt = extern
   @name("scalanative_libc_sigterm")
   def SIGTERM: CInt = extern
+  @name("scalanative_libc_sigusr1")
+  def SIGUSR1: CInt = extern
+  @name("scalanative_libc_sigusr2")
+  def SIGUSR2: CInt = extern
+  @name("scalanative_libc_sigrtmin")
+  def SIGRTMIN: CInt = extern
+  @name("scalanative_libc_sigrtmax")
+  def SIGRTMAX: CInt = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/sysinfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/sysinfo.scala
@@ -1,0 +1,6 @@
+package scala.scalanative.native
+
+@extern
+object sysinfo {
+  def get_nprocs: CInt = extern
+}

--- a/nativelib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -72,6 +72,7 @@ object pthread {
   def pthread_attr_setstacksize(attr: Ptr[pthread_attr_t],
                                 stacksize: CSize): CInt = extern
 
+  @name("scalanative_pthread_cancel")
   def pthread_cancel(thread: pthread_t): CInt = extern
 
   def pthread_cond_broadcast(cond: Ptr[pthread_cond_t]): CInt = extern
@@ -100,15 +101,18 @@ object pthread {
   def pthread_condattr_setpshared(attr: Ptr[pthread_condattr_t],
                                   pshared: CInt): CInt = extern
 
+  @name("scalanative_pthread_create")
   def pthread_create(thread: Ptr[pthread_t],
                      attr: Ptr[pthread_attr_t],
                      startroutine: CFunctionPtr1[Ptr[Byte], Ptr[Byte]],
                      args: Ptr[Byte]): CInt = extern
 
+  @name("scalanative_pthread_detach")
   def pthread_detach(thread: pthread_t): CInt = extern
 
   def pthread_equal(thread1: pthread_t, thread2: pthread_t): CInt = extern
 
+  @name("scalanative_pthread_exit")
   def pthread_exit(retval: Ptr[Byte]): Unit = extern
 
   def pthread_getconcurrency(): CInt = extern
@@ -119,6 +123,7 @@ object pthread {
 
   def pthread_getspecific(key: pthread_key_t): Ptr[Byte] = extern
 
+  @name("scalanative_pthread_join")
   def pthread_join(thread: pthread_t, value_ptr: Ptr[Ptr[Byte]]): CInt = extern
 
   def pthread_key_create(key: Ptr[pthread_key_t],
@@ -126,6 +131,8 @@ object pthread {
     extern
 
   def pthread_key_delete(key: pthread_key_t): CInt = extern
+
+  def pthread_kill(key: pthread_t, sig: CInt): CInt = extern
 
   def pthread_mutex_destroy(mutex: Ptr[pthread_mutex_t]): CInt = extern
 
@@ -285,13 +292,22 @@ object pthread {
   @name("scalanative_pthread_scope_system")
   def PTHREAD_SCOPE_SYSTEM: CInt = extern
 
-  @name("scalanative_pthread_cond_initializer")
-  def PTHREAD_COND_INITIALIZER: pthread_cond_t = extern
+  @name("scalanative_size_of_pthread_t")
+  def pthread_t_size: CSize = extern
 
-  @name("scalanative_pthread_mutex_initializer")
-  def PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = extern
+  @name("scalanative_pthread_attr_t")
+  def pthread_attr_t_size: CSize = extern
 
-  @name("scalanative_pthread_rwlock_initializer")
-  def PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = extern
+  @name("scalanative_size_of_pthread_cond_t")
+  def pthread_cond_t_size: CSize = extern
+
+  @name("scalanative_size_of_pthread_condattr_t")
+  def pthread_condattr_t_size: CSize = extern
+
+  @name("scalanative_size_of_pthread_mutex_t")
+  def pthread_mutex_t_size: CSize = extern
+
+  @name("scalanative_size_of_pthread_mutexattr_t")
+  def pthread_mutexattr_t_size: CSize = extern
 
 }

--- a/nativelib/src/main/scala/scala/scalanative/posix/sys/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/sys/time.scala
@@ -2,9 +2,24 @@ package scala.scalanative
 package posix
 package sys
 
-import scala.scalanative.native.{CLong, CLongInt, CStruct2}
+import scala.scalanative.native.{
+  CInt,
+  CLong,
+  CLongInt,
+  CStruct2,
+  Ptr,
+  extern,
+  name
+}
 
+@extern
 object time {
-  type time_t   = CLongInt
-  type timespec = CStruct2[time_t, CLong]
+  type time_t    = CLongInt
+  type timespec  = CStruct2[time_t, CLong]
+  type clockid_t = CInt
+
+  def clock_gettime(clk_id: clockid_t, ts: Ptr[timespec]): CInt = extern
+
+  @name("scalanative_clock_realtime")
+  def CLOCK_REALTIME: clockid_t = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala
@@ -1,4 +1,4 @@
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 1)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 1)
 package scala.scalanative
 package runtime
 
@@ -17,96 +17,90 @@ import scala.scalanative.native.{
   extern
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 32)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 32)
 
 // see http://en.cppreference.com/w/cpp/atomic
 
 @extern
 object Atomic {
 
-  // Memory
-  def alloc(sz: CSize): Ptr[Byte] = extern
-
-  def free(ptr: Ptr[Byte]): Unit = extern
-
   // Init
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 40)
   def init_byte(atm: CAtomicByte, initValue: Byte): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 40)
   def init_short(atm: CAtomicShort, initValue: CShort): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 40)
   def init_int(atm: CAtomicInt, initValue: CInt): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 40)
   def init_long(atm: CAtomicLong, initValue: CLong): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 40)
   def init_ubyte(atm: CAtomicUnsignedByte, initValue: Byte): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 40)
   def init_ushort(atm: CAtomicUnsignedShort, initValue: CUnsignedShort): Unit =
     extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
-  def init_uint(atm: CAtomicUnsignedInt, initValue: CUnsignedInt): Unit =
-    extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 40)
+  def init_uint(atm: CAtomicUnsignedInt, initValue: CUnsignedInt): Unit = extern
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 40)
   def init_ulong(atm: CAtomicUnsignedLong, initValue: CUnsignedLong): Unit =
     extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 40)
   def init_char(atm: CAtomicChar, initValue: CChar): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 40)
   def init_uchar(atm: CAtomicUnsignedChar, initValue: CUnsignedChar): Unit =
     extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 40)
   def init_csize(atm: CAtomicCSize, initValue: CSize): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 47)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 42)
 
   // Load
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 50)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
   def load_byte(ptr: CAtomicByte): Byte = extern
 
   def store_byte(ptr: CAtomicByte, v: Byte): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 50)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
   def load_short(ptr: CAtomicShort): CShort = extern
 
   def store_short(ptr: CAtomicShort, v: CShort): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 50)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
   def load_int(ptr: CAtomicInt): CInt = extern
 
   def store_int(ptr: CAtomicInt, v: CInt): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 50)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
   def load_long(ptr: CAtomicLong): CLong = extern
 
   def store_long(ptr: CAtomicLong, v: CLong): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 50)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
   def load_ubyte(ptr: CAtomicUnsignedByte): Byte = extern
 
   def store_ubyte(ptr: CAtomicUnsignedByte, v: Byte): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 50)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
   def load_ushort(ptr: CAtomicUnsignedShort): CUnsignedShort = extern
 
   def store_ushort(ptr: CAtomicUnsignedShort, v: CUnsignedShort): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 50)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
   def load_uint(ptr: CAtomicUnsignedInt): CUnsignedInt = extern
 
   def store_uint(ptr: CAtomicUnsignedInt, v: CUnsignedInt): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 50)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
   def load_ulong(ptr: CAtomicUnsignedLong): CUnsignedLong = extern
 
   def store_ulong(ptr: CAtomicUnsignedLong, v: CUnsignedLong): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 50)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
   def load_char(ptr: CAtomicChar): CChar = extern
 
   def store_char(ptr: CAtomicChar, v: CChar): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 50)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
   def load_uchar(ptr: CAtomicUnsignedChar): CUnsignedChar = extern
 
   def store_uchar(ptr: CAtomicUnsignedChar, v: CUnsignedChar): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 50)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 45)
   def load_csize(ptr: CAtomicCSize): CSize = extern
 
   def store_csize(ptr: CAtomicCSize, v: CSize): Unit = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 54)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 49)
 
   // Compare and Swap
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 57)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 52)
   def compare_and_swap_strong_byte(value: CAtomicByte,
                                    expected: CAtomicByte,
                                    desired: Byte): CBool = extern
@@ -114,7 +108,7 @@ object Atomic {
   def compare_and_swap_weak_byte(value: CAtomicByte,
                                  expected: CAtomicByte,
                                  desired: Byte): CBool = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 57)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 52)
   def compare_and_swap_strong_short(value: CAtomicShort,
                                     expected: CAtomicShort,
                                     desired: CShort): CBool = extern
@@ -122,7 +116,7 @@ object Atomic {
   def compare_and_swap_weak_short(value: CAtomicShort,
                                   expected: CAtomicShort,
                                   desired: CShort): CBool = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 57)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 52)
   def compare_and_swap_strong_int(value: CAtomicInt,
                                   expected: CAtomicInt,
                                   desired: CInt): CBool = extern
@@ -130,7 +124,7 @@ object Atomic {
   def compare_and_swap_weak_int(value: CAtomicInt,
                                 expected: CAtomicInt,
                                 desired: CInt): CBool = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 57)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 52)
   def compare_and_swap_strong_long(value: CAtomicLong,
                                    expected: CAtomicLong,
                                    desired: CLong): CBool = extern
@@ -138,7 +132,7 @@ object Atomic {
   def compare_and_swap_weak_long(value: CAtomicLong,
                                  expected: CAtomicLong,
                                  desired: CLong): CBool = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 57)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 52)
   def compare_and_swap_strong_ubyte(value: CAtomicUnsignedByte,
                                     expected: CAtomicUnsignedByte,
                                     desired: Byte): CBool = extern
@@ -146,7 +140,7 @@ object Atomic {
   def compare_and_swap_weak_ubyte(value: CAtomicUnsignedByte,
                                   expected: CAtomicUnsignedByte,
                                   desired: Byte): CBool = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 57)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 52)
   def compare_and_swap_strong_ushort(value: CAtomicUnsignedShort,
                                      expected: CAtomicUnsignedShort,
                                      desired: CUnsignedShort): CBool = extern
@@ -154,7 +148,7 @@ object Atomic {
   def compare_and_swap_weak_ushort(value: CAtomicUnsignedShort,
                                    expected: CAtomicUnsignedShort,
                                    desired: CUnsignedShort): CBool = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 57)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 52)
   def compare_and_swap_strong_uint(value: CAtomicUnsignedInt,
                                    expected: CAtomicUnsignedInt,
                                    desired: CUnsignedInt): CBool = extern
@@ -162,7 +156,7 @@ object Atomic {
   def compare_and_swap_weak_uint(value: CAtomicUnsignedInt,
                                  expected: CAtomicUnsignedInt,
                                  desired: CUnsignedInt): CBool = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 57)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 52)
   def compare_and_swap_strong_ulong(value: CAtomicUnsignedLong,
                                     expected: CAtomicUnsignedLong,
                                     desired: CUnsignedLong): CBool = extern
@@ -170,7 +164,7 @@ object Atomic {
   def compare_and_swap_weak_ulong(value: CAtomicUnsignedLong,
                                   expected: CAtomicUnsignedLong,
                                   desired: CUnsignedLong): CBool = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 57)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 52)
   def compare_and_swap_strong_char(value: CAtomicChar,
                                    expected: CAtomicChar,
                                    desired: CChar): CBool = extern
@@ -178,7 +172,7 @@ object Atomic {
   def compare_and_swap_weak_char(value: CAtomicChar,
                                  expected: CAtomicChar,
                                  desired: CChar): CBool = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 57)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 52)
   def compare_and_swap_strong_uchar(value: CAtomicUnsignedChar,
                                     expected: CAtomicUnsignedChar,
                                     desired: CUnsignedChar): CBool = extern
@@ -186,7 +180,7 @@ object Atomic {
   def compare_and_swap_weak_uchar(value: CAtomicUnsignedChar,
                                   expected: CAtomicUnsignedChar,
                                   desired: CUnsignedChar): CBool = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 57)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 52)
   def compare_and_swap_strong_csize(value: CAtomicCSize,
                                     expected: CAtomicCSize,
                                     desired: CSize): CBool = extern
@@ -194,218 +188,218 @@ object Atomic {
   def compare_and_swap_weak_csize(value: CAtomicCSize,
                                   expected: CAtomicCSize,
                                   desired: CSize): CBool = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 60)
 
   // Add and Sub
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // add
   def atomic_add_byte(ptr: CAtomicByte, value: Byte): Byte = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // sub
   def atomic_sub_byte(ptr: CAtomicByte, value: Byte): Byte = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // or
   def atomic_or_byte(ptr: CAtomicByte, value: Byte): Byte = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // and
   def atomic_and_byte(ptr: CAtomicByte, value: Byte): Byte = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // xor
   def atomic_xor_byte(ptr: CAtomicByte, value: Byte): Byte = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // add
   def atomic_add_short(ptr: CAtomicShort, value: CShort): CShort = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // sub
   def atomic_sub_short(ptr: CAtomicShort, value: CShort): CShort = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // or
   def atomic_or_short(ptr: CAtomicShort, value: CShort): CShort = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // and
   def atomic_and_short(ptr: CAtomicShort, value: CShort): CShort = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // xor
   def atomic_xor_short(ptr: CAtomicShort, value: CShort): CShort = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // add
   def atomic_add_int(ptr: CAtomicInt, value: CInt): CInt = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // sub
   def atomic_sub_int(ptr: CAtomicInt, value: CInt): CInt = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // or
   def atomic_or_int(ptr: CAtomicInt, value: CInt): CInt = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // and
   def atomic_and_int(ptr: CAtomicInt, value: CInt): CInt = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // xor
   def atomic_xor_int(ptr: CAtomicInt, value: CInt): CInt = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // add
   def atomic_add_long(ptr: CAtomicLong, value: CLong): CLong = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // sub
   def atomic_sub_long(ptr: CAtomicLong, value: CLong): CLong = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // or
   def atomic_or_long(ptr: CAtomicLong, value: CLong): CLong = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // and
   def atomic_and_long(ptr: CAtomicLong, value: CLong): CLong = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // xor
   def atomic_xor_long(ptr: CAtomicLong, value: CLong): CLong = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // add
   def atomic_add_ubyte(ptr: CAtomicUnsignedByte, value: Byte): Byte = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // sub
   def atomic_sub_ubyte(ptr: CAtomicUnsignedByte, value: Byte): Byte = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // or
   def atomic_or_ubyte(ptr: CAtomicUnsignedByte, value: Byte): Byte = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // and
   def atomic_and_ubyte(ptr: CAtomicUnsignedByte, value: Byte): Byte = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // xor
   def atomic_xor_ubyte(ptr: CAtomicUnsignedByte, value: Byte): Byte = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // add
   def atomic_add_ushort(ptr: CAtomicUnsignedShort,
                         value: CUnsignedShort): CUnsignedShort = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // sub
   def atomic_sub_ushort(ptr: CAtomicUnsignedShort,
                         value: CUnsignedShort): CUnsignedShort = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // or
   def atomic_or_ushort(ptr: CAtomicUnsignedShort,
                        value: CUnsignedShort): CUnsignedShort = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // and
   def atomic_and_ushort(ptr: CAtomicUnsignedShort,
                         value: CUnsignedShort): CUnsignedShort = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // xor
   def atomic_xor_ushort(ptr: CAtomicUnsignedShort,
                         value: CUnsignedShort): CUnsignedShort = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // add
   def atomic_add_uint(ptr: CAtomicUnsignedInt,
                       value: CUnsignedInt): CUnsignedInt = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // sub
   def atomic_sub_uint(ptr: CAtomicUnsignedInt,
                       value: CUnsignedInt): CUnsignedInt = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // or
   def atomic_or_uint(ptr: CAtomicUnsignedInt,
                      value: CUnsignedInt): CUnsignedInt = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // and
   def atomic_and_uint(ptr: CAtomicUnsignedInt,
                       value: CUnsignedInt): CUnsignedInt = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // xor
   def atomic_xor_uint(ptr: CAtomicUnsignedInt,
                       value: CUnsignedInt): CUnsignedInt = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // add
   def atomic_add_ulong(ptr: CAtomicUnsignedLong,
                        value: CUnsignedLong): CUnsignedLong = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // sub
   def atomic_sub_ulong(ptr: CAtomicUnsignedLong,
                        value: CUnsignedLong): CUnsignedLong = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // or
   def atomic_or_ulong(ptr: CAtomicUnsignedLong,
                       value: CUnsignedLong): CUnsignedLong = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // and
   def atomic_and_ulong(ptr: CAtomicUnsignedLong,
                        value: CUnsignedLong): CUnsignedLong = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // xor
   def atomic_xor_ulong(ptr: CAtomicUnsignedLong,
                        value: CUnsignedLong): CUnsignedLong = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // add
   def atomic_add_char(ptr: CAtomicChar, value: CChar): CChar = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // sub
   def atomic_sub_char(ptr: CAtomicChar, value: CChar): CChar = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // or
   def atomic_or_char(ptr: CAtomicChar, value: CChar): CChar = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // and
   def atomic_and_char(ptr: CAtomicChar, value: CChar): CChar = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // xor
   def atomic_xor_char(ptr: CAtomicChar, value: CChar): CChar = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // add
   def atomic_add_uchar(ptr: CAtomicUnsignedChar,
                        value: CUnsignedChar): CUnsignedChar = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // sub
   def atomic_sub_uchar(ptr: CAtomicUnsignedChar,
                        value: CUnsignedChar): CUnsignedChar = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // or
   def atomic_or_uchar(ptr: CAtomicUnsignedChar,
                       value: CUnsignedChar): CUnsignedChar = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // and
   def atomic_and_uchar(ptr: CAtomicUnsignedChar,
                        value: CUnsignedChar): CUnsignedChar = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // xor
   def atomic_xor_uchar(ptr: CAtomicUnsignedChar,
                        value: CUnsignedChar): CUnsignedChar = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // add
   def atomic_add_csize(ptr: CAtomicCSize, value: CSize): CSize = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // sub
   def atomic_sub_csize(ptr: CAtomicCSize, value: CSize): CSize = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // or
   def atomic_or_csize(ptr: CAtomicCSize, value: CSize): CSize = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // and
   def atomic_and_csize(ptr: CAtomicCSize, value: CSize): CSize = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 65)
   // xor
   def atomic_xor_csize(ptr: CAtomicCSize, value: CSize): CSize = extern
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 75)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 70)
 
   // Types
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 78)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 73)
   type CAtomicByte = Ptr[Byte]
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 78)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 73)
   type CAtomicShort = Ptr[CShort]
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 78)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 73)
   type CAtomicInt = Ptr[CInt]
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 78)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 73)
   type CAtomicLong = Ptr[CLong]
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 78)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 73)
   type CAtomicUnsignedByte = Ptr[Byte]
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 78)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 73)
   type CAtomicUnsignedShort = Ptr[CUnsignedShort]
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 78)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 73)
   type CAtomicUnsignedInt = Ptr[CUnsignedInt]
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 78)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 73)
   type CAtomicUnsignedLong = Ptr[CUnsignedLong]
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 78)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 73)
   type CAtomicChar = Ptr[CChar]
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 78)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 73)
   type CAtomicUnsignedChar = Ptr[CUnsignedChar]
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 78)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 73)
   type CAtomicCSize = Ptr[CSize]
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 80)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb", line: 75)
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Atomic.scala.gyb
@@ -35,11 +35,6 @@ import scala.scalanative.native.{
 @extern
 object Atomic {
 
-  // Memory
-  def alloc(sz: CSize): Ptr[Byte] = extern
-
-  def free(ptr: Ptr[Byte]): Unit = extern
-
   // Init
   % for (C, T, N) in zip(classes, types, names):
   def init_${N}(atm: ${C}, initValue: ${T}): Unit = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala
@@ -1,4 +1,4 @@
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 1)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 1)
 package scala.scalanative
 package runtime
 
@@ -11,22 +11,22 @@ abstract class CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 26)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 26)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
 
 class CAtomicByte(default: Byte = 0.asInstanceOf[Byte]) extends CAtomic {
 
-  private[this] val atm = Atomic.alloc(sizeof[Byte])
+  private[this] val atm = stdlib.malloc(sizeof[Byte])
   init_byte(atm, default)
 
   def load(): Byte = load_byte(atm)
 
   def store(value: Byte): Unit = store_byte(atm, value)
 
-  def free(): Unit = Atomic.free(atm)
+  def free(): Unit = stdlib.free(atm)
 
   def compareAndSwapStrong(expected: Byte, desired: Byte): (Boolean, Byte) = {
     val expectedPtr = stackalloc[Byte]
@@ -103,20 +103,20 @@ object CAtomicByte extends CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
 
 class CAtomicShort(default: CShort = 0.asInstanceOf[CShort]) extends CAtomic {
 
-  private[this] val atm = Atomic.alloc(sizeof[CShort]).cast[Ptr[CShort]]
+  private[this] val atm = stdlib.malloc(sizeof[CShort]).cast[Ptr[CShort]]
   init_short(atm, default)
 
   def load(): CShort = load_short(atm)
 
   def store(value: CShort): Unit = store_short(atm, value)
 
-  def free(): Unit = Atomic.free(atm.cast[Ptr[Byte]])
+  def free(): Unit = stdlib.free(atm.cast[Ptr[Byte]])
 
   def compareAndSwapStrong(expected: CShort,
                            desired: CShort): (Boolean, CShort) = {
@@ -195,20 +195,20 @@ object CAtomicShort extends CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
 
 class CAtomicInt(default: CInt = 0) extends CAtomic {
 
-  private[this] val atm = Atomic.alloc(sizeof[CInt]).cast[Ptr[CInt]]
+  private[this] val atm = stdlib.malloc(sizeof[CInt]).cast[Ptr[CInt]]
   init_int(atm, default)
 
   def load(): CInt = load_int(atm)
 
   def store(value: CInt): Unit = store_int(atm, value)
 
-  def free(): Unit = Atomic.free(atm.cast[Ptr[Byte]])
+  def free(): Unit = stdlib.free(atm.cast[Ptr[Byte]])
 
   def compareAndSwapStrong(expected: CInt, desired: CInt): (Boolean, CInt) = {
     val expectedPtr = stackalloc[CInt]
@@ -285,20 +285,20 @@ object CAtomicInt extends CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
 
 class CAtomicLong(default: CLong = 0.asInstanceOf[CLong]) extends CAtomic {
 
-  private[this] val atm = Atomic.alloc(sizeof[CLong]).cast[Ptr[CLong]]
+  private[this] val atm = stdlib.malloc(sizeof[CLong]).cast[Ptr[CLong]]
   init_long(atm, default)
 
   def load(): CLong = load_long(atm)
 
   def store(value: CLong): Unit = store_long(atm, value)
 
-  def free(): Unit = Atomic.free(atm.cast[Ptr[Byte]])
+  def free(): Unit = stdlib.free(atm.cast[Ptr[Byte]])
 
   def compareAndSwapStrong(expected: CLong,
                            desired: CLong): (Boolean, CLong) = {
@@ -376,21 +376,21 @@ object CAtomicLong extends CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
 
 class CAtomicUnsignedByte(default: Byte = 0.asInstanceOf[Byte])
     extends CAtomic {
 
-  private[this] val atm = Atomic.alloc(sizeof[Byte])
+  private[this] val atm = stdlib.malloc(sizeof[Byte])
   init_ubyte(atm, default)
 
   def load(): Byte = load_ubyte(atm)
 
   def store(value: Byte): Unit = store_ubyte(atm, value)
 
-  def free(): Unit = Atomic.free(atm)
+  def free(): Unit = stdlib.free(atm)
 
   def compareAndSwapStrong(expected: Byte, desired: Byte): (Boolean, Byte) = {
     val expectedPtr = stackalloc[Byte]
@@ -467,23 +467,23 @@ object CAtomicUnsignedByte extends CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
 
 class CAtomicUnsignedShort(
     default: CUnsignedShort = 0.asInstanceOf[CUnsignedShort])
     extends CAtomic {
 
   private[this] val atm =
-    Atomic.alloc(sizeof[CUnsignedShort]).cast[Ptr[CUnsignedShort]]
+    stdlib.malloc(sizeof[CUnsignedShort]).cast[Ptr[CUnsignedShort]]
   init_ushort(atm, default)
 
   def load(): CUnsignedShort = load_ushort(atm)
 
   def store(value: CUnsignedShort): Unit = store_ushort(atm, value)
 
-  def free(): Unit = Atomic.free(atm.cast[Ptr[Byte]])
+  def free(): Unit = stdlib.free(atm.cast[Ptr[Byte]])
 
   def compareAndSwapStrong(
       expected: CUnsignedShort,
@@ -568,22 +568,22 @@ object CAtomicUnsignedShort extends CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
 
 class CAtomicUnsignedInt(default: CUnsignedInt = 0.asInstanceOf[CUnsignedInt])
     extends CAtomic {
 
   private[this] val atm =
-    Atomic.alloc(sizeof[CUnsignedInt]).cast[Ptr[CUnsignedInt]]
+    stdlib.malloc(sizeof[CUnsignedInt]).cast[Ptr[CUnsignedInt]]
   init_uint(atm, default)
 
   def load(): CUnsignedInt = load_uint(atm)
 
   def store(value: CUnsignedInt): Unit = store_uint(atm, value)
 
-  def free(): Unit = Atomic.free(atm.cast[Ptr[Byte]])
+  def free(): Unit = stdlib.free(atm.cast[Ptr[Byte]])
 
   def compareAndSwapStrong(expected: CUnsignedInt,
                            desired: CUnsignedInt): (Boolean, CUnsignedInt) = {
@@ -662,23 +662,23 @@ object CAtomicUnsignedInt extends CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
 
 class CAtomicUnsignedLong(
     default: CUnsignedLong = 0.asInstanceOf[CUnsignedLong])
     extends CAtomic {
 
   private[this] val atm =
-    Atomic.alloc(sizeof[CUnsignedLong]).cast[Ptr[CUnsignedLong]]
+    stdlib.malloc(sizeof[CUnsignedLong]).cast[Ptr[CUnsignedLong]]
   init_ulong(atm, default)
 
   def load(): CUnsignedLong = load_ulong(atm)
 
   def store(value: CUnsignedLong): Unit = store_ulong(atm, value)
 
-  def free(): Unit = Atomic.free(atm.cast[Ptr[Byte]])
+  def free(): Unit = stdlib.free(atm.cast[Ptr[Byte]])
 
   def compareAndSwapStrong(expected: CUnsignedLong,
                            desired: CUnsignedLong): (Boolean, CUnsignedLong) = {
@@ -733,8 +733,7 @@ class CAtomicUnsignedLong(
     load()
   }
 
-  def fetchOr(value: CUnsignedLong): CUnsignedLong =
-    atomic_or_ulong(atm, value)
+  def fetchOr(value: CUnsignedLong): CUnsignedLong = atomic_or_ulong(atm, value)
 
   def xorFetch(value: CUnsignedLong): CUnsignedLong = {
     fetchXor(value)
@@ -762,20 +761,20 @@ object CAtomicUnsignedLong extends CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
 
 class CAtomicChar(default: CChar = 'a'.asInstanceOf[CChar]) extends CAtomic {
 
-  private[this] val atm = Atomic.alloc(sizeof[CChar]).cast[Ptr[CChar]]
+  private[this] val atm = stdlib.malloc(sizeof[CChar]).cast[Ptr[CChar]]
   init_char(atm, default)
 
   def load(): CChar = load_char(atm)
 
   def store(value: CChar): Unit = store_char(atm, value)
 
-  def free(): Unit = Atomic.free(atm.cast[Ptr[Byte]])
+  def free(): Unit = stdlib.free(atm.cast[Ptr[Byte]])
 
   def compareAndSwapStrong(expected: CChar,
                            desired: CChar): (Boolean, CChar) = {
@@ -853,23 +852,23 @@ object CAtomicChar extends CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
 
 class CAtomicUnsignedChar(
     default: CUnsignedChar = 'a'.asInstanceOf[CUnsignedChar])
     extends CAtomic {
 
   private[this] val atm =
-    Atomic.alloc(sizeof[CUnsignedChar]).cast[Ptr[CUnsignedChar]]
+    stdlib.malloc(sizeof[CUnsignedChar]).cast[Ptr[CUnsignedChar]]
   init_uchar(atm, default)
 
   def load(): CUnsignedChar = load_uchar(atm)
 
   def store(value: CUnsignedChar): Unit = store_uchar(atm, value)
 
-  def free(): Unit = Atomic.free(atm.cast[Ptr[Byte]])
+  def free(): Unit = stdlib.free(atm.cast[Ptr[Byte]])
 
   def compareAndSwapStrong(expected: CUnsignedChar,
                            desired: CUnsignedChar): (Boolean, CUnsignedChar) = {
@@ -924,8 +923,7 @@ class CAtomicUnsignedChar(
     load()
   }
 
-  def fetchOr(value: CUnsignedChar): CUnsignedChar =
-    atomic_or_uchar(atm, value)
+  def fetchOr(value: CUnsignedChar): CUnsignedChar = atomic_or_uchar(atm, value)
 
   def xorFetch(value: CUnsignedChar): CUnsignedChar = {
     fetchXor(value)
@@ -953,20 +951,20 @@ object CAtomicUnsignedChar extends CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 28)
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 34)
 
 class CAtomicCSize(default: CSize = 0.asInstanceOf[CSize]) extends CAtomic {
 
-  private[this] val atm = Atomic.alloc(sizeof[CSize]).cast[Ptr[CSize]]
+  private[this] val atm = stdlib.malloc(sizeof[CSize]).cast[Ptr[CSize]]
   init_csize(atm, default)
 
   def load(): CSize = load_csize(atm)
 
   def store(value: CSize): Unit = store_csize(atm, value)
 
-  def free(): Unit = Atomic.free(atm.cast[Ptr[Byte]])
+  def free(): Unit = stdlib.free(atm.cast[Ptr[Byte]])
 
   def compareAndSwapStrong(expected: CSize,
                            desired: CSize): (Boolean, CSize) = {
@@ -1044,7 +1042,7 @@ object CAtomicCSize extends CAtomic {
 
 }
 
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 122)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 122)
 
 class CAtomicRef[T <: AnyRef](default: T = 0L.asInstanceOf[T])
     extends CAtomicLong(default.asInstanceOf[Long]) {}
@@ -1065,28 +1063,28 @@ object CAtomicsImplicits {
   implicit def underlying[T <: AnyRef](a: CAtomicRef[T]): T =
     a.load().asInstanceOf[T]
   implicit def cas[T](v: (Boolean, T)): Boolean = v._1
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
   implicit def underlying(a: CAtomicByte): Byte = a.load()
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
   implicit def underlying(a: CAtomicShort): CShort = a.load()
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
   implicit def underlying(a: CAtomicInt): CInt = a.load()
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
   implicit def underlying(a: CAtomicLong): CLong = a.load()
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
   implicit def underlying(a: CAtomicUnsignedByte): Byte = a.load()
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
   implicit def underlying(a: CAtomicUnsignedShort): CUnsignedShort = a.load()
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
   implicit def underlying(a: CAtomicUnsignedInt): CUnsignedInt = a.load()
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
   implicit def underlying(a: CAtomicUnsignedLong): CUnsignedLong = a.load()
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
   implicit def underlying(a: CAtomicChar): CChar = a.load()
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
   implicit def underlying(a: CAtomicUnsignedChar): CUnsignedChar = a.load()
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 141)
   implicit def underlying(a: CAtomicCSize): CSize = a.load()
-// ###sourceLocation(file: "/home/remi/perso/Projects/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 143)
+// ###sourceLocation(file: "/home/valdis/scala-native/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb", line: 143)
 
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/CAtomics.scala.gyb
@@ -34,14 +34,14 @@ abstract class CAtomic {
 
 class CAtomic${C}(default: ${T} = ${default}) extends CAtomic {
 
-  private[this] val atm = Atomic.alloc(sizeof[${T}])${cast}
+  private[this] val atm = stdlib.malloc(sizeof[${T}])${cast}
   init_${N}(atm, default)
 
   def load(): ${T} = load_${N}(atm)
 
   def store(value: ${T}): Unit = store_${N}(atm, value)
 
-  def free(): Unit = Atomic.free(atm${castB})
+  def free(): Unit = stdlib.free(atm${castB})
 
   def compareAndSwapStrong(expected: ${T}, desired: ${T}): (Boolean, ${T}) = {
     val expectedPtr = stackalloc[${T}]

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ExecutionContext.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ExecutionContext.scala
@@ -1,27 +1,121 @@
 package scala.scalanative
 package runtime
 
-import scala.collection.mutable.ListBuffer
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
 import scala.concurrent.ExecutionContextExecutor
 
 object ExecutionContext {
-  def global: ExecutionContextExecutor = QueueExecutionContext
+  def global: ExecutionContextExecutor = new QueueExecutionContext()
 
-  private object QueueExecutionContext extends ExecutionContextExecutor {
-    def execute(runnable: Runnable): Unit = queue += runnable
-    def reportFailure(t: Throwable): Unit = t.printStackTrace()
+  class Queue {
+    private val ref: AtomicReference[List[Runnable]] = new AtomicReference(Nil)
+    def enqueue(runnable: Runnable): Unit = {
+      var oldValue: List[Runnable] = Nil
+      var newValue: List[Runnable] = Nil
+      do {
+        oldValue = ref.get()
+        newValue = oldValue :+ runnable
+      } while (!ref.compareAndSet(oldValue, newValue))
+    }
+
+    /**
+     * @return null if empty
+     */
+    def dequeue(): Runnable = {
+      var item: Runnable           = null
+      var oldValue: List[Runnable] = Nil
+      var newValue: List[Runnable] = Nil
+      do {
+        oldValue = ref.get()
+        if (!oldValue.isEmpty) {
+          newValue = oldValue.tail
+          item = oldValue.head
+        } else {
+          item = null
+        }
+      } while (!oldValue.isEmpty && !ref.compareAndSet(oldValue, newValue))
+      item
+    }
+
+    def isEmpty: scala.Boolean = ref.get.isEmpty
   }
 
-  private val queue: ListBuffer[Runnable] = new ListBuffer
+  class QueueExecutionContext(
+      val numExecutors: Int = Runtime.getRuntime.availableProcessors())
+      extends ExecutionContextExecutor {
+    private val queue: Queue     = new Queue
+    private val started          = new AtomicBoolean(false)
+    private val parking: Object  = new Object
+    private val doneLock: Object = new Object
+    private val threadGroup      = new ThreadGroup("Executor Thread Group")
+    threadGroup.setDaemon(true)
+    private lazy val threads =
+      scala.collection.immutable.Vector.tabulate(numExecutors) { i =>
+        new ExecutorThread(i)
+      }
 
-  private[runtime] def loop(): Unit = {
-    while (queue.nonEmpty) {
-      val runnable = queue.remove(0)
-      try {
-        runnable.run()
-      } catch {
-        case t: Throwable =>
-          QueueExecutionContext.reportFailure(t)
+    def execute(runnable: Runnable): Unit = {
+      queue enqueue runnable
+      // for better performance checking with .get() first
+      if (!started.get()) {
+        if (started.compareAndSet(false, true)) {
+          start()
+        }
+      }
+      parking.synchronized {
+        parking.notifyAll()
+      }
+    }
+    def reportFailure(t: Throwable): Unit = t.printStackTrace()
+
+    private class ExecutorThread(id: scala.Int)
+        extends Thread(threadGroup, "Executor-" + id) {
+      var waiting       = false
+      def idle: Boolean = !started.get() || waiting
+      override def run(): Unit = {
+        while (true) {
+          val runnable = queue.dequeue()
+          if (runnable != null) {
+            waiting = false
+            try {
+              runnable.run()
+            } catch {
+              case t: Throwable =>
+                QueueExecutionContext.this.reportFailure(t)
+            }
+          } else {
+            doneLock.synchronized {
+              waiting = true
+              doneLock.notifyAll()
+            }
+            parking.synchronized {
+              if (queue.isEmpty) {
+                parking.wait()
+              }
+            }
+          }
+
+        }
+      }
+    }
+
+    private def start(): Unit = {
+      threads.foreach { thread: ExecutorThread =>
+        thread.setDaemon(true)
+        thread.start()
+      }
+    }
+
+    def isDone: Boolean = queue.isEmpty && threads.forall(_.idle)
+
+    def waitUntilDone(): Unit = {
+      while (!isDone) {
+        doneLock.synchronized {
+          if (!isDone) {
+            doneLock.wait()
+          }
+        }
       }
     }
   }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Monitor.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Monitor.scala
@@ -1,15 +1,181 @@
 package scala.scalanative.runtime
 
-final class Monitor private () {
-  def _notify(): Unit                              = ()
-  def _notifyAll(): Unit                           = ()
-  def _wait(): Unit                                = ()
-  def _wait(timeout: scala.Long): Unit             = ()
-  def _wait(timeout: scala.Long, nanos: Int): Unit = ()
-  def enter(): Unit                                = ()
-  def exit(): Unit                                 = ()
+import scala.scalanative.native._
+import scala.scalanative.native.stdlib.malloc
+import scala.scalanative.posix.errno.{EBUSY, EPERM}
+import scala.scalanative.posix.pthread._
+import scala.scalanative.posix.sys.time.{
+  CLOCK_REALTIME,
+  clock_gettime,
+  timespec
+}
+import scala.scalanative.posix.sys.types.{
+  pthread_cond_t,
+  pthread_condattr_t,
+  pthread_mutex_t,
+  pthread_mutexattr_t
+}
+import scala.scalanative.runtime.ThreadBase._
+
+final class Monitor private[runtime] (shadow: Boolean) {
+  // memory leak
+  // TODO destroy the mutex and release the memory
+  private val mutexPtr: Ptr[pthread_mutex_t] = malloc(pthread_mutex_t_size)
+    .asInstanceOf[Ptr[pthread_mutex_t]]
+  pthread_mutex_init(mutexPtr, Monitor.mutexAttrPtr)
+  // memory leak
+  // TODO destroy the condition and release the memory
+  private val condPtr: Ptr[pthread_cond_t] = malloc(pthread_cond_t_size)
+    .asInstanceOf[Ptr[pthread_cond_t]]
+  pthread_cond_init(condPtr, Monitor.condAttrPtr)
+
+  def _notify(): Unit    = pthread_cond_signal(condPtr)
+  def _notifyAll(): Unit = pthread_cond_broadcast(condPtr)
+  def _wait(): Unit = {
+    val thread = ThreadBase.currentThreadInternal
+    if (thread != null) {
+      thread.setLockState(Waiting)
+    }
+    val returnVal = pthread_cond_wait(condPtr, mutexPtr)
+    if (thread != null) {
+      thread.setLockState(Normal)
+    }
+    if (returnVal == EPERM) {
+      throw new IllegalMonitorStateException()
+    }
+  }
+  def _wait(millis: scala.Long): Unit = _wait(millis, 0)
+  def _wait(millis: scala.Long, nanos: Int): Unit = {
+    val thread = ThreadBase.currentThreadInternal
+    if (thread != null) {
+      thread.setLockState(TimedWaiting)
+    }
+    val tsPtr = stackalloc[timespec]
+    clock_gettime(CLOCK_REALTIME, tsPtr)
+    val curSeconds     = !tsPtr._1
+    val curNanos       = !tsPtr._2
+    val overflownNanos = curNanos + nanos + (millis % 1000) * 1000000
+
+    val deadlineNanos   = overflownNanos % 1000000000
+    val deadLineSeconds = curSeconds + millis / 1000 + overflownNanos / 1000000000
+
+    !tsPtr._1 = deadLineSeconds
+    !tsPtr._2 = deadlineNanos
+
+    val returnVal = pthread_cond_timedwait(condPtr, mutexPtr, tsPtr)
+    if (thread != null) {
+      thread.setLockState(Normal)
+    }
+    if (returnVal == EPERM) {
+      throw new IllegalMonitorStateException()
+    }
+  }
+  def enter(): Unit = {
+    if (pthread_mutex_trylock(mutexPtr) == EBUSY) {
+      val thread = ThreadBase.currentThreadInternal()
+      if (thread != null) {
+        thread.setLockState(Blocked)
+        // try again and block until you get one
+        pthread_mutex_lock(mutexPtr)
+        // finally got the lock
+        thread.setLockState(Normal)
+      } else {
+        // Thread class in not initialized yet, just try again
+        pthread_mutex_lock(mutexPtr)
+      }
+    }
+    if (!shadow) {
+      pushLock()
+    }
+  }
+
+  def exit(): Unit = {
+    if (!shadow) {
+      popLock()
+    }
+    pthread_mutex_unlock(mutexPtr)
+  }
+
+  @inline
+  private def pushLock(): Unit = {
+    val thread = ThreadBase.currentThreadInternal()
+    if (thread != null) {
+      thread.locks(thread.size) = this
+      thread.size += 1
+      if (thread.size >= thread.locks.length) {
+        val oldArray = thread.locks
+        val newArray = new scala.Array[Monitor](oldArray.length * 2)
+        System.arraycopy(oldArray, 0, newArray, 0, oldArray.length)
+        thread.locks = newArray
+      }
+    }
+  }
+
+  @inline
+  private def popLock(): Unit = {
+    val thread = ThreadBase.currentThreadInternal()
+    if (thread != null) {
+      if (thread.locks(thread.size - 1) == this) {
+        thread.size -= 1
+      }
+    }
+  }
 }
 
 object Monitor {
-  val dummy = new Monitor()
+  private val mutexAttrPtr: Ptr[pthread_mutexattr_t] = malloc(
+    pthread_mutexattr_t_size).asInstanceOf[Ptr[pthread_mutexattr_t]]
+  pthread_mutexattr_init(mutexAttrPtr)
+  pthread_mutexattr_settype(mutexAttrPtr, PTHREAD_MUTEX_RECURSIVE)
+
+  private val condAttrPtr: Ptr[pthread_condattr_t] = malloc(
+    pthread_condattr_t_size).asInstanceOf[Ptr[pthread_cond_t]]
+  pthread_condattr_init(condAttrPtr)
+  pthread_condattr_setpshared(condAttrPtr, PTHREAD_PROCESS_SHARED)
+
+  private[runtime] val monitorCreationMutexPtr: Ptr[pthread_mutex_t] = malloc(
+    pthread_mutex_t_size)
+    .asInstanceOf[Ptr[pthread_mutex_t]]
+  pthread_mutex_init(monitorCreationMutexPtr, Monitor.mutexAttrPtr)
+
+  def apply(x: java.lang.Object): Monitor = {
+    val o = x.asInstanceOf[_Object]
+    if (o.__monitor != null) {
+      o.__monitor
+    } else {
+      try {
+        pthread_mutex_lock(monitorCreationMutexPtr)
+        if (o.__monitor == null) {
+          o.__monitor = new Monitor(x.isInstanceOf[ShadowLock])
+        }
+        o.__monitor
+      } finally {
+        pthread_mutex_unlock(monitorCreationMutexPtr)
+      }
+    }
+  }
+}
+
+/**
+ * Cannot be checked with Thread.holdsLock
+ */
+class ShadowLock {
+  // workaround so lock is freed when exception is thrown
+  def safeSynchronized[T](f: => T): T = {
+    var throwable: Throwable = null
+    val result = synchronized {
+      try {
+        f
+      } catch {
+        case t: Throwable =>
+          throwable = t
+      }
+    }
+    if (throwable != null) {
+      throw throwable
+    } else {
+      result.asInstanceOf[T]
+    }
+
+  }
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -1,8 +1,8 @@
 package scala.scalanative
 package runtime
 
-import native.{extern, name, CSize, CInt}
-import posix.sys.types.pthread_t
+import native.{CInt, CSize, Ptr, extern, name}
+import posix.sys.types.{pthread_attr_t, pthread_t}
 
 @extern
 object NativeThread {
@@ -22,10 +22,6 @@ object NativeThread {
   @name("set_priority")
   def setPriority(thread: pthread_t, priority: CInt): Unit = extern
 
-  @name("thd_continue")
-  def resume(thread: pthread_t): CInt = extern
-
-  @name("thd_suspend")
-  def suspend(thread: pthread_t): CInt = extern
-
+  @name("attr_set_priority")
+  def attrSetPriority(attr: Ptr[pthread_attr_t], priority: CInt): Unit = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ThreadBase.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ThreadBase.scala
@@ -1,0 +1,64 @@
+package scala.scalanative.runtime
+
+import scala.scalanative.runtime.ThreadBase._
+
+abstract class ThreadBase {
+  def threadModuleBase: ThreadModuleBase
+  def initMainThread(): Unit
+  private var lockState                           = Normal
+  final def getLockState: Int                     = lockState
+  private[runtime] def setLockState(s: Int): Unit = lockState = s
+  // only here to implement holdsLock
+  private[runtime] var locks = new scala.Array[Monitor](8)
+  private[runtime] var size  = 0
+  final def holdsLock(obj: Object): scala.Boolean = {
+    if (size == 0) {
+      false
+    } else {
+      val target = Monitor(obj)
+      var i: Int = 0
+      while (i < size && locks(i) != target) {
+        i += 1
+      }
+      i < size
+    }
+  }
+  final def freeAllLocks(): Unit = {
+    var i: Int = 0
+    while (i < size) {
+      locks(i).exit()
+      i += 1
+    }
+  }
+}
+
+object ThreadBase {
+  private val threadModule: ThreadModuleBase =
+    Thread.currentThread().asInstanceOf[ThreadBase].threadModuleBase
+  final val Normal       = 0
+  final val Blocked      = 1
+  final val Waiting      = 2
+  final val TimedWaiting = 3
+
+  protected[runtime] def initMainThread(): Unit = threadModule.initMainThread()
+  protected[runtime] def shutdownCheckLoop(): Unit =
+    threadModule.shutdownCheckLoop()
+  protected[runtime] def mainThreadEnds(): Unit = threadModule.mainThreadEnds()
+
+  /**
+   *
+   * @return currentThread or `null` if:<br>
+   *         1. it is a non-Scala thread<br>
+   *         2. Scala thinks it is dead<br>
+   *         3. it has not properly initialized because it is handling a signal
+   */
+  protected[runtime] def currentThreadInternal(): Thread with ThreadBase =
+    threadModule.currentThreadInternal()
+}
+
+abstract class ThreadModuleBase {
+  protected[runtime] def shutdownCheckLoop(): Unit
+  protected[runtime] def initMainThread(): Unit
+  protected[runtime] def mainThreadEnds(): Unit
+  protected[runtime] def currentThreadInternal(): Thread with ThreadBase
+}

--- a/scalalib/overrides-2.11/scala/concurrent/impl/AbstractPromise.scala
+++ b/scalalib/overrides-2.11/scala/concurrent/impl/AbstractPromise.scala
@@ -1,5 +1,7 @@
 package scala.concurrent.impl
 
+import java.util.concurrent.atomic.AtomicReference
+
 /**
  * JavaScript specific implementation of AbstractPromise
  *
@@ -9,19 +11,9 @@ package scala.concurrent.impl
  * @author Tobias Schlatter
  */
 abstract class AbstractPromise {
-
-  private var state: AnyRef = _
-
-  protected final
-  def updateState(oldState: AnyRef, newState: AnyRef): Boolean = {
-    if (state eq oldState) {
-      state = newState
-      true
-    } else false
-  }
-
-  protected final def getState: AnyRef = state
-
+  private val state: AtomicReference[AnyRef] = new AtomicReference[AnyRef](null)
+  protected final def updateState(oldState: AnyRef, newState: AnyRef): Boolean = state.compareAndSet(oldState, newState)
+  protected final def getState: AnyRef = state.get()
 }
 
 object AbstractPromise {

--- a/scripted-tests/run/execution-context/build.sbt
+++ b/scripted-tests/run/execution-context/build.sbt
@@ -7,13 +7,5 @@ lazy val runAndCheck = taskKey[Unit]("...")
 runAndCheck := {
   val bin = (nativeLink in Compile).value
   val out = Process(bin.getAbsolutePath).lines_!.toList
-  assert(
-    out == List(
-      "start main",
-      "end main",
-      "future 1",
-      "future 2",
-      "future 3",
-      "result: 10"
-    ))
+  assert(out == List("result: 10"))
 }

--- a/scripted-tests/run/execution-context/src/main/scala/Hello.scala
+++ b/scripted-tests/run/execution-context/src/main/scala/Hello.scala
@@ -3,21 +3,21 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object Test {
   def main(args: Array[String]): Unit = {
-    println("start main")
+    Console.err.println("start main")
     Future {
-      println("future 1")
+      Console.err.println("future 1")
       1 + 2
     }.map { x =>
-        println("future 2")
+        Console.err.println("future 2")
         x + 3
       }
       .map { x =>
-        println("future 3")
+        Console.err.println("future 3")
         x + 4
       }
       .foreach { res =>
         println("result: " + res)
       }
-    println("end main")
+    Console.err.println("end main")
   }
 }

--- a/scripted-tests/run/threads-shutdown/build.sbt
+++ b/scripted-tests/run/threads-shutdown/build.sbt
@@ -1,0 +1,3 @@
+enablePlugins(ScalaNativePlugin)
+
+scalaVersion := "2.11.11"

--- a/scripted-tests/run/threads-shutdown/project/scala-native.sbt
+++ b/scripted-tests/run/threads-shutdown/project/scala-native.sbt
@@ -1,0 +1,8 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scala-native" % "sbt-scala-native" % pluginVersion)
+}

--- a/scripted-tests/run/threads-shutdown/test
+++ b/scripted-tests/run/threads-shutdown/test
@@ -1,0 +1,8 @@
+$ copy-file tests/SingleThread.scala Main.scala
+> run
+
+$ copy-file tests/OneDaemonThread.scala Main.scala
+> run
+
+$ copy-file tests/LongLivingThread.scala Main.scala
+> run

--- a/scripted-tests/run/threads-shutdown/tests/LongLivingThread.scala
+++ b/scripted-tests/run/threads-shutdown/tests/LongLivingThread.scala
@@ -1,0 +1,17 @@
+object LongLivingThread {
+  def main(args: Array[String]): Unit = {
+    println("Main thread starts")
+    val mainThread = Thread.currentThread()
+    val longLivingThread = new Thread("LivesALongTime") {
+      override def run() = {
+        println("Waiting for main thread to finish")
+        mainThread.join()
+        Thread.sleep(100)
+        println("Other thread is still alive")
+      }
+    }
+    assert(!longLivingThread.isDaemon)
+    longLivingThread.start()
+    println("Main thread ends")
+  }
+}

--- a/scripted-tests/run/threads-shutdown/tests/OneDaemonThread.scala
+++ b/scripted-tests/run/threads-shutdown/tests/OneDaemonThread.scala
@@ -1,0 +1,16 @@
+object OneDaemonThread {
+  def main(args: Array[String]): Unit = {
+    val daemonThread = new Thread("JustMindingMyOwnBusiness") {
+      override def run() = {
+        synchronized {
+          while (true) {
+            wait()
+          }
+        }
+      }
+    }
+    daemonThread.setDaemon(true)
+    assert(daemonThread.isDaemon)
+    daemonThread.start()
+  }
+}

--- a/scripted-tests/run/threads-shutdown/tests/SingleThread.scala
+++ b/scripted-tests/run/threads-shutdown/tests/SingleThread.scala
@@ -1,0 +1,5 @@
+object SingleThread {
+  def main(args: Array[String]): Unit = {
+    println("single thread app")
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/StringLowering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/StringLowering.scala
@@ -18,7 +18,7 @@ class StringLowering(implicit top: Top) extends Pass {
   private val stringFieldNames = {
     val node  = ClassRef.unapply(StringName).get
     val names = node.layout.entries.map(_.name)
-    assert(names.length == 4, "java.lang.String is expected to have 4 fields")
+    assert(names.length == 5, "java.lang.String is expected to have 5 fields")
     names
   }
 
@@ -43,7 +43,8 @@ class StringLowering(implicit top: Top) extends Pass {
         case StringOffsetName         => Val.Int(0)
         case StringCountName          => charsLength
         case StringCachedHashCodeName => Val.Int(stringHashCode(v))
-        case _                        => util.unreachable
+        case StringMonitorName        => Val.Null
+        case x                        => util.unreachable
       }
 
       Val.Const(Val.Struct(Global.None, StringCls.rtti.const +: fieldValues))
@@ -74,6 +75,7 @@ object StringLowering extends PassCompanion {
   val StringOffsetName         = StringName member "offset" tag "field"
   val StringCountName          = StringName member "count" tag "field"
   val StringCachedHashCodeName = StringName member "cachedHashCode" tag "field"
+  val StringMonitorName        = Rt.Object.name member "__monitor" tag "field"
 
   val CharArrayName = Global.Top("scala.scalanative.runtime.CharArray")
 

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/UnitLowering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/UnitLowering.scala
@@ -67,7 +67,7 @@ object UnitLowering extends PassCompanion {
   val unit      = Val.Global(unitName, Type.Ptr)
   val unitTy    = Type.Struct(unitName member "layout", Seq(Type.Ptr))
   val unitConst = Val.Global(unitName member "type", Type.Ptr)
-  val unitValue = Val.Struct(unitTy.name, Seq(unitConst))
+  val unitValue = Val.Struct(unitTy.name, Seq(Val.Null, unitConst))
   val unitDefn  = Defn.Const(Attrs.None, unitName, unitTy, unitValue)
 
   override val depends =

--- a/unit-tests/src/main/scala/tests/MultiThreadSuite.scala
+++ b/unit-tests/src/main/scala/tests/MultiThreadSuite.scala
@@ -1,0 +1,234 @@
+package tests
+
+trait MultiThreadSuite extends Suite {
+  def takesAtLeast[R](expectedDelayMs: scala.Long)(f: => R): R = {
+    val start  = System.currentTimeMillis()
+    val result = f
+    val end    = System.currentTimeMillis()
+
+    val actual = end - start
+    Console.out.println(
+      "It took " + actual + " ms, expected at least " + expectedDelayMs + " ms")
+    assert(actual >= expectedDelayMs)
+
+    result
+  }
+
+  def takesAtLeast[R](expectedDelayMs: scala.Long,
+                      expectedDelayNanos: scala.Int)(f: => R): R = {
+    val expectedDelay = expectedDelayMs * 1000000 + expectedDelayMs
+    val start         = System.nanoTime()
+    val result        = f
+    val end           = System.nanoTime()
+
+    val actual = end - start
+    Console.out.println(
+      "It took " + actual + " ns, expected at least " + expectedDelay + " ns")
+    assert(actual >= expectedDelay)
+
+    result
+  }
+
+  def withThreads(numThreads: Int = 2, label: String = "")(f: Int => Unit) = {
+    val threads = Seq.tabulate(numThreads) { id =>
+      new Thread(label + "Thread-" + id) {
+        override def run() = f(id)
+      }
+    }
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+  }
+
+  val eternity = 30000 //ms
+  def eventually(maxDelay: scala.Long = eternity,
+                 recheckEvery: scala.Long = 200,
+                 label: String = "Condition")(p: => scala.Boolean): Unit = {
+    val start    = System.currentTimeMillis()
+    val deadline = start + maxDelay
+    var current  = 0L
+
+    var continue = true
+
+    while (continue && current <= deadline) {
+      current = System.currentTimeMillis()
+      if (p) {
+        continue = false
+      }
+      Thread.sleep(recheckEvery)
+    }
+    if (current <= deadline) {
+      // all is good
+      Console.out.println(
+        label + " reached after " + (current - start) + " ms; max delay: " + maxDelay + " ms")
+    } else {
+      Console.out.println(
+        "Timeout: " + label + " not reached after " + maxDelay + " ms")
+      assert(false)
+    }
+  }
+
+  def eventuallyEquals[T](
+      maxDelay: scala.Long = eternity,
+      recheckEvery: scala.Long = 200,
+      label: String = "Equal values")(left: => T, right: => T): Unit =
+    eventually(maxDelay, recheckEvery, label)(left == right)
+
+  def eventuallyConstant[T](maxDelay: scala.Long = eternity,
+                            recheckEvery: scala.Long = 200,
+                            minDuration: scala.Long = 1000,
+                            label: String = "Value")(value: => T): Option[T] = {
+    val start    = System.currentTimeMillis()
+    val deadline = start + maxDelay + minDuration
+    var current  = 0L
+
+    var continue = true
+    var reached  = false
+
+    var lastValue: T = value
+    var lastValueTs  = start
+
+    while (continue && current <= deadline) {
+      current = System.currentTimeMillis()
+      val currentValue = value
+      if (lastValue == currentValue) {
+        if (current >= lastValueTs + minDuration) {
+          continue = false
+          reached = true
+        }
+      } else {
+        lastValueTs = current
+        lastValue = currentValue
+      }
+      Thread.sleep(recheckEvery)
+    }
+    if (reached) {
+      // all is good
+      Console.out.println(
+        label + " remained constant after " + (lastValueTs - start) + " ms for at least " + minDuration + "ms ; max delay: " + maxDelay + " ms")
+      Some(lastValue)
+    } else {
+      Console.out.println(
+        "Timeout: " + label + " not remained constant after " + maxDelay + " ms")
+      assert(false)
+      None
+    }
+  }
+
+  /**
+   * Runs the `test` with the smallest possible delay parameter which still is enough to detect the issue.
+   * The delay is found by running the counterexample - a function that should reproduce the issue given enough time.
+   */
+  def testWithMinDelay(delays: Seq[scala.Long] =
+                         Seq(50, 100, 200, 500, 1000, 2000, 5000))(
+      counterexample: scala.Long => scala.Boolean)(
+      test: scala.Long => scala.Boolean) = {
+    delays.find(counterexample) match {
+      case Some(minDelay) =>
+        Console.out.println(s"Found min delay: $minDelay")
+        val delay = minDelay * 2
+        Console.out.println(s"Using min delay*2 = $delay for the test")
+        assert(test(delay))
+      case None =>
+        Console.out.println(
+          s"Could not find delay, it may be larger than: ${delays.max}")
+        assert(false)
+    }
+  }
+
+  /**
+   * Runs the `test` with the smallest possible repetitions which still is enough to detect the issue.
+   * The number of repetitions is found by running the counterexample - a function that should reproduce the issue given enough repetitions.
+   */
+  def testWithMinRepetitions(
+      repetitions: Seq[scala.Int] =
+        Seq(1000, 2000, 5000, 10000, 100000, 1000000, 10000000))(
+      counterexample: scala.Int => scala.Boolean)(
+      test: scala.Int => scala.Boolean) = {
+    repetitions.find(counterexample) match {
+      case Some(minDelay) =>
+        Console.out.println(s"Found min repetitions: $minDelay")
+        val repetitions = minDelay * 2
+        Console.out.println(
+          s"Using min repetitions*2 = $repetitions for the test")
+        assert(test(repetitions))
+      case None =>
+        Console.out.println(
+          s"Could not find necessary repetitions, it may be larger than: ${repetitions.max}")
+        assert(false)
+    }
+  }
+
+  def withExceptionHandler[U](handler: Thread.UncaughtExceptionHandler)(
+      f: => U): U = {
+    val oldHandler = Thread.getDefaultUncaughtExceptionHandler
+    Thread.setDefaultUncaughtExceptionHandler(handler)
+    try {
+      f
+    } finally {
+      Thread.setDefaultUncaughtExceptionHandler(oldHandler)
+    }
+  }
+
+  class ExceptionDetector(thread: Thread, exception: Throwable)
+      extends Thread.UncaughtExceptionHandler {
+    private var _wasException       = false
+    def wasException: scala.Boolean = _wasException
+    def uncaughtException(t: Thread, e: Throwable): Unit = {
+      assertEquals(t, thread)
+      assertEquals(e, exception)
+      _wasException = true
+    }
+  }
+
+  class WaitingThread(mutex: AnyRef,
+                      threadGroup: ThreadGroup =
+                        Thread.currentThread().getThreadGroup,
+                      name: String = "WaitingThread")
+      extends Thread(threadGroup, name) {
+    setDaemon(true)
+    private var notified = false
+
+    def timesNotified = if (notified) 1 else 0
+
+    override def run(): Unit = {
+      mutex.synchronized {
+        mutex.wait()
+      }
+      notified = true
+    }
+  }
+
+  class Counter(threadGroup: ThreadGroup, name: String)
+      extends Thread(threadGroup, name) {
+    setDaemon(true)
+    def this() = this(Thread.currentThread().getThreadGroup, "Counter")
+    var count = 0L
+    var goOn  = true
+    override def run() = {
+      while (goOn) {
+        count += 1
+        Thread.`yield`()
+        Thread.sleep(100)
+      }
+    }
+  }
+
+  class FatObject(val id: Int = 0) {
+    var x1, x2, x3, x4, x5, x6, x7, x8 = 0L
+
+    def nextOne = new FatObject(id + 1)
+  }
+
+  class MemoryMuncher(times: Int) extends Thread {
+    setDaemon(true)
+    var visibleState = new FatObject()
+
+    override def run(): Unit = {
+      var remainingCount = times
+      while (remainingCount > 0) {
+        visibleState = visibleState.nextOne
+        remainingCount -= 1
+      }
+    }
+  }
+}

--- a/unit-tests/src/main/scala/tests/Suite.scala
+++ b/unit-tests/src/main/scala/tests/Suite.scala
@@ -9,7 +9,7 @@ final case object AssertionFailed extends Exception
 
 final case class Test(name: String, run: () => Boolean)
 
-abstract class Suite {
+trait Suite {
   private val tests = new mutable.UnrolledBuffer[Test]
 
   def assert(cond: Boolean): Unit =

--- a/unit-tests/src/test/scala/java/lang/RuntimeSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/RuntimeSuite.scala
@@ -1,0 +1,7 @@
+package java.lang
+
+object RuntimeSuite extends tests.Suite {
+  test("availableProcessors") {
+    assert(Runtime.getRuntime.availableProcessors() > 0)
+  }
+}

--- a/unit-tests/src/test/scala/java/lang/ThreadGroupSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/ThreadGroupSuite.scala
@@ -1,0 +1,427 @@
+package java.lang
+
+import scala.collection.mutable
+
+object ThreadGroupSuite extends tests.MultiThreadSuite {
+  test("Constructors") {
+
+    val groupName   = "groupNameGoesHere"
+    val threadGroup = new ThreadGroup(groupName)
+    assertEquals(threadGroup.getName, groupName)
+
+    val subgroupName = "this is a subgroup"
+    val subgroup     = new ThreadGroup(threadGroup, subgroupName)
+    assertEquals(subgroup.getName, subgroupName)
+    assertEquals(subgroup.getParent, threadGroup)
+    assert(threadGroup.parentOf(subgroup))
+    assertNot(subgroup.parentOf(threadGroup))
+  }
+
+  test("ThreadGroup.checkAccess does not crash") {
+    val mainThreadGroup = Thread.currentThread().getThreadGroup
+    val threadGroup     = new ThreadGroup("abc")
+
+    mainThreadGroup.checkAccess()
+    threadGroup.checkAccess()
+
+    val thread = new Thread {
+      override def run() = {
+        mainThreadGroup.checkAccess()
+        threadGroup.checkAccess()
+      }
+    }
+    thread.start()
+    thread.join()
+  }
+
+  abstract class Structure[T <: Thread] {
+    def makeThread(group: ThreadGroup, name: String): T
+
+    val group = new ThreadGroup("group")
+    val groupThreads: Seq[T] = scala.Seq(makeThread(group, "G-1"),
+                                         makeThread(group, "G-2"),
+                                         makeThread(group, "G-3"))
+
+    val subgroup1 = new ThreadGroup(group, "subgroup1")
+    val subgroup1Threads: Seq[T] =
+      scala.Seq(makeThread(subgroup1, "SG-1"), makeThread(subgroup1, "SG-2"))
+
+    val subgroup2 = new ThreadGroup(group, "subgroup2")
+    val subgroup2Threads: Seq[T] =
+      scala.Seq(makeThread(subgroup2, "SG-A"), makeThread(subgroup2, "SG-B"))
+
+    val threads: Seq[T] = groupThreads ++ subgroup1Threads ++ subgroup2Threads
+
+    def destroyAllGroups(): Unit = {
+      try {
+        if (!group.isDestroyed) group.destroy()
+        if (!subgroup1.isDestroyed) subgroup1.destroy()
+        if (!subgroup1.isDestroyed) subgroup1.destroy()
+      } catch {
+        case _: IllegalThreadStateException =>
+      }
+    }
+  }
+
+  test("ThreadGroup.interrupt should interrupt sleep for all threads") {
+    var fail = false
+    class SleepyThread(group: ThreadGroup, name: String)
+        extends Thread(group, name) {
+      override def run() = {
+        expectThrows(classOf[InterruptedException], {
+          Thread.sleep(10 * eternity)
+          fail = true
+        })
+      }
+    }
+    val structure = new Structure[SleepyThread] {
+      def makeThread(group: ThreadGroup, name: String) =
+        new SleepyThread(group, name)
+    }
+    import structure._
+    threads.foreach(_.start())
+    threads.foreach { thread: Thread =>
+      eventuallyEquals(
+        label = thread.getName + "is in Thread.State.TIMED_WAITING")(
+        Thread.State.TIMED_WAITING,
+        thread.getState)
+    }
+    group.interrupt()
+    threads.foreach { thread: Thread =>
+      eventuallyEquals(
+        label = thread.getName + "is in Thread.State.TERMINATED")(
+        Thread.State.TERMINATED,
+        thread.getState)
+    }
+
+    destroyAllGroups()
+
+    assertNot(fail)
+  }
+
+  test("ThreadGroup.destroy") {
+    val threadGroup = new ThreadGroup("abc")
+    val thread      = new Counter(threadGroup, "active")
+    assertNot(threadGroup.isDestroyed)
+
+    thread.start()
+    eventually()(thread.count > 1)
+    //cannot destroy group with running threads
+    assertThrows[IllegalThreadStateException](threadGroup.destroy())
+    assertNot(threadGroup.isDestroyed)
+    thread.goOn = false
+    thread.join()
+
+    threadGroup.destroy()
+    assert(threadGroup.isDestroyed)
+
+    // cannot destroy it twice
+    assertThrows[IllegalThreadStateException](threadGroup.destroy())
+    assert(threadGroup.isDestroyed)
+
+    // cannot add new threads or threadGroups
+    assertThrows[IllegalThreadStateException](
+      new Thread(threadGroup, "Sad Thread"))
+    assertThrows[IllegalThreadStateException](
+      new ThreadGroup(threadGroup, "Sad ThreadGroup"))
+  }
+
+  test("Thread.setPriority respects threadGroups maxPriority") {
+    val fastGroup = new ThreadGroup("fastGroup")
+    assertEquals(fastGroup.getMaxPriority, Thread.MAX_PRIORITY)
+
+    val fastThread = new Thread(fastGroup, "fastThread")
+    fastThread.setPriority(Thread.MAX_PRIORITY)
+    assertEquals(fastThread.getPriority, Thread.MAX_PRIORITY)
+
+    val slowGroup = new ThreadGroup("slowGroup")
+    slowGroup.setMaxPriority(Thread.MIN_PRIORITY)
+    assertEquals(slowGroup.getMaxPriority, Thread.MIN_PRIORITY)
+
+    val slowThread = new Thread(slowGroup, "slowThread")
+    slowThread.setPriority(Thread.MAX_PRIORITY)
+    assertEquals(slowThread.getPriority, Thread.MIN_PRIORITY)
+  }
+
+  test(
+    "A daemon thread group is automatically destroyed when its last thread is stopped or its last thread group is destroyed.") {
+    val structure = new Structure[Counter] {
+      def makeThread(group: ThreadGroup, name: String) =
+        new Counter(group, name)
+    }
+    import structure._
+    threads.foreach(_.start())
+    group.setDaemon(true)
+    subgroup1.setDaemon(true)
+    subgroup2.setDaemon(true)
+    assert(group.isDaemon)
+    assert(subgroup1.isDaemon)
+    assert(subgroup2.isDaemon)
+
+    threads.foreach { thread: Counter =>
+      eventually(label = s"$thread.count > 1")(thread.count > 1)
+    }
+
+    threads.foreach { thread: Counter =>
+      thread.goOn = false
+    }
+    threads.foreach { thread: Counter =>
+      thread.join()
+    }
+    assert(group.isDestroyed)
+    assert(group.isDaemon)
+
+    destroyAllGroups()
+  }
+
+  test("activeCount, activeGroupCount, Thread.enumerate and list") {
+    val structure = new Structure[Counter] {
+      def makeThread(group: ThreadGroup, name: String) =
+        new Counter(group, name)
+    }
+    import structure._
+    threads.foreach(_.start())
+
+    threads.foreach { thread: Counter =>
+      eventually(label = s"$thread.count > 1")(thread.count > 1)
+    }
+
+    assertEquals(group.activeCount(), threads.size)
+    assertEquals(subgroup1.activeCount(), subgroup1Threads.size)
+    assertEquals(subgroup2.activeCount(), subgroup2Threads.size)
+
+    assertEquals(group.activeGroupCount(), 2)
+    assertEquals(subgroup1.activeGroupCount(), 0)
+    assertEquals(subgroup2.activeGroupCount(), 0)
+
+    // also test Thread.activeCount and Thread.enumerate
+    {
+      var count   = 0
+      var success = false
+      val thread = new Thread(group, "checker") {
+        override def run() = {
+          count = Thread.activeCount()
+          assertEquals(Thread.enumerate(new Array[Thread](0)), 0)
+
+          val partialArray = new Array[Thread](threads.size - 1)
+          assertEquals(Thread.enumerate(partialArray), threads.size - 1)
+          val correctValuesPartial = mutable.WrappedArray
+            .make[Thread](partialArray)
+            .forall { t =>
+              threads.contains(t) || t == this
+            }
+          assert(correctValuesPartial)
+
+          val fullArray = new Array[Thread](threads.size + 1)
+          assertEquals(Thread.enumerate(fullArray), threads.size + 1)
+          val wrappedArrayFull = mutable.WrappedArray.make[Thread](fullArray)
+          val correctValuesFull: scala.Boolean = threads.forall(
+            wrappedArrayFull.contains) && wrappedArrayFull.contains(this)
+          assert(correctValuesFull)
+
+          val largeArray = new Array[Thread](threads.size + 50)
+          assertEquals(Thread.enumerate(largeArray), threads.size + 1)
+          val wrappedArrayLarge = mutable.WrappedArray.make[Thread](largeArray)
+          val (prefix, suffix)  = wrappedArrayLarge.splitAt(threads.size + 1)
+          val correctValuesLarge: scala.Boolean = threads.forall(
+            prefix.contains) && prefix.contains(this)
+          assert(correctValuesLarge)
+          assert(suffix.forall(_ == null))
+
+          success = true
+        }
+      }
+      thread.start()
+      thread.join()
+      assertEquals(count, threads.size + 1)
+      assert(success)
+    }
+
+    // also test list
+    {
+      val outputStream = new java.io.ByteArrayOutputStream()
+      Console.withOut(outputStream) {
+        group.list()
+      }
+      val string = outputStream.toString
+      assert(string.contains(group.getName))
+      assert(string.contains(subgroup1.getName))
+      assert(string.contains(subgroup2.getName))
+      assert(threads.forall(t => string.contains(t.getName)))
+    }
+
+    threads.foreach { thread: Counter =>
+      thread.goOn = false
+    }
+    threads.foreach { thread: Counter =>
+      thread.join()
+    }
+
+    assertEquals(group.activeCount(), 0)
+    assertEquals(subgroup1.activeCount(), 0)
+    assertEquals(subgroup2.activeCount(), 0)
+
+    assertEquals(group.activeGroupCount(), 2)
+    assertEquals(subgroup1.activeGroupCount(), 0)
+    assertEquals(subgroup2.activeGroupCount(), 0)
+
+    destroyAllGroups()
+  }
+
+  test("toString should contain the group's name") {
+    val name        = "a very long and descriptive name"
+    val threadGroup = new ThreadGroup(name)
+    assert(threadGroup.toString.contains(name))
+  }
+
+  test("unhandled exception should be correctly delegated") {
+    val thread    = new Thread()
+    val exception = new Error("delegate me")
+    val detector  = new ExceptionDetector(thread, exception)
+    val threadGroup = new ThreadGroup("top") {
+      override def uncaughtException(t: Thread, e: Throwable) =
+        detector.uncaughtException(t, e)
+    }
+
+    val subGroup = new ThreadGroup(threadGroup, "sub")
+    subGroup.uncaughtException(thread, exception)
+
+    assert(detector.wasException)
+  }
+
+  test("*DEPRECATED*  ThreadGroup.suspend and resume should affect all threads") {
+
+    val structure = new Structure[Counter] {
+      def makeThread(group: ThreadGroup, name: String) =
+        new Counter(group, name)
+    }
+    import structure._
+    try {
+      threads.foreach(_.start())
+      threads.foreach { thread: Counter =>
+        eventually(label = s"$thread.count > 1")(thread.count > 1)
+      }
+
+      group.suspend()
+      val countMap: scala.collection.immutable.Map[Counter, scala.Long] =
+        threads.map { thread: Counter =>
+          thread -> eventuallyConstant()(thread.count).get
+        }.toMap
+      group.resume()
+
+      threads.foreach { thread: Counter =>
+        eventually(label = s"$thread.count > countMap")(
+          thread.count > countMap(thread))
+      }
+    } finally {
+
+      threads.foreach { thread: Counter =>
+        thread.goOn = false
+      }
+      threads.foreach { thread: Counter =>
+        thread.join()
+      }
+
+      destroyAllGroups()
+    }
+  }
+
+  test(
+    "*DEPRECATED*  ThreadGroup.suspend and resume should respect allowThreadSuspension") {
+
+    val structure = new Structure[Counter] {
+      def makeThread(group: ThreadGroup, name: String) =
+        new Counter(group, name)
+    }
+    import structure._
+    try {
+      threads.foreach(_.start())
+      group.allowThreadSuspension(false)
+
+      val countMap1: scala.collection.immutable.Map[Counter, scala.Long] =
+        threads.map { thread: Counter =>
+          eventually(label = s"$thread.count > 1")(thread.count > 1)
+          thread -> thread.count
+        }.toMap
+
+      group.suspend()
+      val countMap2: scala.collection.immutable.Map[Counter, scala.Long] =
+        threads.map { thread: Counter =>
+          eventually(label = s"$thread.count > countMap1")(
+            thread.count > countMap1(thread))
+          thread -> thread.count
+        }.toMap
+      group.resume()
+
+      group.allowThreadSuspension(true)
+      subgroup1.allowThreadSuspension(false)
+
+      val countMap3: scala.collection.immutable.Map[Counter, scala.Long] =
+        threads.map { thread: Counter =>
+          eventually(label = s"$thread.count > countMap2")(
+            thread.count > countMap2(thread))
+          thread -> thread.count
+        }.toMap
+
+      group.suspend()
+
+      // only subgroup1Threads should go on
+      val countMap4a: scala.collection.immutable.Map[Counter, scala.Long] =
+        subgroup1Threads.map { thread: Counter =>
+          eventually(label = s"$thread.count > countMap3")(
+            thread.count > countMap3(thread))
+          thread -> thread.count
+        }.toMap
+      // every other thread should be suspended
+      val countMap4b = (groupThreads ++ subgroup2Threads)
+        .map { thread: Counter =>
+          thread -> eventuallyConstant()(thread.count).get
+        }
+      val countMap4
+        : scala.collection.immutable.Map[Counter, scala.Long] = countMap4a ++ countMap4b
+
+      group.resume()
+
+      threads.foreach { thread: Counter =>
+        eventually(label = s"$thread.count > countMap4")(
+          thread.count > countMap4(thread))
+      }
+    } finally {
+
+      threads.foreach { thread: Counter =>
+        thread.goOn = false
+      }
+      threads.foreach { thread: Counter =>
+        thread.join()
+      }
+
+      destroyAllGroups()
+    }
+  }
+
+  test("*DEPRECATED* ThreadGroup.stop should stop all threads") {
+    val mutex = new Object
+    val structure = new Structure[WaitingThread] {
+      def makeThread(group: ThreadGroup, name: String) =
+        new WaitingThread(mutex, group, name)
+    }
+    import structure._
+    threads.foreach(_.start())
+    threads.foreach { thread: Thread =>
+      eventuallyEquals(
+        label = thread.getName + "is in Thread.State.TIMED_WAITING")(
+        Thread.State.WAITING,
+        thread.getState
+      )
+    }
+    group.stop()
+    threads.foreach { thread: Thread =>
+      eventuallyEquals(
+        label = thread.getName + "is in Thread.State.TERMINATED")(
+        Thread.State.TERMINATED,
+        thread.getState)
+    }
+
+    destroyAllGroups()
+  }
+}

--- a/unit-tests/src/test/scala/java/lang/ThreadLocalSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/ThreadLocalSuite.scala
@@ -1,0 +1,78 @@
+package java.lang
+
+object ThreadLocalSuite extends tests.MultiThreadSuite {
+  test("Each thread should have their own copies") {
+    val localString = new ThreadLocal[String]
+    assertEquals(localString.get(), null)
+    localString.set("banana")
+    assertEquals(localString.get(), "banana")
+
+    class ThreadLocalTester(str: String) extends Thread {
+      override def run() = {
+        assertEquals(localString.get(), null)
+        localString.set(str)
+        assertEquals(localString.get(), str)
+        localString.remove()
+        assertEquals(localString.get(), null)
+        localString.set(str)
+        assertEquals(localString.get(), str)
+      }
+    }
+    val appleThread  = new ThreadLocalTester("apple")
+    val orangeThread = new ThreadLocalTester("orange")
+
+    appleThread.start()
+    orangeThread.start()
+    appleThread.join()
+    orangeThread.join()
+
+    assertEquals(localString.get(), "banana")
+    localString.remove()
+    assertEquals(localString.get(), null)
+  }
+  test("Initial values") {
+    val localString = new ThreadLocal[String] {
+      override protected def initialValue = "<empty>"
+    }
+    assertEquals(localString.get(), "<empty>")
+    localString.set("banana")
+
+    class ThreadLocalTester(str: String) extends Thread {
+      override def run() = {
+        assertEquals(localString.get(), "<empty>")
+        localString.set(str)
+        assertEquals(localString.get(), str)
+        localString.remove()
+        assertEquals(localString.get(), "<empty>")
+        localString.set(str)
+        assertEquals(localString.get(), str)
+      }
+    }
+    val appleThread  = new ThreadLocalTester("apple")
+    val orangeThread = new ThreadLocalTester("orange")
+
+    appleThread.start()
+    orangeThread.start()
+    appleThread.join()
+    orangeThread.join()
+
+    assertEquals(localString.get(), "banana")
+    localString.remove()
+    assertEquals(localString.get(), "<empty>")
+  }
+
+  test("Initialized not called more than once") {
+    var timesInitialized = 0
+    val local = new ThreadLocal[Int] {
+      override protected def initialValue() = {
+        timesInitialized += 1
+        42
+      }
+    }
+    assertEquals(local.get(), 42)
+    assertEquals(local.get(), 42)
+    assertEquals(local.get(), 42)
+    assertEquals(local.get(), 42)
+    assertEquals(timesInitialized, 1)
+  }
+}

--- a/unit-tests/src/test/scala/java/lang/ThreadSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/ThreadSuite.scala
@@ -1,24 +1,848 @@
 package java.lang
 
-object ThreadSuite extends tests.Suite {
+import java.io.{OutputStream, PrintStream}
 
-  test("Runtime static variables access and currentThread do not crash") {
+import scala.collection.mutable
+
+object ThreadSuite extends tests.MultiThreadSuite {
+  test("Constructors") {
+    {
+      val thread = new Thread
+      //just do not crash
+      thread.start()
+      thread.join()
+    }
+
+    {
+      val name        = "Dave"
+      val threadGroup = new ThreadGroup("MyGroup")
+      val thread      = new Thread(threadGroup, name)
+      assertEquals(thread.getName, name)
+      assertEquals(thread.getThreadGroup, threadGroup)
+      thread.start()
+      assertEquals(thread.getName, name)
+      // threadGroup may be null or the value, because it may have already ended
+      thread.join()
+      assertEquals(thread.getName, name)
+      assertEquals(thread.getThreadGroup, null)
+    }
+
+    {
+      val name   = "Dave"
+      val thread = new Thread(name)
+      assertEquals(thread.getName, name)
+      thread.start()
+      assertEquals(thread.getName, name)
+      thread.join()
+      assertEquals(thread.getName, name)
+    }
+
+    {
+      val name         = "Dave"
+      var didSomething = false
+      val runnable = new Runnable {
+        def run(): Unit = {
+          didSomething = true
+        }
+      }
+      val thread = new Thread(runnable, name)
+      assertEquals(thread.getName, name)
+      thread.start()
+      assertEquals(thread.getName, name)
+      thread.join()
+      assert(didSomething)
+      assertEquals(thread.getName, name)
+    }
+
+    {
+      val name         = "Dave"
+      var didSomething = false
+      val threadGroup  = new ThreadGroup("MyGroup")
+      val runnable = new Runnable {
+        def run(): Unit = {
+          didSomething = true
+        }
+      }
+      val thread = new Thread(threadGroup, runnable, name)
+      assertEquals(thread.getName, name)
+      assertEquals(thread.getThreadGroup, threadGroup)
+      thread.start()
+      assertEquals(thread.getName, name)
+      // threadGroup may be null or the value, because it may have already ended
+      thread.join()
+      assert(didSomething)
+      assertEquals(thread.getName, name)
+      assertEquals(thread.getThreadGroup, null)
+    }
+
+    {
+      val name         = "Dave"
+      var didSomething = false
+      val threadGroup  = new ThreadGroup("MyGroup")
+      val runnable = new Runnable {
+        def run(): Unit = {
+          didSomething = true
+        }
+      }
+      val stackSize = 6L * 1024L * 1024L
+      val thread    = new Thread(threadGroup, runnable, name, stackSize)
+      // no way to check stack size yet, just do not crash
+      assertEquals(thread.getName, name)
+      assertEquals(thread.getThreadGroup, threadGroup)
+      thread.start()
+      assertEquals(thread.getName, name)
+      // threadGroup may be null or the value, because it may have already ended
+      thread.join()
+      assert(didSomething)
+      assertEquals(thread.getName, name)
+      assertEquals(thread.getThreadGroup, null)
+    }
+  }
+
+  test("Priority constants are valid") {
 
     val max  = Thread.MAX_PRIORITY
     val min  = Thread.MIN_PRIORITY
     val norm = Thread.NORM_PRIORITY
 
-    val current = Thread.currentThread()
-
+    assert(min <= max)
+    assert(min <= norm)
+    assert(norm <= max)
   }
 
   test("Get/Set Priority work as it should with currentThread") {
+    val currentThread = Thread.currentThread()
+    val old           = currentThread.getPriority
+    try {
+      currentThread.setPriority(3)
+      assert(currentThread.getPriority == 3)
+    } finally {
+      currentThread.setPriority(old)
+    }
+  }
 
-    val current = Thread.currentThread()
+  test("Get/Set Priority work as it should with other thread") {
+    val thread = new Thread()
 
-    current.setPriority(3)
-    assert(current.getPriority == 3)
+    thread.setPriority(2)
+    assert(thread.getPriority == 2)
+  }
+
+  test("Thread.yield does not crash") {
+    Thread.`yield`()
+    val thread = new Thread {
+      override def run() = Thread.`yield`()
+    }
+    thread.start()
+    thread.join()
+  }
+
+  test("Thread.checkAccess does not crash") {
+    Thread.currentThread().checkAccess()
+    val thread = new Thread {
+      override def run() = checkAccess()
+    }
+    thread.start()
+    thread.join()
+  }
+
+  test("GC should not crash with multiple threads") {
+    val muncher1 = new MemoryMuncher(10000)
+    val muncher2 = new MemoryMuncher(10000)
+    muncher1.start()
+    muncher2.start()
+    muncher1.join()
+    muncher2.join()
+  }
+
+  test("sleep suspends execution by at least the requested amount") {
+    val millisecondTests = Seq(0, 1, 5, 100)
+    millisecondTests.foreach { ms =>
+      takesAtLeast(ms) {
+        Thread.sleep(ms)
+      }
+    }
+    millisecondTests.foreach { ms =>
+      takesAtLeast(ms) {
+        Thread.sleep(ms, 0)
+      }
+    }
+
+    val tests = Seq(0 -> 0,
+                    0   -> 1,
+                    0   -> 999999,
+                    1   -> 0,
+                    1   -> 1,
+                    5   -> 0,
+                    100 -> 0,
+                    100 -> 50)
+
+    tests.foreach {
+      case (ms, nanos) =>
+        takesAtLeast(ms, nanos) {
+          Thread.sleep(ms, nanos)
+        }
+    }
+  }
+
+  test("wait suspends execution by at least the requested amount") {
+    val mutex            = new Object()
+    val millisecondTests = Seq(0, 1, 5, 100, 1000)
+    millisecondTests.foreach { ms =>
+      mutex.synchronized {
+        takesAtLeast(ms) {
+          mutex.wait(ms)
+        }
+      }
+    }
+    millisecondTests.foreach { ms =>
+      mutex.synchronized {
+        takesAtLeast(ms) {
+          mutex.wait(ms, 0)
+        }
+      }
+    }
+
+    val tests = Seq(0 -> 0,
+                    0   -> 1,
+                    0   -> 999999,
+                    1   -> 0,
+                    1   -> 1,
+                    5   -> 0,
+                    100 -> 0,
+                    100 -> 50)
+
+    tests.foreach {
+      case (ms, nanos) =>
+        mutex.synchronized {
+          takesAtLeast(ms, nanos) {
+            mutex.wait(ms, nanos)
+          }
+        }
+    }
+  }
+
+  test("wait duration should not be reduced by getStackTrace") {
+    val mainThread = Thread.currentThread()
+    val mutex      = new Object
+    val wantsStackTrace = new Thread {
+      override def run() = {
+        eventuallyEquals()(mainThread.getState, Thread.State.WAITING)
+        mainThread.getStackTrace
+      }
+    }
+    wantsStackTrace.start()
+    mutex.synchronized {
+      takesAtLeast(2000) {
+        mutex.wait(2000)
+      }
+    }
+  }
+
+  test("Thread should be able to change a shared var") {
+    var shared: Int = 0
+    new Thread(new Runnable {
+      def run(): Unit = {
+        shared = 1
+      }
+    }).start()
+    eventuallyEquals()(shared, 1)
+  }
+
+  test("Thread should be able to change its internal state") {
+    class StatefulThread extends Thread {
+      var internal = 0
+      override def run() = {
+        internal = 1
+      }
+    }
+    val t = new StatefulThread
+    t.start()
+    eventuallyEquals()(t.internal, 1)
+  }
+
+  test("Thread should be able to change runnable's internal state") {
+    class StatefulRunnable extends Runnable {
+      var internal = 0
+      def run(): Unit = {
+        internal = 1
+      }
+    }
+    val runnable = new StatefulRunnable
+    new Thread(runnable).start()
+    eventuallyEquals()(runnable.internal, 1)
+  }
+
+  test("Thread should be able to call a method") {
+    object hasTwoArgMethod {
+      var timesCalled = 0
+      def call(arg: String, arg2: Int): Unit = {
+        assertEquals("abc", arg)
+        assertEquals(123, arg2)
+        synchronized {
+          timesCalled += 1
+        }
+      }
+    }
+    val t = new Thread(new Runnable {
+      def run(): Unit = {
+        hasTwoArgMethod.call("abc", 123)
+        hasTwoArgMethod.call("abc", 123)
+      }
+    })
+    t.start()
+    t.join(eternity)
+    assertEquals(hasTwoArgMethod.timesCalled, 2)
+  }
+
+  test("Exceptions in Threads should be handled") {
+    val exception = new NullPointerException("There must be a null somewhere")
+    val thread = new Thread(new Runnable {
+      def run(): Unit = {
+        throw exception
+      }
+    })
+    val detector = new ExceptionDetector(thread, exception)
+    thread.setUncaughtExceptionHandler(detector)
+    assertEquals(thread.getUncaughtExceptionHandler, detector)
+
+    thread.start()
+    eventually()(detector.wasException)
+  }
+
+  test("Exceptions in Threads should be handled 2") {
+    val exception = new NullPointerException("There must be a null somewhere")
+    val thread = new Thread(new Runnable {
+      def run(): Unit = {
+        throw exception
+      }
+    })
+    val detector = new ExceptionDetector(thread, exception)
+    withExceptionHandler(detector) {
+      assertEquals(Thread.getDefaultUncaughtExceptionHandler, detector)
+      thread.start()
+      thread.join()
+    }
+    thread.join(eternity)
+    assert(detector.wasException)
+  }
+
+  test("Thread.join(ms) should wait until timeout") {
+    val thread = new Thread {
+      override def run(): Unit = {
+        Thread.sleep(2000)
+      }
+    }
+    thread.start()
+    takesAtLeast(100) {
+      thread.join(100)
+    }
+    assert(thread.isAlive)
+  }
+
+  test("Thread.join(ms,ns) should wait until timeout") {
+    val thread = new Thread {
+      override def run(): Unit = {
+        Thread.sleep(2000)
+      }
+    }
+    thread.start()
+    takesAtLeast(100, 50) {
+      thread.join(100, 50)
+    }
+    assert(thread.isAlive)
+  }
+
+  test("Thread.join should wait for thread finishing") {
+    val thread = new Thread {
+      override def run(): Unit = {
+        Thread.sleep(100)
+      }
+    }
+    thread.start()
+    thread.join(1000)
+    assertNot(thread.isAlive)
+  }
+  test("Thread.join should wait for thread finishing (no timeout)") {
+
+    val thread = new Thread {
+      override def run(): Unit = {
+        Thread.sleep(100)
+      }
+    }
+    thread.start()
+    thread.join()
+    assertNot(thread.isAlive)
+  }
+
+  test("Thread.getState and Thread.isAlive") {
+    var goOn = true
+    val thread = new Thread {
+      override def run(): Unit = {
+        while (goOn) {}
+      }
+    }
+    assertEquals(Thread.State.NEW, thread.getState)
+    thread.start()
+    assert(thread.isAlive)
+    assertEquals(Thread.State.RUNNABLE, thread.getState)
+    goOn = false
+    thread.join()
+    assertEquals(Thread.State.TERMINATED, thread.getState)
+    assertNot(thread.isAlive)
+  }
+
+  test("Thread.clone should fail") {
+    val thread = new Thread("abc")
+    expectThrows(classOf[CloneNotSupportedException], thread.clone())
+  }
+
+  test("Synchronized block should be executed by at most 1 thread") {
+    testWithMinDelay() { delay =>
+      // counter example
+      var tmp = 0
+      withThreads() { _ =>
+        tmp *= 2
+        tmp += 1
+        Thread.sleep(delay)
+        tmp -= 1
+      }
+
+      // counterexample succeeds if we get a bad value
+      tmp != 0
+    } { delay =>
+      // test
+      val mutex = new Object
+      var tmp   = 0
+      withThreads() { _ =>
+        mutex.synchronized {
+          tmp *= 2
+          tmp += 1
+          Thread.sleep(delay)
+          tmp -= 1
+        }
+      }
+      // sychronized should preserve the invariant
+      tmp == 0
+    }
 
   }
 
+  test("Thread.currentThread") {
+    new Thread {
+      override def run(): Unit = {
+        assertEquals(this, Thread.currentThread())
+      }
+    }.start()
+    assert(Thread.currentThread() != null)
+  }
+
+  test("wait-notify") {
+    val mutex = new Object
+    new Thread {
+      override def run() = {
+        Thread.sleep(100)
+        mutex.synchronized {
+          mutex.notify()
+        }
+      }
+    }.start()
+    mutex.synchronized {
+      mutex.wait(1000)
+    }
+  }
+  test("wait-notify 2") {
+    val mutex         = new Object
+    val waiter1       = new WaitingThread(mutex, name = "wait-notify 1")
+    val waiter2       = new WaitingThread(mutex, name = "wait-notify 2")
+    def timesNotified = waiter1.timesNotified + waiter2.timesNotified
+    waiter1.start()
+    waiter2.start()
+    assertEquals(timesNotified, 0)
+    eventuallyEquals(label = "waiter1.getState == Thread.State.WAITING")(
+      waiter1.getState,
+      Thread.State.WAITING)
+    eventuallyEquals(label = "waiter2.getState == Thread.State.WAITING")(
+      waiter2.getState,
+      Thread.State.WAITING)
+    mutex.synchronized {
+      mutex.notify()
+    }
+    eventuallyEquals(label = "timesNotified == 1")(timesNotified, 1)
+    mutex.synchronized {
+      mutex.notify()
+    }
+    eventuallyEquals(label = "timesNotified == 2")(timesNotified, 2)
+  }
+  test("wait-notifyAll") {
+    val mutex         = new Object
+    val waiter1       = new WaitingThread(mutex, name = "wait-notifyAll 1")
+    val waiter2       = new WaitingThread(mutex, name = "wait-notifyAll 2")
+    def timesNotified = waiter1.timesNotified + waiter2.timesNotified
+    waiter1.start()
+    waiter2.start()
+    assertEquals(timesNotified, 0)
+    eventuallyEquals(label = "waiter1.getState == Thread.State.WAITING")(
+      waiter1.getState,
+      Thread.State.WAITING)
+    eventuallyEquals(label = "waiter2.getState == Thread.State.WAITING")(
+      waiter2.getState,
+      Thread.State.WAITING)
+    mutex.synchronized {
+      mutex.notifyAll()
+    }
+    eventuallyEquals(label = "timesNotified == 2")(timesNotified, 2)
+  }
+  test("Object.wait puts the Thread into TIMED_WAITING state") {
+    val mutex = new Object
+    var goOn  = true
+    val thread = new Thread {
+      override def run() = {
+        mutex.synchronized {
+          takesAtLeast(1000) {
+            mutex.wait(1000)
+          }
+        }
+        while (goOn) {}
+      }
+    }
+    thread.start()
+    eventuallyEquals(label = "thread.getState == Thread.State.TIMED_WAITING")(
+      thread.getState,
+      Thread.State.TIMED_WAITING)
+    thread.synchronized {
+      thread.notify()
+    }
+    eventuallyEquals(label = "thread.getState == Thread.State.RUNNABLE")(
+      thread.getState,
+      Thread.State.RUNNABLE)
+    goOn = false
+    eventuallyEquals(label = "thread.getState == Thread.State.TERMINATED")(
+      thread.getState,
+      Thread.State.TERMINATED)
+  }
+  test("Multiple locks should not conflict") {
+    val mutex1     = new Object
+    val mutex2     = new Object
+    var goOn       = true
+    var doingStuff = false
+    val waiter = new Thread {
+      override def run() =
+        mutex1.synchronized {
+          while (goOn) {
+            doingStuff = true
+            Thread.sleep(10)
+          }
+        }
+    }
+    waiter.start()
+    eventually()(doingStuff)
+
+    val stopper = new Thread {
+      override def run() = {
+        Thread.sleep(100)
+        mutex2.synchronized {
+          goOn = false
+        }
+      }
+    }
+    stopper.start()
+    stopper.join(eternity)
+    assertNot(stopper.isAlive)
+  }
+
+  test("Thread.interrupt should interrupt sleep") {
+    val thread = new Thread {
+      override def run() = {
+        expectThrows(classOf[InterruptedException], Thread.sleep(10 * eternity))
+      }
+    }
+    thread.start()
+    eventuallyEquals()(Thread.State.TIMED_WAITING, thread.getState)
+    thread.interrupt()
+    eventuallyEquals()(Thread.State.TERMINATED, thread.getState)
+  }
+  test("Thread.interrupt should interrupt between calculations") {
+    var doingStuff = false
+    val thread = new Thread {
+      override def run() = {
+        while (!Thread.interrupted()) {
+          doingStuff = true
+          //some intense calculation
+          scala.collection.immutable.Range(1, 10000, 1).reduce(_ + _)
+        }
+      }
+    }
+    thread.start()
+    eventually()(doingStuff)
+    thread.interrupt()
+    eventuallyEquals()(Thread.State.TERMINATED, thread.getState)
+  }
+
+  def withErr[T](stream: OutputStream)(f: => T): T = {
+    val old = System.err
+    try {
+      System.setErr(new PrintStream(stream))
+      f
+    } finally {
+      System.setErr(old)
+    }
+  }
+
+  test("Thread.dumpStack should contain the method name") {
+    object Something {
+      def aMethodWithoutAnInterestingName = {
+        Thread.dumpStack()
+      }
+    }
+    val outputStream = new java.io.ByteArrayOutputStream()
+    withErr(outputStream) {
+      Something.aMethodWithoutAnInterestingName
+    }
+    assert(outputStream.toString.contains("aMethodWithoutAnInterestingName"))
+  }
+  test("currentThread().getStackTrace should contain the running method name") {
+    object Something {
+      def aMethodWithoutAnInterestingName = {
+        Thread.currentThread().getStackTrace
+      }
+    }
+    val rawStackTrace = Something.aMethodWithoutAnInterestingName
+    assert(
+      mutable.WrappedArray
+        .make[StackTraceElement](rawStackTrace)
+        .exists(_.getMethodName == "aMethodWithoutAnInterestingName"))
+  }
+  test("Thread.getAllStackTraces should contain our own thread") {
+    object Something {
+      def aMethodWithoutAnInterestingName = {
+        Thread.getAllStackTraces
+      }
+    }
+    val rawStackTraces = Something.aMethodWithoutAnInterestingName
+    val currentThread  = Thread.currentThread()
+    assert(rawStackTraces.containsKey(currentThread))
+    val currentThreadStackTrace = rawStackTraces.get(currentThread)
+    assert(
+      mutable.WrappedArray
+        .make[StackTraceElement](currentThreadStackTrace)
+        .exists(_.getMethodName == "aMethodWithoutAnInterestingName"))
+  }
+  test("thread.getStackTrace should be a stacktrace for that thread") {
+    object Something {
+      def aMethodWithoutAnInterestingName = {
+        Thread.sleep(2000)
+      }
+    }
+    val thread = new Thread {
+      override def run() = {
+        Something.aMethodWithoutAnInterestingName
+      }
+    }
+    thread.start()
+    eventuallyEquals(label = "thread.getState == Thread.State.TIMED_WAITING")(
+      thread.getState,
+      Thread.State.TIMED_WAITING)
+    val rawStackTrace = thread.getStackTrace
+    assert(
+      mutable.WrappedArray
+        .make[StackTraceElement](rawStackTrace)
+        .exists(_.getMethodName == "aMethodWithoutAnInterestingName"))
+  }
+  test("newly created threads should show up in Thread.getAllStackTraces") {
+    val mutex = new Object
+    val thread1 =
+      new WaitingThread(mutex, name = "waiter nc Thread.getAllStackTraces1")
+    val thread2 =
+      new WaitingThread(mutex, name = "waiter nc Thread.getAllStackTraces2")
+
+    {
+      val stackTraces = Thread.getAllStackTraces
+      assertEquals(stackTraces.containsKey(thread1), false)
+      assertEquals(stackTraces.containsKey(thread2), false)
+      Console.out.println("none of threads present as expected")
+    }
+
+    thread1.start()
+
+    {
+      val stackTraces = Thread.getAllStackTraces
+      assertEquals(stackTraces.containsKey(thread1), true)
+      assertEquals(stackTraces.containsKey(thread2), false)
+      Console.out.println("thread1 present as expected")
+    }
+
+    thread2.start()
+
+    {
+      val stackTraces = Thread.getAllStackTraces
+      assertEquals(stackTraces.containsKey(thread1), true)
+      assertEquals(stackTraces.containsKey(thread2), true)
+      Console.out.println("both threads present as expected")
+    }
+
+    eventuallyEquals()(thread1.getState, Thread.State.WAITING)
+    eventuallyEquals()(thread2.getState, Thread.State.WAITING)
+
+    mutex.notifyAll()
+
+    eventuallyEquals()(thread1.getState, Thread.State.TERMINATED)
+    eventuallyEquals()(thread2.getState, Thread.State.TERMINATED)
+
+    eventually(label = "both threads not present") {
+      val stackTraces = Thread.getAllStackTraces
+      !stackTraces.containsKey(thread1) && !stackTraces.containsKey(thread2)
+    }
+  }
+
+  test("holdsLock") {
+    def twoMutexTest = {
+      val mutex1 = new Object
+      val mutex2 = new Object
+
+      assertEquals(Thread.holdsLock(mutex1), false)
+      assertEquals(Thread.holdsLock(mutex2), false)
+      mutex1.synchronized {
+        assertEquals(Thread.holdsLock(mutex1), true)
+        assertEquals(Thread.holdsLock(mutex2), false)
+        mutex2.synchronized {
+          assertEquals(Thread.holdsLock(mutex1), true)
+          assertEquals(Thread.holdsLock(mutex2), true)
+        }
+        assertEquals(Thread.holdsLock(mutex1), true)
+        assertEquals(Thread.holdsLock(mutex2), false)
+      }
+      assertEquals(Thread.holdsLock(mutex1), false)
+      assertEquals(Thread.holdsLock(mutex2), false)
+    }
+
+    twoMutexTest
+
+    val thread = new Thread {
+      override def run() = twoMutexTest
+    }
+    thread.start()
+    thread.join()
+  }
+  test("contextClassLoaders not supported") {
+    assertThrows[NotImplementedError](
+      Thread.currentThread().setContextClassLoader(new ClassLoader() {}))
+    assertThrows[NotImplementedError](
+      Thread.currentThread().getContextClassLoader)
+  }
+
+  test("*DEPRECATED* Thread.suspend and Thread.resume") {
+    val counter = new Counter
+    counter.start()
+    eventually()(counter.count > 1)
+    counter.suspend()
+    val value = eventuallyConstant()(counter.count)
+    counter.resume()
+    eventually()(counter.count > value.get)
+    counter.goOn = false
+    counter.join()
+  }
+
+  test("*DEPRECATED* second Thread.suspend call should not affect anything") {
+    val counter = new Counter
+    counter.start()
+    eventually()(counter.count > 1)
+    counter.suspend()
+    counter.suspend()
+    val value = eventuallyConstant()(counter.count)
+    counter.resume()
+    eventually()(counter.count > value.get)
+    counter.goOn = false
+    counter.join()
+  }
+
+  test("*DEPRECATED* Thread.destroy") {
+    val mutex  = new Object
+    val thread = new WaitingThread(mutex, name = "waiter Thread.destroy")
+    thread.start()
+    eventuallyEquals(label = "thread WAITING")(thread.getState,
+                                               Thread.State.WAITING)
+    thread.destroy()
+    eventually(label = "thread stopped")(!thread.isAlive)
+  }
+
+  test("*DEPRECATED* Thread.stop()") {
+    val mutex  = new Object
+    val thread = new WaitingThread(mutex, name = "waiter Thread.stop")
+    thread.start()
+    eventuallyEquals(label = "thread WAITING")(thread.getState,
+                                               Thread.State.WAITING)
+    thread.stop()
+    eventually(label = "thread stopped")(!thread.isAlive)
+  }
+
+  test("*DEPRECATED* Thread.stop(throwable)") {
+    val mutex  = new Object
+    val thread = new WaitingThread(mutex, name = "waiter Thread.stop 2")
+    thread.start()
+    eventuallyEquals(label = "thread WAITING")(thread.getState,
+                                               Thread.State.WAITING)
+    thread.stop(new Error("something went wrong"))
+    eventually(label = "thread stopped")(!thread.isAlive)
+  }
+
+  test("*DEPRECATED* Thread.countStackFrames") {
+    val counter = new Counter
+    counter.start()
+    eventually()(counter.count > 1)
+    // thread not suspended, throw exception ... sure why not
+    assertThrows[IllegalThreadStateException](counter.countStackFrames())
+    counter.suspend()
+    val value = eventuallyConstant()(counter.count)
+    assert(counter.countStackFrames() > 0)
+    counter.resume()
+    eventually()(counter.count > value.get)
+    counter.goOn = false
+    counter.join()
+  }
+
+  test("toString should contain the name and the name of the group") {
+    val groupName  = "veryNiceGroupName"
+    val group      = new ThreadGroup(groupName)
+    val threadName = "descriptiveNameGivenToAThread"
+    val thread     = new Thread(group, threadName)
+    val toString   = thread.toString
+    assert(toString.contains(groupName))
+    assert(toString.contains(threadName))
+  }
+
+  test("can set name for new and running threads") {
+    var goOn = true
+    val thread = new Thread {
+      override def run() = while (goOn) {
+        Thread.sleep(20)
+      }
+    }
+    val name1 = "Larry"
+    thread.setName(name1)
+    assertEquals(thread.getName, name1)
+
+    thread.start()
+    val name2 = "Curly"
+    thread.setName(name2)
+    assertEquals(thread.getName, name2)
+
+    goOn = false
+    thread.join()
+
+    val name3 = "Moe"
+    thread.setName(name3)
+    assertEquals(thread.getName, name3)
+  }
+
+  test("threadIds increment") {
+    var oldId        = -1L
+    var timeToRepeat = 10
+    while (timeToRepeat > 0) {
+      val id = new Thread().getId
+      assert(id > oldId)
+      oldId = id
+      timeToRepeat -= 1
+    }
+  }
 }

--- a/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicSuite.scala
+++ b/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicSuite.scala
@@ -1,39 +1,295 @@
 package java.util.concurrent.atomic
 
-object AtomicSuite extends tests.Suite {
+object AtomicSuite extends tests.MultiThreadSuite {
 
   test("Atomic Boolean") {
-
     val a = new AtomicBoolean(true)
     assert(a.get())
     assert(a.compareAndSet(true, false))
     assert(!a.get())
+  }
 
+  test("Atomic Reference") {
+    val thing1 = new Object
+    val thing2 = new Object
+    val a      = new AtomicReference[AnyRef]()
+
+    assertEquals(a.get(), null)
+    a.set(thing1)
+    assertEquals(a.get(), thing1)
+
+    assertNot(a.compareAndSet(null, thing2))
+    assert(a.compareAndSet(thing1, thing2))
+    assertEquals(a.get(), thing2)
+  }
+
+  test("Atomic Integer") {
+    val a = new AtomicInteger()
+
+    assertEquals(a.get(), 0)
+    a.set(1)
+    assertEquals(a.get(), 1)
+
+    assertNot(a.compareAndSet(0, 2))
+    assert(a.compareAndSet(1, 2))
+    assertEquals(a.get(), 2)
+
+    assertEquals(a.incrementAndGet(), 3)
+    assertEquals(a.getAndIncrement(), 3)
+    assertEquals(a.get(), 4)
+
+    assertEquals(a.decrementAndGet(), 3)
+    assertEquals(a.getAndDecrement(), 3)
+    assertEquals(a.get(), 2)
+  }
+
+  test("Atomic Integer is atomic") {
+    val numThreads = 2
+    testWithMinRepetitions() { n: Int =>
+      var number = 0
+      withThreads(numThreads, label = "Atomic Integer CounterExample") { _ =>
+        var i = n
+        // making this as fast as possible
+        while (i > 0) {
+          number = number + 1
+          i -= 1
+        }
+      }
+      number != (n * numThreads)
+    } { n: Int =>
+      val number = new AtomicInteger()
+      withThreads(numThreads, label = "Atomic Integer Test") { _ =>
+        var i = n
+        // making this as fast as possible
+        while (i > 0) {
+          number.addAndGet(1)
+          i -= 1
+        }
+      }
+
+      val value    = number.get()
+      val expected = n * numThreads
+      Console.out.println(s"value: $value, expected: $expected")
+      value == expected
+    }
+  }
+
+  test("Atomic Long") {
+    val a = new AtomicLong()
+
+    assertEquals(a.get(), 0L)
+    a.set(1L)
+    assertEquals(a.get(), 1L)
+
+    assertNot(a.compareAndSet(0L, 2L))
+    assert(a.compareAndSet(1L, 2L))
+    assertEquals(a.get(), 2L)
+
+    assertEquals(a.incrementAndGet(), 3L)
+    assertEquals(a.getAndIncrement(), 3L)
+    assertEquals(a.get(), 4L)
+
+    assertEquals(a.decrementAndGet(), 3L)
+    assertEquals(a.getAndDecrement(), 3L)
+    assertEquals(a.get(), 2L)
+  }
+
+  test("Atomic Long is atomic") {
+    val numThreads = 2
+    testWithMinRepetitions() { n: Int =>
+      var number = 0L
+      withThreads(numThreads, label = "Atomic Long CounterExample") { _ =>
+        var i = n
+        // making this as fast as possible
+        while (i > 0) {
+          number = number + 1L
+          i -= 1
+        }
+      }
+      number != (n * numThreads)
+    } { n: Int =>
+      val number = new AtomicLong()
+      withThreads(numThreads, label = "Atomic Long Test") { _ =>
+        var i = n
+        // making this as fast as possible
+        while (i > 0) {
+          number.addAndGet(1L)
+          i -= 1
+        }
+      }
+
+      val value    = number.get()
+      val expected = n.toLong * numThreads
+      Console.out.println(s"value: $value, expected: $expected")
+      value == expected
+    }
+  }
+
+  test("Atomic Reference Array") {
+    val a = new AtomicReferenceArray[AnyRef](3)
+
+    val thing1 = new Object
+    val thing2 = new Object
+    val thing3 = new Object
+
+    assertEquals(a.get(0), null)
+    assertEquals(a.get(1), null)
+    assertEquals(a.get(2), null)
+
+    a.set(1, thing1)
+    a.set(2, thing2)
+
+    assertEquals(a.get(0), null)
+    assertEquals(a.get(1), thing1)
+    assertEquals(a.get(2), thing2)
+
+    // the wrong indexes
+    assertNot(a.compareAndSet(0, thing2, thing3))
+    assertNot(a.compareAndSet(1, null, thing1))
+    assertNot(a.compareAndSet(2, thing1, thing2))
+
+    assert(a.compareAndSet(0, null, thing1))
+    assert(a.compareAndSet(1, thing1, thing2))
+    assert(a.compareAndSet(2, thing2, thing3))
+
+    assertEquals(a.get(0), thing1)
+    assertEquals(a.get(1), thing2)
+    assertEquals(a.get(2), thing3)
+
+    assertThrows[IndexOutOfBoundsException](a.get(3))
+    assertThrows[IndexOutOfBoundsException](a.get(-1))
   }
 
   test("Atomic Integer Array") {
-
     val a = new AtomicIntegerArray(3)
+
+    assertEquals(a.get(0), 0)
+    assertEquals(a.get(1), 0)
+    assertEquals(a.get(2), 0)
 
     a.set(0, 0)
     a.set(1, 1)
     a.set(2, 2)
 
-    assert(a.get(0) == 0)
-    assert(a.get(1) == 1)
-    assert(a.get(2) == 2)
+    assertEquals(a.get(0), 0)
+    assertEquals(a.get(1), 1)
+    assertEquals(a.get(2), 2)
+
+    // the wrong indexes
+    assertNot(a.compareAndSet(0, 2, 3))
+    assertNot(a.compareAndSet(1, 0, 1))
+    assertNot(a.compareAndSet(2, 1, 2))
 
     assert(a.compareAndSet(0, 0, 1))
     assert(a.compareAndSet(1, 1, 2))
     assert(a.compareAndSet(2, 2, 3))
 
-    assert(a.get(0) == 1)
-    assert(a.get(1) == 2)
-    assert(a.get(2) == 3)
+    assertEquals(a.get(0), 1)
+    assertEquals(a.get(1), 2)
+    assertEquals(a.get(2), 3)
 
     assertThrows[IndexOutOfBoundsException](a.get(3))
     assertThrows[IndexOutOfBoundsException](a.get(-1))
-
   }
 
+  test("Atomic Integer Array is atomic") {
+    val numThreads = 4
+    testWithMinRepetitions() { n: Int =>
+      val array = new Array[Int](2)
+      withThreads(numThreads, label = "Atomic Integer Array CounterExample") {
+        id: Int =>
+          val index = id / 2
+          var i     = n
+          // making this as fast as possible
+          while (i > 0) {
+            array(index) = array(index) + 1
+            i -= 1
+          }
+      }
+      array.sum != (n * numThreads)
+    } { n: Int =>
+      val array = new AtomicIntegerArray(2)
+      withThreads(numThreads, label = "Atomic Integer Array Test") { id: Int =>
+        val index = id / 2
+        var i     = n
+        // making this as fast as possible
+        while (i > 0) {
+          array.addAndGet(index, 1)
+          i -= 1
+        }
+      }
+
+      val value    = array.get(0) + array.get(1)
+      val expected = n * numThreads
+      Console.out.println(s"value: $value, expected: $expected")
+      value == expected
+    }
+  }
+
+  test("Atomic Long Array") {
+
+    val a = new AtomicLongArray(3)
+
+    assertEquals(a.get(0), 0L)
+    assertEquals(a.get(1), 0L)
+    assertEquals(a.get(2), 0L)
+
+    a.set(0, 0L)
+    a.set(1, 1L)
+    a.set(2, 2L)
+
+    assertEquals(a.get(0), 0L)
+    assertEquals(a.get(1), 1L)
+    assertEquals(a.get(2), 2L)
+
+    // the wrong indexes
+    assertNot(a.compareAndSet(0, 2L, 3L))
+    assertNot(a.compareAndSet(1, 0L, 1L))
+    assertNot(a.compareAndSet(2, 1L, 2L))
+
+    assert(a.compareAndSet(0, 0L, 1L))
+    assert(a.compareAndSet(1, 1L, 2L))
+    assert(a.compareAndSet(2, 2L, 3L))
+
+    assertEquals(a.get(0), 1L)
+    assertEquals(a.get(1), 2L)
+    assertEquals(a.get(2), 3L)
+
+    assertThrows[IndexOutOfBoundsException](a.get(3))
+    assertThrows[IndexOutOfBoundsException](a.get(-1))
+  }
+
+  test("Atomic Long Array is atomic") {
+    val numThreads = 4
+    testWithMinRepetitions() { n: Int =>
+      val array = new Array[Long](2)
+      withThreads(numThreads, label = "Atomic Long Array CounterExample") {
+        id: Int =>
+          val index = id / 2
+          var i     = n
+          // making this as fast as possible
+          while (i > 0) {
+            array(index) = array(index) + 1L
+            i -= 1
+          }
+      }
+      array.sum != (n * numThreads)
+    } { n: Int =>
+      val array = new AtomicLongArray(2)
+      withThreads(numThreads, label = "Atomic Long Array Test") { id: Int =>
+        val index = id / 2
+        var i     = n
+        // making this as fast as possible
+        while (i > 0) {
+          array.addAndGet(index, 1L)
+          i -= 1
+        }
+      }
+
+      val value    = array.get(0) + array.get(1)
+      val expected = n * numThreads
+      Console.out.println(s"value: $value, expected: $expected")
+      value == expected
+    }
+  }
 }

--- a/unit-tests/src/test/scala/scala/concurrent/FutureSuite.scala
+++ b/unit-tests/src/test/scala/scala/concurrent/FutureSuite.scala
@@ -1,0 +1,156 @@
+package scala.concurrent
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object FutureSuite extends tests.MultiThreadSuite {
+  def getResult[T](delay: Long = eternity)(future: Future[T]): Option[T] = {
+    var value: Option[T] = None
+    val mutex            = new Object
+    future.foreach { v: T =>
+      mutex.synchronized {
+        value = Some(v)
+        mutex.notifyAll()
+      }
+    }
+    if (value.isEmpty) {
+      mutex.synchronized {
+        if (value.isEmpty) {
+          mutex.wait(delay)
+        }
+      }
+    }
+    value
+  }
+
+  test("Future.successful") {
+    val future = Future.successful(3)
+    assertEquals(getResult()(future), Some(3))
+  }
+
+  test("Future.failed") {
+    val future = Future.failed(new NullPointerException("Nothing here"))
+    assertEquals(getResult(200)(future), None)
+  }
+
+  test("Future.apply") {
+    val future = Future(3)
+    assertEquals(getResult()(future), Some(3))
+  }
+
+  private val futureDelay = 1000
+  test("Future.apply delayed") {
+    val future = Future {
+      Thread.sleep(futureDelay)
+      3
+    }
+    assertEquals(getResult()(future), Some(3))
+  }
+
+  test("Future.map") {
+    val future = Future(7).map(_ * 191)
+    assertEquals(getResult()(future), Some(1337))
+  }
+
+  test("Future.map delayed") {
+    val future = Future {
+      Thread.sleep(futureDelay)
+      7
+    }.map { x =>
+      Thread.sleep(futureDelay)
+      x * 191
+    }
+    assertEquals(getResult()(future), Some(1337))
+  }
+
+  test("Future.flatMap instant") {
+    val future1 = Future.successful(7)
+    val future = Future.successful(6).flatMap { b =>
+      future1.map { a =>
+        a * b
+      }
+    }
+    assertEquals(getResult()(future), Some(42))
+  }
+
+  test("Future.flatMap") {
+    val future1 = Future(7)
+    val future = Future(6).flatMap { b =>
+      future1.map { a =>
+        a * b
+      }
+    }
+    assertEquals(getResult()(future), Some(42))
+  }
+
+  test("Future.flatMap delayed") {
+    val future1 = Future {
+      Thread.sleep(futureDelay)
+      7
+    }
+    val future = Future {
+      Thread.sleep(futureDelay)
+      6
+    }.flatMap { b =>
+      future1.map { a =>
+        a * b
+      }
+    }
+    assertEquals(getResult()(future), Some(42))
+  }
+
+  test("Future.reduce instant") {
+    val futures =
+      Seq(Future.successful(1), Future.successful(2), Future.successful(3))
+    val sumFuture = Future.reduce(futures)(_ + _)
+    assertEquals(getResult()(sumFuture), Some(6))
+  }
+
+  test("Future.reduce") {
+    val futures   = Seq(Future(1), Future(2), Future(3))
+    val sumFuture = Future.reduce(futures)(_ + _)
+    assertEquals(getResult()(sumFuture), Some(6))
+  }
+
+  test("Future.reduce delayed") {
+    val futures = Seq(Future {
+      Thread.sleep(futureDelay)
+      1
+    }, Future {
+      Thread.sleep(futureDelay)
+      2
+    }, Future {
+      Thread.sleep(futureDelay)
+      3
+    })
+    val sumFuture = Future.reduce(futures)(_ + _)
+    assertEquals(getResult()(sumFuture), Some(6))
+  }
+
+  test("Future.fold instant") {
+    val futures =
+      Seq(Future.successful(1), Future.successful(2), Future.successful(3))
+    val sumFuture = Future.fold(futures)(1)(_ + _)
+    assertEquals(getResult()(sumFuture), Some(7))
+  }
+
+  test("Future.fold") {
+    val futures   = Seq(Future(1), Future(2), Future(3))
+    val sumFuture = Future.fold(futures)(1)(_ + _)
+    assertEquals(getResult()(sumFuture), Some(7))
+  }
+
+  test("Future.fold delayed") {
+    val futures = Seq(Future {
+      Thread.sleep(futureDelay)
+      1
+    }, Future {
+      Thread.sleep(futureDelay)
+      2
+    }, Future {
+      Thread.sleep(futureDelay)
+      3
+    })
+    val sumFuture = Future.fold(futures)(1)(_ + _)
+    assertEquals(getResult()(sumFuture), Some(7))
+  }
+}

--- a/unit-tests/src/test/scala/scala/scalanative/runtime/AtomicSuite.scala.gyb
+++ b/unit-tests/src/test/scala/scala/scalanative/runtime/AtomicSuite.scala.gyb
@@ -5,7 +5,7 @@ import runtime._
 import native._
 import stdlib._
 
-object AtomicSuite extends tests.Suite {
+object AtomicSuite extends tests.MultiThreadSuite {
 
 %{
    classes = ['Byte', 'Short', 'Int', 'Long',
@@ -16,14 +16,28 @@ object AtomicSuite extends tests.Suite {
             'Byte', 'CUnsignedShort', 'CUnsignedInt', 'CUnsignedLong',
             'CSize']
 
+   companionObjects = ['Byte', 'CShort', 'CInt', 'CLong',
+                       'Byte', 'UShort', 'UInt', 'ULong',
+                       'CSize']
+
    names = ['byte', 'short', 'int', 'long',
             'ubyte', 'ushort', 'uint', 'ulong', 'csize']
 }%
 
-% for (C, T, N) in zip(classes, types, names):
+% for (C, O, T, N) in zip(classes, companionObjects, types, names):
 %{
    default = '0' if N in ['int'] else '0.asInstanceOf['+T+']'
    cast = '' if N == 'int' else '.asInstanceOf['+T+']'
+
+   if N in ['int','byte','short','ubyte']:
+       defaultCounter = '0'
+       counterT = 'Int'
+   elif N in ['ushort']:
+       defaultCounter = '0.asInstanceOf[CUnsignedInt]'
+       counterT = 'UInt'
+   else:
+       defaultCounter = '0.asInstanceOf['+T+']'
+       counterT = T
 }%
 % for cmp in ['Strong', 'Weak']:
 
@@ -39,6 +53,67 @@ object AtomicSuite extends tests.Suite {
     a.free()
   }
 % end
+
+test("compare_and_swap (weak and strong) is atomic for ${N}") {
+
+    val numThreads = 2
+    testWithMinRepetitions() { n: Int =>
+      var number = ${defaultCounter}
+      withThreads(numThreads, label = "CounterExample") { _: Int =>
+        @inline def badCaS(expectedValue: ${counterT}, newValue: ${counterT}): ${counterT} = {
+          val oldValue = number
+          if (number == expectedValue) {
+            number = newValue
+          }
+          oldValue
+        }
+
+        var i = n
+        val b = 1${cast}
+        // making this as fast as possible
+        while (i > 0) {
+          var newValue = ${defaultCounter}
+          var expected = ${defaultCounter}
+          do {
+            expected = number
+            newValue = expected + b
+          } while (badCaS(expected, newValue) != expected)
+          i -= 1
+        }
+      }
+      number != (n * numThreads)${cast}
+    } { n: Int =>
+% for cmp in ['Strong', 'Weak']:
+      {
+      val number = CAtomic${C}()
+      withThreads(numThreads, label = "Test") { _: Int =>
+        var i = n
+        val b = 1${cast}
+        // making this as fast as possible
+        while (i > 0) {
+          var newValue = 0${cast}
+          var expected = 0${cast}
+          do {
+            expected = number.load()
+%   if N == 'ushort':
+            newValue = (expected + b).toUShort
+%   else:
+            newValue = (expected + b)${cast}
+%   end
+          } while (!number.compareAndSwap${cmp}(expected, newValue)._1)
+          i -= 1
+        }
+      }
+
+      val value    = number.load()
+      val expected = (n * numThreads)${cast}
+      number.free()
+      assertEquals(value, expected)
+      }
+% end
+      true
+    }
+  }
 
   test("load and store ${N}") {
     val a = CAtomic${C}()
@@ -77,6 +152,66 @@ object AtomicSuite extends tests.Suite {
 
     a.free()
   }
+
+    test("fetch_add, add_fetch, fetch_sub, sub_fetch are atomic for ${N}") {
+        val numThreads = 2
+        testWithMinRepetitions() {
+          n: Int =>
+            var number = ${defaultCounter}
+            withThreads(numThreads, label = "CounterExample") {_: Int =>
+              var i = n
+              val b = 1${cast}
+              // making this as fast as possible
+              while (i > 0) {
+                number  = number + b
+                i -= 1
+              }
+            }
+            number != (n * numThreads)${cast}
+        } {
+          n: Int =>
+% for op in ['fetchAdd', 'addFetch']:
+            {
+            val number = CAtomic${C}()
+            withThreads(numThreads, label = "Test") {_: Int =>
+              var i = n
+              val b = 1${cast}
+              // making this as fast as possible
+              while (i > 0) {
+                number.${op}(b)
+                i -= 1
+              }
+            }
+
+            val value = number.load()
+            val expected = (n * numThreads)${cast}
+            number.free()
+            assertEquals(value, expected)
+            }
+% end
+% for op in ['fetchSub', 'subFetch']:
+% minusOne = '-1'+cast if N in ['byte', 'ubyte', 'short', 'int', 'long', 'csize'] else O+'.MaxValue'
+            {
+            val number = CAtomic${C}()
+            withThreads(numThreads, label = "Test") {_: Int =>
+              var i = n
+              val b = ${minusOne}
+              // making this as fast as possible
+              while (i > 0) {
+                number.${op}(b)
+                i -= 1
+              }
+            }
+
+            val value = number.load()
+            val expected = (n * numThreads)${cast}
+            number.free()
+            assertEquals(value, expected)
+            }
+% end
+            true
+        }
+      }
 
   test("fetch_sub ${N}") {
     val a = CAtomic${C}(1${cast})


### PR DESCRIPTION
Includes #1042 and #1035.

# What's new:
## Functionality
1. Thread creation and `Thread.join`
2.  `synchronized` blocks, `wait`-`notify`
3. `Thread.sleep` with `Thread.interrupt` support
4. `ThreadLocal` 
5. fixed `java.lang.AtomicReference` and `java.lang.AtomicReferenceArray`
6. fixed state in `AbstractPromise` by making it thread-safe
7. global `ExecutionContext` uses all available cores and `Future` s are running in parallel with the main Thread
8. made `StackTraceElement` thread-safe
9. added missing `System.setIn`, `System.setOut`, `System.setErr` methods needed for testing 
10. bound more methods and constants from `sysinfo`, `pthread`, `time` and `signal`
11. A Scala-native program now automatically shuts down when there are no non-daemon threads running, just like Scala/Java on JVM. For comparison, a C/C++ program on posix will automatically shutdown when main thread ends.

See full details in the attached Gist below.
## GC
1. made "none" GC Thread-safe (and wait-free)
2. configured "boehm" GC for multithreading
3.  **"immix" GC does not support multithreading yet.** Attempting to create a thread under immix will stop the program with an error. For this reason "immix" is now excluded from running automated tests.
## Testing
1. Added `MultiThreadSuite` trait with utilities for multi-threaded testing
  a. simple utilities: `takesAtLeast(ms,ns)(function)`,  `withThreads(numTreads)(function)` and `withExceptionHandler`
  b. testing constructions `eventually`, `eventuallyEquals`, `eventuallyConstant`
  c. self-adjusting constructions `testWithMinDelay` and `testWithMinRepetitions`
  d. useful threads`WaitingThread(mutex)`, stoppable `Counter` and `MemoryMuncher`
2. Almost every functionality has an automated test. See full details in the attached Gist below.
3. Atomics are also automatically tested for atomicity by running a lot of operations concurrently.

# Known issues:
1. Uncaught exception in `synchronized` block, which is caught outside it, does not immediately release the lock. Note that when the thread terminates, it tries to release all the locks it might be holding, which prevents issues in some cases.
   a. **Workaround**: the exception can be passed "around" the  `synchronized` See  `ShadowLock` in `Monitor.scala` for an example.
2. Boehm might break memory consistency for some multi-threaded programs. For example, something Future-heavy like one of my benchmarks.
> Thread users should also be aware that on many platforms objects reachable only from thread-local variables may be prematurely reclaimed. Thus objects pointed to by thread-local variables should also be pointed to by a globally visible data structure. (This is viewed as a bug, but as one that is exceedingly hard to fix without some libc hooks.)
http://www.hboehm.info/gc/gcinterface.html
3. `Thread.suspend` can fail and getting the stack of another thread may block if the `signal` fails to be delivered. In **some environments** even real-time signals might **sometimes** fail to deliver. This is the case with the Travis-CI server. 
  a. **Workaround**: Repeat `Thread.suspend` until you get the desired result. For getting stacktraces: use two threads: one for reading the results (this one may block) and another one to resend the signal manually if there are no results.
4. `Thread.join()` (the one without the timeout) might block indefinitely even when that thread has finished. It happened 1 in 1000 times of running a suit with every multi-threaded test (extremely rare). The underlying issue might even be fixed as I have not seen it in a while.
  a. **Workaround**:  Use `Thread.join` with timeout. Wrap in a while loop if necessary.
5. Memory/resource leak when using `synchronized`. Mutexes and cond objects are not destroyed when the object on which you synchronize is garbage collected. Currently, there is no finalizers or special GC treatment for Monitor objects.

Detailed progress: https://gist.github.com/valdisxp1/b0127ee52e90b42835dbdabbf6a31d04