### PR TITLE
Add support for extern objects inside other classes

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -662,7 +662,13 @@ trait NirGenExpr { self: NirGenPhase =>
                         curMethodThis.get.get,
                         args)
         case Select(New(_), nme.CONSTRUCTOR) =>
-          genApplyNew(app)
+          val Apply(Select(New(tpt), nme.CONSTRUCTOR), _) = app
+
+          SimpleType.fromType(tpt.tpe) match {
+            case st if st.isExternModule =>
+              Val.Null
+            case _ => genApplyNew(app)
+          }
         case _ =>
           val sym = fun.symbol
 


### PR DESCRIPTION
Before, creating an `@extern` object inside a method or another class would result in linking errors, since the constructor for the object would not be eliminated. This changes the constructor for `@extern` objects to return `null`, which works since the constructor is never used, instead of not being generated.