### PR TITLE
Provide/fix signature for math.ceil(Double)

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/native/math.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/math.scala
@@ -100,7 +100,7 @@ object math {
   // Nearest integer floating-point operations
 
   def ceilf(x: CFloat): CFloat       = extern
-  def ceil(x: CFloat): CFloat        = extern
+  def ceil(x: CDouble): CDouble      = extern
   def floorf(x: CFloat): CFloat      = extern
   def floor(x: CDouble): CDouble     = extern
   def truncf(x: CFloat): CFloat      = extern


### PR DESCRIPTION
  * An apparent cut & paste error in the signature of ceil(Double) has
    survived unnoticed for two years. This change provides the
    correct signature.

  * I examined the rest of the file for similar errors and found none.

  * This error was able to remain unfound for so long because the
    signature is never used in the normal call chain. scalalib scala/math
    calls java.lang.Math which has an optimization to call an LLVM intrinsic,
    not this ceil().  Still worth fixing for the eventual C programmer
    who stumbles upon the affected method.

64/32 bit issues:

      None known.

Documentation:

      Deserves a release note.

Testing:

	* Built and tested ("test-all") on X86_64.