### PR TITLE
Use AnyRefMap as a foundation for java.util.HashMap

### DIFF
--- a/javalib/src/main/scala/java/util/HashMap.scala
+++ b/javalib/src/main/scala/java/util/HashMap.scala
@@ -47,8 +47,13 @@ class HashMap[K, V] protected (inner: mutable.Map[AnyRef, V])
   override def entrySet(): Set[Map.Entry[K, V]] =
     new EntrySet
 
-  override def get(key: Any): V =
-    inner.get(boxKey(key.asInstanceOf[K])).getOrElse(null.asInstanceOf[V])
+  override def get(key: Any): V = inner match {
+    case _: mutable.AnyRefMap[_, _] =>
+      val inner = this.inner.asInstanceOf[mutable.AnyRefMap[AnyRef, V]]
+      inner.getOrNull(boxKey(key.asInstanceOf[K]))
+    case _ =>
+      inner.get(boxKey(key.asInstanceOf[K])).getOrElse(null.asInstanceOf[V])
+  }
 
   override def isEmpty(): Boolean =
     inner.isEmpty

--- a/javalib/src/main/scala/java/util/HashMap.scala
+++ b/javalib/src/main/scala/java/util/HashMap.scala
@@ -2,13 +2,18 @@ package java.util
 
 import scala.collection.mutable
 
