### PR TITLE
Fix many math.round() issues including #1071 "Weird Behavior of round"

### DIFF
--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -234,11 +234,35 @@ object Math {
   @inline def rint(a: scala.Double): scala.Double =
     `llvm.rint.f64`(a)
 
-  @inline def round(a: scala.Float): scala.Int =
-    `llvm.round.f32`(a).toInt
+  @inline def round(a: scala.Float): scala.Int = {
+    if (a.isNaN) {
+      0
+    } else if (a >= scala.Int.MaxValue.toFloat - 0.5f) {
+      scala.Int.MaxValue
+    } else if (a <= scala.Int.MinValue.toFloat) {
+      scala.Int.MinValue
+    } else {
+      // Java rounds both +/- half to towards +Infinity.
+      // In its default rounding mode, llvm.round.f32 rounds half away
+      // from zero (+/- Infinity).
+      math.floor(a + 0.5f).toInt
+    }
+  }
 
-  @inline def round(a: scala.Double): scala.Long =
-    `llvm.round.f64`(a).toLong
+  @inline def round(a: scala.Double): scala.Long = {
+    if (a.isNaN) {
+      0L
+    } else if (a >= scala.Long.MaxValue.toDouble - 0.5d) {
+      scala.Long.MaxValue
+    } else if (a <= scala.Long.MinValue.toDouble) {
+      scala.Long.MinValue
+    } else {
+      // Java rounds both +/- half towards +Infinity.
+      // In its default rounding mode, llvm.round.f64 rounds half away
+      // from zero (+/- Infinity).
+      math.floor(a + 0.5d).toLong
+    }
+  }
 
   @inline def scalb(a: scala.Float, scaleFactor: scala.Int): scala.Float =
     cmath.scalbnf(a, scaleFactor)

--- a/unit-tests/src/test/scala/java/lang/MathSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/MathSuite.scala
@@ -2,12 +2,6 @@ package java.lang
 
 object MathSuite extends tests.Suite {
 
-  // This method can/will be removed when/if pull request #1305 is merged.
-  // Until then, this allows tests to be written as though #1305 were
-  // effective yet still pass Travis CI until then.
-  private def assert(cond: Boolean, message: String): Unit =
-    assert(cond)
-
   test("max") {
     val a = 123.123d
     val b = 456.456d

--- a/unit-tests/src/test/scala/java/lang/MathSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/MathSuite.scala
@@ -1,6 +1,13 @@
 package java.lang
 
 object MathSuite extends tests.Suite {
+
+  // This method can/will be removed when/if pull request #1305 is merged.
+  // Until then, this allows tests to be written as though #1305 were
+  // effective yet still pass Travis CI until then.
+  private def assert(cond: Boolean, message: String): Unit =
+    assert(cond)
+
   test("max") {
     val a = 123.123d
     val b = 456.456d
@@ -18,4 +25,175 @@ object MathSuite extends tests.Suite {
     assert(Math.min(a.toInt, b.toInt) == a.toInt)
     assert(Math.min(a.toLong, b.toLong) == a.toLong)
   }
+
+// round()
+
+  test("round(Double) - special values") {
+
+    assert(Math.round(Double.NaN) == 0L, "round(NaN) != 0L")
+
+    // value d as reported in issue #1071
+    val dTooLarge: Double      = 4228438087383875356545203991520.000000d
+    val roundedTooLarge: Long  = Math.round(dTooLarge)
+    val expectedTooLarge: Long = scala.Long.MaxValue
+
+    assert(roundedTooLarge == expectedTooLarge,
+           s"${roundedTooLarge} != ${expectedTooLarge}" +
+             " when Double > Long.MaxValue")
+
+    val roundedTooNegative: Long  = Math.round(-1.0 * dTooLarge)
+    val expectedTooNegative: Long = scala.Long.MinValue
+
+    assert(roundedTooNegative == expectedTooNegative,
+           s"${roundedTooNegative} != ${expectedTooNegative}" +
+             " when Double < Long.MinValue")
+  }
+
+  test("round(Double) - ties rounding towards +Infinity") {
+
+    case class TestPoint(value: Double, expected: Long)
+
+    // Check that implementation addition of 0.5 does not cause
+    // overflow into negative numbers. Values near MinValue do not
+    // have this potential flaw.
+
+    val testPointsOverflow = Seq(
+      TestPoint((scala.Double.MaxValue - 0.4d), scala.Long.MaxValue)
+    )
+
+    // Useful/Definitive cases from URL:
+    // https://docs.oracle.com/javase/10/docs/api/java/math/RoundingMode.html
+    //
+    // The expected values are from the Scala REPL/JVM.
+    // The "ties towards +Infinity" rule best explains the observed results.
+    // Note well that _none_ of the rounding modes at that URL describe the
+    // the Scala REPL results, not even HALF_UP.
+
+    val testPointsJavaApi = Seq(
+      TestPoint(+5.5d, +6L),
+      TestPoint(+2.5d, +3L),
+      TestPoint(+1.6d, +2L),
+      TestPoint(+1.1d, +1L),
+      TestPoint(+1.0d, +1L),
+      TestPoint(-1.0d, -1L),
+      TestPoint(-1.1d, -1L),
+      TestPoint(-1.6d, -2L),
+      TestPoint(-2.5d, -2L),
+      TestPoint(-5.5d, -5L)
+    )
+
+// +2.5 and -2.5 are the distinguishing cases. They show that
+// math.round() is correctly rounding towards positive Infinity,
+//
+// The other cases are sanity cases to establish context.
+
+    val testPoints = Seq(
+      TestPoint(-2.6d, -3L),
+      TestPoint(-2.5d, -2L),
+      TestPoint(-2.4d, -2L),
+      TestPoint(+2.4d, +2L),
+      TestPoint(+2.5d, +3L),
+      TestPoint(+2.6d, +3L)
+    )
+
+    val TestPointGroup = Seq(
+      testPointsOverflow,
+      testPointsJavaApi,
+      testPoints
+    )
+
+    for (testPoints <- TestPointGroup) {
+      for (testPoint <- testPoints) {
+        val v: Double      = testPoint.value
+        val result: Long   = math.round(v)
+        val expected: Long = testPoint.expected
+
+        assert(result == testPoint.expected,
+               s"round(${v}) result: ${result} != expected: ${expected}")
+      }
+    }
+  }
+
+  test("round(Float) - special values") {
+
+    assert(Math.round(Float.NaN) == 0, "round(NaN) != 0")
+
+    val fTooLarge: Float      = scala.Float.MaxValue
+    val roundedTooLarge: Int  = Math.round(fTooLarge)
+    val expectedTooLarge: Int = scala.Int.MaxValue
+
+    assert(roundedTooLarge == expectedTooLarge,
+           s"${roundedTooLarge} != ${expectedTooLarge}" +
+             " when Float > Int.MaxValue")
+
+    val roundedTooNegative: Int  = Math.round(scala.Float.MinValue)
+    val expectedTooNegative: Int = scala.Int.MinValue
+
+    assert(roundedTooNegative == expectedTooNegative,
+           s"${roundedTooNegative} != ${expectedTooNegative}" +
+             " when Float < Int.MinValue")
+  }
+
+  test("round(Float) - ties rounding towards +Infinity") {
+
+    case class TestPoint(value: Float, expected: Int)
+
+// See extensive comments in test for round(Double) above.
+
+    // Check that implementation addition of 0.5 does not cause
+    // overflow into negative numbers. Values near MinValue do not
+    // have this potential flaw.
+
+    val testPointsOverflow = Seq(
+      TestPoint((scala.Float.MaxValue - 0.4f), scala.Int.MaxValue)
+    )
+
+    // Useful/Definitive cases from URL:
+    // https://docs.oracle.com/javase/10/docs/api/java/math/RoundingMode.html
+    //
+    // The expected values are from the Scala REPL/JVM.
+    // The "ties towards +Infinity" rule best explains the observed results.
+    // Note well that _none_ of the rounding modes at that URL describe the
+    // the Scala REPL results, not even HALF_UP.
+
+    val testPointsJavaApi = Seq(
+      TestPoint(+5.5f, +6),
+      TestPoint(+2.5f, +3),
+      TestPoint(+1.6f, +2),
+      TestPoint(+1.1f, +1),
+      TestPoint(+1.0f, +1),
+      TestPoint(-1.0f, -1),
+      TestPoint(-1.1f, -1),
+      TestPoint(-1.6f, -2),
+      TestPoint(-2.5f, -2),
+      TestPoint(-5.5f, -5)
+    )
+
+    val testPoints = Seq(
+      TestPoint(-97.6f, -98),
+      TestPoint(-97.5f, -97),
+      TestPoint(-97.4f, -97),
+      TestPoint(+97.4f, +97),
+      TestPoint(+97.5f, +98),
+      TestPoint(+97.6f, +98)
+    )
+
+    val TestPointGroup = Seq(
+      testPointsOverflow,
+      testPointsJavaApi,
+      testPoints
+    )
+
+    for (testPoints <- TestPointGroup) {
+      for (testPoint <- testPoints) {
+        val v: Float      = testPoint.value
+        val result: Int   = math.round(v)
+        val expected: Int = testPoint.expected
+
+        assert(result == testPoint.expected,
+               s"round(${v}) result: ${result} != expected: ${expected}")
+      }
+    }
+  }
+
 }

--- a/unit-tests/src/test/scala/java/lang/MathSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/MathSuite.scala
@@ -2,25 +2,87 @@ package java.lang
 
 object MathSuite extends tests.Suite {
 
-  test("max") {
+  // Max()
+
+  test("max with NaN arguments") {
     val a = 123.123d
     val b = 456.456d
-    assert(Math.max(a, b) == b)
-    assert(Math.max(a.toFloat, b.toFloat) == b.toFloat)
-    assert(Math.max(a.toInt, b.toInt) == b.toInt)
-    assert(Math.max(a.toLong, b.toLong) == b.toLong)
+
+    assert(Math.max(Double.NaN, b).isNaN, "Double.NaN as first argument")
+    assert(Math.max(a, Double.NaN).isNaN, "Double.NaN as second argument")
+
+    assert(Math.max(Float.NaN, b.toFloat).isNaN, "Float.NaN as first argument")
+    assert(Math.max(a, Float.NaN).isNaN, "Float.NaN as second argument")
   }
 
-  test("min") {
+  test("max a > b") {
+    val a = 578.910d
+    val b = 456.456d
+    assert(Math.max(a, b) == a, "Double")
+    assert(Math.max(a.toFloat, b.toFloat) == a.toFloat, "Float")
+    assert(Math.max(a.toInt, b.toInt) == a.toInt, "Int")
+    assert(Math.max(a.toLong, b.toLong) == a.toLong, "Long")
+  }
+
+  test("max a == b") {
+    val a = 576528
+    val b = a
+    assert(Math.max(a, b) == a, "Double")
+    assert(Math.max(a.toFloat, b.toFloat) == a.toFloat, "Float")
+    assert(Math.max(a.toInt, b.toInt) == a.toInt, "Int")
+    assert(Math.max(a.toLong, b.toLong) == a.toLong, "Long")
+  }
+
+  test("max a < b") {
     val a = 123.123d
     val b = 456.456d
-    assert(Math.min(a, b) == a)
-    assert(Math.min(a.toFloat, b.toFloat) == a.toFloat)
-    assert(Math.min(a.toInt, b.toInt) == a.toInt)
-    assert(Math.min(a.toLong, b.toLong) == a.toLong)
+    assert(Math.max(a, b) == b, "Double")
+    assert(Math.max(a.toFloat, b.toFloat) == b.toFloat, "Float")
+    assert(Math.max(a.toInt, b.toInt) == b.toInt, "Int")
+    assert(Math.max(a.toLong, b.toLong) == b.toLong, "Long")
   }
 
-// round()
+  // Min()
+
+  test("min with NaN arguments") {
+    val a = 773.211d
+    val b = 843.531d
+
+    assert(Math.max(Double.NaN, b).isNaN, "Double.NaN as first argument")
+    assert(Math.max(a, Double.NaN).isNaN, "Double.NaN as second argument")
+
+    assert(Math.max(Float.NaN, b.toFloat).isNaN, "Float.NaN as first argument")
+    assert(Math.max(a, Float.NaN).isNaN, "Float.NaN as second argument")
+  }
+
+  test("min a > b") {
+    val a = 949.538d
+    val b = 233.411d
+    assert(Math.min(a, b) == b, "Double")
+    assert(Math.min(a.toFloat, b.toFloat) == b.toFloat, "Float")
+    assert(Math.min(a.toInt, b.toInt) == b.toInt, "Int")
+    assert(Math.min(a.toLong, b.toLong) == b.toLong, "Long")
+  }
+
+  test("min a == b") {
+    val a = 553.838d
+    val b = a
+    assert(Math.min(a, b) == b, "Double")
+    assert(Math.min(a.toFloat, b.toFloat) == b.toFloat, "Float")
+    assert(Math.min(a.toInt, b.toInt) == b.toInt, "Int")
+    assert(Math.min(a.toLong, b.toLong) == b.toLong, "Long")
+  }
+
+  test("min a < b") {
+    val a = 312.966d
+    val b = 645.521d
+    assert(Math.min(a, b) == a, "Double")
+    assert(Math.min(a.toFloat, b.toFloat) == a.toFloat, "Float")
+    assert(Math.min(a.toInt, b.toInt) == a.toInt, "Int")
+    assert(Math.min(a.toLong, b.toLong) == a.toLong, "Long")
+  }
+
+  // round()
 
   test("round(Double) - special values") {
 
@@ -76,10 +138,10 @@ object MathSuite extends tests.Suite {
       TestPoint(-5.5d, -5L)
     )
 
-// +2.5 and -2.5 are the distinguishing cases. They show that
-// math.round() is correctly rounding towards positive Infinity,
-//
-// The other cases are sanity cases to establish context.
+    // +2.5 and -2.5 are the distinguishing cases. They show that
+    // math.round() is correctly rounding towards positive Infinity,
+    //
+    // The other cases are sanity cases to establish context.
 
     val testPoints = Seq(
       TestPoint(-2.6d, -3L),
@@ -132,7 +194,7 @@ object MathSuite extends tests.Suite {
 
     case class TestPoint(value: Float, expected: Int)
 
-// See extensive comments in test for round(Double) above.
+    // See extensive comments in test for round(Double) above.
 
     // Check that implementation addition of 0.5 does not cause
     // overflow into negative numbers. Values near MinValue do not


### PR DESCRIPTION
  * The presenting problem was expressed in issue #1071
    "Weird Behavior of Double's round Method". This issue is now fixed.
    MathSuite.scala was updated to prevent its silent recurrence.

  * To get the CI tests to run, Suite.scala from PR #1305 is included
    in this PR.  I will probably have to rebase after #1305 is merged.

  * This is the first in what is likely to be a long series of fixes
    to Math.Scala. Investigation of #1071 revealed a number of related
    problems in round(). These problems occurred in parallel in the
    handling of Double & Float.

  * Limiting consideration to the two flavors of round() there were
    three classes of problems.

  * The first class of problem is that round() did not properly clamp
    values to the range of a Long or Int, as the argument overload
    demanded.

  * The second class of problem is that round() did not properly
    round NaN arguments to +0.0, as the Java API describes.

  * The third and arguably most important class of problem is that
    round() did not properly round() ties to positive Infinity, as
    the Java API describes.

    The prior code used llvm intrinsics, which are documented to
    use the behavior of libm by default.  Unless its current rounding
    mode is explicitly set differently, libm rounds 0.5 ties away
    from zero.

    Changing llvm/C/libm rounding modes is not entirely thread-friendly.
    Open coding the round method, as this PR does, is easier to get
    correct, is thread-friendly, and almost certainly faster at runtime.

  * Extensive tests have been added to the new round() sections of
    MathSuite.scala.

64/32 bit issues:

      None known

Documentation:

      Deserves a release note.

Testing:

	* Built and tested ("test-all") on X86_64 and X86.