### PR TITLE
Add optimized split

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -738,11 +738,58 @@ final class _String()
   def replaceFirst(expr: _String, substitute: _String): _String =
     Pattern.compile(expr).matcher(this).replaceFirst(substitute)
 
+  def fastSplit(ch: Char, max: Int): Array[String] = {
+    var separatorCount = 0
+    var begin          = 0
+    var end            = 0
+    while (separatorCount + 1 != max && { end = indexOf(ch, begin); end != -1 }) {
+      separatorCount += 1
+      begin = end + 1
+    }
+    val lastPartEnd = if (max == 0 && begin == count) {
+      if (separatorCount == count) {
+        return Array.empty[String]
+      }
+      do {
+        begin -= 1
+      } while (charAt(begin - 1) == ch)
+      separatorCount -= count - begin
+      begin
+    } else {
+      count
+    }
+
+    val result = new Array[String](separatorCount + 1)
+    begin = 0
+    var i = 0
+    while (i < separatorCount) {
+      end = indexOf(ch, begin)
+      result(i) = substring(begin, end);
+      begin = end + 1
+      i += 1
+    }
+    result(separatorCount) = substring(begin, lastPartEnd)
+    result
+  }
+
+  private[this] final val REGEX_METACHARACTERS = ".$()[{^?*+\\"
+  @inline private def isRegexMeta(c: Char) =
+    REGEX_METACHARACTERS.indexOf(c) >= 0
+
   def split(expr: _String): Array[String] =
-    Pattern.compile(expr).split(this)
+    split(expr, 0)
 
   def split(expr: _String, max: Int): Array[String] =
-    Pattern.compile(expr).split(this, max)
+    if (isEmpty) {
+      Array("")
+    } else {
+      expr.length match {
+        case 1 if !isRegexMeta(expr.charAt(0)) => fastSplit(expr.charAt(0), max)
+        case 2 if expr.charAt(0) == '\\' && isRegexMeta(expr.charAt(1)) =>
+          fastSplit(expr.charAt(1), max)
+        case _ => Pattern.compile(expr).split(this, max)
+      }
+    }
 
   def subSequence(start: Int, end: Int): CharSequence =
     substring(start, end)

--- a/unit-tests/src/test/scala/java/lang/StringSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/StringSuite.scala
@@ -92,6 +92,72 @@ object StringSuite extends tests.Suite {
     assert("Grueszszszeszszszszsze".replaceAll("sz", "ß") == "Grueßßßeßßßßße")
   }
 
+  private implicit class StringOps(val s: String) extends AnyVal {
+    def splitVec(sep: String, limit: Int = 0) = s.split(sep, limit).toVector
+  }
+  private def splitTest(sep: String, splitExpr: Option[String] = None) = {
+    val splitSep = splitExpr getOrElse sep
+    val n        = 4
+    val limit    = 2
+
+    assert("".splitVec(splitSep) == Vector(""))
+    assert("".splitVec(splitSep, limit) == Vector(""))
+
+    val noSep = "b"
+    assert(noSep.splitVec(splitSep) == Vector(noSep))
+    assert(noSep.splitVec(splitSep, limit) == Vector(noSep))
+
+    (1 to n) foreach { i =>
+      val allSep = sep * n
+      assert(allSep.splitVec(splitSep) == Vector.empty)
+      assert(
+        allSep.splitVec(splitSep, n) == (0 until (n - 1))
+          .map(_ => "")
+          .toVector :+ sep)
+      assert(
+        allSep.splitVec(splitSep, limit) == (0 until (limit - 1))
+          .map(_ => "")
+          .toVector :+ allSep.drop((limit - 1) * sep.length))
+    }
+
+    val oneSep = noSep + sep
+    assert(oneSep.splitVec(splitSep) == Vector(noSep))
+    assert(oneSep.splitVec(splitSep, 1) == Vector(oneSep))
+    assert(oneSep.splitVec(splitSep, 2) == Vector(noSep, ""))
+
+    val twoSep = oneSep * 2
+    assert(twoSep.splitVec(splitSep) == Vector(noSep, noSep))
+    assert(twoSep.splitVec(splitSep, 1) == Vector(twoSep))
+    assert(twoSep.splitVec(splitSep, 2) == Vector(noSep, oneSep))
+    assert(twoSep.splitVec(splitSep, 3) == Vector(noSep, noSep, ""))
+
+    val leadingSep = sep + noSep
+    assert(leadingSep.splitVec(splitSep) == Vector("", noSep))
+    assert(leadingSep.splitVec(splitSep, 1) == Vector(leadingSep))
+    assert(leadingSep.splitVec(splitSep, 2) == Vector("", noSep))
+    assert(leadingSep.splitVec(splitSep, 3) == Vector("", noSep))
+
+    val trailingSep = noSep + sep
+    assert(trailingSep.splitVec(splitSep) == Vector(noSep))
+    assert(trailingSep.splitVec(splitSep, 1) == Vector(trailingSep))
+    assert(trailingSep.splitVec(splitSep, 2) == Vector(noSep, ""))
+    assert(trailingSep.splitVec(splitSep, 3) == Vector(noSep, ""))
+
+    val leadingPlusTrailing = sep + noSep + sep
+    assert(leadingPlusTrailing.splitVec(splitSep) == Vector("", noSep))
+    assert(
+      leadingPlusTrailing.splitVec(splitSep, 1) == Vector(leadingPlusTrailing))
+    assert(leadingPlusTrailing.splitVec(splitSep, 2) == Vector("", oneSep))
+    assert(leadingPlusTrailing.splitVec(splitSep, 3) == Vector("", noSep, ""))
+    assert(leadingPlusTrailing.splitVec(splitSep, 4) == Vector("", noSep, ""))
+  }
+  test("split") {
+    splitTest("a")
+    splitTest(".", splitExpr = Some("\\."))
+    splitTest("ab", splitExpr = Some("ab"))
+    splitTest("ab", splitExpr = Some("(ab)"))
+  }
+
   test("getBytes") {
     val b = new Array[scala.Byte](4)
     "This is a test".getBytes(10, 14, b, 0)


### PR DESCRIPTION
It is very slow to have to compile a regex pattern for every call to
split so I provided an optimized version of split that is similar to the
versions provided by other jvm providers. In the case of a happy path
where the separator is a single character that isn't a regex special
character or when the separator is an escaped regex special character,
we use the optimized version.

I made a crude benchmark where I split the string "abcdefghijklnop" * 10
on the letter j 10000 times and the runtime for the fast version was 4us
per iteration while using Pattern.compile.split took 300us.