### PR TITLE
Fix #855: Add support for @volatile annotation

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -20,6 +20,7 @@ object Attr {
 
   final case object Pure                  extends Attr
   final case object Extern                extends Attr
+  final case object JavaVolatile          extends Attr
   final case class Override(name: Global) extends Attr
 
   final case class Align(value: Int) extends Attr
@@ -37,6 +38,7 @@ final case class Attrs(inline: Inline = MayInline,
                        isExtern: Boolean = false,
                        isDyn: Boolean = false,
                        isStub: Boolean = false,
+                       isJavaVolatile: Boolean = false,
                        overrides: Seq[Global] = Seq(),
                        pins: Seq[Pin] = Seq(),
                        links: Seq[Attr.Link] = Seq(),
@@ -49,6 +51,8 @@ final case class Attrs(inline: Inline = MayInline,
     if (isExtern) out += Extern
     if (isDyn) out += Dyn
     if (isStub) out += Stub
+    if (isJavaVolatile) out += JavaVolatile
+
     overrides.foreach { out += Override(_) }
     out ++= pins
     out ++= links
@@ -61,15 +65,16 @@ object Attrs {
   val None = new Attrs()
 
   def fromSeq(attrs: Seq[Attr]) = {
-    var inline    = None.inline
-    var isPure    = false
-    var isExtern  = false
-    var isDyn     = false
-    var isStub    = false
-    var align     = Option.empty[Int]
-    val overrides = mutable.UnrolledBuffer.empty[Global]
-    val pins      = mutable.UnrolledBuffer.empty[Pin]
-    val links     = mutable.UnrolledBuffer.empty[Attr.Link]
+    var inline         = None.inline
+    var isPure         = false
+    var isExtern       = false
+    var isDyn          = false
+    var isStub         = false
+    var isJavaVolatile = false
+    var align          = Option.empty[Int]
+    val overrides      = mutable.UnrolledBuffer.empty[Global]
+    val pins           = mutable.UnrolledBuffer.empty[Pin]
+    val links          = mutable.UnrolledBuffer.empty[Attr.Link]
 
     attrs.foreach {
       case attr: Inline    => inline = attr
@@ -81,16 +86,20 @@ object Attrs {
       case Override(name)  => overrides += name
       case attr: Pin       => pins += attr
       case link: Attr.Link => links += link
+      case JavaVolatile    => isJavaVolatile = true
     }
 
-    new Attrs(inline,
-              isPure,
-              isExtern,
-              isDyn,
-              isStub,
-              overrides,
-              pins,
-              links,
-              align)
+    new Attrs(
+      inline = inline,
+      isPure = isPure,
+      isExtern = isExtern,
+      isDyn = isDyn,
+      isStub = isStub,
+      isJavaVolatile = isJavaVolatile,
+      overrides = overrides,
+      pins = pins,
+      links = links,
+      align = align
+    )
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -43,10 +43,17 @@ class Buffer(implicit fresh: Fresh) {
     let(fresh(), op)
   def call(ty: Type, ptr: Val, args: Seq[Val], unwind: Next): Val =
     let(Op.Call(ty, ptr, args, unwind))
-  def load(ty: Type, ptr: Val, isVolatile: Boolean = false): Val =
-    let(Op.Load(ty, ptr, isVolatile))
-  def store(ty: Type, ptr: Val, value: Val, isVolatile: Boolean = false): Val =
-    let(Op.Store(ty, ptr, value, isVolatile))
+  def load(ty: Type,
+           ptr: Val,
+           isVolatile: Boolean = false,
+           isAtomic: Boolean = false): Val =
+    let(Op.Load(ty, ptr, isVolatile, isAtomic))
+  def store(ty: Type,
+            ptr: Val,
+            value: Val,
+            isVolatile: Boolean = false,
+            isAtomic: Boolean = false): Val =
+    let(Op.Store(ty, ptr, value, isVolatile, isAtomic))
   def elem(ty: Type, ptr: Val, indexes: Seq[Val]): Val =
     let(Op.Elem(ty, ptr, indexes))
   def extract(aggr: Val, indexes: Seq[Int]): Val =

--- a/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
@@ -1,8 +1,6 @@
 package scala.scalanative
 package nir
 
-import java.util.concurrent.atomic.AtomicInteger
-
 final class Fresh private (private var start: Int) {
   def apply(): Local = {
     start += 1

--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -7,8 +7,8 @@ sealed abstract class Op {
   final def resty: Type = this match {
     case Op.Call(Type.Function(_, ret), _, _, _) => ret
     case Op.Call(_, _, _, _)                     => unreachable
-    case Op.Load(ty, _, _)                       => ty
-    case Op.Store(_, _, _, _)                    => Type.Unit
+    case Op.Load(ty, _, _, _)                    => ty
+    case Op.Store(_, _, _, _, _)                 => Type.Unit
     case Op.Elem(_, _, _)                        => Type.Ptr
     case Op.Extract(aggr, indexes)               => aggr.ty.elemty(indexes.map(Val.Int(_)))
     case Op.Insert(aggr, _, _)                   => aggr.ty
@@ -43,8 +43,16 @@ object Op {
   // low-level
   final case class Call(ty: Type, ptr: Val, args: Seq[Val], unwind: Next)
       extends Unwind
-  final case class Load(ty: Type, ptr: Val, isVolatile: Boolean) extends Op
-  final case class Store(ty: Type, ptr: Val, value: Val, isVolatile: Boolean)
+  final case class Load(ty: Type,
+                        ptr: Val,
+                        isVolatile: Boolean,
+                        isAtomic: Boolean)
+      extends Op
+  final case class Store(ty: Type,
+                         ptr: Val,
+                         value: Val,
+                         isVolatile: Boolean,
+                         isAtomic: Boolean)
       extends Op
   final case class Elem(ty: Type, ptr: Val, indexes: Seq[Val])      extends Pure
   final case class Extract(aggr: Val, indexes: Seq[Int])            extends Pure
@@ -56,9 +64,9 @@ object Op {
   final case class Select(cond: Val, thenv: Val, elsev: Val)        extends Pure
 
   def Load(ty: Type, ptr: Val): Load =
-    Load(ty, ptr, isVolatile = false)
+    Load(ty, ptr, isVolatile = false, isAtomic = false)
   def Store(ty: Type, ptr: Val, value: Val): Store =
-    Store(ty, ptr, value, isVolatile = false)
+    Store(ty, ptr, value, isVolatile = false, isAtomic = false)
 
   // high-level
   final case class Classalloc(name: Global)                        extends Op

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -1,12 +1,11 @@
 package scala.scalanative
 package nir
 
-import scala.util.matching.Regex
-
-import util.{unreachable, ShowBuilder}
+import scala.scalanative.util.{ShowBuilder, unreachable}
 
 object Show {
   def newBuilder: NirShowBuilder = new NirShowBuilder(new ShowBuilder)
+
   def debug[T](msg: String)(f: => T): T = {
     val value = f
     println("$msg: " + value)
@@ -45,6 +44,8 @@ object Show {
     }
 
     def attr_(attr: Attr): Unit = attr match {
+      case Attr.JavaVolatile =>
+        str("javavolatile")
       case Attr.MayInline =>
         str("mayinline")
       case Attr.InlineHint =>
@@ -183,13 +184,17 @@ object Show {
           str(" ")
           next_(unwind)
         }
-      case Op.Load(ty, ptr, isVolatile) =>
-        str(if (isVolatile) "volatile load[" else "load[")
+      case Op.Load(ty, ptr, isVolatile, isAtomic) =>
+        if (isAtomic) str("atomic ")
+        if (isVolatile) str("volatile ")
+        str("load[")
         type_(ty)
         str("] ")
         val_(ptr)
-      case Op.Store(ty, ptr, value, isVolatile) =>
-        str(if (isVolatile) "volatile store[" else "store[")
+      case Op.Store(ty, ptr, value, isVolatile, isAtomic) =>
+        if (isAtomic) str("atomic ")
+        if (isVolatile) str("volatile ")
+        str("store[")
         type_(ty)
         str("] ")
         val_(ptr)
@@ -608,4 +613,5 @@ object Show {
 
     override def toString: String = builder.toString
   }
+
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -90,9 +90,10 @@ final class BinaryDeserializer(_buffer: => ByteBuffer) {
         case T.DynAttr  => buf += Attr.Dyn
         case T.StubAttr => buf += Attr.Stub
 
-        case T.PureAttr     => buf += Attr.Pure
-        case T.ExternAttr   => buf += Attr.Extern
-        case T.OverrideAttr => buf += Attr.Override(getGlobal)
+        case T.PureAttr         => buf += Attr.Pure
+        case T.ExternAttr       => buf += Attr.Extern
+        case T.OverrideAttr     => buf += Attr.Override(getGlobal)
+        case T.JavaVolatileAttr => buf += Attr.JavaVolatile
 
         case T.LinkAttr      => links += Attr.Link(getString)
         case T.PinAlwaysAttr => deps += Dep.Direct(getGlobalNoDep)
@@ -235,9 +236,11 @@ final class BinaryDeserializer(_buffer: => ByteBuffer) {
   }
 
   private def getOp(): Op = getInt match {
-    case T.CallOp       => Op.Call(getType, getVal, getVals, getNext)
-    case T.LoadOp       => Op.Load(getType, getVal, isVolatile = false)
-    case T.StoreOp      => Op.Store(getType, getVal, getVal, isVolatile = false)
+    case T.CallOp => Op.Call(getType, getVal, getVals, getNext)
+    case T.LoadOp =>
+      Op.Load(getType, getVal, isVolatile = false, isAtomic = getBool)
+    case T.StoreOp =>
+      Op.Store(getType, getVal, getVal, isVolatile = false, isAtomic = getBool)
     case T.ElemOp       => Op.Elem(getType, getVal, getVals)
     case T.ExtractOp    => Op.Extract(getVal, getInts)
     case T.InsertOp     => Op.Insert(getVal, getVal, getInts)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -76,9 +76,10 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Attr.Align(_) =>
       assert(false, "alignment attribute is not serializable")
 
-    case Attr.Pure        => putInt(T.PureAttr)
-    case Attr.Extern      => putInt(T.ExternAttr)
-    case Attr.Override(n) => putInt(T.OverrideAttr); putGlobal(n)
+    case Attr.Pure         => putInt(T.PureAttr)
+    case Attr.Extern       => putInt(T.ExternAttr)
+    case Attr.Override(n)  => putInt(T.OverrideAttr); putGlobal(n)
+    case Attr.JavaVolatile => putInt(T.JavaVolatileAttr)
 
     case Attr.Link(s)      => putInt(T.LinkAttr); putString(s)
     case Attr.PinAlways(n) => putInt(T.PinAlwaysAttr); putGlobal(n)
@@ -274,18 +275,20 @@ final class BinarySerializer(buffer: ByteBuffer) {
       putVals(args)
       putNext(unwind)
 
-    case Op.Load(ty, ptr, isVolatile) =>
+    case Op.Load(ty, ptr, isVolatile, isAtomic) =>
       assert(!isVolatile, "volatile loads are not serializable")
       putInt(T.LoadOp)
       putType(ty)
       putVal(ptr)
+      putBool(isAtomic)
 
-    case Op.Store(ty, value, ptr, isVolatile) =>
+    case Op.Store(ty, value, ptr, isVolatile, isAtomic) =>
       assert(!isVolatile, "volatile stores are not serializable")
       putInt(T.StoreOp)
       putType(ty)
       putVal(value)
       putVal(ptr)
+      putBool(isAtomic)
 
     case Op.Elem(ty, v, indexes) =>
       putInt(T.ElemOp)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -26,6 +26,7 @@ object Tags {
   final val PinWeakAttr      = 1 + PinIfAttr
   final val DynAttr          = 1 + PinWeakAttr
   final val StubAttr         = 1 + DynAttr
+  final val JavaVolatileAttr = 1 + StubAttr
 
   // Binary ops
 

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Op.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Op.scala
@@ -19,14 +19,21 @@ object Op extends Base[nir.Op] {
       case (ty, f, args, unwind) => nir.Op.Call(ty, f, args, unwind)
     }
   val Load =
-    P("volatile".!.? ~ "load[" ~ Type.parser ~ "]" ~ Val.parser map {
-      case (volatile, ty, ptr) =>
-        nir.Op.Load(ty, ptr, isVolatile = volatile.nonEmpty)
+    P("atomic".!.? ~ "volatile".!.? ~ "load[" ~ Type.parser ~ "]" ~ Val.parser map {
+      case (atomic, volatile, ty, ptr) =>
+        nir.Op.Load(ty,
+                    ptr,
+                    isVolatile = volatile.nonEmpty,
+                    isAtomic = atomic.nonEmpty)
     })
   val Store =
-    P("volatile".!.? ~ "store[" ~ Type.parser ~ "]" ~ Val.parser ~ "," ~ Val.parser map {
-      case (volatile, ty, ptr, value) =>
-        nir.Op.Store(ty, ptr, value, isVolatile = volatile.nonEmpty)
+    P("atomic".!.? ~ "volatile".!.? ~ "store[" ~ Type.parser ~ "]" ~ Val.parser ~ "," ~ Val.parser map {
+      case (atomic, volatile, ty, ptr, value) =>
+        nir.Op.Store(ty,
+                     ptr,
+                     value,
+                     isVolatile = volatile.nonEmpty,
+                     isAtomic = atomic.nonEmpty)
     })
   val Elem =
     P(

--- a/nirparser/src/test/scala/scala/scalanative/nir/OpParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/OpParserTest.scala
@@ -22,28 +22,18 @@ class OpParserTest extends FlatSpec with Matchers {
     result should be(call)
   }
 
-  it should "parse non-volatile `Op.Load`" in {
-    val load: Op                  = Op.Load(noTpe, Val.None)
-    val Parsed.Success(result, _) = parser.Op.Load.parse(load.show)
-    result should be(load)
+  it should "parse `Op.Load`" in {
+    shouldParseLoad(isVolatile = true, isAtomic = true)
+    shouldParseLoad(isVolatile = true, isAtomic = false)
+    shouldParseLoad(isVolatile = false, isAtomic = true)
+    shouldParseLoad(isVolatile = false, isAtomic = false)
   }
 
-  it should "parse volatile `Op.Load`" in {
-    val load: Op                  = Op.Load(noTpe, Val.None, isVolatile = true)
-    val Parsed.Success(result, _) = parser.Op.Load.parse(load.show)
-    result should be(load)
-  }
-
-  it should "parse non-volatile `Op.Store`" in {
-    val store: Op                 = Op.Store(noTpe, Val.None, Val.None)
-    val Parsed.Success(result, _) = parser.Op.Store.parse(store.show)
-    result should be(store)
-  }
-
-  it should "parse volatile `Op.Store`" in {
-    val store: Op                 = Op.Store(noTpe, Val.None, Val.None, isVolatile = true)
-    val Parsed.Success(result, _) = parser.Op.Store.parse(store.show)
-    result should be(store)
+  it should "parse `Op.Store`" in {
+    shouldParseStore(isVolatile = true, isAtomic = true)
+    shouldParseStore(isVolatile = true, isAtomic = false)
+    shouldParseStore(isVolatile = false, isAtomic = true)
+    shouldParseStore(isVolatile = false, isAtomic = false)
   }
 
   it should "parse `Op.Elem`" in {
@@ -173,4 +163,17 @@ class OpParserTest extends FlatSpec with Matchers {
     val Parsed.Success(result, _) = parser.Op.Unbox.parse(unbox.show)
     result should be(unbox)
   }
+
+  private def shouldParseLoad(isVolatile: Boolean, isAtomic: Boolean): Unit = {
+    val load: Op                  = Op.Load(noTpe, Val.None)
+    val Parsed.Success(result, _) = parser.Op.Load.parse(load.show)
+    result should be(load)
+  }
+
+  private def shouldParseStore(isVolatile: Boolean, isAtomic: Boolean): Unit = {
+    val store: Op                 = Op.Store(noTpe, Val.None, Val.None)
+    val Parsed.Success(result, _) = parser.Op.Store.parse(store.show)
+    result should be(store)
+  }
+
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -207,11 +207,12 @@ trait NirDefinitions { self: NirGlobalAddons =>
 
     // Scala library & runtime
 
-    lazy val InlineClass      = getRequiredClass("scala.inline")
-    lazy val NoInlineClass    = getRequiredClass("scala.noinline")
-    lazy val EnumerationClass = getRequiredClass("scala.Enumeration")
-    lazy val PropertiesTrait  = getRequiredClass("scala.util.PropertiesTrait")
-    lazy val JavaProperties   = getRequiredClass("java.util.Properties")
+    lazy val InlineClass        = getRequiredClass("scala.inline")
+    lazy val NoInlineClass      = getRequiredClass("scala.noinline")
+    lazy val EnumerationClass   = getRequiredClass("scala.Enumeration")
+    lazy val PropertiesTrait    = getRequiredClass("scala.util.PropertiesTrait")
+    lazy val VolatileClass      = getRequiredClass("scala.volatile")
+    lazy val JavaProperties     = getRequiredClass("java.util.Properties")
 
     lazy val StringConcatMethod = getMember(StringClass, TermName("concat"))
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -207,12 +207,12 @@ trait NirDefinitions { self: NirGlobalAddons =>
 
     // Scala library & runtime
 
-    lazy val InlineClass        = getRequiredClass("scala.inline")
-    lazy val NoInlineClass      = getRequiredClass("scala.noinline")
-    lazy val EnumerationClass   = getRequiredClass("scala.Enumeration")
-    lazy val PropertiesTrait    = getRequiredClass("scala.util.PropertiesTrait")
-    lazy val VolatileClass      = getRequiredClass("scala.volatile")
-    lazy val JavaProperties     = getRequiredClass("java.util.Properties")
+    lazy val InlineClass      = getRequiredClass("scala.inline")
+    lazy val NoInlineClass    = getRequiredClass("scala.noinline")
+    lazy val EnumerationClass = getRequiredClass("scala.Enumeration")
+    lazy val PropertiesTrait  = getRequiredClass("scala.util.PropertiesTrait")
+    lazy val VolatileClass    = getRequiredClass("scala.volatile")
+    lazy val JavaProperties   = getRequiredClass("java.util.Properties")
 
     lazy val StringConcatMethod = getMember(StringClass, TermName("concat"))
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
@@ -53,7 +53,7 @@ trait NirGenName { self: NirGenPhase =>
     val owner = genTypeName(sym.owner)
     val id    = nativeIdOf(sym)
     val tag   = if (sym.owner.isExternModule) "extern" else "field"
-    owner member id tag tag
+    owner.member(id).tag(tag)
   }
 
   def genMethodSignature(sym: Symbol): String = {

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -155,12 +155,14 @@ trait NirGenStat { self: NirGenPhase =>
       }
 
     def genClassFields(sym: Symbol): Unit = {
-      val attrs = nir.Attrs(isExtern = sym.isExternModule)
+      val isExtern = sym.isExternModule
 
-      for (f <- sym.info.decls if f.isField) {
-        val ty   = genType(f.tpe, box = false)
-        val name = genFieldName(f)
-
+      for (f: Symbol <- sym.info.decls if f.isField) {
+        val ty          = genType(f.tpe, box = false)
+        val name        = genFieldName(f)
+        val annotations = f.annotations
+        val isVolatile  = annotations.exists(_.symbol == VolatileClass)
+        val attrs       = nir.Attrs(isExtern = isExtern, isJavaVolatile = isVolatile)
         buf += Defn.Var(attrs, name, ty, Val.None)
       }
     }

--- a/tools/src/main/scala/scala/scalanative/linker/Linker.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Linker.scala
@@ -2,12 +2,10 @@ package scala.scalanative
 package linker
 
 import scala.collection.mutable
-import scalanative.nir._
-import scalanative.nir.serialization._
-import scalanative.io.VirtualDirectory
-import scalanative.util.Scope
-
-import ReflectiveProxy._
+import scala.scalanative.io.VirtualDirectory
+import scala.scalanative.linker.ReflectiveProxy._
+import scala.scalanative.nir._
+import scala.scalanative.util.Scope
 
 sealed trait Linker {
 
@@ -45,7 +43,7 @@ object Linker {
             path.load(global)
         }.flatten
 
-      def processDirect =
+      def processDirect(): Unit =
         while (direct.nonEmpty) {
           val workitem = direct.pop()
           if (!workitem.isIntrinsic && !resolved.contains(workitem) &&
@@ -106,7 +104,7 @@ object Linker {
           }
         }
 
-      def processConditional = {
+      def processConditional(): Unit = {
         val rest = mutable.UnrolledBuffer.empty[Dep.Conditional]
 
         conditional.foreach {
@@ -132,8 +130,8 @@ object Linker {
       }
 
       while (direct.nonEmpty) {
-        processDirect
-        processConditional
+        processDirect()
+        processConditional()
       }
 
       val reflectiveProxies =

--- a/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
@@ -65,6 +65,7 @@ object Driver {
     pass.AsLowering,
     pass.IsLowering,
     pass.MethodLowering,
+    pass.AtomicBooleanToBytePass,
     pass.TraitLowering,
     pass.ClassLowering,
     pass.StringLowering,
@@ -102,4 +103,5 @@ object Driver {
     def withOptimizerReporter(value: optimizer.Reporter): Driver =
       copy(optimizerReporter = value)
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/optimizer/Pass.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Pass.scala
@@ -71,10 +71,10 @@ trait Pass extends AnyPass {
   def onOp(op: Op): Op = op match {
     case Op.Call(ty, ptrv, argvs, unwind) =>
       Op.Call(onType(ty), onVal(ptrv), argvs.map(onVal), onNext(unwind))
-    case Op.Load(ty, ptrv, isVolatile) =>
-      Op.Load(onType(ty), onVal(ptrv), isVolatile)
-    case Op.Store(ty, ptrv, v, isVolatile) =>
-      Op.Store(onType(ty), onVal(ptrv), onVal(v), isVolatile)
+    case Op.Load(ty, ptrv, isVolatile, isAtomic) =>
+      Op.Load(onType(ty), onVal(ptrv), isVolatile, isAtomic)
+    case Op.Store(ty, ptrv, v, isVolatile, isAtomic) =>
+      Op.Store(onType(ty), onVal(ptrv), onVal(v), isVolatile, isAtomic)
     case Op.Elem(ty, ptrv, indexvs) =>
       Op.Elem(onType(ty), onVal(ptrv), indexvs.map(onVal))
     case Op.Extract(aggrv, indexvs) =>

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/AtomicBooleanToBytePass.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/AtomicBooleanToBytePass.scala
@@ -1,0 +1,67 @@
+package scala.scalanative
+package optimizer
+package pass
+
+import scala.scalanative.nir._
+import scala.scalanative.optimizer.analysis.ClassHierarchy.Top
+import scala.scalanative.optimizer.analysis.ClassHierarchyExtractors.FieldRef
+
+/**
+ * We implement Java's 'volatile' fields with LLVM's 'atomic' stores and loads.
+ * Since LLVM specification mandates atomic types to be at list 8 bits wide,
+ * we need to transform volatile booleans (i1) to volatile bytes (i8).
+ *
+ * For each volatile boolean field transform:
+ * 1. it to a byte field
+ * 2. each store to a byte cast followed by an atomic byte store
+ * 3. each load to a byte load followed by a boolean cast
+ */
+class AtomicBooleanToBytePass(implicit top: Top) extends Pass {
+
+  override def onDefn(defn: Defn): Defn = defn match {
+
+    // atomic boolean field
+    case field @ Defn.Var(attrs, FieldRef(_, _), Type.Bool, rhs)
+        if attrs.isJavaVolatile =>
+      if (rhs ne Val.None) {
+        sys.error(s"Unexpected non empty rhs of a volatile field: $field")
+      } else {
+        field.copy(ty = Type.Byte)
+      }
+
+    case _ => super.onDefn(defn)
+
+  }
+
+  override def onInsts(insts: Seq[Inst]): Seq[Inst] = {
+    val buf = new nir.Buffer
+    import buf._
+
+    insts.foreach {
+
+      // atomic boolean load
+      case Inst.Let(name,
+                    loadOp @ Op.Load(Type.Bool, _, _, _isAtomic @ true)) =>
+        val readByte = let(loadOp.copy(ty = Type.Byte))
+        let(name, Op.Conv(Conv.Trunc, Type.Bool, readByte))
+
+      // atomic boolean store
+      case Inst.Let(
+          name,
+          store @ Op.Store(Type.Bool, _, value, _, _isAtomic @ true)) =>
+        val zextToByte = let(Op.Conv(Conv.Zext, Type.Byte, value))
+        let(name, store.copy(ty = Type.Byte, value = zextToByte))
+
+      case other => buf += other
+
+    }
+
+    buf.toSeq
+  }
+
+}
+
+object AtomicBooleanToBytePass extends PassCompanion {
+  override def apply(config: build.Config, top: Top) =
+    new AtomicBooleanToBytePass()(top)
+}

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/ClassLowering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/ClassLowering.scala
@@ -2,10 +2,8 @@ package scala.scalanative
 package optimizer
 package pass
 
-import scala.collection.mutable
 import analysis.ClassHierarchy._
 import analysis.ClassHierarchyExtractors._
-import util.unsupported
 import nir._
 
 /** Lowers class definitions, and field accesses to structs

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/GlobalValueNumbering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/GlobalValueNumbering.scala
@@ -277,10 +277,11 @@ object GlobalValueNumbering extends PassCompanion {
     def hashOp(op: Op): Hash = {
       import Op._
       val opFields: Seq[Any] = op match {
-        case Call(ty, ptr, args, _)    => "Call" +: ty +: ptr +: args
-        case Load(ty, ptr, isVolatile) => Seq("Load", ty, ptr, isVolatile)
-        case Store(ty, ptr, value, isVolatile) =>
-          Seq("Store", ty, ptr, value, isVolatile)
+        case Call(ty, ptr, args, _) => "Call" +: ty +: ptr +: args
+        case Load(ty, ptr, isVolatile, isAtomic) =>
+          Seq("Load", ty, ptr, isVolatile, isAtomic)
+        case Store(ty, ptr, value, isVolatile, isAtomic) =>
+          Seq("Store", ty, ptr, value, isVolatile, isAtomic)
         case Elem(ty, ptr, indexes) => "Elem" +: ty +: ptr +: indexes
         case Extract(aggr, indexes) => "Extract" +: aggr +: indexes
         case Insert(aggr, value, indexes) =>

--- a/tools/src/test/scala/scala/scalanative/optimizer/pass/AsLoweringTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/pass/AsLoweringTest.scala
@@ -2,22 +2,27 @@ package scala.scalanative
 package optimizer
 package pass
 
+import org.scalatest.Matchers
+
 import analysis.ClassHierarchy.Top
 import build.Config
 import nir._
 
-class AsLoweringTest extends OptimizerSpec {
+class AsLoweringTest extends OptimizerSpec with Matchers {
 
   "The `AsLoweringPhase`" should "have an effect (this is a self-test)" in {
-    val driver = Some(Driver.empty.withPasses(Seq(AsLoweringCheck)))
-    assertThrows[Exception] {
+    val driver =
+      Some(Driver.empty.withPasses(Seq(inject.Main, AsLoweringCheck)))
+    val e = intercept[Exception] {
       optimize("A$", code, driver) { case (_, _, _) => () }
     }
+    e.getMessage should include("Found an occurrence of `Op.As` in:")
   }
 
   it should "remove all occurrences of `Op.As`" in {
     val driver =
-      Some(Driver.empty.withPasses(Seq(AsLowering, AsLoweringCheck)))
+      Some(
+        Driver.empty.withPasses(Seq(inject.Main, AsLowering, AsLoweringCheck)))
     optimize("A$", code, driver) { case (_, _, _) => () }
   }
 

--- a/tools/src/test/scala/scala/scalanative/optimizer/pass/AtomicBooleanToBytePassTest.scala
+++ b/tools/src/test/scala/scala/scalanative/optimizer/pass/AtomicBooleanToBytePassTest.scala
@@ -1,0 +1,71 @@
+package scala.scalanative
+package optimizer
+package pass
+
+import org.scalatest.Matchers
+
+import scala.scalanative.nir.{Defn, Inst, Op, Type}
+import scala.scalanative.optimizer.analysis.ClassHierarchy.Top
+import scala.scalanative.optimizer.analysis.ClassHierarchyExtractors.FieldRef
+import scala.scalanative.build.Config
+
+class AtomicBooleanToBytePassTest extends OptimizerSpec with Matchers {
+
+  val code =
+    """object A {
+      |  @volatile var foo = true
+      |
+      |  def main(args: Array[String]): Unit = {
+      |    println(foo)
+      |  }
+      |}""".stripMargin
+
+  it should "have an effect (this is a self-test)" in {
+    // given
+    val driver = Some(
+      Driver.empty.withPasses(Seq(inject.Main, AtomicBooleanToBytePassCheck)))
+
+    // when
+    val e = intercept[Exception] {
+      optimize("$A", code, driver) { case (_, _, _) => () }
+    }
+
+    // then
+    e.getMessage should include(
+      "Found an occurrence of volatile boolean field in:")
+  }
+
+  it should "convert all volatile boolean fields to byte fields" in {
+    // given
+    val driver = Some(Driver.empty.withPasses(
+      Seq(inject.Main, AtomicBooleanToBytePass, AtomicBooleanToBytePassCheck)))
+
+    // when & then
+    optimize("$A", code, driver) { case (_, _, _) => () }
+  }
+
+  private class AtomicBooleanToBytePassCheck(implicit top: Top) extends Pass {
+
+    override def onDefn(defn: Defn): Defn = defn match {
+      case Defn.Var(attrs, FieldRef(_, _), Type.Bool, _)
+          if attrs.isJavaVolatile =>
+        fail(
+          s"Found an occurrence of volatile boolean field in: ${defn.show}.stripMargin")
+      case _ => defn
+    }
+
+    override def onInst(inst: Inst): Inst = inst match {
+      case Inst.Let(_, _ @Op.Load(Type.Bool, _, _, _isAtomic @ true)) =>
+        fail(s"Found an occurence of atomic boolean load in: ${inst.show}")
+      case Inst.Let(_, _ @Op.Store(Type.Bool, _, _, _, _isAtomic @ true)) =>
+        fail(s"Found an occurence of atomic boolean store in: ${inst.show}")
+      case _ => inst
+    }
+  }
+
+  private object AtomicBooleanToBytePassCheck extends PassCompanion {
+    override def apply(config: Config, top: Top): AnyPass =
+      new AtomicBooleanToBytePassCheck()(top)
+  }
+
+}

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -7,7 +7,7 @@ import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.file._
 import java.nio.channels._
-import scalanative.util.{acquire, defer, Scope}
+import scala.scalanative.util.{acquire, defer, Scope}
 
 sealed trait VirtualDirectory {
 

--- a/util/src/main/scala/scala/scalanative/util/Scope.scala
+++ b/util/src/main/scala/scala/scalanative/util/Scope.scala
@@ -6,7 +6,7 @@ package util
  *  The main idea behind the Scope is to encode resource lifetimes through
  *  a concept of an implicit scope. Scopes are necessary to acquire resources.
  *  They are responsible for disposal of the resources once the evaluation exits
- *  the demarkated block in the source code.
+ *  the demarcated block in the source code.
  *
  *  See https://www.youtube.com/watch?v=MV2eJkwarT4 for details.
  */
@@ -23,20 +23,12 @@ trait Scope {
 object Scope {
 
   /** Opens an implicit scope, evaluates the function and cleans up all the
-   *  resources as soon as execution leaves the demercated block.
+   *  resources as soon as execution leaves the demarcated block.
    */
   def apply[T](f: Scope => T): T = {
     val scope = new Impl
     try f(scope)
     finally scope.close()
-  }
-
-  /** Scope that never closes. Resources allocated in this scope are
-   *  going to be acquired as long as application is running.
-   */
-  val forever: Scope = new Impl {
-    override def close(): Unit =
-      throw new UnsupportedOperationException("Can't close forever Scope.")
   }
 
   private sealed class Impl extends Scope {

--- a/util/src/main/scala/scala/scalanative/util/package.scala
+++ b/util/src/main/scala/scala/scalanative/util/package.scala
@@ -1,7 +1,5 @@
 package scala.scalanative
 
-import java.nio.ByteBuffer
-
 package object util {
 
   /** Marker methods, called whenever a specific control-flow branch


### PR DESCRIPTION
This is still in a rough shape. I'm creating this PR to see if I'm going in the right direction.


1. In nscplugin
a. Add `JavaVolatile` to `@volatile` fields
b. Set `isAtomic` to load and stores from `@volatile` fields 


2. In codegen
a. emit stores and loads with `atomic seq_cst` and explicit alignment
`%_20 = load atomic i8, i8* %_28 seq_cst, align 8 `
`store atomic i8 %_21, i8* %_37 seq_cst, align 8`

3. A new pass
LLVM requires that atomic loads and stores operate on types with bit width 8 or higher and because booleans are represented as `i1` a new pass `scala.scalanative.optimizer.pass.VolatileBooleanToIntegerLowering`:
a. converts all `@volatile` boolean fields into byte fields,
b. fixs types of all loads and stores from/to `@volatile` boolean to operate on bytes,
c. inserts casts to/from booleans immediately after/prior loads/stores from/to byte fields.  


- [x] Write tests