### PR TITLE
Add shell fallback for processes

### DIFF
--- a/unit-tests/src/test/resources/process/hello.sh
+++ b/unit-tests/src/test/resources/process/hello.sh
@@ -1,0 +1,1 @@
+echo "hello"


### PR DESCRIPTION
On the JDK, if the command cannot be exec'd, there is a fallback to
running the command using /bin/sh. It was an oversight that I didn't
originally add this fallback. This came up while I was working on
getting ammonite ops to run under scala native.