### PR TITLE
Add autoImport alias to preserve build source compatibility

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -51,6 +51,9 @@ object ScalaNativePlugin extends AutoPlugin {
       settingKey[String]("GC choice, either \"none\", \"boehm\" or \"immix\".")
   }
 
+  @deprecated("use autoImport instead", "0.3.7")
+  val AutoImport = autoImport
+
   override def globalSettings: Seq[Setting[_]] =
     ScalaNativePluginInternal.scalaNativeGlobalSettings
 


### PR DESCRIPTION
In #1147 we renamed `AutoImport` to `autoImport`. This breaks
source compatibility for existing builds. This commit adds
a deprecated alias `autoImport` instead.