### PR TITLE
Fix regex semantics

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -96,7 +96,9 @@ final class Matcher private[regex] (var _pattern: Pattern,
         var i = 0
         while (i < nMatches) {
           val m = matches + i
-          groups(i) = if (m.length == 0) {
+          groups(i) = if (m.data == null) {
+            (-1, -1)
+          } else if (m.length == 0) {
             (0, 0)
           } else {
             // Takes from inre2 until m...
@@ -158,8 +160,10 @@ final class Matcher private[regex] (var _pattern: Pattern,
     val startIndex = start(group)
     val endIndex   = end(group)
 
-    if (startIndex <= 0 && endIndex <= 0) {
+    if (startIndex < 0 && endIndex < 0) {
       null
+    } else if (startIndex == 0 && endIndex == 0) {
+      ""
     } else {
       inputSequence.subSequence(startIndex, endIndex).toString
     }

--- a/unit-tests/src/test/scala/java/util/regex/MatcherSuite.scala
+++ b/unit-tests/src/test/scala/java/util/regex/MatcherSuite.scala
@@ -289,6 +289,12 @@ object MatcherSuite extends tests.Suite {
     assertEquals(m.end, 0)
   }
 
+  test("empty strings for optional match") {
+    val OptionalA = "(a?)".r
+    "a" match { case OptionalA("a") => assert(true) }
+    "" match { case OptionalA("")   => assert(true) }
+  }
+
   private def matcher(regex: String, text: String): Matcher =
     Pattern.compile(regex).matcher(text)
 }


### PR DESCRIPTION
When there is a capturing group with optional content and the content is
empty, the Matcher is supposed to return "", not null.