### PR TITLE
Improve rebuild workflow and environment variable-based defaults

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,9 +34,10 @@ addCommandAlias(
     "javalib/publishLocal",
     "auxlib/publishLocal",
     "scalalib/publishLocal",
-    "publishLocal"
-//    "sbtScalaNative/publishLocal",
-//    "testInterface/publishLocal"
+    "sbtScalaNative/publishLocal",
+    "testInterfaceSbtDefs/publishLocal",
+    "testInterfaceSerialization/publishLocal",
+    "testInterface/publishLocal"
   ).mkString(";", ";", "")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -192,21 +192,12 @@ lazy val libSettings =
     scalacOptions ++= Seq("-encoding", "utf8")
   )
 
-lazy val gcSetting =
-  nativeGC in ThisBuild := {
-    val log     = sLog.value
-    val default = (nativeGC in ThisBuild).value
-    val gc      = Option(System.getenv.get("SCALANATIVE_GC")).getOrElse(default)
-    log.info(s"Using $gc gc")
-    gc
-  }
-
 lazy val projectSettings =
   ScalaNativePlugin.projectSettings ++ Seq(
     scalaVersion := libScalaVersion,
     resolvers := Nil,
     scalacOptions ++= Seq("-target:jvm-1.8")
-  ) :+ gcSetting
+  )
 
 lazy val util =
   project

--- a/build.sbt
+++ b/build.sbt
@@ -279,11 +279,9 @@ lazy val sbtScalaNative =
       sources in Compile ++= (sources in Compile in testInterfaceSerialization).value,
       // publish the other projects before running scripted tests.
       scripted := scripted
-        .dependsOn(
-          publishLocal in scalalib,
-          publishLocal in ThisProject,
-          publishLocal in testInterface
-        )
+        .dependsOn(publishLocal in testInterface)
+        .dependsOn(publishLocal in ThisProject)
+        .dependsOn(publishLocal in scalalib)
         .evaluated,
       publishLocal := publishLocal.dependsOn(publishLocal in tools).value
     )

--- a/build.sbt
+++ b/build.sbt
@@ -193,7 +193,7 @@ lazy val libSettings =
   )
 
 lazy val gcSetting =
-  nativeGC := {
+  nativeGC in ThisBuild := {
     val log     = sLog.value
     val default = (nativeGC in ThisBuild).value
     val gc      = Option(System.getenv.get("SCALANATIVE_GC")).getOrElse(default)

--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,8 @@ addCommandAlias(
     "auxlib/publishLocal",
     "scalalib/publishLocal",
     "publishLocal"
+//    "sbtScalaNative/publishLocal",
+//    "testInterface/publishLocal"
   ).mkString(";", ";", "")
 )
 
@@ -45,7 +47,7 @@ addCommandAlias(
     "tests/test",
     "tools/test",
     "benchmarks/run --test",
-    "scripted"
+    "sbtScalaNative/scripted"
   ).mkString(";", ";", "")
 )
 
@@ -189,14 +191,13 @@ lazy val libSettings =
     scalacOptions ++= Seq("-encoding", "utf8")
   )
 
-lazy val gcSettings =
-  if (!System.getenv.containsKey("SCALANATIVE_GC")) {
-    println("Using default gc")
-    Seq.empty
-  } else {
-    val gc = System.getenv.get("SCALANATIVE_GC")
-    println(s"Using gc based on SCALANATIVE_GC=$gc")
-    Seq(nativeGC := gc)
+lazy val gcSetting =
+  nativeGC := {
+    val log     = sLog.value
+    val default = (nativeGC in ThisBuild).value
+    val gc      = Option(System.getenv.get("SCALANATIVE_GC")).getOrElse(default)
+    log.info(s"Using $gc gc")
+    gc
   }
 
 lazy val projectSettings =
@@ -204,7 +205,7 @@ lazy val projectSettings =
     scalaVersion := libScalaVersion,
     resolvers := Nil,
     scalacOptions ++= Seq("-target:jvm-1.8")
-  ) ++ gcSettings
+  ) :+ gcSetting
 
 lazy val util =
   project

