### PR TITLE
Use hidden visibility for runtime code

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -94,8 +94,8 @@ private[scalanative] object LLVM {
       if (include(path) && !Files.exists(Paths.get(opath))) {
         val isCpp    = path.endsWith(".cpp")
         val compiler = if (isCpp) config.clangPP.abs else config.clang.abs
-        val flags = (if (isCpp) Seq("-std=c++11")
-                     else Seq("-std=gnu11")) ++ config.compileOptions
+        val stdflag  = if (isCpp) "-std=c++11" else "-std=gnu11"
+        val flags    = stdflag +: "-fvisibility=hidden" +: config.compileOptions
         val compilec = Seq(compiler) ++ flto(config) ++ flags ++ Seq("-c",
                                                                      path,
                                                                      "-o",

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -217,7 +217,7 @@ object CodeGen {
       str("@")
       genGlobal(name)
       str(" = ")
-      str(if (attrs.isExtern) "external " else "")
+      str(if (attrs.isExtern) "external " else "hidden ")
       str(if (isConst) "constant" else "global")
       str(" ")
       rhs match {


### PR DESCRIPTION
This change allows LLVM's LTO to eliminate all
symbols which are not reachable after optimizations
(e.g., methods that are always inlined).

The main goal of this change is to reduce binary size.
Bundling libunwind into the runtime code increased the
hello world binary size to 3.3M in release mode. After
this change it gets down to 3.1M (compared to 2.1M before
bundling).