### PR TITLE
Devirtualize trait methods with 1 or less implementations

### DIFF
--- a/tools/src/main/scala/scala/scalanative/optimizer/analysis/ClassHierarchy.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/analysis/ClassHierarchy.scala
@@ -56,10 +56,11 @@ object ClassHierarchy {
   final class Method(val attrs: Attrs,
                      val name: Global,
                      val ty: nir.Type,
-                     val isConcrete: Boolean)
+                     val insts: Seq[nir.Inst])
       extends Node {
-    val overrides = mutable.UnrolledBuffer.empty[Method]
-    val overriden = mutable.UnrolledBuffer.empty[Method]
+    def isConcrete = insts.nonEmpty
+    val overrides  = mutable.UnrolledBuffer.empty[Method]
+    val overriden  = mutable.UnrolledBuffer.empty[Method]
     val value =
       if (isConcrete) Val.Global(name, Type.Ptr)
       else Val.Null
@@ -130,12 +131,10 @@ object ClassHierarchy {
         enter(defn.name, new Field(defn.attrs, defn.name, defn.ty))
 
       case defn: Defn.Declare =>
-        enter(defn.name,
-              new Method(defn.attrs, defn.name, defn.ty, isConcrete = false))
+        enter(defn.name, new Method(defn.attrs, defn.name, defn.ty, Seq.empty))
 
       case defn: Defn.Define =>
-        enter(defn.name,
-              new Method(defn.attrs, defn.name, defn.ty, isConcrete = true))
+        enter(defn.name, new Method(defn.attrs, defn.name, defn.ty, defn.insts))
 
       case defn: Defn.Struct =>
         enter(defn.name, new Struct(defn.attrs, defn.name, defn.tys))

--- a/tools/src/main/scala/scala/scalanative/optimizer/analysis/ClassHierarchy.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/analysis/ClassHierarchy.scala
@@ -56,11 +56,10 @@ object ClassHierarchy {
   final class Method(val attrs: Attrs,
                      val name: Global,
                      val ty: nir.Type,
-                     val insts: Seq[nir.Inst])
+                     val isConcrete: Boolean)
       extends Node {
-    def isConcrete = insts.nonEmpty
-    val overrides  = mutable.UnrolledBuffer.empty[Method]
-    val overriden  = mutable.UnrolledBuffer.empty[Method]
+    val overrides = mutable.UnrolledBuffer.empty[Method]
+    val overriden = mutable.UnrolledBuffer.empty[Method]
     val value =
       if (isConcrete) Val.Global(name, Type.Ptr)
       else Val.Null
@@ -131,10 +130,12 @@ object ClassHierarchy {
         enter(defn.name, new Field(defn.attrs, defn.name, defn.ty))
 
       case defn: Defn.Declare =>
-        enter(defn.name, new Method(defn.attrs, defn.name, defn.ty, Seq.empty))
+        enter(defn.name,
+              new Method(defn.attrs, defn.name, defn.ty, isConcrete = false))
 
       case defn: Defn.Define =>
-        enter(defn.name, new Method(defn.attrs, defn.name, defn.ty, defn.insts))
+        enter(defn.name,
+              new Method(defn.attrs, defn.name, defn.ty, isConcrete = true))
 
       case defn: Defn.Struct =>
         enter(defn.name, new Struct(defn.attrs, defn.name, defn.tys))

--- a/tools/src/main/scala/scala/scalanative/optimizer/analysis/TraitDispatchTables.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/analysis/TraitDispatchTables.scala
@@ -12,6 +12,7 @@ class TraitDispatchTables(top: Top) {
   var dispatchTy: Type                      = _
   var dispatchDefn: Defn                    = _
   var dispatchOffset: mutable.Map[Int, Int] = _
+  var dispatchTable: Array[Val]             = _
 
   val classHasTraitName       = Global.Top("__class_has_trait")
   val classHasTraitVal        = Val.Global(classHasTraitName, Type.Ptr)
@@ -23,23 +24,56 @@ class TraitDispatchTables(top: Top) {
   var traitHasTraitTy: Type   = _
   var traitHasTraitDefn: Defn = _
 
-  val traitMethods = top.methods.filter(_.inTrait).sortBy(_.id)
-  val traitMethodSigs = {
-    val sigs = mutable.Map.empty[String, Int]
-    var i    = 0
-    traitMethods.foreach { meth =>
-      val sig = meth.name.id
-      if (!sigs.contains(sig)) {
-        sigs(sig) = i
-        i += 1
-      }
+  val (traitInlineSigs, traitDispatchSigs) = {
+    // Collect signatures of trait methods
+    val methods = top.methods.filter(_.inTrait)
+    val sigs    = mutable.Set.empty[String]
+    methods.foreach { meth =>
+      sigs += meth.name.id
     }
-    sigs
+
+    // Collect implementations per signature
+    val impls = mutable.Map.empty[String, mutable.Set[Val]]
+    sigs.foreach { sig =>
+      impls(sig) = mutable.Set.empty[Val]
+    }
+    top.classes.foreach { cls =>
+      def visit(cur: Class): Unit = {
+        cur.methods.foreach { meth =>
+          val sig = meth.name.id
+          if (sigs.contains(sig)) {
+            impls(sig) += meth.value
+          }
+        }
+        cur.parent.foreach(visit)
+      }
+      visit(cls)
+    }
+
+    // Extract one-or-less implementation signatures
+    val inlineImpls = impls.collect {
+      case (sig, impls) if impls.size <= 1 =>
+        if (impls.isEmpty) {
+          (sig, Val.Undef(Type.Ptr))
+        } else {
+          (sig, impls.head)
+        }
+    }
+    val tableImpls = impls.toSeq
+      .collect {
+        case (sig, impls) if impls.size > 1 =>
+          sig
+      }
+      .sorted
+      .zipWithIndex
+      .toMap
+
+    (inlineImpls, tableImpls)
   }
 
   def initDispatch(): Unit = {
-    val sigs          = traitMethodSigs
-    val sigsLength    = traitMethodSigs.size
+    val sigs          = traitDispatchSigs
+    val sigsLength    = traitDispatchSigs.size
     val classes       = top.classes.sortBy(_.id)
     val classesLength = classes.length
     val table =
@@ -114,6 +148,7 @@ class TraitDispatchTables(top: Top) {
     dispatchOffset = offsets
     dispatchTy = Type.Ptr
     dispatchDefn = Defn.Const(Attrs.None, dispatchName, value.ty, value)
+    dispatchTable = table
   }
 
   def markTraits(row: Array[Boolean], cls: Class): Unit = {

--- a/tools/src/main/scala/scala/scalanative/optimizer/analysis/TraitDispatchTables.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/analysis/TraitDispatchTables.scala
@@ -12,7 +12,6 @@ class TraitDispatchTables(top: Top) {
   var dispatchTy: Type                      = _
   var dispatchDefn: Defn                    = _
   var dispatchOffset: mutable.Map[Int, Int] = _
-  var dispatchTable: Array[Val]             = _
 
   val classHasTraitName       = Global.Top("__class_has_trait")
   val classHasTraitVal        = Val.Global(classHasTraitName, Type.Ptr)
@@ -148,7 +147,6 @@ class TraitDispatchTables(top: Top) {
     dispatchOffset = offsets
     dispatchTy = Type.Ptr
     dispatchDefn = Defn.Const(Attrs.None, dispatchName, value.ty, value)
-    dispatchTable = table
   }
 
   def markTraits(row: Array[Boolean], cls: Class): Unit = {

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/MethodLowering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/MethodLowering.scala
@@ -34,17 +34,23 @@ class MethodLowering(implicit top: Top) extends Pass {
         let(n, Op.Copy(Val.Global(meth.name, Type.Ptr)))
 
       case Let(n, Op.Method(obj, MethodRef(trt: Trait, meth))) =>
-        val sigid   = top.tables.traitMethodSigs(meth.name.id)
-        val typeptr = let(Op.Load(Type.Ptr, obj))
-        val idptr   = let(Op.Elem(Rt.Type, typeptr, Seq(Val.Int(0), Val.Int(0))))
-        val id      = let(Op.Load(Type.Int, idptr))
-        val rowptr = let(
-          Op.Elem(Type.Ptr,
-                  top.tables.dispatchVal,
-                  Seq(Val.Int(top.tables.dispatchOffset(sigid)))))
-        val methptrptr =
-          let(Op.Elem(Type.Ptr, rowptr, Seq(id)))
-        let(n, Op.Load(Type.Ptr, methptrptr))
+        val sig = meth.name.id
+        if (top.tables.traitInlineSigs.contains(sig)) {
+          let(n, Op.Copy(top.tables.traitInlineSigs(sig)))
+        } else {
+          val sigid   = top.tables.traitDispatchSigs(meth.name.id)
+          val typeptr = let(Op.Load(Type.Ptr, obj))
+          val idptr =
+            let(Op.Elem(Rt.Type, typeptr, Seq(Val.Int(0), Val.Int(0))))
+          val id = let(Op.Load(Type.Int, idptr))
+          val rowptr = let(
+            Op.Elem(Type.Ptr,
+                    top.tables.dispatchVal,
+                    Seq(Val.Int(top.tables.dispatchOffset(sigid)))))
+          val methptrptr =
+            let(Op.Elem(Type.Ptr, rowptr, Seq(id)))
+          let(n, Op.Load(Type.Ptr, methptrptr))
+        }
 
       case inst =>
         buf += inst


### PR DESCRIPTION
Previously, we would only statically devirtualize class methods. This PR addresses the discrepancy. 