### PR TITLE
Clarify docs on zone allocation

### DIFF
--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -200,6 +200,10 @@ runtime system, one has to be extra careful when working with unmanaged memory.
         val buffer = native.alloc[Byte](n)
       }
 
+   `native.alloc` requests memory sufficient to contain `n` values of a given type.
+   If number of elements is not specified, it defaults to a single element.
+   Memory is zeroed out by default.
+
    Zone allocation is the preferred way to allocate temporary unmanaged memory.
    It's idiomatic to use implicit zone parameters to abstract over code that
    has to zone allocate.

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -227,7 +227,7 @@ runtime system, one has to be extra careful when working with unmanaged memory.
 
    This code will allocate 256 bytes that are going to be available until
    the enclosing method returns. Number of elements to be allocated is optional
-   and defaults to 1 otherwise.
+   and defaults to 1 otherwise. Memory is not zeroed out by default.
 
    When using stack allocated memory one has to be careful not to capture
    this memory beyond the lifetime of the method. Dereferencing stack allocated


### PR DESCRIPTION
In particular, zone allocation using `alloc[T](n)` and `alloc[T]` does zero-out memory.