### PR TITLE
Fix dependencies of `testingCompiler`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -469,7 +469,7 @@ lazy val benchmarks =
 lazy val testingCompilerInterface =
   project
     .in(file("testing-compiler-interface"))
-    .settings(libSettings)
+    .settings(toolSettings)
     .settings(noPublishSettings)
     .settings(
       crossPaths := false,
@@ -480,7 +480,7 @@ lazy val testingCompilerInterface =
 lazy val testingCompiler =
   project
     .in(file("testing-compiler"))
-    .settings(libSettings)
+    .settings(toolSettings)
     .settings(noPublishSettings)
     .settings(
       libraryDependencies ++= Seq(


### PR DESCRIPTION
It doesn't need to have all the dependencies on all the libraries and
the scalac plugin.