### PR TITLE
Split test-runner out of sbt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ addCommandAlias(
   "dirty-rebuild",
   Seq(
     "scalalib/publishLocal",
+    "testRunner/publishLocal",
     "sbtScalaNative/publishLocal",
     "testInterface/publishLocal"
   ).mkString(";", ";", "")
@@ -324,7 +325,7 @@ lazy val sbtScalaNative =
         .evaluated,
       publishLocal := publishLocal.dependsOn(publishLocal in tools).value
     )
-    .dependsOn(tools)
+    .dependsOn(tools, testRunner)
 
 lazy val nativelib =
   project
@@ -579,3 +580,15 @@ lazy val testInterfaceSbtDefs =
       libraryDependencies -= "org.scala-native" %%% "test-interface" % version.value % Test
     )
     .enablePlugins(ScalaNativePlugin)
+
+lazy val testRunner =
+  project
+    .settings(toolSettings)
+    .settings(mavenPublishSettings)
+    .in(file("test-runner"))
+    .settings(
+      crossScalaVersions := Seq(sbt13ScalaVersion, sbt10ScalaVersion),
+      libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0",
+      sources in Compile ++= (sources in testInterfaceSerialization in Compile).value
+    )
+    .dependsOn(tools)

--- a/build.sbt
+++ b/build.sbt
@@ -323,7 +323,9 @@ lazy val sbtScalaNative =
         .dependsOn(publishLocal in ThisProject)
         .dependsOn(publishLocal in scalalib)
         .evaluated,
-      publishLocal := publishLocal.dependsOn(publishLocal in tools).value
+      publishLocal := publishLocal
+        .dependsOn(publishLocal in tools, publishLocal in testRunner)
+        .value
     )
     .dependsOn(tools, testRunner)
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -7,7 +7,8 @@ unmanagedSourceDirectories in Compile ++= {
     "nir",
     "tools",
     "sbt-scala-native",
-    "test-interface-serialization"
+    "test-interface-serialization",
+    "test-runner"
   ).map(dir => root / s"$dir/src/main/scala")
 }
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -21,7 +21,7 @@ import scalanative.sbtplugin.Utilities._
 import scalanative.sbtplugin.TestUtilities._
 import scalanative.sbtplugin.ScalaNativePlugin.autoImport._
 import scalanative.sbtplugin.SBTCompat.{Process, _}
-import scalanative.sbtplugin.testinterface.ScalaNativeFramework
+import scalanative.testinterface.ScalaNativeFramework
 
 object ScalaNativePluginInternal {
 
@@ -186,7 +186,12 @@ object ScalaNativePluginInternal {
         val envVars    = (Keys.envVars in (Test, test)).value
         (frameworks.zipWithIndex).map {
           case ((tf, f), id) =>
-            (tf, new ScalaNativeFramework(f, id, logger, testBinary, envVars))
+            (tf,
+             new ScalaNativeFramework(f,
+                                      id,
+                                      logger.toLogger,
+                                      testBinary,
+                                      envVars))
         }
       },
       definedTests := (definedTests in Test).value

--- a/scripts/release
+++ b/scripts/release
@@ -8,4 +8,4 @@ sbt publishSigned
 sbt "project nscplugin" ++2.11.12 publishSigned
 sbt "project nscplugin" ++2.11.11 publishSigned
 sbt "project nscplugin" ++2.11.8 publishSigned
-sbt ^^1.0.4 sbtScalaNative/publishSigned nir/publishSigned tools/publishSigned util/publishSigned
+sbt ^^1.0.4 sbtScalaNative/publishSigned nir/publishSigned tools/publishSigned util/publishSigned testRunner/publishSigned

--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ScalaNativeFramework.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ScalaNativeFramework.scala
@@ -1,13 +1,12 @@
 package scala.scalanative
-package sbtplugin
 package testinterface
 
 import java.io.File
 
-import sbt.Logger
 import sbt.testing.{Fingerprint, Framework, Runner}
 
-import scala.scalanative.testinterface.serialization.{Command, FrameworkInfo}
+import scalanative.build.Logger
+import scalanative.testinterface.serialization.{Command, FrameworkInfo}
 
 class ScalaNativeFramework(val framework: Framework,
                            val id: Int,

--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ScalaNativeRunner.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ScalaNativeRunner.scala
@@ -1,17 +1,12 @@
 package scala.scalanative
-package sbtplugin
 package testinterface
 
 import java.io.File
 
-import sbt.Logger
 import sbt.testing.{Runner, Task, TaskDef}
 
-import scala.scalanative.testinterface.serialization.{
-  Command,
-  Message,
-  TaskInfos
-}
+import scalanative.build.Logger
+import scalanative.testinterface.serialization.{Command, Message, TaskInfos}
 
 class ScalaNativeRunner(val framework: ScalaNativeFramework,
                         bin: File,

--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ScalaNativeTask.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ScalaNativeTask.scala
@@ -1,11 +1,10 @@
 package scala.scalanative
-package sbtplugin
 package testinterface
 
-import sbt.MessageOnlyException
 import sbt.testing.{EventHandler, Logger, Task, TaskDef}
 
-import scala.scalanative.testinterface.serialization.{
+import scalanative.build.BuildException
+import scalanative.testinterface.serialization.{
   Command,
   Event,
   TaskInfo,
@@ -36,7 +35,7 @@ final case class ScalaNativeTask private (
           handler.handle(ev)
           receive()
         case other =>
-          throw new MessageOnlyException(
+          throw new BuildException(
             s"Unexpected message: ${other.getClass.getName}")
       }
 


### PR DESCRIPTION
This module contains the sources for the test adapter. It can be useful
for other tools such as Mill or Bloop that want to support running tests
with Scala Native projects.