### PR TITLE
Fix binary version regression introduced in #1039

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativeCrossVersion.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativeCrossVersion.scala
@@ -14,8 +14,8 @@ object ScalaNativeCrossVersion {
   val currentBinaryVersion = binaryVersion(Versions.current)
 
   def binaryVersion(full: String): String = full match {
-    case ReleaseVersion(major, _, _) => major
-    case _                           => full
+    case ReleaseVersion(major, minor, _) => s"$major.$minor"
+    case _                               => full
   }
 
   def scalaNativeMapped(cross: CrossVersion): CrossVersion =


### PR DESCRIPTION
Binary version must include both major and minor versions of
Scala Native, not just major.