### PR TITLE
Fix: Correct the exception type thrown by String.getBytes.

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -291,9 +291,14 @@ final class _String()
   }
 
   def getBytes(encoding: _String): Array[scala.Byte] = {
-    val charset = Charset.forName(encoding)
-    val buffer  = charset.encode(CharBuffer.wrap(value, offset, count))
-    val bytes   = new Array[scala.Byte](buffer.limit())
+    val charset = try {
+      Charset.forName(encoding)
+    } catch {
+      case e: UnsupportedCharsetException =>
+        throw new java.io.UnsupportedEncodingException(encoding)
+    }
+    val buffer = charset.encode(CharBuffer.wrap(value, offset, count))
+    val bytes  = new Array[scala.Byte](buffer.limit())
     buffer.get(bytes)
     bytes
   }

--- a/unit-tests/src/test/scala/java/lang/StringSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/StringSuite.scala
@@ -98,6 +98,12 @@ object StringSuite extends tests.Suite {
     assert(new String(b) equals "test")
   }
 
+  test("getBytes unsupported encoding") {
+    assertThrows[java.io.UnsupportedEncodingException] {
+      "This is a test".getBytes("unsupported encoding")
+    }
+  }
+
   test("literals have consistent hash code implementation") {
     assert(
       "foobar".hashCode == new String(Array('f', 'o', 'o', 'b', 'a', 'r')).hashCode)


### PR DESCRIPTION
String.getBytes should throw a UnsupportedEncodingException not UnsupportedCharsetException in the
case of unsupported charset. This is per documentation for String.getBytes and as demonstrated by
the following test program.

This is also required for URLEncoder.encode's expected exception behavior.

~~~
import java.nio.charset.*;
import java.net.*;

class Main {
    public static void main(String []args) {
        try {
            String data = "test string";
            data.getBytes("unsupported");
        } catch(Exception e) {
            System.out.println(e.toString());
        }
    }
}
~~~