### PR TITLE
Fix #1078: Fix '%' overflow on division by -1

### DIFF
--- a/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Driver.scala
@@ -44,6 +44,7 @@ object Driver {
   )
 
   private val loweringPasses = Seq(
+    pass.SRemOverflow,
     pass.DynmethodLowering,
     pass.ExternHoisting,
     pass.ModuleLowering,
@@ -80,4 +81,5 @@ object Driver {
     def withPasses(passes: Seq[AnyPassCompanion]): Driver =
       new Impl(passes)
   }
+
 }

--- a/tools/src/main/scala/scala/scalanative/optimizer/Pass.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Pass.scala
@@ -1,8 +1,6 @@
 package scala.scalanative
 package optimizer
 
-import analysis.ClassHierarchy.Top
-import tools.Config
 import scala.collection.mutable
 import nir._
 
@@ -16,6 +14,7 @@ trait Inject extends AnyPass {
 
 trait Pass extends AnyPass {
   private var _fresh: Fresh = _
+
   implicit def fresh: Fresh = _fresh
 
   def onDefns(assembly: Seq[Defn]): Seq[Defn] =

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/IsLowering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/IsLowering.scala
@@ -2,7 +2,6 @@ package scala.scalanative
 package optimizer
 package pass
 
-import scala.collection.mutable
 import analysis.ClassHierarchy._
 import analysis.ClassHierarchyExtractors._
 import nir._, Inst.Let
@@ -29,11 +28,11 @@ class IsLowering(implicit top: Top) extends Pass {
         // in case it's null, result is always false
         label(thenL)
         val res1 = let(Op.Copy(Val.False))
-        jump(Next.Label(contL, Seq(res1)))
+        jump(contL, Seq(res1))
         // otherwise, do an actual instance check
         label(elseL)
         val res2 = genIs(buf, ty, obj)
-        jump(Next.Label(contL, Seq(res2)))
+        jump(contL, Seq(res2))
         // merge the result of two branches
         label(contL, Seq(result))
         let(n, Op.Copy(result))

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/SRemOverflow.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/SRemOverflow.scala
@@ -1,0 +1,57 @@
+package scala.scalanative.optimizer.pass
+
+import scala.scalanative.nir
+import scala.scalanative.nir._
+import scala.scalanative.optimizer.analysis.ClassHierarchy.Top
+import scala.scalanative.optimizer.{Pass, PassCompanion}
+import scala.scalanative.tools.Config
+
+/**
+ * Detects taking remainder for division by -1 and replaces it by division by 1 which can't overflow.
+ *
+ *
+ * We implement '%' (remainder) with LLVM's 'srem' and it can overflow for cases:
+ * Int.MinValue % -1
+ * Long.MinValue % -1
+ * E.g. On x86_64 'srem' might get translated to 'idiv' which computes both quotient and remainder at once
+ * and quotient can overflow.
+ */
+class SRemOverflow(implicit top: Top) extends Pass {
+
+  override def onInsts(insts: Seq[Inst]): Seq[Inst] = {
+    val buf = new nir.Buffer
+    import buf._
+
+    insts.foreach {
+      case Inst.Let(name,
+                    sremBin @ Op.Bin(Bin.Srem, intType: Type.I, _, divisor))
+          if intType.width == 32 || intType.width == 64 =>
+        val safeDivisor         = Val.Local(fresh(), intType)
+        val thenL, elseL, contL = fresh()
+
+        val isPossibleOverflow =
+          let(Op.Comp(Comp.Ieq, intType, divisor, Val.Int(-1)))
+        branch(isPossibleOverflow, Next(thenL), Next(elseL))
+
+        label(thenL)
+        jump(contL, Seq(Val.Int(1)))
+
+        label(elseL)
+        jump(contL, Seq(divisor))
+
+        label(contL, Seq(safeDivisor))
+
+        let(name, sremBin.copy(r = safeDivisor))
+
+      case other => buf += other
+    }
+
+    buf.toSeq
+  }
+}
+
+object SRemOverflow extends PassCompanion {
+
+  def apply(config: Config, top: Top): Pass = new SRemOverflow()(top)
+
+}

--- a/unit-tests/src/test/scala/scala/PrimitiveSuite.scala
+++ b/unit-tests/src/test/scala/scala/PrimitiveSuite.scala
@@ -50,4 +50,43 @@ object PrimitiveSuite extends tests.Suite {
     val y: Long = 33
     assert((x << y) == 6)
   }
+
+  test(" x % y doesn't overflow (noinline)") {
+    assert(intRemByNegOne(4) == 0)
+    assert(intRemByNegOne(Int.MinValue) == 0)
+    assert(longRemByNegOne(4) == 0L)
+    assert(longRemByNegOne(Long.MinValue) == 0L)
+
+    // prevent partial evaluation
+    @noinline
+    def intRemByNegOne(i: Int): Int = {
+      i % -1
+    }
+
+    // prevent partial evaluation
+    @noinline
+    def longRemByNegOne(l: Long): Long = {
+      l % -1L
+    }
+  }
+
+  test(" x % y doesn't overflow (inline)") {
+    assert(intRemByNegOne(4) == 0)
+    assert(intRemByNegOne(Int.MinValue) == 0)
+    assert(longRemByNegOne(4) == 0L)
+    assert(longRemByNegOne(Long.MinValue) == 0L)
+
+    // facilitate partial evaluation
+    @inline
+    def intRemByNegOne(i: Int): Int = {
+      i % -1
+    }
+
+    // facilitate partial evaluation
+    @inline
+    def longRemByNegOne(l: Long): Long = {
+      l % -1L
+    }
+  }
+
 }


### PR DESCRIPTION
Inserts check for divisor being -1 and in such case changes it to 1.