### PR TITLE
Keep using unailableBlockCount in ShouldGrow

### DIFF
--- a/nativelib/src/main/resources/gc/immix/Allocator.c
+++ b/nativelib/src/main/resources/gc/immix/Allocator.c
@@ -83,10 +83,11 @@ void Allocator_InitCursors(Allocator *allocator) {
  * Heuristic that tells if the heap should be grown or not.
  */
 bool Allocator_ShouldGrow(Allocator *allocator) {
-#ifdef DEBUG_PRINT
     uint64_t unavailableBlockCount =
         allocator->blockCount -
         (allocator->freeBlockCount + allocator->recycledBlockCount);
+
+#ifdef DEBUG_PRINT
     printf("\n\nBlock count: %llu\n", allocator->blockCount);
     printf("Unavailable: %llu\n", unavailableBlockCount);
     printf("Free: %llu\n", allocator->freeBlockCount);
@@ -94,7 +95,8 @@ bool Allocator_ShouldGrow(Allocator *allocator) {
     fflush(stdout);
 #endif
 
-    return allocator->freeBlockCount * 2 < allocator->blockCount;
+    return allocator->freeBlockCount * 2 < allocator->blockCount ||
+           4 * unavailableBlockCount > allocator->blockCount;
 }
 
 /**


### PR DESCRIPTION
PR #1085 changed growth heuristic not to account for
unavailableBlockCount. This regresses gcbench (a benchmark that
simulates high GC pressure). This commit brings it back.