### PR TITLE
Fixing incompatibility of FileSystemException message

### DIFF
--- a/javalib/src/main/scala/java/nio/file/FileSystemException.scala
+++ b/javalib/src/main/scala/java/nio/file/FileSystemException.scala
@@ -17,9 +17,9 @@ class FileSystemException(file: String, other: String, reason: String)
     val files =
       (file, other) match {
         case (null, null) => ""
-        case (null, f2)   => s":  -> $f2"
-        case (f1, null)   => s": $f1"
-        case (f1, f2)     => s": $f1 -> $f2"
+        case (null, f2)   => s" -> $f2"
+        case (f1, null)   => s"$f1"
+        case (f1, f2)     => s"$f1 -> $f2"
       }
     s"$files$message"
   }

--- a/unit-tests/src/test/scala/java/nio/file/FileSystemExceptionSuite.scala
+++ b/unit-tests/src/test/scala/java/nio/file/FileSystemExceptionSuite.scala
@@ -1,0 +1,28 @@
+package java.nio.file
+
+object FileSystemExceptionSuite extends tests.Suite {
+
+  test("FileSystemException.getMessage() formats error message") {
+    assert(
+      new FileSystemException("file", "other", "reason")
+        .getMessage() == "file -> other: reason")
+    assert(
+      new FileSystemException("file", "other", null)
+        .getMessage() == "file -> other")
+    assert(
+      new FileSystemException("file", null, "reason")
+        .getMessage() == "file: reason")
+    assert(
+      new FileSystemException(null, "other", "reason")
+        .getMessage() == " -> other: reason")
+    assert(
+      new FileSystemException(null, null, "reason").getMessage() == ": reason")
+    assert(
+      new FileSystemException(null, "other", null).getMessage() == " -> other")
+    assert(new FileSystemException("file", null, null).getMessage() == "file")
+    assert(new FileSystemException(null, null, null).getMessage() == "")
+
+    assert(new FileSystemException("file").getMessage() == "file")
+    assert(new FileSystemException(null).getMessage() == "")
+  }
+}


### PR DESCRIPTION
The message returned by `FileSystemException` should be formatted in the same way as in other JDK implementations. 