### PR TITLE
Fix #1032: Simplify stack trace element caching

### DIFF
--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -1,92 +1,15 @@
 package java.lang
 
-import scala.scalanative.native.{
-  fromCString,
-  stackalloc,
-  string,
-  CChar,
-  CString,
-  CUnsignedLong,
-  Ptr
-}
-import scala.scalanative.runtime.{ByteArray, unwind}
+final class StackTraceElement(val getClassName: String,
+                              val getMethodName: String,
+                              val getFileName: String,
+                              val getLineNumber: Int) {
 
-final class StackTraceElement private (_symbol: CString) {
-  var symbol: Array[Byte] = _
+  if (getClassName == null)
+    throw new NullPointerException("Declaring class is null")
 
-  if (_symbol != null) {
-    symbol = new Array[Byte](256)
-    string.memcpy(symbol.asInstanceOf[ByteArray].at(0), _symbol, 256)
-  }
-
-  def this(className: String,
-           methodName: String,
-           fileName: String,
-           lineNumber: Int) = {
-    this(null)
-    if (className == null)
-      throw new NullPointerException("Declaring class is null")
-
-    if (methodName == null)
-      throw new NullPointerException("Method name is null")
-
-    initDone = true
-    _className = className
-    _methodName = methodName
-    _fileName = fileName
-    _lineNumber = lineNumber
-  }
-
-  private var initDone: Boolean   = false
-  private var _className: String  = _
-  private var _methodName: String = _
-  private var _fileName: String   = _
-  private var _lineNumber: Int    = _
-
-  def getClassName: String = {
-    if (!initDone) initMembers()
-    _className
-  }
-
-  def getMethodName: String = {
-    if (!initDone) initMembers()
-    _methodName
-  }
-
-  def getFileName: String = {
-    if (!initDone) initMembers()
-    _fileName
-  }
-
-  def getLineNumber: Int = {
-    if (!initDone) initMembers()
-    _lineNumber
-  }
-
-  // symbol is "classname::methodName_T1_..._TN"
-  // where classname doesn't include colons and method name underscores.
-  private def initMembers(): Unit = {
-    val sym = fromCString(symbol.asInstanceOf[ByteArray].at(0))
-    val (className, methodName) =
-      sym.indexOf("::") match {
-        case -1 =>
-          ("<none>", sym)
-        case sep =>
-          sym.indexOf("_", sep) match {
-            case -1 =>
-              (sym.substring(0, sep), sym.substring(sep + 2))
-            case end =>
-              (sym.substring(0, sep), sym.substring(sep + 2, end))
-          }
-      }
-
-    initDone = true
-    _className = className
-    _methodName = methodName
-    _fileName = null
-    _lineNumber = 0
-    symbol = null
-  }
+  if (getMethodName == null)
+    throw new NullPointerException("Method name is null")
 
   def isNativeMethod: scala.Boolean = false
 
@@ -114,27 +37,21 @@ final class StackTraceElement private (_symbol: CString) {
 }
 
 private[lang] object StackTraceElement {
-  private val cache =
-    collection.mutable.HashMap.empty[CUnsignedLong, StackTraceElement]
-  private def makeStackTraceElement(
-      cursor: Ptr[scala.Byte]): StackTraceElement = {
-    val name   = stackalloc[CChar](256)
-    val offset = stackalloc[scala.Byte](8)
-
-    unwind.get_proc_name(cursor, name, 256, offset)
-    new StackTraceElement(name)
+  // symbol is "classname::methodName_T1_..._TN"
+  // where classname doesn't include colons and method name underscores.
+  def fromSymbol(symbol: String): StackTraceElement = {
+    val (className, methodName) =
+      symbol.indexOf("::") match {
+        case -1 =>
+          ("<none>", symbol)
+        case sep =>
+          symbol.indexOf("_", sep) match {
+            case -1 =>
+              (symbol.substring(0, sep), symbol.substring(sep + 2))
+            case end =>
+              (symbol.substring(0, sep), symbol.substring(sep + 2, end))
+          }
+      }
+    new StackTraceElement(className, methodName, null, 0)
   }
-
-  /**
-   * Tries to retrieve a pre-computed `StackTraceElement`, or computes it.
-   * We use `startIp` (ie. the address of the first instruction of the function)
-   * as cache key.
-   *
-   * Computing stack traces is expensive because we need to collect names of
-   * functions, and convert those names from C strings to Scala strings.
-   */
-  private[lang] def cached(cursor: Ptr[scala.Byte],
-                           startIp: CUnsignedLong): StackTraceElement =
-    cache.getOrElseUpdate(startIp, makeStackTraceElement(cursor))
-
 }

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -4,6 +4,45 @@ import scala.collection.mutable
 import scalanative.native._
 import scalanative.runtime.unwind
 
+private[lang] object StackTrace {
+  private val cache =
+    collection.mutable.HashMap.empty[CUnsignedLong, StackTraceElement]
+
+  private def makeStackTraceElement(
+      cursor: Ptr[scala.Byte]): StackTraceElement = {
+    val name   = stackalloc[CChar](256)
+    val offset = stackalloc[scala.Byte](8)
+
+    unwind.get_proc_name(cursor, name, 256, offset)
+    StackTraceElement.fromSymbol(scalanative.native.fromCString(name))
+  }
+
+  /** Creates a stack trace element in given unwind context.
+   *  Finding a name of the symbol for current function is expensive,
+   *  so we cache stack trace elements based on current instruction pointer.
+   */
+  private def cachedStackTraceElement(cursor: Ptr[scala.Byte],
+                                      ip: CUnsignedLong): StackTraceElement =
+    cache.getOrElseUpdate(ip, makeStackTraceElement(cursor))
+
+  private[lang] def currentStackTrace(): Array[StackTraceElement] = {
+    val cursor  = stackalloc[scala.Byte](2048)
+    val context = stackalloc[scala.Byte](2048)
+    val offset  = stackalloc[scala.Byte](8)
+    val ip      = stackalloc[CUnsignedLongLong]
+    var buffer  = mutable.ArrayBuffer.empty[StackTraceElement]
+
+    unwind.get_context(context)
+    unwind.init_local(cursor, context)
+    while (unwind.step(cursor) > 0) {
+      unwind.get_reg(cursor, unwind.UNW_REG_IP, ip)
+      buffer += cachedStackTraceElement(cursor, !ip)
+    }
+
+    buffer.toArray
+  }
+}
+
 class Throwable(s: String, private var e: Throwable)
     extends Object
     with java.io.Serializable {
@@ -27,19 +66,7 @@ class Throwable(s: String, private var e: Throwable)
   def getLocalizedMessage(): String = getMessage()
 
   def fillInStackTrace(): Throwable = {
-    val cursor  = stackalloc[scala.Byte](2048)
-    val context = stackalloc[scala.Byte](2048)
-    val ip      = stackalloc[CUnsignedLongLong]
-    var buffer  = mutable.ArrayBuffer.empty[StackTraceElement]
-
-    unwind.get_context(context)
-    unwind.init_local(cursor, context)
-    while (unwind.step(cursor) > 0) {
-      unwind.get_reg(cursor, unwind.UNW_REG_IP, ip)
-      buffer += StackTraceElement.cached(cursor, !ip)
-    }
-
-    this.stackTrace = buffer.toArray
+    this.stackTrace = StackTrace.currentStackTrace()
     this
   }
 


### PR DESCRIPTION
Stack trace elements used to lazily convert from CString for the underlying native symbol to the corresponding class/method name. Now it's done eagerly, similarly to the original implementation before stack trace caching. 