### PR TITLE
Faster String::{equals, hashCode}

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/native/string.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/string.scala
@@ -20,7 +20,7 @@ object string {
   def strstr(str: CString, substr: CString): CString                   = extern
   def strtok(str: CString, delim: CString): CString                    = extern
   def memchr(ptr: Ptr[Byte], ch: CInt, count: CSize): Ptr[Byte]        = extern
-  def memcmp(lhs: Ptr[Byte], rhs: Ptr[Byte], count: CSize): Ptr[Byte]  = extern
+  def memcmp(lhs: Ptr[Byte], rhs: Ptr[Byte], count: CSize): CInt       = extern
   def memset(dest: Ptr[Byte], ch: CInt, count: CSize): Ptr[Byte]       = extern
   def memcpy(dest: Ptr[Byte], src: Ptr[Byte], count: CSize): Ptr[Byte] = extern
   def memmove(dest: Ptr[Byte], src: Ptr[Byte], count: CSize): Ptr[Byte] =


### PR DESCRIPTION
This PR improves performance of `equals` and `hashCode` on strings.

1. Only use cached hash code to avoid full comparison, and never compute it if it's not available.
2. Access data directly avoiding range checks in the main loops of `equals` and `hashCode`.