### PR TITLE
Fix broken compile of URLEncoderSuite.scala in some environments.

### DIFF
--- a/unit-tests/src/test/scala/java/net/URLEncoderSuite.scala
+++ b/unit-tests/src/test/scala/java/net/URLEncoderSuite.scala
@@ -13,13 +13,13 @@ package java.net
 object URLEncoderSuite extends tests.Suite {
   test("null input string") {
     assertThrows[NullPointerException] {
-      URLEncoder.encode(null, "ignored")
+      URLEncoder.encode(null: String, "ignored")
     }
   }
 
   test("null encoding name") {
     assertThrows[NullPointerException] {
-      URLEncoder.encode("any", null)
+      URLEncoder.encode("any", null: String)
     }
   }
 


### PR DESCRIPTION

UPDATE 2018-08-28:
```
        Utilizing recently gained knowledge about javalib features/quirks,
        this may be a Java8 vs. Java10 issue. My guess is that it shows only
	in Java > 8. If that guess is correct, this fix is still
	innocuous on Java8 but heads off a problem with Java > 8.
```

For a while now, I have been encountering a problem compiling
URLEncoderSuite.scala in my environment.  I have not seen this
problem with Travis CI.

I have done a fresh clone directly from the master S-N Github repository,
deleted my ~/.ivy2, and done a complete rebuild from the newly cloned
directory. This is on an X86_64 system, so there should be no
architectural issues.

The presenting problem from an sbt session is (lightly edited for
clarity):

unit-tests/src/test/scala/java/net/URLEncoderSuite.scala:22:
        ambiguous reference to overloaded definition,
[error] both method encode in object URLEncoder of type
        (x$1: String, x$2: java.nio.charset.Charset)String
[error] and  method encode in object URLEncoder of type
        (x$1: String, x$2: String)String
[error] match argument types (String,Null)
[error]       URLEncoder.encode("any", null)
[error]                  ^
[error] one error found
[error] (tests/test:compileIncremental) Compilation failed

I do not know how the URLEncoder.encode(string, Charset): String
is being found. The file javalib/src/main/scala/java/net/URLEncoder.scala
has one encode method, which takes two strings.

I searched for contributions to java.net in strange places, like
nativelib. If it is there it is hidden beyond my skill or fortune.

Is there a name hash conflict somewhere?

Since I believe it almost certain that the intent of URLEncoderSuite.scala
was to test the method in URLEncoder.scala, I fixed the test by having
null be taken as a string (is this type ascription?).

I believe this change is innocuous in environments which were not having
the problem I saw. I need URLEncoderSuite.scala compiling for
a PR I am about to submit.

No documentation issues. No known 64/32 bit issues.

Tested by running "test/test-only java.net.URLEncoderSuite" and
the test-all. Compiles & executes. Nothing else breaks.