-class HashMap[K, V] protected (inner: mutable.Map[Box[K], V])
+class HashMap[K, V] protected (inner: mutable.Map[AnyRef, V])
     extends AbstractMap[K, V]
     with Serializable
     with Cloneable { self =>
 
+  protected def boxKey(key: K): AnyRef =
+    key.asInstanceOf[AnyRef]
+  protected def unboxKey(box: AnyRef): K =
+    box.asInstanceOf[K]
+
   def this() =
-    this(mutable.HashMap.empty[Box[K], V])
+    this(mutable.AnyRefMap.empty[AnyRef, V])
 
   def this(initialCapacity: Int, loadFactor: Float) = {
     this()
@@ -34,7 +39,7 @@ class HashMap[K, V] protected (inner: mutable.Map[Box[K], V])
   }
 
   override def containsKey(key: Any): Boolean =
-    inner.contains(Box(key.asInstanceOf[K]))
+    inner.contains(boxKey(key.asInstanceOf[K]))
 
   override def containsValue(value: Any): Boolean =
     inner.valuesIterator.contains(value.asInstanceOf[V])
@@ -43,7 +48,7 @@ class HashMap[K, V] protected (inner: mutable.Map[Box[K], V])
     new EntrySet
 
   override def get(key: Any): V =
-    inner.get(Box(key.asInstanceOf[K])).getOrElse(null.asInstanceOf[V])
+    inner.get(boxKey(key.asInstanceOf[K])).getOrElse(null.asInstanceOf[V])
 
   override def isEmpty(): Boolean =
     inner.isEmpty
@@ -52,10 +57,10 @@ class HashMap[K, V] protected (inner: mutable.Map[Box[K], V])
     new KeySet
 
   override def put(key: K, value: V): V =
-    inner.put(Box(key), value).getOrElse(null.asInstanceOf[V])
+    inner.put(boxKey(key), value).getOrElse(null.asInstanceOf[V])
 
   override def remove(key: Any): V = {
-    val boxedKey = Box(key.asInstanceOf[K])
+    val boxedKey = boxKey(key.asInstanceOf[K])
     inner.get(boxedKey).fold(null.asInstanceOf[V]) { value =>
       inner -= boxedKey
       value
@@ -73,8 +78,8 @@ class HashMap[K, V] protected (inner: mutable.Map[Box[K], V])
       with AbstractMapView[Map.Entry[K, V]] {
     override def iterator(): Iterator[Map.Entry[K, V]] = {
       new AbstractMapViewIterator[Map.Entry[K, V]] {
-        override protected def getNextForm(key: Box[K]): Map.Entry[K, V] = {
-          new AbstractMap.SimpleEntry(key.inner, inner(key)) {
+        override protected def getNextForm(key: AnyRef): Map.Entry[K, V] = {
+          new AbstractMap.SimpleEntry(unboxKey(key), inner(key)) {
             override def setValue(value: V): V = {
               inner.update(key, value)
               super.setValue(value)
@@ -87,7 +92,7 @@ class HashMap[K, V] protected (inner: mutable.Map[Box[K], V])
 
   private class KeySet extends AbstractSet[K] with AbstractMapView[K] {
     override def remove(o: Any): Boolean = {
-      val boxedKey = Box(o.asInstanceOf[K])
+      val boxedKey = boxKey(o.asInstanceOf[K])
       val contains = inner.contains(boxedKey)
       if (contains)
         inner -= boxedKey
@@ -96,8 +101,8 @@ class HashMap[K, V] protected (inner: mutable.Map[Box[K], V])
 
     override def iterator(): Iterator[K] = {
       new AbstractMapViewIterator[K] {
-        protected def getNextForm(key: Box[K]): K =
-          key.inner
+        protected def getNextForm(key: AnyRef): K =
+          unboxKey(key)
       }
     }
   }
@@ -108,7 +113,7 @@ class HashMap[K, V] protected (inner: mutable.Map[Box[K], V])
 
     override def iterator(): Iterator[V] = {
       new AbstractMapViewIterator[V] {
-        protected def getNextForm(key: Box[K]): V = inner(key)
+        protected def getNextForm(key: AnyRef): V = inner(key)
       }
     }
   }
@@ -124,9 +129,9 @@ class HashMap[K, V] protected (inner: mutable.Map[Box[K], V])
   private abstract class AbstractMapViewIterator[E] extends Iterator[E] {
     protected val innerIterator = inner.keySet.iterator
 
-    protected var lastKey: Option[Box[K]] = None
+    protected var lastKey: Option[AnyRef] = None
 
-    protected def getNextForm(key: Box[K]): E
+    protected def getNextForm(key: AnyRef): E
 
     final override def next: E = {
       lastKey = Some(innerIterator.next())
@@ -146,6 +151,9 @@ class HashMap[K, V] protected (inner: mutable.Map[Box[K], V])
       }
     }
   }
+
+  override def putAll(m: Map[_ <: K, _ <: V]): Unit =
+    super.putAll(m)
 }
 
 object HashMap {

--- a/javalib/src/main/scala/java/util/LinkedHashMap.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashMap.scala
@@ -2,15 +2,20 @@ package java.util
 
 import scala.collection.mutable
 
-class LinkedHashMap[K, V] private (inner: mutable.LinkedHashMap[Box[K], V],
+class LinkedHashMap[K, V] private (inner: mutable.LinkedHashMap[AnyRef, V],
                                    accessOrder: Boolean)
     extends HashMap[K, V](inner) { self =>
 
+  override protected def boxKey(key: K): AnyRef =
+    Box(key)
+  override protected def unboxKey(box: AnyRef): K =
+    box.asInstanceOf[Box[K]].inner
+
   def this() =
-    this(mutable.LinkedHashMap.empty[Box[K], V], false)
+    this(mutable.LinkedHashMap.empty[AnyRef, V], false)
 
   def this(initialCapacity: Int, loadFactor: Float, accessOrder: Boolean) = {
-    this(mutable.LinkedHashMap.empty[Box[K], V], accessOrder)
+    this(mutable.LinkedHashMap.empty[AnyRef, V], accessOrder)
     if (initialCapacity < 0)
       throw new IllegalArgumentException("initialCapacity < 0")
     else if (loadFactor < 0.0)
@@ -61,6 +66,21 @@ class LinkedHashMap[K, V] private (inner: mutable.LinkedHashMap[Box[K], V],
   override def clone(): AnyRef = {
     new LinkedHashMap(inner.clone(), accessOrder)
   }
+
+  override def clear(): Unit =
+    super.clear()
+
+  override def containsValue(value: Any): Boolean =
+    super.containsValue(value)
+
+  override def entrySet(): Set[Map.Entry[K, V]] =
+    super.entrySet()
+
+  override def keySet(): Set[K] =
+    super.keySet()
+
+  override def values(): Collection[V] =
+    super.values()
 }
 
 object LinkedHashMap {

--- a/javalib/src/main/scala/java/util/Set.scala
+++ b/javalib/src/main/scala/java/util/Set.scala
@@ -4,16 +4,17 @@ trait Set[E] extends Collection[E] {
   def size(): scala.Int
   def add(obj: E): scala.Boolean
   def contains(obj: Any): scala.Boolean
+  def containsAll(c: Collection[_]): Boolean
   def isEmpty(): scala.Boolean
   def iterator(): Iterator[E]
   def clear(): Unit
   def remove(obj: Any): scala.Boolean
+  def removeAll(c: Collection[_]): Boolean
+  def retainAll(c: Collection[_]): Boolean
 
   //TODO:
   //def addAll(coll: Collection[_ <: E]): scala.Boolean
   //def hashCode(): scala.Int
-  //def removeAll(coll: Collection[_]): scala.Boolean
-  //def retainAll(coll: Collection[_]): scala.Boolean
   //def toArray(): Array[Any]
   //def toArray[T](array: Array[T]): Array[T]
   //def contains(coll: Collection[_]): scala.Boolean

--- a/unit-tests/src/main/scala/tests/Suite.scala
+++ b/unit-tests/src/main/scala/tests/Suite.scala
@@ -15,8 +15,20 @@ abstract class Suite {
   def assert(cond: Boolean): Unit =
     if (!cond) throw AssertionFailed else ()
 
+  def assertTrue(cond: Boolean): Unit =
+    assert(cond)
+
   def assertNot(cond: Boolean): Unit =
     if (cond) throw AssertionFailed else ()
+
+  def assertFalse(cond: Boolean): Unit =
+    assertNot(cond)
+
+  def assertNull[A](a: A): Unit =
+    assert(a == null)
+
+  def assertNotNull[A](a: A): Unit =
+    assertNot(a == null)
 
   def assertThrowsAnd[T: ClassTag](f: => Unit)(fe: T => Boolean): Unit = {
     try {
@@ -37,6 +49,9 @@ abstract class Suite {
 
   def assertEquals[T](left: T, right: T): Unit =
     assert(left == right)
+
+  def assertEquals(expected: Double, actual: Double, delta: Double): Unit =
+    assert(Math.abs(expected - actual) <= delta)
 
   private def assertThrowsImpl(cls: Class[_], f: => Unit): Unit = {
     try {

--- a/unit-tests/src/test/scala/java/util/AbstractMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/AbstractMapSuite.scala
@@ -1,0 +1,17 @@
+package java.util
+
+// Ported from Scal.ajs
+
+import java.{util => ju}
+
+import scala.reflect.ClassTag
+
+abstract class AbstractMapSuite extends MapSuite {
+  def factory(): AbstractMapSuiteFactory
+}
+
+abstract class AbstractMapSuiteFactory extends MapFactory {
+  def implementationName: String
+
+  def empty[K: ClassTag, V: ClassTag]: ju.AbstractMap[K, V]
+}

--- a/unit-tests/src/test/scala/java/util/AbstractMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/AbstractMapSuite.scala
@@ -1,9 +1,8 @@
 package java.util
 
-// Ported from Scal.ajs
+// Ported from Scala.js
 
 import java.{util => ju}
-
 import scala.reflect.ClassTag
 
 abstract class AbstractMapSuite extends MapSuite {

--- a/unit-tests/src/test/scala/java/util/FormatterSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterSuite.scala
@@ -79,15 +79,6 @@ object FormatterSuite extends tests.Suite {
       }
     }
 
-  def assertNull[A](a: A): Unit =
-    assert(a == null)
-
-  def assertNotNull[A](a: A): Unit =
-    assertNot(a == null)
-
-  def assertTrue[A](a: A): Unit =
-    assert(a == true)
-
   private class MockAppendable extends Appendable {
     def append(arg0: CharSequence): Appendable = null
 

--- a/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
@@ -80,15 +80,6 @@ object FormatterUSSuite extends tests.Suite {
       }
     }
 
-  def assertNull[A](a: A): Unit =
-    assert(a == null)
-
-  def assertNotNull[A](a: A): Unit =
-    assertNot(a == null)
-
-  def assertTrue[A](a: A): Unit =
-    assert(a == true)
-
   private class MockAppendable extends Appendable {
     def append(arg0: CharSequence): Appendable = null
 

--- a/unit-tests/src/test/scala/java/util/HashMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/HashMapSuite.scala
@@ -1,0 +1,27 @@
+package java.util
+
+import java.{util => ju}
+
+// Ported from Scala.js
+
+import scala.reflect.ClassTag
+
+object HashMapSuite extends MapSuite {
+  def factory(): HashMapSuiteFactory = new HashMapSuiteFactory
+}
+
+object HashMapSuiteFactory {
+  def allFactories: scala.Iterator[MapFactory] =
+    scala.Iterator(new HashMapSuiteFactory) ++ LinkedHashMapSuiteFactory.allFactories
+}
+
+class HashMapSuiteFactory extends AbstractMapSuiteFactory {
+  override def implementationName: String =
+    "java.util.HashMap"
+
+  override def empty[K: ClassTag, V: ClassTag]: ju.HashMap[K, V] =
+    new ju.HashMap[K, V]
+
+  def allowsNullKeys: Boolean = true
+  def allowsNullValues: Boolean = true
+}

--- a/unit-tests/src/test/scala/java/util/HashMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/HashMapSuite.scala
@@ -1,9 +1,8 @@
 package java.util
 
-import java.{util => ju}
-
 // Ported from Scala.js
 
+import java.{util => ju}
 import scala.reflect.ClassTag
 
 object HashMapSuite extends MapSuite {
@@ -22,6 +21,6 @@ class HashMapSuiteFactory extends AbstractMapSuiteFactory {
   override def empty[K: ClassTag, V: ClassTag]: ju.HashMap[K, V] =
     new ju.HashMap[K, V]
 
-  def allowsNullKeys: Boolean = true
+  def allowsNullKeys: Boolean   = true
   def allowsNullValues: Boolean = true
 }

--- a/unit-tests/src/test/scala/java/util/LinkedHashMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/LinkedHashMapSuite.scala
@@ -28,7 +28,7 @@ abstract class LinkedHashMapSuite extends MapSuite {
   override def factory: LinkedHashMapSuiteFactory =
     new LinkedHashMapSuiteFactory(accessOrder = false, withSizeLimit = None)
 
-  val accessOrder = factory.accessOrder
+  val accessOrder   = factory.accessOrder
   val withSizeLimit = factory.withSizeLimit
 
   test("should iterate in insertion order after building") {
@@ -101,10 +101,11 @@ abstract class LinkedHashMapSuite extends MapSuite {
     val expectedKey = {
       if (factory.accessOrder) {
         val keys = (2 until 42) ++ (43 until 52) ++ (53 until 98) ++
-            im.List(99, 0, 100, 42, 52, 1, 98)
+          im.List(99, 0, 100, 42, 52, 1, 98)
         keys.takeRight(withSizeLimit.getOrElse(keys.length))
       } else {
-        if (withSizeLimit.isDefined) (55 until 100) ++ im.List(0, 100, 42, 52, 1)
+        if (withSizeLimit.isDefined)
+          (55 until 100) ++ im.List(0, 100, 42, 52, 1)
         else 0 to 100
       }
     }.toArray
@@ -192,12 +193,17 @@ abstract class LinkedHashMapSuite extends MapSuite {
 
 object LinkedHashMapSuiteFactory {
   def allFactories: scala.Iterator[MapFactory] = {
-    scala.Iterator(new LinkedHashMapSuiteFactory(true, Some(50)), new LinkedHashMapSuiteFactory(true, None),
-        new LinkedHashMapSuiteFactory(false, Some(50)), new LinkedHashMapSuiteFactory(false, None))
+    scala.Iterator(
+      new LinkedHashMapSuiteFactory(true, Some(50)),
+      new LinkedHashMapSuiteFactory(true, None),
+      new LinkedHashMapSuiteFactory(false, Some(50)),
+      new LinkedHashMapSuiteFactory(false, None)
+    )
   }
 }
 
-class LinkedHashMapSuiteFactory(val accessOrder: Boolean, val withSizeLimit: Option[Int])
+class LinkedHashMapSuiteFactory(val accessOrder: Boolean,
+                                val withSizeLimit: Option[Int])
     extends HashMapSuiteFactory {
   def orderName: String =
     if (accessOrder) "access-order"
@@ -212,7 +218,8 @@ class LinkedHashMapSuiteFactory(val accessOrder: Boolean, val withSizeLimit: Opt
     withSizeLimit match {
       case Some(limit) =>
         new ju.LinkedHashMap[K, V](16, 0.75f, accessOrder) {
-          override protected def removeEldestEntry(eldest: ju.Map.Entry[K, V]): Boolean =
+          override protected def removeEldestEntry(
+              eldest: ju.Map.Entry[K, V]): Boolean =
             size() > limit
         }
 

--- a/unit-tests/src/test/scala/java/util/LinkedHashMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/LinkedHashMapSuite.scala
@@ -1,0 +1,223 @@
+package java.util
+
+// Ported from Scala.js
+
+import java.{util => ju, lang => jl}
+import scala.collection.JavaConversions._
+import scala.collection.{immutable => im}
+import scala.reflect.ClassTag
+
+class LinkedHashMapInsertionOrderSuite extends LinkedHashMapSuite
+
+object LinkedHashMapInsertionOrderLimitedSuite extends LinkedHashMapSuite {
+  override def factory: LinkedHashMapSuiteFactory =
+    new LinkedHashMapSuiteFactory(accessOrder = false, withSizeLimit = Some(50))
+}
+
+object LinkedHashMapAccessOrderSuite extends LinkedHashMapSuite {
+  override def factory: LinkedHashMapSuiteFactory =
+    new LinkedHashMapSuiteFactory(accessOrder = true, withSizeLimit = None)
+}
+
+object LinkedHashMapAccessOrderLimitedSuite extends LinkedHashMapSuite {
+  override def factory: LinkedHashMapSuiteFactory =
+    new LinkedHashMapSuiteFactory(accessOrder = true, withSizeLimit = Some(50))
+}
+
+abstract class LinkedHashMapSuite extends MapSuite {
+  override def factory: LinkedHashMapSuiteFactory =
+    new LinkedHashMapSuiteFactory(accessOrder = false, withSizeLimit = None)
+
+  val accessOrder = factory.accessOrder
+  val withSizeLimit = factory.withSizeLimit
+
+  test("should iterate in insertion order after building") {
+    val lhm = factory.empty[jl.Integer, String]
+    (0 until 100).foreach(key => lhm.put(key, s"elem $key"))
+
+    def expectedKey(index: Int): Int =
+      withSizeLimit.getOrElse(0) + index
+
+    def expectedValue(index: Int): String =
+      s"elem ${expectedKey(index)}"
+
+    val expectedSize = withSizeLimit.getOrElse(100)
+
+    assertEquals(expectedSize, lhm.entrySet().size())
+    for ((entry, index) <- lhm.entrySet().zipWithIndex) {
+      assertEquals(expectedKey(index), entry.getKey)
+      assertEquals(expectedValue(index), entry.getValue)
+    }
+
+    assertEquals(expectedSize, lhm.keySet().size())
+    for ((key, index) <- lhm.keySet().zipWithIndex)
+      assertEquals(expectedKey(index), key)
+
+    assertEquals(expectedSize, lhm.entrySet().size())
+    for ((value, index) <- lhm.values().zipWithIndex)
+      assertEquals(expectedValue(index), value)
+  }
+
+  test("should iterate in the same order after removal of elements") {
+    val lhm = factory.empty[jl.Integer, String]
+    (0 until 100).foreach(key => lhm.put(key, s"elem $key"))
+
+    (0 until 100 by 3).foreach(key => lhm.remove(key))
+
+    val expectedKey =
+      ((100 - withSizeLimit.getOrElse(100)) to 100).filter(_ % 3 != 0).toArray
+
+    def expectedValue(index: Int): String =
+      s"elem ${expectedKey(index)}"
+
+    val expectedSize = if (withSizeLimit.isDefined) 33 else 66
+
+    assertEquals(expectedSize, lhm.entrySet().size())
+    for ((entry, index) <- lhm.entrySet().zipWithIndex) {
+      assertEquals(expectedKey(index), entry.getKey)
+      assertEquals(expectedValue(index), entry.getValue)
+    }
+
+    assertEquals(expectedSize, lhm.keySet().size())
+    for ((key, index) <- lhm.keySet().zipWithIndex)
+      assertEquals(expectedKey(index), key)
+
+    assertEquals(expectedSize, lhm.entrySet().size())
+    for ((value, index) <- lhm.values().zipWithIndex)
+      assertEquals(expectedValue(index), value)
+  }
+
+  test("should iterate in order after adding elements") {
+    val lhm = factory.empty[jl.Integer, String]
+    (0 until 100).foreach(key => lhm.put(key, s"elem $key"))
+
+    lhm(0) = "new 0"
+    lhm(100) = "elem 100"
+    lhm(42) = "new 42"
+    lhm(52) = "new 52"
+    lhm(1) = "new 1"
+    lhm(98) = "new 98"
+
+    val expectedKey = {
+      if (factory.accessOrder) {
+        val keys = (2 until 42) ++ (43 until 52) ++ (53 until 98) ++
+            im.List(99, 0, 100, 42, 52, 1, 98)
+        keys.takeRight(withSizeLimit.getOrElse(keys.length))
+      } else {
+        if (withSizeLimit.isDefined) (55 until 100) ++ im.List(0, 100, 42, 52, 1)
+        else 0 to 100
+      }
+    }.toArray
+
+    def expectedElem(index: Int): String = {
+      val key = expectedKey(index)
+      if (key == 0 || key == 1 || key == 42 || key == 52 || key == 98)
+        s"new $key"
+      else
+        s"elem $key"
+    }
+
+    val expectedSize = withSizeLimit.getOrElse(101)
+
+    assertEquals(expectedSize, lhm.entrySet().size())
+
+    for ((entry, index) <- lhm.entrySet().zipWithIndex) {
+      assertEquals(expectedKey(index), entry.getKey)
+      assertEquals(expectedElem(index), entry.getValue)
+    }
+
+    assertEquals(expectedSize, lhm.keySet().size())
+    for ((key, index) <- lhm.keySet().zipWithIndex)
+      assertEquals(expectedKey(index), key)
+
+    assertEquals(expectedSize, lhm.entrySet().size())
+    for ((value, index) <- lhm.values().zipWithIndex)
+      assertEquals(expectedElem(index), value)
+  }
+
+  test("should iterate in after accessing elements") {
+    val lhm = factory.empty[jl.Integer, String]
+    (0 until 100).foreach(key => lhm.put(key, s"elem $key"))
+
+    lhm.get(42)
+    lhm.get(52)
+    lhm.get(5)
+
+    def expectedKey(index: Int): Int = {
+      if (accessOrder) {
+        // elements ordered by insertion order except for those accessed
+        if (withSizeLimit.isEmpty) {
+          if (index < 5) index // no elements removed in this range
+          else if (index + 1 < 42) index + 1 // shifted by 1 removed element
+          else if (index + 2 < 52) index + 2 // shifted by 2 removed element
+          else if (index < 97) index + 3 // shifted by 3 removed element
+          // elements reordered by accesses
+          else if (index == 97) 42
+          else if (index == 98) 52
+          else 5
+        } else {
+          // note that 5 and 42 are not accessed because they where dropped
+          // due to the size limit
+          if (index < 2) index + 50 // no elements removed in this range
+          else if (index < 49) index + 51 // shifted by 1 removed element
+          // element reordered by accesses
+          else 52
+        }
+      } else {
+        // accesses shouldn't modify the order
+        withSizeLimit.getOrElse(0) + index
+      }
+    }
+
+    def expectedValue(index: Int): String =
+      s"elem ${expectedKey(index)}"
+
+    val expectedSize = withSizeLimit.getOrElse(100)
+
+    assertEquals(expectedSize, lhm.entrySet().size())
+    for ((entry, index) <- lhm.entrySet().zipWithIndex) {
+      assertEquals(expectedKey(index), entry.getKey)
+      assertEquals(expectedValue(index), entry.getValue)
+    }
+
+    assertEquals(expectedSize, lhm.keySet().size())
+    for ((key, index) <- lhm.keySet().zipWithIndex)
+      assertEquals(expectedKey(index), key)
+
+    assertEquals(expectedSize, lhm.entrySet().size())
+    for ((value, index) <- lhm.values().zipWithIndex)
+      assertEquals(expectedValue(index), value)
+  }
+}
+
+object LinkedHashMapSuiteFactory {
+  def allFactories: scala.Iterator[MapFactory] = {
+    scala.Iterator(new LinkedHashMapSuiteFactory(true, Some(50)), new LinkedHashMapSuiteFactory(true, None),
+        new LinkedHashMapSuiteFactory(false, Some(50)), new LinkedHashMapSuiteFactory(false, None))
+  }
+}
+
+class LinkedHashMapSuiteFactory(val accessOrder: Boolean, val withSizeLimit: Option[Int])
+    extends HashMapSuiteFactory {
+  def orderName: String =
+    if (accessOrder) "access-order"
+    else "insertion-order"
+
+  override def implementationName: String = {
+    val sizeLimitSting = withSizeLimit.fold("")(", maxSize=" + _)
+    s"java.util.LinkedHashMap{$orderName$sizeLimitSting}"
+  }
+
+  override def empty[K: ClassTag, V: ClassTag]: ju.LinkedHashMap[K, V] = {
+    withSizeLimit match {
+      case Some(limit) =>
+        new ju.LinkedHashMap[K, V](16, 0.75f, accessOrder) {
+          override protected def removeEldestEntry(eldest: ju.Map.Entry[K, V]): Boolean =
+            size() > limit
+        }
+
+      case None =>
+        new ju.LinkedHashMap[K, V](16, 0.75f, accessOrder)
+    }
+  }
+}

--- a/unit-tests/src/test/scala/java/util/MapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/MapSuite.scala
@@ -211,22 +211,20 @@ trait MapSuite extends tests.Suite {
   test("should put a whole map into") {
     val mp = factory.empty[String, String]
 
-    val m = mu.Map[String, String](
-      "X" -> "y")
+    val m = mu.Map[String, String]("X" -> "y")
     mp.putAll(mutableMapAsJavaMap(m))
     assertEquals(1, mp.size())
     assertEquals("y", mp.get("X"))
 
-    val nullMap = mu.Map[String, String](
-      (null: String) -> "y",
-      "X" -> "y")
+    val nullMap = mu.Map[String, String]((null: String) -> "y", "X" -> "y")
 
     if (factory.allowsNullKeys) {
       mp.putAll(mutableMapAsJavaMap(nullMap))
       assertEquals("y", mp.get(null))
       assertEquals("y", mp.get("X"))
     } else {
-      expectThrows(classOf[NullPointerException], mp.putAll(mutableMapAsJavaMap(nullMap)))
+      expectThrows(classOf[NullPointerException],
+                   mp.putAll(mutableMapAsJavaMap(nullMap)))
     }
   }
 
@@ -264,18 +262,10 @@ trait MapSuite extends tests.Suite {
 
     assertTrue(values.isEmpty)
 
-    val hm1 = mu.HashMap(
-      "ONE" -> "one",
-      "TWO" -> "two")
-    val hm2 = mu.HashMap(
-      "ONE" -> null,
-      "TWO" -> "two")
-    val hm3 = mu.HashMap(
-      (null: String) -> "one",
-      "TWO" -> "two")
-    val hm4 = mu.HashMap(
-      (null: String) -> null,
-      "TWO" -> "two")
+    val hm1 = mu.HashMap("ONE"          -> "one", "TWO" -> "two")
+    val hm2 = mu.HashMap("ONE"          -> null, "TWO"  -> "two")
+    val hm3 = mu.HashMap((null: String) -> "one", "TWO" -> "two")
+    val hm4 = mu.HashMap((null: String) -> null, "TWO"  -> "two")
 
     assertEquals(2, new SimpleQueryableMap(hm1).values().size())
     assertEquals(2, new SimpleQueryableMap(hm2).values().size())
@@ -329,15 +319,9 @@ trait MapSuite extends tests.Suite {
     assertTrue(numValues.contains(-0.0))
     assertTrue(numValues.contains(Double.NaN))
 
-    val hm1 = mu.HashMap(
-      1.0 -> null,
-      2.0 -> 2.0)
-    val hm2 = mu.HashMap(
-      (null: Any) -> 1.0,
-      2.0 -> 2.0)
-    val hm3 = mu.HashMap(
-      (null: Any) -> null,
-      2.0 -> 2.0)
+    val hm1 = mu.HashMap(1.0         -> null, 2.0 -> 2.0)
+    val hm2 = mu.HashMap((null: Any) -> 1.0, 2.0  -> 2.0)
+    val hm3 = mu.HashMap((null: Any) -> null, 2.0 -> 2.0)
 
     assertFalse(new SimpleQueryableMap(hm1).values().contains(1.0))
     assertTrue(new SimpleQueryableMap(hm2).values().contains(1.0))
@@ -425,18 +409,10 @@ trait MapSuite extends tests.Suite {
 
     assertTrue(keySet.isEmpty)
 
-    val hm1 = mu.HashMap(
-      "ONE" -> "one",
-      "TWO" -> "two")
-    val hm2 = mu.HashMap(
-      "ONE" -> null,
-      "TWO" -> "two")
-    val hm3 = mu.HashMap(
-      (null: String) -> "one",
-      "TWO" -> "two")
-    val hm4 = mu.HashMap(
-      (null: String) -> null,
-      "TWO" -> "two")
+    val hm1 = mu.HashMap("ONE"          -> "one", "TWO" -> "two")
+    val hm2 = mu.HashMap("ONE"          -> null, "TWO"  -> "two")
+    val hm3 = mu.HashMap((null: String) -> "one", "TWO" -> "two")
+    val hm4 = mu.HashMap((null: String) -> null, "TWO"  -> "two")
 
     assertEquals(2, new SimpleQueryableMap(hm1).keySet().size())
     assertEquals(2, new SimpleQueryableMap(hm2).keySet().size())
@@ -493,15 +469,9 @@ trait MapSuite extends tests.Suite {
     assertTrue(numkeySet.contains(-0.0))
     assertTrue(numkeySet.contains(Double.NaN))
 
-    val hm1 = mu.HashMap(
-      1.0 -> null,
-      2.0 -> 2.0)
-    val hm2 = mu.HashMap(
-      (null: Any) -> 1.0,
-      2.0 -> 2.0)
-    val hm3 = mu.HashMap(
-      (null: Any) -> null,
-      2.0 -> 2.0)
+    val hm1 = mu.HashMap(1.0         -> null, 2.0 -> 2.0)
+    val hm2 = mu.HashMap((null: Any) -> 1.0, 2.0  -> 2.0)
+    val hm3 = mu.HashMap((null: Any) -> null, 2.0 -> 2.0)
 
     assertTrue(new SimpleQueryableMap(hm1).keySet().contains(1.0))
     assertFalse(new SimpleQueryableMap(hm2).keySet().contains(1.0))

--- a/unit-tests/src/test/scala/java/util/MapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/MapSuite.scala
@@ -1,0 +1,586 @@
+package java.util
+
+// Ported from Scala.js
+
+import java.{util => ju}
+import scala.collection.JavaConversions._
+import scala.collection.{immutable => im}
+import scala.collection.{mutable => mu}
+import scala.reflect.ClassTag
+
+trait MapSuite extends tests.Suite {
+  def factory: MapFactory
+
+  test("should store strings") {
+    val mp = factory.empty[String, String]
+
+    assertEquals(0, mp.size())
+    mp.put("ONE", "one")
+    assertEquals(1, mp.size())
+    assertEquals("one", mp.get("ONE"))
+    mp.put("TWO", "two")
+    assertEquals(2, mp.size())
+    assertEquals("two", mp.get("TWO"))
+  }
+
+  test("should store integers") {
+    val mp = factory.empty[Int, Int]
+
+    mp.put(100, 12345)
+    assertEquals(1, mp.size())
+    val one = mp.get(100)
+    assertEquals(12345, one)
+  }
+
+  test("should store doubles also in corner cases") {
+    val mp = factory.empty[Double, Double]
+
+    mp.put(1.2345, 11111.0)
+    assertEquals(1, mp.size())
+    val one = mp.get(1.2345)
+    assertEquals(11111.0, one, 0.0)
+
+    mp.put(Double.NaN, 22222.0)
+    assertEquals(2, mp.size())
+    val two = mp.get(Double.NaN)
+    assertEquals(22222.0, two, 0.0)
+
+    mp.put(+0.0, 33333.0)
+    assertEquals(3, mp.size())
+    val three = mp.get(+0.0)
+    assertEquals(33333.0, three, 0.0)
+
+    mp.put(-0.0, 44444.0)
+    assertEquals(4, mp.size())
+    val four = mp.get(-0.0)
+    assertEquals(44444.0, four, 0.0)
+  }
+
+  test("should store custom objects") {
+    case class TestObj(num: Int)
+
+    val mp = factory.empty[TestObj, TestObj]
+
+    mp.put(TestObj(100), TestObj(12345))
+    assertEquals(1, mp.size())
+    val one = mp.get(TestObj(100))
+    assertEquals(12345, one.num)
+  }
+
+  test("should remove stored elements") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    assertEquals(1, mp.size())
+    assertEquals("one", mp.remove("ONE"))
+    val newOne = mp.get("ONE")
+    assertNull(mp.get("ONE"))
+  }
+
+  test("should remove stored elements on double corner cases") {
+    val mp = factory.empty[Double, String]
+
+    mp.put(1.2345, "11111.0")
+    mp.put(Double.NaN, "22222.0")
+    mp.put(+0.0, "33333.0")
+    mp.put(-0.0, "44444.0")
+
+    assertEquals("11111.0", mp.get(1.2345))
+    assertEquals("22222.0", mp.get(Double.NaN))
+    assertEquals("33333.0", mp.get(+0.0))
+    assertEquals("44444.0", mp.get(-0.0))
+
+    assertEquals("44444.0", mp.remove(-0.0))
+    assertNull(mp.get(-0.0))
+
+    mp.put(-0.0, "55555.0")
+
+    assertEquals("33333.0", mp.remove(+0.0))
+    assertNull(mp.get(+0.0))
+
+    mp.put(+0.0, "66666.0")
+
+    assertEquals("22222.0", mp.remove(Double.NaN))
+    assertNull(mp.get(Double.NaN))
+
+    mp.put(Double.NaN, "77777.0")
+
+    mp.clear()
+
+    assertTrue(mp.isEmpty)
+  }
+
+  test("should put or fail on null keys") {
+    if (factory.allowsNullKeys) {
+      val mp = factory.empty[String, String]
+      mp.put(null, "one")
+      assertEquals("one", mp.get(null))
+    } else {
+      val mp = factory.empty[String, String]
+      expectThrows(classOf[NullPointerException], mp.put(null, "one"))
+    }
+  }
+
+  test("should put or fail on null values") {
+    if (factory.allowsNullValues) {
+      val mp = factory.empty[String, String]
+      mp.put("one", null)
+      assertNull(mp.get("one"))
+    } else {
+      val mp = factory.empty[String, String]
+      expectThrows(classOf[NullPointerException], mp.put("one", null))
+    }
+  }
+
+  test("should be cleared with one operation") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    assertEquals(2, mp.size())
+    mp.clear()
+    assertEquals(0, mp.size())
+  }
+
+  test("should check contained key presence") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    assertTrue(mp.containsKey("ONE"))
+    assertFalse(mp.containsKey("TWO"))
+    if (factory.allowsNullKeysQueries)
+      assertFalse(mp.containsKey(null))
+    else
+      expectThrows(classOf[Throwable], mp.containsKey(null))
+  }
+
+  test("should check contained value presence") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    assertTrue(mp.containsValue("one"))
+    assertFalse(mp.containsValue("two"))
+    if (factory.allowsNullValuesQueries)
+      assertFalse(mp.containsValue(null))
+    else
+      expectThrows(classOf[Throwable], mp.containsValue(null))
+  }
+
+  test("should give proper Collection over values") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    val values = mp.values()
+    assertEquals(1, values.size())
+    val iter = values.iterator
+    assertTrue(iter.hasNext)
+    assertEquals("one", iter.next)
+    assertFalse(iter.hasNext)
+  }
+
+  test("should give proper EntrySet over key value pairs") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    val entrySet = mp.entrySet
+
+    assertEquals(1, entrySet.size())
+
+    val iter = entrySet.iterator
+    assertTrue(iter.hasNext)
+    val next = iter.next
+    assertFalse(iter.hasNext)
+    assertEquals("ONE", next.getKey)
+    assertEquals("one", next.getValue)
+  }
+
+  test("should give proper KeySet over keys") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    val keySet = mp.keySet()
+
+    assertEquals(1, keySet.size())
+
+    val iter = keySet.iterator
+    assertTrue(iter.hasNext)
+    assertEquals("ONE", iter.next)
+    assertFalse(iter.hasNext)
+  }
+
+  test("should put a whole map into") {
+    val mp = factory.empty[String, String]
+
+    val m = mu.Map[String, String](
+      "X" -> "y")
+    mp.putAll(mutableMapAsJavaMap(m))
+    assertEquals(1, mp.size())
+    assertEquals("y", mp.get("X"))
+
+    val nullMap = mu.Map[String, String](
+      (null: String) -> "y",
+      "X" -> "y")
+
+    if (factory.allowsNullKeys) {
+      mp.putAll(mutableMapAsJavaMap(nullMap))
+      assertEquals("y", mp.get(null))
+      assertEquals("y", mp.get("X"))
+    } else {
+      expectThrows(classOf[NullPointerException], mp.putAll(mutableMapAsJavaMap(nullMap)))
+    }
+  }
+
+  class SimpleQueryableMap[K, V](inner: mu.HashMap[K, V])
+      extends ju.AbstractMap[K, V] {
+    def entrySet(): java.util.Set[java.util.Map.Entry[K, V]] = {
+      setAsJavaSet(inner.map {
+        case (k, v) => new ju.AbstractMap.SimpleImmutableEntry(k, v)
+      }.toSet)
+    }
+  }
+
+  test("values should mirror the related map size") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+
+    val values = mp.values()
+    assertEquals(2, values.size())
+
+    mp.put("THREE", "three")
+
+    assertEquals(3, values.size())
+
+    mp.remove("ONE")
+
+    assertEquals(2, values.size())
+
+    assertFalse(values.isEmpty)
+
+    mp.clear()
+
+    assertEquals(0, values.size())
+
+    assertTrue(values.isEmpty)
+
+    val hm1 = mu.HashMap(
+      "ONE" -> "one",
+      "TWO" -> "two")
+    val hm2 = mu.HashMap(
+      "ONE" -> null,
+      "TWO" -> "two")
+    val hm3 = mu.HashMap(
+      (null: String) -> "one",
+      "TWO" -> "two")
+    val hm4 = mu.HashMap(
+      (null: String) -> null,
+      "TWO" -> "two")
+
+    assertEquals(2, new SimpleQueryableMap(hm1).values().size())
+    assertEquals(2, new SimpleQueryableMap(hm2).values().size())
+    assertEquals(2, new SimpleQueryableMap(hm3).values().size())
+    assertEquals(2, new SimpleQueryableMap(hm4).values().size())
+  }
+
+  test("values should check single and multiple objects presence") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+
+    val values = mp.values()
+    assertTrue(values.contains("one"))
+    assertTrue(values.contains("two"))
+    assertFalse(values.contains("three"))
+    if (factory.allowsNullValuesQueries)
+      assertFalse(values.contains(null))
+    else
+      expectThrows(classOf[Throwable], mp.contains(null))
+
+    mp.put("THREE", "three")
+
+    assertTrue(values.contains("three"))
+
+    val coll1 = asJavaCollection(im.Set("one", "two", "three"))
+    assertTrue(values.containsAll(coll1))
+
+    val coll2 = asJavaCollection(im.Set("one", "two", "three", "four"))
+    assertFalse(values.containsAll(coll2))
+
+    val coll3 = asJavaCollection(im.Set("one", "two", "three", null))
+    assertFalse(values.containsAll(coll2))
+
+    val nummp = factory.empty[Double, Double]
+
+    val numValues = nummp.values()
+    nummp.put(1, +0.0)
+    assertTrue(numValues.contains(+0.0))
+    assertFalse(numValues.contains(-0.0))
+    assertFalse(numValues.contains(Double.NaN))
+
+    nummp.put(2, -0.0)
+    assertTrue(numValues.contains(+0.0))
+    assertTrue(numValues.contains(-0.0))
+    assertFalse(numValues.contains(Double.NaN))
+
+    nummp.put(3, Double.NaN)
+    assertTrue(numValues.contains(+0.0))
+    assertTrue(numValues.contains(-0.0))
+    assertTrue(numValues.contains(Double.NaN))
+
+    val hm1 = mu.HashMap(
+      1.0 -> null,
+      2.0 -> 2.0)
+    val hm2 = mu.HashMap(
+      (null: Any) -> 1.0,
+      2.0 -> 2.0)
+    val hm3 = mu.HashMap(
+      (null: Any) -> null,
+      2.0 -> 2.0)
+
+    assertFalse(new SimpleQueryableMap(hm1).values().contains(1.0))
+    assertTrue(new SimpleQueryableMap(hm2).values().contains(1.0))
+    assertFalse(new SimpleQueryableMap(hm3).values().contains(1.0))
+
+    assertTrue(new SimpleQueryableMap(hm1).values().contains(null))
+    assertFalse(new SimpleQueryableMap(hm2).values().contains(null))
+    assertTrue(new SimpleQueryableMap(hm3).values().contains(null))
+  }
+
+  test("values should side effect clear remove retain on the related map") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+
+    val values = mp.values()
+    assertFalse(values.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    values.clear()
+
+    assertTrue(values.isEmpty)
+    assertTrue(mp.isEmpty)
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+
+    assertTrue(mp.containsKey("ONE"))
+
+    values.remove("one")
+
+    assertFalse(mp.containsKey("ONE"))
+
+    mp.put("ONE", "one")
+    mp.put("THREE", "three")
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    values.removeAll(asJavaCollection(im.List("one", "two")))
+
+    assertFalse(mp.containsKey("ONE"))
+    assertFalse(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    mp.put("THREE", "three")
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    values.retainAll(asJavaCollection(im.List("one", "two")))
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertFalse(mp.containsKey("THREE"))
+  }
+
+  test("keySet should mirror the related map size") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+
+    val keySet = mp.keySet()
+    assertEquals(2, keySet.size())
+
+    mp.put("THREE", "three")
+
+    assertEquals(3, keySet.size())
+
+    mp.remove("ONE")
+
+    assertEquals(2, keySet.size())
+
+    assertFalse(keySet.isEmpty)
+
+    mp.clear()
+
+    assertEquals(0, keySet.size())
+
+    assertTrue(keySet.isEmpty)
+
+    val hm1 = mu.HashMap(
+      "ONE" -> "one",
+      "TWO" -> "two")
+    val hm2 = mu.HashMap(
+      "ONE" -> null,
+      "TWO" -> "two")
+    val hm3 = mu.HashMap(
+      (null: String) -> "one",
+      "TWO" -> "two")
+    val hm4 = mu.HashMap(
+      (null: String) -> null,
+      "TWO" -> "two")
+
+    assertEquals(2, new SimpleQueryableMap(hm1).keySet().size())
+    assertEquals(2, new SimpleQueryableMap(hm2).keySet().size())
+    assertEquals(2, new SimpleQueryableMap(hm3).keySet().size())
+    assertEquals(2, new SimpleQueryableMap(hm4).keySet().size())
+  }
+
+  test("keySet should check single and multiple objects presence") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+
+    val keySet = mp.keySet()
+    assertTrue(keySet.contains("ONE"))
+    assertTrue(keySet.contains("TWO"))
+    assertFalse(keySet.contains("THREE"))
+    if (factory.allowsNullKeysQueries)
+      assertFalse(keySet.contains(null))
+    else
+      expectThrows(classOf[Throwable], mp.contains(null))
+
+    mp.put("THREE", "three")
+
+    assertTrue(keySet.contains("THREE"))
+
+    val coll1 =
+      asJavaCollection(im.Set("ONE", "TWO", "THREE"))
+    assertTrue(keySet.containsAll(coll1))
+
+    val coll2 =
+      asJavaCollection(im.Set("ONE", "TWO", "THREE", "FOUR"))
+    assertFalse(keySet.containsAll(coll2))
+
+    val coll3 =
+      asJavaCollection(im.Set("ONE", "TWO", "THREE", null))
+    assertFalse(keySet.containsAll(coll2))
+
+    val nummp = factory.empty[Double, Double]
+
+    val numkeySet = nummp.keySet()
+    nummp.put(+0.0, 1)
+    assertTrue(numkeySet.contains(+0.0))
+    assertFalse(numkeySet.contains(-0.0))
+    assertFalse(numkeySet.contains(Double.NaN))
+
+    nummp.put(-0.0, 2)
+    assertTrue(numkeySet.contains(+0.0))
+    assertTrue(numkeySet.contains(-0.0))
+    assertFalse(numkeySet.contains(Double.NaN))
+
+    nummp.put(Double.NaN, 3)
+    assertTrue(numkeySet.contains(+0.0))
+    assertTrue(numkeySet.contains(-0.0))
+    assertTrue(numkeySet.contains(Double.NaN))
+
+    val hm1 = mu.HashMap(
+      1.0 -> null,
+      2.0 -> 2.0)
+    val hm2 = mu.HashMap(
+      (null: Any) -> 1.0,
+      2.0 -> 2.0)
+    val hm3 = mu.HashMap(
+      (null: Any) -> null,
+      2.0 -> 2.0)
+
+    assertTrue(new SimpleQueryableMap(hm1).keySet().contains(1.0))
+    assertFalse(new SimpleQueryableMap(hm2).keySet().contains(1.0))
+    assertFalse(new SimpleQueryableMap(hm3).keySet().contains(1.0))
+
+    assertFalse(new SimpleQueryableMap(hm1).keySet().contains(null))
+    assertTrue(new SimpleQueryableMap(hm2).keySet().contains(null))
+    assertTrue(new SimpleQueryableMap(hm3).keySet().contains(null))
+  }
+
+  test("keySet should side effect clear remove retain on the related map") {
+    val mp = factory.empty[String, String]
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+
+    val keySet = mp.keySet()
+    assertFalse(keySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    keySet.clear()
+
+    assertTrue(keySet.isEmpty)
+
+    assertTrue(mp.isEmpty)
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+
+    assertTrue(mp.containsKey("ONE"))
+
+    keySet.remove("ONE")
+
+    assertFalse(mp.containsKey("ONE"))
+
+    mp.put("ONE", "one")
+    mp.put("THREE", "three")
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    keySet.removeAll(asJavaCollection(im.List("ONE", "TWO")))
+
+    assertFalse(mp.containsKey("ONE"))
+    assertFalse(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    mp.put("THREE", "three")
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    keySet.retainAll(asJavaCollection(im.List("ONE", "TWO")))
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertFalse(mp.containsKey("THREE"))
+  }
+}
+
+object MapFactory {
+  def allFactories: Iterator[MapFactory] =
+    HashMapSuiteFactory.allFactories
+}
+
+trait MapFactory {
+  def implementationName: String
+
+  def empty[K: ClassTag, V: ClassTag]: ju.Map[K, V]
+
+  def allowsNullKeys: Boolean
+
+  def allowsNullValues: Boolean
+
+  def allowsNullKeysQueries: Boolean = true
+
+  def allowsNullValuesQueries: Boolean = true
+}


### PR DESCRIPTION
This avoids double-boxing to preserve the same semantics as the reference `java.util.HashMap` that uses `equals` and `hashCode` rather than `==` and `##` like regular mutable maps in Scala. Unsurprisingly, the change improves performance. 

Additionally, this PR also includes a port of hash map tests from Scala.js. 