### PR TITLE
Fix #1123: Assign 0 to group pos instead of -1 on empty string

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -97,7 +97,7 @@ final class Matcher private[regex] (var _pattern: Pattern,
         while (i < nMatches) {
           val m = matches + i
           groups(i) = if (m.length == 0) {
-            (-1, -1)
+            (0, 0)
           } else {
             // Takes from inre2 until m...
             val before = alloc[cre2.string_t]
@@ -158,7 +158,7 @@ final class Matcher private[regex] (var _pattern: Pattern,
     val startIndex = start(group)
     val endIndex   = end(group)
 
-    if (startIndex < 0 && endIndex < 0) {
+    if (startIndex <= 0 && endIndex <= 0) {
       null
     } else {
       inputSequence.subSequence(startIndex, endIndex).toString

--- a/unit-tests/src/test/scala/java/util/regex/MatcherSuite.scala
+++ b/unit-tests/src/test/scala/java/util/regex/MatcherSuite.scala
@@ -282,6 +282,13 @@ object MatcherSuite extends tests.Suite {
     assert(expStr == null)
   }
 
+  test("start/end 0,0 on empty match") {
+    val m = Pattern.compile(".*").matcher("")
+    assert(m.find())
+    assertEquals(m.start, 0)
+    assertEquals(m.end, 0)
+  }
+
   private def matcher(regex: String, text: String): Matcher =
     Pattern.compile(regex).matcher(text)
 }


### PR DESCRIPTION
Match the behaviour of Scala. The test added with #740 still passes.