### PR TITLE
Fix math.max() & math.min() handling of NaN

### DIFF
--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -131,11 +131,13 @@ object Math {
   @inline def log1p(a: scala.Double): scala.Double =
     cmath.log1p(a)
 
-  @inline def max(a: scala.Double, b: scala.Double): scala.Double =
-    `llvm.maxnum.f64`(a, b)
+  @inline def max(a: scala.Double, b: scala.Double): scala.Double = {
+    if (a.isNaN || b.isNaN) Double.NaN else `llvm.maxnum.f64`(a, b)
+  }
 
-  @inline def max(a: scala.Float, b: scala.Float): scala.Float =
-    `llvm.maxnum.f32`(a, b)
+  @inline def max(a: scala.Float, b: scala.Float): scala.Float = {
+    if (a.isNaN || b.isNaN) Float.NaN else `llvm.maxnum.f32`(a, b)
+  }
 
   @inline def max(a: scala.Int, b: scala.Int): scala.Int =
     if (a > b) a else b
@@ -143,11 +145,13 @@ object Math {
   @inline def max(a: scala.Long, b: scala.Long): scala.Long =
     if (a > b) a else b
 
-  @inline def min(a: scala.Double, b: scala.Double): scala.Double =
-    `llvm.minnum.f64`(a, b)
+  @inline def min(a: scala.Double, b: scala.Double): scala.Double = {
+    if (a.isNaN || b.isNaN) Double.NaN else `llvm.minnum.f64`(a, b)
+  }
 
-  @inline def min(a: scala.Float, b: scala.Float): scala.Float =
-    `llvm.minnum.f32`(a, b)
+  @inline def min(a: scala.Float, b: scala.Float): scala.Float = {
+    if (a.isNaN || b.isNaN) Float.NaN else `llvm.minnum.f32`(a, b)
+  }
 
   @inline def min(a: scala.Int, b: scala.Int): scala.Int =
     if (a < b) a else b
@@ -171,7 +175,7 @@ object Math {
     subtractExact(0, a)
 
   @inline def negateExact(a: scala.Long): scala.Long =
-    subtractExact(0, a)
+    subtractExact(0L, a)
 
   def nextAfter(a: scala.Float, b: scala.Double): scala.Float = {
     val aabs = abs(a.toDouble)
@@ -179,7 +183,7 @@ object Math {
 
     if (Float.isNaN(a) || Double.isNaN(b)) {
       Float.NaN
-    } else if (aabs == 0f && babs == 0d) {
+    } else if (aabs == 0.0f && babs == 0.0d) {
       b.toFloat
     } else if (aabs == Float.MIN_VALUE && babs < aabs) {
       copySign(0, a)
@@ -200,10 +204,10 @@ object Math {
 
     if (Double.isNaN(a) || Double.isNaN(b)) {
       Double.NaN
-    } else if (aabs == 0f && babs == 0d) {
+    } else if (aabs == 0.0d && babs == 0.0d) {
       b
     } else if (aabs == Double.MIN_VALUE && babs < aabs) {
-      copySign(0, a)
+      copySign(0.0d, a)
     } else if (Double.isInfinite(a) && babs < aabs) {
       copySign(Double.MAX_VALUE, a)
     } else if (aabs == Double.MAX_VALUE && babs > aabs) {

--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -131,13 +131,11 @@ object Math {
   @inline def log1p(a: scala.Double): scala.Double =
     cmath.log1p(a)
 
-  @inline def max(a: scala.Double, b: scala.Double): scala.Double = {
+  @inline def max(a: scala.Double, b: scala.Double): scala.Double =
     if (a.isNaN || b.isNaN) Double.NaN else `llvm.maxnum.f64`(a, b)
-  }
 
-  @inline def max(a: scala.Float, b: scala.Float): scala.Float = {
+  @inline def max(a: scala.Float, b: scala.Float): scala.Float =
     if (a.isNaN || b.isNaN) Float.NaN else `llvm.maxnum.f32`(a, b)
-  }
 
   @inline def max(a: scala.Int, b: scala.Int): scala.Int =
     if (a > b) a else b
@@ -145,13 +143,11 @@ object Math {
   @inline def max(a: scala.Long, b: scala.Long): scala.Long =
     if (a > b) a else b
 
-  @inline def min(a: scala.Double, b: scala.Double): scala.Double = {
+  @inline def min(a: scala.Double, b: scala.Double): scala.Double =
     if (a.isNaN || b.isNaN) Double.NaN else `llvm.minnum.f64`(a, b)
-  }
 
-  @inline def min(a: scala.Float, b: scala.Float): scala.Float = {
+  @inline def min(a: scala.Float, b: scala.Float): scala.Float =
     if (a.isNaN || b.isNaN) Float.NaN else `llvm.minnum.f32`(a, b)
-  }
 
   @inline def min(a: scala.Int, b: scala.Int): scala.Int =
     if (a < b) a else b

--- a/unit-tests/src/test/scala/java/lang/MathSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/MathSuite.scala
@@ -1,21 +1,91 @@
 package java.lang
 
 object MathSuite extends tests.Suite {
-  test("max") {
+
+  // This method can/will be removed when/if pull request #1305 is merged.
+  // Until then, this allows tests to be written as though #1305 were
+  // effective yet still pass Travis CI until then.
+  private def assert(cond: Boolean, message: String): Unit =
+    assert(cond)
+
+// Max()
+
+  test("max with NaN arguments") {
     val a = 123.123d
     val b = 456.456d
-    assert(Math.max(a, b) == b)
-    assert(Math.max(a.toFloat, b.toFloat) == b.toFloat)
-    assert(Math.max(a.toInt, b.toInt) == b.toInt)
-    assert(Math.max(a.toLong, b.toLong) == b.toLong)
+
+    assert(Math.max(Double.NaN, b).isNaN, "Double.NaN as first argument")
+    assert(Math.max(a, Double.NaN).isNaN, "Double.NaN as second argument")
+
+    assert(Math.max(Float.NaN, b.toFloat).isNaN, "Float.NaN as first argument")
+    assert(Math.max(a, Float.NaN).isNaN, "Float.NaN as second argument")
   }
 
-  test("min") {
+  test("max a > b") {
+    val a = 578.910d
+    val b = 456.456d
+    assert(Math.max(a, b) == a, "Double")
+    assert(Math.max(a.toFloat, b.toFloat) == a.toFloat, "Float")
+    assert(Math.max(a.toInt, b.toInt) == a.toInt, "Int")
+    assert(Math.max(a.toLong, b.toLong) == a.toLong, "Long")
+  }
+
+  test("max a == b") {
+    val a = 576528
+    val b = a
+    assert(Math.max(a, b) == a, "Double")
+    assert(Math.max(a.toFloat, b.toFloat) == a.toFloat, "Float")
+    assert(Math.max(a.toInt, b.toInt) == a.toInt, "Int")
+    assert(Math.max(a.toLong, b.toLong) == a.toLong, "Long")
+  }
+
+  test("max a < b") {
     val a = 123.123d
     val b = 456.456d
-    assert(Math.min(a, b) == a)
-    assert(Math.min(a.toFloat, b.toFloat) == a.toFloat)
-    assert(Math.min(a.toInt, b.toInt) == a.toInt)
-    assert(Math.min(a.toLong, b.toLong) == a.toLong)
+    assert(Math.max(a, b) == b, "Double")
+    assert(Math.max(a.toFloat, b.toFloat) == b.toFloat, "Float")
+    assert(Math.max(a.toInt, b.toInt) == b.toInt, "Int")
+    assert(Math.max(a.toLong, b.toLong) == b.toLong, "Long")
   }
+
+// Min()
+
+  test("min with NaN arguments") {
+    val a = 773.211d
+    val b = 843.531d
+
+    assert(Math.max(Double.NaN, b).isNaN, "Double.NaN as first argument")
+    assert(Math.max(a, Double.NaN).isNaN, "Double.NaN as second argument")
+
+    assert(Math.max(Float.NaN, b.toFloat).isNaN, "Float.NaN as first argument")
+    assert(Math.max(a, Float.NaN).isNaN, "Float.NaN as second argument")
+  }
+
+  test("min a > b") {
+    val a = 949.538d
+    val b = 233.411d
+    assert(Math.min(a, b) == b, "Double")
+    assert(Math.min(a.toFloat, b.toFloat) == b.toFloat, "Float")
+    assert(Math.min(a.toInt, b.toInt) == b.toInt, "Int")
+    assert(Math.min(a.toLong, b.toLong) == b.toLong, "Long")
+  }
+
+  test("min a == b") {
+    val a = 553.838d
+    val b = a
+    assert(Math.min(a, b) == b, "Double")
+    assert(Math.min(a.toFloat, b.toFloat) == b.toFloat, "Float")
+    assert(Math.min(a.toInt, b.toInt) == b.toInt, "Int")
+    assert(Math.min(a.toLong, b.toLong) == b.toLong, "Long")
+  }
+
+  test("min a < b") {
+    val a = 312.966d
+    val b = 645.521d
+    assert(Math.min(a, b) == a, "Double")
+    assert(Math.min(a.toFloat, b.toFloat) == a.toFloat, "Float")
+    assert(Math.min(a.toInt, b.toInt) == a.toInt, "Int")
+    assert(Math.min(a.toLong, b.toLong) == a.toLong, "Long")
+  }
+
 }

--- a/unit-tests/src/test/scala/java/lang/MathSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/MathSuite.scala
@@ -2,12 +2,6 @@ package java.lang
 
 object MathSuite extends tests.Suite {
 
-  // This method can/will be removed when/if pull request #1305 is merged.
-  // Until then, this allows tests to be written as though #1305 were
-  // effective yet still pass Travis CI until then.
-  private def assert(cond: Boolean, message: String): Unit =
-    assert(cond)
-
   // Max()
 
   test("max with NaN arguments") {

--- a/unit-tests/src/test/scala/java/lang/MathSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/MathSuite.scala
@@ -8,7 +8,7 @@ object MathSuite extends tests.Suite {
   private def assert(cond: Boolean, message: String): Unit =
     assert(cond)
 
-// Max()
+  // Max()
 
   test("max with NaN arguments") {
     val a = 123.123d
@@ -48,7 +48,7 @@ object MathSuite extends tests.Suite {
     assert(Math.max(a.toLong, b.toLong) == b.toLong, "Long")
   }
 
-// Min()
+  // Min()
 
   test("min with NaN arguments") {
     val a = 773.211d


### PR DESCRIPTION
  * The presenting problem is that Double & Float max() and min() on
    Scala JVM all return NaN when presented with either or both NaN
    arguments. ScalaNative was returning digits. This pull request
    fixes that problem.

  * This is the second in what is likely to be a long series of fixes
    to Math.Scala. During and after the changes to math.round()
    submitted in PR #1306, I visually examined a number of other
    methods with Double or Float arguments in Math.scala for similar
    issues. I cleared some methods but discovered issues with
    the Double & Float variants of max() and min(). Those issues
    are fixed in the pull request.

    Eventually it will take a fully implemented MathSuite.scala
    to machine test _every_ method.

  * I added extensive sections for Double & Float max() & min()
    to MathSuite.scala. This should help prevent silent recurrence of
    these particular issues.

    For consistency, to ease reading, and reduce cognitive load,
    I changed all floating point numbers I could find to have a
    decimal point. 0f is technically correct, but 0.0f is
    more evidently a floating point number. The influence of Fortran
    never dies.

  * To get the CI tests to run, Suite.scala from PR #1305 is included
    in this PR.  I will probably have to rebase after #1305 is merged.

64/32 bit issues:

      None known

Documentation:

      Deserves a release note.

Testing:

	* Built and tested ("test-all") on X86_64 and X86.