### PR TITLE
Improve codegen scalability 

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -6,7 +6,7 @@ import java.nio.ByteBuffer
 import java.nio.file.Paths
 import scala.annotation.tailrec
 import scala.collection.mutable
-import scalanative.util.{Scope, ShowBuilder, unsupported}
+import scalanative.util.{Scope, ShowBuilder, unsupported, partition, procs}
 import scalanative.io.{VirtualDirectory, withScratchBuffer}
 import scalanative.sema.ControlFlow.{Graph => CFG, Block, Edge}
 import scalanative.nir._
@@ -19,44 +19,25 @@ object CodeGen {
       val env     = assembly.map(defn => defn.name -> defn).toMap
       val workdir = VirtualDirectory.real(config.workdir)
 
-      // Generate one LLVM IR file per package. This
-      // prevents LLVM from optimizing across IR module
-      // boundary unless LTO is turned on.
-      def separate(): Unit = {
-        val batches = mutable.Map.empty[String, mutable.Buffer[Defn]]
-        assembly.foreach { defn =>
-          val top = defn.name.top.id
-          val key =
-            if (top.startsWith("__")) top
-            else if (top == "main") "__main"
-            else {
-              val pkg = top.split("\\.").init.mkString(".")
-              if (pkg == "") "__empty"
-              else pkg
-            }
-          if (!batches.contains(key)) {
-            batches(key) = mutable.UnrolledBuffer.empty[Defn]
-          }
-          batches(key) += defn
-        }
-        batches.par.foreach {
-          case (k, defns) =>
+      // Partition into multiple LLVM IR files proportional to number
+      // of available processesors. This prevents LLVM from optimizing
+      // across IR module boundary unless LTO is turned on.
+      def separate(): Unit =
+        partition(assembly, procs).par.foreach {
+          case (id, defns) =>
             val sorted = defns.sortBy(_.name.show)
-            val impl =
-              new Impl(config.targetTriple, env, sorted, workdir)
-            val outpath = k + ".ll"
-            val buffer  = impl.gen()
+            val impl   = new Impl(config.targetTriple, env, sorted)
+            val buffer = impl.gen()
             buffer.flip
-            workdir.write(Paths.get(outpath), buffer)
+            workdir.write(Paths.get(s"$id.ll"), buffer)
         }
-      }
 
       // Generate a single LLVM IR file for the whole application.
       // This is an adhoc form of LTO. We use it in release mode if
       // Clang's LTO is not available.
       def single(): Unit = {
         val sorted = assembly.sortBy(_.name.show)
-        val impl   = new Impl(config.targetTriple, env, sorted, workdir)
+        val impl   = new Impl(config.targetTriple, env, sorted)
         val buffer = impl.gen()
         buffer.flip
         workdir.write(Paths.get("out.ll"), buffer)
@@ -71,8 +52,7 @@ object CodeGen {
 
   private final class Impl(targetTriple: String,
                            env: Map[Global, Defn],
-                           defns: Seq[Defn],
-                           workdir: VirtualDirectory) {
+                           defns: Seq[Defn]) {
     import Impl._
 
     var currentBlockName: Local = _

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -6,7 +6,7 @@ import java.nio.ByteBuffer
 import java.nio.file.Paths
 import scala.annotation.tailrec
 import scala.collection.mutable
-import scalanative.util.{Scope, ShowBuilder, unsupported, partition, procs}
+import scalanative.util.{Scope, ShowBuilder, unsupported, partitionBy, procs}
 import scalanative.io.{VirtualDirectory, withScratchBuffer}
 import scalanative.sema.ControlFlow.{Graph => CFG, Block, Edge}
 import scalanative.nir._
@@ -23,7 +23,7 @@ object CodeGen {
       // of available processesors. This prevents LLVM from optimizing
       // across IR module boundary unless LTO is turned on.
       def separate(): Unit =
-        partition(assembly, procs).par.foreach {
+        partitionBy(assembly, procs)(_.name).par.foreach {
           case (id, defns) =>
             val sorted = defns.sortBy(_.name.show)
             val impl   = new Impl(config.targetTriple, env, sorted)

--- a/tools/src/main/scala/scala/scalanative/lower/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/lower/Lower.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package lower
 
 import scala.collection.mutable
-import scalanative.util.{ScopedVar, partition}
+import scalanative.util.{ScopedVar, partitionBy}
 import scalanative.nir._
 import scalanative.sema._
 
@@ -18,7 +18,7 @@ object Lower {
     val buf   = mutable.UnrolledBuffer.empty[Defn]
     val input = assembly ++ Generate(Global.Top(config.mainClass))
 
-    partition(input).par
+    partitionBy(input)(_.name).par
       .map {
         case (_, defns) =>
           (new Impl).onDefns(defns)

--- a/tools/src/main/scala/scala/scalanative/lower/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/lower/Lower.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package lower
 
 import scala.collection.mutable
-import scalanative.util.ScopedVar
+import scalanative.util.{ScopedVar, partition}
 import scalanative.nir._
 import scalanative.sema._
 
@@ -18,9 +18,7 @@ object Lower {
     val buf   = mutable.UnrolledBuffer.empty[Defn]
     val input = assembly ++ Generate(Global.Top(config.mainClass))
 
-    optimizer.Optimizer
-      .partition(input)
-      .par
+    partition(input).par
       .map {
         case (_, defns) =>
           (new Impl).onDefns(defns)

--- a/tools/src/main/scala/scala/scalanative/optimizer/Optimizer.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Optimizer.scala
@@ -2,8 +2,8 @@ package scala.scalanative
 package optimizer
 
 import scala.collection.mutable
-import nir._
-import scalanative.util.partition
+import scalanative.nir._
+import scalanative.util.partitionBy
 
 /** Optimizer reporters can override one of the corresponding methods to
  *  get notified whenever one of the optimization events happens.
@@ -37,7 +37,7 @@ object Optimizer {
           loop(batchId, passResult, rest)
       }
 
-    partition(assembly).par
+    partitionBy(assembly)(_.name).par
       .map {
         case (batchId, batchDefns) =>
           onStart(batchId, batchDefns)

--- a/tools/src/main/scala/scala/scalanative/optimizer/Optimizer.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/Optimizer.scala
@@ -3,19 +3,12 @@ package optimizer
 
 import scala.collection.mutable
 import nir._
+import scalanative.util.partition
 
 /** Optimizer reporters can override one of the corresponding methods to
  *  get notified whenever one of the optimization events happens.
  */
 object Optimizer {
-
-  def partition(defns: Seq[Defn]) = {
-    val procs   = java.lang.Runtime.getRuntime.availableProcessors
-    val batches = procs * procs
-    defns.groupBy { defn =>
-      Math.abs(System.identityHashCode(defn)) % batches
-    }
-  }
 
   /** Run all of the passes on given assembly. */
   def apply(config: build.Config,

--- a/util/src/main/scala/scala/scalanative/util/Stats.scala
+++ b/util/src/main/scala/scala/scalanative/util/Stats.scala
@@ -4,35 +4,80 @@ package util
 import scala.collection.mutable
 
 object Stats {
-  private val times    = mutable.Map.empty[String, Long]
-  private val counters = mutable.Map.empty[String, Long]
+  private val times  = mutable.Map.empty[String, Long]
+  private val counts = mutable.Map.empty[String, Long]
+  private def printTotal(): Unit = {
+    val totalTimes   = mutable.Map.empty[String, Long]
+    val totalCounts  = mutable.Map.empty[String, Long]
+    val totalThreads = mutable.Map.empty[String, Long]
+    times.foreach {
+      case (k, v) =>
+        val key = k.split(":")(1)
+        totalTimes(key) = totalTimes.getOrElse(key, 0L) + v
+        totalThreads(key) = totalThreads.getOrElse(key, 0L) + 1
+    }
+    counts.foreach {
+      case (k, v) =>
+        val key = k.split(":")(1)
+        totalCounts(key) = totalCounts.getOrElse(key, 0L) + v
+    }
+    println("--- Total")
+    totalTimes.toSeq.sortBy(_._1).foreach {
+      case (key, time) =>
+        val ms      = (time / 1000000D).toString
+        val count   = totalCounts(key)
+        val threads = totalThreads(key)
+        println(s"$key: $ms ms, $count times, $threads threads")
+    }
+  }
+  private def printThread(id: String): Unit = {
+    println(s"--- Thread $id")
+    times.toSeq.sortBy(_._1).foreach {
+      case (key, time) if key.startsWith(id) =>
+        val ms    = (time / 1000000D).toString
+        val count = counts(key)
+        val k     = key.split(":")(1)
+        println(s"$k: $ms ms, $count times")
+      case _ =>
+        ()
+    }
+  }
+  private def printThreads(): Unit = {
+    val threads = mutable.Set.empty[String]
+    times.keys.foreach { k =>
+      threads += k.split(":")(0)
+    }
+    threads.toSeq.sorted.foreach(printThread)
+  }
+  private def print(): Unit = synchronized {
+    printTotal()
+    printThreads()
+  }
+  private def clear(): Unit = synchronized {
+    times.clear()
+    counts.clear()
+  }
+  private def threadKey(key: String): String =
+    java.lang.Thread.currentThread.getId + ":" + key
+  def in[T](f: => T): T = {
+    clear()
+    val res = f
+    print()
+    res
+  }
   def time[T](key: String)(f: => T): T = {
     import System.nanoTime
     val start = nanoTime()
     val res   = f
     val end   = nanoTime()
-    synchronized {
-      times(key) = times.getOrElse(key, 0L) + (end - start)
+    val t     = end - start
+    val k     = threadKey(key)
+    times.synchronized {
+      times(k) = times.getOrElse(k, 0L) + t
+    }
+    counts.synchronized {
+      counts(k) = counts.getOrElse(k, 0L) + 1
     }
     res
-  }
-  def count(key: String): Unit = synchronized {
-    counters(key) = counters.getOrElse(key, 0L) + 1L
-  }
-  def print(): Unit = synchronized {
-    println("--- Times")
-    times.toSeq.sortBy(_._1).foreach {
-      case (key, time) =>
-        println(key + ": " + (time / 1000000D).toString + " ms")
-    }
-    println("--- Counters")
-    counters.toSeq.sortBy(_._1).foreach {
-      case (key, n) =>
-        println(key + ": " + n + " times")
-    }
-  }
-  def clear(): Unit = synchronized {
-    times.clear()
-    counters.clear()
   }
 }

--- a/util/src/main/scala/scala/scalanative/util/package.scala
+++ b/util/src/main/scala/scala/scalanative/util/package.scala
@@ -48,11 +48,12 @@ package object util {
   def procs: Int =
     java.lang.Runtime.getRuntime.availableProcessors
 
-  def partition[T](elems: Seq[T]): Map[Int, Seq[T]] =
-    partition(elems, procs * procs)
+  def partitionBy[T](elems: Seq[T])(f: T => Any): Map[Int, Seq[T]] =
+    partitionBy(elems, procs * procs)(f)
 
-  def partition[T](elems: Seq[T], batches: Int): Map[Int, Seq[T]] =
+  def partitionBy[T](elems: Seq[T], batches: Int)(
+      f: T => Any): Map[Int, Seq[T]] =
     elems.groupBy { elem =>
-      Math.abs(System.identityHashCode(elem)) % batches
+      Math.abs(f(elem).##) % batches
     }
 }

--- a/util/src/main/scala/scala/scalanative/util/package.scala
+++ b/util/src/main/scala/scala/scalanative/util/package.scala
@@ -44,4 +44,15 @@ package object util {
     println(s"$msg (${(end - start).toFloat / 1000000} ms)")
     res
   }
+
+  def procs: Int =
+    java.lang.Runtime.getRuntime.availableProcessors
+
+  def partition[T](elems: Seq[T]): Map[Int, Seq[T]] =
+    partition(elems, procs * procs)
+
+  def partition[T](elems: Seq[T], batches: Int): Map[Int, Seq[T]] =
+    elems.groupBy { elem =>
+      Math.abs(System.identityHashCode(elem)) % batches
+    }
 }


### PR DESCRIPTION
This change improves work balancing for the
codegen and native compilation steps. Previously
we would emit one file per package. Some packages
contain more definitions than the others, which
causes work skew (a few threads do most of the work)
which in turn leads to poor scalability to 6+ cores.

Instead, the work should be split randomly across a
number of files proportional to the number of available
processors. This minimizes the risk of any single file
taking longer to compile than the others.

This change shaves off 1s of compilation on the tests
project on 6 core machine with hyper threading.