### PR TITLE
Resolve #1198: Fix FileChannel.read to have same semantics as JVM

### DIFF
--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -57,20 +57,25 @@ final class FileChannelImpl(path: Path,
                     start: Int,
                     number: Int): Long = {
     ensureOpen()
-    val dst = new Array[Byte](1)
-    val nb  = raf.read(dst)
-    var i   = 0
-    while (i < number) {
-      buffers(start + i).put(dst)
-      i += 1
+
+    var bread: Long = 0
+
+    for (i <- start until number) {
+      val len = buffers(i).limit() - buffers(i).position()
+      val dst = new Array[Byte](len)
+      val nb  = raf.read(dst)
+      if (nb > 0) buffers(i).put(dst)
+      bread += nb
     }
-    nb
+
+    bread
   }
 
   override def read(buffer: ByteBuffer, pos: Long): Int = {
     ensureOpen()
     position(pos)
-    val dst = new Array[Byte](1)
+    val len = buffer.limit() - buffer.position()
+    val dst = new Array[Byte](len)
     val nb  = raf.read(dst)
     if (nb > 0) buffer.put(dst)
     nb

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -58,9 +58,10 @@ final class FileChannelImpl(path: Path,
                     number: Int): Long = {
     ensureOpen()
 
-    var bread: Long = 0
+    var bytesRead = 0l
+    var i         = 0
 
-    for (i <- start until number) {
+    while (i < number) {
       val startPos = buffers(i).position()
       val len      = buffers(i).limit() - startPos
       val dst      = new Array[Byte](len)
@@ -71,10 +72,11 @@ final class FileChannelImpl(path: Path,
         buffers(i).position(startPos + nb)
       }
 
-      bread += nb
+      bytesRead += nb
+      i += 1
     }
 
-    bread
+    bytesRead
   }
 
   override def read(buffer: ByteBuffer, pos: Long): Int = {

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -61,10 +61,16 @@ final class FileChannelImpl(path: Path,
     var bread: Long = 0
 
     for (i <- start until number) {
-      val len = buffers(i).limit() - buffers(i).position()
-      val dst = new Array[Byte](len)
-      val nb  = raf.read(dst)
-      if (nb > 0) buffers(i).put(dst)
+      val startPos = buffers(i).position()
+      val len      = buffers(i).limit() - startPos
+      val dst      = new Array[Byte](len)
+      val nb       = raf.read(dst)
+
+      if (nb > 0) {
+        buffers(i).put(dst)
+        buffers(i).position(startPos + nb)
+      }
+
       bread += nb
     }
 
@@ -74,10 +80,17 @@ final class FileChannelImpl(path: Path,
   override def read(buffer: ByteBuffer, pos: Long): Int = {
     ensureOpen()
     position(pos)
-    val len = buffer.limit() - buffer.position()
-    val dst = new Array[Byte](len)
-    val nb  = raf.read(dst)
-    if (nb > 0) buffer.put(dst)
+
+    val startPos = buffer.position()
+    val len      = buffer.limit() - startPos
+    val dst      = new Array[Byte](len)
+    val nb       = raf.read(dst)
+
+    if (nb > 0) {
+      buffer.put(dst)
+      buffer.position(startPos + nb)
+    }
+
     nb
   }
 

--- a/unit-tests/src/test/scala/java/nio/file/FilesSuite.scala
+++ b/unit-tests/src/test/scala/java/nio/file/FilesSuite.scala
@@ -1129,10 +1129,11 @@ object FilesSuite extends tests.Suite {
       Files.write(f, Array[Byte](1, 2, 3))
       val channel = Files.newByteChannel(f)
       val buffer  = ByteBuffer.allocate(10)
-      var read    = 0
-      while (channel.read(buffer) != -1) {
-        read += 1
-      }
+
+      val read = channel.read(buffer)
+      buffer.flip()
+
+      assert(buffer.limit() == 3)
       assert(read == 3)
       assert(buffer.get(0) == 1)
       assert(buffer.get(1) == 2)


### PR DESCRIPTION
Scala-Native's FileChannel.read operations were only reading a Byte at a time. The JVM's reads from the `ByteBuffer.position() until ByteBuffer.limit()` or less, if there aren't that many bytes to read.

Added/Changed/Fixed tests in FilesSuite and FileChannelSuite to accommodate the changes.