### PR TITLE
Fix #1128, *Socket & release mode, breaks scala-native 0.3.n, requires #1242 & #1243

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/posix/poll.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/poll.scala
@@ -1,0 +1,84 @@
+package scala.scalanative
+package posix
+
+import scalanative.native.{CStruct3, extern, Ptr}
+import scalanative.native.{CInt, CShort, CUnsignedLongInt}
+
+import scalanative.native._
+
+object pollNfds {
+
+  type nfds_t = CUnsignedLongInt
+
+  // Keep the breakage in the nfds_t abstraction confined to here.
+  // The following code will work on both 64 and 32 bit machines.
+  //
+  // posix FOPEN_MAX is currently defined in scalanative wrap.c
+  // as an unsigned int. So any scala Long with bits greater than #31
+  // set are going to fail anyway. Some/most systems will probably
+  // exceed FOPEN_MAX earlier than that.
+  //
+  // Revisit & simplify when better 32/64 bit support arrives.
+
+  @inline
+  def toNfsd_t(in: Int): nfds_t = in.toUInt
+
+  def toNfsd_t(in: ULong): nfds_t = {
+    val uIntMax = UInt.MaxValue
+    if (in > uIntMax) {
+      throw new Exception(s"pollNfds: too many nfds: ${in}  > ${uIntMax}")
+    } else {
+      // may still fail later if greater than FOPEN_MAX. Let code
+      // more closely concerned test for that.
+      // On 64 bit machines UInt will get silently promoted match the
+      // ULong nfsd_t on that machine, so types work out.
+      in.toUInt // truncation is now harmless.
+    }
+  }
+}
+
+@extern
+object poll {
+
+  type pollEvent_t = CShort
+
+  type struct_pollfd = CStruct3[CInt, // file descriptor
+                                pollEvent_t, // requested events
+                                pollEvent_t] // returned events
+
+  import pollNfds.nfds_t
+
+  def poll(fds: Ptr[struct_pollfd], nfds: nfds_t, timeout: CInt): CInt = extern
+}
+
+object pollEvents {
+
+  final val POLLIN  = 0x001 // Data ready to be read
+  final val POLLPRI = 0x002 // Urgent data ready to be read
+  final val POLLOUT = 0x004 // Writing now will not block
+
+// XOpen events
+  final val POLLRDNORM = 0x040 // Normal data may be read
+  final val POLLRDBAND = 0x080 // Priority data may be read
+  final val POLLWRNORM = 0x100 // Writing now will not block
+  final val POLLWRBAND = 0x200 // Priority data may be written
+
+// Always checked in revents
+  final val POLLERR  = 0x008 // Error condition
+  final val POLLHUP  = 0x010 // Hung up
+  final val POLLNVAL = 0x020 // Invalid polling request
+}
+
+object pollOps {
+  import poll._
+
+  implicit class pollOps(val ptr: Ptr[struct_pollfd]) extends AnyVal {
+    def fd: CInt             = !(ptr._1)
+    def events: pollEvent_t  = !(ptr._2)
+    def revents: pollEvent_t = !(ptr._3)
+
+    def fd_=(v: CInt): Unit             = !ptr._1 = v
+    def events_=(v: pollEvent_t): Unit  = !ptr._2 = v
+    def revents_=(v: pollEvent_t): Unit = !ptr._3 = v
+  }
+}

--- a/nativelib/src/main/scala/scala/scalanative/posix/sys/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/posix/sys/time.scala
@@ -14,6 +14,7 @@ object time {
 }
 
 object timeOps {
+
   import time.timeval
 
   implicit class timevalOps(val ptr: Ptr[timeval]) extends AnyVal {
@@ -22,5 +23,6 @@ object timeOps {
 
     def tv_sec_=(v: time_t): Unit       = !ptr._1 = v
     def tv_usec_=(v: suseconds_t): Unit = !ptr._2 = v
+
   }
 }


### PR DESCRIPTION
This is the fourth of four PRs needed to fix #1128, *Socket not working in release mode.

The git commit message gives extensive comments.  Primarily that in addition to fixing the presenting problem, this PR improves error detection and reporting (errno).  I needed that to isolate the problem before any fix could be attempted submit it because it is more generally useful, _especially_ in the network world. Testing and document issues are also in that message (all tests passed, only release note needed).  

#### Notes before merge: 
* Because Exception message strings change (to give errno, remove contractions) this PR should 
be held for the next s-n release allowing breaking changes.

* This PR contains the files from #1242 & #1243 so that integration testing can succeed. Those two earlier PR should probably be merged first.  Let me know I I should have or should do something different.  My goal is to make life easier, not harder for the s-n git majordomo.