### PR TITLE
Add support for ThinLTO 

### DIFF
--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -70,11 +70,13 @@ Since Name                     Type            Description
 0.1   ``nativeMode``           ``String``      Either ``"debug"`` or ``"release"`` (2)
 0.2   ``nativeGC``             ``String``      Either ``"none"``, ``"boehm"`` or ``"immix"`` (3)
 0.3.3 ``nativeLinkStubs``      ``Boolean``     Whether to link ``@stub`` definitions, or to ignore them
+0.3.9 ``nativeLTO``            ``String``      Either ``"none"``, ``"full"`` or ``"thin"`` (4)
 ===== ======================== =============== =========================================================
 
 1. See `Publishing`_ and `Cross compilation`_ for details.
 2. See `Compilation modes`_ for details.
 3. See `Garbage collectors`_ for details.
+4. See `Link-Time Optimization (LTO)`_ for details.
 
 Compilation modes
 -----------------
@@ -112,6 +114,34 @@ Garbage collectors
    Garbage collector that allocates things without ever freeing them. Useful
    for short-running command-line applications or applications where garbage
    collections pauses are not acceptable.
+
+Link-Time Optimization (LTO)
+----------------------------
+
+Scala Native relies on link-time optimization to maximize runtime performance
+of release builds. There are three possible modes that are currently supported:
+
+1. **none.** (default)
+
+   Does not inline across Scala/C boundary. Scala to Scala calls
+   are still optimized by emitting one fat LLVM IR module for
+   the whole application.
+
+2. **full.** (Clang 3.8 or older)
+
+   Inlines across Scala/C boundary by merging all of the LLVM IR
+   modules into a single module for the whole application. Unlike
+   **none** this module also includes the runtime code thus allows
+   for additional optimization opportunities.
+
+3. **thin.** (recommended on Clang 3.9 or newer)
+
+   Inlines across Scala/C boundary using LLVM's
+   `ThinLTO <https://clang.llvm.org/docs/ThinLTO.html>`_.
+   Unlike **none** and **full**
+   it's able to optimize the application in parallel.
+   It also offers the best runtime performance according
+   to our benchmarks.
 
 Publishing
 ----------

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -39,6 +39,10 @@ object ScalaNativePlugin extends AutoPlugin {
 
     val nativeGC =
       settingKey[String]("GC choice, either \"none\", \"boehm\" or \"immix\".")
+
+    val nativeLTO =
+      taskKey[String](
+        "LTO variant used for release mode (either \"none\", \"thin\" or \"full\").")
   }
 
   @deprecated("use autoImport instead", "0.3.7")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -67,7 +67,9 @@ object ScalaNativePluginInternal {
     nativeLinkStubs in NativeTest := (nativeLinkStubs in Test).value,
     nativeGC := Option(System.getenv.get("SCALANATIVE_GC"))
       .getOrElse(build.GC.default.name),
-    nativeGC in NativeTest := (nativeGC in Test).value
+    nativeGC in NativeTest := (nativeGC in Test).value,
+    nativeLTO := Discover.LTO(),
+    nativeLTO in NativeTest := (nativeLTO in Test).value
   )
 
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
@@ -126,6 +128,7 @@ object ScalaNativePluginInternal {
         .withGC(gc)
         .withMode(mode)
         .withLinkStubs(nativeLinkStubs.value)
+        .withLTO(nativeLTO.value)
     },
     nativeLink := {
       val logger  = streams.value.log.toLogger

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -47,6 +47,9 @@ sealed trait Config {
   /** The logger used by the toolchain. */
   def logger: Logger
 
+  /** The LTO variant used for release mode. */
+  def LTO: String
+
   /** Create a new config with given garbage collector. */
   def withGC(value: GC): Config
 
@@ -85,6 +88,9 @@ sealed trait Config {
 
   /** Create a new config with the given logger. */
   def withLogger(value: Logger): Config
+
+  /** The LTO variant used for release mode. */
+  def withLTO(value: String): Config
 }
 
 object Config {
@@ -104,7 +110,8 @@ object Config {
       gc = GC.default,
       mode = Mode.default,
       linkStubs = false,
-      logger = Logger.default
+      logger = Logger.default,
+      LTO = "none"
     )
 
   private final case class Impl(nativelib: Path,
@@ -119,7 +126,8 @@ object Config {
                                 gc: GC,
                                 mode: Mode,
                                 linkStubs: Boolean,
-                                logger: Logger)
+                                logger: Logger,
+                                LTO: String)
       extends Config {
     def withNativelib(value: Path): Config =
       copy(nativelib = value)
@@ -159,5 +167,8 @@ object Config {
 
     def withLogger(value: Logger): Config =
       copy(logger = value)
+
+    def withLTO(value: String): Config =
+      copy(LTO = value)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -12,6 +12,10 @@ import scalanative.build.IO.RichPath
  */
 object Discover {
 
+  /** LTO variant used for release mode. */
+  def LTO(): String =
+    getenv("SCALANATIVE_LTO").getOrElse("none")
+
   /** Find nativelib jar on the classpath. */
   def nativelib(classpath: Seq[Path]): Option[Path] =
     classpath.find { path =>
@@ -166,4 +170,7 @@ object Discover {
 
   private def silentLogger(): ProcessLogger =
     ProcessLogger(_ => (), _ => ())
+
+  private def getenv(key: String): Option[String] =
+    Option(System.getenv.get(key))
 }


### PR DESCRIPTION
Previously we relied on one large LLVM file for the whole application as our means to let LLVM optimize whole program together.

This change uses [ThinLTO introduced LLVM 3.9](http://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html). It lets us compile the last step in parallel and also offers 5.2% geomean throughput improvement on our benchmarks due to inlining across Scala/C boundary which our previous approach could not do.

Naturally, this increases minimal version of LLVM we are going to support from now on to 3.9. I benchmarked older LTO mode as well (`-flto=full`) and it offers 3.2% performance improvement and degrades some benchmarks by 10%, so it's not a viable alternative.

Resolves #280 

Review @jonas @ekrich 