### PR TITLE
Add bindings for cpio.h from POSIX

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -13,7 +13,7 @@ C Header          Scala Native Module
 `arpa/inet.h`_    scala.scalanative.posix.arpa.inet_
 `assert.h`_       N/A
 `complex.h`_      N/A
-`cpio.h`_         N/A
+`cpio.h`_         scala.scalanative.posix.cpio_
 `ctype.h`_        N/A
 `dirent.h`_       scala.scalanative.posix.dirent_
 `dlfcn.h`_        N/A
@@ -177,6 +177,7 @@ C Header          Scala Native Module
 .. _wordexp.h: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/wordexp.h.html
 
 .. _scala.scalanative.posix.arpa.inet: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
+.. _scala.scalanative.posix.cpio: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/cpio.scala
 .. _scala.scalanative.posix.dirent: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/dirent.scala
 .. _scala.scalanative.posix.errno: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/errno.scala
 .. _scala.scalanative.posix.fcntl: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/fcntl.scala

--- a/nativelib/src/main/resources/posix/cpio.c
+++ b/nativelib/src/main/resources/posix/cpio.c
@@ -1,0 +1,24 @@
+#include <cpio.h>
+
+unsigned short scalanative_c_issock() { return C_ISSOCK; }
+unsigned short scalanative_c_islnk() { return C_ISLNK; }
+unsigned short scalanative_c_isctg() { return C_ISCTG; }
+unsigned short scalanative_c_isreg() { return C_ISREG; }
+unsigned short scalanative_c_isblk() { return C_ISBLK; }
+unsigned short scalanative_c_isdir() { return C_ISDIR; }
+unsigned short scalanative_c_ischr() { return C_ISCHR; }
+unsigned short scalanative_c_isfifo() { return C_ISFIFO; }
+unsigned short scalanative_c_isuid() { return C_ISUID; }
+unsigned short scalanative_c_isgid() { return C_ISGID; }
+unsigned short scalanative_c_isvtx() { return C_ISVTX; }
+unsigned short scalanative_c_irusr() { return C_IRUSR; }
+unsigned short scalanative_c_iwusr() { return C_IWUSR; }
+unsigned short scalanative_c_ixusr() { return C_IXUSR; }
+unsigned short scalanative_c_irgrp() { return C_IRGRP; }
+unsigned short scalanative_c_iwgrp() { return C_IWGRP; }
+unsigned short scalanative_c_ixgrp() { return C_IXGRP; }
+unsigned short scalanative_c_iroth() { return C_IROTH; }
+unsigned short scalanative_c_iwoth() { return C_IWOTH; }
+unsigned short scalanative_c_ixoth() { return C_IXOTH; }
+
+const char *scalanative_magic() { return MAGIC; }

--- a/nativelib/src/main/scala/scala/scalanative/posix/cpio.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/cpio.scala
@@ -1,0 +1,70 @@
+package scala.scalanative
+package posix
+
+import scalanative.native._
+
+@extern
+object cpio {
+  @name("scalanative_c_issock")
+  def C_ISSOCK: CUnsignedShort = extern
+
+  @name("scalanative_c_islnk")
+  def C_ISLNK: CUnsignedShort = extern
+
+  @name("scalanative_c_isctg")
+  def C_ISCTG: CUnsignedShort = extern
+
+  @name("scalanative_c_isreg")
+  def C_ISREG: CUnsignedShort = extern
+
+  @name("scalanative_c_isblk")
+  def C_ISBLK: CUnsignedShort = extern
+
+  @name("scalanative_c_isdir")
+  def C_ISDIR: CUnsignedShort = extern
+
+  @name("scalanative_c_ischr")
+  def C_ISCHR: CUnsignedShort = extern
+
+  @name("scalanative_c_isfifo")
+  def C_ISFIFO: CUnsignedShort = extern
+
+  @name("scalanative_c_isuid")
+  def C_ISUID: CUnsignedShort = extern
+
+  @name("scalanative_c_isgid")
+  def C_ISGID: CUnsignedShort = extern
+
+  @name("scalanative_c_isvtx")
+  def C_ISVTX: CUnsignedShort = extern
+
+  @name("scalanative_c_irusr")
+  def C_IRUSR: CUnsignedShort = extern
+
+  @name("scalanative_c_iwusr")
+  def C_IWUSR: CUnsignedShort = extern
+
+  @name("scalanative_c_ixusr")
+  def C_IXUSR: CUnsignedShort = extern
+
+  @name("scalanative_c_irgrp")
+  def C_IRGRP: CUnsignedShort = extern
+
+  @name("scalanative_c_iwgrp")
+  def C_IWGRP: CUnsignedShort = extern
+
+  @name("scalanative_c_ixgrp")
+  def C_IXGRP: CUnsignedShort = extern
+
+  @name("scalanative_c_iroth")
+  def C_IROTH: CUnsignedShort = extern
+
+  @name("scalanative_c_iwoth")
+  def C_IWOTH: CUnsignedShort = extern
+
+  @name("scalanative_c_ixoth")
+  def C_IXOTH: CUnsignedShort = extern
+
+  @name("scalanative_magic")
+  def MAGIC: CString = extern
+}


### PR DESCRIPTION
This is a rebase #1095 with a `cpio.h` renamed as `cpio.c`. 