### PR TITLE
Don't rely on unsafe memory in String implementation

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -1,8 +1,7 @@
 package java.lang
 
 import scalanative.native._
-import scalanative.native.string.memcmp
-import scalanative.runtime.CharArray
+import scalanative.runtime
 import java.io.Serializable
 import java.util._
 import java.util.regex._
@@ -222,11 +221,7 @@ final class _String()
           if (thisHash != thatHash && thisHash != 0 && thatHash != 0) {
             false
           } else {
-            val data1 =
-              value.asInstanceOf[CharArray].at(offset).cast[Ptr[scala.Byte]]
-            val data2 =
-              s.value.asInstanceOf[CharArray].at(s.offset).cast[Ptr[scala.Byte]]
-            memcmp(data1, data2, count * 2) == 0
+            runtime.Array.compare(value, offset, s.value, s.offset, count) == 0
           }
         }
       }
@@ -325,11 +320,12 @@ final class _String()
       if (count == 0) {
         0
       } else {
-        val data = value.asInstanceOf[CharArray].at(offset)
+        val base = offset
+        val data = value
         var hash = 0
         var i    = 0
         while (i < count) {
-          hash = data(i) + ((hash << 5) - hash)
+          hash = data(base + i) + ((hash << 5) - hash)
           i += 1
         }
         cachedHashCode = hash

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -86,6 +86,50 @@ object Array {
       `llvm.memmove.p0i8.p0i8.i64`(toPtr, fromPtr, size, 1, false)
     }
   }
+
+  def compare(left: AnyRef,
+              leftPos: Int,
+              right: AnyRef,
+              rightPos: Int,
+              len: Int): Int = {
+    if (left == null || right == null) {
+      throw new NullPointerException()
+    } else if (!left.isInstanceOf[Array[_]]) {
+      throw new IllegalArgumentException("left argument must be an array")
+    } else if (!right.isInstanceOf[Array[_]]) {
+      throw new IllegalArgumentException("right argument must be an array")
+    } else {
+      compare(left.asInstanceOf[Array[_]],
+              leftPos,
+              right.asInstanceOf[Array[_]],
+              rightPos,
+              len)
+    }
+  }
+
+  def compare(left: Array[_],
+              leftPos: Int,
+              right: Array[_],
+              rightPos: Int,
+              len: Int): Int = {
+    if (left == null || right == null) {
+      throw new NullPointerException()
+    } else if (getType(left) != getType(right)) {
+      throw new ArrayStoreException("Invalid array copy.")
+    } else if (len < 0) {
+      throw new IndexOutOfBoundsException("length is negative")
+    } else if (leftPos < 0 || leftPos + len > left.length) {
+      throw new IndexOutOfBoundsException(leftPos.toString)
+    } else if (rightPos < 0 || rightPos + len > right.length) {
+      throw new IndexOutOfBoundsException(rightPos.toString)
+    } else if (len == 0) {
+      0
+    } else {
+      val leftPtr  = left.at(leftPos).cast[Ptr[Byte]]
+      val rightPtr = right.at(rightPos).cast[Ptr[Byte]]
+      string.memcmp(leftPtr, rightPtr, len * left.stride)
+    }
+  }
 }
 
 // ###sourceLocation(file: "/home/denys/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 82)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -73,6 +73,41 @@ object Array {
       `llvm.memmove.p0i8.p0i8.i64`(toPtr, fromPtr, size, 1, false)
     }
   }
+
+  def compare(left: AnyRef, leftPos: Int,
+              right: AnyRef, rightPos: Int, len: Int): Int = {
+    if (left == null || right == null) {
+      throw new NullPointerException()
+    } else if (!left.isInstanceOf[Array[_]]) {
+      throw new IllegalArgumentException("left argument must be an array")
+    } else if (!right.isInstanceOf[Array[_]]) {
+      throw new IllegalArgumentException("right argument must be an array")
+    } else {
+      compare(left.asInstanceOf[Array[_]], leftPos,
+              right.asInstanceOf[Array[_]], rightPos, len)
+    }
+  }
+
+  def compare(left: Array[_], leftPos: Int,
+              right: Array[_], rightPos: Int, len: Int): Int = {
+    if (left == null || right == null) {
+      throw new NullPointerException()
+    } else if (getType(left) != getType(right)) {
+      throw new ArrayStoreException("Invalid array copy.")
+    } else if (len < 0) {
+      throw new IndexOutOfBoundsException("length is negative")
+    } else if (leftPos < 0 || leftPos + len > left.length) {
+      throw new IndexOutOfBoundsException(leftPos.toString)
+    } else if (rightPos < 0 || rightPos + len > right.length) {
+      throw new IndexOutOfBoundsException(rightPos.toString)
+    } else if (len == 0) {
+      0
+    } else {
+      val leftPtr  = left.at(leftPos).cast[Ptr[Byte]]
+      val rightPtr = right.at(rightPos).cast[Ptr[Byte]]
+      string.memcmp(leftPtr, rightPtr, len * left.stride)
+    }
+  }
 }
 
 %{


### PR DESCRIPTION
This change introduces a new intrinsic-like method called `runtime.Array.compare` to replace direct call to memcp in the `java.lang.String` implementation. This makes it easier to partially evaluate memcmp away in Interflow (#1278).