### PR TITLE
 Reorder linker options to pass -l options last

### DIFF
--- a/scripted-tests/run/link-order/Main.scala
+++ b/scripted-tests/run/link-order/Main.scala
@@ -1,0 +1,12 @@
+import scalanative.native
+
+object Main {
+  def main(args: Array[String]): Unit =
+    println(s"The answer is ${Util.forty_two().toInt}")
+}
+
+@native.link("link-order-test")
+@native.extern
+object Util {
+  def forty_two(): native.CInt = native.extern
+}

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -24,7 +24,7 @@ compile in Compile := {
   val opaths = cpaths.map { cpath =>
     val opath = abs(cwd / s"${cpath.getName}.o")
     val command = Seq(clangPath) ++ compileOptions ++
-                  Seq("-c", abs(cpath), "-o", opath)
+      Seq("-c", abs(cpath), "-o", opath)
 
     if (run(command) != 0) {
       sys.error(s"Failed to compile $cpath")

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -1,0 +1,42 @@
+enablePlugins(ScalaNativePlugin)
+
+scalaVersion := "2.11.12"
+
+nativeLinkingOptions in Compile += s"-L${target.value.getAbsoluteFile}"
+
+compile in Compile := {
+  val log            = streams.value.log
+  val cwd            = target.value
+  val compileOptions = nativeCompileOptions.value
+  val cpaths         = (baseDirectory.value.getAbsoluteFile * "*.c").get
+  val clangPath      = nativeClang.value.toPath.toAbsolutePath.toString
+
+  cwd.mkdirs()
+
+  def abs(path: File): String =
+    path.getAbsolutePath
+
+  def run(command: Seq[String]): Int = {
+    log.info("Running " + command.mkString(" "))
+    Process(command, cwd) ! log
+  }
+
+  val opaths = cpaths.map { cpath =>
+    val opath = abs(cwd / s"${cpath.getName}.o")
+    val command = Seq(clangPath) ++ compileOptions ++
+                  Seq("-c", abs(cpath), "-o", opath)
+
+    if (run(command) != 0) {
+      sys.error(s"Failed to compile $cpath")
+    }
+    opath
+  }
+
+  val archivePath = cwd / "liblink-order-test.a"
+  val archive     = Seq("ar", "cr", abs(archivePath)) ++ opaths
+  if (run(archive) != 0) {
+    sys.error(s"Failed to create archive $archivePath")
+  }
+
+  (compile in Compile).value
+}

--- a/scripted-tests/run/link-order/project/scala-native.sbt
+++ b/scripted-tests/run/link-order/project/scala-native.sbt
@@ -1,0 +1,8 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scala-native" % "sbt-scala-native" % pluginVersion)
+}

--- a/scripted-tests/run/link-order/test
+++ b/scripted-tests/run/link-order/test
@@ -1,0 +1,2 @@
+> nativeLink
+> run

--- a/scripted-tests/run/link-order/util.c
+++ b/scripted-tests/run/link-order/util.c
@@ -1,0 +1,2 @@
+
+int forty_two(void) { return 42; }

--- a/scripted-tests/run/link-order/util.c
+++ b/scripted-tests/run/link-order/util.c
@@ -1,2 +1,1 @@
-
 int forty_two(void) { return 42; }

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -159,16 +159,15 @@ private[scalanative] object LLVM {
         case "Mac OS X" => Seq.empty
         case _          => Seq("unwind", "unwind-" + arch)
       }
-      librt ++ libunwind ++ linkerResult.links
-        .map(_.name) ++ config.gc.links
+      linkerResult.links.map(_.name) ++ librt ++ libunwind ++ config.gc.links
     }
-    val linkopts = links.map("-l" + _) ++ config.linkingOptions ++ Seq(
+    val linkopts = config.linkingOptions ++ links.map("-l" + _) ++ Seq(
       "-lpthread")
     val targetopt = Seq("-target", config.targetTriple)
-    val flags     = Seq("-o", outpath.abs) ++ linkopts ++ targetopt
+    val flags     = Seq("-o", outpath.abs) ++ targetopt
     val opaths    = IO.getAll(nativelib, "glob:**.o").map(_.abs)
     val paths     = llPaths.map(_.abs) ++ opaths
-    val compile   = config.clangPP.abs +: (flags ++ paths)
+    val compile   = config.clangPP.abs +: (flags ++ paths ++ linkopts)
 
     config.logger.time(s"Linking native code (${config.gc.name} gc)") {
       config.logger.running(compile)


### PR DESCRIPTION
`clang++` uses the system linker (`ld`) for linking and on certain systems
the order of `-l` options is significant when linking archives `.a`.
This also moves system libraries after user-defined linked libraries to
support symbol resolutions for such libraries.

---

Fixes #468 (if considering #657) as well as problem in https://github.com/kornilova-l/scala-native-bindgen where we currently link end-to-end tests using a [custom linker script](https://github.com/kornilova-l/scala-native-bindgen/blob/15ded8a6eda792592c1beb6abe53846c0a201cf7/scripts/linker.sh) activated using [`-fuse-ld=...`](https://github.com/kornilova-l/scala-native-bindgen/blob/15ded8a6eda792592c1beb6abe53846c0a201cf7/build.sbt#L48).

Related to https://github.com/scala-native/scala-native/issues/657#issuecomment-306178233
Inspired by https://eli.thegreenplace.net/2013/07/09/library-order-in-static-linking

---
The failure from the scripted test added in  54d2770 can be seen [here](https://travis-ci.org/jonas/scala-native/jobs/400606127#L6869-L6871):
```
[info] [error] /tmp/sbt_853a51cc/link-order/target/scala-2.11/native/__empty.ll.o: In function `Main$::main_scala.scalanative.runtime.ObjectArray_unit':
[info] [error] /tmp/sbt_853a51cc/link-order/target/scala-2.11/native/__empty.ll:(.text+0x162): undefined reference to `forty_two'
[info] [error] clang-5.0: error: linker command failed with exit code 1 (use -v to see invocation)
```
