### PR TITLE
Implement #746 Add support for java.lang.{Process, ProcessBuilder}

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -421,7 +421,8 @@ lazy val tests =
         "HOME"                           -> baseDirectory.value.getAbsolutePath,
         "SCALA_NATIVE_ENV_WITH_EQUALS"   -> "1+1=2",
         "SCALA_NATIVE_ENV_WITHOUT_VALUE" -> "",
-        "SCALA_NATIVE_ENV_WITH_UNICODE"  -> 0x2192.toChar.toString
+        "SCALA_NATIVE_ENV_WITH_UNICODE"  -> 0x2192.toChar.toString,
+        "SCALA_NATIVE_USER_DIR"          -> System.getProperty("user.dir")
       )
     )
     .enablePlugins(ScalaNativePlugin)

--- a/javalib/src/main/scala/java/io/BufferedInputStream.scala
+++ b/javalib/src/main/scala/java/io/BufferedInputStream.scala
@@ -1,7 +1,7 @@
 package java.io
 
-class BufferedInputStream(in: InputStream, size: Int)
-    extends FilterInputStream(in)
+class BufferedInputStream(_in: InputStream, size: Int)
+    extends FilterInputStream(_in)
     with Closeable
     with AutoCloseable {
 

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -22,7 +22,7 @@ class FileInputStream(fd: FileDescriptor) extends InputStream {
   override protected def finalize(): Unit =
     close()
 
-  final def getFD: FileDescriptor =
+  final def getFD(): FileDescriptor =
     fd
 
   override def read(): Int = {

--- a/javalib/src/main/scala/java/lang/PipeIO.scala
+++ b/javalib/src/main/scala/java/lang/PipeIO.scala
@@ -1,0 +1,98 @@
+package java
+package lang
+
+import java.io._
+import scala.scalanative.native._, signal._
+import scala.scalanative.posix.sys.ioctl._
+
+/*
+ * Used to set up input/output streams for a child process spawned by
+ * a ProcessBuilder using the Redirect info for the stream.
+ */
+private[lang] final class PipeIO[T](val nullStream: T,
+                                    val fdStream: FileDescriptor => T)
+private[lang] object PipeIO {
+  def apply[T](
+      childFd: Int,
+      redirect: ProcessBuilder.Redirect
+  )(implicit ioStream: PipeIO[T]): T = {
+    redirect.`type` match {
+      case ProcessBuilder.Redirect.Type.PIPE =>
+        ioStream.fdStream(new FileDescriptor(childFd))
+      case _ =>
+        ioStream.nullStream
+    }
+  }
+  trait Stream extends InputStream {
+    def drain(): Unit = {}
+  }
+  class StreamImpl(is: FileInputStream)
+      extends BufferedInputStream(is)
+      with Stream {
+    override def available() = UnixProcess.locked { _ =>
+      super.available() match {
+        // Check the FileInputStream in case the BufferedInputStream hasn't been filled yet.
+        case 0 =>
+          in.available() match {
+            case 0 if !drained => availableFD()
+            case a             => a
+          }
+        case a => a
+      }
+    }
+    override def read(): Int = UnixProcess.locked { _ =>
+      super.read()
+    }
+    override def read(buf: Array[scala.Byte], offset: Int, len: Int) =
+      UnixProcess.locked { _ =>
+        super.read(buf, offset, len)
+      }
+    override def drain() = {
+      // No lock needed because it's called from the interrupt handler while
+      // the monitor thread is holding the lock.
+      var toRead                     = 0
+      var readBuf: Array[scala.Byte] = Array()
+      while ({
+        toRead = availableFD
+        toRead > 0
+      }) {
+        val size = if (readBuf == null) 0 else readBuf.size
+        readBuf =
+          if (readBuf == null) new Array[scala.Byte](toRead)
+          else {
+            readBuf = java.util.Arrays.copyOf(readBuf, size + toRead)
+            readBuf
+          }
+        val bytesRead = is.read(readBuf, size, toRead)
+      }
+      is.close()
+      this.in = new ByteArrayInputStream(readBuf)
+    }
+
+    private[this] var drained = false
+    private def availableFD() = {
+      val res = stackalloc[CInt]
+      ioctl(is.getFD.fd, FIONREAD, res.cast[Ptr[scala.Byte]]) match {
+        case -1 => 0
+        case _  => !res
+      }
+    }
+  }
+
+  implicit val InputPipeIO: PipeIO[Stream] =
+    new PipeIO(NullInput, fd => new StreamImpl(new FileInputStream(fd)))
+  implicit val outputPipeIO: PipeIO[OutputStream] =
+    new PipeIO(NullOutput,
+               fd => new BufferedOutputStream(new FileOutputStream(fd)))
+
+  private final object NullInput extends Stream {
+    override def available(): Int                                    = 0
+    override def close(): Unit                                       = {}
+    override def read(): Int                                         = 0
+    override def read(buf: Array[scala.Byte], offset: Int, len: Int) = -1
+  }
+  private final object NullOutput extends OutputStream {
+    override def close(): Unit       = {}
+    override def write(b: Int): Unit = {}
+  }
+}

--- a/javalib/src/main/scala/java/lang/Process.scala
+++ b/javalib/src/main/scala/java/lang/Process.scala
@@ -1,0 +1,24 @@
+package java.lang
+
+import java.io.{InputStream, OutputStream}
+import java.util.concurrent.TimeUnit
+
+abstract class Process {
+  def destroy(): Unit
+
+  def destroyForcibly(): Process
+
+  def exitValue(): Int
+
+  def getErrorStream(): InputStream
+
+  def getInputStream(): InputStream
+
+  def getOutputStream(): OutputStream
+
+  def isAlive(): scala.Boolean
+
+  def waitFor(): Int
+
+  def waitFor(timeout: scala.Long, unit: TimeUnit): scala.Boolean
+}

--- a/javalib/src/main/scala/java/lang/ProcessBuilder.scala
+++ b/javalib/src/main/scala/java/lang/ProcessBuilder.scala
@@ -1,0 +1,207 @@
+package java.lang
+
+import java.util.{ArrayList, List}
+import java.util.Map
+import java.io.{File, IOException}
+import java.util
+import java.util.Arrays
+import scala.scalanative.native._
+import scala.scalanative.posix.unistd
+import scala.scalanative.runtime.Platform
+import ProcessBuilder.Redirect
+
+final class ProcessBuilder(private var _command: List[String]) {
+  def this(command: Array[String]) {
+    this(Arrays.asList(command))
+  }
+
+  def command(): List[String] = _command
+
+  def command(command: Array[String]): ProcessBuilder =
+    set(_command = Arrays.asList(command))
+
+  def command(command: List[String]): ProcessBuilder = set(_command = command)
+
+  def environment(): Map[String, String] = _environment
+
+  def directory(): File = _directory
+
+  def directory(dir: File): ProcessBuilder =
+    set(_directory = dir match {
+      case null => defaultDirectory
+      case _    => dir
+    })
+
+  def inheritIO(): ProcessBuilder = {
+    redirectInput(Redirect.INHERIT)
+    redirectOutput(Redirect.INHERIT)
+    redirectError(Redirect.INHERIT)
+  }
+
+  def redirectError(destination: Redirect): ProcessBuilder = destination match {
+    case null => set(_redirectOutput = Redirect.PIPE)
+    case d =>
+      d.`type` match {
+        case Redirect.Type.READ =>
+          throw new IllegalArgumentException(
+            s"Redirect.READ cannot be used for error.")
+        case _ =>
+          set(_redirectError = destination)
+      }
+  }
+
+  def redirectInput(source: Redirect): ProcessBuilder = source match {
+    case null => set(_redirectInput = Redirect.PIPE)
+    case s =>
+      s.`type` match {
+        case Redirect.Type.WRITE | Redirect.Type.APPEND =>
+          throw new IllegalArgumentException(s"$s cannot be used for input.")
+        case _ =>
+          set(_redirectInput = source)
+      }
+  }
+
+  def redirectOutput(destination: Redirect): ProcessBuilder =
+    destination match {
+      case null => set(_redirectOutput = Redirect.PIPE)
+      case s =>
+        s.`type` match {
+          case Redirect.Type.READ =>
+            throw new IllegalArgumentException(
+              s"Redirect.READ cannot be used for output.")
+          case _ =>
+            set(_redirectOutput = destination)
+        }
+    }
+
+  def redirectInput(file: File): ProcessBuilder = {
+    redirectInput(Redirect.from(file))
+  }
+
+  def redirectOutput(file: File): ProcessBuilder = {
+    redirectOutput(Redirect.to(file))
+  }
+
+  def redirectError(file: File): ProcessBuilder = {
+    redirectError(Redirect.to(file))
+  }
+
+  def redirectInput(): Redirect = _redirectInput
+
+  def redirectOutput(): Redirect = _redirectOutput
+
+  def redirectError(): Redirect = _redirectError
+
+  def redirectErrorStream(): scala.Boolean = _redirectErrorStream
+
+  def redirectErrorStream(redirectErrorStream: scala.Boolean): ProcessBuilder =
+    set(_redirectErrorStream = redirectErrorStream)
+
+  def start(): Process = {
+    if (_command.isEmpty()) throw new IndexOutOfBoundsException()
+    if (_command.contains(null)) throw new NullPointerException()
+    if (Platform.isWindows) {
+      val msg = "No windows implementation of java.lang.Process"
+      throw new UnsupportedOperationException(msg)
+    } else {
+      UnixProcess(this)
+    }
+  }
+
+  @inline private[this] def set(f: => Unit): ProcessBuilder = {
+    f
+    this
+  }
+  private def defaultDirectory = System.getenv("user.dir") match {
+    case null => new File(".")
+    case f    => new File(f)
+  }
+  private var _directory = defaultDirectory
+  private val _environment = {
+    import scala.collection.JavaConverters._
+    val env = System.getenv
+    val res = new java.util.HashMap[String, String]
+    env.asScala foreach { case (k, v) => res.put(k, v) }
+    res
+  }
+  private var _redirectInput       = Redirect.PIPE
+  private var _redirectOutput      = Redirect.PIPE
+  private var _redirectError       = Redirect.PIPE
+  private var _redirectErrorStream = false
+}
+
+object ProcessBuilder {
+  abstract class Redirect {
+    def file(): File = null
+
+    def `type`(): Redirect.Type
+
+    override def equals(other: Any): scala.Boolean = other match {
+      case that: Redirect => file == that.file && `type` == that.`type`
+      case _              => false
+    }
+
+    override def hashCode(): Int = {
+      var hash = 1
+      hash = hash * 31 + file.hashCode()
+      hash = hash * 31 + `type`.hashCode()
+      hash
+    }
+  }
+
+  object Redirect {
+    private class RedirectImpl(tpe: Redirect.Type, file: File)
+        extends Redirect {
+      override def `type`(): Type = tpe
+
+      override def file(): File = file
+
+      override def toString =
+        s"Redirect.$tpe${if (file != null) s": ${file}" else ""}"
+    }
+
+    val INHERIT: Redirect = new RedirectImpl(Type.INHERIT, null)
+
+    val PIPE: Redirect = new RedirectImpl(Type.PIPE, null)
+
+    def appendTo(file: File): Redirect = {
+      if (file == null) throw new NullPointerException()
+      new RedirectImpl(Type.APPEND, file)
+    }
+
+    def from(file: File): Redirect = {
+      if (file == null) throw new NullPointerException()
+      new RedirectImpl(Type.READ, file)
+    }
+
+    def to(file: File): Redirect = {
+      if (file == null) throw new NullPointerException()
+      new RedirectImpl(Type.WRITE, file)
+    }
+
+    class Type private (name: String, ordinal: Int)
+        extends Enum[Type](name, ordinal)
+
+    object Type {
+      final val PIPE    = new Type("PIPE", 0)
+      final val INHERIT = new Type("INHERIT", 1)
+      final val READ    = new Type("READ", 2)
+      final val WRITE   = new Type("WRITE", 3)
+      final val APPEND  = new Type("APPEND", 4)
+
+      def valueOf(name: String): Type = {
+        if (name == null) throw new NullPointerException()
+        _values.toSeq.find(_.name == name) match {
+          case Some(t) => t
+          case None =>
+            throw new IllegalArgumentException(
+              s"$name is not a valid Type name")
+        }
+      }
+
+      def values(): Array[Type] = _values
+
+      private val _values = Array(PIPE, INHERIT, READ, WRITE, APPEND)
+    }
+  }
+}

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -63,6 +63,11 @@ object System {
         sysProps.setProperty("user.country", userCountry)
       }
       sysProps.setProperty("user.home", getenv("HOME"))
+      val buf = stackalloc[scala.Byte](1024)
+      unistd.getcwd(buf, 1024) match {
+        case null =>
+        case b    => sysProps.setProperty("user.dir", fromCString(b))
+      }
     }
 
     sysProps

--- a/javalib/src/main/scala/java/lang/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/UnixProcess.scala
@@ -1,0 +1,299 @@
+package java
+package lang
+
+import java.io.{File, IOException, InputStream, OutputStream}
+import java.util.concurrent.TimeUnit
+
+import scala.annotation.tailrec
+import scala.scalanative.native.{errno => err, signal => sig, _}
+import sig._
+import err.errno
+import scala.scalanative.posix.{fcntl, pthread, sys, unistd, errno => e}
+import sys.time._
+import e.ETIMEDOUT
+import UnixProcess._
+import java.lang.ProcessBuilder.Redirect
+
+import pthread._
+import scala.collection.mutable
+import scala.scalanative.posix.sys.types.{pthread_cond_t, pthread_mutex_t}
+
+private[lang] class UnixProcess private (
+    pid: CInt,
+    _inputStream: PipeIO.Stream,
+    _errorStream: PipeIO.Stream,
+    _outputStream: OutputStream
+) extends Process {
+  override def destroy(): Unit = kill(pid, 9)
+
+  override def destroyForcibly(): Process = {
+    destroy()
+    this
+  }
+
+  override def exitValue(): scala.Int = locked { _ =>
+    _exitValue match {
+      case -1 =>
+        throw new IllegalThreadStateException(
+          s"Process $pid has not exited yet")
+      case v => v
+    }
+  }
+
+  override def getErrorStream(): InputStream = _errorStream
+
+  override def getInputStream(): InputStream = _inputStream
+
+  override def getOutputStream(): OutputStream = _outputStream
+
+  override def isAlive(): scala.Boolean = locked(_ => _exitValue == -1)
+
+  override def toString = s"UnixProcess($pid)"
+
+  override def waitFor(): scala.Int = locked { m =>
+    _exitValue match {
+      case -1 =>
+        waitImpl(() => waitFor(m, null))
+        _exitValue
+      case v => v
+    }
+  }
+  override def waitFor(timeout: scala.Long, unit: TimeUnit): scala.Boolean =
+    locked {
+      case m =>
+        _exitValue match {
+          case -1 =>
+            val ts = stackalloc[timespec]
+            val tv = stackalloc[timeval]
+            throwOnError(gettimeofday(tv, null), "Failed to set time of day.")
+            val nsec = unit.toNanos(timeout) + TimeUnit.MICROSECONDS.toNanos(
+              !tv._2.cast[Ptr[CInt]])
+            val sec = TimeUnit.NANOSECONDS.toSeconds(nsec)
+            !ts._1 = !tv._1 + sec
+            !ts._2 = if (sec > 0) nsec - TimeUnit.SECONDS.toNanos(sec) else nsec
+            waitImpl(() => waitFor(m, ts)) == 0
+          case _ => true
+        }
+    }
+
+  @inline private def waitImpl(f: () => Int) = {
+    var res = 1
+    do res = f() while (if (res == 0) _exitValue == -1 else res != ETIMEDOUT)
+    res
+  }
+
+  private[this] var _condId    = 0
+  private[this] var _exitValue = -1
+  private[this] val _conds     = mutable.Map.empty[Int, PtrWrapper[pthread_cond_t]]
+  private def alertWaitingThreads(): Unit = {
+    _conds.values.foreach(c => pthread_cond_broadcast(c.value))
+  }
+  private def setExitValue(value: CInt): Unit = {
+    _exitValue = value
+    _inputStream.drain()
+    _errorStream.drain()
+    _outputStream.close()
+  }
+  private[this] def waitFor(mutex: PtrWrapper[pthread_mutex_t],
+                            ts: Ptr[timespec]): Int = Zone { implicit z =>
+    val id   = { _condId += 1; _condId }
+    val cond = alloc[scala.Byte](pthread_cond_t_size).cast[Ptr[pthread_cond_t]]
+    pthread_cond_init(cond, null)
+    _conds += id -> PtrWrapper(cond)
+    val res =
+      if (ts != null) pthread_cond_timedwait(cond, mutex.value, ts)
+      else pthread_cond_wait(cond, mutex.value)
+    _conds -= id
+    pthread_cond_destroy(cond)
+    res
+  }
+}
+
+object UnixProcess {
+  @link("pthread")
+  @extern
+  private[this] object ProcessMonitor {
+    type proc_info = CStruct2[CInt, CInt]
+    @name("scalanative_process_monitor_init")
+    def init(): Unit = extern
+
+    @name("scalanative_process_monitor_last_proc_info")
+    def lastProcInfo(info: Ptr[proc_info]): Unit = extern
+
+    @name("scalanative_process_monitor_shared_mutex")
+    def sharedMutex(): Ptr[pthread_mutex_t] = extern
+
+    @name("scalanative_process_monitor_wakeup")
+    def wakeup(): CInt = extern
+  }
+  ProcessMonitor.init()
+
+  case class PtrWrapper[T](value: Ptr[T])
+  def locked[R](f: PtrWrapper[pthread_mutex_t] => R): R = {
+    val mutex = ProcessMonitor.sharedMutex()
+    try {
+      throwOnError(pthread_mutex_lock(mutex), "Couldn't lock shared mutex.")
+      f(PtrWrapper(mutex))
+    } finally {
+      throwOnError(pthread_mutex_unlock(mutex), "Couldn't unlock shared mutex.")
+    }
+  }
+  def apply(builder: ProcessBuilder): Process = Zone { implicit z =>
+    import scala.collection.JavaConverters._
+    val infds  = stackalloc[CInt](2)
+    val outfds = stackalloc[CInt](2)
+    val errfds =
+      if (builder.redirectErrorStream) outfds else stackalloc[CInt](2)
+
+    throwOnError(unistd.pipe(infds), s"Couldn't create pipe.")
+    throwOnError(unistd.pipe(outfds), s"Couldn't create pipe.")
+    if (!builder.redirectErrorStream)
+      throwOnError(unistd.pipe(errfds), s"Couldn't create pipe.")
+
+    val cmd  = builder.command.asScala
+    val dir  = builder.directory
+    val argv = nullTerminate(cmd)
+    val envp = nullTerminate(builder.environment.asScala.map {
+      case (k, v) => s"$k=$v"
+    }.toSeq)
+    val binaries = binaryPaths(builder.environment, cmd.head)
+
+    /*
+     * Use vfork rather than fork to avoid copying the parent process memory to the child. It also
+     * ensures that the parent won't try to read or write to the child file descriptors before the
+     * child process has called execve. In an ideal world, we'd use posix_spawn, but it doesn't
+     * support changing the working directory of the child process or closing all of the unused
+     * parent file descriptors. Using posix_spawn would require adding an additional step in which
+     * we spawned a new process that called execve with a helper binary. This may be necessary
+     * eventually to increase portability but, for now, just use vfork, which is suppported on
+     * OSX and Linux (despite warnings about vfork's future, it seems somewhat unlikely that support
+     * will be dropped soon.
+     */
+    unistd.vfork() match {
+      case -1 =>
+        throw new IOException("Unable to fork process")
+      case 0 =>
+        if (dir != null) unistd.chdir(toCString(dir.toString))
+        setupChildFDS(!infds, builder.redirectInput, unistd.STDIN_FILENO)
+        setupChildFDS(!(outfds + 1),
+                      builder.redirectOutput,
+                      unistd.STDOUT_FILENO)
+        setupChildFDS(!(errfds + 1),
+                      if (builder.redirectErrorStream) Redirect.PIPE
+                      else builder.redirectError,
+                      unistd.STDERR_FILENO)
+        unistd.close(!infds)
+        unistd.close(!(infds + 1))
+        unistd.close(!outfds)
+        unistd.close(!(outfds + 1))
+        unistd.close(!errfds)
+        unistd.close(!(errfds + 1))
+
+        binaries.foreach { b =>
+          unistd.execve(toCString(b), argv, envp)
+        }
+        // The spec of vfork requires calling _exit if the child process fails to execve.
+        unistd._exit(1)
+        throw new IOException(s"Failed to create process for command: $cmd")
+      case pid =>
+        Seq(!(outfds + 1), !(errfds + 1), !infds) foreach unistd.close
+        val res = new UnixProcess(
+          pid,
+          PipeIO[PipeIO.Stream](!outfds, builder.redirectOutput),
+          PipeIO[PipeIO.Stream](!errfds, builder.redirectError),
+          PipeIO[OutputStream](!(infds + 1), builder.redirectInput)
+        )
+        processes += pid -> res
+        res
+    }
+  }
+
+  private val processes =
+    scala.collection.mutable.HashMap.empty[CInt, UnixProcess]
+  private def signalHandler(sig: CInt): Unit = {
+    val procInfo = stackalloc[ProcessMonitor.proc_info]
+    ProcessMonitor.lastProcInfo(procInfo)
+    val pid = !procInfo._1
+    processes get pid match {
+      case Some(process) =>
+        process.setExitValue(!procInfo._2)
+        processes -= pid
+        process.alertWaitingThreads()
+      case _ =>
+    }
+    throwOnError(ProcessMonitor.wakeup(), "Couldn't wake up process monitor.")
+  }
+  signal(SIGUSR1, CFunctionPtr.fromFunction1(signalHandler))
+
+  @inline
+  private[lang] def throwOnError(rc: CInt, msg: => String): CInt = {
+    if (rc != 0) {
+      throw new IOException(s"$msg Error code: $rc, Error number: $errno")
+    } else {
+      rc
+    }
+  }
+
+  @inline private def nullTerminate(seq: Seq[String])(implicit z: Zone) = {
+    val res = alloc[CString](seq.length + 1)
+    seq.zipWithIndex foreach { case (s, i) => !(res + i) = toCString(s) }
+    res
+  }
+
+  @inline private def setupChildFDS(childFd: CInt,
+                                    redirect: ProcessBuilder.Redirect,
+                                    procFd: CInt): Unit = {
+    import fcntl.{open => _, _}
+    redirect.`type` match {
+      case ProcessBuilder.Redirect.Type.INHERIT =>
+      case ProcessBuilder.Redirect.Type.PIPE =>
+        if (unistd.dup2(childFd, procFd) == -1) {
+          throw new IOException(
+            s"Couldn't duplicate pipe file descriptor $errno")
+        }
+      case r @ ProcessBuilder.Redirect.Type.READ =>
+        val fd = open(redirect.file, O_RDONLY)
+        if (unistd.dup2(fd, procFd) == -1) {
+          throw new IOException(
+            s"Couldn't duplicate read file descriptor $errno")
+        }
+      case r @ ProcessBuilder.Redirect.Type.WRITE =>
+        val fd = open(redirect.file, O_CREAT | O_WRONLY | O_TRUNC)
+        if (unistd.dup2(fd, procFd) == -1) {
+          throw new IOException(
+            s"Couldn't duplicate write file descriptor $errno")
+        }
+      case r @ ProcessBuilder.Redirect.Type.APPEND =>
+        val fd = open(redirect.file, O_CREAT | O_WRONLY | O_APPEND)
+        if (unistd.dup2(fd, procFd) == -1) {
+          throw new IOException(
+            s"Couldn't duplicate append file descriptor $errno")
+        }
+    }
+  }
+
+  @inline def open(f: File, flags: CInt) = Zone { implicit z =>
+    fcntl.open(toCString(f.getAbsolutePath), flags) match {
+      case -1 => throw new IOException(s"Unable to open file $f ($errno)")
+      case fd => fd
+    }
+  }
+
+  // The execvpe function isn't available on all platforms so find the possible binaries to exec.
+  private def binaryPaths(environment: java.util.Map[String, String],
+                          bin: String): Seq[String] = {
+    if ((bin startsWith "/") || (bin startsWith ".")) {
+      Seq(bin)
+    } else {
+      val path = environment get "PATH" match {
+        case null => "/bin:/usr/bin:/usr/local/bin"
+        case p    => p
+      }
+      path split ":" map { absPath =>
+        new File(s"$absPath/$bin")
+      } collect {
+        case f if f.canExecute => f.toString
+      }
+    }
+  }
+}

--- a/nativelib/src/main/resources/process_monitor.c
+++ b/nativelib/src/main/resources/process_monitor.c
@@ -1,0 +1,72 @@
+#include <pthread.h>
+#include <signal.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+
+#define RETURN_ON_ERROR(f) do { \
+    int res = f; \
+    if (res != 0) return res; \
+} while (0)
+
+struct proc_info {
+    int pid;
+    int result;
+};
+static pthread_mutex_t shared_mutex;
+static pthread_mutex_t private_mutex;
+static pthread_cond_t cond;
+static pthread_t main_thread;
+static int last_pid = -1;
+static int last_result = -1;
+
+void *wait_loop(void *arg) {
+    int status;
+    // Block all signals on the monitor thread.
+    sigset_t set;
+    sigfillset(&set);
+    pthread_sigmask(SIG_BLOCK, &set, NULL);
+
+    pthread_mutex_lock(&private_mutex);
+    while (1) {
+        int pid = waitpid(-1, &status, 0);
+        if (pid != -1) {
+            pthread_mutex_lock(&shared_mutex);
+            last_pid = pid;
+            last_result = WIFSIGNALED(status) ? 0x80 + status : status;
+            pthread_kill(main_thread, SIGUSR1);
+            // Wait until the main thread has handled the signal to start
+            // polling for pids again.
+            pthread_cond_wait(&cond, &private_mutex);
+            pthread_mutex_unlock(&shared_mutex);
+        }
+    }
+    // should be unreachable
+    pthread_mutex_unlock(&private_mutex);
+    return NULL;
+}
+
+pthread_mutex_t *scalanative_process_monitor_shared_mutex() {
+    return &shared_mutex;
+}
+
+void scalanative_process_monitor_last_proc_info(struct proc_info *info) {
+    info->pid = last_pid;
+    info->result = last_result;
+}
+
+int scalanative_process_monitor_wakeup() {
+    RETURN_ON_ERROR(pthread_mutex_lock(&private_mutex));
+    RETURN_ON_ERROR(pthread_cond_broadcast(&cond));
+    return pthread_mutex_unlock(&private_mutex);
+}
+
+void scalanative_process_monitor_init() {
+    pthread_t thread;
+    pthread_mutex_init(&shared_mutex, NULL);
+    pthread_mutex_init(&private_mutex, NULL);
+    pthread_cond_init(&cond, NULL);
+    pthread_create(&thread, NULL, wait_loop, NULL);
+    pthread_detach(thread);
+    main_thread = pthread_self();
+}

--- a/nativelib/src/main/resources/pthread.c
+++ b/nativelib/src/main/resources/pthread.c
@@ -1,0 +1,66 @@
+#include <pthread.h>
+#include <sys/types.h>
+#include <string.h>
+
+size_t scalanative_size_of_pthread_t() { return sizeof(pthread_t); }
+
+size_t scalanative_pthread_attr_t() { return sizeof(pthread_attr_t); }
+
+size_t scalanative_size_of_pthread_cond_t() { return sizeof(pthread_cond_t); }
+
+size_t scalanative_size_of_pthread_condattr_t() {
+    return sizeof(pthread_condattr_t);
+}
+
+size_t scalanative_size_of_pthread_mutex_t() { return sizeof(pthread_mutex_t); }
+
+size_t scalanative_size_of_pthread_mutexattr_t() {
+    return sizeof(pthread_mutexattr_t);
+}
+
+int scalanative_pthread_cancel_asynchronous() {
+    return PTHREAD_CANCEL_ASYNCHRONOUS;
+}
+
+int scalanative_pthread_cancel_enable() { return PTHREAD_CANCEL_ENABLE; }
+
+int scalanative_pthread_cancel_ered() { return PTHREAD_CANCEL_DEFERRED; }
+
+int scalanative_pthread_cancel_disable() { return PTHREAD_CANCEL_DISABLE; }
+
+void *scalanative_pthread_canceled() { return PTHREAD_CANCELED; }
+
+int scalanative_pthread_create_deteached() { return PTHREAD_CREATE_DETACHED; }
+
+int scalanative_pthread_create_joinale() { return PTHREAD_CREATE_JOINABLE; }
+
+int scalanative_pthread_explicit_sched() { return PTHREAD_EXPLICIT_SCHED; }
+
+int scalanative_pthread_inherit_sched() { return PTHREAD_INHERIT_SCHED; }
+
+int scalanative_pthread_mutex_ault() { return PTHREAD_MUTEX_DEFAULT; }
+
+int scalanative_pthread_mutex_errorcheck() { return PTHREAD_MUTEX_ERRORCHECK; }
+
+int scalanative_pthread_mutex_normal() { return PTHREAD_MUTEX_NORMAL; }
+
+int scalanative_pthread_mutex_recursive() { return PTHREAD_MUTEX_RECURSIVE; }
+
+pthread_once_t scalanative_pthread_once_init() {
+    pthread_once_t once_block = PTHREAD_ONCE_INIT;
+    return once_block;
+}
+
+int scalanative_pthread_prio_inherit() { return PTHREAD_PRIO_INHERIT; }
+
+int scalanative_pthread_prio_none() { return PTHREAD_PRIO_NONE; }
+
+int scalanative_pthread_prio_protect() { return PTHREAD_PRIO_PROTECT; }
+
+int scalanative_pthread_process_shared() { return PTHREAD_PROCESS_SHARED; }
+
+int scalanative_pthread_process_private() { return PTHREAD_PROCESS_PRIVATE; }
+
+int scalanative_pthread_scope_process() { return PTHREAD_SCOPE_PROCESS; }
+
+int scalanative_pthread_scope_system() { return PTHREAD_SCOPE_SYSTEM; }

--- a/nativelib/src/main/resources/time.c
+++ b/nativelib/src/main/resources/time.c
@@ -18,3 +18,15 @@ long long scalanative_current_time_millis() {
 
     return current_time_millis;
 }
+
+char ** scalanative_tzname() {
+  return tzname;
+}
+
+long scalanative_timezone() {
+  return timezone;
+}
+
+int scalanative_daylight() {
+  return daylight;
+}

--- a/nativelib/src/main/resources/wrap.c
+++ b/nativelib/src/main/resources/wrap.c
@@ -63,6 +63,8 @@ int scalanative_libc_sigsegv() { return SIGSEGV; }
 
 int scalanative_libc_sigterm() { return SIGTERM; }
 
+int scalanative_libc_sigusr1() { return SIGUSR1; }
+
 int scalanative_libc_rand_max() { return RAND_MAX; }
 
 float scalanative_libc_huge_valf() { return HUGE_VALF; }

--- a/nativelib/src/main/scala/scala/scalanative/native/signal.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/signal.scala
@@ -6,6 +6,7 @@ object signal {
 
   // Signals
 
+  def kill(pid: CInt, sig: CInt): CInt = extern
   def signal(sig: CInt,
              handler: CFunctionPtr1[CInt, Unit]): CFunctionPtr1[CInt, Unit] =
     extern
@@ -31,4 +32,6 @@ object signal {
   def SIGSEGV: CInt = extern
   @name("scalanative_libc_sigterm")
   def SIGTERM: CInt = extern
+  @name("scalanative_libc_sigusr1")
+  def SIGUSR1: CInt = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/time.scala
@@ -15,7 +15,7 @@ object time {
   def ctime(time: Ptr[time_t]): CString                                 = extern
   def ctime_s(buffer: Ptr[CChar], bufsz: CSize, time: Ptr[time_t]): CInt =
     extern
-  def difftime(time_end: CLong, time_beg: CLong): time_t       = extern
+  def difftime(time_end: CLong, time_beg: CLong): CDouble      = extern
   def gmtime(time: Ptr[time_t]): Ptr[tm]                       = extern
   def gmtime_s(time: Ptr[time_t], result: Ptr[tm]): Ptr[tm]    = extern
   def localtime(time: Ptr[time_t]): Ptr[tm]                    = extern
@@ -27,10 +27,18 @@ object time {
                time: Ptr[tm]): CSize                    = extern
   def time(arg: Ptr[time_t]): time_t                    = extern
   def timespec_get(ts: Ptr[timespec], base: CInt): CInt = extern
+  def tzset(): Unit                                     = extern
   def wcsftime(str: CWideChar,
                count: CSize,
                format: Ptr[CWideChar],
                time: Ptr[tm]): CSize = extern
+
+  @name("scalanative_daylight")
+  def daylight(): CInt = extern
+  @name("scalanative_timezone")
+  def timezone(): CLong = extern
+  @name("scalanative_tzname")
+  def tzname(): Ptr[CStruct2[CString, CString]] = extern
 }
 
 object timeOps {

--- a/nativelib/src/main/scala/scala/scalanative/native/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/time.scala
@@ -9,28 +9,28 @@ object time {
   type timespec = CStruct2[time_t, CLong]
   type tm       = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
 
-  def difftime(time_end: CLong, time_beg: CLong): time_t                = extern
-  def time(arg: Ptr[time_t]): time_t                                    = extern
-  def clock(): clock_t                                                  = extern
-  def timespec_get(ts: Ptr[timespec], base: CInt): CInt                 = extern
   def asctime(time_ptr: Ptr[tm]): CString                               = extern
   def asctime_s(buf: Ptr[CChar], bufsz: CSize, time_ptr: Ptr[tm]): CInt = extern
+  def clock(): clock_t                                                  = extern
   def ctime(time: Ptr[time_t]): CString                                 = extern
   def ctime_s(buffer: Ptr[CChar], bufsz: CSize, time: Ptr[time_t]): CInt =
     extern
-  def strftime(str: Ptr[CChar],
-               count: CSize,
-               format: CString,
-               time: Ptr[tm]): CSize = extern
-  def wcsftime(str: CWideChar,
-               count: CSize,
-               format: Ptr[CWideChar],
-               time: Ptr[tm]): CSize                           = extern
+  def difftime(time_end: CLong, time_beg: CLong): time_t       = extern
   def gmtime(time: Ptr[time_t]): Ptr[tm]                       = extern
   def gmtime_s(time: Ptr[time_t], result: Ptr[tm]): Ptr[tm]    = extern
   def localtime(time: Ptr[time_t]): Ptr[tm]                    = extern
   def localtime_s(time: Ptr[time_t], result: Ptr[tm]): Ptr[tm] = extern
   def mktime(time: Ptr[tm]): time_t                            = extern
+  def strftime(str: Ptr[CChar],
+               count: CSize,
+               format: CString,
+               time: Ptr[tm]): CSize                    = extern
+  def time(arg: Ptr[time_t]): time_t                    = extern
+  def timespec_get(ts: Ptr[timespec], base: CInt): CInt = extern
+  def wcsftime(str: CWideChar,
+               count: CSize,
+               format: Ptr[CWideChar],
+               time: Ptr[tm]): CSize = extern
 }
 
 object timeOps {

--- a/nativelib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -1,0 +1,313 @@
+package scala.scalanative
+package posix
+
+import scala.scalanative.native.{
+  CFunctionPtr0,
+  CFunctionPtr1,
+  CInt,
+  CSize,
+  Ptr,
+  extern,
+  name
+}
+import scala.scalanative.posix.sched.sched_param
+import scala.scalanative.posix.sys.time.timespec
+import scala.scalanative.posix.sys.types._
+
+// SUSv2 version is used for compatibility
+// see http://pubs.opengroup.org/onlinepubs/007908799/xsh/threads.html
+
+@extern
+object pthread {
+
+  def pthread_atfork(prepare: routine, parent: routine, child: routine): CInt =
+    extern
+
+  def pthread_attr_destroy(attr: Ptr[pthread_attr_t]): CInt = extern
+
+  def pthread_attr_getdetachstate(attr: Ptr[pthread_attr_t],
+                                  detachstate: Ptr[CInt]): CInt = extern
+
+  def pthread_attr_getguardsize(attr: Ptr[pthread_attr_t],
+                                guardsize: Ptr[CSize]): CInt = extern
+
+  def pthread_attr_getinheritsched(attr: Ptr[pthread_attr_t],
+                                   inheritsched: Ptr[CInt]): CInt = extern
+
+  def pthread_attr_getschedparam(attr: Ptr[pthread_attr_t],
+                                 param: Ptr[sched_param]): CInt = extern
+
+  def pthread_attr_getschedpolicy(attr: Ptr[pthread_attr_t],
+                                  policy: Ptr[CInt]): CInt = extern
+
+  def pthread_attr_getscope(attr: Ptr[pthread_attr_t], scope: Ptr[CInt]): CInt =
+    extern
+
+  def pthread_attr_getstacksize(attr: Ptr[pthread_attr_t],
+                                stacksize: Ptr[CSize]): CInt = extern
+
+  def pthread_attr_init(attr: Ptr[pthread_attr_t]): CInt = extern
+
+  def pthread_attr_setdetachstate(attr: Ptr[pthread_attr_t],
+                                  detachstate: CInt): CInt = extern
+
+  def pthread_attr_setguardsize(attr: Ptr[pthread_attr_t],
+                                guardsize: CSize): CInt = extern
+
+  def pthread_attr_setinheritsched(attr: Ptr[pthread_attr_t],
+                                   inheritsched: CInt): CInt = extern
+
+  def pthread_attr_setschedparam(attr: Ptr[pthread_attr_t],
+                                 param: Ptr[sched_param]): CInt = extern
+
+  def pthread_attr_setschedpolicy(attr: Ptr[pthread_attr_t],
+                                  policy: CInt): CInt = extern
+
+  def pthread_attr_setscope(attr: Ptr[pthread_attr_t], scope: CInt): CInt =
+    extern
+
+  def pthread_attr_setstackaddr(attr: Ptr[pthread_attr_t],
+                                stackaddr: Ptr[Byte]): CInt = extern
+
+  def pthread_attr_setstacksize(attr: Ptr[pthread_attr_t],
+                                stacksize: CSize): CInt = extern
+
+  @name("scalanative_pthread_cancel")
+  def pthread_cancel(thread: pthread_t): CInt = extern
+
+  def pthread_cond_broadcast(cond: Ptr[pthread_cond_t]): CInt = extern
+
+  def pthread_cond_destroy(cond: Ptr[pthread_cond_t]): CInt = extern
+
+  def pthread_cond_init(cond: Ptr[pthread_cond_t],
+                        attr: Ptr[pthread_condattr_t]): CInt = extern
+
+  def pthread_cond_signal(cond: Ptr[pthread_cond_t]): CInt = extern
+
+  def pthread_cond_timedwait(cond: Ptr[pthread_cond_t],
+                             mutex: Ptr[pthread_mutex_t],
+                             timespec: Ptr[timespec]): CInt = extern
+
+  def pthread_cond_wait(cond: Ptr[pthread_cond_t],
+                        mutex: Ptr[pthread_mutex_t]): CInt = extern
+
+  def pthread_condattr_destroy(attr: Ptr[pthread_condattr_t]): CInt = extern
+
+  def pthread_condattr_getpshared(attr: Ptr[pthread_condattr_t],
+                                  pshared: Ptr[CInt]): CInt = extern
+
+  def pthread_condattr_init(attr: Ptr[pthread_condattr_t]): CInt = extern
+
+  def pthread_condattr_setpshared(attr: Ptr[pthread_condattr_t],
+                                  pshared: CInt): CInt = extern
+
+  @name("scalanative_pthread_create")
+  def pthread_create(thread: Ptr[pthread_t],
+                     attr: Ptr[pthread_attr_t],
+                     startroutine: CFunctionPtr1[Ptr[Byte], Ptr[Byte]],
+                     args: Ptr[Byte]): CInt = extern
+
+  @name("scalanative_pthread_detach")
+  def pthread_detach(thread: pthread_t): CInt = extern
+
+  def pthread_equal(thread1: pthread_t, thread2: pthread_t): CInt = extern
+
+  @name("scalanative_pthread_exit")
+  def pthread_exit(retval: Ptr[Byte]): Unit = extern
+
+  def pthread_getconcurrency(): CInt = extern
+
+  def pthread_getschedparam(thread: pthread_t,
+                            policy: Ptr[CInt],
+                            param: Ptr[sched_param]): CInt = extern
+
+  def pthread_getspecific(key: pthread_key_t): Ptr[Byte] = extern
+
+  @name("scalanative_pthread_join")
+  def pthread_join(thread: pthread_t, value_ptr: Ptr[Ptr[Byte]]): CInt = extern
+
+  def pthread_key_create(key: Ptr[pthread_key_t],
+                         destructor: CFunctionPtr1[Ptr[Byte], Unit]): CInt =
+    extern
+
+  def pthread_key_delete(key: pthread_key_t): CInt = extern
+
+  def pthread_kill(key: pthread_t, sig: CInt): CInt = extern
+
+  def pthread_mutex_destroy(mutex: Ptr[pthread_mutex_t]): CInt = extern
+
+  def pthread_mutex_getprioceiling(mutex: Ptr[pthread_mutex_t],
+                                   prioceiling: Ptr[CInt]): CInt = extern
+
+  def pthread_mutex_init(mutex: Ptr[pthread_mutex_t],
+                         attr: Ptr[pthread_mutexattr_t]): CInt = extern
+
+  def pthread_mutex_lock(mutex: Ptr[pthread_mutex_t]): CInt = extern
+
+  def pthread_mutex_setprioceiling(mutex: Ptr[pthread_mutex_t],
+                                   prioceiling: CInt,
+                                   old_prioceiling: Ptr[CInt]): CInt = extern
+
+  def pthread_mutex_trylock(mutex: Ptr[pthread_mutex_t]): CInt = extern
+
+  def pthread_mutex_unlock(mutex: Ptr[pthread_mutex_t]): CInt = extern
+
+  def pthread_mutexattr_destroy(attr: Ptr[pthread_mutexattr_t]): CInt = extern
+
+  def pthread_mutexattr_getprioceiling(attr: Ptr[pthread_mutexattr_t],
+                                       prioceiling: Ptr[CInt]): CInt = extern
+
+  def pthread_mutexattr_getprotocol(attr: Ptr[pthread_mutexattr_t],
+                                    protocol: Ptr[CInt]): CInt = extern
+
+  def pthread_mutexattr_getpshared(attr: Ptr[pthread_mutexattr_t],
+                                   pshared: Ptr[CInt]): CInt = extern
+
+  def pthread_mutexattr_gettype(attr: Ptr[pthread_mutexattr_t],
+                                tp: Ptr[CInt]): CInt = extern
+
+  def pthread_mutexattr_init(attr: Ptr[pthread_mutexattr_t]): CInt = extern
+
+  def pthread_mutexattr_setprioceiling(attr: Ptr[pthread_mutexattr_t],
+                                       prioceiling: CInt): CInt = extern
+
+  def pthread_mutexattr_setprotocol(attr: Ptr[pthread_mutexattr_t],
+                                    protocol: CInt): CInt = extern
+
+  def pthread_mutexattr_setpshared(attr: Ptr[pthread_mutexattr_t],
+                                   pshared: CInt): CInt = extern
+
+  def pthread_mutexattr_settype(attr: Ptr[pthread_mutexattr_t],
+                                tp: CInt): CInt = extern
+
+  def pthread_once(once_control: Ptr[pthread_once_t],
+                   init_routine: routine): CInt = extern
+
+  def pthread_rwlock_destroy(rwlock: Ptr[pthread_rwlock_t]): CInt = extern
+
+  def pthread_rwlock_init(rwlock: Ptr[pthread_rwlock_t],
+                          attr: Ptr[pthread_rwlockattr_t]): CInt = extern
+
+  def pthread_rwlock_rdlock(rwlock: Ptr[pthread_rwlock_t]): CInt = extern
+
+  def pthread_rwlock_tryrdlock(rwlock: Ptr[pthread_rwlock_t]): CInt = extern
+
+  def pthread_rwlock_trywrlock(rwlock: Ptr[pthread_rwlock_t]): CInt = extern
+
+  def pthread_rwlock_unlock(rwlock: Ptr[pthread_rwlock_t]): CInt = extern
+
+  def pthread_rwlock_wrlock(rwlock: Ptr[pthread_rwlock_t]): CInt = extern
+
+  def pthread_rwlockattr_destroy(attr: Ptr[pthread_rwlockattr_t]): CInt =
+    extern
+
+  def pthread_rwlockattr_getpshared(attr: Ptr[pthread_rwlockattr_t],
+                                    pshared: Ptr[CInt]): CInt = extern
+
+  def pthread_rwlockattr_init(attr: Ptr[pthread_rwlockattr_t]): CInt = extern
+
+  def pthread_rwlockattr_setpshared(attr: Ptr[pthread_rwlockattr_t],
+                                    pshared: CInt): CInt = extern
+
+  def pthread_self(): pthread_t = extern
+
+  def pthread_setcancelstate(state: CInt, oldstate: Ptr[CInt]): CInt = extern
+
+  def pthread_setcanceltype(tp: CInt, oldtype: Ptr[CInt]): CInt = extern
+
+  def pthread_setconcurrency(concurrency: CInt): CInt = extern
+
+  def pthread_setschedparam(thread: pthread_t,
+                            policy: CInt,
+                            param: Ptr[sched_param]): CInt = extern
+
+  def pthread_setspecific(key: pthread_key_t, value: Ptr[Byte]): CInt = extern
+
+  def pthread_testcancel(): Unit = extern
+
+  // Types
+  type routine = CFunctionPtr0[Unit]
+
+  // Macros
+  @name("scalanative_pthread_cancel_asynchronous")
+  def PTHREAD_CANCEL_ASYNCHRONOUS: CInt = extern
+
+  @name("scalanative_pthread_cancel_enable")
+  def PTHREAD_CANCEL_ENABLE: CInt = extern
+
+  @name("scalanative_pthread_cancel_defered")
+  def PTHREAD_CANCEL_DEFERRED: CInt = extern
+
+  @name("scalanative_pthread_cancel_disable")
+  def PTHREAD_CANCEL_DISABLE: CInt = extern
+
+  @name("scalanative_pthread_canceled")
+  def PTHREAD_CANCELED: Ptr[Byte] = extern
+
+  @name("scalanative_pthread_create_deteached")
+  def PTHREAD_CREATE_DETACHED: CInt = extern
+
+  @name("scalanative_pthread_create_joinale")
+  def PTHREAD_CREATE_JOINABLE: CInt = extern
+
+  @name("scalanative_pthread_explicit_sched")
+  def PTHREAD_EXPLICIT_SCHED: CInt = extern
+
+  @name("scalanative_pthread_inherit_sched")
+  def PTHREAD_INHERIT_SCHED: CInt = extern
+
+  @name("scalanative_pthread_mutex_default")
+  def PTHREAD_MUTEX_DEFAULT: CInt = extern
+
+  @name("scalanative_pthread_mutex_errorcheck")
+  def PTHREAD_MUTEX_ERRORCHECK: CInt = extern
+
+  @name("scalanative_pthread_mutex_normal")
+  def PTHREAD_MUTEX_NORMAL: CInt = extern
+
+  @name("scalanative_pthread_mutex_recursive")
+  def PTHREAD_MUTEX_RECURSIVE: CInt = extern
+
+  @name("scalanative_pthread_once_init")
+  def PTHREAD_ONCE_INIT: pthread_once_t = extern
+
+  @name("scalanative_pthread_prio_inherit")
+  def PTHREAD_PRIO_INHERIT: CInt = extern
+
+  @name("scalanative_pthread_prio_none")
+  def PTHREAD_PRIO_NONE: CInt = extern
+
+  @name("scalanative_pthread_prio_protect")
+  def PTHREAD_PRIO_PROTECT: CInt = extern
+
+  @name("scalanative_pthread_process_shared")
+  def PTHREAD_PROCESS_SHARED: CInt = extern
+
+  @name("scalanative_pthread_process_private")
+  def PTHREAD_PROCESS_PRIVATE: CInt = extern
+
+  @name("scalanative_pthread_scope_process")
+  def PTHREAD_SCOPE_PROCESS: CInt = extern
+
+  @name("scalanative_pthread_scope_system")
+  def PTHREAD_SCOPE_SYSTEM: CInt = extern
+
+  @name("scalanative_size_of_pthread_t")
+  def pthread_t_size: CSize = extern
+
+  @name("scalanative_pthread_attr_t")
+  def pthread_attr_t_size: CSize = extern
+
+  @name("scalanative_size_of_pthread_cond_t")
+  def pthread_cond_t_size: CSize = extern
+
+  @name("scalanative_size_of_pthread_condattr_t")
+  def pthread_condattr_t_size: CSize = extern
+
+  @name("scalanative_size_of_pthread_mutex_t")
+  def pthread_mutex_t_size: CSize = extern
+
+  @name("scalanative_size_of_pthread_mutexattr_t")
+  def pthread_mutexattr_t_size: CSize = extern
+
+}

--- a/nativelib/src/main/scala/scala/scalanative/posix/sched.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/sched.scala
@@ -1,0 +1,42 @@
+package scala.scalanative.posix
+
+import scala.scalanative.native.{CInt, CSize, CStruct1, CStruct5, Ptr, extern}
+import scala.scalanative.posix.sys.time.timespec
+import scala.scalanative.posix.sys.types.pid_t
+
+@extern
+object sched {
+
+  def sched_setparam(pid: pid_t, param: Ptr[sched_param]): CInt = extern
+
+  def sched_getparam(pid: pid_t, param: Ptr[sched_param]): CInt = extern
+
+  def sched_setscheduler(pid: pid_t,
+                         policy: CInt,
+                         param: Ptr[sched_param]): CInt =
+    extern
+
+  def sched_getscheduler(pid: pid_t): CInt = extern
+
+  def sched_yield(): CInt = extern
+
+  def sched_get_priority_max(algorithm: CInt): CInt = extern
+
+  def sched_get_priority_min(algorithm: CInt): CInt = extern
+
+  def sched_rr_get_interval(pid: pid_t, t: Ptr[timespec]): CInt = extern
+
+  def sched_setaffinity(pid: pid_t,
+                        cpusetsize: CSize,
+                        cpuset: Ptr[cpu_set_t]): CInt = extern
+
+  def sched_getaffinity(pid: pid_t,
+                        cpusetsize: CSize,
+                        cpuset: Ptr[cpu_set_t]): CInt = extern
+
+  // Types
+  type cpu_set_t = CInt
+
+  type sched_param = CStruct5[CInt, CInt, timespec, timespec, CInt]
+
+}

--- a/nativelib/src/main/scala/scala/scalanative/posix/sys/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/sys/time.scala
@@ -2,8 +2,13 @@ package scala.scalanative
 package posix
 package sys
 
-import scalanative.native.CLongInt
+import scalanative.native.{CInt, CLong, CLongInt, CStruct2, Ptr, extern}
 
+@extern
 object time {
-  type time_t = CLongInt
+  type time_t   = CLongInt
+  type timespec = CStruct2[time_t, CLong]
+  type timeval  = CStruct2[time_t, CLong]
+
+  def gettimeofday(tv: Ptr[timeval], tz: Ptr[scala.Byte]): CInt = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/posix/sys/types.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/sys/types.scala
@@ -1,0 +1,38 @@
+package scala.scalanative
+package posix.sys
+
+import scala.scalanative.native.{CInt, CUnsignedInt, ULong, extern}
+
+@extern
+object types {
+
+  type pid_t = CInt
+
+  type pthread_attr_t = ULong
+
+  type pthread_barrier_t = ULong
+
+  type pthread_barrierattr_t = ULong
+
+  type pthread_cond_t = ULong
+
+  type pthread_condattr_t = ULong
+
+  type pthread_key_t = ULong
+
+  type pthread_mutex_t = ULong
+
+  type pthread_mutexattr_t = ULong
+
+  type pthread_once_t = ULong
+
+  type pthread_rwlock_t = ULong
+
+  type pthread_rwlockattr_t = ULong
+
+  type pthread_spinlock_t = ULong
+
+  type pthread_t = ULong
+
+  type clockid_t = CInt
+}

--- a/nativelib/src/main/scala/scala/scalanative/posix/sys/types.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/sys/types.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package posix.sys
 
-import scala.scalanative.native.{CInt, CUnsignedInt, ULong, extern}
+import scala.scalanative.native.{CInt, ULong, extern}
 
 @extern
 object types {

--- a/nativelib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -9,37 +9,25 @@ object unistd {
 
   type off_t = CLongLong
 
-  def sleep(seconds: CUnsignedInt): CUnsignedInt                  = extern
-  def usleep(usecs: CUnsignedInt): CInt                           = extern
-  def unlink(path: CString): CInt                                 = extern
   def access(pathname: CString, mode: CInt): CInt                 = extern
-  def readlink(path: CString, buf: CString, bufsize: CSize): CInt = extern
-  def getcwd(buf: CString, size: CSize): CString                  = extern
-  def write(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt        = extern
-  def read(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt         = extern
+  def chdir(path: CString): CInt                                  = extern
   def close(fildes: CInt): CInt                                   = extern
   def fsync(fildes: CInt): CInt                                   = extern
-  def lseek(fildes: CInt, offset: off_t, whence: CInt): off_t     = extern
   def ftruncate(fildes: CInt, length: off_t): CInt                = extern
-  def truncate(path: CString, length: off_t): CInt                = extern
+  def getcwd(buf: CString, size: CSize): CString                  = extern
   def gethostname(name: CString, len: CSize): CInt                = extern
+  def lseek(fildes: CInt, offset: off_t, whence: CInt): off_t     = extern
+  def read(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt         = extern
+  def readlink(path: CString, buf: CString, bufsize: CSize): CInt = extern
   def sethostname(name: CString, len: CSize): CInt                = extern
-  def chdir(path: CString): CInt                                  = extern
+  def sleep(seconds: CUnsignedInt): CUnsignedInt                  = extern
+  def truncate(path: CString, length: off_t): CInt                = extern
+  def unlink(path: CString): CInt                                 = extern
+  def usleep(usecs: CUnsignedInt): CInt                           = extern
+  def write(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt        = extern
 
-  @name("scalanative_stdin_fileno")
-  def STDIN_FILENO: CInt = extern
-
-  @name("scalanative_stdout_fileno")
-  def STDOUT_FILENO: CInt = extern
-
-  @name("scalanative_stderr_fileno")
-  def STDERR_FILENO: CInt = extern
-
-  @name("scalanative_symlink")
-  def symlink(path1: CString, path2: CString): CInt = extern
-
-  @name("scalanative_symlinkat")
-  def symlinkat(path1: CString, fd: CInt, path2: CString): CInt = extern
+  @name("scalanative_chown")
+  def chown(path: CString, owner: uid_t, group: gid_t): CInt = extern
 
   @name("scalanative_link")
   def link(path1: CString, path2: CString): CInt = extern
@@ -51,8 +39,20 @@ object unistd {
              path2: CString,
              flag: CInt): CInt = extern
 
-  @name("scalanative_chown")
-  def chown(path: CString, owner: uid_t, group: gid_t): CInt = extern
+  @name("scalanative_stderr_fileno")
+  def STDERR_FILENO: CInt = extern
+
+  @name("scalanative_stdin_fileno")
+  def STDIN_FILENO: CInt = extern
+
+  @name("scalanative_stdout_fileno")
+  def STDOUT_FILENO: CInt = extern
+
+  @name("scalanative_symlink")
+  def symlink(path1: CString, path2: CString): CInt = extern
+
+  @name("scalanative_symlinkat")
+  def symlinkat(path1: CString, fd: CInt, path2: CString): CInt = extern
 
   // Macros
 

--- a/nativelib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -9,14 +9,22 @@ object unistd {
 
   type off_t = CLongLong
 
-  def access(pathname: CString, mode: CInt): CInt                 = extern
-  def chdir(path: CString): CInt                                  = extern
-  def close(fildes: CInt): CInt                                   = extern
+  def _exit(status: CInt): Unit                   = extern
+  def access(pathname: CString, mode: CInt): CInt = extern
+  def chdir(path: CString): CInt                  = extern
+  def close(fildes: CInt): CInt                   = extern
+  def dup(fildes: CInt): CInt                     = extern
+  def dup2(fildes: CInt, fildesnew: CInt): CInt   = extern
+  def execve(path: CString, argv: Ptr[CString], envp: Ptr[CString]): CInt =
+    extern
+  def fork(): CInt                                                = extern
   def fsync(fildes: CInt): CInt                                   = extern
   def ftruncate(fildes: CInt, length: off_t): CInt                = extern
   def getcwd(buf: CString, size: CSize): CString                  = extern
   def gethostname(name: CString, len: CSize): CInt                = extern
+  def getpid(): CInt                                              = extern
   def lseek(fildes: CInt, offset: off_t, whence: CInt): off_t     = extern
+  def pipe(fildes: Ptr[CInt]): CInt                               = extern
   def read(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt         = extern
   def readlink(path: CString, buf: CString, bufsize: CSize): CInt = extern
   def sethostname(name: CString, len: CSize): CInt                = extern
@@ -24,6 +32,7 @@ object unistd {
   def truncate(path: CString, length: off_t): CInt                = extern
   def unlink(path: CString): CInt                                 = extern
   def usleep(usecs: CUnsignedInt): CInt                           = extern
+  def vfork(): CInt                                               = extern
   def write(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt        = extern
 
   @name("scalanative_chown")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -390,7 +390,7 @@ object ScalaNativePluginInternal {
         librt ++ libunwind ++ linked.links
           .map(_.name) ++ garbageCollector(gc).links
       }
-      val linkopts  = links.map("-l" + _) ++ linkingOpts
+      val linkopts  = links.map("-l" + _) ++ linkingOpts ++ Seq("-lpthread")
       val targetopt = Seq("-target", target)
       val flags     = Seq("-o", outpath.abs) ++ linkopts ++ targetopt
       val opaths    = (nativelib ** "*.o").get.map(_.abs)

--- a/unit-tests/src/test/resources/process/echo.sh
+++ b/unit-tests/src/test/resources/process/echo.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+while IFS='$\n' read -r line || true; do
+  if [[ $line == "quit" ]]; then
+    exit 0
+  fi
+  printf $line
+done

--- a/unit-tests/src/test/resources/process/err.sh
+++ b/unit-tests/src/test/resources/process/err.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+printf "foo" 1>&2
+printf "bar"

--- a/unit-tests/src/test/resources/process/ls
+++ b/unit-tests/src/test/resources/process/ls
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+printf 1

--- a/unit-tests/src/test/scala/java/lang/ProcessSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/ProcessSuite.scala
@@ -1,0 +1,152 @@
+package java.lang
+
+import java.util.concurrent.TimeUnit
+import java.io._
+import java.nio.file.Files
+
+import scala.scalanative.native.{Zone, toCString}
+import scala.scalanative.posix.{fcntl, unistd}
+import scala.io.Source
+
+object ProcessSuite extends tests.Suite {
+  def readInputStream(s: InputStream) = Source.fromInputStream(s).mkString
+  val resourceDir =
+    s"${System.getProperty("user.dir")}/unit-tests/src/test/resources/process"
+  // This makes it easy to decorate the test for debugging
+  def addTest[R](name: String)(f: => R): Unit = test(name) {
+    f
+  }
+  addTest("ls") {
+    val proc = new ProcessBuilder("ls", resourceDir).start()
+    val out  = readInputStream(proc.getInputStream)
+    proc.waitFor
+    assert(out.split("\n").toSet == Set("echo.sh", "err.sh", "ls"))
+  }
+
+  addTest("inherit") {
+    val f       = Files.createTempFile("/tmp", "out")
+    val savedFD = unistd.dup(unistd.STDOUT_FILENO)
+    val flags   = fcntl.O_RDWR | fcntl.O_TRUNC | fcntl.O_CREAT
+    val fd = Zone { implicit z =>
+      fcntl.open(toCString(f.toAbsolutePath.toString), flags)
+    }
+    val out = try {
+      unistd.dup2(fd, unistd.STDOUT_FILENO)
+      fcntl.close(fd)
+      val proc = new ProcessBuilder("ls", resourceDir).inheritIO().start()
+      proc.waitFor(5, TimeUnit.SECONDS)
+      readInputStream(new FileInputStream(f.toFile))
+    } finally {
+      unistd.dup2(savedFD, unistd.STDOUT_FILENO)
+      fcntl.close(savedFD)
+    }
+    assert(out.split("\n").toSet == Set("echo.sh", "err.sh", "ls"))
+  }
+
+  private def checkPathOverride(pb: ProcessBuilder) = {
+    val proc = pb.start()
+    val out  = readInputStream(proc.getInputStream)
+    proc.waitFor
+    assert(out == "1")
+  }
+
+  addTest("PATH override") {
+    val pb = new ProcessBuilder("ls", resourceDir)
+    pb.environment.put("PATH", resourceDir)
+    checkPathOverride(pb)
+  }
+
+  addTest("PATH prefix override") {
+    val pb = new ProcessBuilder("ls", resourceDir)
+    pb.environment.put("PATH", s"$resourceDir:${pb.environment.get("PATH")}")
+    checkPathOverride(pb)
+  }
+
+  addTest("input and error stream") {
+    val pb  = new ProcessBuilder("err.sh")
+    val cwd = System.getProperty("user.dir")
+    pb.environment.put("PATH", s"$cwd/unit-tests/src/test/resources/process")
+    val proc = pb.start()
+    proc.waitFor
+    assert(readInputStream(proc.getErrorStream) == "foo")
+    assert(readInputStream(proc.getInputStream) == "bar")
+  }
+
+  addTest("input stream writes to file") {
+    val pb = new ProcessBuilder("echo.sh")
+    pb.environment.put("PATH", resourceDir)
+    val file = File.createTempFile("istest", ".tmp", new File("/tmp"))
+    pb.redirectOutput(file)
+    try {
+      val proc = pb.start()
+      proc.getOutputStream.write("hello\n".getBytes)
+      proc.getOutputStream.write("quit\n".getBytes)
+      proc.getOutputStream.flush()
+      proc.waitFor
+      val out = Source.fromFile(file.toString).getLines mkString "\n"
+      assert(out == "hello")
+    } finally {
+      file.delete()
+    }
+  }
+
+  addTest("output stream reads from file") {
+    val pb = new ProcessBuilder("echo.sh")
+    pb.environment.put("PATH", resourceDir)
+    val file = File.createTempFile("istest", ".tmp", new File("/tmp"))
+    pb.redirectInput(file)
+    try {
+      val proc = pb.start()
+      val os   = new FileOutputStream(file)
+      os.write("hello\n".getBytes)
+      os.write("quit\n".getBytes)
+      proc.waitFor
+      val out = readInputStream(proc.getInputStream)
+      assert(out == "hello")
+    } finally {
+      file.delete()
+    }
+  }
+
+  addTest("redirectErrorStream") {
+    val pb  = new ProcessBuilder("err.sh")
+    val cwd = System.getProperty("user.dir")
+    pb.environment.put("PATH", s"$cwd/unit-tests/src/test/resources/process")
+    pb.redirectErrorStream(true)
+    val proc = pb.start()
+    proc.waitFor
+    val out = readInputStream(proc.getInputStream)
+    val err = readInputStream(proc.getErrorStream)
+    assert(out == "foobar")
+    assert(err == "")
+  }
+
+  addTest("waitFor with timeout completes") {
+    val proc = new ProcessBuilder("sleep", "0.001").start()
+    assert(proc.waitFor(1, TimeUnit.SECONDS))
+    assert(proc.exitValue == 0)
+  }
+
+  addTest("waitFor with timeout times out") {
+    val proc = new ProcessBuilder("sleep", ".005").start()
+    assert(!proc.waitFor(1, TimeUnit.MILLISECONDS))
+    assert(proc.isAlive)
+    proc.waitFor(1, TimeUnit.SECONDS)
+  }
+
+  addTest("destroy") {
+    val proc = new ProcessBuilder("sleep", ".005").start()
+    assert(proc.isAlive)
+    proc.destroy()
+    assert(proc.waitFor(100, TimeUnit.MILLISECONDS))
+    assert(proc.exitValue == 0x80 + 9)
+  }
+
+  addTest("destroyForcibly") {
+    val proc = new ProcessBuilder("sleep", ".005").start()
+    assert(proc.isAlive)
+    val p = proc.destroyForcibly()
+    assert(p.waitFor(100, TimeUnit.MILLISECONDS))
+    assert(p.exitValue == 0x80 + 9)
+  }
+}

--- a/unit-tests/src/test/scala/java/lang/SystemSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/SystemSuite.scala
@@ -41,4 +41,9 @@ object SystemSuite extends tests.Suite {
   test("Property user.home should be set") {
     assertEquals(System.getProperty("user.home"), System.getenv("HOME"))
   }
+
+  test("Property user.dir should be set") {
+    assertEquals(System.getProperty("user.dir"),
+                 System.getenv("SCALA_NATIVE_USER_DIR"))
+  }
 }

--- a/unit-tests/src/test/scala/scala/scalanative/native/TimeSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/native/TimeSuite.scala
@@ -1,81 +1,36 @@
 package scala.scalanative.native
 
-import scala.scalanative.native.time.{
-  asctime,
-  difftime,
-  localtime,
-  mktime,
-  strftime,
-  wcsftime,
-  gmtime,
-  time_t,
-  tm
-}
+import scala.scalanative.native.time._
 import scala.scalanative.native.timeOps.tmOps
 
 object TimeSuite extends tests.Suite {
-
-  val now_ptr: Ptr[time_t] = stackalloc[time_t]
-  val now_time_t: time_t   = time.time(now_ptr)
+  tzset()
+  val now_time_t: time_t = time.time(null)
+  val epoch: time_t      = 0
 
   test("asctime() with a given known state should match its representation") {
-
-    val anno_zero_ptr: Ptr[tm] = stackalloc[tm]
-    anno_zero_ptr.tm_sec = 0
-    anno_zero_ptr.tm_min = 0
-    anno_zero_ptr.tm_hour = 0
-    anno_zero_ptr.tm_mday = 1
-    anno_zero_ptr.tm_mon = 0
-    anno_zero_ptr.tm_year = 0
-    anno_zero_ptr.tm_wday = 0
-    anno_zero_ptr.tm_yday = 0
-    anno_zero_ptr.tm_isdst = 0
-
-    val cstr: CString = asctime(anno_zero_ptr)
-    val str: String   = fromCString(cstr)
-    assert("Sun Jan  1 00:00:00 1900\n".equals(str))
+    Zone { implicit z =>
+      val anno_zero_ptr = alloc[tm]
+      anno_zero_ptr.tm_mday = 1
+      val cstr: CString = asctime(anno_zero_ptr)
+      val str: String   = fromCString(cstr)
+      assert("Sun Jan  1 00:00:00 1900\n".equals(str))
+    }
   }
 
-  test("localtime() should transform day zero time to localtime (+0100=CET)") {
-
-    val anno_zero_ptr: Ptr[tm] = stackalloc[tm]
-    anno_zero_ptr.tm_sec = 0
-    anno_zero_ptr.tm_min = 0
-    anno_zero_ptr.tm_hour = 0
-    anno_zero_ptr.tm_mday = 1
-    anno_zero_ptr.tm_mon = 0
-    anno_zero_ptr.tm_year = 0
-    anno_zero_ptr.tm_wday = 0
-    anno_zero_ptr.tm_yday = 0
-    anno_zero_ptr.tm_isdst = 0
-
-    val theTime: time_t = mktime(anno_zero_ptr)
-    val time_ptr        = stackalloc[time_t]
-    !time_ptr = theTime
+  test("localtime() should transform the epoch to localtime") {
+    val time_ptr = stackalloc[time_t]
+    !time_ptr = epoch + timezone
     val time: Ptr[tm] = localtime(time_ptr)
     val cstr: CString = asctime(time)
     val str: String   = fromCString(cstr)
 
-    assert("Thu Jan  1 00:59:59 1970\n".equals(str))
+    assert("Thu Jan  1 00:00:00 1970\n".equals(str))
   }
 
   test(
     "difftime() between epoch and now should be bigger than the timestamp when I wrote this code") {
-
-    val anno_zero_ptr: Ptr[tm] = stackalloc[tm]
-    anno_zero_ptr.tm_sec = 0
-    anno_zero_ptr.tm_min = 0
-    anno_zero_ptr.tm_hour = 0
-    anno_zero_ptr.tm_mday = 1
-    anno_zero_ptr.tm_mon = 0
-    anno_zero_ptr.tm_year = 0
-    anno_zero_ptr.tm_wday = 0
-    anno_zero_ptr.tm_yday = 0
-    anno_zero_ptr.tm_isdst = 0
-    val anno_zero_time_t: time_t = mktime(anno_zero_ptr)
-
-    val diff: time_t = difftime(now_time_t, anno_zero_time_t)
-    assert(diff > 1502752688)
+    assert(difftime(now_time_t, epoch) > 1502752688)
   }
 
   test("time() should be bigger than the timestamp when I wrote this code") {
@@ -84,57 +39,27 @@ object TimeSuite extends tests.Suite {
   }
 
   test("strftime() for 1900-01-00T00:00:00Z") {
-    val isoDatePtr: Ptr[CChar] = stackalloc[CChar](70)
-    val timePtr: Ptr[tm]       = stackalloc[tm]
-    timePtr.tm_sec = 0
-    timePtr.tm_min = 0
-    timePtr.tm_hour = 0
-    timePtr.tm_mday = 0
-    timePtr.tm_mon = 0
-    timePtr.tm_year = 0
-    timePtr.tm_wday = 0
-    timePtr.tm_yday = 0
-    timePtr.tm_isdst = 0
+    Zone { implicit z =>
+      val isoDatePtr: Ptr[CChar] = alloc[CChar](70)
+      val timePtr                = alloc[tm]
 
-    strftime(isoDatePtr, 70, c"%FT%TZ", timePtr)
+      strftime(isoDatePtr, 70, c"%FT%TZ", timePtr)
 
-    val isoDateString: String = fromCString(isoDatePtr)
+      val isoDateString: String = fromCString(isoDatePtr)
 
-    assert("1900-01-00T00:00:00Z".equals(isoDateString))
-  }
-
-  test("wcsftime() not implemented yet. Waiting for fromWideChar") {
-    val isoDatePtr: Ptr[CWideChar] = stackalloc[CWideChar](70)
-    val timePtr: Ptr[tm]           = stackalloc[tm]
-    timePtr.tm_sec = 0
-    timePtr.tm_min = 0
-    timePtr.tm_hour = 0
-    timePtr.tm_mday = 0
-    timePtr.tm_mon = 0
-    timePtr.tm_year = 0
-    timePtr.tm_wday = 0
-    timePtr.tm_yday = 0
-    timePtr.tm_isdst = 0
+      assert("1900-01-00T00:00:00Z".equals(isoDateString))
+    }
   }
 
   test("gmtime()") {
-    val datePtr: Ptr[CChar] = stackalloc[CChar](70)
+    Zone { implicit z =>
+      val timePtr             = alloc[tm]
+      val datePtr: Ptr[CChar] = alloc[CChar](70)
 
-    val timePtr: Ptr[tm] = stackalloc[tm]
-    timePtr.tm_sec = 0
-    timePtr.tm_min = 0
-    timePtr.tm_hour = 0
-    timePtr.tm_mday = 0
-    timePtr.tm_mon = 0
-    timePtr.tm_year = 0
-    timePtr.tm_wday = 0
-    timePtr.tm_yday = 0
-    timePtr.tm_isdst = 0
+      strftime(datePtr, 70, c"%A %c", timePtr)
 
-    strftime(datePtr, 70, c"%A %c", timePtr)
-
-    val dateString: String = fromCString(datePtr)
-    assert("Sunday Sun Jan  0 00:00:00 1900".equals(dateString))
+      val dateString: String = fromCString(datePtr)
+      assert("Sunday Sun Jan  0 00:00:00 1900".equals(dateString))
+    }
   }
-
 }


### PR DESCRIPTION
It took a surprisingly long time for me to get this working reliably due to the lack of thread support in scala-native. There is discussion of this in the commit with message "Implement #746..."

I tested these changes quite extensively with a simple script that created some new processes, read the input streams and waited on the results. I would run the executable in a bash loop and often the script would hang because of deadlock. At this point, I can't get it to lock up, but concurrency is hard and I don't doubt there are some edge cases I've missed.

I view the process monitoring portion of this PR as a partial solution until scala native has full thread support.

I also tested with @lihaoyi's [ammonite](http://ammonite.io/) (which was why I wanted to implement this in the first place) and everything was working fine.