### PR TITLE
Fix #554: Report error on extern function without return type 

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -2,14 +2,12 @@ package scala.scalanative
 package nscplugin
 
 import java.nio.file.Path
-import scala.collection.mutable, mutable.UnrolledBuffer
-import scala.tools.nsc.{util => _, _}
+
+import scala.collection.mutable
+import scala.scalanative.nir._
+import scala.scalanative.util.ScopedVar.scoped
 import scala.tools.nsc.plugins._
-import scala.util.{Either, Left, Right}
-import scala.reflect.internal.Flags._
-import util._, util.ScopedVar.scoped
-import nir._
-import NirPrimitives._
+import scala.tools.nsc.{util => _, _}
 
 abstract class NirGenPhase
     extends PluginComponent
@@ -26,8 +24,6 @@ abstract class NirGenPhase
   import global._
   import definitions._
   import nirAddons._
-  import nirDefinitions._
-  import SimpleType.{fromType, fromSymbol}
 
   val phaseName = "nir"
 

--- a/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -1,8 +1,8 @@
 package scala.scalanative
 
-import java.io.File
-
 import org.scalatest._
+
+import scala.scalanative.api.CompilationFailedException
 
 class NIRCompilerTest extends FlatSpec with Matchers with Inspectors {
 
@@ -55,6 +55,25 @@ class NIRCompilerTest extends FlatSpec with Matchers with Inspectors {
       NIRCompiler(outDir = temporaryDir) { _ compile "class A" }
         .filter(_.isFile)
     forAll(nirFiles) { _.getParentFile should be(temporaryDir) }
+  }
+
+  it should "report error for extern method without result type" in {
+    // given
+    val code =
+      """import scala.scalanative.native.extern
+        |
+        |@extern
+        |object Dummy {
+        |  def foo() = extern
+        |}""".stripMargin
+
+    // when
+    val caught = intercept[CompilationFailedException] {
+      NIRCompiler(_.compile(code))
+    }
+
+    // then
+    caught.getMessage should include("extern method foo needs result type")
   }
 
 }

--- a/util/src/main/scala/scala/scalanative/util/package.scala
+++ b/util/src/main/scala/scala/scalanative/util/package.scala
@@ -13,8 +13,11 @@ package object util {
   /** Marker method, called whenever a specific control-flow branch
    *  is not supported.
    */
-  def unsupported(v: Any = ""): Nothing =
+  def unsupported(v: Any): Nothing =
     throw UnsupportedException(s"$v (${v.getClass})")
+
+  def unsupported(s: String = ""): Nothing =
+    throw UnsupportedException(s)
 
   /** Scope-managed resource. */
   type Resource = java.lang.AutoCloseable


### PR DESCRIPTION
Example error message:

```
[info] Compiling 1 Scala source to /home/pbatko/src/scala-native/sandbox/target/scala-2.11/classes...
[error] /home/pbatko/src/scala-native/sandbox/Test.scala:16: extern method SDL_Delay needs result type
[error]   def SDL_Delay(ms: UInt) = extern
[error]       ^
[error] one error found
[error] (sandbox/compile:compileIncremental) Compilation failed
[error] Total time: 5 s, completed Dec 3, 2017 10:12:59 PM
```

TODO:
- [x] Write tests
- [x] Revert sandbox changes