--- a/build.sbt
+++ b/build.sbt
@@ -280,16 +280,8 @@ lazy val sbtScalaNative =
       // publish the other projects before running scripted tests.
       scripted := scripted
         .dependsOn(
-          publishLocal in util,
-          publishLocal in nir,
-          publishLocal in tools,
-          publishLocal in nscplugin,
-          publishLocal in nativelib,
-          publishLocal in javalib,
-          publishLocal in auxlib,
           publishLocal in scalalib,
-          publishLocal in testInterfaceSbtDefs,
-          publishLocal in testInterfaceSerialization,
+          publishLocal in ThisProject,
           publishLocal in testInterface
         )
         .evaluated,

--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -124,7 +124,7 @@ Setting this as follows will set the value in the plugin when `sbt` is run.
     > show nativeGC
 
 This setting remains unless changed at the `sbt` prompt. If changed, the value
-will be restored the the environment variable value if `sbt` is restarted or
+will be restored to the environment variable value if `sbt` is restarted or
 `reload` is called at the `sbt` prompt. You can also revert to the default
 setting value via `unset SCALANATIVE_GC` and then restarting `sbt`.
 

--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -1,0 +1,76 @@
+.. _build:
+
+Guide to the sbt build
+======================================
+
+This section gives some basic information and tips about the build system. The
+``sbt`` build system is quite complex and effectively brings together all the
+components of Scala Native. The ``build.sbt`` file is at the root of the project
+along with the sub-projects that make up the system.
+
+Overview
+--------------------------------
+In order to effectively work with Scala Native, a knowledge of the build system
+is very helpful. In general the code is built and published to your local Ivy
+repository so that other components in the system can depend on each other.
+Although the ``build.sbt`` file and other code in the system is the way to learn the system
+thoroughly, the following sections will give information that should be helpful.
+
+The build has roughly four groups of sub-projects as follows:
+
+1.  The Native Scala Compiler plugin and libraries. Each of these depend on the next project
+    in the list.
+
+    - `nscplugin`
+
+    - `nativelib`
+
+    - `javalib`
+
+    - `auxlib`
+
+    - `scalalib`
+
+
+2.  The Scala Native plugin and dependencies (directory names are in parentheses).
+
+    - `sbtScalaNative (sbt-scala-native)`
+
+    - `tools`
+
+    - `nir`
+
+    - `util`
+
+3.  The Scala Native test interface and dependencies.
+
+    - `testInterface (test-interface)`
+
+    - `testInterfaceSerialization (test-interface-serialization)`
+
+    - `testInterfaceSbtDefs (test-interface-sbt-defs)`
+
+4.  Tests and benchmarks (no dependencies on each other).
+
+    - `tests (unit-tests)`
+
+    - `tools` This has tests within the project
+
+    - `(scripted-tests)`
+
+    - `benchmarks`
+
+Each of the groups above also depend on the previous group being compiled and
+published locally. The sbt plugin ``sbtScalaNative`` is used inside Scala Native
+exactly as it is used in a project using Scala Native. The plugin is needed to
+by the ``testInterface`` and also the `tests` that use the ``testInterface``
+to compile native code.
+
+Helpful Hints and Tips
+--------------------------------
+
+
+
+The next section has more build and development information for those wanting
+to work on :ref:`compiler`.
+

--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -12,14 +12,16 @@ Overview
 --------------------------------
 In order to effectively work with Scala Native, a knowledge of the build system
 is very helpful. In general the code is built and published to your local Ivy
-repository so that other components in the system can depend on each other.
-Although the ``build.sbt`` file and other code in the system is the way to learn the system
-thoroughly, the following sections will give information that should be helpful.
+repository using the `sbt` `publishLocal` command so that other components in the
+system can depend on each other via normal `sbt` dependencies. Although the
+``build.sbt`` file and other code in the system is the way to learn the system
+thoroughly, the following sections will give information that should be helpful
+to get started.
 
 The build has roughly four groups of sub-projects as follows:
 
-1.  The Native Scala Compiler plugin and libraries. Each of these depend on the next project
-    in the list.
+1.  The Native Scala Compiler plugin and libraries. Each of these projects depend
+    on the next project in the list.
 
     - `nscplugin`
 
