### PR TITLE
Fix timing of the "Compiling to native code" step

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -76,13 +76,13 @@ object Build {
       ScalaNative.codegen(config, optimized)
       IO.getAll(config.workdir, "glob:**.ll")
     }
-    val objectFiles = LLVM.compile(config, generated)
     val unpackedLib = LLVM.unpackNativelib(config.nativelib, config.workdir)
-
-    val nativelibConfig =
-      config.withCompileOptions("-O2" +: config.compileOptions)
-    val _ =
+    val objectFiles = config.logger.time("Compiling to native code") {
+      val nativelibConfig =
+        config.withCompileOptions("-O2" +: config.compileOptions)
       LLVM.compileNativelib(nativelibConfig, linkerResult, unpackedLib)
+      LLVM.compile(config, generated)
+    }
 
     LLVM.link(config, linkerResult, objectFiles, unpackedLib, outpath)
   }

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -122,24 +122,22 @@ private[scalanative] object LLVM {
       }
     val opts = optimizationOpt +: config.compileOptions
 
-    config.logger.time("Compiling to native code") {
-      llPaths.par
-        .map { ll =>
-          val apppath = ll.abs
-          val outpath = apppath + ".o"
-          val compile = Seq(config.clang.abs) ++ flto(config) ++ Seq(
-            "-c",
-            apppath,
-            "-o",
-            outpath) ++ opts
-          config.logger.running(compile)
-          Process(compile, config.workdir.toFile) ! Logger.toProcessLogger(
-            config.logger)
-          Paths.get(outpath)
-        }
-        .seq
-        .toSeq
-    }
+    llPaths.par
+      .map { ll =>
+        val apppath = ll.abs
+        val outpath = apppath + ".o"
+        val compile = Seq(config.clang.abs) ++ flto(config) ++ Seq(
+          "-c",
+          apppath,
+          "-o",
+          outpath) ++ opts
+        config.logger.running(compile)
+        Process(compile, config.workdir.toFile) ! Logger.toProcessLogger(
+          config.logger)
+        Paths.get(outpath)
+      }
+      .seq
+      .toSeq
   }
 
   /**


### PR DESCRIPTION
Previously we only counted the time necessary to
compile .ll files emitted by Scala Native. This excluded
the time necessary to compile C/C++ library code.
After we bundling libunwind into the library, the
time to compile the runtime increased. This change
fixes the timing numbers by reporting both runtime
and .ll file compilation as "Compiling to native code".