### PR TITLE
Define posix cpio.h

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -13,7 +13,7 @@ C Header          Scala Native Module
 `arpa/inet.h`_    scala.scalanative.posix.arpa.inet_
 `assert.h`_       N/A
 `complex.h`_      N/A
-`cpio.h`_         N/A
+`cpio.h`_         scala.scalanative.posix.cpio_
 `ctype.h`_        N/A
 `dirent.h`_       scala.scalanative.posix.dirent_
 `dlfcn.h`_        N/A
@@ -177,6 +177,7 @@ C Header          Scala Native Module
 .. _wordexp.h: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/wordexp.h.html
 
 .. _scala.scalanative.posix.arpa.inet: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
+.. _scala.scalanative.posix.cpio: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/cpio.scala
 .. _scala.scalanative.posix.dirent: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/dirent.scala
 .. _scala.scalanative.posix.errno: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/errno.scala
 .. _scala.scalanative.posix.fcntl: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/fcntl.scala

--- a/nativelib/src/main/resources/posix/cpio.h
+++ b/nativelib/src/main/resources/posix/cpio.h
@@ -1,0 +1,24 @@
+#include <cpio.h>
+
+unsigned short scalanative_c_issock() { return C_ISSOCK; }
+unsigned short scalanative_c_islnk() { return C_ISLNK; }
+unsigned short scalanative_c_isctg() { return C_ISCTG; }
+unsigned short scalanative_c_isreg() { return C_ISREG; }
+unsigned short scalanative_c_isblk() { return C_ISBLK; }
+unsigned short scalanative_c_isdir() { return C_ISDIR; }
+unsigned short scalanative_c_ischr() { return C_ISCHR; }
+unsigned short scalanative_c_isfifo() { return C_ISFIFO; }
+unsigned short scalanative_c_isuid() { return C_ISUID; }
+unsigned short scalanative_c_isgid() { return C_ISGID; }
+unsigned short scalanative_c_isvtx() { return C_ISVTX; }
+unsigned short scalanative_c_irusr() { return C_IRUSR; }
+unsigned short scalanative_c_iwusr() { return C_IWUSR; }
+unsigned short scalanative_c_ixusr() { return C_IXUSR; }
+unsigned short scalanative_c_irgrp() { return C_IRGRP; }
+unsigned short scalanative_c_iwgrp() { return C_IWGRP; }
+unsigned short scalanative_c_ixgrp() { return C_IXGRP; }
+unsigned short scalanative_c_iroth() { return C_IROTH; }
+unsigned short scalanative_c_iwoth() { return C_IWOTH; }
+unsigned short scalanative_c_ixoth() { return C_IXOTH; }
+
+const char *scalanative_magic() { return MAGIC; }

--- a/nativelib/src/main/scala/scala/scalanative/posix/cpio.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/cpio.scala
@@ -1,0 +1,70 @@
+package scala.scalanative
+package posix
+
+import scalanative.native._
+
+@extern
+object cpio {
+  @name("scalanative_c_issock")
+  def C_ISSOCK: CUnsignedShort = extern
+
+  @name("scalanative_c_islnk")
+  def C_ISLNK: CUnsignedShort = extern
+
+  @name("scalanative_c_isctg")
+  def C_ISCTG: CUnsignedShort = extern
+
+  @name("scalanative_c_isreg")
+  def C_ISREG: CUnsignedShort = extern
+
+  @name("scalanative_c_isblk")
+  def C_ISBLK: CUnsignedShort = extern
+
+  @name("scalanative_c_isdir")
+  def C_ISDIR: CUnsignedShort = extern
+
+  @name("scalanative_c_ischr")
+  def C_ISCHR: CUnsignedShort = extern
+
+  @name("scalanative_c_isfifo")
+  def C_ISFIFO: CUnsignedShort = extern
+
+  @name("scalanative_c_isuid")
+  def C_ISUID: CUnsignedShort = extern
+
+  @name("scalanative_c_isgid")
+  def C_ISGID: CUnsignedShort = extern
+
+  @name("scalanative_c_isvtx")
+  def C_ISVTX: CUnsignedShort = extern
+
+  @name("scalanative_c_irusr")
+  def C_IRUSR: CUnsignedShort = extern
+
+  @name("scalanative_c_iwusr")
+  def C_IWUSR: CUnsignedShort = extern
+
+  @name("scalanative_c_ixusr")
+  def C_IXUSR: CUnsignedShort = extern
+
+  @name("scalanative_c_irgrp")
+  def C_IRGRP: CUnsignedShort = extern
+
+  @name("scalanative_c_iwgrp")
+  def C_IWGRP: CUnsignedShort = extern
+
+  @name("scalanative_c_ixgrp")
+  def C_IXGRP: CUnsignedShort = extern
+
+  @name("scalanative_c_iroth")
+  def C_IROTH: CUnsignedShort = extern
+
+  @name("scalanative_c_iwoth")
+  def C_IWOTH: CUnsignedShort = extern
+
+  @name("scalanative_c_ixoth")
+  def C_IXOTH: CUnsignedShort = extern
+
+  @name("scalanative_magic")
+  def MAGIC: CString = extern
+}


### PR DESCRIPTION
This pull request is not complete and would like some advice on how to correctly link the undefined symbols. After binding definitions from [cpio.h](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/cpio.h.html) and trying to compile a simple project that references a definition, the following linker exception is thrown. Example project [cpio-example](https://github.com/adam-singer/scala-native-examples/blob/adams/cpio-example/cpio-example/src/main/scala/Main.scala).

```
    > run -verbose
    [info] Linking (758 ms)
    [info] Discovered 1270 classes and 9347 methods
    [info] Optimizing (734 ms)
    [info] Generating intermediate code (225 ms)
    [info] Produced 37 files
    [info] Compiling to native code (672 ms)
    [error] Undefined symbols for architecture x86_64:
    [error]   "_scalanative_c_iwgrp", referenced from:
    [error]       _Main$::main_scala.scalanative.runtime.ObjectArray_unit in __empty.ll.o
    [error] ld: symbol(s) not found for architecture x86_64
    [error] clang: error: linker command failed with exit code 1 (use -v to see invocation)
    [info] Linking native code (86 ms)
    java.io.IOException: Cannot run program "/Users/adam/scala/scala-native-examples/cpio-example/target/scala-2.11/cpio-example-out": error=2, No such file or directory
            at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
    Caused by: java.io.IOException: error=2, No such file or directory
            at java.lang.UNIXProcess.forkAndExec(Native Method)
            at java.lang.UNIXProcess.<init>(UNIXProcess.java:185)
            at java.lang.ProcessImpl.start(ProcessImpl.java:134)
            at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
    [trace] Stack trace suppressed: run last compile:run for the full output.
    [error] (compile:run) java.io.IOException: Cannot run program "/Users/adam/scala/scala-native-examples/cpio-example/target/scala-2.11/cpio-example-out": error=2, No such file or directory
    [error] Total time: 3 s, completed Nov 25, 2017 11:44:27 PM
```