@@ -30,7 +32,6 @@ The build has roughly four groups of sub-projects as follows:
     - `auxlib`
 
     - `scalalib`
-
 
 2.  The Scala Native plugin and dependencies (directory names are in parentheses).
 
@@ -62,15 +63,97 @@ The build has roughly four groups of sub-projects as follows:
 
 Each of the groups above also depend on the previous group being compiled and
 published locally. The sbt plugin ``sbtScalaNative`` is used inside Scala Native
-exactly as it is used in a project using Scala Native. The plugin is needed to
-by the ``testInterface`` and also the `tests` that use the ``testInterface``
+exactly as it is used in a project using Scala Native. The plugin is needed
+by the `testInterface` and also the `tests` that use the `testInterface`
 to compile native code.
 
-Helpful Hints and Tips
---------------------------------
+Building Scala Native
+---------------------
+Once you have cloned Scala Native from git, `cd` into the base directory. Inside
+this directory is the `build.sbt` file which is used to build Scala Native. This
+file has `sbt` command aliases which are used to help build the system. In order
+to build Scala Native for the first time you should run the following commands:
 
+.. code-block:: text
+
+    $ sbt
+    > rebuild
+
+If you want to run all the tests and benchmarks, which take awhile you can run
+the `test-all` command after the systems builds.
+
+Normal development workflow
+---------------------------
+Let us suppose that you wish to work on the `javalib` project to add some code
+or fix a bug. Once you make a change to the code, run the following command
+at the sbt prompt to compile the code and run the tests:
+
+.. code-block:: text
+
+    > javalib/publishLocal
+    > tests/test
+
+You can run only the test of interest by using one of the following commands:
+
+.. code-block:: text
+
+    > tests/testOnly java.lang.StringSuite
+    > tests/testOnly *StringSuite
+
+
+
+Setting the GC setting via an environment variable
+--------------------------------------------------
+One of the build settings that can be changed is the ``nativeGC``. There
+is a default setting value that will be used unless changed. The
+Scala Native has a high performance Garbage Collector (GC) ``immix`` that
+comes with the system or the `boehm` GC which can be used when the
+supporting library is installed. The setting `none` also exists for a
+short running script or where memory is not an issue.
+
+Scala Native uses Continuous integration (CI) to compile and test the code on
+different platforms [1]_ and using different garbage collectors [2]_.
+The Scala Native `sbt` plugin includes the ability to set an environment
+variable `SCALANATIVE_GC` to set the garbage collector value used by `sbt`.
+Setting this as follows will set the value in the plugin when `sbt` is run.
+
+.. code-block:: text
+
+    $ set SCALANATIVE_GC=immix
+    $ sbt
+    > show nativeGC
+
+This setting remains unless changed at the `sbt` prompt. If changed, the value
+will be restored the the environment variable value if `sbt` is restarted or
+`reload` is called at the `sbt` prompt. You can also revert to the default
+setting value via `unset SCALANATIVE_GC` and then restarting `sbt`.
+
+Setting the GC setting via `sbt`
+--------------------------------
+The GC setting is only used during the link phase of the Scala Native
+compiler so it can be applied to one or all the Scala Native projects
+that use the `sbtScalaNative` plugin. This is an example to only change the
+setting for the `sandbox`.
+
+.. code-block:: text
+
+    $ sbt
+    > show nativeGC
+    > set nativeGC in sandbox := "none"
+    > show nativeGC
+    > sandbox/run
+
+The following shows how to set ``nativeGC`` on all the projects.
+
+.. code-block:: text
+
+    > set every nativeGC := "immix"
+    > show nativeGC
 
 
 The next section has more build and development information for those wanting
 to work on :ref:`compiler`.
+
+.. [1] http://www.scala-native.org/en/latest/user/setup.html
+.. [2] http://www.scala-native.org/en/latest/user/sbt.html
 

--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -79,7 +79,7 @@ to build Scala Native for the first time you should run the following commands:
     $ sbt
     > rebuild
 
