### PR TITLE
[WIP] For discussion, an alternate TimeSuite.scala fix using setenv & friends

### DIFF
--- a/nativelib/src/main/resources/time.c
+++ b/nativelib/src/main/resources/time.c
@@ -18,3 +18,11 @@ long long scalanative_current_time_millis() {
 
     return current_time_millis;
 }
+
+// There is an argument that these three should be in resources/wrap.c or
+// resources resources/posix.c. tzname() is declared in time.h, so
+// place here, in time.c.
+
+char **scalanative_time_tzname() { return tzname; }
+long scalanative_time_timezone() { return timezone; }
+int scalanative_time_daylight() { return daylight; }

--- a/nativelib/src/main/scala/scala/scalanative/native/stdlib.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/stdlib.scala
@@ -24,7 +24,11 @@ object stdlib {
   // Communicating with the environment
 
   def system(command: CString): CInt = extern
-  def getenv(name: CString): CString = extern
+
+  def getenv(name: CString): CString                              = extern
+  def putenv(name: CString): CInt                                 = extern
+  def setenv(name: CString, value: CString, overwrite: Int): CInt = extern
+  def unsetenv(name: CString): CInt                               = extern
 
   // Pseudo-random number generation
 

--- a/nativelib/src/main/scala/scala/scalanative/native/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/time.scala
@@ -7,7 +7,17 @@ object time {
   type time_t   = CLong
   type clock_t  = CLong
   type timespec = CStruct2[time_t, CLong]
-  type tm       = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
+  type tm = CStruct11[CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CLong,
+                      Ptr[CChar]]
 
   def difftime(time_end: CLong, time_beg: CLong): CDouble               = extern
   def time(arg: Ptr[time_t]): time_t                                    = extern
@@ -82,6 +92,10 @@ object timeOps {
 
     def tm_isdst: CInt = !ptr._9
 
+    def tm_gmtoff: CLong = !ptr._10
+
+    def tm_zone: Ptr[CChar] = !ptr._11
+
     def tm_sec_=(v: CInt): Unit = !ptr._1 = v
 
     def tm_min_=(v: CInt): Unit = !ptr._2 = v
@@ -99,6 +113,10 @@ object timeOps {
     def tm_yday_=(v: CInt): Unit = !ptr._8 = v
 
     def tm_isdst_=(v: CInt): Unit = !ptr._9 = v
+
+    def tm_gmtoff_=(v: CLong): Unit = !ptr._10 = v
+
+    def tm_zone_=(v: Ptr[CChar]): Unit = !ptr._11 = v
 
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/native/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/time.scala
@@ -9,7 +9,7 @@ object time {
   type timespec = CStruct2[time_t, CLong]
   type tm       = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
 
-  def difftime(time_end: CLong, time_beg: CLong): time_t                = extern
+  def difftime(time_end: CLong, time_beg: CLong): CDouble               = extern
   def time(arg: Ptr[time_t]): time_t                                    = extern
   def clock(): clock_t                                                  = extern
   def timespec_get(ts: Ptr[timespec], base: CInt): CInt                 = extern
@@ -25,12 +25,27 @@ object time {
   def wcsftime(str: CWideChar,
                count: CSize,
                format: Ptr[CWideChar],
-               time: Ptr[tm]): CSize                           = extern
+               time: Ptr[tm]): CSize = extern
+
+  def strptime(str: CString, format: CString, tm: Ptr[tm]): CString = extern
+
   def gmtime(time: Ptr[time_t]): Ptr[tm]                       = extern
   def gmtime_s(time: Ptr[time_t], result: Ptr[tm]): Ptr[tm]    = extern
   def localtime(time: Ptr[time_t]): Ptr[tm]                    = extern
   def localtime_s(time: Ptr[time_t], result: Ptr[tm]): Ptr[tm] = extern
   def mktime(time: Ptr[tm]): time_t                            = extern
+
+  def tzset(): Unit = extern
+
+  @name("scalanative_time_tzname")
+  def tzname: Ptr[CString] = extern
+
+  @name("scalanative_time_timezone")
+  def timezone: CLong = extern
+
+  @name("scalanative_time_daylight")
+  def daylight: CInt = extern
+
 }
 
 object timeOps {

--- a/unit-tests/src/test/scala/scala/scalanative/native/StdlibSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/native/StdlibSuite.scala
@@ -1,0 +1,222 @@
+package scala.scalanative.native
+
+import scala.scalanative.native.stdio.{snprintf}
+import scala.scalanative.native.stdlib.{getenv, putenv, setenv, unsetenv}
+import scala.scalanative.native.stdlib.{free, malloc}
+import scala.scalanative.native.string.{strcmp, strlen, strncpy}
+
+object StdlibSuite extends tests.Suite {
+
+  // Attempts at unique/reserved names. Suite will break if these
+  // are in use by somebody else. Uniqueness is too hard a problem for now.
+  //
+  // When changing values for these variables, make sure that the new
+  // values will still fit into putEnvBufLen!!
+
+  val putEnvBufLen = 128
+
+  // BE _EXQUSITELY_ careful with the lifetime of this variable!
+  var putEnvBuf: Ptr[CChar] = malloc(putEnvBufLen)
+  assertNotNull(putEnvBuf)
+
+  val putEnvVarName    = c"SCALANATIVE_UNIT_TEST_STDLIB_PUTENV"
+  val putEnvVarValue_1 = c"putEnvVarValue_1_value"
+  val putEnvVarValue_2 = c"putEnvVarValue_2_value"
+  val putEnvVarValue_3 = c"Ain't nobody here but us chickens" // L. Armstrong
+
+  val setEnvVarName    = c"SCALANATIVE_UNIT_TEST_STDLIB_SETENV"
+  val setEnvVarValue_1 = c"setEnvVarValue_1_value"
+  val setEnvVarValue_2 = c"setEnvVarValue_2_value"
+
+  val unsetEnvVarName = c"SCALANATIVE_UNIT_TEST_STDLIB_UNSETENV"
+
+  /* This Suite tests functions/methods which are __defined_ as
+   * having no requirement to be thread-safe. In addition, it changes
+   * the value of environment variables. Other simultaneous threads may
+   * pickup value bogus to them.
+   *
+   * Tests must be run sequentially, not in parallel, because there is
+   * an explicit order to some of the tests. For example, one must
+   * set an environment variable before unsetting it.
+   *
+   * So this Suite __must__ be run in an environment which is guaranteed
+   * to be single-threaded for the duration of the Suite. There is no
+   * good runtime for single-threadedness here. The guarantee must come
+   * from the enveloping test framework.
+   */
+
+  // getenv section
+
+  test("getenv name '=' which can never already be in environment") {
+
+    val result = getenv(c"=")
+    assertNull(result)
+  }
+
+  test("getenv name PATH already in environment") {
+    // Every linux environment should have PATH.
+    // There is __bound__ to be some OS which does not.
+    // Cross-platform life is hard.
+
+    val result = getenv(c"PATH")
+    assertNotNull(result)
+  }
+
+  // putenv section
+
+  test("putenv name not already in environment") {
+
+    val result_1 = getenv(putEnvVarName)
+    assertNull(result_1)
+
+    val result_2 = snprintf(putEnvBuf,
+                            putEnvBufLen,
+                            c"%s=%s",
+                            putEnvVarName,
+                            putEnvVarValue_1)
+    assert(result_2 > 0)
+
+    val result_3 = putenv(putEnvBuf)
+    assert(result_3 == 0)
+
+    val result_4 = getenv(putEnvVarName)
+    assertNotNull(result_4)
+
+    val result_5 = strcmp(putEnvVarValue_1, result_4)
+    assert(result_5 == 0)
+  }
+
+  test("putenv name already in environment, value changes") {
+
+    val result_1 = getenv(putEnvVarName)
+    assertNotNull(result_1)
+
+    val result_2 =
+      snprintf(putEnvBuf,
+               putEnvBufLen,
+               c"%s=%s",
+               putEnvVarName,
+               putEnvVarValue_2)
+    assert(result_2 > 0)
+
+    val result_3 = putenv(putEnvBuf)
+    assert(result_3 == 0)
+
+    val result_4 = getenv(putEnvVarName)
+    assertNotNull(result_4)
+
+    val result_5 = strcmp(putEnvVarValue_2, result_4)
+    assert(result_5 == 0)
+  }
+
+  test("putenv change value of string given in previous call") {
+
+    // "Everything not forbidden is compulsory". Murray Gell-Mann
+    // People use putenv() in preference to setenv() to avoid potential
+    // memory leak in latter. From there, it is but a short step to
+    // modifying the string. Hence, this test.
+
+    val result_1 = getenv(putEnvVarName)
+    assertNotNull(result_1)
+
+    val insertPoint     = putEnvBuf + strlen(putEnvVarName) + 1 // skip '='
+    val remainingLength = putEnvBufLen - (insertPoint - putEnvBuf)
+
+    strncpy(insertPoint, putEnvVarValue_3, remainingLength)
+    putEnvBuf(putEnvBufLen - 1) = 0.toByte
+
+    val result_2 = putenv(putEnvBuf)
+    assert(result_2 == 0)
+
+    val result_3 = getenv(putEnvVarName)
+    assertNotNull(result_3)
+
+    val result_4 = strcmp(putEnvVarValue_3, result_3)
+    assert(result_4 == 0)
+  }
+
+  // setenv section
+
+  test("setenv name not already in environment, no overwrite") {
+
+    val result_1 = getenv(setEnvVarName)
+    assertNull(result_1)
+
+    val result_2 = setenv(setEnvVarName, setEnvVarValue_1, 0)
+    assert(result_2 == 0)
+
+    val result_3 = getenv(setEnvVarName)
+    assertNotNull(result_3)
+
+    val result_4 = strcmp(setEnvVarValue_1, result_3)
+    assert(result_4 == 0)
+  }
+
+  test("setenv name already in environment, no overwrite") {
+
+    val result_1 = getenv(setEnvVarName)
+    assertNotNull(result_1)
+
+    val result_2 = setenv(setEnvVarName, setEnvVarValue_2, 0)
+    assert(result_2 == 0)
+
+    val result_3 = getenv(setEnvVarName)
+    assertNotNull(result_3)
+
+    val result_4 = strcmp(setEnvVarValue_1, result_3)
+    assert(result_4 == 0)
+  }
+
+  test("setenv name already in environment, overwrite") {
+
+    val result_1 = getenv(setEnvVarName)
+    assertNotNull(result_1)
+
+    val result_2 = setenv(setEnvVarName, setEnvVarValue_2, 1)
+    assert(result_2 == 0)
+
+    val result_3 = getenv(setEnvVarName)
+    assertNotNull(result_3)
+
+    val result_4 = strcmp(setEnvVarValue_2, result_3)
+    assert(result_4 == 0)
+  }
+
+  // End of suite, clean up environment.
+  // unsetenv section.
+
+  test(s"unsetenv name not already in environment") {
+
+    val envVar = unsetEnvVarName
+
+    val result_1 = getenv(envVar)
+    assertNull(result_1)
+
+    val result_2 = unsetenv(envVar)
+    assert(result_2 == 0)
+  }
+
+  test(s"unsetenv putenv name already in environment") {
+
+    val envVar = putEnvVarName
+
+    val result_1 = getenv(envVar)
+    assertNotNull(result_1)
+
+    val result_2 = unsetenv(envVar)
+    assert(result_2 == 0)
+
+    free(putEnvBuf)
+  }
+
+  test("unsetenv setenv name already in environment") {
+
+    val envVar = setEnvVarName
+
+    val result_1 = getenv(envVar)
+    assertNotNull(result_1)
+
+    val result_2 = unsetenv(envVar)
+    assert(result_2 == 0)
+  }
+}

--- a/unit-tests/src/test/scala/scala/scalanative/native/TimeSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/native/TimeSuite.scala
@@ -2,21 +2,77 @@ package scala.scalanative.native
 
 import scala.scalanative.native.time.{
   asctime,
+  daylight,
   difftime,
+  gmtime,
   localtime,
   mktime,
   strftime,
-  wcsftime,
-  gmtime,
+  strptime,
   time_t,
-  tm
+  timezone,
+  tm,
+  tzname,
+  tzset,
+  wcsftime
 }
+
 import scala.scalanative.native.timeOps.tmOps
+
+import scala.scalanative.native.stdlib.{getenv, setenv, unsetenv}
+import scala.scalanative.native.string.{memset, strcmp}
 
 object TimeSuite extends tests.Suite {
 
   val now_ptr: Ptr[time_t] = stackalloc[time_t]
   val now_time_t: time_t   = time.time(now_ptr)
+
+  var tzEnvVarName     = c"TZ"
+  var savedTZ: CString = _
+
+  /* TimeSuite must execute in a single threaded environment. The only
+   * sure way to meet this requirement is for the enclosing testing
+   * environment to guarantee it.
+   *
+   * The four functions in the suite (localtime & friends) are defined
+   * as returning pointers to static buffers and THREAD_UNSAFE!.  In
+   * addition, this code possibly/probably changes the environment variable
+   * TZ for the duration of the suite run. Any other thread running in
+   * the same process may pick up a bogus, to it, value for TZ.
+   *
+   * A runtime test is possible here (stat /proc/self/task. If it
+   * is successful and nlinks == 3, then process is single threaded, at
+   * moment of testing). This test however is a weak one, because without
+   * a guarantee from the testing environment, a new thread can be created
+   * at any time after the initial test.
+   */
+
+  test("save unknown current TZ, set to known Central European Time (CET)") {
+
+    savedTZ = getenv(tzEnvVarName)
+
+    val result = setenv(tzEnvVarName, c"CET-1CEST,M3.5.0,M10.5.0", 1)
+
+    assert(result == 0)
+
+    tzset()
+  }
+
+  test("tzname(0) should now be CET & tzname(1) should be CEST") {
+    // must be early in file but after tzset() had been called, either
+    // directly or indirectly (mktime).
+    assert(strcmp(tzname(0), c"CET") == 0)
+    assert(strcmp(tzname(1), c"CEST") == 0)
+  }
+
+  test("timezone & daylight variables for CEST should be valid") {
+    // must be after tzname test, preferably as immediately next test.
+    val cetOffset  = -1 * (60 * 60)
+    val cestOffset = cetOffset * 2
+
+    assert((timezone == cetOffset) || (timezone == cestOffset))
+    assert((daylight == 0) || (daylight == 1))
+  }
 
   test("asctime() with a given known state should match its representation") {
 
@@ -36,31 +92,68 @@ object TimeSuite extends tests.Suite {
     assert("Sun Jan  1 00:00:00 1900\n".equals(str))
   }
 
-  test("localtime() should transform day zero time to localtime (+0100=CET)") {
+  test("localtime() should convert Unix Epoch to expected") {
 
-    val anno_zero_ptr: Ptr[tm] = stackalloc[tm]
-    anno_zero_ptr.tm_sec = 0
-    anno_zero_ptr.tm_min = 0
-    anno_zero_ptr.tm_hour = 0
-    anno_zero_ptr.tm_mday = 1
-    anno_zero_ptr.tm_mon = 0
-    anno_zero_ptr.tm_year = 0
-    anno_zero_ptr.tm_wday = 0
-    anno_zero_ptr.tm_yday = 0
-    anno_zero_ptr.tm_isdst = 0
+    val unix_epoch: time_t = 0
 
-    val theTime: time_t = mktime(anno_zero_ptr)
-    val time_ptr        = stackalloc[time_t]
-    !time_ptr = theTime
+    val time_ptr = stackalloc[time_t]
+
+    !time_ptr = unix_epoch
+
+    // TZ set to known "CET" (Central European Time) on entry to Suite above.
+
     val time: Ptr[tm] = localtime(time_ptr)
     val cstr: CString = asctime(time)
     val str: String   = fromCString(cstr)
 
-    assert("Thu Jan  1 00:59:59 1970\n".equals(str))
+    assert("Thu Jan  1 01:00:00 1970\n".equals(str))
+  }
+
+  test("strptime() should convert 1969-07-21T02:56:15 UTC to expected") {
+
+    // A human, Neil Armstrong, first stepped onto the Moon at
+    // 1969-07-21T02:56:15 UTC.
+
+    val tmPtr: Ptr[tm] = stackalloc[tm]
+
+    memset(tmPtr.asInstanceOf[Ptr[Byte]], 0, sizeof[tm])
+
+    val result =
+      strptime(c"1969-07-21T02:56:15 UTC", c"%Y-%m-%dT%H:%M:%S", tmPtr);
+
+    assertNotNull(result)
+
+    assert(tmPtr.tm_sec == 15)
+    assert(tmPtr.tm_min == 56)
+    assert(tmPtr.tm_hour == 2)
+    assert(tmPtr.tm_mday == 21)
+    assert(tmPtr.tm_mon == 6)
+    assert(tmPtr.tm_year == (1969 - 1900))
+    assert(tmPtr.tm_wday == 1)
+    assert(tmPtr.tm_yday == 201)
+    assert(tmPtr.tm_isdst == 0) // Never dst in UTC
+  }
+
+  test("mktime() should convert 1969-07-21T04:56:15 CEST to expected") {
+
+    val tmPtr: Ptr[tm] = stackalloc[tm]
+
+    memset(tmPtr.asInstanceOf[Ptr[Byte]], 0, sizeof[tm])
+
+    val result =
+      strptime(c"1969-07-21T02:56:15 UTC", c"%Y-%m-%dT%H:%M:%S", tmPtr);
+
+    assertNotNull(result)
+
+    tmPtr.tm_hour += 2 // Convert from UTC to CEST
+
+    val utcOffset = mktime(tmPtr)
+
+    assert(utcOffset == -14155425) // negative because tmPtr earlier than Epoch
   }
 
   test(
-    "difftime() between epoch and now should be bigger than the timestamp when I wrote this code") {
+    "difftime(1900-01-01, now) should be > time this test was written") {
 
     val anno_zero_ptr: Ptr[tm] = stackalloc[tm]
     anno_zero_ptr.tm_sec = 0
@@ -72,10 +165,12 @@ object TimeSuite extends tests.Suite {
     anno_zero_ptr.tm_wday = 0
     anno_zero_ptr.tm_yday = 0
     anno_zero_ptr.tm_isdst = 0
-    val anno_zero_time_t: time_t = mktime(anno_zero_ptr)
 
-    val diff: time_t = difftime(now_time_t, anno_zero_time_t)
-    assert(diff > 1502752688)
+    val anno_zero_time_t = mktime(anno_zero_ptr)
+
+    val diff = difftime(now_time_t, anno_zero_time_t)
+
+    assert(diff.toLong > 1502752688L) // Use Long to prevent sign flip
   }
 
   test("time() should be bigger than the timestamp when I wrote this code") {
@@ -83,24 +178,25 @@ object TimeSuite extends tests.Suite {
     assert(now_time_t > 1502752688)
   }
 
-  test("strftime() for 1900-01-00T00:00:00Z") {
-    val isoDatePtr: Ptr[CChar] = stackalloc[CChar](70)
+  test("strftime() should convert 1900-01-01T00:00:00Z to expected") {
+
+    val isoDateBuf: Ptr[CChar] = stackalloc[CChar](70)
     val timePtr: Ptr[tm]       = stackalloc[tm]
     timePtr.tm_sec = 0
     timePtr.tm_min = 0
     timePtr.tm_hour = 0
-    timePtr.tm_mday = 0
+    timePtr.tm_mday = 1
     timePtr.tm_mon = 0
     timePtr.tm_year = 0
     timePtr.tm_wday = 0
     timePtr.tm_yday = 0
     timePtr.tm_isdst = 0
 
-    strftime(isoDatePtr, 70, c"%FT%TZ", timePtr)
+    strftime(isoDateBuf, 70, c"%FT%TZ", timePtr)
 
-    val isoDateString: String = fromCString(isoDatePtr)
+    val isoDateString = fromCString(isoDateBuf)
 
-    assert("1900-01-00T00:00:00Z".equals(isoDateString))
+    assert("1900-01-01T00:00:00Z".equals(isoDateString))
   }
 
   test("wcsftime() not implemented yet. Waiting for fromWideChar") {
@@ -117,24 +213,77 @@ object TimeSuite extends tests.Suite {
     timePtr.tm_isdst = 0
   }
 
-  test("gmtime()") {
-    val datePtr: Ptr[CChar] = stackalloc[CChar](70)
+  test("gmtime() should convert 2000-01-01T00:01:02 CET to expected") {
 
-    val timePtr: Ptr[tm] = stackalloc[tm]
-    timePtr.tm_sec = 0
-    timePtr.tm_min = 0
-    timePtr.tm_hour = 0
-    timePtr.tm_mday = 0
-    timePtr.tm_mon = 0
-    timePtr.tm_year = 0
-    timePtr.tm_wday = 0
-    timePtr.tm_yday = 0
-    timePtr.tm_isdst = 0
+    // mktime() using TZ of CET set on entry to suite.
+    // so tm_hour for Month 0 (January) is +1.
+    // No CEST in January.
 
-    strftime(datePtr, 70, c"%A %c", timePtr)
+    // Chose a year, day, & hour, 2000-01-01T00:01:02 CET, which will
+    // trigger plenty of change/havoc.
+    // tm_hour, tm_mday, tm_mon, tm_year, tm_wday, & tm_yday all change.
+    // Non-zero tm_min and tm_sec values are used to exercise something other
+    // than zero, which has previously been used.
 
-    val dateString: String = fromCString(datePtr)
-    assert("Sunday Sun Jan  0 00:00:00 1900".equals(dateString))
+    val tmPtr: Ptr[tm] = stackalloc[tm]
+
+    // Single point of truth
+    val tm_sec   = 2
+    val tm_min   = 1
+    val tm_hour  = 0 // so -1 for UTC will be in previous day, month, year
+    val tm_mday  = 1
+    val tm_mon   = 0
+    val tm_year  = 2000 - 1900
+    val tm_wday  = 6 // Saturday
+    val tm_yday  = 0
+    val tm_isdst = 0
+
+    tmPtr.tm_sec = tm_sec
+    tmPtr.tm_min = tm_min
+    tmPtr.tm_hour = tm_hour
+    tmPtr.tm_mday = tm_mday
+    tmPtr.tm_mon = tm_mon
+    tmPtr.tm_year = tm_year
+    tmPtr.tm_wday = tm_wday
+    tmPtr.tm_yday = tm_yday
+    tmPtr.tm_isdst = tm_isdst
+
+    val havocTime = mktime(tmPtr)
+
+    val havocPtr = stackalloc[time_t]
+
+    !havocPtr = havocTime
+
+    val gmtTmPtr = gmtime(havocPtr)
+
+    // These stay the same
+    assert(gmtTmPtr.tm_sec == tm_sec)
+    assert(gmtTmPtr.tm_min == tm_min)
+    assert(gmtTmPtr.tm_isdst == tm_isdst)
+
+    // These change
+    assert(gmtTmPtr.tm_hour == 23)
+    assert(gmtTmPtr.tm_mday == 31)
+    assert(gmtTmPtr.tm_mon == 11)
+
+    assert(gmtTmPtr.tm_year == (tm_year - 1))
+    assert(gmtTmPtr.tm_wday == 5)
+    assert(gmtTmPtr.tm_yday == 364)
+  }
+
+  test("restore saved TZ") {
+
+    // This test must come last.
+
+    val result = if (savedTZ == null) {
+      unsetenv(tzEnvVarName)
+    } else {
+      setenv(tzEnvVarName, savedTZ, 1)
+    }
+
+    assert(result == 0)
+
+    tzset();
   }
 
 }


### PR DESCRIPTION
I expect this PR to be discarded in favor of @eatkins earlier PR #1170 . I offer it as a 
base for discussing an alternate fix to issue #1167.  This approach  uses setenv and unsetenv
to set the TZ environment variable.  I believe this more closely approximates use in the wild.
The TZ environment is established at the beginning of the suite and cleaned up at the end.

There is also a discussion about the need for a uni-threaded environment  __guaranteed__
by the testing framework.

The commit message is quite detailed about the changes & why.

I implemented strptime(). I can add that and the missing reentrant (_r) functions
in a separate PR after #1170 is merged.  I would also like to change the gmtime
test so that gmtime() actually gets called/exercised.

There is a HACK in TimeSuite.scala.  I am chasing a memory allocation bug on X86_64
(but, strangely enough on X86 32 bit).  I suspect an issue with padding in structures.
Scala-native & mktime() seem to have different ideas about where the latter can write.
For now, I allocate extra space.  I hope th chase issue down at some point. The memory
corruption only shows up at the unsetenv() at the end where sysmalloc reports an assertion failure.
