### PR TITLE
clang-format update 5.0 and add docs for brew install

### DIFF
--- a/bin/clangfmt
+++ b/bin/clangfmt
@@ -13,7 +13,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # The required version of clang-format.
-CLANG_FORMAT_VERSION=4.0
+CLANG_FORMAT_VERSION=5.0
 CLANG_FORMAT_VERSION_STRING="clang-format version $CLANG_FORMAT_VERSION"
 
 die() {

--- a/demo/cpp/smallpt.cpp
+++ b/demo/cpp/smallpt.cpp
@@ -106,13 +106,13 @@ Vec radiance(const Ray &r, int depth, unsigned short *Xi) {
            c = 1 - (into ? -ddn : tdir.dot(n));
     double Re = R0 + (1 - R0) * c * c * c * c * c, Tr = 1 - Re,
            P = .25 + .5 * Re, RP = Re / P, TP = Tr / (1 - P);
-    return obj.e +
-           f.mult(depth > 2 ? (erand48(Xi) < P
-                                   ? // Russian roulette
-                                   radiance(reflRay, depth, Xi) * RP
-                                   : radiance(Ray(x, tdir), depth, Xi) * TP)
-                            : radiance(reflRay, depth, Xi) * Re +
-                                  radiance(Ray(x, tdir), depth, Xi) * Tr);
+    return obj.e + f.mult(depth > 2
+                              ? (erand48(Xi) < P
+                                     ? // Russian roulette
+                                     radiance(reflRay, depth, Xi) * RP
+                                     : radiance(Ray(x, tdir), depth, Xi) * TP)
+                              : radiance(reflRay, depth, Xi) * Re +
+                                    radiance(Ray(x, tdir), depth, Xi) * Tr);
 }
 int main(int argc, char *argv[]) {
     int w = 800, h = 600,

--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -56,6 +56,7 @@ Native has been used with:
 
     $ brew install llvm
     $ brew install bdw-gc re2 # optional
+    $ brew install clang-format # required if using ./bin/clangfmt
 
 *Note:* A version of zlib that is sufficiently recent comes with the
 installation of macOS.

--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -56,7 +56,6 @@ Native has been used with:
 
     $ brew install llvm
     $ brew install bdw-gc re2 # optional
-    $ brew install clang-format # required if using ./bin/clangfmt
 
 *Note:* A version of zlib that is sufficiently recent comes with the
 installation of macOS.

--- a/nativelib/src/main/resources/eh.cpp
+++ b/nativelib/src/main/resources/eh.cpp
@@ -13,7 +13,7 @@ class ExceptionWrapper : public std::exception {
     ExceptionWrapper(void *_obj) : obj(_obj) {}
     void *obj;
 };
-}
+} // namespace scalanative
 
 extern "C" {
 void scalanative_throw(void *obj) { throw scalanative::ExceptionWrapper(obj); }

--- a/nativelib/src/main/resources/gc/immix/Heap.c
+++ b/nativelib/src/main/resources/gc/immix/Heap.c
@@ -59,8 +59,8 @@ Heap *Heap_Create(size_t initialSmallHeapSize, size_t initialLargeHeapSize) {
     heap->smallHeapSize = initialSmallHeapSize;
     heap->heapStart = smallHeapStart;
     heap->heapEnd = smallHeapStart + initialSmallHeapSize / WORD_SIZE;
-    heap->allocator =
-        Allocator_Create(smallHeapStart, initialSmallHeapSize / BLOCK_TOTAL_SIZE);
+    heap->allocator = Allocator_Create(smallHeapStart,
+                                       initialSmallHeapSize / BLOCK_TOTAL_SIZE);
 
     // Init heap for large objects
     word_t *largeHeapStart = Heap_mapAndAlign(memoryLimit, MIN_BLOCK_SIZE);

--- a/nativelib/src/main/resources/optional/re2.h
+++ b/nativelib/src/main/resources/optional/re2.h
@@ -133,7 +133,7 @@ typedef enum scalanative_cre2_error_code_t {
     scalanative_cre2_ERROR_MISSING_PAREN,      /* missing closing ) */
     scalanative_cre2_ERROR_TRAILING_BACKSLASH, /* trailing \ at end of regexp */
     scalanative_cre2_ERROR_REPEAT_ARGUMENT, /* repeat argument missing, e.g. "*"
-                                               */
+                                             */
     scalanative_cre2_ERROR_REPEAT_SIZE,     /* bad repetition argument */
     scalanative_cre2_ERROR_REPEAT_OP,       /* bad repetition operator */
     scalanative_cre2_ERROR_BAD_PERL_OP,     /* bad perl operator */


### PR DESCRIPTION
* Updated the required version to 5.0 as its default to `brew install` on mac osx
* Reformatted c code with `./bin/clangfmt`