-If you want to run all the tests and benchmarks, which take awhile you can run
+If you want to run all the tests and benchmarks, which takes awhile, you can run
 the `test-all` command after the systems builds.
 
 Normal development workflow
@@ -100,15 +100,23 @@ You can run only the test of interest by using one of the following commands:
     > tests/testOnly java.lang.StringSuite
     > tests/testOnly *StringSuite
 
+Some additional tips are as follows.
 
+- If you change anything in `tools` (linker, optimizer, codegen), you need to
+  `reload`, not `rebuild`. It's possible because we textually include code of
+  the `sbt` plugin and the toolchain.
 
-Setting the GC setting via an environment variable
+- If you change `nscplugin`, `rebuild` is the only option. This is because
+  the Scala compiler uses this plugin to generate the code that Scala Native uses.
+
+Build settings via environment variables
 --------------------------------------------------
-One of the build settings that can be changed is the ``nativeGC``. There
-is a default setting value that will be used unless changed. The
-Scala Native has a high performance Garbage Collector (GC) ``immix`` that
-comes with the system or the `boehm` GC which can be used when the
-supporting library is installed. The setting `none` also exists for a
+Two build settings, ``nativeGC`` and ``nativeMode`` can be changed via
+environment variables. They have default settings that are used unless
+changed. The setting that controls the garbage collector is `nativeGC`.
+Scala Native has a high performance Garbage Collector (GC) ``immix``
+that comes with the system or the `boehm` GC which can be used when
+the supporting library is installed. The setting `none` also exists for a
 short running script or where memory is not an issue.
 
 Scala Native uses Continuous integration (CI) to compile and test the code on
@@ -119,14 +127,20 @@ Setting this as follows will set the value in the plugin when `sbt` is run.
 
 .. code-block:: text
 
-    $ set SCALANATIVE_GC=immix
+    $ export SCALANATIVE_GC=immix
     $ sbt
     > show nativeGC
 
 This setting remains unless changed at the `sbt` prompt. If changed, the value
 will be restored to the environment variable value if `sbt` is restarted or
 `reload` is called at the `sbt` prompt. You can also revert to the default
-setting value via `unset SCALANATIVE_GC` and then restarting `sbt`.
+setting value by running `unset SCALANATIVE_GC` at the command line
+and then restarting `sbt`.
+
+The `nativeMode` setting is controlled via the `SCALANATIVE_MODE` environment
+variable. The default mode, `debug` is designed to optimize but compile fast
+whereas the `release` mode performs additional optimizations and takes longer
+to compile.
 
 Setting the GC setting via `sbt`
 --------------------------------
@@ -149,6 +163,8 @@ The following shows how to set ``nativeGC`` on all the projects.
 
     > set every nativeGC := "immix"
     > show nativeGC
+
+The same process above will work for setting `nativeMode`.
 
 
 The next section has more build and development information for those wanting

--- a/docs/contrib/compiler.rst
+++ b/docs/contrib/compiler.rst
@@ -1,3 +1,5 @@
+.. _compiler:
+
 The compiler plugin and code generator
 ======================================
 

--- a/docs/contrib/index.rst
+++ b/docs/contrib/index.rst
@@ -7,5 +7,7 @@ Contributor's Guide
   :maxdepth: 2
 
   contributing
+  build
   compiler
   nir
+

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -115,10 +115,11 @@ object ScalaNativePluginInternal {
       libs
     },
     nativeLinkingOptions in NativeTest := (nativeLinkingOptions in Test).value,
-    nativeMode := "debug",
+    nativeMode := Option(System.getenv.get("SCALANATIVE_MODE"))
+      .getOrElse("debug"),
+    nativeMode in NativeTest := (nativeMode in Test).value,
     nativeLinkStubs := false,
     nativeLinkStubs in NativeTest := (nativeLinkStubs in Test).value,
-    nativeMode in NativeTest := (nativeMode in Test).value,
     nativeLinkerReporter := tools.LinkerReporter.empty,
     nativeLinkerReporter in NativeTest := (nativeLinkerReporter in Test).value,
     nativeOptimizerReporter := tools.OptimizerReporter.empty,
