### PR TITLE
Fix copyright date in LICENSE file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,7 +4,7 @@ The original source code of the Scala Native toolchain and accompanying
 libraries is provided under Scala License:
 
 ```
-    Copyright (c) 2015-2017 EPFL
+    Copyright (c) 2015-2018 EPFL
 
     All rights reserved.
 


### PR DESCRIPTION
It's 2018 now, this should probably be expressed in a LICENSE file