### PR TITLE
Fix #1062: Difference behaviour JVM and Native with BufferedInputStream

### DIFF
--- a/javalib/src/main/scala/java/io/BufferedInputStream.scala
+++ b/javalib/src/main/scala/java/io/BufferedInputStream.scala
@@ -31,7 +31,7 @@ class BufferedInputStream(in: InputStream, size: Int)
 
   override def available(): Int = {
     if (closed) throw new IOException()
-    end - pos
+    end - pos + in.available()
   }
 
   override def close(): Unit = {

--- a/unit-tests/src/test/scala/java/io/BufferedInputStreamSuite.scala
+++ b/unit-tests/src/test/scala/java/io/BufferedInputStreamSuite.scala
@@ -121,4 +121,24 @@ object BufferedInputStreamSuite extends tests.Suite {
 
   }
 
+  test("available behave correctly") {
+
+    val inputArray = Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte)
+    val in         = new BufferedInputStream(new ByteArrayInputStream(inputArray))
+
+    assert(in.available() > 0)
+
+    val tmp        = new Array[Byte](10)
+    var countBytes = 0
+    while (in.available() > 0) {
+      countBytes += in.read(tmp, 0, 5)
+    }
+
+    assert(countBytes == 10)
+    assert(in.available() == 0)
+
+    val emptyIn = new BufferedInputStream(new ByteArrayInputStream(Array()))
+    assert(emptyIn.available() == 0)
+  }
+
 }


### PR DESCRIPTION
The original code didn't return the expected `available` when the internal `buf` was empty.
To fix #1062,  `available` returns now the number of bytes available in the buffer + `in.available`