@@ -319,7 +320,8 @@ object ScalaNativePluginInternal {
       val config   = nativeConfig.value
       val reporter = nativeOptimizerReporter.value
       val driver   = nativeOptimizerDriver.value
-      logger.time("Optimizing") {
+      val mode     = nativeMode.value
+      logger.time(s"Optimizing ($mode mode)") {
         tools.optimize(config, driver, result.defns, result.dyns, reporter)
       }
     },
@@ -395,7 +397,7 @@ object ScalaNativePluginInternal {
       val paths     = apppaths.map(_.abs) ++ opaths
       val compile   = clangpp.abs +: (flags ++ paths)
 
-      logger.time(s"Linking native code - $gc gc") {
+      logger.time(s"Linking native code ($gc gc)") {
         logger.running(compile)
         Process(compile, cwd) ! logger
       }

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -122,9 +122,7 @@ object ScalaNativePluginInternal {
     nativeLinkerReporter := tools.LinkerReporter.empty,
     nativeLinkerReporter in NativeTest := (nativeLinkerReporter in Test).value,
     nativeOptimizerReporter := tools.OptimizerReporter.empty,
-    nativeOptimizerReporter in NativeTest := (nativeOptimizerReporter in Test).value,
-    nativeGC := "boehm",
-    nativeGC in NativeTest := (nativeGC in Test).value
+    nativeOptimizerReporter in NativeTest := (nativeOptimizerReporter in Test).value
   )
 
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
@@ -136,7 +134,9 @@ object ScalaNativePluginInternal {
         case Some(_) =>
           ()
       }
-    }
+    },
+    nativeGC := "boehm",
+    nativeGC in NativeTest := (nativeGC in Test).value
   )
 
   lazy val scalaNativeConfigSettings: Seq[Setting[_]] = Seq(
@@ -395,7 +395,7 @@ object ScalaNativePluginInternal {
       val paths     = apppaths.map(_.abs) ++ opaths
       val compile   = clangpp.abs +: (flags ++ paths)
 
-      logger.time("Linking native code") {
+      logger.time(s"Linking native code - $gc GC") {
         logger.running(compile)
         Process(compile, cwd) ! logger
       }

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -122,7 +122,9 @@ object ScalaNativePluginInternal {
     nativeLinkerReporter := tools.LinkerReporter.empty,
     nativeLinkerReporter in NativeTest := (nativeLinkerReporter in Test).value,
     nativeOptimizerReporter := tools.OptimizerReporter.empty,
-    nativeOptimizerReporter in NativeTest := (nativeOptimizerReporter in Test).value
+    nativeOptimizerReporter in NativeTest := (nativeOptimizerReporter in Test).value,
+    nativeGC := Option(System.getenv.get("SCALANATIVE_GC")).getOrElse("boehm"),
+    nativeGC in NativeTest := (nativeGC in Test).value
   )
 
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
@@ -134,9 +136,7 @@ object ScalaNativePluginInternal {
         case Some(_) =>
           ()
       }
-    },
-    nativeGC := "boehm",
-    nativeGC in NativeTest := (nativeGC in Test).value
+    }
   )
 
   lazy val scalaNativeConfigSettings: Seq[Setting[_]] = Seq(
@@ -395,7 +395,7 @@ object ScalaNativePluginInternal {
       val paths     = apppaths.map(_.abs) ++ opaths
       val compile   = clangpp.abs +: (flags ++ paths)
 
-      logger.time(s"Linking native code - $gc GC") {
+      logger.time(s"Linking native code - $gc gc") {
         logger.running(compile)
         Process(compile, cwd) ! logger
       }


### PR DESCRIPTION
This approach does not use a root project and addresses most of the issues raised in the first PR review. https://github.com/scala-native/scala-native/pull/1041

I would like to reduce the items in `rebuild` by using `publishLocal` dependencies for `scala` and `test-interface`. This will make developing Scala Native easier if changes span more than one project. `sbtScalaNative/publishLocal` depends on `tools/publishLocal` which in turn depends on `nir/publishLocal` and `util/publishLocal`.