### PR TITLE
Match Scala JVM hash codes for case classes

### DIFF
--- a/auxlib/src/main/scala/scala/runtime/Statics.scala
+++ b/auxlib/src/main/scala/scala/runtime/Statics.scala
@@ -18,7 +18,7 @@ object Statics {
   }
 
   def finalizeHash(hash: Int, length: Int): Int =
-    avalanche(hash & length)
+    avalanche(hash ^ length)
 
   def avalanche(h: Int): Int = {
     val h1 = h ^ (h >>> 16)

--- a/unit-tests/src/test/scala/scala/HashCodeSuite.scala
+++ b/unit-tests/src/test/scala/scala/HashCodeSuite.scala
@@ -1,0 +1,13 @@
+package scala
+
+object HashCodeSuite extends tests.Suite {
+  case class MyData(string: String, num: Int)
+
+  test("Hash code of string matches Scala JVM") {
+    assert("hello".hashCode == 99162322)
+  }
+
+  test("Hash code of case class matches Scala JVM") {
+    assert(MyData("hello", 12345).hashCode == -1824015247)
+  }
+}


### PR DESCRIPTION
Scala Native's `finalizeHash` didn't match Scala JVM, so hash codes for case classes were different between the two platforms. This updates it to use the same implementation.