### PR TITLE
Correct function toDouble in ULong.scala

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/native/ULong.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/ULong.scala
@@ -18,7 +18,7 @@ final class ULong private[scala] (private val underlying: Long)
   @inline final def toFloat: Float = toDouble.toFloat
   @inline final def toDouble: Double =
     if (underlying >= 0) underlying.toDouble
-    else 18446744073709551616.0 - underlying.toDouble // TODO Verify precision
+    else 18446744073709551616.0 + underlying.toDouble
 
   @inline final def toUByte: UByte   = new UByte(toByte)
   @inline final def toUShort: UShort = new UShort(toShort)


### PR DESCRIPTION
For example
`long x = Long.parseUnsignedLong(9223372036854775808);`
// `(x == -9223372036854775808L)` is always `true`
Okey, old version of function `toDouble` return `27670116110564327000.0` for call with `x` as argument, while this function must return exactly `9223372036854775808.0` because this value is representable in `double` type.