### PR TITLE
Fix typo in wrap.c that causes two math.h bindings to fail

### DIFF
--- a/nativelib/src/main/resources/wrap.c
+++ b/nativelib/src/main/resources/wrap.c
@@ -71,9 +71,9 @@ float scalanative_libc_huge_valf() { return HUGE_VALF; }
 
 double scalanative_libc_huge_val() { return HUGE_VAL; }
 
-float scanative_libc_infinity() { return INFINITY; }
+float scalanative_libc_infinity() { return INFINITY; }
 
-float scanative_libc_nan() { return NAN; }
+float scalanative_libc_nan() { return NAN; }
 
 int scalanative_libc_math_errhandling() { return math_errhandling; }
 


### PR DESCRIPTION
Fix typo `scanative` -> `scalanative` that causes math.NAN and math.INFINITY bindings to fail.