### PR TITLE
Link to mvn repository index instead of scaladex

### DIFF
--- a/docs/lib/communitylib.rst
+++ b/docs/lib/communitylib.rst
@@ -5,7 +5,7 @@ Community Libraries
 
 Third-party libraries for Scala Native can be found using:
 
-* `Scala Native libraries indexed by Scaladex <https://index.scala-lang.org/search?q=*&targetTypes=Native>`_.
+* `Scala Native libraries indexed by MVN Repository <https://mvnrepository.com/artifact/org.scala-native/nativelib/usages>`_.
 
 * `Awesome Scala Native <https://github.com/tindzk/awesome-scala-native>`_, a curated list of Scala Native libraries and projects.
 


### PR DESCRIPTION
Scaladex list of artifacts published for Scala Native
seems to be either out of date or otherwise incomplete.