### PR TITLE
Fix #1079: Less restrictive assertThrows

### DIFF
--- a/unit-tests/src/main/scala/tests/Suite.scala
+++ b/unit-tests/src/main/scala/tests/Suite.scala
@@ -63,19 +63,6 @@ abstract class Suite {
     throw AssertionFailed
   }
 
-  private def assertThrowsImpl(cls: Class[_], f: => Unit): Unit = {
-    try {
-      f
-    } catch {
-      case exc: Throwable =>
-        if (cls.isAssignableFrom(exc.getClass))
-          return
-        else
-          throw AssertionFailed
-    }
-    throw AssertionFailed
-  }
-
   def test(name: String)(body: => Unit): Unit =
     tests += Test(name, { () =>
       try {

--- a/unit-tests/src/test/scala/java/nio/BaseBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/BaseBufferTest.scala
@@ -18,11 +18,11 @@ abstract class BaseBufferTest extends tests.Suite {
 
       assertEquals(0, allocBuffer(0).capacity)
 
-      /*assertThrows[RuntimeException] { allocBuffer(-1) }
+      assertThrows[RuntimeException] { allocBuffer(-1) }
       assertThrows[RuntimeException] { allocBuffer(0, -1, 1) }
       assertThrows[RuntimeException] { allocBuffer(1, 0, 1) }
       assertThrows[RuntimeException] { allocBuffer(0, 1, 0) }
-      assertThrows[RuntimeException] { allocBuffer(1, 0, 0) } */
+      assertThrows[RuntimeException] { allocBuffer(1, 0, 0) }
 
       val buf2 = allocBuffer(1, 5, 9)
       assertEquals(1, buf2.position())

--- a/unit-tests/src/test/scala/tests/SuiteSuite.scala
+++ b/unit-tests/src/test/scala/tests/SuiteSuite.scala
@@ -4,6 +4,10 @@ class A             extends Exception
 class B             extends Exception
 class C(val v: Int) extends Exception
 
+object Foo {
+  def bar(): Unit = throw new IllegalStateException()
+}
+
 object SuiteSuite extends Suite {
   test("expects true") {
     assert(true)
@@ -39,5 +43,13 @@ object SuiteSuite extends Suite {
 
   testFails("expects A and doesn't throw", issue = -1) {
     assertThrows[A] {}
+  }
+
+  test("catch IllegalStateException") {
+    assertThrows[IllegalStateException] { Foo.bar() }
+  }
+
+  test("catch RuntimeException") {
+    assertThrows[RuntimeException] { Foo.bar() }
   }
 }


### PR DESCRIPTION
Previously we would check that class is exactly the same the
one given in the assertion. Any subtype should be admitted as well.