### PR TITLE
Port of java.nio buffers and tests from Scala.js

### DIFF
--- a/javalib/src/main/scala/java/nio/ByteArrayBits.scala
+++ b/javalib/src/main/scala/java/nio/ByteArrayBits.scala
@@ -1,0 +1,220 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] object ByteArrayBits {
+  def apply(array: Array[Byte], arrayOffset: Int,
+      isBigEndian: Boolean, indexMultiplier: Int = 1): ByteArrayBits =
+    new ByteArrayBits(array, arrayOffset, isBigEndian, indexMultiplier)
+}
+
+@inline
+private[nio] final class ByteArrayBits(
+    array: Array[Byte], arrayOffset: Int, isBigEndian: Boolean,
+    indexMultiplier: Int) {
+
+  /* We use tuples of bytes instead of, say, arrays, because they can be
+   * completely stack-allocated.
+   *
+   * When used in a place where it can be stack-allocated, an "instance" of
+   * this class has zero overhead.
+   */
+
+  // API
+
+  def loadChar(index: Int): Char = makeChar(load2Bytes(index))
+  def loadShort(index: Int): Short = makeShort(load2Bytes(index))
+  def loadInt(index: Int): Int = makeInt(load4Bytes(index))
+  def loadLong(index: Int): Long = makeLong(load8Bytes(index))
+  def loadFloat(index: Int): Float = makeFloat(load4Bytes(index))
+  def loadDouble(index: Int): Double = makeDouble(load8Bytes(index))
+
+  def storeChar(index: Int, v: Char): Unit = store2Bytes(index, unmakeChar(v))
+  def storeShort(index: Int, v: Short): Unit = store2Bytes(index, unmakeShort(v))
+  def storeInt(index: Int, v: Int): Unit = store4Bytes(index, unmakeInt(v))
+  def storeLong(index: Int, v: Long): Unit = store8Bytes(index, unmakeLong(v))
+  def storeFloat(index: Int, v: Float): Unit = store4Bytes(index, unmakeFloat(v))
+  def storeDouble(index: Int, v: Double): Unit = store8Bytes(index, unmakeDouble(v))
+
+  // Making and unmaking values
+
+  @inline
+  private def makeChar(bs: (Byte, Byte)): Char =
+    makeChar(bs._1, bs._2)
+
+  @inline
+  private def makeChar(b0: Byte, b1: Byte): Char =
+    if (isBigEndian) makeCharBE(b0, b1)
+    else             makeCharBE(b1, b0)
+
+  @inline
+  private def makeCharBE(b0: Byte, b1: Byte): Char =
+    ((b0 << 8) | (b1 & 0xff)).toChar
+
+  @inline
+  private def makeShort(bs: (Byte, Byte)): Short =
+    makeShort(bs._1, bs._2)
+
+  @inline
+  private def makeShort(b0: Byte, b1: Byte): Short =
+    if (isBigEndian) makeShortBE(b0, b1)
+    else             makeShortBE(b1, b0)
+
+  @inline
+  private def makeShortBE(b0: Byte, b1: Byte): Short =
+    ((b0 << 8) | (b1 & 0xff)).toShort
+
+  @inline
+  private def makeInt(bs: (Byte, Byte, Byte, Byte)): Int =
+    makeInt(bs._1, bs._2, bs._3, bs._4)
+
+  @inline
+  private def makeInt(b0: Byte, b1: Byte, b2: Byte, b3: Byte): Int =
+    if (isBigEndian) makeIntBE(b0, b1, b2, b3)
+    else             makeIntBE(b3, b2, b1, b0)
+
+  @inline
+  private def makeIntBE(b0: Byte, b1: Byte, b2: Byte, b3: Byte): Int =
+    ((b0 << 24) | ((b1 & 0xff) << 16) | ((b2 & 0xff) << 8) | (b3 & 0xff))
+
+  @inline
+  private def makeLong(
+      bs: (Byte, Byte, Byte, Byte, Byte, Byte, Byte, Byte)): Long =
+    makeLong(bs._1, bs._2, bs._3, bs._4, bs._5, bs._6, bs._7, bs._8)
+
+  @inline
+  private def makeLong(
+      b0: Byte, b1: Byte, b2: Byte, b3: Byte,
+      b4: Byte, b5: Byte, b6: Byte, b7: Byte): Long =
+    if (isBigEndian) makeLongBE(b0, b1, b2, b3, b4, b5, b6, b7)
+    else             makeLongBE(b7, b6, b5, b4, b3, b2, b1, b0)
+
+  @inline
+  private def makeLongBE(
+      b0: Byte, b1: Byte, b2: Byte, b3: Byte,
+      b4: Byte, b5: Byte, b6: Byte, b7: Byte): Long = {
+    (makeIntBE(b0, b1, b2, b3).toLong << 32) |
+      (makeIntBE(b4, b5, b6, b7).toLong & 0xffffffffL)
+  }
+
+  @inline
+  private def makeFloat(bs: (Byte, Byte, Byte, Byte)): Float =
+    makeFloat(bs._1, bs._2, bs._3, bs._4)
+
+  @inline
+  private def makeFloat(b0: Byte, b1: Byte, b2: Byte, b3: Byte): Float =
+    java.lang.Float.intBitsToFloat(makeInt(b0, b1, b2, b3))
+
+  @inline
+  private def makeDouble(
+      bs: (Byte, Byte, Byte, Byte, Byte, Byte, Byte, Byte)): Double =
+    makeDouble(bs._1, bs._2, bs._3, bs._4, bs._5, bs._6, bs._7, bs._8)
+
+  @inline
+  private def makeDouble(
+      b0: Byte, b1: Byte, b2: Byte, b3: Byte,
+      b4: Byte, b5: Byte, b6: Byte, b7: Byte): Double =
+    java.lang.Double.longBitsToDouble(makeLong(b0, b1, b2, b3, b4, b5, b6, b7))
+
+  @inline
+  private def unmakeChar(c: Char): (Byte, Byte) = {
+    val bs = unmakeCharBE(c)
+    if (isBigEndian) bs
+    else             (bs._2, bs._1)
+  }
+
+  @inline
+  private def unmakeCharBE(c: Char): (Byte, Byte) =
+    ((c >> 8).toByte, c.toByte)
+
+  @inline
+  private def unmakeShort(s: Short): (Byte, Byte) = {
+    val bs = unmakeShortBE(s)
+    if (isBigEndian) bs
+    else             (bs._2, bs._1)
+  }
+
+  @inline
+  private def unmakeShortBE(s: Short): (Byte, Byte) =
+    ((s >> 8).toByte, s.toByte)
+
+  @inline
+  private def unmakeInt(i: Int): (Byte, Byte, Byte, Byte) = {
+    val bs = unmakeIntBE(i)
+    if (isBigEndian) bs
+    else             (bs._4, bs._3, bs._2, bs._1)
+  }
+
+  @inline
+  private def unmakeIntBE(i: Int): (Byte, Byte, Byte, Byte) =
+    ((i >> 24).toByte, (i >> 16).toByte, (i >> 8).toByte, i.toByte)
+
+  @inline
+  private def unmakeLong(
+      l: Long): (Byte, Byte, Byte, Byte, Byte, Byte, Byte, Byte) = {
+    val bs0 = unmakeIntBE((l >>> 32).toInt)
+    val bs1 = unmakeIntBE(l.toInt)
+    if (isBigEndian) (bs0._1, bs0._2, bs0._3, bs0._4, bs1._1, bs1._2, bs1._3, bs1._4)
+    else             (bs1._4, bs1._3, bs1._2, bs1._1, bs0._4, bs0._3, bs0._2, bs0._1)
+  }
+
+  @inline
+  private def unmakeFloat(f: Float): (Byte, Byte, Byte, Byte) =
+    unmakeInt(java.lang.Float.floatToIntBits(f))
+
+  @inline
+  private def unmakeDouble(
+      d: Double): (Byte, Byte, Byte, Byte, Byte, Byte, Byte, Byte) =
+    unmakeLong(java.lang.Double.doubleToLongBits(d))
+
+  // Loading and storing bytes
+
+  @inline
+  private def load2Bytes(index: Int): (Byte, Byte) = {
+    val idx = indexMultiplier*index + arrayOffset
+    (array(idx), array(idx + 1))
+  }
+
+  @inline
+  private def load4Bytes(index: Int): (Byte, Byte, Byte, Byte) = {
+    val idx = indexMultiplier*index + arrayOffset
+    (array(idx), array(idx + 1), array(idx + 2), array(idx + 3))
+  }
+
+  @inline
+  private def load8Bytes(
+      index: Int): (Byte, Byte, Byte, Byte, Byte, Byte, Byte, Byte) = {
+    val idx = indexMultiplier*index + arrayOffset
+    (array(idx), array(idx + 1), array(idx + 2), array(idx + 3),
+        array(idx + 4), array(idx + 5), array(idx + 6), array(idx + 7))
+  }
+
+  @inline
+  private def store2Bytes(index: Int, bs: (Byte, Byte)): Unit = {
+    val idx = indexMultiplier*index + arrayOffset
+    array(idx) = bs._1
+    array(idx + 1) = bs._2
+  }
+
+  @inline
+  private def store4Bytes(index: Int, bs: (Byte, Byte, Byte, Byte)): Unit = {
+    val idx = indexMultiplier*index + arrayOffset
+    array(idx) = bs._1
+    array(idx + 1) = bs._2
+    array(idx + 2) = bs._3
+    array(idx + 3) = bs._4
+  }
+
+  @inline
+  private def store8Bytes(index: Int,
+      bs: (Byte, Byte, Byte, Byte, Byte, Byte, Byte, Byte)): Unit = {
+    val idx = indexMultiplier*index + arrayOffset
+    array(idx) = bs._1
+    array(idx + 1) = bs._2
+    array(idx + 2) = bs._3
+    array(idx + 3) = bs._4
+    array(idx + 4) = bs._5
+    array(idx + 5) = bs._6
+    array(idx + 6) = bs._7
+    array(idx + 7) = bs._8
+  }
+}

--- a/javalib/src/main/scala/java/nio/ByteArrayBits.scala
+++ b/javalib/src/main/scala/java/nio/ByteArrayBits.scala
@@ -2,15 +2,18 @@ package java.nio
 
 // Ported from Scala.js
 private[nio] object ByteArrayBits {
-  def apply(array: Array[Byte], arrayOffset: Int,
-      isBigEndian: Boolean, indexMultiplier: Int = 1): ByteArrayBits =
+  def apply(array: Array[Byte],
+            arrayOffset: Int,
+            isBigEndian: Boolean,
+            indexMultiplier: Int = 1): ByteArrayBits =
     new ByteArrayBits(array, arrayOffset, isBigEndian, indexMultiplier)
 }
 
 @inline
-private[nio] final class ByteArrayBits(
-    array: Array[Byte], arrayOffset: Int, isBigEndian: Boolean,
-    indexMultiplier: Int) {
+private[nio] final class ByteArrayBits(array: Array[Byte],
+                                       arrayOffset: Int,
+                                       isBigEndian: Boolean,
+                                       indexMultiplier: Int) {
 
   /* We use tuples of bytes instead of, say, arrays, because they can be
    * completely stack-allocated.
@@ -21,19 +24,22 @@ private[nio] final class ByteArrayBits(
 
   // API
 
-  def loadChar(index: Int): Char = makeChar(load2Bytes(index))
-  def loadShort(index: Int): Short = makeShort(load2Bytes(index))
-  def loadInt(index: Int): Int = makeInt(load4Bytes(index))
-  def loadLong(index: Int): Long = makeLong(load8Bytes(index))
-  def loadFloat(index: Int): Float = makeFloat(load4Bytes(index))
+  def loadChar(index: Int): Char     = makeChar(load2Bytes(index))
+  def loadShort(index: Int): Short   = makeShort(load2Bytes(index))
+  def loadInt(index: Int): Int       = makeInt(load4Bytes(index))
+  def loadLong(index: Int): Long     = makeLong(load8Bytes(index))
+  def loadFloat(index: Int): Float   = makeFloat(load4Bytes(index))
   def loadDouble(index: Int): Double = makeDouble(load8Bytes(index))
 
   def storeChar(index: Int, v: Char): Unit = store2Bytes(index, unmakeChar(v))
-  def storeShort(index: Int, v: Short): Unit = store2Bytes(index, unmakeShort(v))
-  def storeInt(index: Int, v: Int): Unit = store4Bytes(index, unmakeInt(v))
+  def storeShort(index: Int, v: Short): Unit =
+    store2Bytes(index, unmakeShort(v))
+  def storeInt(index: Int, v: Int): Unit   = store4Bytes(index, unmakeInt(v))
   def storeLong(index: Int, v: Long): Unit = store8Bytes(index, unmakeLong(v))
-  def storeFloat(index: Int, v: Float): Unit = store4Bytes(index, unmakeFloat(v))
-  def storeDouble(index: Int, v: Double): Unit = store8Bytes(index, unmakeDouble(v))
+  def storeFloat(index: Int, v: Float): Unit =
+    store4Bytes(index, unmakeFloat(v))
+  def storeDouble(index: Int, v: Double): Unit =
+    store8Bytes(index, unmakeDouble(v))
 
   // Making and unmaking values
 
@@ -44,7 +50,7 @@ private[nio] final class ByteArrayBits(
   @inline
   private def makeChar(b0: Byte, b1: Byte): Char =
     if (isBigEndian) makeCharBE(b0, b1)
-    else             makeCharBE(b1, b0)
+    else makeCharBE(b1, b0)
 
   @inline
   private def makeCharBE(b0: Byte, b1: Byte): Char =
@@ -57,7 +63,7 @@ private[nio] final class ByteArrayBits(
   @inline
   private def makeShort(b0: Byte, b1: Byte): Short =
     if (isBigEndian) makeShortBE(b0, b1)
-    else             makeShortBE(b1, b0)
+    else makeShortBE(b1, b0)
 
   @inline
   private def makeShortBE(b0: Byte, b1: Byte): Short =
@@ -70,7 +76,7 @@ private[nio] final class ByteArrayBits(
   @inline
   private def makeInt(b0: Byte, b1: Byte, b2: Byte, b3: Byte): Int =
     if (isBigEndian) makeIntBE(b0, b1, b2, b3)
-    else             makeIntBE(b3, b2, b1, b0)
+    else makeIntBE(b3, b2, b1, b0)
 
   @inline
   private def makeIntBE(b0: Byte, b1: Byte, b2: Byte, b3: Byte): Int =
@@ -82,16 +88,26 @@ private[nio] final class ByteArrayBits(
     makeLong(bs._1, bs._2, bs._3, bs._4, bs._5, bs._6, bs._7, bs._8)
 
   @inline
-  private def makeLong(
-      b0: Byte, b1: Byte, b2: Byte, b3: Byte,
-      b4: Byte, b5: Byte, b6: Byte, b7: Byte): Long =
+  private def makeLong(b0: Byte,
+                       b1: Byte,
+                       b2: Byte,
+                       b3: Byte,
+                       b4: Byte,
+                       b5: Byte,
+                       b6: Byte,
+                       b7: Byte): Long =
     if (isBigEndian) makeLongBE(b0, b1, b2, b3, b4, b5, b6, b7)
-    else             makeLongBE(b7, b6, b5, b4, b3, b2, b1, b0)
+    else makeLongBE(b7, b6, b5, b4, b3, b2, b1, b0)
 
   @inline
-  private def makeLongBE(
-      b0: Byte, b1: Byte, b2: Byte, b3: Byte,
-      b4: Byte, b5: Byte, b6: Byte, b7: Byte): Long = {
+  private def makeLongBE(b0: Byte,
+                         b1: Byte,
+                         b2: Byte,
+                         b3: Byte,
+                         b4: Byte,
+                         b5: Byte,
+                         b6: Byte,
+                         b7: Byte): Long = {
     (makeIntBE(b0, b1, b2, b3).toLong << 32) |
       (makeIntBE(b4, b5, b6, b7).toLong & 0xffffffffL)
   }
@@ -110,16 +126,21 @@ private[nio] final class ByteArrayBits(
     makeDouble(bs._1, bs._2, bs._3, bs._4, bs._5, bs._6, bs._7, bs._8)
 
   @inline
-  private def makeDouble(
-      b0: Byte, b1: Byte, b2: Byte, b3: Byte,
-      b4: Byte, b5: Byte, b6: Byte, b7: Byte): Double =
+  private def makeDouble(b0: Byte,
+                         b1: Byte,
+                         b2: Byte,
+                         b3: Byte,
+                         b4: Byte,
+                         b5: Byte,
+                         b6: Byte,
+                         b7: Byte): Double =
     java.lang.Double.longBitsToDouble(makeLong(b0, b1, b2, b3, b4, b5, b6, b7))
 
   @inline
   private def unmakeChar(c: Char): (Byte, Byte) = {
     val bs = unmakeCharBE(c)
     if (isBigEndian) bs
-    else             (bs._2, bs._1)
+    else (bs._2, bs._1)
   }
 
   @inline
@@ -130,7 +151,7 @@ private[nio] final class ByteArrayBits(
   private def unmakeShort(s: Short): (Byte, Byte) = {
     val bs = unmakeShortBE(s)
     if (isBigEndian) bs
-    else             (bs._2, bs._1)
+    else (bs._2, bs._1)
   }
 
   @inline
@@ -141,7 +162,7 @@ private[nio] final class ByteArrayBits(
   private def unmakeInt(i: Int): (Byte, Byte, Byte, Byte) = {
     val bs = unmakeIntBE(i)
     if (isBigEndian) bs
-    else             (bs._4, bs._3, bs._2, bs._1)
+    else (bs._4, bs._3, bs._2, bs._1)
   }
 
   @inline
@@ -153,8 +174,9 @@ private[nio] final class ByteArrayBits(
       l: Long): (Byte, Byte, Byte, Byte, Byte, Byte, Byte, Byte) = {
     val bs0 = unmakeIntBE((l >>> 32).toInt)
     val bs1 = unmakeIntBE(l.toInt)
-    if (isBigEndian) (bs0._1, bs0._2, bs0._3, bs0._4, bs1._1, bs1._2, bs1._3, bs1._4)
-    else             (bs1._4, bs1._3, bs1._2, bs1._1, bs0._4, bs0._3, bs0._2, bs0._1)
+    if (isBigEndian)
+      (bs0._1, bs0._2, bs0._3, bs0._4, bs1._1, bs1._2, bs1._3, bs1._4)
+    else (bs1._4, bs1._3, bs1._2, bs1._1, bs0._4, bs0._3, bs0._2, bs0._1)
   }
 
   @inline
@@ -170,34 +192,40 @@ private[nio] final class ByteArrayBits(
 
   @inline
   private def load2Bytes(index: Int): (Byte, Byte) = {
-    val idx = indexMultiplier*index + arrayOffset
+    val idx = indexMultiplier * index + arrayOffset
     (array(idx), array(idx + 1))
   }
 
   @inline
   private def load4Bytes(index: Int): (Byte, Byte, Byte, Byte) = {
-    val idx = indexMultiplier*index + arrayOffset
+    val idx = indexMultiplier * index + arrayOffset
     (array(idx), array(idx + 1), array(idx + 2), array(idx + 3))
   }
 
   @inline
   private def load8Bytes(
       index: Int): (Byte, Byte, Byte, Byte, Byte, Byte, Byte, Byte) = {
-    val idx = indexMultiplier*index + arrayOffset
-    (array(idx), array(idx + 1), array(idx + 2), array(idx + 3),
-        array(idx + 4), array(idx + 5), array(idx + 6), array(idx + 7))
+    val idx = indexMultiplier * index + arrayOffset
+    (array(idx),
+     array(idx + 1),
+     array(idx + 2),
+     array(idx + 3),
+     array(idx + 4),
+     array(idx + 5),
+     array(idx + 6),
+     array(idx + 7))
   }
 
   @inline
   private def store2Bytes(index: Int, bs: (Byte, Byte)): Unit = {
-    val idx = indexMultiplier*index + arrayOffset
+    val idx = indexMultiplier * index + arrayOffset
     array(idx) = bs._1
     array(idx + 1) = bs._2
   }
 
   @inline
   private def store4Bytes(index: Int, bs: (Byte, Byte, Byte, Byte)): Unit = {
-    val idx = indexMultiplier*index + arrayOffset
+    val idx = indexMultiplier * index + arrayOffset
     array(idx) = bs._1
     array(idx + 1) = bs._2
     array(idx + 2) = bs._3
@@ -205,9 +233,10 @@ private[nio] final class ByteArrayBits(
   }
 
   @inline
-  private def store8Bytes(index: Int,
+  private def store8Bytes(
+      index: Int,
       bs: (Byte, Byte, Byte, Byte, Byte, Byte, Byte, Byte)): Unit = {
-    val idx = indexMultiplier*index + arrayOffset
+    val idx = indexMultiplier * index + arrayOffset
     array(idx) = bs._1
     array(idx + 1) = bs._2
     array(idx + 2) = bs._3

--- a/javalib/src/main/scala/java/nio/ByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ByteBuffer.scala
@@ -8,7 +8,7 @@ object ByteBuffer {
   def allocate(capacity: Int): ByteBuffer =
     wrap(new Array[Byte](capacity))
 
-  // TODO def allocateDirect(capacity: Int): ByteBuffer = ???
+  def allocateDirect(capacity: Int): ByteBuffer = allocate(capacity)
 
   def wrap(array: Array[Byte], offset: Int, length: Int): ByteBuffer =
     HeapByteBuffer.wrap(array, 0, array.length, offset, length, false)

--- a/javalib/src/main/scala/java/nio/DoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DoubleBuffer.scala
@@ -15,12 +15,14 @@ object DoubleBuffer {
 }
 
 abstract class DoubleBuffer private[nio] (
-    _capacity: Int, private[nio] val _array: Array[Double],
+    _capacity: Int,
+    private[nio] val _array: Array[Double],
     private[nio] val _arrayOffset: Int)
-    extends Buffer(_capacity) with Comparable[DoubleBuffer] {
+    extends Buffer(_capacity)
+    with Comparable[DoubleBuffer] {
 
   private[nio] type ElementType = Double
-  private[nio] type BufferType = DoubleBuffer
+  private[nio] type BufferType  = DoubleBuffer
 
   def this(_capacity: Int) = this(_capacity, null, -1)
 
@@ -94,11 +96,15 @@ abstract class DoubleBuffer private[nio] (
 
   @inline
   private[nio] def load(startIndex: Int,
-      dst: Array[Double], offset: Int, length: Int): Unit =
+                        dst: Array[Double],
+                        offset: Int,
+                        length: Int): Unit =
     GenBuffer(this).generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(startIndex: Int,
-      src: Array[Double], offset: Int, length: Int): Unit =
+                         src: Array[Double],
+                         offset: Int,
+                         length: Int): Unit =
     GenBuffer(this).generic_store(startIndex, src, offset, length)
 }

--- a/javalib/src/main/scala/java/nio/DoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DoubleBuffer.scala
@@ -1,0 +1,104 @@
+package java.nio
+
+// Ported from Scala.js
+object DoubleBuffer {
+  private final val HashSeed = 2140173175 // "java.nio.DoubleBuffer".##
+
+  def allocate(capacity: Int): DoubleBuffer =
+    wrap(new Array[Double](capacity))
+
+  def wrap(array: Array[Double], offset: Int, length: Int): DoubleBuffer =
+    HeapDoubleBuffer.wrap(array, 0, array.length, offset, length, false)
+
+  def wrap(array: Array[Double]): DoubleBuffer =
+    wrap(array, 0, array.length)
+}
+
+abstract class DoubleBuffer private[nio] (
+    _capacity: Int, private[nio] val _array: Array[Double],
+    private[nio] val _arrayOffset: Int)
+    extends Buffer(_capacity) with Comparable[DoubleBuffer] {
+
+  private[nio] type ElementType = Double
+  private[nio] type BufferType = DoubleBuffer
+
+  def this(_capacity: Int) = this(_capacity, null, -1)
+
+  def slice(): DoubleBuffer
+
+  def duplicate(): DoubleBuffer
+
+  def asReadOnlyBuffer(): DoubleBuffer
+
+  def get(): Double
+
+  def put(d: Double): DoubleBuffer
+
+  def get(index: Int): Double
+
+  def put(index: Int, d: Double): DoubleBuffer
+
+  @noinline
+  def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  def get(dst: Array[Double]): DoubleBuffer =
+    get(dst, 0, dst.length)
+
+  @noinline
+  def put(src: DoubleBuffer): DoubleBuffer =
+    GenBuffer(this).generic_put(src)
+
+  @noinline
+  def put(src: Array[Double], offset: Int, length: Int): DoubleBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  final def put(src: Array[Double]): DoubleBuffer =
+    put(src, 0, src.length)
+
+  @inline final def hasArray(): Boolean =
+    GenBuffer(this).generic_hasArray()
+
+  @inline final def array(): Array[Double] =
+    GenBuffer(this).generic_array()
+
+  @inline final def arrayOffset(): Int =
+    GenBuffer(this).generic_arrayOffset()
+
+  def compact(): DoubleBuffer
+
+  def isDirect(): Boolean
+
+  // toString(): String inherited from Buffer
+
+  @noinline
+  override def hashCode(): Int =
+    GenBuffer(this).generic_hashCode(DoubleBuffer.HashSeed)
+
+  override def equals(that: Any): Boolean = that match {
+    case that: DoubleBuffer => compareTo(that) == 0
+    case _                  => false
+  }
+
+  @noinline
+  def compareTo(that: DoubleBuffer): Int =
+    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+
+  def order(): ByteOrder
+
+  // Internal API
+
+  private[nio] def load(index: Int): Double
+
+  private[nio] def store(index: Int, elem: Double): Unit
+
+  @inline
+  private[nio] def load(startIndex: Int,
+      dst: Array[Double], offset: Int, length: Int): Unit =
+    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+
+  @inline
+  private[nio] def store(startIndex: Int,
+      src: Array[Double], offset: Int, length: Int): Unit =
+    GenBuffer(this).generic_store(startIndex, src, offset, length)
+}

--- a/javalib/src/main/scala/java/nio/FloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/FloatBuffer.scala
@@ -14,13 +14,14 @@ object FloatBuffer {
     wrap(array, 0, array.length)
 }
 
-abstract class FloatBuffer private[nio] (
-    _capacity: Int, private[nio] val _array: Array[Float],
-    private[nio] val _arrayOffset: Int)
-    extends Buffer(_capacity) with Comparable[FloatBuffer] {
+abstract class FloatBuffer private[nio] (_capacity: Int,
+                                         private[nio] val _array: Array[Float],
+                                         private[nio] val _arrayOffset: Int)
+    extends Buffer(_capacity)
+    with Comparable[FloatBuffer] {
 
   private[nio] type ElementType = Float
-  private[nio] type BufferType = FloatBuffer
+  private[nio] type BufferType  = FloatBuffer
 
   def this(_capacity: Int) = this(_capacity, null, -1)
 
@@ -94,11 +95,15 @@ abstract class FloatBuffer private[nio] (
 
   @inline
   private[nio] def load(startIndex: Int,
-      dst: Array[Float], offset: Int, length: Int): Unit =
+                        dst: Array[Float],
+                        offset: Int,
+                        length: Int): Unit =
     GenBuffer(this).generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(startIndex: Int,
-      src: Array[Float], offset: Int, length: Int): Unit =
+                         src: Array[Float],
+                         offset: Int,
+                         length: Int): Unit =
     GenBuffer(this).generic_store(startIndex, src, offset, length)
 }

--- a/javalib/src/main/scala/java/nio/FloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/FloatBuffer.scala
@@ -1,0 +1,104 @@
+package java.nio
+
+// Ported from Scala.js
+object FloatBuffer {
+  private final val HashSeed = 1920204022 // "java.nio.FloatBuffer".##
+
+  def allocate(capacity: Int): FloatBuffer =
+    wrap(new Array[Float](capacity))
+
+  def wrap(array: Array[Float], offset: Int, length: Int): FloatBuffer =
+    HeapFloatBuffer.wrap(array, 0, array.length, offset, length, false)
+
+  def wrap(array: Array[Float]): FloatBuffer =
+    wrap(array, 0, array.length)
+}
+
+abstract class FloatBuffer private[nio] (
+    _capacity: Int, private[nio] val _array: Array[Float],
+    private[nio] val _arrayOffset: Int)
+    extends Buffer(_capacity) with Comparable[FloatBuffer] {
+
+  private[nio] type ElementType = Float
+  private[nio] type BufferType = FloatBuffer
+
+  def this(_capacity: Int) = this(_capacity, null, -1)
+
+  def slice(): FloatBuffer
+
+  def duplicate(): FloatBuffer
+
+  def asReadOnlyBuffer(): FloatBuffer
+
+  def get(): Float
+
+  def put(f: Float): FloatBuffer
+
+  def get(index: Int): Float
+
+  def put(index: Int, f: Float): FloatBuffer
+
+  @noinline
+  def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  def get(dst: Array[Float]): FloatBuffer =
+    get(dst, 0, dst.length)
+
+  @noinline
+  def put(src: FloatBuffer): FloatBuffer =
+    GenBuffer(this).generic_put(src)
+
+  @noinline
+  def put(src: Array[Float], offset: Int, length: Int): FloatBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  final def put(src: Array[Float]): FloatBuffer =
+    put(src, 0, src.length)
+
+  @inline final def hasArray(): Boolean =
+    GenBuffer(this).generic_hasArray()
+
+  @inline final def array(): Array[Float] =
+    GenBuffer(this).generic_array()
+
+  @inline final def arrayOffset(): Int =
+    GenBuffer(this).generic_arrayOffset()
+
+  def compact(): FloatBuffer
+
+  def isDirect(): Boolean
+
+  // toString(): String inherited from Buffer
+
+  @noinline
+  override def hashCode(): Int =
+    GenBuffer(this).generic_hashCode(FloatBuffer.HashSeed)
+
+  override def equals(that: Any): Boolean = that match {
+    case that: FloatBuffer => compareTo(that) == 0
+    case _                 => false
+  }
+
+  @noinline
+  def compareTo(that: FloatBuffer): Int =
+    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+
+  def order(): ByteOrder
+
+  // Internal API
+
+  private[nio] def load(index: Int): Float
+
+  private[nio] def store(index: Int, elem: Float): Unit
+
+  @inline
+  private[nio] def load(startIndex: Int,
+      dst: Array[Float], offset: Int, length: Int): Unit =
+    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+
+  @inline
+  private[nio] def store(startIndex: Int,
+      src: Array[Float], offset: Int, length: Int): Unit =
+    GenBuffer(this).generic_store(startIndex, src, offset, length)
+}

--- a/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
@@ -24,7 +24,10 @@ private[nio] object GenHeapBuffer {
                                                       isReadOnly: Boolean)(
       implicit newHeapBuffer: NewHeapBuffer[BufferType, ElementType])
     : BufferType = {
-    if (arrayOffset < 0 || capacity < 0 ||
+    if (capacity < 0) {
+      throw new IllegalArgumentException()
+    }
+    if (arrayOffset < 0 ||
         arrayOffset + capacity > array.length)
       throw new IndexOutOfBoundsException
     val initialLimit = initialPosition + initialLength

--- a/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
@@ -1,0 +1,90 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] object GenHeapBufferView {
+  def apply[B <: Buffer](self: B): GenHeapBufferView[B] =
+    new GenHeapBufferView(self)
+
+  trait NewHeapBufferView[BufferType <: Buffer] {
+    def bytesPerElem: Int
+
+    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
+        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
+        isBigEndian: Boolean): BufferType
+  }
+
+  @inline
+  def generic_fromHeapByteBuffer[BufferType <: Buffer](
+      byteBuffer: HeapByteBuffer)(
+      implicit newHeapBufferView: NewHeapBufferView[BufferType]): BufferType = {
+    val byteBufferPos = byteBuffer.position
+    val viewCapacity =
+      (byteBuffer.limit - byteBufferPos) / newHeapBufferView.bytesPerElem
+    newHeapBufferView(viewCapacity, byteBuffer._array,
+        byteBuffer._arrayOffset + byteBufferPos,
+        0, viewCapacity, byteBuffer.isReadOnly, byteBuffer.isBigEndian)
+  }
+}
+
+private[nio] final class GenHeapBufferView[B <: Buffer](val self: B) extends AnyVal {
+  import self._
+
+  type NewThisHeapBufferView = GenHeapBufferView.NewHeapBufferView[BufferType]
+
+  @inline
+  def generic_slice()(
+      implicit newHeapBufferView: NewThisHeapBufferView): BufferType = {
+    val newCapacity = remaining
+    val bytesPerElem = newHeapBufferView.bytesPerElem
+    newHeapBufferView(newCapacity, _byteArray,
+        _byteArrayOffset + bytesPerElem*position,
+        0, newCapacity, isReadOnly, isBigEndian)
+  }
+
+  @inline
+  def generic_duplicate()(
+      implicit newHeapBufferView: NewThisHeapBufferView): BufferType = {
+    val result = newHeapBufferView(capacity, _byteArray, _byteArrayOffset,
+        position, limit, isReadOnly, isBigEndian)
+    result._mark = _mark
+    result
+  }
+
+  @inline
+  def generic_asReadOnlyBuffer()(
+      implicit newHeapBufferView: NewThisHeapBufferView): BufferType = {
+    val result = newHeapBufferView(capacity, _byteArray, _byteArrayOffset,
+        position, limit, true, isBigEndian)
+    result._mark = _mark
+    result
+  }
+
+  @inline
+  def generic_compact()(
+      implicit newHeapBufferView: NewThisHeapBufferView): BufferType = {
+    if (isReadOnly)
+      throw new ReadOnlyBufferException
+
+    val len = remaining
+    val bytesPerElem = newHeapBufferView.bytesPerElem
+    System.arraycopy(_byteArray, _byteArrayOffset + bytesPerElem*position,
+        _byteArray, _byteArrayOffset, bytesPerElem * len)
+    _mark = -1
+    limit(capacity)
+    position(len)
+    self
+  }
+
+  @inline
+  def generic_order(): ByteOrder =
+    if (isBigEndian) ByteOrder.BIG_ENDIAN
+    else             ByteOrder.LITTLE_ENDIAN
+
+  @inline
+  def byteArrayBits(
+      implicit newHeapBufferView: NewThisHeapBufferView): ByteArrayBits = {
+    ByteArrayBits(_byteArray, _byteArrayOffset, isBigEndian,
+        newHeapBufferView.bytesPerElem)
+  }
+
+}

--- a/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
@@ -8,9 +8,13 @@ private[nio] object GenHeapBufferView {
   trait NewHeapBufferView[BufferType <: Buffer] {
     def bytesPerElem: Int
 
-    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
-        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): BufferType
+    def apply(capacity: Int,
+              byteArray: Array[Byte],
+              byteArrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean,
+              isBigEndian: Boolean): BufferType
   }
 
   @inline
@@ -20,13 +24,18 @@ private[nio] object GenHeapBufferView {
     val byteBufferPos = byteBuffer.position
     val viewCapacity =
       (byteBuffer.limit - byteBufferPos) / newHeapBufferView.bytesPerElem
-    newHeapBufferView(viewCapacity, byteBuffer._array,
-        byteBuffer._arrayOffset + byteBufferPos,
-        0, viewCapacity, byteBuffer.isReadOnly, byteBuffer.isBigEndian)
+    newHeapBufferView(viewCapacity,
+                      byteBuffer._array,
+                      byteBuffer._arrayOffset + byteBufferPos,
+                      0,
+                      viewCapacity,
+                      byteBuffer.isReadOnly,
+                      byteBuffer.isBigEndian)
   }
 }
 
-private[nio] final class GenHeapBufferView[B <: Buffer](val self: B) extends AnyVal {
+private[nio] final class GenHeapBufferView[B <: Buffer](val self: B)
+    extends AnyVal {
   import self._
 
   type NewThisHeapBufferView = GenHeapBufferView.NewHeapBufferView[BufferType]
@@ -34,18 +43,27 @@ private[nio] final class GenHeapBufferView[B <: Buffer](val self: B) extends Any
   @inline
   def generic_slice()(
       implicit newHeapBufferView: NewThisHeapBufferView): BufferType = {
-    val newCapacity = remaining
+    val newCapacity  = remaining
     val bytesPerElem = newHeapBufferView.bytesPerElem
-    newHeapBufferView(newCapacity, _byteArray,
-        _byteArrayOffset + bytesPerElem*position,
-        0, newCapacity, isReadOnly, isBigEndian)
+    newHeapBufferView(newCapacity,
+                      _byteArray,
+                      _byteArrayOffset + bytesPerElem * position,
+                      0,
+                      newCapacity,
+                      isReadOnly,
+                      isBigEndian)
   }
 
   @inline
   def generic_duplicate()(
       implicit newHeapBufferView: NewThisHeapBufferView): BufferType = {
-    val result = newHeapBufferView(capacity, _byteArray, _byteArrayOffset,
-        position, limit, isReadOnly, isBigEndian)
+    val result = newHeapBufferView(capacity,
+                                   _byteArray,
+                                   _byteArrayOffset,
+                                   position,
+                                   limit,
+                                   isReadOnly,
+                                   isBigEndian)
     result._mark = _mark
     result
   }
@@ -53,8 +71,13 @@ private[nio] final class GenHeapBufferView[B <: Buffer](val self: B) extends Any
   @inline
   def generic_asReadOnlyBuffer()(
       implicit newHeapBufferView: NewThisHeapBufferView): BufferType = {
-    val result = newHeapBufferView(capacity, _byteArray, _byteArrayOffset,
-        position, limit, true, isBigEndian)
+    val result = newHeapBufferView(capacity,
+                                   _byteArray,
+                                   _byteArrayOffset,
+                                   position,
+                                   limit,
+                                   true,
+                                   isBigEndian)
     result._mark = _mark
     result
   }
@@ -65,10 +88,13 @@ private[nio] final class GenHeapBufferView[B <: Buffer](val self: B) extends Any
     if (isReadOnly)
       throw new ReadOnlyBufferException
 
-    val len = remaining
+    val len          = remaining
     val bytesPerElem = newHeapBufferView.bytesPerElem
-    System.arraycopy(_byteArray, _byteArrayOffset + bytesPerElem*position,
-        _byteArray, _byteArrayOffset, bytesPerElem * len)
+    System.arraycopy(_byteArray,
+                     _byteArrayOffset + bytesPerElem * position,
+                     _byteArray,
+                     _byteArrayOffset,
+                     bytesPerElem * len)
     _mark = -1
     limit(capacity)
     position(len)
@@ -78,13 +104,15 @@ private[nio] final class GenHeapBufferView[B <: Buffer](val self: B) extends Any
   @inline
   def generic_order(): ByteOrder =
     if (isBigEndian) ByteOrder.BIG_ENDIAN
-    else             ByteOrder.LITTLE_ENDIAN
+    else ByteOrder.LITTLE_ENDIAN
 
   @inline
   def byteArrayBits(
       implicit newHeapBufferView: NewThisHeapBufferView): ByteArrayBits = {
-    ByteArrayBits(_byteArray, _byteArrayOffset, isBigEndian,
-        newHeapBufferView.bytesPerElem)
+    ByteArrayBits(_byteArray,
+                  _byteArrayOffset,
+                  isBigEndian,
+                  newHeapBufferView.bytesPerElem)
   }
 
 }

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -62,115 +62,104 @@ private[nio] final class HeapByteBuffer private (_capacity: Int,
 
   // Here begins the stuff specific to ByteArrays
 
-  def asCharBuffer(): java.nio.CharBuffer                       = ???
-  def asDoubleBuffer(): java.nio.DoubleBuffer                   = ???
-  def asFloatBuffer(): java.nio.FloatBuffer                     = ???
-  def asIntBuffer(): java.nio.IntBuffer                         = ???
-  def asLongBuffer(): java.nio.LongBuffer                       = ???
-  def asShortBuffer(): java.nio.ShortBuffer                     = ???
-  def getChar(index: Int): Char                                 = ???
-  def getChar(): Char                                           = ???
-  def getDouble(index: Int): Double                             = ???
-  def getDouble(): Double                                       = ???
-  def getFloat(index: Int): Float                               = ???
-  def getFloat(): Float                                         = ???
-  def getInt(index: Int): Int                                   = ???
-  def getInt(): Int                                             = ???
-  def getLong(index: Int): Long                                 = ???
-  def getLong(): Long                                           = ???
-  def getShort(index: Int): Short                               = ???
-  def getShort(): Short                                         = ???
-  def putChar(index: Int, value: Char): java.nio.ByteBuffer     = ???
-  def putChar(value: Char): java.nio.ByteBuffer                 = ???
-  def putDouble(index: Int, value: Double): java.nio.ByteBuffer = ???
-  def putDouble(value: Double): java.nio.ByteBuffer             = ???
-  def putFloat(index: Int, value: Float): java.nio.ByteBuffer   = ???
-  def putFloat(value: Float): java.nio.ByteBuffer               = ???
-  def putInt(index: Int, value: Int): java.nio.ByteBuffer       = ???
-  def putInt(value: Int): java.nio.ByteBuffer                   = ???
-  def putLong(index: Int, value: Long): java.nio.ByteBuffer     = ???
-  def putLong(value: Long): java.nio.ByteBuffer                 = ???
-  def putShort(index: Int, value: Short): java.nio.ByteBuffer   = ???
-  def putShort(value: Short): java.nio.ByteBuffer               = ???
-
-  /*
-
   @inline private def arrayBits: ByteArrayBits =
     ByteArrayBits(_array, _arrayOffset, isBigEndian)
 
   @noinline def getChar(): Char =
     arrayBits.loadChar(getPosAndAdvanceRead(2))
-  @noinline def putChar(value: Char): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeChar(getPosAndAdvanceWrite(2), value); this }
+  @noinline def putChar(value: Char): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeChar(getPosAndAdvanceWrite(2), value);
+    this
+  }
   @noinline def getChar(index: Int): Char =
     arrayBits.loadChar(validateIndex(index, 2))
-  @noinline def putChar(index: Int, value: Char): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeChar(validateIndex(index, 2), value); this }
+  @noinline def putChar(index: Int, value: Char): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeChar(validateIndex(index, 2), value);
+    this
+  }
 
   def asCharBuffer(): CharBuffer =
     HeapByteBufferCharView.fromHeapByteBuffer(this)
 
   @noinline def getShort(): Short =
     arrayBits.loadShort(getPosAndAdvanceRead(2))
-  @noinline def putShort(value: Short): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeShort(getPosAndAdvanceWrite(2), value); this }
+  @noinline def putShort(value: Short): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeShort(getPosAndAdvanceWrite(2), value);
+    this
+  }
   @noinline def getShort(index: Int): Short =
     arrayBits.loadShort(validateIndex(index, 2))
-  @noinline def putShort(index: Int, value: Short): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeShort(validateIndex(index, 2), value); this }
+  @noinline def putShort(index: Int, value: Short): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeShort(validateIndex(index, 2), value);
+    this
+  }
 
   def asShortBuffer(): ShortBuffer =
     HeapByteBufferShortView.fromHeapByteBuffer(this)
 
   @noinline def getInt(): Int =
     arrayBits.loadInt(getPosAndAdvanceRead(4))
-  @noinline def putInt(value: Int): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeInt(getPosAndAdvanceWrite(4), value); this }
+  @noinline def putInt(value: Int): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeInt(getPosAndAdvanceWrite(4), value);
+    this
+  }
   @noinline def getInt(index: Int): Int =
     arrayBits.loadInt(validateIndex(index, 4))
-  @noinline def putInt(index: Int, value: Int): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeInt(validateIndex(index, 4), value); this }
+  @noinline def putInt(index: Int, value: Int): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeInt(validateIndex(index, 4), value);
+    this
+  }
 
   def asIntBuffer(): IntBuffer =
     HeapByteBufferIntView.fromHeapByteBuffer(this)
 
   @noinline def getLong(): Long =
     arrayBits.loadLong(getPosAndAdvanceRead(8))
-  @noinline def putLong(value: Long): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeLong(getPosAndAdvanceWrite(8), value); this }
+  @noinline def putLong(value: Long): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeLong(getPosAndAdvanceWrite(8), value);
+    this
+  }
   @noinline def getLong(index: Int): Long =
     arrayBits.loadLong(validateIndex(index, 8))
-  @noinline def putLong(index: Int, value: Long): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeLong(validateIndex(index, 8), value); this }
+  @noinline def putLong(index: Int, value: Long): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeLong(validateIndex(index, 8), value);
+    this
+  }
 
   def asLongBuffer(): LongBuffer =
     HeapByteBufferLongView.fromHeapByteBuffer(this)
 
   @noinline def getFloat(): Float =
     arrayBits.loadFloat(getPosAndAdvanceRead(4))
-  @noinline def putFloat(value: Float): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeFloat(getPosAndAdvanceWrite(4), value); this }
+  @noinline def putFloat(value: Float): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeFloat(getPosAndAdvanceWrite(4), value);
+    this
+  }
   @noinline def getFloat(index: Int): Float =
     arrayBits.loadFloat(validateIndex(index, 4))
-  @noinline def putFloat(index: Int, value: Float): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeFloat(validateIndex(index, 4), value); this }
+  @noinline def putFloat(index: Int, value: Float): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeFloat(validateIndex(index, 4), value);
+    this
+  }
 
   def asFloatBuffer(): FloatBuffer =
     HeapByteBufferFloatView.fromHeapByteBuffer(this)
 
   @noinline def getDouble(): Double =
     arrayBits.loadDouble(getPosAndAdvanceRead(8))
-  @noinline def putDouble(value: Double): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeDouble(getPosAndAdvanceWrite(8), value); this }
+  @noinline def putDouble(value: Double): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeDouble(getPosAndAdvanceWrite(8), value);
+    this
+  }
   @noinline def getDouble(index: Int): Double =
     arrayBits.loadDouble(validateIndex(index, 8))
-  @noinline def putDouble(index: Int, value: Double): ByteBuffer =
-    { ensureNotReadOnly(); arrayBits.storeDouble(validateIndex(index, 8), value); this }
+  @noinline def putDouble(index: Int, value: Double): ByteBuffer = {
+    ensureNotReadOnly(); arrayBits.storeDouble(validateIndex(index, 8), value);
+    this
+  }
 
   def asDoubleBuffer(): DoubleBuffer =
     HeapByteBufferDoubleView.fromHeapByteBuffer(this)
-
-   */
 
   // Internal API
 

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -18,7 +18,7 @@ private[nio] final class HeapByteBuffer private (_capacity: Int,
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = true
 
   @noinline
   def slice(): ByteBuffer =

--- a/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
@@ -5,8 +5,10 @@ private[nio] final class HeapByteBufferCharView private (
     _capacity: Int,
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
-    _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _initialPosition: Int,
+    _initialLimit: Int,
+    _readOnly: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends CharBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -34,8 +36,13 @@ private[nio] final class HeapByteBufferCharView private (
   def subSequence(start: Int, end: Int): CharBuffer = {
     if (start < 0 || end < start || end > remaining)
       throw new IndexOutOfBoundsException
-    new HeapByteBufferCharView(capacity, _byteArray, _byteArrayOffset,
-        position + start, position + end, isReadOnly, isBigEndian)
+    new HeapByteBufferCharView(capacity,
+                               _byteArray,
+                               _byteArrayOffset,
+                               position + start,
+                               position + end,
+                               isReadOnly,
+                               isBigEndian)
   }
 
   @noinline
@@ -86,11 +93,20 @@ private[nio] object HeapByteBufferCharView {
       extends GenHeapBufferView.NewHeapBufferView[CharBuffer] {
     def bytesPerElem: Int = 2
 
-    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
-        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): CharBuffer = {
-      new HeapByteBufferCharView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+    def apply(capacity: Int,
+              byteArray: Array[Byte],
+              byteArrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean,
+              isBigEndian: Boolean): CharBuffer = {
+      new HeapByteBufferCharView(capacity,
+                                 byteArray,
+                                 byteArrayOffset,
+                                 initialPosition,
+                                 initialLimit,
+                                 readOnly,
+                                 isBigEndian)
     }
   }
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
@@ -19,7 +19,7 @@ private[nio] final class HeapByteBufferCharView private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = true
 
   @noinline
   def slice(): CharBuffer =

--- a/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
@@ -1,0 +1,100 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] final class HeapByteBufferCharView private (
+    _capacity: Int,
+    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArrayOffset: Int,
+    _initialPosition: Int, _initialLimit: Int,
+    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    extends CharBuffer(_capacity, null, -1) {
+
+  position(_initialPosition)
+  limit(_initialLimit)
+
+  private[this] implicit def newHeapCharBufferView =
+    HeapByteBufferCharView.NewHeapByteBufferCharView
+
+  def isReadOnly(): Boolean = _readOnly
+
+  def isDirect(): Boolean = false
+
+  @noinline
+  def slice(): CharBuffer =
+    GenHeapBufferView(this).generic_slice()
+
+  @noinline
+  def duplicate(): CharBuffer =
+    GenHeapBufferView(this).generic_duplicate()
+
+  @noinline
+  def asReadOnlyBuffer(): CharBuffer =
+    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+
+  def subSequence(start: Int, end: Int): CharBuffer = {
+    if (start < 0 || end < start || end > remaining)
+      throw new IndexOutOfBoundsException
+    new HeapByteBufferCharView(capacity, _byteArray, _byteArrayOffset,
+        position + start, position + end, isReadOnly, isBigEndian)
+  }
+
+  @noinline
+  def get(): Char =
+    GenBuffer(this).generic_get()
+
+  @noinline
+  def put(c: Char): CharBuffer =
+    GenBuffer(this).generic_put(c)
+
+  @noinline
+  def get(index: Int): Char =
+    GenBuffer(this).generic_get(index)
+
+  @noinline
+  def put(index: Int, c: Char): CharBuffer =
+    GenBuffer(this).generic_put(index, c)
+
+  @noinline
+  override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  @noinline
+  override def put(src: Array[Char], offset: Int, length: Int): CharBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  @noinline
+  def compact(): CharBuffer =
+    GenHeapBufferView(this).generic_compact()
+
+  @noinline
+  def order(): ByteOrder =
+    GenHeapBufferView(this).generic_order()
+
+  // Private API
+
+  @inline
+  private[nio] def load(index: Int): Char =
+    GenHeapBufferView(this).byteArrayBits.loadChar(index)
+
+  @inline
+  private[nio] def store(index: Int, elem: Char): Unit =
+    GenHeapBufferView(this).byteArrayBits.storeChar(index, elem)
+}
+
+private[nio] object HeapByteBufferCharView {
+  private[nio] implicit object NewHeapByteBufferCharView
+      extends GenHeapBufferView.NewHeapBufferView[CharBuffer] {
+    def bytesPerElem: Int = 2
+
+    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
+        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
+        isBigEndian: Boolean): CharBuffer = {
+      new HeapByteBufferCharView(capacity, byteArray, byteArrayOffset,
+          initialPosition, initialLimit, readOnly, isBigEndian)
+    }
+  }
+
+  @inline
+  private[nio] def fromHeapByteBuffer(byteBuffer: HeapByteBuffer): CharBuffer =
+    GenHeapBufferView.generic_fromHeapByteBuffer(byteBuffer)
+}

--- a/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
@@ -1,0 +1,93 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] final class HeapByteBufferDoubleView private (
+    _capacity: Int,
+    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArrayOffset: Int,
+    _initialPosition: Int, _initialLimit: Int,
+    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    extends DoubleBuffer(_capacity, null, -1) {
+
+  position(_initialPosition)
+  limit(_initialLimit)
+
+  private[this] implicit def newHeapDoubleBufferView =
+    HeapByteBufferDoubleView.NewHeapByteBufferDoubleView
+
+  def isReadOnly(): Boolean = _readOnly
+
+  def isDirect(): Boolean = false
+
+  @noinline
+  def slice(): DoubleBuffer =
+    GenHeapBufferView(this).generic_slice()
+
+  @noinline
+  def duplicate(): DoubleBuffer =
+    GenHeapBufferView(this).generic_duplicate()
+
+  @noinline
+  def asReadOnlyBuffer(): DoubleBuffer =
+    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+
+  @noinline
+  def get(): Double =
+    GenBuffer(this).generic_get()
+
+  @noinline
+  def put(c: Double): DoubleBuffer =
+    GenBuffer(this).generic_put(c)
+
+  @noinline
+  def get(index: Int): Double =
+    GenBuffer(this).generic_get(index)
+
+  @noinline
+  def put(index: Int, c: Double): DoubleBuffer =
+    GenBuffer(this).generic_put(index, c)
+
+  @noinline
+  override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  @noinline
+  override def put(src: Array[Double], offset: Int, length: Int): DoubleBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  @noinline
+  def compact(): DoubleBuffer =
+    GenHeapBufferView(this).generic_compact()
+
+  @noinline
+  def order(): ByteOrder =
+    GenHeapBufferView(this).generic_order()
+
+  // Private API
+
+  @inline
+  private[nio] def load(index: Int): Double =
+    GenHeapBufferView(this).byteArrayBits.loadDouble(index)
+
+  @inline
+  private[nio] def store(index: Int, elem: Double): Unit =
+    GenHeapBufferView(this).byteArrayBits.storeDouble(index, elem)
+}
+
+private[nio] object HeapByteBufferDoubleView {
+  private[nio] implicit object NewHeapByteBufferDoubleView
+      extends GenHeapBufferView.NewHeapBufferView[DoubleBuffer] {
+    def bytesPerElem: Int = 8
+
+    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
+        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
+        isBigEndian: Boolean): DoubleBuffer = {
+      new HeapByteBufferDoubleView(capacity, byteArray, byteArrayOffset,
+          initialPosition, initialLimit, readOnly, isBigEndian)
+    }
+  }
+
+  @inline
+  private[nio] def fromHeapByteBuffer(byteBuffer: HeapByteBuffer): DoubleBuffer =
+    GenHeapBufferView.generic_fromHeapByteBuffer(byteBuffer)
+}

--- a/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
@@ -19,7 +19,7 @@ private[nio] final class HeapByteBufferDoubleView private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = true
 
   @noinline
   def slice(): DoubleBuffer =

--- a/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
@@ -5,8 +5,10 @@ private[nio] final class HeapByteBufferDoubleView private (
     _capacity: Int,
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
-    _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _initialPosition: Int,
+    _initialLimit: Int,
+    _readOnly: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends DoubleBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -79,15 +81,25 @@ private[nio] object HeapByteBufferDoubleView {
       extends GenHeapBufferView.NewHeapBufferView[DoubleBuffer] {
     def bytesPerElem: Int = 8
 
-    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
-        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): DoubleBuffer = {
-      new HeapByteBufferDoubleView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+    def apply(capacity: Int,
+              byteArray: Array[Byte],
+              byteArrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean,
+              isBigEndian: Boolean): DoubleBuffer = {
+      new HeapByteBufferDoubleView(capacity,
+                                   byteArray,
+                                   byteArrayOffset,
+                                   initialPosition,
+                                   initialLimit,
+                                   readOnly,
+                                   isBigEndian)
     }
   }
 
   @inline
-  private[nio] def fromHeapByteBuffer(byteBuffer: HeapByteBuffer): DoubleBuffer =
+  private[nio] def fromHeapByteBuffer(
+      byteBuffer: HeapByteBuffer): DoubleBuffer =
     GenHeapBufferView.generic_fromHeapByteBuffer(byteBuffer)
 }

--- a/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
@@ -1,0 +1,93 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] final class HeapByteBufferFloatView private (
+    _capacity: Int,
+    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArrayOffset: Int,
+    _initialPosition: Int, _initialLimit: Int,
+    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    extends FloatBuffer(_capacity, null, -1) {
+
+  position(_initialPosition)
+  limit(_initialLimit)
+
+  private[this] implicit def newHeapFloatBufferView =
+    HeapByteBufferFloatView.NewHeapByteBufferFloatView
+
+  def isReadOnly(): Boolean = _readOnly
+
+  def isDirect(): Boolean = false
+
+  @noinline
+  def slice(): FloatBuffer =
+    GenHeapBufferView(this).generic_slice()
+
+  @noinline
+  def duplicate(): FloatBuffer =
+    GenHeapBufferView(this).generic_duplicate()
+
+  @noinline
+  def asReadOnlyBuffer(): FloatBuffer =
+    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+
+  @noinline
+  def get(): Float =
+    GenBuffer(this).generic_get()
+
+  @noinline
+  def put(c: Float): FloatBuffer =
+    GenBuffer(this).generic_put(c)
+
+  @noinline
+  def get(index: Int): Float =
+    GenBuffer(this).generic_get(index)
+
+  @noinline
+  def put(index: Int, c: Float): FloatBuffer =
+    GenBuffer(this).generic_put(index, c)
+
+  @noinline
+  override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  @noinline
+  override def put(src: Array[Float], offset: Int, length: Int): FloatBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  @noinline
+  def compact(): FloatBuffer =
+    GenHeapBufferView(this).generic_compact()
+
+  @noinline
+  def order(): ByteOrder =
+    GenHeapBufferView(this).generic_order()
+
+  // Private API
+
+  @inline
+  private[nio] def load(index: Int): Float =
+    GenHeapBufferView(this).byteArrayBits.loadFloat(index)
+
+  @inline
+  private[nio] def store(index: Int, elem: Float): Unit =
+    GenHeapBufferView(this).byteArrayBits.storeFloat(index, elem)
+}
+
+private[nio] object HeapByteBufferFloatView {
+  private[nio] implicit object NewHeapByteBufferFloatView
+      extends GenHeapBufferView.NewHeapBufferView[FloatBuffer] {
+    def bytesPerElem: Int = 4
+
+    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
+        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
+        isBigEndian: Boolean): FloatBuffer = {
+      new HeapByteBufferFloatView(capacity, byteArray, byteArrayOffset,
+          initialPosition, initialLimit, readOnly, isBigEndian)
+    }
+  }
+
+  @inline
+  private[nio] def fromHeapByteBuffer(byteBuffer: HeapByteBuffer): FloatBuffer =
+    GenHeapBufferView.generic_fromHeapByteBuffer(byteBuffer)
+}

--- a/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
@@ -19,7 +19,7 @@ private[nio] final class HeapByteBufferFloatView private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = true
 
   @noinline
   def slice(): FloatBuffer =

--- a/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
@@ -5,8 +5,10 @@ private[nio] final class HeapByteBufferFloatView private (
     _capacity: Int,
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
-    _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _initialPosition: Int,
+    _initialLimit: Int,
+    _readOnly: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends FloatBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -79,11 +81,20 @@ private[nio] object HeapByteBufferFloatView {
       extends GenHeapBufferView.NewHeapBufferView[FloatBuffer] {
     def bytesPerElem: Int = 4
 
-    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
-        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): FloatBuffer = {
-      new HeapByteBufferFloatView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+    def apply(capacity: Int,
+              byteArray: Array[Byte],
+              byteArrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean,
+              isBigEndian: Boolean): FloatBuffer = {
+      new HeapByteBufferFloatView(capacity,
+                                  byteArray,
+                                  byteArrayOffset,
+                                  initialPosition,
+                                  initialLimit,
+                                  readOnly,
+                                  isBigEndian)
     }
   }
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
@@ -19,7 +19,7 @@ private[nio] final class HeapByteBufferIntView private (
 
   val isReadOnly: Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = true
 
   @noinline
   def slice(): IntBuffer =

--- a/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
@@ -5,8 +5,10 @@ private[nio] final class HeapByteBufferIntView private (
     _capacity: Int,
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
-    _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _initialPosition: Int,
+    _initialLimit: Int,
+    _readOnly: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends IntBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -15,7 +17,7 @@ private[nio] final class HeapByteBufferIntView private (
   private[this] implicit def newHeapIntBufferView =
     HeapByteBufferIntView.NewHeapByteBufferIntView
 
-  def isReadOnly(): Boolean = _readOnly
+  val isReadOnly: Boolean = _readOnly
 
   def isDirect(): Boolean = false
 
@@ -79,11 +81,20 @@ private[nio] object HeapByteBufferIntView {
       extends GenHeapBufferView.NewHeapBufferView[IntBuffer] {
     def bytesPerElem: Int = 4
 
-    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
-        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): IntBuffer = {
-      new HeapByteBufferIntView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+    def apply(capacity: Int,
+              byteArray: Array[Byte],
+              byteArrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean,
+              isBigEndian: Boolean): IntBuffer = {
+      new HeapByteBufferIntView(capacity,
+                                byteArray,
+                                byteArrayOffset,
+                                initialPosition,
+                                initialLimit,
+                                readOnly,
+                                isBigEndian)
     }
   }
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
@@ -1,0 +1,93 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] final class HeapByteBufferIntView private (
+    _capacity: Int,
+    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArrayOffset: Int,
+    _initialPosition: Int, _initialLimit: Int,
+    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    extends IntBuffer(_capacity, null, -1) {
+
+  position(_initialPosition)
+  limit(_initialLimit)
+
+  private[this] implicit def newHeapIntBufferView =
+    HeapByteBufferIntView.NewHeapByteBufferIntView
+
+  def isReadOnly(): Boolean = _readOnly
+
+  def isDirect(): Boolean = false
+
+  @noinline
+  def slice(): IntBuffer =
+    GenHeapBufferView(this).generic_slice()
+
+  @noinline
+  def duplicate(): IntBuffer =
+    GenHeapBufferView(this).generic_duplicate()
+
+  @noinline
+  def asReadOnlyBuffer(): IntBuffer =
+    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+
+  @noinline
+  def get(): Int =
+    GenBuffer(this).generic_get()
+
+  @noinline
+  def put(c: Int): IntBuffer =
+    GenBuffer(this).generic_put(c)
+
+  @noinline
+  def get(index: Int): Int =
+    GenBuffer(this).generic_get(index)
+
+  @noinline
+  def put(index: Int, c: Int): IntBuffer =
+    GenBuffer(this).generic_put(index, c)
+
+  @noinline
+  override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  @noinline
+  override def put(src: Array[Int], offset: Int, length: Int): IntBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  @noinline
+  def compact(): IntBuffer =
+    GenHeapBufferView(this).generic_compact()
+
+  @noinline
+  def order(): ByteOrder =
+    GenHeapBufferView(this).generic_order()
+
+  // Private API
+
+  @inline
+  private[nio] def load(index: Int): Int =
+    GenHeapBufferView(this).byteArrayBits.loadInt(index)
+
+  @inline
+  private[nio] def store(index: Int, elem: Int): Unit =
+    GenHeapBufferView(this).byteArrayBits.storeInt(index, elem)
+}
+
+private[nio] object HeapByteBufferIntView {
+  private[nio] implicit object NewHeapByteBufferIntView
+      extends GenHeapBufferView.NewHeapBufferView[IntBuffer] {
+    def bytesPerElem: Int = 4
+
+    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
+        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
+        isBigEndian: Boolean): IntBuffer = {
+      new HeapByteBufferIntView(capacity, byteArray, byteArrayOffset,
+          initialPosition, initialLimit, readOnly, isBigEndian)
+    }
+  }
+
+  @inline
+  private[nio] def fromHeapByteBuffer(byteBuffer: HeapByteBuffer): IntBuffer =
+    GenHeapBufferView.generic_fromHeapByteBuffer(byteBuffer)
+}

--- a/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
@@ -5,8 +5,10 @@ private[nio] final class HeapByteBufferLongView private (
     _capacity: Int,
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
-    _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _initialPosition: Int,
+    _initialLimit: Int,
+    _readOnly: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends LongBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -79,11 +81,20 @@ private[nio] object HeapByteBufferLongView {
       extends GenHeapBufferView.NewHeapBufferView[LongBuffer] {
     def bytesPerElem: Int = 8
 
-    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
-        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): LongBuffer = {
-      new HeapByteBufferLongView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+    def apply(capacity: Int,
+              byteArray: Array[Byte],
+              byteArrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean,
+              isBigEndian: Boolean): LongBuffer = {
+      new HeapByteBufferLongView(capacity,
+                                 byteArray,
+                                 byteArrayOffset,
+                                 initialPosition,
+                                 initialLimit,
+                                 readOnly,
+                                 isBigEndian)
     }
   }
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
@@ -19,7 +19,7 @@ private[nio] final class HeapByteBufferLongView private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = true
 
   @noinline
   def slice(): LongBuffer =

--- a/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
@@ -1,0 +1,93 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] final class HeapByteBufferLongView private (
+    _capacity: Int,
+    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArrayOffset: Int,
+    _initialPosition: Int, _initialLimit: Int,
+    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    extends LongBuffer(_capacity, null, -1) {
+
+  position(_initialPosition)
+  limit(_initialLimit)
+
+  private[this] implicit def newHeapLongBufferView =
+    HeapByteBufferLongView.NewHeapByteBufferLongView
+
+  def isReadOnly(): Boolean = _readOnly
+
+  def isDirect(): Boolean = false
+
+  @noinline
+  def slice(): LongBuffer =
+    GenHeapBufferView(this).generic_slice()
+
+  @noinline
+  def duplicate(): LongBuffer =
+    GenHeapBufferView(this).generic_duplicate()
+
+  @noinline
+  def asReadOnlyBuffer(): LongBuffer =
+    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+
+  @noinline
+  def get(): Long =
+    GenBuffer(this).generic_get()
+
+  @noinline
+  def put(c: Long): LongBuffer =
+    GenBuffer(this).generic_put(c)
+
+  @noinline
+  def get(index: Int): Long =
+    GenBuffer(this).generic_get(index)
+
+  @noinline
+  def put(index: Int, c: Long): LongBuffer =
+    GenBuffer(this).generic_put(index, c)
+
+  @noinline
+  override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  @noinline
+  override def put(src: Array[Long], offset: Int, length: Int): LongBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  @noinline
+  def compact(): LongBuffer =
+    GenHeapBufferView(this).generic_compact()
+
+  @noinline
+  def order(): ByteOrder =
+    GenHeapBufferView(this).generic_order()
+
+  // Private API
+
+  @inline
+  private[nio] def load(index: Int): Long =
+    GenHeapBufferView(this).byteArrayBits.loadLong(index)
+
+  @inline
+  private[nio] def store(index: Int, elem: Long): Unit =
+    GenHeapBufferView(this).byteArrayBits.storeLong(index, elem)
+}
+
+private[nio] object HeapByteBufferLongView {
+  private[nio] implicit object NewHeapByteBufferLongView
+      extends GenHeapBufferView.NewHeapBufferView[LongBuffer] {
+    def bytesPerElem: Int = 8
+
+    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
+        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
+        isBigEndian: Boolean): LongBuffer = {
+      new HeapByteBufferLongView(capacity, byteArray, byteArrayOffset,
+          initialPosition, initialLimit, readOnly, isBigEndian)
+    }
+  }
+
+  @inline
+  private[nio] def fromHeapByteBuffer(byteBuffer: HeapByteBuffer): LongBuffer =
+    GenHeapBufferView.generic_fromHeapByteBuffer(byteBuffer)
+}

--- a/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
@@ -1,0 +1,93 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] final class HeapByteBufferShortView private (
+    _capacity: Int,
+    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArrayOffset: Int,
+    _initialPosition: Int, _initialLimit: Int,
+    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    extends ShortBuffer(_capacity, null, -1) {
+
+  position(_initialPosition)
+  limit(_initialLimit)
+
+  private[this] implicit def newHeapShortBufferView =
+    HeapByteBufferShortView.NewHeapByteBufferShortView
+
+  def isReadOnly(): Boolean = _readOnly
+
+  def isDirect(): Boolean = false
+
+  @noinline
+  def slice(): ShortBuffer =
+    GenHeapBufferView(this).generic_slice()
+
+  @noinline
+  def duplicate(): ShortBuffer =
+    GenHeapBufferView(this).generic_duplicate()
+
+  @noinline
+  def asReadOnlyBuffer(): ShortBuffer =
+    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+
+  @noinline
+  def get(): Short =
+    GenBuffer(this).generic_get()
+
+  @noinline
+  def put(c: Short): ShortBuffer =
+    GenBuffer(this).generic_put(c)
+
+  @noinline
+  def get(index: Int): Short =
+    GenBuffer(this).generic_get(index)
+
+  @noinline
+  def put(index: Int, c: Short): ShortBuffer =
+    GenBuffer(this).generic_put(index, c)
+
+  @noinline
+  override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  @noinline
+  override def put(src: Array[Short], offset: Int, length: Int): ShortBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  @noinline
+  def compact(): ShortBuffer =
+    GenHeapBufferView(this).generic_compact()
+
+  @noinline
+  def order(): ByteOrder =
+    GenHeapBufferView(this).generic_order()
+
+  // Private API
+
+  @inline
+  private[nio] def load(index: Int): Short =
+    GenHeapBufferView(this).byteArrayBits.loadShort(index)
+
+  @inline
+  private[nio] def store(index: Int, elem: Short): Unit =
+    GenHeapBufferView(this).byteArrayBits.storeShort(index, elem)
+}
+
+private[nio] object HeapByteBufferShortView {
+  private[nio] implicit object NewHeapByteBufferShortView
+      extends GenHeapBufferView.NewHeapBufferView[ShortBuffer] {
+    def bytesPerElem: Int = 2
+
+    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
+        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
+        isBigEndian: Boolean): ShortBuffer = {
+      new HeapByteBufferShortView(capacity, byteArray, byteArrayOffset,
+          initialPosition, initialLimit, readOnly, isBigEndian)
+    }
+  }
+
+  @inline
+  private[nio] def fromHeapByteBuffer(byteBuffer: HeapByteBuffer): ShortBuffer =
+    GenHeapBufferView.generic_fromHeapByteBuffer(byteBuffer)
+}

--- a/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
@@ -5,8 +5,10 @@ private[nio] final class HeapByteBufferShortView private (
     _capacity: Int,
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
-    _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _initialPosition: Int,
+    _initialLimit: Int,
+    _readOnly: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends ShortBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -79,11 +81,20 @@ private[nio] object HeapByteBufferShortView {
       extends GenHeapBufferView.NewHeapBufferView[ShortBuffer] {
     def bytesPerElem: Int = 2
 
-    def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
-        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): ShortBuffer = {
-      new HeapByteBufferShortView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+    def apply(capacity: Int,
+              byteArray: Array[Byte],
+              byteArrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean,
+              isBigEndian: Boolean): ShortBuffer = {
+      new HeapByteBufferShortView(capacity,
+                                  byteArray,
+                                  byteArrayOffset,
+                                  initialPosition,
+                                  initialLimit,
+                                  readOnly,
+                                  isBigEndian)
     }
   }
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
@@ -19,7 +19,7 @@ private[nio] final class HeapByteBufferShortView private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = true
 
   @noinline
   def slice(): ShortBuffer =

--- a/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
@@ -1,15 +1,19 @@
 package java.nio
 
 // Ported from Scala.js
-private[nio] final class HeapDoubleBuffer private (
-    _capacity: Int, _array0: Array[Double], _arrayOffset0: Int,
-    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean)
+private[nio] final class HeapDoubleBuffer private (_capacity: Int,
+                                                   _array0: Array[Double],
+                                                   _arrayOffset0: Int,
+                                                   _initialPosition: Int,
+                                                   _initialLimit: Int,
+                                                   _readOnly: Boolean)
     extends DoubleBuffer(_capacity, _array0, _arrayOffset0) {
 
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapDoubleBuffer = HeapDoubleBuffer.NewHeapDoubleBuffer
+  private[this] implicit def newHeapDoubleBuffer =
+    HeapDoubleBuffer.NewHeapDoubleBuffer
 
   def isReadOnly(): Boolean = _readOnly
 
@@ -69,32 +73,49 @@ private[nio] final class HeapDoubleBuffer private (
 
   @inline
   override private[nio] def load(startIndex: Int,
-      dst: Array[Double], offset: Int, length: Int): Unit =
+                                 dst: Array[Double],
+                                 offset: Int,
+                                 length: Int): Unit =
     GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(startIndex: Int,
-      src: Array[Double], offset: Int, length: Int): Unit =
+                                  src: Array[Double],
+                                  offset: Int,
+                                  length: Int): Unit =
     GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapDoubleBuffer {
   private[nio] implicit object NewHeapDoubleBuffer
       extends GenHeapBuffer.NewHeapBuffer[DoubleBuffer, Double] {
-    def apply(capacity: Int, array: Array[Double], arrayOffset: Int,
-        initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): DoubleBuffer = {
-      new HeapDoubleBuffer(capacity, array, arrayOffset,
-          initialPosition, initialLimit, readOnly)
+    def apply(capacity: Int,
+              array: Array[Double],
+              arrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean): DoubleBuffer = {
+      new HeapDoubleBuffer(capacity,
+                           array,
+                           arrayOffset,
+                           initialPosition,
+                           initialLimit,
+                           readOnly)
     }
   }
 
   @noinline
-  private[nio] def wrap(array: Array[Double], arrayOffset: Int, capacity: Int,
-      initialPosition: Int, initialLength: Int,
-      isReadOnly: Boolean): DoubleBuffer = {
-    GenHeapBuffer.generic_wrap(
-        array, arrayOffset, capacity,
-        initialPosition, initialLength, isReadOnly)
+  private[nio] def wrap(array: Array[Double],
+                        arrayOffset: Int,
+                        capacity: Int,
+                        initialPosition: Int,
+                        initialLength: Int,
+                        isReadOnly: Boolean): DoubleBuffer = {
+    GenHeapBuffer.generic_wrap(array,
+                               arrayOffset,
+                               capacity,
+                               initialPosition,
+                               initialLength,
+                               isReadOnly)
   }
 }

--- a/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
@@ -1,0 +1,100 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] final class HeapDoubleBuffer private (
+    _capacity: Int, _array0: Array[Double], _arrayOffset0: Int,
+    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean)
+    extends DoubleBuffer(_capacity, _array0, _arrayOffset0) {
+
+  position(_initialPosition)
+  limit(_initialLimit)
+
+  private[this] implicit def newHeapDoubleBuffer = HeapDoubleBuffer.NewHeapDoubleBuffer
+
+  def isReadOnly(): Boolean = _readOnly
+
+  def isDirect(): Boolean = false
+
+  @noinline
+  def slice(): DoubleBuffer =
+    GenHeapBuffer(this).generic_slice()
+
+  @noinline
+  def duplicate(): DoubleBuffer =
+    GenHeapBuffer(this).generic_duplicate()
+
+  @noinline
+  def asReadOnlyBuffer(): DoubleBuffer =
+    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+
+  @noinline
+  def get(): Double =
+    GenBuffer(this).generic_get()
+
+  @noinline
+  def put(d: Double): DoubleBuffer =
+    GenBuffer(this).generic_put(d)
+
+  @noinline
+  def get(index: Int): Double =
+    GenBuffer(this).generic_get(index)
+
+  @noinline
+  def put(index: Int, d: Double): DoubleBuffer =
+    GenBuffer(this).generic_put(index, d)
+
+  @noinline
+  override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  @noinline
+  override def put(src: Array[Double], offset: Int, length: Int): DoubleBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  @noinline
+  def compact(): DoubleBuffer =
+    GenHeapBuffer(this).generic_compact()
+
+  def order(): ByteOrder = ByteOrder.nativeOrder()
+
+  // Internal API
+
+  @inline
+  private[nio] def load(index: Int): Double =
+    GenHeapBuffer(this).generic_load(index)
+
+  @inline
+  private[nio] def store(index: Int, elem: Double): Unit =
+    GenHeapBuffer(this).generic_store(index, elem)
+
+  @inline
+  override private[nio] def load(startIndex: Int,
+      dst: Array[Double], offset: Int, length: Int): Unit =
+    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+
+  @inline
+  override private[nio] def store(startIndex: Int,
+      src: Array[Double], offset: Int, length: Int): Unit =
+    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+}
+
+private[nio] object HeapDoubleBuffer {
+  private[nio] implicit object NewHeapDoubleBuffer
+      extends GenHeapBuffer.NewHeapBuffer[DoubleBuffer, Double] {
+    def apply(capacity: Int, array: Array[Double], arrayOffset: Int,
+        initialPosition: Int, initialLimit: Int,
+        readOnly: Boolean): DoubleBuffer = {
+      new HeapDoubleBuffer(capacity, array, arrayOffset,
+          initialPosition, initialLimit, readOnly)
+    }
+  }
+
+  @noinline
+  private[nio] def wrap(array: Array[Double], arrayOffset: Int, capacity: Int,
+      initialPosition: Int, initialLength: Int,
+      isReadOnly: Boolean): DoubleBuffer = {
+    GenHeapBuffer.generic_wrap(
+        array, arrayOffset, capacity,
+        initialPosition, initialLength, isReadOnly)
+  }
+}

--- a/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
@@ -1,15 +1,19 @@
 package java.nio
 
 // Ported from Scala.js
-private[nio] final class HeapFloatBuffer private (
-    _capacity: Int, _array0: Array[Float], _arrayOffset0: Int,
-    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean)
+private[nio] final class HeapFloatBuffer private (_capacity: Int,
+                                                  _array0: Array[Float],
+                                                  _arrayOffset0: Int,
+                                                  _initialPosition: Int,
+                                                  _initialLimit: Int,
+                                                  _readOnly: Boolean)
     extends FloatBuffer(_capacity, _array0, _arrayOffset0) {
 
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapFloatBuffer = HeapFloatBuffer.NewHeapFloatBuffer
+  private[this] implicit def newHeapFloatBuffer =
+    HeapFloatBuffer.NewHeapFloatBuffer
 
   def isReadOnly(): Boolean = _readOnly
 
@@ -69,32 +73,49 @@ private[nio] final class HeapFloatBuffer private (
 
   @inline
   override private[nio] def load(startIndex: Int,
-      dst: Array[Float], offset: Int, length: Int): Unit =
+                                 dst: Array[Float],
+                                 offset: Int,
+                                 length: Int): Unit =
     GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(startIndex: Int,
-      src: Array[Float], offset: Int, length: Int): Unit =
+                                  src: Array[Float],
+                                  offset: Int,
+                                  length: Int): Unit =
     GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapFloatBuffer {
   private[nio] implicit object NewHeapFloatBuffer
       extends GenHeapBuffer.NewHeapBuffer[FloatBuffer, Float] {
-    def apply(capacity: Int, array: Array[Float], arrayOffset: Int,
-        initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): FloatBuffer = {
-      new HeapFloatBuffer(capacity, array, arrayOffset,
-          initialPosition, initialLimit, readOnly)
+    def apply(capacity: Int,
+              array: Array[Float],
+              arrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean): FloatBuffer = {
+      new HeapFloatBuffer(capacity,
+                          array,
+                          arrayOffset,
+                          initialPosition,
+                          initialLimit,
+                          readOnly)
     }
   }
 
   @noinline
-  private[nio] def wrap(array: Array[Float], arrayOffset: Int, capacity: Int,
-      initialPosition: Int, initialLength: Int,
-      isReadOnly: Boolean): FloatBuffer = {
-    GenHeapBuffer.generic_wrap(
-        array, arrayOffset, capacity,
-        initialPosition, initialLength, isReadOnly)
+  private[nio] def wrap(array: Array[Float],
+                        arrayOffset: Int,
+                        capacity: Int,
+                        initialPosition: Int,
+                        initialLength: Int,
+                        isReadOnly: Boolean): FloatBuffer = {
+    GenHeapBuffer.generic_wrap(array,
+                               arrayOffset,
+                               capacity,
+                               initialPosition,
+                               initialLength,
+                               isReadOnly)
   }
 }

--- a/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
@@ -1,0 +1,100 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] final class HeapFloatBuffer private (
+    _capacity: Int, _array0: Array[Float], _arrayOffset0: Int,
+    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean)
+    extends FloatBuffer(_capacity, _array0, _arrayOffset0) {
+
+  position(_initialPosition)
+  limit(_initialLimit)
+
+  private[this] implicit def newHeapFloatBuffer = HeapFloatBuffer.NewHeapFloatBuffer
+
+  def isReadOnly(): Boolean = _readOnly
+
+  def isDirect(): Boolean = false
+
+  @noinline
+  def slice(): FloatBuffer =
+    GenHeapBuffer(this).generic_slice()
+
+  @noinline
+  def duplicate(): FloatBuffer =
+    GenHeapBuffer(this).generic_duplicate()
+
+  @noinline
+  def asReadOnlyBuffer(): FloatBuffer =
+    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+
+  @noinline
+  def get(): Float =
+    GenBuffer(this).generic_get()
+
+  @noinline
+  def put(f: Float): FloatBuffer =
+    GenBuffer(this).generic_put(f)
+
+  @noinline
+  def get(index: Int): Float =
+    GenBuffer(this).generic_get(index)
+
+  @noinline
+  def put(index: Int, f: Float): FloatBuffer =
+    GenBuffer(this).generic_put(index, f)
+
+  @noinline
+  override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  @noinline
+  override def put(src: Array[Float], offset: Int, length: Int): FloatBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  @noinline
+  def compact(): FloatBuffer =
+    GenHeapBuffer(this).generic_compact()
+
+  def order(): ByteOrder = ByteOrder.nativeOrder()
+
+  // Internal API
+
+  @inline
+  private[nio] def load(index: Int): Float =
+    GenHeapBuffer(this).generic_load(index)
+
+  @inline
+  private[nio] def store(index: Int, elem: Float): Unit =
+    GenHeapBuffer(this).generic_store(index, elem)
+
+  @inline
+  override private[nio] def load(startIndex: Int,
+      dst: Array[Float], offset: Int, length: Int): Unit =
+    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+
+  @inline
+  override private[nio] def store(startIndex: Int,
+      src: Array[Float], offset: Int, length: Int): Unit =
+    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+}
+
+private[nio] object HeapFloatBuffer {
+  private[nio] implicit object NewHeapFloatBuffer
+      extends GenHeapBuffer.NewHeapBuffer[FloatBuffer, Float] {
+    def apply(capacity: Int, array: Array[Float], arrayOffset: Int,
+        initialPosition: Int, initialLimit: Int,
+        readOnly: Boolean): FloatBuffer = {
+      new HeapFloatBuffer(capacity, array, arrayOffset,
+          initialPosition, initialLimit, readOnly)
+    }
+  }
+
+  @noinline
+  private[nio] def wrap(array: Array[Float], arrayOffset: Int, capacity: Int,
+      initialPosition: Int, initialLength: Int,
+      isReadOnly: Boolean): FloatBuffer = {
+    GenHeapBuffer.generic_wrap(
+        array, arrayOffset, capacity,
+        initialPosition, initialLength, isReadOnly)
+  }
+}

--- a/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
@@ -1,9 +1,12 @@
 package java.nio
 
 // Ported from Scala.js
-private[nio] final class HeapIntBuffer private (
-    _capacity: Int, _array0: Array[Int], _arrayOffset0: Int,
-    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean)
+private[nio] final class HeapIntBuffer private (_capacity: Int,
+                                                _array0: Array[Int],
+                                                _arrayOffset0: Int,
+                                                _initialPosition: Int,
+                                                _initialLimit: Int,
+                                                _readOnly: Boolean)
     extends IntBuffer(_capacity, _array0, _arrayOffset0) {
 
   position(_initialPosition)
@@ -69,32 +72,49 @@ private[nio] final class HeapIntBuffer private (
 
   @inline
   override private[nio] def load(startIndex: Int,
-      dst: Array[Int], offset: Int, length: Int): Unit =
+                                 dst: Array[Int],
+                                 offset: Int,
+                                 length: Int): Unit =
     GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(startIndex: Int,
-      src: Array[Int], offset: Int, length: Int): Unit =
+                                  src: Array[Int],
+                                  offset: Int,
+                                  length: Int): Unit =
     GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapIntBuffer {
   private[nio] implicit object NewHeapIntBuffer
       extends GenHeapBuffer.NewHeapBuffer[IntBuffer, Int] {
-    def apply(capacity: Int, array: Array[Int], arrayOffset: Int,
-        initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): IntBuffer = {
-      new HeapIntBuffer(capacity, array, arrayOffset,
-          initialPosition, initialLimit, readOnly)
+    def apply(capacity: Int,
+              array: Array[Int],
+              arrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean): IntBuffer = {
+      new HeapIntBuffer(capacity,
+                        array,
+                        arrayOffset,
+                        initialPosition,
+                        initialLimit,
+                        readOnly)
     }
   }
 
   @noinline
-  private[nio] def wrap(array: Array[Int], arrayOffset: Int, capacity: Int,
-      initialPosition: Int, initialLength: Int,
-      isReadOnly: Boolean): IntBuffer = {
-    GenHeapBuffer.generic_wrap(
-        array, arrayOffset, capacity,
-        initialPosition, initialLength, isReadOnly)
+  private[nio] def wrap(array: Array[Int],
+                        arrayOffset: Int,
+                        capacity: Int,
+                        initialPosition: Int,
+                        initialLength: Int,
+                        isReadOnly: Boolean): IntBuffer = {
+    GenHeapBuffer.generic_wrap(array,
+                               arrayOffset,
+                               capacity,
+                               initialPosition,
+                               initialLength,
+                               isReadOnly)
   }
 }

--- a/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
@@ -1,0 +1,100 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] final class HeapIntBuffer private (
+    _capacity: Int, _array0: Array[Int], _arrayOffset0: Int,
+    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean)
+    extends IntBuffer(_capacity, _array0, _arrayOffset0) {
+
+  position(_initialPosition)
+  limit(_initialLimit)
+
+  private[this] implicit def newHeapIntBuffer = HeapIntBuffer.NewHeapIntBuffer
+
+  def isReadOnly(): Boolean = _readOnly
+
+  def isDirect(): Boolean = false
+
+  @noinline
+  def slice(): IntBuffer =
+    GenHeapBuffer(this).generic_slice()
+
+  @noinline
+  def duplicate(): IntBuffer =
+    GenHeapBuffer(this).generic_duplicate()
+
+  @noinline
+  def asReadOnlyBuffer(): IntBuffer =
+    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+
+  @noinline
+  def get(): Int =
+    GenBuffer(this).generic_get()
+
+  @noinline
+  def put(i: Int): IntBuffer =
+    GenBuffer(this).generic_put(i)
+
+  @noinline
+  def get(index: Int): Int =
+    GenBuffer(this).generic_get(index)
+
+  @noinline
+  def put(index: Int, i: Int): IntBuffer =
+    GenBuffer(this).generic_put(index, i)
+
+  @noinline
+  override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  @noinline
+  override def put(src: Array[Int], offset: Int, length: Int): IntBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  @noinline
+  def compact(): IntBuffer =
+    GenHeapBuffer(this).generic_compact()
+
+  def order(): ByteOrder = ByteOrder.nativeOrder()
+
+  // Internal API
+
+  @inline
+  private[nio] def load(index: Int): Int =
+    GenHeapBuffer(this).generic_load(index)
+
+  @inline
+  private[nio] def store(index: Int, elem: Int): Unit =
+    GenHeapBuffer(this).generic_store(index, elem)
+
+  @inline
+  override private[nio] def load(startIndex: Int,
+      dst: Array[Int], offset: Int, length: Int): Unit =
+    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+
+  @inline
+  override private[nio] def store(startIndex: Int,
+      src: Array[Int], offset: Int, length: Int): Unit =
+    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+}
+
+private[nio] object HeapIntBuffer {
+  private[nio] implicit object NewHeapIntBuffer
+      extends GenHeapBuffer.NewHeapBuffer[IntBuffer, Int] {
+    def apply(capacity: Int, array: Array[Int], arrayOffset: Int,
+        initialPosition: Int, initialLimit: Int,
+        readOnly: Boolean): IntBuffer = {
+      new HeapIntBuffer(capacity, array, arrayOffset,
+          initialPosition, initialLimit, readOnly)
+    }
+  }
+
+  @noinline
+  private[nio] def wrap(array: Array[Int], arrayOffset: Int, capacity: Int,
+      initialPosition: Int, initialLength: Int,
+      isReadOnly: Boolean): IntBuffer = {
+    GenHeapBuffer.generic_wrap(
+        array, arrayOffset, capacity,
+        initialPosition, initialLength, isReadOnly)
+  }
+}

--- a/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
@@ -1,0 +1,100 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] final class HeapLongBuffer private (
+    _capacity: Int, _array0: Array[Long], _arrayOffset0: Int,
+    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean)
+    extends LongBuffer(_capacity, _array0, _arrayOffset0) {
+
+  position(_initialPosition)
+  limit(_initialLimit)
+
+  private[this] implicit def newHeapLongBuffer = HeapLongBuffer.NewHeapLongBuffer
+
+  def isReadOnly(): Boolean = _readOnly
+
+  def isDirect(): Boolean = false
+
+  @noinline
+  def slice(): LongBuffer =
+    GenHeapBuffer(this).generic_slice()
+
+  @noinline
+  def duplicate(): LongBuffer =
+    GenHeapBuffer(this).generic_duplicate()
+
+  @noinline
+  def asReadOnlyBuffer(): LongBuffer =
+    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+
+  @noinline
+  def get(): Long =
+    GenBuffer(this).generic_get()
+
+  @noinline
+  def put(l: Long): LongBuffer =
+    GenBuffer(this).generic_put(l)
+
+  @noinline
+  def get(index: Int): Long =
+    GenBuffer(this).generic_get(index)
+
+  @noinline
+  def put(index: Int, l: Long): LongBuffer =
+    GenBuffer(this).generic_put(index, l)
+
+  @noinline
+  override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  @noinline
+  override def put(src: Array[Long], offset: Int, length: Int): LongBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  @noinline
+  def compact(): LongBuffer =
+    GenHeapBuffer(this).generic_compact()
+
+  def order(): ByteOrder = ByteOrder.nativeOrder()
+
+  // Internal API
+
+  @inline
+  private[nio] def load(index: Int): Long =
+    GenHeapBuffer(this).generic_load(index)
+
+  @inline
+  private[nio] def store(index: Int, elem: Long): Unit =
+    GenHeapBuffer(this).generic_store(index, elem)
+
+  @inline
+  override private[nio] def load(startIndex: Int,
+      dst: Array[Long], offset: Int, length: Int): Unit =
+    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+
+  @inline
+  override private[nio] def store(startIndex: Int,
+      src: Array[Long], offset: Int, length: Int): Unit =
+    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+}
+
+private[nio] object HeapLongBuffer {
+  private[nio] implicit object NewHeapLongBuffer
+      extends GenHeapBuffer.NewHeapBuffer[LongBuffer, Long] {
+    def apply(capacity: Int, array: Array[Long], arrayOffset: Int,
+        initialPosition: Int, initialLimit: Int,
+        readOnly: Boolean): LongBuffer = {
+      new HeapLongBuffer(capacity, array, arrayOffset,
+          initialPosition, initialLimit, readOnly)
+    }
+  }
+
+  @noinline
+  private[nio] def wrap(array: Array[Long], arrayOffset: Int, capacity: Int,
+      initialPosition: Int, initialLength: Int,
+      isReadOnly: Boolean): LongBuffer = {
+    GenHeapBuffer.generic_wrap(
+        array, arrayOffset, capacity,
+        initialPosition, initialLength, isReadOnly)
+  }
+}

--- a/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
@@ -1,15 +1,19 @@
 package java.nio
 
 // Ported from Scala.js
-private[nio] final class HeapLongBuffer private (
-    _capacity: Int, _array0: Array[Long], _arrayOffset0: Int,
-    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean)
+private[nio] final class HeapLongBuffer private (_capacity: Int,
+                                                 _array0: Array[Long],
+                                                 _arrayOffset0: Int,
+                                                 _initialPosition: Int,
+                                                 _initialLimit: Int,
+                                                 _readOnly: Boolean)
     extends LongBuffer(_capacity, _array0, _arrayOffset0) {
 
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapLongBuffer = HeapLongBuffer.NewHeapLongBuffer
+  private[this] implicit def newHeapLongBuffer =
+    HeapLongBuffer.NewHeapLongBuffer
 
   def isReadOnly(): Boolean = _readOnly
 
@@ -69,32 +73,49 @@ private[nio] final class HeapLongBuffer private (
 
   @inline
   override private[nio] def load(startIndex: Int,
-      dst: Array[Long], offset: Int, length: Int): Unit =
+                                 dst: Array[Long],
+                                 offset: Int,
+                                 length: Int): Unit =
     GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(startIndex: Int,
-      src: Array[Long], offset: Int, length: Int): Unit =
+                                  src: Array[Long],
+                                  offset: Int,
+                                  length: Int): Unit =
     GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapLongBuffer {
   private[nio] implicit object NewHeapLongBuffer
       extends GenHeapBuffer.NewHeapBuffer[LongBuffer, Long] {
-    def apply(capacity: Int, array: Array[Long], arrayOffset: Int,
-        initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): LongBuffer = {
-      new HeapLongBuffer(capacity, array, arrayOffset,
-          initialPosition, initialLimit, readOnly)
+    def apply(capacity: Int,
+              array: Array[Long],
+              arrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean): LongBuffer = {
+      new HeapLongBuffer(capacity,
+                         array,
+                         arrayOffset,
+                         initialPosition,
+                         initialLimit,
+                         readOnly)
     }
   }
 
   @noinline
-  private[nio] def wrap(array: Array[Long], arrayOffset: Int, capacity: Int,
-      initialPosition: Int, initialLength: Int,
-      isReadOnly: Boolean): LongBuffer = {
-    GenHeapBuffer.generic_wrap(
-        array, arrayOffset, capacity,
-        initialPosition, initialLength, isReadOnly)
+  private[nio] def wrap(array: Array[Long],
+                        arrayOffset: Int,
+                        capacity: Int,
+                        initialPosition: Int,
+                        initialLength: Int,
+                        isReadOnly: Boolean): LongBuffer = {
+    GenHeapBuffer.generic_wrap(array,
+                               arrayOffset,
+                               capacity,
+                               initialPosition,
+                               initialLength,
+                               isReadOnly)
   }
 }

--- a/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
@@ -1,0 +1,100 @@
+package java.nio
+
+// Ported from Scala.js
+private[nio] final class HeapShortBuffer private (
+    _capacity: Int, _array0: Array[Short], _arrayOffset0: Int,
+    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean)
+    extends ShortBuffer(_capacity, _array0, _arrayOffset0) {
+
+  position(_initialPosition)
+  limit(_initialLimit)
+
+  private[this] implicit def newHeapShortBuffer = HeapShortBuffer.NewHeapShortBuffer
+
+  def isReadOnly(): Boolean = _readOnly
+
+  def isDirect(): Boolean = false
+
+  @noinline
+  def slice(): ShortBuffer =
+    GenHeapBuffer(this).generic_slice()
+
+  @noinline
+  def duplicate(): ShortBuffer =
+    GenHeapBuffer(this).generic_duplicate()
+
+  @noinline
+  def asReadOnlyBuffer(): ShortBuffer =
+    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+
+  @noinline
+  def get(): Short =
+    GenBuffer(this).generic_get()
+
+  @noinline
+  def put(s: Short): ShortBuffer =
+    GenBuffer(this).generic_put(s)
+
+  @noinline
+  def get(index: Int): Short =
+    GenBuffer(this).generic_get(index)
+
+  @noinline
+  def put(index: Int, s: Short): ShortBuffer =
+    GenBuffer(this).generic_put(index, s)
+
+  @noinline
+  override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  @noinline
+  override def put(src: Array[Short], offset: Int, length: Int): ShortBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  @noinline
+  def compact(): ShortBuffer =
+    GenHeapBuffer(this).generic_compact()
+
+  def order(): ByteOrder = ByteOrder.nativeOrder()
+
+  // Internal API
+
+  @inline
+  private[nio] def load(index: Int): Short =
+    GenHeapBuffer(this).generic_load(index)
+
+  @inline
+  private[nio] def store(index: Int, elem: Short): Unit =
+    GenHeapBuffer(this).generic_store(index, elem)
+
+  @inline
+  override private[nio] def load(startIndex: Int,
+      dst: Array[Short], offset: Int, length: Int): Unit =
+    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+
+  @inline
+  override private[nio] def store(startIndex: Int,
+      src: Array[Short], offset: Int, length: Int): Unit =
+    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+}
+
+private[nio] object HeapShortBuffer {
+  private[nio] implicit object NewHeapShortBuffer
+      extends GenHeapBuffer.NewHeapBuffer[ShortBuffer, Short] {
+    def apply(capacity: Int, array: Array[Short], arrayOffset: Int,
+        initialPosition: Int, initialLimit: Int,
+        readOnly: Boolean): ShortBuffer = {
+      new HeapShortBuffer(capacity, array, arrayOffset,
+          initialPosition, initialLimit, readOnly)
+    }
+  }
+
+  @noinline
+  private[nio] def wrap(array: Array[Short], arrayOffset: Int, capacity: Int,
+      initialPosition: Int, initialLength: Int,
+      isReadOnly: Boolean): ShortBuffer = {
+    GenHeapBuffer.generic_wrap(
+        array, arrayOffset, capacity,
+        initialPosition, initialLength, isReadOnly)
+  }
+}

--- a/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
@@ -1,15 +1,19 @@
 package java.nio
 
 // Ported from Scala.js
-private[nio] final class HeapShortBuffer private (
-    _capacity: Int, _array0: Array[Short], _arrayOffset0: Int,
-    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean)
+private[nio] final class HeapShortBuffer private (_capacity: Int,
+                                                  _array0: Array[Short],
+                                                  _arrayOffset0: Int,
+                                                  _initialPosition: Int,
+                                                  _initialLimit: Int,
+                                                  _readOnly: Boolean)
     extends ShortBuffer(_capacity, _array0, _arrayOffset0) {
 
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapShortBuffer = HeapShortBuffer.NewHeapShortBuffer
+  private[this] implicit def newHeapShortBuffer =
+    HeapShortBuffer.NewHeapShortBuffer
 
   def isReadOnly(): Boolean = _readOnly
 
@@ -69,32 +73,49 @@ private[nio] final class HeapShortBuffer private (
 
   @inline
   override private[nio] def load(startIndex: Int,
-      dst: Array[Short], offset: Int, length: Int): Unit =
+                                 dst: Array[Short],
+                                 offset: Int,
+                                 length: Int): Unit =
     GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(startIndex: Int,
-      src: Array[Short], offset: Int, length: Int): Unit =
+                                  src: Array[Short],
+                                  offset: Int,
+                                  length: Int): Unit =
     GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapShortBuffer {
   private[nio] implicit object NewHeapShortBuffer
       extends GenHeapBuffer.NewHeapBuffer[ShortBuffer, Short] {
-    def apply(capacity: Int, array: Array[Short], arrayOffset: Int,
-        initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): ShortBuffer = {
-      new HeapShortBuffer(capacity, array, arrayOffset,
-          initialPosition, initialLimit, readOnly)
+    def apply(capacity: Int,
+              array: Array[Short],
+              arrayOffset: Int,
+              initialPosition: Int,
+              initialLimit: Int,
+              readOnly: Boolean): ShortBuffer = {
+      new HeapShortBuffer(capacity,
+                          array,
+                          arrayOffset,
+                          initialPosition,
+                          initialLimit,
+                          readOnly)
     }
   }
 
   @noinline
-  private[nio] def wrap(array: Array[Short], arrayOffset: Int, capacity: Int,
-      initialPosition: Int, initialLength: Int,
-      isReadOnly: Boolean): ShortBuffer = {
-    GenHeapBuffer.generic_wrap(
-        array, arrayOffset, capacity,
-        initialPosition, initialLength, isReadOnly)
+  private[nio] def wrap(array: Array[Short],
+                        arrayOffset: Int,
+                        capacity: Int,
+                        initialPosition: Int,
+                        initialLength: Int,
+                        isReadOnly: Boolean): ShortBuffer = {
+    GenHeapBuffer.generic_wrap(array,
+                               arrayOffset,
+                               capacity,
+                               initialPosition,
+                               initialLength,
+                               isReadOnly)
   }
 }

--- a/javalib/src/main/scala/java/nio/IntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/IntBuffer.scala
@@ -1,0 +1,104 @@
+package java.nio
+
+// Ported from Scala.js
+object IntBuffer {
+  private final val HashSeed = 39599817 // "java.nio.IntBuffer".##
+
+  def allocate(capacity: Int): IntBuffer =
+    wrap(new Array[Int](capacity))
+
+  def wrap(array: Array[Int], offset: Int, length: Int): IntBuffer =
+    HeapIntBuffer.wrap(array, 0, array.length, offset, length, false)
+
+  def wrap(array: Array[Int]): IntBuffer =
+    wrap(array, 0, array.length)
+}
+
+abstract class IntBuffer private[nio] (
+    _capacity: Int, private[nio] val _array: Array[Int],
+    private[nio] val _arrayOffset: Int)
+    extends Buffer(_capacity) with Comparable[IntBuffer] {
+
+  private[nio] type ElementType = Int
+  private[nio] type BufferType = IntBuffer
+
+  def this(_capacity: Int) = this(_capacity, null, -1)
+
+  def slice(): IntBuffer
+
+  def duplicate(): IntBuffer
+
+  def asReadOnlyBuffer(): IntBuffer
+
+  def get(): Int
+
+  def put(i: Int): IntBuffer
+
+  def get(index: Int): Int
+
+  def put(index: Int, i: Int): IntBuffer
+
+  @noinline
+  def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  def get(dst: Array[Int]): IntBuffer =
+    get(dst, 0, dst.length)
+
+  @noinline
+  def put(src: IntBuffer): IntBuffer =
+    GenBuffer(this).generic_put(src)
+
+  @noinline
+  def put(src: Array[Int], offset: Int, length: Int): IntBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  final def put(src: Array[Int]): IntBuffer =
+    put(src, 0, src.length)
+
+  @inline final def hasArray(): Boolean =
+    GenBuffer(this).generic_hasArray()
+
+  @inline final def array(): Array[Int] =
+    GenBuffer(this).generic_array()
+
+  @inline final def arrayOffset(): Int =
+    GenBuffer(this).generic_arrayOffset()
+
+  def compact(): IntBuffer
+
+  def isDirect(): Boolean
+
+  // toString(): String inherited from Buffer
+
+  @noinline
+  override def hashCode(): Int =
+    GenBuffer(this).generic_hashCode(IntBuffer.HashSeed)
+
+  override def equals(that: Any): Boolean = that match {
+    case that: IntBuffer => compareTo(that) == 0
+    case _               => false
+  }
+
+  @noinline
+  def compareTo(that: IntBuffer): Int =
+    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+
+  def order(): ByteOrder
+
+  // Internal API
+
+  private[nio] def load(index: Int): Int
+
+  private[nio] def store(index: Int, elem: Int): Unit
+
+  @inline
+  private[nio] def load(startIndex: Int,
+      dst: Array[Int], offset: Int, length: Int): Unit =
+    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+
+  @inline
+  private[nio] def store(startIndex: Int,
+      src: Array[Int], offset: Int, length: Int): Unit =
+    GenBuffer(this).generic_store(startIndex, src, offset, length)
+}

--- a/javalib/src/main/scala/java/nio/IntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/IntBuffer.scala
@@ -14,13 +14,14 @@ object IntBuffer {
     wrap(array, 0, array.length)
 }
 
-abstract class IntBuffer private[nio] (
-    _capacity: Int, private[nio] val _array: Array[Int],
-    private[nio] val _arrayOffset: Int)
-    extends Buffer(_capacity) with Comparable[IntBuffer] {
+abstract class IntBuffer private[nio] (_capacity: Int,
+                                       private[nio] val _array: Array[Int],
+                                       private[nio] val _arrayOffset: Int)
+    extends Buffer(_capacity)
+    with Comparable[IntBuffer] {
 
   private[nio] type ElementType = Int
-  private[nio] type BufferType = IntBuffer
+  private[nio] type BufferType  = IntBuffer
 
   def this(_capacity: Int) = this(_capacity, null, -1)
 
@@ -69,6 +70,9 @@ abstract class IntBuffer private[nio] (
 
   def isDirect(): Boolean
 
+  // HERE
+  def isReadOnly: Boolean
+
   // toString(): String inherited from Buffer
 
   @noinline
@@ -94,11 +98,15 @@ abstract class IntBuffer private[nio] (
 
   @inline
   private[nio] def load(startIndex: Int,
-      dst: Array[Int], offset: Int, length: Int): Unit =
+                        dst: Array[Int],
+                        offset: Int,
+                        length: Int): Unit =
     GenBuffer(this).generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(startIndex: Int,
-      src: Array[Int], offset: Int, length: Int): Unit =
+                         src: Array[Int],
+                         offset: Int,
+                         length: Int): Unit =
     GenBuffer(this).generic_store(startIndex, src, offset, length)
 }

--- a/javalib/src/main/scala/java/nio/InvalidMarkException.scala
+++ b/javalib/src/main/scala/java/nio/InvalidMarkException.scala
@@ -1,0 +1,3 @@
+package java.nio
+
+class InvalidMarkException extends IllegalStateException

--- a/javalib/src/main/scala/java/nio/LongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/LongBuffer.scala
@@ -1,0 +1,104 @@
+package java.nio
+
+// Ported from Scala.js
+object LongBuffer {
+  private final val HashSeed = -1709696158 // "java.nio.LongBuffer".##
+
+  def allocate(capacity: Int): LongBuffer =
+    wrap(new Array[Long](capacity))
+
+  def wrap(array: Array[Long], offset: Int, length: Int): LongBuffer =
+    HeapLongBuffer.wrap(array, 0, array.length, offset, length, false)
+
+  def wrap(array: Array[Long]): LongBuffer =
+    wrap(array, 0, array.length)
+}
+
+abstract class LongBuffer private[nio] (
+    _capacity: Int, private[nio] val _array: Array[Long],
+    private[nio] val _arrayOffset: Int)
+    extends Buffer(_capacity) with Comparable[LongBuffer] {
+
+  private[nio] type ElementType = Long
+  private[nio] type BufferType = LongBuffer
+
+  def this(_capacity: Int) = this(_capacity, null, -1)
+
+  def slice(): LongBuffer
+
+  def duplicate(): LongBuffer
+
+  def asReadOnlyBuffer(): LongBuffer
+
+  def get(): Long
+
+  def put(l: Long): LongBuffer
+
+  def get(index: Int): Long
+
+  def put(index: Int, l: Long): LongBuffer
+
+  @noinline
+  def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  def get(dst: Array[Long]): LongBuffer =
+    get(dst, 0, dst.length)
+
+  @noinline
+  def put(src: LongBuffer): LongBuffer =
+    GenBuffer(this).generic_put(src)
+
+  @noinline
+  def put(src: Array[Long], offset: Int, length: Int): LongBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  final def put(src: Array[Long]): LongBuffer =
+    put(src, 0, src.length)
+
+  @inline final def hasArray(): Boolean =
+    GenBuffer(this).generic_hasArray()
+
+  @inline final def array(): Array[Long] =
+    GenBuffer(this).generic_array()
+
+  @inline final def arrayOffset(): Int =
+    GenBuffer(this).generic_arrayOffset()
+
+  def compact(): LongBuffer
+
+  def isDirect(): Boolean
+
+  // toString(): String inherited from Buffer
+
+  @noinline
+  override def hashCode(): Int =
+    GenBuffer(this).generic_hashCode(LongBuffer.HashSeed)
+
+  override def equals(that: Any): Boolean = that match {
+    case that: LongBuffer => compareTo(that) == 0
+    case _                => false
+  }
+
+  @noinline
+  def compareTo(that: LongBuffer): Int =
+    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+
+  def order(): ByteOrder
+
+  // Internal API
+
+  private[nio] def load(index: Int): Long
+
+  private[nio] def store(index: Int, elem: Long): Unit
+
+  @inline
+  private[nio] def load(startIndex: Int,
+      dst: Array[Long], offset: Int, length: Int): Unit =
+    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+
+  @inline
+  private[nio] def store(startIndex: Int,
+      src: Array[Long], offset: Int, length: Int): Unit =
+    GenBuffer(this).generic_store(startIndex, src, offset, length)
+}

--- a/javalib/src/main/scala/java/nio/LongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/LongBuffer.scala
@@ -14,13 +14,14 @@ object LongBuffer {
     wrap(array, 0, array.length)
 }
 
-abstract class LongBuffer private[nio] (
-    _capacity: Int, private[nio] val _array: Array[Long],
-    private[nio] val _arrayOffset: Int)
-    extends Buffer(_capacity) with Comparable[LongBuffer] {
+abstract class LongBuffer private[nio] (_capacity: Int,
+                                        private[nio] val _array: Array[Long],
+                                        private[nio] val _arrayOffset: Int)
+    extends Buffer(_capacity)
+    with Comparable[LongBuffer] {
 
   private[nio] type ElementType = Long
-  private[nio] type BufferType = LongBuffer
+  private[nio] type BufferType  = LongBuffer
 
   def this(_capacity: Int) = this(_capacity, null, -1)
 
@@ -94,11 +95,15 @@ abstract class LongBuffer private[nio] (
 
   @inline
   private[nio] def load(startIndex: Int,
-      dst: Array[Long], offset: Int, length: Int): Unit =
+                        dst: Array[Long],
+                        offset: Int,
+                        length: Int): Unit =
     GenBuffer(this).generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(startIndex: Int,
-      src: Array[Long], offset: Int, length: Int): Unit =
+                         src: Array[Long],
+                         offset: Int,
+                         length: Int): Unit =
     GenBuffer(this).generic_store(startIndex, src, offset, length)
 }

--- a/javalib/src/main/scala/java/nio/ShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ShortBuffer.scala
@@ -1,0 +1,104 @@
+package java.nio
+
+// Ported from Scala.js
+object ShortBuffer {
+  private final val HashSeed = 383731478 // "java.nio.ShortBuffer".##
+
+  def allocate(capacity: Int): ShortBuffer =
+    wrap(new Array[Short](capacity))
+
+  def wrap(array: Array[Short], offset: Int, length: Int): ShortBuffer =
+    HeapShortBuffer.wrap(array, 0, array.length, offset, length, false)
+
+  def wrap(array: Array[Short]): ShortBuffer =
+    wrap(array, 0, array.length)
+}
+
+abstract class ShortBuffer private[nio] (
+    _capacity: Int, private[nio] val _array: Array[Short],
+    private[nio] val _arrayOffset: Int)
+    extends Buffer(_capacity) with Comparable[ShortBuffer] {
+
+  private[nio] type ElementType = Short
+  private[nio] type BufferType = ShortBuffer
+
+  def this(_capacity: Int) = this(_capacity, null, -1)
+
+  def slice(): ShortBuffer
+
+  def duplicate(): ShortBuffer
+
+  def asReadOnlyBuffer(): ShortBuffer
+
+  def get(): Short
+
+  def put(s: Short): ShortBuffer
+
+  def get(index: Int): Short
+
+  def put(index: Int, s: Short): ShortBuffer
+
+  @noinline
+  def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
+    GenBuffer(this).generic_get(dst, offset, length)
+
+  def get(dst: Array[Short]): ShortBuffer =
+    get(dst, 0, dst.length)
+
+  @noinline
+  def put(src: ShortBuffer): ShortBuffer =
+    GenBuffer(this).generic_put(src)
+
+  @noinline
+  def put(src: Array[Short], offset: Int, length: Int): ShortBuffer =
+    GenBuffer(this).generic_put(src, offset, length)
+
+  final def put(src: Array[Short]): ShortBuffer =
+    put(src, 0, src.length)
+
+  @inline final def hasArray(): Boolean =
+    GenBuffer(this).generic_hasArray()
+
+  @inline final def array(): Array[Short] =
+    GenBuffer(this).generic_array()
+
+  @inline final def arrayOffset(): Int =
+    GenBuffer(this).generic_arrayOffset()
+
+  def compact(): ShortBuffer
+
+  def isDirect(): Boolean
+
+  // toString(): String inherited from Buffer
+
+  @noinline
+  override def hashCode(): Int =
+    GenBuffer(this).generic_hashCode(ShortBuffer.HashSeed)
+
+  override def equals(that: Any): Boolean = that match {
+    case that: ShortBuffer => compareTo(that) == 0
+    case _                 => false
+  }
+
+  @noinline
+  def compareTo(that: ShortBuffer): Int =
+    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+
+  def order(): ByteOrder
+
+  // Internal API
+
+  private[nio] def load(index: Int): Short
+
+  private[nio] def store(index: Int, elem: Short): Unit
+
+  @inline
+  private[nio] def load(startIndex: Int,
+      dst: Array[Short], offset: Int, length: Int): Unit =
+    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+
+  @inline
+  private[nio] def store(startIndex: Int,
+      src: Array[Short], offset: Int, length: Int): Unit =
+    GenBuffer(this).generic_store(startIndex, src, offset, length)
+}

--- a/javalib/src/main/scala/java/nio/ShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ShortBuffer.scala
@@ -14,13 +14,14 @@ object ShortBuffer {
     wrap(array, 0, array.length)
 }
 
-abstract class ShortBuffer private[nio] (
-    _capacity: Int, private[nio] val _array: Array[Short],
-    private[nio] val _arrayOffset: Int)
-    extends Buffer(_capacity) with Comparable[ShortBuffer] {
+abstract class ShortBuffer private[nio] (_capacity: Int,
+                                         private[nio] val _array: Array[Short],
+                                         private[nio] val _arrayOffset: Int)
+    extends Buffer(_capacity)
+    with Comparable[ShortBuffer] {
 
   private[nio] type ElementType = Short
-  private[nio] type BufferType = ShortBuffer
+  private[nio] type BufferType  = ShortBuffer
 
   def this(_capacity: Int) = this(_capacity, null, -1)
 
@@ -94,11 +95,15 @@ abstract class ShortBuffer private[nio] (
 
   @inline
   private[nio] def load(startIndex: Int,
-      dst: Array[Short], offset: Int, length: Int): Unit =
+                        dst: Array[Short],
+                        offset: Int,
+                        length: Int): Unit =
     GenBuffer(this).generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(startIndex: Int,
-      src: Array[Short], offset: Int, length: Int): Unit =
+                         src: Array[Short],
+                         offset: Int,
+                         length: Int): Unit =
     GenBuffer(this).generic_store(startIndex, src, offset, length)
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
@@ -14,6 +14,6 @@ object Platform {
   @name("scalanative_windows_get_user_country")
   def windowsGetUserCountry(): CString = extern
 
-  @name("scalanative_litle_endian")
+  @name("scalanative_little_endian")
   def littleEndian(): Boolean = extern
 }

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/testinterface/ComRunner.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/testinterface/ComRunner.scala
@@ -40,7 +40,7 @@ class ComRunner(bin: File,
 
       runner.start()
 
-      serverSocket.setSoTimeout(30 * 1000)
+      serverSocket.setSoTimeout(40 * 1000)
       serverSocket.accept()
     } catch {
       case _: SocketTimeoutException =>

--- a/unit-tests/src/test/scala/java/nio/BaseBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/BaseBufferTest.scala
@@ -1,0 +1,386 @@
+package java.nio
+
+// Ported from Scala.js
+abstract class BaseBufferTest extends tests.Suite {
+
+  type Factory <: BufferFactory
+
+  val factory: Factory
+
+  import factory._
+
+  def runTests(): Unit = {
+    test("allocate") {
+      val buf = allocBuffer(10)
+      assertEquals(0, buf.position)
+      assertEquals(10, buf.limit)
+      assertEquals(10, buf.capacity)
+
+      assertEquals(0, allocBuffer(0).capacity)
+
+      /*assertThrows[RuntimeException] { allocBuffer(-1) }
+      assertThrows[RuntimeException] { allocBuffer(0, -1, 1) }
+      assertThrows[RuntimeException] { allocBuffer(1, 0, 1) }
+      assertThrows[RuntimeException] { allocBuffer(0, 1, 0) }
+      assertThrows[RuntimeException] { allocBuffer(1, 0, 0) } */
+
+      val buf2 = allocBuffer(1, 5, 9)
+      assertEquals(1, buf2.position())
+      assertEquals(5, buf2.limit())
+      assertEquals(9, buf2.capacity())
+    }
+
+    test("is read only") {
+      val buf = allocBuffer(10)
+      if (createsReadOnly)
+        assert(buf.isReadOnly())
+      else
+        assert(!buf.isReadOnly())
+    }
+
+    test("position") {
+      val buf = allocBuffer(10)
+      buf.position(3)
+      assertEquals(3, buf.position())
+      buf.position(10)
+      assertEquals(10, buf.position())
+      buf.position(0)
+      assertEquals(0, buf.position())
+
+      assertThrows[IllegalArgumentException] { buf.position(-1) }
+      assertThrows[IllegalArgumentException] { buf.position(11) }
+      assertEquals(0, buf.position())
+
+      val buf2 = allocBuffer(1, 5, 9)
+      assertEquals(1, buf2.position())
+
+      buf2.position(5)
+      assertEquals(5, buf2.position())
+      assertThrows[IllegalArgumentException] { buf2.position(6) }
+      assertEquals(5, buf2.position())
+    }
+
+    test("limit") {
+      val buf = allocBuffer(10)
+      buf.position(3)
+      buf.limit(7)
+      assertEquals(7, buf.limit())
+      assertEquals(3, buf.position())
+      assertThrows[IllegalArgumentException] { buf.limit(11) }
+      assertEquals(7, buf.limit())
+      assertThrows[IllegalArgumentException] { buf.limit(-1) }
+      assertEquals(7, buf.limit())
+      assertEquals(3, buf.position())
+
+      buf.position(5)
+      buf.limit(4)
+      assertEquals(4, buf.limit())
+      assertEquals(4, buf.position())
+    }
+
+    test("mark and reset") {
+      val buf = allocBuffer(10)
+
+      // Initially, the mark should not be set
+      assertThrows[InvalidMarkException] { buf.reset() }
+
+      // Simple test
+      buf.position(3)
+      buf.mark()
+      buf.position(8)
+      buf.reset()
+      assertEquals(3, buf.position())
+
+      // reset() should not have cleared the mark
+      buf.position(5)
+      buf.reset()
+      assertEquals(3, buf.position())
+
+      // setting position() below the mark should clear the mark
+      buf.position(2)
+      assertThrows[InvalidMarkException] { buf.reset() }
+    }
+
+    test("clear") {
+      val buf = allocBuffer(3, 6, 10)
+      buf.mark()
+      buf.position(4)
+
+      buf.clear()
+      assertEquals(0, buf.position())
+      assertEquals(10, buf.limit()) // the capacity
+      assertEquals(10, buf.capacity())
+      assertThrows[InvalidMarkException] { buf.reset() }
+    }
+
+    test("flip") {
+      val buf = allocBuffer(3, 6, 10)
+      buf.mark()
+      buf.position(4)
+
+      buf.flip()
+      assertEquals(0, buf.position())
+      assertEquals(4, buf.limit()) // old position
+      assertEquals(10, buf.capacity())
+      assertThrows[InvalidMarkException] { buf.reset() }
+    }
+
+    test("rewind") {
+      val buf = allocBuffer(3, 6, 10)
+      buf.mark()
+      buf.position(4)
+
+      buf.rewind()
+      assertEquals(0, buf.position())
+      assertEquals(6, buf.limit()) // unchanged
+      assertEquals(10, buf.capacity())
+      assertThrows[InvalidMarkException] { buf.reset() }
+    }
+
+    test("remaining and has remaining") {
+      val buf = allocBuffer(3, 7, 10)
+      assertEquals(7 - 3, buf.remaining())
+
+      assert(buf.hasRemaining())
+
+      buf.position(6)
+      assertEquals(7 - 6, buf.remaining())
+      assert(buf.hasRemaining())
+
+      buf.limit(9)
+      assertEquals(9 - 6, buf.remaining())
+      assert(buf.hasRemaining())
+
+      buf.limit(2)
+      assertEquals(0, buf.remaining())
+      assert(!buf.hasRemaining())
+
+      buf.position(0)
+      assertEquals(2, buf.remaining())
+      assert(buf.hasRemaining())
+    }
+
+    test("absolute get") {
+      val buf = withContent(10, elemRange(0, 10): _*)
+      assertEquals(elemFromInt(0), buf.get(0))
+      assertEquals(0, buf.position())
+      assertEquals(elemFromInt(3), buf.get(3))
+      assertEquals(0, buf.position())
+
+      assertThrows[IndexOutOfBoundsException] { buf.get(-1) }
+      assertThrows[IndexOutOfBoundsException] { buf.get(15) }
+
+      buf.limit(4)
+      assertThrows[IndexOutOfBoundsException] { buf.get(5) }
+    }
+
+    test("absolute put") {
+      val buf = allocBuffer(10)
+      if (!createsReadOnly) {
+        buf.put(5, 42)
+        assertEquals(0, buf.position())
+        buf.put(3, 2)
+        assertEquals(elemFromInt(2), buf.get(3))
+        assertEquals(elemFromInt(42), buf.get(5))
+        assertEquals(elemFromInt(0), buf.get(7))
+
+        assertThrows[IndexOutOfBoundsException] { buf.put(-1, 2) }
+        assertThrows[IndexOutOfBoundsException] { buf.put(14, 9) }
+
+        buf.limit(4)
+        assertThrows[IndexOutOfBoundsException] { buf.put(4, 1) }
+      } else {
+        assertThrows[ReadOnlyBufferException] { buf.put(2, 1) }
+        assertEquals(elemFromInt(0), buf.get(2))
+        assertEquals(0, buf.position())
+
+        assertThrows[ReadOnlyBufferException] { buf.put(-2, 1) }
+        assertThrows[ReadOnlyBufferException] { buf.put(12, 1) }
+      }
+    }
+
+    test("relative get") {
+      val buf = withContent(10, elemRange(0, 10): _*)
+      assertEquals(elemFromInt(0), buf.get())
+      assertEquals(1, buf.position())
+      buf.position(3)
+      assertEquals(elemFromInt(3), buf.get())
+      assertEquals(4, buf.position())
+
+      buf.limit(4)
+      assertThrows[BufferUnderflowException] { buf.get() }
+    }
+
+    test("relative put") {
+      val buf = allocBuffer(10)
+      if (!createsReadOnly) {
+        buf.put(5)
+        assertEquals(1, buf.position())
+        assertEquals(elemFromInt(5), buf.get(0))
+
+        buf.position(3)
+        buf.put(36)
+        assertEquals(4, buf.position())
+        assertEquals(elemFromInt(36), buf.get(3))
+
+        buf.position(10)
+        assertThrows[BufferOverflowException] { buf.put(3) }
+      } else {
+        assertThrows[ReadOnlyBufferException] { buf.put(5) }
+        assertEquals(0, buf.position())
+        assertEquals(elemFromInt(0), buf.get(0))
+
+        buf.position(10)
+        assertThrows[ReadOnlyBufferException] { buf.put(3) }
+      }
+    }
+
+    test("relative bulk get") {
+      val buf = withContent(10, elemRange(0, 10): _*)
+      val a   = new Array[ElementType](4)
+      buf.get(a)
+      (boxedElemsFromInt(0, 1, 2, 3) zip boxed(a))
+        .foreach { case (a, b) => assertEquals(a, b) }
+      assertEquals(4, buf.position())
+
+      buf.position(6)
+      buf.get(a, 1, 2)
+      (boxedElemsFromInt(0, 6, 7, 3) zip boxed(a))
+        .foreach { case (a, b) => assertEquals(a, b) }
+      assertEquals(8, buf.position())
+
+      assertThrows[BufferUnderflowException] { buf.get(a) }
+      assertEquals(8, buf.position())
+      (boxedElemsFromInt(0, 6, 7, 3) zip boxed(a))
+        .foreach { case (a, b) => assertEquals(a, b) }
+    }
+
+    test("relative bulk put") {
+      val buf = allocBuffer(10)
+      if (!createsReadOnly) {
+        buf.put(Array[ElementType](6, 7, 12))
+        (boxedElemsFromInt(6, 7, 12, 0) zip boxed(
+          (0 to 3).map(buf.get).toArray))
+          .foreach { case (a, b) => assertEquals(a, b) }
+        assertEquals(3, buf.position())
+
+        buf.position(2)
+        buf.put(Array[ElementType](44, 55, 66, 77, 88), 2, 2)
+        (boxedElemsFromInt(6, 7, 66, 77, 0) zip boxed(
+          (0 to 4).map(buf.get).toArray))
+          .foreach { case (a, b) => assertEquals(a, b) }
+        assertEquals(4, buf.position())
+
+        assertThrows[BufferOverflowException] {
+          buf.put(Array.fill[ElementType](10)(0))
+        }
+        assertEquals(4, buf.position())
+        (boxedElemsFromInt(6, 7, 66, 77, 0) zip boxed(
+          (0 to 4).map(buf.get).toArray))
+          .foreach { case (a, b) => assertEquals(a, b) }
+      } else {
+        assertThrows[ReadOnlyBufferException] {
+          buf.put(Array[ElementType](6, 7, 12))
+        }
+        assertEquals(0, buf.position())
+        assertEquals(elemFromInt(0), buf.get(0))
+
+        buf.position(8)
+        assertEquals(8, buf.position())
+        assertEquals(elemFromInt(0), buf.get(8))
+      }
+    }
+
+    test("compact") {
+      if (!createsReadOnly) {
+        val buf = withContent(10, elemRange(0, 10): _*)
+        buf.position(6)
+        buf.mark()
+
+        buf.compact()
+        assertEquals(4, buf.position())
+        assertEquals(10, buf.limit())
+        assertThrows[InvalidMarkException] { buf.reset() }
+
+        for (i <- 0 until 4)
+          assertEquals(elemFromInt(i + 6), buf.get(i))
+      } else {
+        val buf = allocBuffer(10)
+        assertThrows[ReadOnlyBufferException] { buf.compact() }
+      }
+    }
+
+    test("slice") {
+      val buf1 = withContent(10, elemRange(0, 10): _*)
+      buf1.position(3)
+      buf1.limit(7)
+      buf1.mark()
+      val buf2 = buf1.slice()
+      assertEquals(0, buf2.position())
+      assertEquals(4, buf2.limit())
+      assertEquals(4, buf2.capacity())
+      assertThrows[InvalidMarkException] { buf2.reset() }
+
+      assertEquals(elemFromInt(4), buf2.get(1))
+
+      buf2.position(2)
+      assertEquals(3, buf1.position())
+
+      if (!createsReadOnly) {
+        buf2.put(89)
+        assertEquals(elemFromInt(89), buf1.get(5))
+        assertEquals(3, buf2.position())
+        assertEquals(3, buf1.position())
+      }
+
+      assertThrows[IllegalArgumentException] { buf2.limit(5) }
+      assertEquals(4, buf2.limit())
+
+      buf2.limit(3)
+      assertEquals(7, buf1.limit())
+
+      if (!createsReadOnly) {
+        buf1.put(3, 23)
+        assertEquals(elemFromInt(23), buf2.get(0))
+      }
+    }
+
+    test("duplicate") {
+      val buf1 = withContent(10, elemRange(0, 10): _*)
+      buf1.position(3)
+      buf1.limit(7)
+      buf1.mark()
+      val buf2 = buf1.duplicate()
+      assertEquals(3, buf2.position())
+      assertEquals(7, buf2.limit())
+      assertEquals(10, buf2.capacity())
+      assertEquals(elemFromInt(4), buf2.get(4))
+
+      buf2.position(4)
+      assertEquals(3, buf1.position())
+      assertEquals(4, buf2.position())
+
+      buf2.reset()
+      assertEquals(3, buf2.position())
+      buf2.position(4)
+
+      if (!createsReadOnly) {
+        buf2.put(89)
+        assertEquals(elemFromInt(89), buf1.get(4))
+        assertEquals(5, buf2.position())
+        assertEquals(3, buf1.position())
+      }
+
+      buf2.limit(5)
+      assertEquals(7, buf1.limit())
+
+      if (!createsReadOnly) {
+        buf1.put(6, 23)
+        buf2.limit(10)
+        assertEquals(elemFromInt(23), buf2.get(6))
+      }
+    }
+  }
+
+  runTests()
+}

--- a/unit-tests/src/test/scala/java/nio/BufferAdapter.scala
+++ b/unit-tests/src/test/scala/java/nio/BufferAdapter.scala
@@ -1,0 +1,202 @@
+package java.nio
+
+// Ported from Scala.js
+sealed abstract class BufferAdapter[BT <: Buffer, ET] {
+  type BufferType  = BT
+  type ElementType = ET
+
+  def slice(): BufferType
+  def duplicate(): BufferType
+  def asReadOnlyBuffer(): BufferType
+  def get(): ElementType
+  def put(e: ElementType): BufferType
+  def get(index: Int): ElementType
+  def put(index: Int, e: ElementType): BufferType
+  def get(dst: Array[ElementType], offset: Int, length: Int): BufferType
+  def get(dst: Array[ElementType]): BufferType
+  def put(src: BufferType): BufferType
+  def put(src: Array[ElementType], offset: Int, length: Int): BufferType
+  def put(src: Array[ElementType])(implicit dummy: DummyImplicit): BufferType
+  def hasArray(): Boolean
+  def array(): Array[ElementType]
+  def arrayOffset(): Int
+  def compact(): BufferType
+  def order(): ByteOrder
+}
+
+object BufferAdapter {
+  class ByteBufferAdapater(val buffer: ByteBuffer)
+      extends BufferAdapter[ByteBuffer, Byte] {
+    def slice(): BufferType                         = buffer.slice()
+    def duplicate(): BufferType                     = buffer.duplicate()
+    def asReadOnlyBuffer(): BufferType              = buffer.asReadOnlyBuffer()
+    def get(): ElementType                          = buffer.get()
+    def put(e: ElementType): BufferType             = buffer.put(e)
+    def get(index: Int): ElementType                = buffer.get(index)
+    def put(index: Int, e: ElementType): BufferType = buffer.put(index, e)
+    def get(dst: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.get(dst, offset, length)
+    def get(dst: Array[ElementType]): BufferType = buffer.get(dst)
+    def put(src: BufferType): BufferType         = buffer.put(src)
+    def put(src: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.put(src, offset, length)
+    def put(src: Array[ElementType])(
+        implicit dummy: DummyImplicit): BufferType =
+      buffer.put(src)
+    def hasArray(): Boolean         = buffer.hasArray()
+    def array(): Array[ElementType] = buffer.array()
+    def arrayOffset(): Int          = buffer.arrayOffset()
+    def compact(): BufferType       = buffer.compact()
+    def order(): ByteOrder          = buffer.order()
+  }
+
+  class CharBufferAdapater(val buffer: CharBuffer)
+      extends BufferAdapter[CharBuffer, Char] {
+    def slice(): BufferType                         = buffer.slice()
+    def duplicate(): BufferType                     = buffer.duplicate()
+    def asReadOnlyBuffer(): BufferType              = buffer.asReadOnlyBuffer()
+    def get(): ElementType                          = buffer.get()
+    def put(e: ElementType): BufferType             = buffer.put(e)
+    def get(index: Int): ElementType                = buffer.get(index)
+    def put(index: Int, e: ElementType): BufferType = buffer.put(index, e)
+    def get(dst: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.get(dst, offset, length)
+    def get(dst: Array[ElementType]): BufferType = buffer.get(dst)
+    def put(src: BufferType): BufferType         = buffer.put(src)
+    def put(src: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.put(src, offset, length)
+    def put(src: Array[ElementType])(
+        implicit dummy: DummyImplicit): BufferType =
+      buffer.put(src)
+    def hasArray(): Boolean         = buffer.hasArray()
+    def array(): Array[ElementType] = buffer.array()
+    def arrayOffset(): Int          = buffer.arrayOffset()
+    def compact(): BufferType       = buffer.compact()
+    def order(): ByteOrder          = buffer.order()
+  }
+
+  class ShortBufferAdapater(val buffer: ShortBuffer)
+      extends BufferAdapter[ShortBuffer, Short] {
+    def slice(): BufferType                         = buffer.slice()
+    def duplicate(): BufferType                     = buffer.duplicate()
+    def asReadOnlyBuffer(): BufferType              = buffer.asReadOnlyBuffer()
+    def get(): ElementType                          = buffer.get()
+    def put(e: ElementType): BufferType             = buffer.put(e)
+    def get(index: Int): ElementType                = buffer.get(index)
+    def put(index: Int, e: ElementType): BufferType = buffer.put(index, e)
+    def get(dst: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.get(dst, offset, length)
+    def get(dst: Array[ElementType]): BufferType = buffer.get(dst)
+    def put(src: BufferType): BufferType         = buffer.put(src)
+    def put(src: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.put(src, offset, length)
+    def put(src: Array[ElementType])(
+        implicit dummy: DummyImplicit): BufferType =
+      buffer.put(src)
+    def hasArray(): Boolean         = buffer.hasArray()
+    def array(): Array[ElementType] = buffer.array()
+    def arrayOffset(): Int          = buffer.arrayOffset()
+    def compact(): BufferType       = buffer.compact()
+    def order(): ByteOrder          = buffer.order()
+  }
+
+  class IntBufferAdapater(val buffer: IntBuffer)
+      extends BufferAdapter[IntBuffer, Int] {
+    def slice(): BufferType                         = buffer.slice()
+    def duplicate(): BufferType                     = buffer.duplicate()
+    def asReadOnlyBuffer(): BufferType              = buffer.asReadOnlyBuffer()
+    def get(): ElementType                          = buffer.get()
+    def put(e: ElementType): BufferType             = buffer.put(e)
+    def get(index: Int): ElementType                = buffer.get(index)
+    def put(index: Int, e: ElementType): BufferType = buffer.put(index, e)
+    def get(dst: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.get(dst, offset, length)
+    def get(dst: Array[ElementType]): BufferType = buffer.get(dst)
+    def put(src: BufferType): BufferType         = buffer.put(src)
+    def put(src: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.put(src, offset, length)
+    def put(src: Array[ElementType])(
+        implicit dummy: DummyImplicit): BufferType =
+      buffer.put(src)
+    def hasArray(): Boolean         = buffer.hasArray()
+    def array(): Array[ElementType] = buffer.array()
+    def arrayOffset(): Int          = buffer.arrayOffset()
+    def compact(): BufferType       = buffer.compact()
+    def order(): ByteOrder          = buffer.order()
+  }
+
+  class LongBufferAdapater(val buffer: LongBuffer)
+      extends BufferAdapter[LongBuffer, Long] {
+    def slice(): BufferType                         = buffer.slice()
+    def duplicate(): BufferType                     = buffer.duplicate()
+    def asReadOnlyBuffer(): BufferType              = buffer.asReadOnlyBuffer()
+    def get(): ElementType                          = buffer.get()
+    def put(e: ElementType): BufferType             = buffer.put(e)
+    def get(index: Int): ElementType                = buffer.get(index)
+    def put(index: Int, e: ElementType): BufferType = buffer.put(index, e)
+    def get(dst: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.get(dst, offset, length)
+    def get(dst: Array[ElementType]): BufferType = buffer.get(dst)
+    def put(src: BufferType): BufferType         = buffer.put(src)
+    def put(src: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.put(src, offset, length)
+    def put(src: Array[ElementType])(
+        implicit dummy: DummyImplicit): BufferType =
+      buffer.put(src)
+    def hasArray(): Boolean         = buffer.hasArray()
+    def array(): Array[ElementType] = buffer.array()
+    def arrayOffset(): Int          = buffer.arrayOffset()
+    def compact(): BufferType       = buffer.compact()
+    def order(): ByteOrder          = buffer.order()
+  }
+
+  class FloatBufferAdapater(val buffer: FloatBuffer)
+      extends BufferAdapter[FloatBuffer, Float] {
+    def slice(): BufferType                         = buffer.slice()
+    def duplicate(): BufferType                     = buffer.duplicate()
+    def asReadOnlyBuffer(): BufferType              = buffer.asReadOnlyBuffer()
+    def get(): ElementType                          = buffer.get()
+    def put(e: ElementType): BufferType             = buffer.put(e)
+    def get(index: Int): ElementType                = buffer.get(index)
+    def put(index: Int, e: ElementType): BufferType = buffer.put(index, e)
+    def get(dst: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.get(dst, offset, length)
+    def get(dst: Array[ElementType]): BufferType = buffer.get(dst)
+    def put(src: BufferType): BufferType         = buffer.put(src)
+    def put(src: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.put(src, offset, length)
+    def put(src: Array[ElementType])(
+        implicit dummy: DummyImplicit): BufferType =
+      buffer.put(src)
+    def hasArray(): Boolean         = buffer.hasArray()
+    def array(): Array[ElementType] = buffer.array()
+    def arrayOffset(): Int          = buffer.arrayOffset()
+    def compact(): BufferType       = buffer.compact()
+    def order(): ByteOrder          = buffer.order()
+  }
+
+  class DoubleBufferAdapater(val buffer: DoubleBuffer)
+      extends BufferAdapter[DoubleBuffer, Double] {
+    def slice(): BufferType                         = buffer.slice()
+    def duplicate(): BufferType                     = buffer.duplicate()
+    def asReadOnlyBuffer(): BufferType              = buffer.asReadOnlyBuffer()
+    def get(): ElementType                          = buffer.get()
+    def put(e: ElementType): BufferType             = buffer.put(e)
+    def get(index: Int): ElementType                = buffer.get(index)
+    def put(index: Int, e: ElementType): BufferType = buffer.put(index, e)
+    def get(dst: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.get(dst, offset, length)
+    def get(dst: Array[ElementType]): BufferType = buffer.get(dst)
+    def put(src: BufferType): BufferType         = buffer.put(src)
+    def put(src: Array[ElementType], offset: Int, length: Int): BufferType =
+      buffer.put(src, offset, length)
+    def put(src: Array[ElementType])(
+        implicit dummy: DummyImplicit): BufferType =
+      buffer.put(src)
+    def hasArray(): Boolean         = buffer.hasArray()
+    def array(): Array[ElementType] = buffer.array()
+    def arrayOffset(): Int          = buffer.arrayOffset()
+    def compact(): BufferType       = buffer.compact()
+    def order(): ByteOrder          = buffer.order()
+  }
+}

--- a/unit-tests/src/test/scala/java/nio/BufferFactory.scala
+++ b/unit-tests/src/test/scala/java/nio/BufferFactory.scala
@@ -185,16 +185,6 @@ object BufferFactory {
     }
   }
 
-  trait WrappedTypedArrayBufferFactory extends WrappedBufferFactory {
-    protected def baseWrap(array: Array[ElementType],
-                           offset: Int,
-                           length: Int): BufferType = {
-      val buf = baseWrap(array)
-      buf.limit(offset + length).position(offset)
-      buf
-    }
-  }
-
   trait ReadOnlyBufferFactory extends BufferFactory {
     override val createsReadOnly = true
 

--- a/unit-tests/src/test/scala/java/nio/BufferFactory.scala
+++ b/unit-tests/src/test/scala/java/nio/BufferFactory.scala
@@ -1,0 +1,267 @@
+package java.nio
+
+import scala.language.implicitConversions
+import scala.reflect._
+
+// Ported from Scala.js
+sealed abstract class BufferFactory {
+  type BufferType <: Buffer with Comparable[BufferType]
+  type ElementType
+
+  implicit val elemClassTag: ClassTag[ElementType]
+
+  implicit def elemFromInt(value: Int): ElementType
+
+  implicit def elemToAnyRef(elem: ElementType): AnyRef
+
+  implicit def bufferAdapter(
+      buffer: BufferType): BufferAdapter[BufferType, ElementType]
+
+  def boxed(array: Array[ElementType]): Array[AnyRef] =
+    array.map(elemToAnyRef)
+
+  def boxedElemsFromInt(elems: Int*): Array[AnyRef] =
+    boxed(elems.map(elemFromInt).toArray)
+
+  val createsReadOnly: Boolean = false
+
+  def allocBuffer(capacity: Int): BufferType
+
+  def allocBuffer(pos: Int, limit: Int, capacity: Int): BufferType = {
+    val buf = allocBuffer(capacity)
+    buf.limit(limit).position(pos)
+    buf
+  }
+
+  def elemRange(start: Int, end: Int): Array[ElementType] =
+    (start until end).map(elemFromInt).toArray
+
+  def withContent(capacity: Int, content: ElementType*): BufferType =
+    withContent(0, capacity, capacity, content: _*)
+
+  def withContent(pos: Int,
+                  limit: Int,
+                  capacity: Int,
+                  content: ElementType*): BufferType = {
+    val buf = allocBuffer(pos, limit, capacity)
+    buf.put(content.toArray)
+    buf.position(pos)
+    buf
+  }
+}
+
+object BufferFactory {
+  abstract class ByteBufferFactory extends BufferFactory {
+    type BufferType  = ByteBuffer
+    type ElementType = Byte
+
+    implicit val elemClassTag: ClassTag[ElementType] = ClassTag.Byte
+
+    implicit def elemFromInt(value: Int): ElementType = value.toByte
+
+    implicit def elemToAnyRef(elem: ElementType): AnyRef = elem: java.lang.Byte
+
+    implicit def bufferAdapter(
+        buffer: BufferType): BufferAdapter[BufferType, ElementType] =
+      new BufferAdapter.ByteBufferAdapater(buffer)
+  }
+
+  abstract class CharBufferFactory extends BufferFactory {
+    type BufferType  = CharBuffer
+    type ElementType = Char
+
+    implicit val elemClassTag: ClassTag[ElementType] = ClassTag.Char
+
+    implicit def elemFromInt(value: Int): ElementType = value.toChar
+
+    implicit def elemToAnyRef(elem: ElementType): AnyRef =
+      elem: java.lang.Character
+
+    implicit def bufferAdapter(
+        buffer: BufferType): BufferAdapter[BufferType, ElementType] =
+      new BufferAdapter.CharBufferAdapater(buffer)
+  }
+
+  abstract class ShortBufferFactory extends BufferFactory {
+    type BufferType  = ShortBuffer
+    type ElementType = Short
+
+    implicit val elemClassTag: ClassTag[ElementType] = ClassTag.Short
+
+    implicit def elemFromInt(value: Int): ElementType = value.toShort
+
+    implicit def elemToAnyRef(elem: ElementType): AnyRef = elem: java.lang.Short
+
+    implicit def bufferAdapter(
+        buffer: BufferType): BufferAdapter[BufferType, ElementType] =
+      new BufferAdapter.ShortBufferAdapater(buffer)
+  }
+
+  abstract class IntBufferFactory extends BufferFactory {
+    type BufferType  = IntBuffer
+    type ElementType = Int
+
+    implicit val elemClassTag: ClassTag[ElementType] = ClassTag.Int
+
+    implicit def elemFromInt(value: Int): ElementType = value.toInt
+
+    implicit def elemToAnyRef(elem: ElementType): AnyRef =
+      elem: java.lang.Integer
+
+    implicit def bufferAdapter(
+        buffer: BufferType): BufferAdapter[BufferType, ElementType] =
+      new BufferAdapter.IntBufferAdapater(buffer)
+  }
+
+  abstract class LongBufferFactory extends BufferFactory {
+    type BufferType  = LongBuffer
+    type ElementType = Long
+
+    implicit val elemClassTag: ClassTag[ElementType] = ClassTag.Long
+
+    implicit def elemFromInt(value: Int): ElementType = value.toLong
+
+    implicit def elemToAnyRef(elem: ElementType): AnyRef = elem: java.lang.Long
+
+    implicit def bufferAdapter(
+        buffer: BufferType): BufferAdapter[BufferType, ElementType] =
+      new BufferAdapter.LongBufferAdapater(buffer)
+  }
+
+  abstract class FloatBufferFactory extends BufferFactory {
+    type BufferType  = FloatBuffer
+    type ElementType = Float
+
+    implicit val elemClassTag: ClassTag[ElementType] = ClassTag.Float
+
+    implicit def elemFromInt(value: Int): ElementType = value.toFloat
+
+    implicit def elemToAnyRef(elem: ElementType): AnyRef = elem: java.lang.Float
+
+    implicit def bufferAdapter(
+        buffer: BufferType): BufferAdapter[BufferType, ElementType] =
+      new BufferAdapter.FloatBufferAdapater(buffer)
+  }
+
+  abstract class DoubleBufferFactory extends BufferFactory {
+    type BufferType  = DoubleBuffer
+    type ElementType = Double
+
+    implicit val elemClassTag: ClassTag[ElementType] = ClassTag.Double
+
+    implicit def elemFromInt(value: Int): ElementType = value.toDouble
+
+    implicit def elemToAnyRef(elem: ElementType): AnyRef =
+      elem: java.lang.Double
+
+    implicit def bufferAdapter(
+        buffer: BufferType): BufferAdapter[BufferType, ElementType] =
+      new BufferAdapter.DoubleBufferAdapater(buffer)
+  }
+
+  trait WrappedBufferFactory extends BufferFactory {
+    protected def baseWrap(array: Array[ElementType]): BufferType
+
+    protected def baseWrap(array: Array[ElementType],
+                           offset: Int,
+                           length: Int): BufferType
+
+    def allocBuffer(capacity: Int): BufferType =
+      baseWrap(new Array[ElementType](capacity))
+
+    override def allocBuffer(pos: Int, limit: Int, capacity: Int): BufferType =
+      baseWrap(new Array[ElementType](capacity), pos, limit - pos)
+
+    override def withContent(pos: Int,
+                             limit: Int,
+                             capacity: Int,
+                             content: ElementType*): BufferType = {
+      val after = capacity - (pos + content.size)
+      val fullContent =
+        (Seq.fill(pos)(elemFromInt(0)) ++
+          content ++
+          Seq.fill(after)(elemFromInt(0))).toArray
+      baseWrap(fullContent, pos, limit - pos)
+    }
+  }
+
+  trait WrappedTypedArrayBufferFactory extends WrappedBufferFactory {
+    protected def baseWrap(array: Array[ElementType],
+                           offset: Int,
+                           length: Int): BufferType = {
+      val buf = baseWrap(array)
+      buf.limit(offset + length).position(offset)
+      buf
+    }
+  }
+
+  trait ReadOnlyBufferFactory extends BufferFactory {
+    override val createsReadOnly = true
+
+    abstract override def allocBuffer(capacity: Int): BufferType =
+      super.allocBuffer(capacity).asReadOnlyBuffer()
+
+    override def allocBuffer(pos: Int, limit: Int, capacity: Int): BufferType =
+      super.allocBuffer(pos, limit, capacity).asReadOnlyBuffer()
+
+    override def withContent(pos: Int,
+                             limit: Int,
+                             capacity: Int,
+                             content: ElementType*): BufferType =
+      super.withContent(pos, limit, capacity, content: _*).asReadOnlyBuffer()
+  }
+
+  trait SlicedBufferFactory extends BufferFactory {
+    abstract override def allocBuffer(capacity: Int): BufferType = {
+      if (capacity < 0)
+        throw new IllegalArgumentException
+      val buf = super.allocBuffer(capacity + 25)
+      buf.position(17)
+      buf.limit(17 + capacity)
+      buf.slice()
+    }
+
+    override def withContent(pos: Int,
+                             limit: Int,
+                             capacity: Int,
+                             content: ElementType*): BufferType = {
+      if (!(0 <= pos && pos <= limit && limit <= capacity))
+        throw new IllegalArgumentException
+      val buf = super.allocBuffer(capacity + 25)
+      buf.position(9 + pos)
+      buf.put(content.toArray)
+      buf.position(9)
+      buf.limit(9 + capacity)
+      val buf2 = buf.slice()
+      buf2.position(pos)
+      buf2.limit(limit)
+      buf2
+    }
+  }
+
+  trait ByteBufferViewFactory extends BufferFactory {
+    def baseAllocBuffer(capacity: Int): BufferType
+
+    def allocBuffer(capacity: Int): BufferType =
+      baseAllocBuffer(capacity)
+
+    override def allocBuffer(pos: Int,
+                             limit: Int,
+                             capacity: Int): BufferType = {
+      val buf = baseAllocBuffer(capacity)
+      buf.limit(limit).position(pos)
+      buf
+    }
+
+    override def withContent(pos: Int,
+                             limit: Int,
+                             capacity: Int,
+                             content: ElementType*): BufferType = {
+      val buf = baseAllocBuffer(capacity)
+      buf.limit(limit).position(pos)
+      buf.put(content.toArray)
+      buf.position(pos)
+      buf
+    }
+  }
+}

--- a/unit-tests/src/test/scala/java/nio/ByteBufferFactiories.scala
+++ b/unit-tests/src/test/scala/java/nio/ByteBufferFactiories.scala
@@ -1,0 +1,38 @@
+package java.nio
+
+// Ported from Scala.js
+object ByteBufferFactories {
+  import BufferFactory._
+
+  class AllocByteBufferFactory extends ByteBufferFactory {
+    def allocBuffer(capacity: Int): ByteBuffer =
+      ByteBuffer.allocate(capacity)
+  }
+
+  class WrappedByteBufferFactory
+      extends ByteBufferFactory
+      with WrappedBufferFactory {
+    def baseWrap(array: Array[Byte]): ByteBuffer =
+      ByteBuffer.wrap(array)
+
+    def baseWrap(array: Array[Byte], offset: Int, length: Int): ByteBuffer =
+      ByteBuffer.wrap(array, offset, length)
+  }
+
+  class AllocDirectByteBufferFactory extends ByteBufferFactory {
+    def allocBuffer(capacity: Int): ByteBuffer =
+      ByteBuffer.allocateDirect(capacity)
+  }
+
+  class ReadOnlyWrappedByteBufferFactory
+      extends WrappedByteBufferFactory
+      with ReadOnlyBufferFactory
+
+  class SlicedAllocByteBufferFactory
+      extends AllocByteBufferFactory
+      with SlicedBufferFactory
+
+  class SlicedAllocDirectByteBufferFactory
+      extends AllocDirectByteBufferFactory
+      with SlicedBufferFactory
+}

--- a/unit-tests/src/test/scala/java/nio/ByteBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/ByteBufferTest.scala
@@ -1,0 +1,1232 @@
+package java.nio
+
+import java.nio.BufferFactory.ByteBufferFactory
+
+// Ported from Scala.js
+abstract class ByteBufferTest extends BaseBufferTest {
+  type Factory = BufferFactory.ByteBufferFactory
+
+  import factory._
+
+  def runByteBufferTests() = {
+    test("order") {
+      val buf = allocBuffer(10)
+      assertEquals(ByteOrder.BIG_ENDIAN, buf.order())
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      assertEquals(ByteOrder.LITTLE_ENDIAN, buf.order())
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(ByteOrder.BIG_ENDIAN, buf.order())
+    }
+
+    test("relative getChar") {
+      val buf = withContent(10, elemRange(0x7b, 0x85): _*)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(0x7b7c, buf.getChar().toInt)
+      assertEquals(2, buf.position)
+      assertEquals(0x7d7e, buf.getChar().toInt)
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(6)
+      assertEquals(0x8281, buf.getChar().toInt)
+      assertEquals(0x8483, buf.getChar().toInt)
+
+      assertThrows[BufferUnderflowException] { buf.getChar() }
+    }
+
+    test("relative putChar") {
+      val buf = allocBuffer(10)
+      if (!createsReadOnly) {
+        buf.putChar(0x7b7c)
+        assertEquals(2, buf.position())
+        assertEquals(0x7b, buf.get(0))
+        assertEquals(0x7c, buf.get(1))
+        buf.putChar(0x7d7e)
+        assertEquals(0x7d, buf.get(2))
+        assertEquals(0x7e, buf.get(3))
+        assertEquals(0, buf.get(4))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(7)
+        buf.putChar(0x8182)
+        assertEquals(0, buf.get(6))
+        assertEquals(0x82.toByte, buf.get(7))
+        assertEquals(0x81.toByte, buf.get(8))
+
+        assertThrows[BufferOverflowException] { buf.putChar(0x8384) }
+      } else {
+        assertThrows[ReadOnlyBufferException] { buf.putChar(0x7576) }
+        assertEquals(0, buf.get(0))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("absolute getChar") {
+      val buf = withContent(10, elemRange(0x7b, 0x85): _*)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(0x7e7f, buf.getChar(3).toInt)
+      assertEquals(0, buf.position)
+      assertEquals(0x7f80, buf.getChar(4).toInt)
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(6)
+      assertEquals(0x7e7d, buf.getChar(2).toInt)
+      assertEquals(0x8483, buf.getChar(8).toInt)
+
+      assertThrows[IndexOutOfBoundsException] { buf.getChar(9) }
+    }
+
+    test("absolute putChar") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(10)
+        buf.putChar(2, 0x7b7c)
+        assertEquals(0, buf.position())
+        assertEquals(0, buf.get(0))
+        assertEquals(0x7b, buf.get(2))
+        assertEquals(0x7c, buf.get(3))
+        buf.putChar(3, 0x7d7e)
+        assertEquals(0x7b, buf.get(2))
+        assertEquals(0x7d, buf.get(3))
+        assertEquals(0x7e, buf.get(4))
+        assertEquals(0, buf.get(5))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(7)
+        buf.putChar(6, 0x8182)
+        assertEquals(0, buf.get(5))
+        assertEquals(0x82.toByte, buf.get(6))
+        assertEquals(0x81.toByte, buf.get(7))
+
+        assertThrows[IndexOutOfBoundsException] { buf.putChar(9, 0x8384) }
+      } else {
+        val buf = allocBuffer(10)
+        assertThrows[ReadOnlyBufferException] { buf.putChar(3, 0x7576) }
+        assertEquals(0, buf.get(3))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("asCharBuffer - Bytes to Chars") {
+      val buf = withContent(10, elemRange(0x7b, 0x85): _*)
+      buf.limit(8).position(1)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      val charBuf1 = buf.asCharBuffer()
+      assertEquals(createsReadOnly, charBuf1.isReadOnly())
+      assertEquals(3, charBuf1.capacity)
+      assertEquals(0, charBuf1.position)
+      assertEquals(3, charBuf1.limit)
+      assertEquals(ByteOrder.BIG_ENDIAN, charBuf1.order)
+      assertEquals(0x7e7f, charBuf1.get(1).toInt)
+      assertEquals(0, charBuf1.position)
+      assertEquals(0x7c7d, charBuf1.get().toInt)
+      assertEquals(1, charBuf1.position)
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      val charBuf2 = buf.asCharBuffer()
+      assertEquals(createsReadOnly, charBuf2.isReadOnly())
+      assertEquals(3, charBuf2.capacity)
+      assertEquals(0, charBuf2.position)
+      assertEquals(3, charBuf2.limit)
+      assertEquals(ByteOrder.LITTLE_ENDIAN, charBuf2.order)
+      assertEquals(0x7f7e, charBuf2.get(1).toInt)
+      assertEquals(0, charBuf2.position)
+      assertEquals(0x7d7c, charBuf2.get().toInt)
+      assertEquals(1, charBuf2.position)
+    }
+
+    test("asCharBuffer - Chars to Bytes") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(10)
+        buf.limit(8).position(1)
+
+        buf.order(ByteOrder.BIG_ENDIAN)
+        val charBuf1 = buf.asCharBuffer()
+        charBuf1.put(1, 0x7e7f)
+        assertEquals(0x7e, buf.get(3))
+        assertEquals(0x7f, buf.get(4))
+        assertEquals(0, charBuf1.position)
+        charBuf1.put(0x7c7d.toChar)
+        assertEquals(0x7c, buf.get(1))
+        assertEquals(0x7d, buf.get(2))
+        assertEquals(1, charBuf1.position)
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        val charBuf2 = buf.asCharBuffer()
+        charBuf2.put(1, 0x7e7f)
+        assertEquals(0x7f, buf.get(3))
+        assertEquals(0x7e, buf.get(4))
+        assertEquals(0, charBuf2.position)
+        charBuf2.put(0x7c7d.toChar)
+        assertEquals(0x7d, buf.get(1))
+        assertEquals(0x7c, buf.get(2))
+        assertEquals(1, charBuf2.position)
+      } else {
+        val buf = allocBuffer(10)
+        buf.limit(8).position(1)
+
+        val charBuf1 = buf.asReadOnlyBuffer().asCharBuffer()
+        assertThrows[ReadOnlyBufferException] { charBuf1.put(1, 0x7e7f) }
+      }
+    }
+
+    test("relative getShort") {
+      val buf = withContent(10, elemRange(0x7b, 0x85): _*)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(0x7b7c, buf.getShort())
+      assertEquals(2, buf.position)
+      assertEquals(0x7d7e, buf.getShort())
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(6)
+      assertEquals(0xffff8281, buf.getShort())
+      assertEquals(0xffff8483, buf.getShort())
+
+      assertThrows[BufferUnderflowException] { buf.getShort() }
+    }
+
+    test("relative putShort") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(10)
+        buf.putShort(0x7b7c)
+        assertEquals(2, buf.position())
+        assertEquals(0x7b, buf.get(0))
+        assertEquals(0x7c, buf.get(1))
+        buf.putShort(0x7d7e)
+        assertEquals(0x7d, buf.get(2))
+        assertEquals(0x7e, buf.get(3))
+        assertEquals(0, buf.get(4))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(7)
+        buf.putShort(0xffff8182)
+        assertEquals(0, buf.get(6))
+        assertEquals(0x82.toByte, buf.get(7))
+        assertEquals(0x81.toByte, buf.get(8))
+
+        assertThrows[BufferOverflowException] { buf.putShort(0xffff8384) }
+      } else {
+        val buf = allocBuffer(10)
+        assertThrows[ReadOnlyBufferException] { buf.putShort(0x7576) }
+        assertEquals(0, buf.get(0))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("absolute getShort") {
+      val buf = withContent(10, elemRange(0x7b, 0x85): _*)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(0x7e7f, buf.getShort(3))
+      assertEquals(0, buf.position)
+      assertEquals(0x7f80, buf.getShort(4))
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(6)
+      assertEquals(0x7e7d, buf.getShort(2))
+      assertEquals(0xffff8483, buf.getShort(8))
+
+      assertThrows[IndexOutOfBoundsException] { buf.getShort(9) }
+    }
+
+    test("absolute putShort") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(10)
+        buf.putShort(2, 0x7b7c)
+        assertEquals(0, buf.position())
+        assertEquals(0, buf.get(0))
+        assertEquals(0x7b, buf.get(2))
+        assertEquals(0x7c, buf.get(3))
+        buf.putShort(3, 0x7d7e)
+        assertEquals(0x7b, buf.get(2))
+        assertEquals(0x7d, buf.get(3))
+        assertEquals(0x7e, buf.get(4))
+        assertEquals(0, buf.get(5))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(7)
+        buf.putShort(6, 0xffff8182)
+        assertEquals(0, buf.get(5))
+        assertEquals(0x82.toByte, buf.get(6))
+        assertEquals(0x81.toByte, buf.get(7))
+
+        assertThrows[IndexOutOfBoundsException] { buf.putShort(9, 0xffff8384) }
+      } else {
+        val buf = allocBuffer(10)
+        assertThrows[ReadOnlyBufferException] { buf.putShort(3, 0x7576) }
+        assertEquals(0, buf.get(3))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("asShortBuffer - Bytes to Shorts") {
+      val buf = withContent(10, elemRange(0x7b, 0x85): _*)
+      buf.limit(8).position(1)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      val shortBuf1 = buf.asShortBuffer()
+      assertEquals(createsReadOnly, shortBuf1.isReadOnly())
+      assertEquals(3, shortBuf1.capacity)
+      assertEquals(0, shortBuf1.position)
+      assertEquals(3, shortBuf1.limit)
+      assertEquals(ByteOrder.BIG_ENDIAN, shortBuf1.order)
+      assertEquals(0x7e7f, shortBuf1.get(1))
+      assertEquals(0, shortBuf1.position)
+      assertEquals(0x7c7d, shortBuf1.get())
+      assertEquals(1, shortBuf1.position)
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      val shortBuf2 = buf.asShortBuffer()
+      assertEquals(createsReadOnly, shortBuf2.isReadOnly())
+      assertEquals(3, shortBuf2.capacity)
+      assertEquals(0, shortBuf2.position)
+      assertEquals(3, shortBuf2.limit)
+      assertEquals(ByteOrder.LITTLE_ENDIAN, shortBuf2.order)
+      assertEquals(0x7f7e, shortBuf2.get(1))
+      assertEquals(0, shortBuf2.position)
+      assertEquals(0x7d7c, shortBuf2.get())
+      assertEquals(1, shortBuf2.position)
+    }
+
+    test("asShortBuffer - Shorts to Bytes") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(10)
+        buf.limit(8).position(1)
+
+        buf.order(ByteOrder.BIG_ENDIAN)
+        val shortBuf1 = buf.asShortBuffer()
+        shortBuf1.put(1, 0x7e7f)
+        assertEquals(0x7e, buf.get(3))
+        assertEquals(0x7f, buf.get(4))
+        assertEquals(0, shortBuf1.position)
+        shortBuf1.put(0x7c7d.toShort)
+        assertEquals(0x7c, buf.get(1))
+        assertEquals(0x7d, buf.get(2))
+        assertEquals(1, shortBuf1.position)
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        val shortBuf2 = buf.asShortBuffer()
+        shortBuf2.put(1, 0x7e7f)
+        assertEquals(0x7f, buf.get(3))
+        assertEquals(0x7e, buf.get(4))
+        assertEquals(0, shortBuf2.position)
+        shortBuf2.put(0x7c7d.toShort)
+        assertEquals(0x7d, buf.get(1))
+        assertEquals(0x7c, buf.get(2))
+        assertEquals(1, shortBuf2.position)
+      } else {
+        val buf = allocBuffer(10)
+        buf.limit(8).position(1)
+
+        val shortBuf1 = buf.asReadOnlyBuffer().asShortBuffer()
+        assertThrows[ReadOnlyBufferException] { shortBuf1.put(1, 0x7e7f) }
+      }
+    }
+
+    test("relative getInt") {
+      val buf = withContent(10, elemRange(0x7b, 0x85): _*)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(0x7b7c7d7e, buf.getInt())
+      assertEquals(4, buf.position)
+      assertEquals(0x7f808182, buf.getInt())
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(6)
+      assertEquals(0x84838281, buf.getInt())
+
+      assertThrows[BufferUnderflowException] { buf.getInt() }
+    }
+
+    test("relative putInt") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(10)
+        buf.putInt(0x7b7c7d7e)
+        assertEquals(4, buf.position())
+        assertEquals(0x7b, buf.get(0))
+        assertEquals(0x7c, buf.get(1))
+        assertEquals(0x7d, buf.get(2))
+        assertEquals(0x7e, buf.get(3))
+        buf.putInt(0x7f808182)
+        assertEquals(0x7f, buf.get(4))
+        assertEquals(0x80.toByte, buf.get(5))
+        assertEquals(0x81.toByte, buf.get(6))
+        assertEquals(0x82.toByte, buf.get(7))
+        assertEquals(0, buf.get(8))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(3)
+        buf.putInt(0x81828384)
+        assertEquals(0x7d, buf.get(2))
+        assertEquals(0x84.toByte, buf.get(3))
+        assertEquals(0x83.toByte, buf.get(4))
+        assertEquals(0x82.toByte, buf.get(5))
+        assertEquals(0x81.toByte, buf.get(6))
+
+        assertThrows[BufferOverflowException] { buf.putInt(0xffff8384) }
+      } else {
+        val buf = allocBuffer(10)
+        assertThrows[ReadOnlyBufferException] { buf.putInt(0x75767778) }
+        assertEquals(0, buf.get(0))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("absolute getInt") {
+      val buf = withContent(10, elemRange(0x7b, 0x85): _*)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(0x7e7f8081, buf.getInt(3))
+      assertEquals(0, buf.position)
+      assertEquals(0x7f808182, buf.getInt(4))
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(6)
+      assertEquals(0x807f7e7d, buf.getInt(2))
+      assertEquals(0x84838281, buf.getInt(6))
+
+      assertThrows[IndexOutOfBoundsException] { buf.getInt(7) }
+    }
+
+    test("absolute putInt") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(10)
+        buf.putInt(2, 0x7b7c7d7e)
+        assertEquals(0, buf.position())
+        assertEquals(0, buf.get(0))
+        assertEquals(0x7b, buf.get(2))
+        assertEquals(0x7c, buf.get(3))
+        assertEquals(0x7d, buf.get(4))
+        assertEquals(0x7e, buf.get(5))
+        buf.putInt(3, 0x7d7e7f80)
+        assertEquals(0x7b, buf.get(2))
+        assertEquals(0x7d, buf.get(3))
+        assertEquals(0x7e, buf.get(4))
+        assertEquals(0x7f, buf.get(5))
+        assertEquals(0x80.toByte, buf.get(6))
+        assertEquals(0, buf.get(7))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(7)
+        buf.putInt(6, 0x81828384)
+        assertEquals(0x7f, buf.get(5))
+        assertEquals(0x84.toByte, buf.get(6))
+        assertEquals(0x83.toByte, buf.get(7))
+        assertEquals(0x82.toByte, buf.get(8))
+        assertEquals(0x81.toByte, buf.get(9))
+
+        assertThrows[IndexOutOfBoundsException] { buf.putInt(9, 0xffff8384) }
+      } else {
+        val buf = allocBuffer(10)
+        assertThrows[ReadOnlyBufferException] { buf.putInt(3, 0x7576) }
+        assertEquals(0, buf.get(3))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("asIntBuffer - Bytes to Ints") {
+      val buf = withContent(14, elemRange(0x7b, 0x89): _*)
+      buf.limit(10).position(1)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      val intBuf1 = buf.asIntBuffer()
+      assertEquals(createsReadOnly, intBuf1.isReadOnly())
+      assertEquals(2, intBuf1.capacity)
+      assertEquals(0, intBuf1.position)
+      assertEquals(2, intBuf1.limit)
+      assertEquals(ByteOrder.BIG_ENDIAN, intBuf1.order)
+      assertEquals(0x80818283, intBuf1.get(1))
+      assertEquals(0, intBuf1.position)
+      assertEquals(0x7c7d7e7f, intBuf1.get())
+      assertEquals(1, intBuf1.position)
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      val intBuf2 = buf.asIntBuffer()
+      assertEquals(createsReadOnly, intBuf2.isReadOnly())
+      assertEquals(2, intBuf2.capacity)
+      assertEquals(0, intBuf2.position)
+      assertEquals(2, intBuf2.limit)
+      assertEquals(ByteOrder.LITTLE_ENDIAN, intBuf2.order)
+      assertEquals(0x83828180, intBuf2.get(1))
+      assertEquals(0, intBuf2.position)
+      assertEquals(0x7f7e7d7c, intBuf2.get())
+      assertEquals(1, intBuf2.position)
+    }
+
+    test("asIntBuffer - Ints to Bytes") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(14)
+        buf.limit(10).position(1)
+
+        buf.order(ByteOrder.BIG_ENDIAN)
+        val intBuf1 = buf.asIntBuffer()
+        intBuf1.put(1, 0x81828384)
+        assertEquals(0x81.toByte, buf.get(5))
+        assertEquals(0x82.toByte, buf.get(6))
+        assertEquals(0x83.toByte, buf.get(7))
+        assertEquals(0x84.toByte, buf.get(8))
+        assertEquals(0, intBuf1.position)
+        intBuf1.put(0x7c7d7e7f)
+        assertEquals(0x7c, buf.get(1))
+        assertEquals(0x7d, buf.get(2))
+        assertEquals(0x7e, buf.get(3))
+        assertEquals(0x7f, buf.get(4))
+        assertEquals(1, intBuf1.position)
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        val intBuf2 = buf.asIntBuffer()
+        intBuf2.put(1, 0x81828384)
+        assertEquals(0x84.toByte, buf.get(5))
+        assertEquals(0x83.toByte, buf.get(6))
+        assertEquals(0x82.toByte, buf.get(7))
+        assertEquals(0x81.toByte, buf.get(8))
+        assertEquals(0, intBuf2.position)
+        intBuf2.put(0x7c7d7e7f)
+        assertEquals(0x7f, buf.get(1))
+        assertEquals(0x7e, buf.get(2))
+        assertEquals(0x7d, buf.get(3))
+        assertEquals(0x7c, buf.get(4))
+        assertEquals(1, intBuf2.position)
+      } else {
+        val buf = allocBuffer(14)
+        buf.limit(10).position(1)
+
+        val intBuf1 = buf.asReadOnlyBuffer().asIntBuffer()
+        assertThrows[ReadOnlyBufferException] { intBuf1.put(1, 0x7e7f8081) }
+      }
+    }
+
+    test("relative getLong") {
+      val buf = withContent(20, elemRange(0x76, 0x8a): _*)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(0x767778797a7b7c7dL, buf.getLong())
+      assertEquals(8, buf.position)
+      assertEquals(0x7e7f808182838485L, buf.getLong())
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(6)
+      assertEquals(0x838281807f7e7d7cL, buf.getLong())
+
+      assertThrows[BufferUnderflowException] { buf.getLong() }
+    }
+
+    test("relative putLong") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(20)
+        buf.putLong(0x767778797a7b7c7dL)
+        assertEquals(8, buf.position())
+        assertEquals(0x76, buf.get(0))
+        assertEquals(0x77, buf.get(1))
+        assertEquals(0x78, buf.get(2))
+        assertEquals(0x79, buf.get(3))
+        assertEquals(0x7a, buf.get(4))
+        assertEquals(0x7b, buf.get(5))
+        assertEquals(0x7c, buf.get(6))
+        assertEquals(0x7d, buf.get(7))
+        buf.putLong(0x7e7f808182838485L)
+        assertEquals(0x7e, buf.get(8))
+        assertEquals(0x7f, buf.get(9))
+        assertEquals(0x80.toByte, buf.get(10))
+        assertEquals(0x81.toByte, buf.get(11))
+        assertEquals(0x82.toByte, buf.get(12))
+        assertEquals(0x83.toByte, buf.get(13))
+        assertEquals(0x84.toByte, buf.get(14))
+        assertEquals(0x85.toByte, buf.get(15))
+        assertEquals(0, buf.get(16))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(7)
+        buf.putLong(0x8182838485868788L)
+        assertEquals(0x7c, buf.get(6))
+        assertEquals(0x88.toByte, buf.get(7))
+        assertEquals(0x87.toByte, buf.get(8))
+        assertEquals(0x86.toByte, buf.get(9))
+        assertEquals(0x85.toByte, buf.get(10))
+        assertEquals(0x84.toByte, buf.get(11))
+        assertEquals(0x83.toByte, buf.get(12))
+        assertEquals(0x82.toByte, buf.get(13))
+        assertEquals(0x81.toByte, buf.get(14))
+
+        assertThrows[BufferOverflowException] { buf.putLong(0xffff8384) }
+      } else {
+        val buf = allocBuffer(20)
+        assertThrows[ReadOnlyBufferException] { buf.putLong(0x75767778) }
+        assertEquals(0, buf.get(0))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("absolute getLong") {
+      val buf = withContent(20, elemRange(0x76, 0x8a): _*)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(0x797a7b7c7d7e7f80L, buf.getLong(3))
+      assertEquals(0, buf.position)
+      assertEquals(0x7c7d7e7f80818283L, buf.getLong(6))
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(6)
+      assertEquals(0x8584838281807f7eL, buf.getLong(8))
+      assertEquals(0x8988878685848382L, buf.getLong(12))
+
+      assertThrows[IndexOutOfBoundsException] { buf.getLong(15) }
+    }
+
+    test("absolute putLong") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(20)
+        buf.putLong(2, 0x7b7c7d7e7f808182L)
+        assertEquals(0, buf.position())
+        assertEquals(0, buf.get(0))
+        assertEquals(0x7b, buf.get(2))
+        assertEquals(0x7c, buf.get(3))
+        assertEquals(0x7d, buf.get(4))
+        assertEquals(0x7e, buf.get(5))
+        assertEquals(0x7f, buf.get(6))
+        assertEquals(0x80.toByte, buf.get(7))
+        assertEquals(0x81.toByte, buf.get(8))
+        assertEquals(0x82.toByte, buf.get(9))
+        buf.putLong(7, 0x7d7e7f8081828384L)
+        assertEquals(0x7f, buf.get(6))
+        assertEquals(0x7d, buf.get(7))
+        assertEquals(0x7e, buf.get(8))
+        assertEquals(0x7f, buf.get(9))
+        assertEquals(0x80.toByte, buf.get(10))
+        assertEquals(0x81.toByte, buf.get(11))
+        assertEquals(0x82.toByte, buf.get(12))
+        assertEquals(0x83.toByte, buf.get(13))
+        assertEquals(0x84.toByte, buf.get(14))
+        assertEquals(0, buf.get(15))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(11)
+        buf.putLong(9, 0x8182838485868788L)
+        assertEquals(0x7e, buf.get(8))
+        assertEquals(0x88.toByte, buf.get(9))
+        assertEquals(0x87.toByte, buf.get(10))
+        assertEquals(0x86.toByte, buf.get(11))
+        assertEquals(0x85.toByte, buf.get(12))
+        assertEquals(0x84.toByte, buf.get(13))
+        assertEquals(0x83.toByte, buf.get(14))
+        assertEquals(0x82.toByte, buf.get(15))
+        assertEquals(0x81.toByte, buf.get(16))
+
+        assertThrows[IndexOutOfBoundsException] { buf.putLong(16, 0xffff8384) }
+      } else {
+        val buf = allocBuffer(20)
+        assertThrows[ReadOnlyBufferException] { buf.putLong(3, 0x7576) }
+        assertEquals(0, buf.get(3))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("asLongBuffer - Bytes to Longs") {
+      val buf = withContent(20, elemRange(0x76, 0x8a): _*)
+      buf.limit(19).position(3)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      val longBuf1 = buf.asLongBuffer()
+      assertEquals(createsReadOnly, longBuf1.isReadOnly())
+      assertEquals(2, longBuf1.capacity)
+      assertEquals(0, longBuf1.position)
+      assertEquals(2, longBuf1.limit)
+      assertEquals(ByteOrder.BIG_ENDIAN, longBuf1.order)
+      assertEquals(0x8182838485868788L, longBuf1.get(1))
+      assertEquals(0, longBuf1.position)
+      assertEquals(0x797a7b7c7d7e7f80L, longBuf1.get())
+      assertEquals(1, longBuf1.position)
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      val longBuf2 = buf.asLongBuffer()
+      assertEquals(createsReadOnly, longBuf2.isReadOnly())
+      assertEquals(2, longBuf2.capacity)
+      assertEquals(0, longBuf2.position)
+      assertEquals(2, longBuf2.limit)
+      assertEquals(ByteOrder.LITTLE_ENDIAN, longBuf2.order)
+      assertEquals(0x8887868584838281L, longBuf2.get(1))
+      assertEquals(0, longBuf2.position)
+      assertEquals(0x807f7e7d7c7b7a79L, longBuf2.get())
+      assertEquals(1, longBuf2.position)
+    }
+
+    test("asLongBuffer - Longs to Bytes") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(20)
+        buf.limit(19).position(3)
+
+        buf.order(ByteOrder.BIG_ENDIAN)
+        val longBuf1 = buf.asLongBuffer()
+        longBuf1.put(1, 0x8182838485868788L)
+        assertEquals(0x81.toByte, buf.get(11))
+        assertEquals(0x82.toByte, buf.get(12))
+        assertEquals(0x83.toByte, buf.get(13))
+        assertEquals(0x84.toByte, buf.get(14))
+        assertEquals(0x85.toByte, buf.get(15))
+        assertEquals(0x86.toByte, buf.get(16))
+        assertEquals(0x87.toByte, buf.get(17))
+        assertEquals(0x88.toByte, buf.get(18))
+        assertEquals(0, longBuf1.position)
+        longBuf1.put(0x797a7b7c7d7e7f80L)
+        assertEquals(0x79, buf.get(3))
+        assertEquals(0x7a, buf.get(4))
+        assertEquals(0x7b, buf.get(5))
+        assertEquals(0x7c, buf.get(6))
+        assertEquals(0x7d, buf.get(7))
+        assertEquals(0x7e, buf.get(8))
+        assertEquals(0x7f, buf.get(9))
+        assertEquals(0x80.toByte, buf.get(10))
+        assertEquals(1, longBuf1.position)
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        val longBuf2 = buf.asLongBuffer()
+        longBuf2.put(1, 0x8182838485868788L)
+        assertEquals(0x88.toByte, buf.get(11))
+        assertEquals(0x87.toByte, buf.get(12))
+        assertEquals(0x86.toByte, buf.get(13))
+        assertEquals(0x85.toByte, buf.get(14))
+        assertEquals(0x84.toByte, buf.get(15))
+        assertEquals(0x83.toByte, buf.get(16))
+        assertEquals(0x82.toByte, buf.get(17))
+        assertEquals(0x81.toByte, buf.get(18))
+        assertEquals(0, longBuf2.position)
+        longBuf2.put(0x797a7b7c7d7e7f80L)
+        assertEquals(0x80.toByte, buf.get(3))
+        assertEquals(0x7f, buf.get(4))
+        assertEquals(0x7e, buf.get(5))
+        assertEquals(0x7d, buf.get(6))
+        assertEquals(0x7c, buf.get(7))
+        assertEquals(0x7b, buf.get(8))
+        assertEquals(0x7a, buf.get(9))
+        assertEquals(0x79, buf.get(10))
+        assertEquals(1, longBuf2.position)
+      } else {
+        val buf = allocBuffer(20)
+        buf.limit(19).position(3)
+
+        val longBuf1 = buf.asReadOnlyBuffer().asLongBuffer()
+        assertThrows[ReadOnlyBufferException] {
+          longBuf1.put(1, 0x8182838485868788L)
+        }
+      }
+    }
+
+    test("relative getFloat") {
+      val buf = withContent(pos = 0,
+                            limit = 10,
+                            capacity = 10,
+                            0x40,
+                            0x49,
+                            0x0f,
+                            0xd8.toByte,
+                            0x43,
+                            0x17,
+                            0x30,
+                            0x62,
+                            0x4d,
+                            0xab.toByte)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(3.141592f, buf.getFloat())
+      assertEquals(4, buf.position)
+      assertEquals(151.189f, buf.getFloat())
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(6)
+      assertEquals(-7.2966893e-13f, buf.getFloat())
+
+      assertThrows[BufferUnderflowException] { buf.getFloat() }
+    }
+
+    test("relative putFloat") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(10)
+        buf.putFloat(3.141592f)
+        assertEquals(4, buf.position())
+        assertEquals(0x40, buf.get(0))
+        assertEquals(0x49, buf.get(1))
+        assertEquals(0x0f, buf.get(2))
+        assertEquals(0xd8.toByte, buf.get(3))
+        buf.putFloat(151.189f)
+        assertEquals(0x43, buf.get(4))
+        assertEquals(0x17, buf.get(5))
+        assertEquals(0x30, buf.get(6))
+        assertEquals(0x62, buf.get(7))
+        assertEquals(0, buf.get(8))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(3)
+        buf.putFloat(-7.2966893e-13f)
+        assertEquals(0x0f, buf.get(2))
+        assertEquals(0x30, buf.get(3))
+        assertEquals(0x62, buf.get(4))
+        assertEquals(0x4d, buf.get(5))
+        assertEquals(0xab.toByte, buf.get(6))
+
+        assertThrows[BufferOverflowException] { buf.putFloat(654.4f) }
+      } else {
+        val buf = allocBuffer(10)
+        assertThrows[ReadOnlyBufferException] { buf.putFloat(151.189f) }
+        assertEquals(0, buf.get(0))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("absolute getFloat") {
+      val buf = withContent(pos = 0,
+                            limit = 10,
+                            capacity = 10,
+                            0x40,
+                            0x49,
+                            0x0f,
+                            0xd8.toByte,
+                            0x43,
+                            0x17,
+                            0x30,
+                            0x62,
+                            0x4d,
+                            0xab.toByte)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(3.141592f, buf.getFloat(0))
+      assertEquals(0, buf.position)
+      assertEquals(151.189f, buf.getFloat(4))
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(8)
+      assertEquals(-7.2966893e-13f, buf.getFloat(6))
+
+      assertThrows[IndexOutOfBoundsException] { buf.getFloat(7) }
+    }
+
+    test("absolute putFloat") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(10)
+        buf.putFloat(2, 3.141592f)
+        assertEquals(0, buf.position())
+        assertEquals(0, buf.get(0))
+        assertEquals(0x40, buf.get(2))
+        assertEquals(0x49, buf.get(3))
+        assertEquals(0x0f, buf.get(4))
+        assertEquals(0xd8.toByte, buf.get(5))
+        buf.putFloat(5, 151.189f)
+        assertEquals(0x0f, buf.get(4))
+        assertEquals(0x43, buf.get(5))
+        assertEquals(0x17, buf.get(6))
+        assertEquals(0x30, buf.get(7))
+        assertEquals(0x62, buf.get(8))
+        assertEquals(0, buf.get(9))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(7)
+        buf.putFloat(5, -7.2966893e-13f)
+        assertEquals(0x0f, buf.get(4))
+        assertEquals(0x30, buf.get(5))
+        assertEquals(0x62, buf.get(6))
+        assertEquals(0x4d, buf.get(7))
+        assertEquals(0xab.toByte, buf.get(8))
+
+        assertThrows[IndexOutOfBoundsException] { buf.putFloat(9, 3.141592f) }
+      } else {
+        val buf = allocBuffer(10)
+        assertThrows[ReadOnlyBufferException] { buf.putFloat(3, 151.189f) }
+        assertEquals(0, buf.get(3))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("asFloatBuffer - Bytes to Floats") {
+      val buf = withContent(pos = 0,
+                            limit = 12,
+                            capacity = 12,
+                            0x10,
+                            0x23,
+                            0x40,
+                            0x49,
+                            0x0f,
+                            0xd8.toByte,
+                            0x62,
+                            0x30,
+                            0x17,
+                            0x43,
+                            0x4d,
+                            0xab.toByte)
+      buf.limit(11).position(2)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      val floatBuf1 = buf.asFloatBuffer()
+      assertEquals(createsReadOnly, floatBuf1.isReadOnly())
+      assertEquals(2, floatBuf1.capacity)
+      assertEquals(0, floatBuf1.position)
+      assertEquals(2, floatBuf1.limit)
+      assertEquals(ByteOrder.BIG_ENDIAN, floatBuf1.order)
+      assertEquals(8.120758e20f, floatBuf1.get(1))
+      assertEquals(0, floatBuf1.position)
+      assertEquals(3.141592f, floatBuf1.get())
+      assertEquals(1, floatBuf1.position)
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      val floatBuf2 = buf.asFloatBuffer()
+      assertEquals(createsReadOnly, floatBuf2.isReadOnly())
+      assertEquals(2, floatBuf2.capacity)
+      assertEquals(0, floatBuf2.position)
+      assertEquals(2, floatBuf2.limit)
+      assertEquals(ByteOrder.LITTLE_ENDIAN, floatBuf2.order)
+      assertEquals(151.189f, floatBuf2.get(1))
+      assertEquals(0, floatBuf2.position)
+      assertEquals(-6.3017908e14f, floatBuf2.get())
+      assertEquals(1, floatBuf2.position)
+    }
+
+    test("asFloatBuffer - Floats to Bytes") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(14)
+        buf.limit(10).position(1)
+
+        buf.order(ByteOrder.BIG_ENDIAN)
+        val floatBuf1 = buf.asFloatBuffer()
+        floatBuf1.put(1, 3.141592f)
+        assertEquals(0x40, buf.get(5))
+        assertEquals(0x49, buf.get(6))
+        assertEquals(0x0f, buf.get(7))
+        assertEquals(0xd8.toByte, buf.get(8))
+        assertEquals(0, floatBuf1.position)
+        floatBuf1.put(151.189f)
+        assertEquals(0x43, buf.get(1))
+        assertEquals(0x17, buf.get(2))
+        assertEquals(0x30, buf.get(3))
+        assertEquals(0x62, buf.get(4))
+        assertEquals(1, floatBuf1.position)
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        val floatBuf2 = buf.asFloatBuffer()
+        floatBuf2.put(1, 3.141592f)
+        assertEquals(0xd8.toByte, buf.get(5))
+        assertEquals(0x0f, buf.get(6))
+        assertEquals(0x49, buf.get(7))
+        assertEquals(0x40, buf.get(8))
+        assertEquals(0, floatBuf2.position)
+        floatBuf2.put(151.189f)
+        assertEquals(0x62, buf.get(1))
+        assertEquals(0x30, buf.get(2))
+        assertEquals(0x17, buf.get(3))
+        assertEquals(0x43, buf.get(4))
+        assertEquals(1, floatBuf2.position)
+      } else {
+        val buf = allocBuffer(14)
+        buf.limit(10).position(1)
+
+        val floatBuf1 = buf.asReadOnlyBuffer().asFloatBuffer()
+        assertThrows[ReadOnlyBufferException] { floatBuf1.put(1, 3.141592f) }
+      }
+    }
+
+    test("relative getDouble") {
+      val buf = withContent(
+        pos = 0,
+        limit = 20,
+        capacity = 20,
+        0x40,
+        0x09,
+        0x21,
+        0xfb.toByte,
+        0x54,
+        0x44,
+        0x2d,
+        0x18,
+        0x40,
+        0x97.toByte,
+        0x9c.toByte,
+        0xcb.toByte,
+        0xac.toByte,
+        0x71,
+        0x0c,
+        0xb3.toByte,
+        0x20,
+        0xe8.toByte,
+        0x74,
+        0xb5.toByte
+      )
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(Math.PI, buf.getDouble())
+      assertEquals(8, buf.position)
+      assertEquals(1511.1989, buf.getDouble())
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(12)
+      assertEquals(-3.492426300334232e-51, buf.getDouble())
+
+      assertThrows[BufferUnderflowException] { buf.getDouble() }
+    }
+
+    test("relative putDouble") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(20)
+        buf.putDouble(Math.PI)
+        assertEquals(8, buf.position())
+        assertEquals(0x40, buf.get(0))
+        assertEquals(0x09, buf.get(1))
+        assertEquals(0x21, buf.get(2))
+        assertEquals(0xfb.toByte, buf.get(3))
+        assertEquals(0x54, buf.get(4))
+        assertEquals(0x44, buf.get(5))
+        assertEquals(0x2d, buf.get(6))
+        assertEquals(0x18, buf.get(7))
+        buf.putDouble(1511.1989)
+        assertEquals(0x40, buf.get(8))
+        assertEquals(0x97.toByte, buf.get(9))
+        assertEquals(0x9c.toByte, buf.get(10))
+        assertEquals(0xcb.toByte, buf.get(11))
+        assertEquals(0xac.toByte, buf.get(12))
+        assertEquals(0x71, buf.get(13))
+        assertEquals(0x0c, buf.get(14))
+        assertEquals(0xb3.toByte, buf.get(15))
+        assertEquals(0, buf.get(16))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(7)
+        buf.putDouble(-3.492426300334232e-51)
+        assertEquals(0x2d, buf.get(6))
+        assertEquals(0xac.toByte, buf.get(7))
+        assertEquals(0x71, buf.get(8))
+        assertEquals(0x0c, buf.get(9))
+        assertEquals(0xb3.toByte, buf.get(10))
+        assertEquals(0x20, buf.get(11))
+        assertEquals(0xe8.toByte, buf.get(12))
+        assertEquals(0x74, buf.get(13))
+        assertEquals(0xb5.toByte, buf.get(14))
+
+        assertThrows[BufferOverflowException] { buf.putDouble(1511.1989) }
+      } else {
+        val buf = allocBuffer(20)
+        assertThrows[ReadOnlyBufferException] { buf.putDouble(1511.1989) }
+        assertEquals(0, buf.get(0))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("absolute getDouble") {
+      val buf = withContent(
+        pos = 0,
+        limit = 20,
+        capacity = 20,
+        0x40,
+        0x09,
+        0x21,
+        0xfb.toByte,
+        0x54,
+        0x44,
+        0x2d,
+        0x18,
+        0x40,
+        0x97.toByte,
+        0x9c.toByte,
+        0xcb.toByte,
+        0xac.toByte,
+        0x71,
+        0x0c,
+        0xb3.toByte,
+        0x20,
+        0xe8.toByte,
+        0x74,
+        0xb5.toByte
+      )
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      assertEquals(Math.PI, buf.getDouble(0))
+      assertEquals(0, buf.position)
+      assertEquals(1511.1989, buf.getDouble(8))
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      buf.position(8)
+      assertEquals(-3.492426300334232e-51, buf.getDouble(12))
+
+      assertThrows[IndexOutOfBoundsException] { buf.getDouble(15) }
+    }
+
+    test("absolute_putDouble") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(20)
+        buf.putDouble(2, Math.PI)
+        assertEquals(0, buf.position())
+        assertEquals(0, buf.get(0))
+        assertEquals(0x40, buf.get(2))
+        assertEquals(0x09, buf.get(3))
+        assertEquals(0x21, buf.get(4))
+        assertEquals(0xfb.toByte, buf.get(5))
+        assertEquals(0x54, buf.get(6))
+        assertEquals(0x44, buf.get(7))
+        assertEquals(0x2d, buf.get(8))
+        assertEquals(0x18, buf.get(9))
+        buf.putDouble(5, 1511.1989)
+        assertEquals(0x21, buf.get(4))
+        assertEquals(0x40, buf.get(5))
+        assertEquals(0x97.toByte, buf.get(6))
+        assertEquals(0x9c.toByte, buf.get(7))
+        assertEquals(0xcb.toByte, buf.get(8))
+        assertEquals(0xac.toByte, buf.get(9))
+        assertEquals(0x71, buf.get(10))
+        assertEquals(0x0c, buf.get(11))
+        assertEquals(0xb3.toByte, buf.get(12))
+        assertEquals(0, buf.get(13))
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        buf.position(7)
+        buf.putDouble(9, -3.492426300334232e-51)
+        assertEquals(0xcb.toByte, buf.get(8))
+        assertEquals(0xac.toByte, buf.get(9))
+        assertEquals(0x71, buf.get(10))
+        assertEquals(0x0c, buf.get(11))
+        assertEquals(0xb3.toByte, buf.get(12))
+        assertEquals(0x20, buf.get(13))
+        assertEquals(0xe8.toByte, buf.get(14))
+        assertEquals(0x74, buf.get(15))
+        assertEquals(0xb5.toByte, buf.get(16))
+
+        assertThrows[IndexOutOfBoundsException] { buf.putDouble(17, 1511.1989) }
+      } else {
+        val buf = allocBuffer(20)
+        assertThrows[ReadOnlyBufferException] { buf.putDouble(3, 1511.1989) }
+        assertEquals(0, buf.get(3))
+        assertEquals(0, buf.position())
+      }
+    }
+
+    test("asDoubleBuffer - Bytes to Doubles") {
+      val buf = withContent(
+        pos = 0,
+        limit = 20,
+        capacity = 20,
+        0x20,
+        0xe8.toByte,
+        0x40,
+        0x09,
+        0x21,
+        0xfb.toByte,
+        0x54,
+        0x44,
+        0x2d,
+        0x18,
+        0xb3.toByte,
+        0x0c,
+        0x71,
+        0xac.toByte,
+        0xcb.toByte,
+        0x9c.toByte,
+        0x97.toByte,
+        0x40,
+        0x74,
+        0xb5.toByte
+      )
+      buf.limit(19).position(2)
+
+      buf.order(ByteOrder.BIG_ENDIAN)
+      val doubleBuf1 = buf.asDoubleBuffer()
+      assertEquals(createsReadOnly, doubleBuf1.isReadOnly())
+      assertEquals(2, doubleBuf1.capacity)
+      assertEquals(0, doubleBuf1.position)
+      assertEquals(2, doubleBuf1.limit)
+      assertEquals(ByteOrder.BIG_ENDIAN, doubleBuf1.order)
+      assertEquals(-8.642954761616149e-63, doubleBuf1.get(1))
+      assertEquals(0, doubleBuf1.position)
+      assertEquals(Math.PI, doubleBuf1.get())
+      assertEquals(1, doubleBuf1.position)
+
+      buf.order(ByteOrder.LITTLE_ENDIAN)
+      val doubleBuf2 = buf.asDoubleBuffer()
+      assertEquals(createsReadOnly, doubleBuf2.isReadOnly())
+      assertEquals(2, doubleBuf2.capacity)
+      assertEquals(0, doubleBuf2.position)
+      assertEquals(2, doubleBuf2.limit)
+      assertEquals(ByteOrder.LITTLE_ENDIAN, doubleBuf2.order)
+      assertEquals(1511.1989, doubleBuf2.get(1))
+      assertEquals(0, doubleBuf2.position)
+      assertEquals(3.207375630676366e-192, doubleBuf2.get())
+      assertEquals(1, doubleBuf2.position)
+    }
+
+    test("asDoubleBuffer - Doubles to Bytes") {
+      if (!createsReadOnly) {
+        val buf = allocBuffer(20)
+        buf.limit(19).position(3)
+
+        buf.order(ByteOrder.BIG_ENDIAN)
+        val doubleBuf1 = buf.asDoubleBuffer()
+        doubleBuf1.put(1, Math.PI)
+        assertEquals(0x40, buf.get(11))
+        assertEquals(0x09, buf.get(12))
+        assertEquals(0x21, buf.get(13))
+        assertEquals(0xfb.toByte, buf.get(14))
+        assertEquals(0x54, buf.get(15))
+        assertEquals(0x44, buf.get(16))
+        assertEquals(0x2d, buf.get(17))
+        assertEquals(0x18, buf.get(18))
+        assertEquals(0, doubleBuf1.position)
+        doubleBuf1.put(1511.1989)
+        assertEquals(0x40, buf.get(3))
+        assertEquals(0x97.toByte, buf.get(4))
+        assertEquals(0x9c.toByte, buf.get(5))
+        assertEquals(0xcb.toByte, buf.get(6))
+        assertEquals(0xac.toByte, buf.get(7))
+        assertEquals(0x71, buf.get(8))
+        assertEquals(0x0c, buf.get(9))
+        assertEquals(0xb3.toByte, buf.get(10))
+        assertEquals(1, doubleBuf1.position)
+
+        buf.order(ByteOrder.LITTLE_ENDIAN)
+        val doubleBuf2 = buf.asDoubleBuffer()
+        doubleBuf2.put(1, Math.PI)
+        assertEquals(0x18, buf.get(11))
+        assertEquals(0x2d, buf.get(12))
+        assertEquals(0x44, buf.get(13))
+        assertEquals(0x54, buf.get(14))
+        assertEquals(0xfb.toByte, buf.get(15))
+        assertEquals(0x21, buf.get(16))
+        assertEquals(0x09, buf.get(17))
+        assertEquals(0x40, buf.get(18))
+        assertEquals(0, doubleBuf2.position)
+        doubleBuf2.put(1511.1989)
+        assertEquals(0xb3.toByte, buf.get(3))
+        assertEquals(0x0c, buf.get(4))
+        assertEquals(0x71, buf.get(5))
+        assertEquals(0xac.toByte, buf.get(6))
+        assertEquals(0xcb.toByte, buf.get(7))
+        assertEquals(0x9c.toByte, buf.get(8))
+        assertEquals(0x97.toByte, buf.get(9))
+        assertEquals(0x40, buf.get(10))
+        assertEquals(1, doubleBuf2.position)
+      } else {
+        val buf = allocBuffer(20)
+        buf.limit(19).position(3)
+
+        val doubleBuf1 = buf.asReadOnlyBuffer().asDoubleBuffer()
+        assertThrows[ReadOnlyBufferException] { doubleBuf1.put(1, Math.PI) }
+      }
+    }
+  }
+
+  runByteBufferTests()
+}
+
+object AllocByteBufferTest extends ByteBufferTest {
+  val factory: ByteBufferFactory =
+    new ByteBufferFactories.AllocByteBufferFactory
+}
+
+object WrappedByteBufferTest extends ByteBufferTest {
+  val factory: ByteBufferFactory =
+    new ByteBufferFactories.WrappedByteBufferFactory
+}
+
+object ReadOnlyWrappedByteBufferTest extends ByteBufferTest {
+  val factory: ByteBufferFactory =
+    new ByteBufferFactories.ReadOnlyWrappedByteBufferFactory
+}
+
+object SlicedAllocByteBufferTest extends ByteBufferTest {
+  val factory: ByteBufferFactory =
+    new ByteBufferFactories.SlicedAllocByteBufferFactory
+}

--- a/unit-tests/src/test/scala/java/nio/CharBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/CharBufferTest.scala
@@ -1,0 +1,193 @@
+package java.nio
+
+import java.nio.BufferFactory.CharBufferFactory
+import java.nio.ByteBufferFactories._
+
+// Ported from Scala.js
+abstract class CharBufferTest extends BaseBufferTest {
+  type Factory = BufferFactory.CharBufferFactory
+
+  def zeros(n: Int): String =
+    "\u0000" * n
+
+  class AllocCharBufferFactory extends Factory {
+    def allocBuffer(capacity: Int): CharBuffer =
+      CharBuffer.allocate(capacity)
+  }
+
+  class WrappedCharBufferFactory
+      extends Factory
+      with BufferFactory.WrappedBufferFactory {
+    def baseWrap(array: Array[Char]): CharBuffer =
+      CharBuffer.wrap(array)
+
+    def baseWrap(array: Array[Char], offset: Int, length: Int): CharBuffer =
+      CharBuffer.wrap(array, offset, length)
+  }
+
+  class ByteBufferCharViewFactory(
+      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      order: ByteOrder)
+      extends Factory
+      with BufferFactory.ByteBufferViewFactory {
+    require(!byteBufferFactory.createsReadOnly)
+
+    def baseAllocBuffer(capacity: Int): CharBuffer =
+      byteBufferFactory.allocBuffer(capacity * 2).order(order).asCharBuffer()
+  }
+}
+
+object AllocCharBufferTest extends CharBufferTest {
+  val factory: CharBufferFactory = new AllocCharBufferFactory
+}
+
+object WrappedCharBufferTest extends CharBufferTest {
+  val factory: CharBufferFactory = new WrappedCharBufferFactory
+}
+
+object WrappedCharReadOnlyBufferTest extends CharBufferTest {
+  val factory: CharBufferFactory =
+    new WrappedCharBufferFactory with BufferFactory.ReadOnlyBufferFactory
+}
+
+object AllocCharSlicedBufferTest extends CharBufferTest {
+  val factory: CharBufferFactory =
+    new AllocCharBufferFactory with BufferFactory.SlicedBufferFactory
+}
+
+object CharBufferWrappingACharSequenceTest extends CharBufferTest {
+
+  val factory: CharBufferFactory = new CharBufferWrappingACharSequenceFactory
+
+  class CharBufferWrappingACharSequenceFactory extends Factory {
+    override val createsReadOnly = true
+
+    def allocBuffer(capacity: Int): CharBuffer = {
+      if (capacity < 0)
+        throw new IllegalArgumentException
+      CharBuffer.wrap(zeros(capacity))
+    }
+
+    override def allocBuffer(pos: Int,
+                             limit: Int,
+                             capacity: Int): CharBuffer = {
+      if (capacity < 0)
+        throw new IllegalArgumentException
+      CharBuffer.wrap(zeros(capacity), pos, limit)
+    }
+
+    override def withContent(pos: Int,
+                             limit: Int,
+                             capacity: Int,
+                             content: Char*): CharBuffer = {
+      val after = capacity - (pos + content.size)
+      CharBuffer.wrap(zeros(pos) + content.mkString + zeros(after), pos, limit)
+    }
+  }
+}
+
+object SlicedCharBufferWrappingACharSequenceTest extends CharBufferTest {
+
+  val factory: CharBufferFactory =
+    new SlicedCharBufferWrappingACharSequenceFactory
+
+  class SlicedCharBufferWrappingACharSequenceFactory extends Factory {
+    override val createsReadOnly = true
+
+    def allocBuffer(capacity: Int): CharBuffer = {
+      if (capacity < 0)
+        throw new IllegalArgumentException
+      val buf = CharBuffer.wrap(zeros(capacity + 25))
+      buf.position(17)
+      buf.limit(17 + capacity)
+      buf.slice()
+    }
+
+    override def withContent(pos: Int,
+                             limit: Int,
+                             capacity: Int,
+                             content: Char*): CharBuffer = {
+      if (!(0 <= pos && pos <= limit && limit <= capacity))
+        throw new IllegalArgumentException
+      val after = (25 + capacity) - (9 + pos + content.size)
+      val buf =
+        CharBuffer.wrap(zeros(9 + pos) + content.mkString + zeros(after))
+      buf.position(9)
+      buf.limit(9 + capacity)
+      val buf2 = buf.slice()
+      buf2.position(pos)
+      buf2.limit(limit)
+      buf2
+    }
+  }
+}
+
+// Char views of byte buffers
+
+abstract class CharViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends CharBufferTest {
+  val factory: CharBufferFactory =
+    new ByteBufferCharViewFactory(byteBufferFactory, order)
+}
+
+object CharViewOfAllocByteBufferBigEndianTest
+    extends CharViewOfByteBufferTest(new AllocByteBufferFactory,
+                                     ByteOrder.BIG_ENDIAN)
+
+object CharViewOfWrappedByteBufferBigEndianTest
+    extends CharViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                     ByteOrder.BIG_ENDIAN)
+
+object CharViewOfSlicedAllocByteBufferBigEndianTest
+    extends CharViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                     ByteOrder.BIG_ENDIAN)
+
+object CharViewOfAllocByteBufferLittleEndianTest
+    extends CharViewOfByteBufferTest(new AllocByteBufferFactory,
+                                     ByteOrder.LITTLE_ENDIAN)
+
+object CharViewOfWrappedByteBufferLittleEndianTest
+    extends CharViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                     ByteOrder.LITTLE_ENDIAN)
+
+object CharViewOfSlicedAllocByteBufferLittleEndianTest
+    extends CharViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                     ByteOrder.LITTLE_ENDIAN)
+
+// Read only Char views of byte buffers
+
+abstract class ReadOnlyCharViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends CharBufferTest {
+  val factory: CharBufferFactory =
+    new ByteBufferCharViewFactory(byteBufferFactory, order)
+    with BufferFactory.ReadOnlyBufferFactory
+
+}
+
+object ReadOnlyCharViewOfAllocByteBufferBigEndianTest
+    extends ReadOnlyCharViewOfByteBufferTest(new AllocByteBufferFactory,
+                                             ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyCharViewOfWrappedByteBufferBigEndianTest
+    extends ReadOnlyCharViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                             ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyCharViewOfSlicedAllocByteBufferBigEndianTest
+    extends ReadOnlyCharViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                             ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyCharViewOfAllocByteBufferLittleEndianTest
+    extends ReadOnlyCharViewOfByteBufferTest(new AllocByteBufferFactory,
+                                             ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyCharViewOfWrappedByteBufferLittleEndianTest
+    extends ReadOnlyCharViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                             ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyCharViewOfSlicedAllocByteBufferLittleEndianTest
+    extends ReadOnlyCharViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                             ByteOrder.LITTLE_ENDIAN)

--- a/unit-tests/src/test/scala/java/nio/DoubleBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/DoubleBufferTest.scala
@@ -1,0 +1,125 @@
+package java.nio
+
+import java.nio.ByteBufferFactories._
+
+// Ported from Scala.js
+abstract class DoubleBufferTest extends BaseBufferTest {
+  type Factory = BufferFactory.DoubleBufferFactory
+
+  class AllocDoubleBufferFactory extends Factory {
+    def allocBuffer(capacity: Int): DoubleBuffer =
+      DoubleBuffer.allocate(capacity)
+  }
+
+  class WrappedDoubleBufferFactory
+      extends Factory
+      with BufferFactory.WrappedBufferFactory {
+    def baseWrap(array: Array[Double]): DoubleBuffer =
+      DoubleBuffer.wrap(array)
+
+    def baseWrap(array: Array[Double], offset: Int, length: Int): DoubleBuffer =
+      DoubleBuffer.wrap(array, offset, length)
+  }
+
+  class ByteBufferDoubleViewFactory(
+      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      order: ByteOrder)
+      extends Factory
+      with BufferFactory.ByteBufferViewFactory {
+    require(!byteBufferFactory.createsReadOnly)
+
+    def baseAllocBuffer(capacity: Int): DoubleBuffer =
+      byteBufferFactory.allocBuffer(capacity * 8).order(order).asDoubleBuffer()
+  }
+
+}
+
+object AllocDoubleBufferTest extends DoubleBufferTest {
+  val factory: Factory = new AllocDoubleBufferFactory
+}
+
+object WrappedDoubleBufferTest extends DoubleBufferTest {
+  val factory: Factory = new WrappedDoubleBufferFactory
+}
+
+object WrappedDoubleReadOnlyBufferTest extends DoubleBufferTest {
+  val factory: Factory =
+    new WrappedDoubleBufferFactory with BufferFactory.ReadOnlyBufferFactory
+}
+
+object AllocDoubleSlicedBufferTest extends DoubleBufferTest {
+  val factory: Factory =
+    new AllocDoubleBufferFactory with BufferFactory.SlicedBufferFactory
+}
+
+// Double views of byte buffers
+
+abstract class DoubleViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends DoubleBufferTest {
+
+  val factory: BufferFactory.DoubleBufferFactory =
+    new ByteBufferDoubleViewFactory(byteBufferFactory, order)
+}
+
+object DoubleViewOfAllocByteBufferBigEndianTest
+    extends DoubleViewOfByteBufferTest(new AllocByteBufferFactory,
+                                       ByteOrder.BIG_ENDIAN)
+
+object DoubleViewOfWrappedByteBufferBigEndianTest
+    extends DoubleViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                       ByteOrder.BIG_ENDIAN)
+
+object DoubleViewOfSlicedAllocByteBufferBigEndianTest
+    extends DoubleViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                       ByteOrder.BIG_ENDIAN)
+
+object DoubleViewOfAllocByteBufferLittleEndianTest
+    extends DoubleViewOfByteBufferTest(new AllocByteBufferFactory,
+                                       ByteOrder.LITTLE_ENDIAN)
+
+object DoubleViewOfWrappedByteBufferLittleEndianTest
+    extends DoubleViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                       ByteOrder.LITTLE_ENDIAN)
+
+object DoubleViewOfSlicedAllocByteBufferLittleEndianTest
+    extends DoubleViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                       ByteOrder.LITTLE_ENDIAN)
+
+// Read only Double views of byte buffers
+
+abstract class ReadOnlyDoubleViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends DoubleBufferTest {
+
+  val factory: BufferFactory.DoubleBufferFactory = {
+    new ByteBufferDoubleViewFactory(byteBufferFactory, order)
+    with BufferFactory.ReadOnlyBufferFactory
+  }
+}
+
+object ReadOnlyDoubleViewOfAllocByteBufferBigEndianTest
+    extends ReadOnlyDoubleViewOfByteBufferTest(new AllocByteBufferFactory,
+                                               ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyDoubleViewOfWrappedByteBufferBigEndianTest
+    extends ReadOnlyDoubleViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                               ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyDoubleViewOfSlicedAllocByteBufferBigEndianTest
+    extends ReadOnlyDoubleViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                               ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyDoubleViewOfAllocByteBufferLittleEndianTest
+    extends ReadOnlyDoubleViewOfByteBufferTest(new AllocByteBufferFactory,
+                                               ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyDoubleViewOfWrappedByteBufferLittleEndianTest
+    extends ReadOnlyDoubleViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                               ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyDoubleViewOfSlicedAllocByteBufferLittleEndianTest
+    extends ReadOnlyDoubleViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                               ByteOrder.LITTLE_ENDIAN)

--- a/unit-tests/src/test/scala/java/nio/FloatBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/FloatBufferTest.scala
@@ -1,0 +1,124 @@
+package java.nio
+import java.nio.ByteBufferFactories._
+
+// Ported from Scala.js
+abstract class FloatBufferTest extends BaseBufferTest {
+  type Factory = BufferFactory.FloatBufferFactory
+
+  class AllocFloatBufferFactory extends Factory {
+    def allocBuffer(capacity: Int): FloatBuffer =
+      FloatBuffer.allocate(capacity)
+  }
+
+  class WrappedFloatBufferFactory
+      extends Factory
+      with BufferFactory.WrappedBufferFactory {
+    def baseWrap(array: Array[Float]): FloatBuffer =
+      FloatBuffer.wrap(array)
+
+    def baseWrap(array: Array[Float], offset: Int, length: Int): FloatBuffer =
+      FloatBuffer.wrap(array, offset, length)
+  }
+
+  class ByteBufferFloatViewFactory(
+      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      order: ByteOrder)
+      extends Factory
+      with BufferFactory.ByteBufferViewFactory {
+    require(!byteBufferFactory.createsReadOnly)
+
+    def baseAllocBuffer(capacity: Int): FloatBuffer =
+      byteBufferFactory.allocBuffer(capacity * 4).order(order).asFloatBuffer()
+  }
+
+}
+
+object AllocFloatBufferTest extends FloatBufferTest {
+  val factory: Factory = new AllocFloatBufferFactory
+}
+
+object WrappedFloatBufferTest extends FloatBufferTest {
+  val factory: Factory = new WrappedFloatBufferFactory
+}
+
+object WrappedFloatReadOnlyBufferTest extends FloatBufferTest {
+  val factory: Factory =
+    new WrappedFloatBufferFactory with BufferFactory.ReadOnlyBufferFactory
+}
+
+object AllocFloatSlicedBufferTest extends FloatBufferTest {
+  val factory: Factory =
+    new AllocFloatBufferFactory with BufferFactory.SlicedBufferFactory
+}
+
+// Float views of byte buffers
+
+abstract class FloatViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends FloatBufferTest {
+
+  val factory: BufferFactory.FloatBufferFactory =
+    new ByteBufferFloatViewFactory(byteBufferFactory, order)
+}
+
+object FloatViewOfAllocByteBufferBigEndianTest
+    extends FloatViewOfByteBufferTest(new AllocByteBufferFactory,
+                                      ByteOrder.BIG_ENDIAN)
+
+object FloatViewOfWrappedByteBufferBigEndianTest
+    extends FloatViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                      ByteOrder.BIG_ENDIAN)
+
+object FloatViewOfSlicedAllocByteBufferBigEndianTest
+    extends FloatViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                      ByteOrder.BIG_ENDIAN)
+
+object FloatViewOfAllocByteBufferLittleEndianTest
+    extends FloatViewOfByteBufferTest(new AllocByteBufferFactory,
+                                      ByteOrder.LITTLE_ENDIAN)
+
+object FloatViewOfWrappedByteBufferLittleEndianTest
+    extends FloatViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                      ByteOrder.LITTLE_ENDIAN)
+
+object FloatViewOfSlicedAllocByteBufferLittleEndianTest
+    extends FloatViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                      ByteOrder.LITTLE_ENDIAN)
+
+// Read only Float views of byte buffers
+
+abstract class ReadOnlyFloatViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends FloatBufferTest {
+
+  val factory: BufferFactory.FloatBufferFactory = {
+    new ByteBufferFloatViewFactory(byteBufferFactory, order)
+    with BufferFactory.ReadOnlyBufferFactory
+  }
+}
+
+object ReadOnlyFloatViewOfAllocByteBufferBigEndianTest
+    extends ReadOnlyFloatViewOfByteBufferTest(new AllocByteBufferFactory,
+                                              ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyFloatViewOfWrappedByteBufferBigEndianTest
+    extends ReadOnlyFloatViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                              ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyFloatViewOfSlicedAllocByteBufferBigEndianTest
+    extends ReadOnlyFloatViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                              ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyFloatViewOfAllocByteBufferLittleEndianTest
+    extends ReadOnlyFloatViewOfByteBufferTest(new AllocByteBufferFactory,
+                                              ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyFloatViewOfWrappedByteBufferLittleEndianTest
+    extends ReadOnlyFloatViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                              ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyFloatViewOfSlicedAllocByteBufferLittleEndianTest
+    extends ReadOnlyFloatViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                              ByteOrder.LITTLE_ENDIAN)

--- a/unit-tests/src/test/scala/java/nio/IntBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/IntBufferTest.scala
@@ -1,0 +1,123 @@
+package java.nio
+
+import java.nio.ByteBufferFactories._
+
+// Ported from Scala.js
+abstract class IntBufferTest extends BaseBufferTest {
+  type Factory = BufferFactory.IntBufferFactory
+
+  class AllocIntBufferFactory extends Factory {
+    def allocBuffer(capacity: Int): IntBuffer =
+      IntBuffer.allocate(capacity)
+  }
+
+  class WrappedIntBufferFactory
+      extends Factory
+      with BufferFactory.WrappedBufferFactory {
+    def baseWrap(array: Array[Int]): IntBuffer =
+      IntBuffer.wrap(array)
+
+    def baseWrap(array: Array[Int], offset: Int, length: Int): IntBuffer =
+      IntBuffer.wrap(array, offset, length)
+  }
+
+  class ByteBufferIntViewFactory(
+      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      order: ByteOrder)
+      extends Factory
+      with BufferFactory.ByteBufferViewFactory {
+    require(!byteBufferFactory.createsReadOnly)
+
+    def baseAllocBuffer(capacity: Int): IntBuffer =
+      byteBufferFactory.allocBuffer(capacity * 4).order(order).asIntBuffer()
+  }
+
+}
+
+object AllocIntBufferTest extends IntBufferTest {
+  val factory: Factory = new AllocIntBufferFactory
+}
+
+object WrappedIntBufferTest extends IntBufferTest {
+  val factory: Factory = new WrappedIntBufferFactory
+}
+
+object WrappedIntReadOnlyBufferTest extends IntBufferTest {
+  val factory: Factory =
+    new WrappedIntBufferFactory with BufferFactory.ReadOnlyBufferFactory
+}
+
+object AllocIntSlicedBufferTest extends IntBufferTest {
+  val factory: Factory =
+    new AllocIntBufferFactory with BufferFactory.SlicedBufferFactory
+}
+
+abstract class IntViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends IntBufferTest {
+
+  val factory: BufferFactory.IntBufferFactory =
+    new ByteBufferIntViewFactory(byteBufferFactory, order)
+}
+
+object IntViewOfAllocByteBufferBigEndianTest
+    extends IntViewOfByteBufferTest(new AllocByteBufferFactory,
+                                    ByteOrder.BIG_ENDIAN)
+
+object IntViewOfWrappedByteBufferBigEndianTest
+    extends IntViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                    ByteOrder.BIG_ENDIAN)
+
+object IntViewOfSlicedAllocByteBufferBigEndianTest
+    extends IntViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                    ByteOrder.BIG_ENDIAN)
+
+object IntViewOfAllocByteBufferLittleEndianTest
+    extends IntViewOfByteBufferTest(new AllocByteBufferFactory,
+                                    ByteOrder.LITTLE_ENDIAN)
+
+object IntViewOfWrappedByteBufferLittleEndianTest
+    extends IntViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                    ByteOrder.LITTLE_ENDIAN)
+
+object IntViewOfSlicedAllocByteBufferLittleEndianTest
+    extends IntViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                    ByteOrder.LITTLE_ENDIAN)
+
+// Read only Int views of byte buffers
+
+abstract class ReadOnlyIntViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends IntBufferTest {
+
+  val factory: BufferFactory.IntBufferFactory = {
+    new ByteBufferIntViewFactory(byteBufferFactory, order)
+    with BufferFactory.ReadOnlyBufferFactory
+  }
+}
+
+object ReadOnlyIntViewOfAllocByteBufferBigEndianTest
+    extends ReadOnlyIntViewOfByteBufferTest(new AllocByteBufferFactory,
+                                            ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyIntViewOfWrappedByteBufferBigEndianTest
+    extends ReadOnlyIntViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                            ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyIntViewOfSlicedAllocByteBufferBigEndianTest
+    extends ReadOnlyIntViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                            ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyIntViewOfAllocByteBufferFactoryEndianTest
+    extends ReadOnlyIntViewOfByteBufferTest(new AllocByteBufferFactory,
+                                            ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyIntViewOfWrappedByteBufferLittleEndianTest
+    extends ReadOnlyIntViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                            ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyIntViewOfSlicedAllocByteBufferLittleEndianTest
+    extends ReadOnlyIntViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                            ByteOrder.LITTLE_ENDIAN)

--- a/unit-tests/src/test/scala/java/nio/LongBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/LongBufferTest.scala
@@ -1,0 +1,125 @@
+package java.nio
+
+import java.nio.ByteBufferFactories._
+
+// Ported from Scala.js
+abstract class LongBufferTest extends BaseBufferTest {
+  type Factory = BufferFactory.LongBufferFactory
+
+  class AllocLongBufferFactory extends Factory {
+    def allocBuffer(capacity: Int): LongBuffer =
+      LongBuffer.allocate(capacity)
+  }
+
+  class WrappedLongBufferFactory
+      extends Factory
+      with BufferFactory.WrappedBufferFactory {
+    def baseWrap(array: Array[Long]): LongBuffer =
+      LongBuffer.wrap(array)
+
+    def baseWrap(array: Array[Long], offset: Int, length: Int): LongBuffer =
+      LongBuffer.wrap(array, offset, length)
+  }
+
+  class ByteBufferLongViewFactory(
+      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      order: ByteOrder)
+      extends Factory
+      with BufferFactory.ByteBufferViewFactory {
+    require(!byteBufferFactory.createsReadOnly)
+
+    def baseAllocBuffer(capacity: Int): LongBuffer =
+      byteBufferFactory.allocBuffer(capacity * 8).order(order).asLongBuffer()
+  }
+
+}
+
+object AllocLongBufferTest extends LongBufferTest {
+  val factory: Factory = new AllocLongBufferFactory
+}
+
+object WrappedLongBufferTest extends LongBufferTest {
+  val factory: Factory = new WrappedLongBufferFactory
+}
+
+object WrappedLongReadOnlyBufferTest extends LongBufferTest {
+  val factory: Factory =
+    new WrappedLongBufferFactory with BufferFactory.ReadOnlyBufferFactory
+}
+
+object AllocLongSlicedBufferTest extends LongBufferTest {
+  val factory: Factory =
+    new AllocLongBufferFactory with BufferFactory.SlicedBufferFactory
+}
+
+// Long views of byte buffers
+
+abstract class LongViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends LongBufferTest {
+
+  val factory: BufferFactory.LongBufferFactory =
+    new ByteBufferLongViewFactory(byteBufferFactory, order)
+}
+
+object LongViewOfAllocByteBufferBigEndianTest
+    extends LongViewOfByteBufferTest(new AllocByteBufferFactory,
+                                     ByteOrder.BIG_ENDIAN)
+
+object LongViewOfWrappedByteBufferBigEndianTest
+    extends LongViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                     ByteOrder.BIG_ENDIAN)
+
+object LongViewOfSlicedAllocByteBufferBigEndianTest
+    extends LongViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                     ByteOrder.BIG_ENDIAN)
+
+object LongViewOfAllocByteBufferLittleEndianTest
+    extends LongViewOfByteBufferTest(new AllocByteBufferFactory,
+                                     ByteOrder.LITTLE_ENDIAN)
+
+object LongViewOfWrappedByteBufferLittleEndianTest
+    extends LongViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                     ByteOrder.LITTLE_ENDIAN)
+
+object LongViewOfSlicedAllocByteBufferLittleEndianTest
+    extends LongViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                     ByteOrder.LITTLE_ENDIAN)
+
+// Read only Long views of byte buffers
+
+abstract class ReadOnlyLongViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends LongBufferTest {
+
+  val factory: BufferFactory.LongBufferFactory = {
+    new ByteBufferLongViewFactory(byteBufferFactory, order)
+    with BufferFactory.ReadOnlyBufferFactory
+  }
+}
+
+object ReadOnlyLongViewOfAllocByteBufferBigEndianTest
+    extends ReadOnlyLongViewOfByteBufferTest(new AllocByteBufferFactory,
+                                             ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyLongViewOfWrappedByteBufferBigEndianTest
+    extends ReadOnlyLongViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                             ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyLongViewOfSlicedAllocByteBufferBigEndianTest
+    extends ReadOnlyLongViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                             ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyLongViewOfAllocByteBufferLittleEndianTest
+    extends ReadOnlyLongViewOfByteBufferTest(new AllocByteBufferFactory,
+                                             ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyLongViewOfWrappedByteBufferLittleEndianTest
+    extends ReadOnlyLongViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                             ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyLongViewOfSlicedAllocByteBufferLittleEndianTest
+    extends ReadOnlyLongViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                             ByteOrder.LITTLE_ENDIAN)

--- a/unit-tests/src/test/scala/java/nio/ShortBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/ShortBufferTest.scala
@@ -1,0 +1,125 @@
+package java.nio
+
+import java.nio.ByteBufferFactories._
+
+// Ported from Scala.js
+abstract class ShortBufferTest extends BaseBufferTest {
+  type Factory = BufferFactory.ShortBufferFactory
+
+  class AllocShortBufferFactory extends Factory {
+    def allocBuffer(capacity: Int): ShortBuffer =
+      ShortBuffer.allocate(capacity)
+  }
+
+  class WrappedShortBufferFactory
+      extends Factory
+      with BufferFactory.WrappedBufferFactory {
+    def baseWrap(array: Array[Short]): ShortBuffer =
+      ShortBuffer.wrap(array)
+
+    def baseWrap(array: Array[Short], offset: Int, length: Int): ShortBuffer =
+      ShortBuffer.wrap(array, offset, length)
+  }
+
+  class ByteBufferShortViewFactory(
+      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      order: ByteOrder)
+      extends Factory
+      with BufferFactory.ByteBufferViewFactory {
+    require(!byteBufferFactory.createsReadOnly)
+
+    def baseAllocBuffer(capacity: Int): ShortBuffer =
+      byteBufferFactory.allocBuffer(capacity * 2).order(order).asShortBuffer()
+  }
+
+}
+
+object AllocShortBufferTest extends ShortBufferTest {
+  val factory: Factory = new AllocShortBufferFactory
+}
+
+object WrappedShortBufferTest extends ShortBufferTest {
+  val factory: Factory = new WrappedShortBufferFactory
+}
+
+object WrappedShortReadOnlyBufferTest extends ShortBufferTest {
+  val factory: Factory =
+    new WrappedShortBufferFactory with BufferFactory.ReadOnlyBufferFactory
+}
+
+object AllocShortSlicedBufferTest extends ShortBufferTest {
+  val factory: Factory =
+    new AllocShortBufferFactory with BufferFactory.SlicedBufferFactory
+}
+
+// Short views of byte buffers
+
+abstract class ShortViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends ShortBufferTest {
+
+  val factory: BufferFactory.ShortBufferFactory =
+    new ByteBufferShortViewFactory(byteBufferFactory, order)
+}
+
+object ShortViewOfAllocByteBufferBigEndianTest
+    extends ShortViewOfByteBufferTest(new AllocByteBufferFactory,
+                                      ByteOrder.BIG_ENDIAN)
+
+object ShortViewOfWrappedByteBufferBigEndianTest
+    extends ShortViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                      ByteOrder.BIG_ENDIAN)
+
+object ShortViewOfSlicedAllocByteBufferBigEndianTest
+    extends ShortViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                      ByteOrder.BIG_ENDIAN)
+
+object ShortViewOfAllocByteBufferLittleEndianTest
+    extends ShortViewOfByteBufferTest(new AllocByteBufferFactory,
+                                      ByteOrder.LITTLE_ENDIAN)
+
+object ShortViewOfWrappedByteBufferLittleEndianTest
+    extends ShortViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                      ByteOrder.LITTLE_ENDIAN)
+
+object ShortViewOfSlicedAllocByteBufferLittleEndianTest
+    extends ShortViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                      ByteOrder.LITTLE_ENDIAN)
+
+// Read only Short views of byte buffers
+
+abstract class ReadOnlyShortViewOfByteBufferTest(
+    byteBufferFactory: BufferFactory.ByteBufferFactory,
+    order: ByteOrder)
+    extends ShortBufferTest {
+
+  val factory: BufferFactory.ShortBufferFactory = {
+    new ByteBufferShortViewFactory(byteBufferFactory, order)
+    with BufferFactory.ReadOnlyBufferFactory
+  }
+}
+
+object ReadOnlyShortViewOfAllocByteBufferBigEndianTest
+    extends ReadOnlyShortViewOfByteBufferTest(new AllocByteBufferFactory,
+                                              ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyShortViewOfWrappedByteBufferBigEndianTest
+    extends ReadOnlyShortViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                              ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyShortViewOfSlicedAllocByteBufferBigEndianTest
+    extends ReadOnlyShortViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                              ByteOrder.BIG_ENDIAN)
+
+object ReadOnlyShortViewOfAllocByteBufferLittleEndianTest
+    extends ReadOnlyShortViewOfByteBufferTest(new AllocByteBufferFactory,
+                                              ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyShortViewOfWrappedByteBufferLittleEndianTest
+    extends ReadOnlyShortViewOfByteBufferTest(new WrappedByteBufferFactory,
+                                              ByteOrder.LITTLE_ENDIAN)
+
+object ReadOnlyShortViewOfSlicedAllocByteBufferLittleEndianTest
+    extends ReadOnlyShortViewOfByteBufferTest(new SlicedAllocByteBufferFactory,
+                                              ByteOrder.LITTLE_ENDIAN)


### PR DESCRIPTION
What's inside:
- Fixed a typo in `scala.scalanative.runtime.Platform.littleEndian`
- Port of java.nio buffers from Scala.js but simplified (all buffers are direct as ByteArray is "direct" itself, so we can't really have indirect buffers)
- Port of the test suite for buffers (arround 2000 total, they consist of less tests but repeated for a lot of buffer variations - for example IntBuffer, Int view of ByteBuffer with big and small endian, read-only IntBuffer etc.)

`assertThrow`s from the "allocate" test in BaseBufferTest are commented out because of #1079

Related to #925 