### PR TITLE
Store unwind handler in every let instruction

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -35,56 +35,60 @@ class Buffer(implicit fresh: Fresh) {
     this += Inst.Throw(value, unwind)
 
   // Compute ops
-  def let(name: Local, op: Op): Val = {
-    this += Inst.Let(name, op)
+  def let(name: Local, op: Op, unwind: Next): Val = {
+    this += Inst.Let(name, op, unwind)
     Val.Local(name, op.resty)
   }
-  def let(op: Op): Val =
-    let(fresh(), op)
+  def let(op: Op, unwind: Next): Val =
+    let(fresh(), op, unwind)
   def call(ty: Type, ptr: Val, args: Seq[Val], unwind: Next): Val =
-    let(Op.Call(ty, ptr, args, unwind))
-  def load(ty: Type, ptr: Val, isVolatile: Boolean = false): Val =
-    let(Op.Load(ty, ptr, isVolatile))
-  def store(ty: Type, ptr: Val, value: Val, isVolatile: Boolean = false): Val =
-    let(Op.Store(ty, ptr, value, isVolatile))
-  def elem(ty: Type, ptr: Val, indexes: Seq[Val]): Val =
-    let(Op.Elem(ty, ptr, indexes))
-  def extract(aggr: Val, indexes: Seq[Int]): Val =
-    let(Op.Extract(aggr, indexes))
-  def insert(aggr: Val, value: Val, indexes: Seq[Int]): Val =
-    let(Op.Insert(aggr, value, indexes))
-  def stackalloc(ty: Type, n: Val): Val =
-    let(Op.Stackalloc(ty, n))
-  def bin(bin: nir.Bin, ty: Type, l: Val, r: Val): Val =
-    let(Op.Bin(bin, ty, l, r))
-  def comp(comp: nir.Comp, ty: Type, l: Val, r: Val): Val =
-    let(Op.Comp(comp, ty, l, r))
-  def conv(conv: nir.Conv, ty: Type, value: Val): Val =
-    let(Op.Conv(conv, ty, value))
-  def select(cond: Val, thenv: Val, elsev: Val): Val =
-    let(Op.Select(cond, thenv, elsev))
-  def classalloc(name: Global): Val =
-    let(Op.Classalloc(name))
-  def field(obj: Val, name: Global): Val =
-    let(Op.Field(obj, name))
-  def method(obj: Val, name: Global): Val =
-    let(Op.Method(obj, name))
-  def dynmethod(obj: Val, signature: String): Val =
-    let(Op.Dynmethod(obj, signature))
+    let(Op.Call(ty, ptr, args), unwind)
+  def load(ty: Type, ptr: Val, unwind: Next, isVolatile: Boolean = false): Val =
+    let(Op.Load(ty, ptr, isVolatile), unwind)
+  def store(ty: Type,
+            ptr: Val,
+            value: Val,
+            unwind: Next,
+            isVolatile: Boolean = false): Val =
+    let(Op.Store(ty, ptr, value, isVolatile), unwind)
+  def elem(ty: Type, ptr: Val, indexes: Seq[Val], unwind: Next): Val =
+    let(Op.Elem(ty, ptr, indexes), unwind)
+  def extract(aggr: Val, indexes: Seq[Int], unwind: Next): Val =
+    let(Op.Extract(aggr, indexes), unwind)
+  def insert(aggr: Val, value: Val, indexes: Seq[Int], unwind: Next): Val =
+    let(Op.Insert(aggr, value, indexes), unwind)
+  def stackalloc(ty: Type, n: Val, unwind: Next): Val =
+    let(Op.Stackalloc(ty, n), unwind)
+  def bin(bin: nir.Bin, ty: Type, l: Val, r: Val, unwind: Next): Val =
+    let(Op.Bin(bin, ty, l, r), unwind)
+  def comp(comp: nir.Comp, ty: Type, l: Val, r: Val, unwind: Next): Val =
+    let(Op.Comp(comp, ty, l, r), unwind)
+  def conv(conv: nir.Conv, ty: Type, value: Val, unwind: Next): Val =
+    let(Op.Conv(conv, ty, value), unwind)
+  def select(cond: Val, thenv: Val, elsev: Val, unwind: Next): Val =
+    let(Op.Select(cond, thenv, elsev), unwind)
+  def classalloc(name: Global, unwind: Next): Val =
+    let(Op.Classalloc(name), unwind)
+  def field(obj: Val, name: Global, unwind: Next): Val =
+    let(Op.Field(obj, name), unwind)
+  def method(obj: Val, name: Global, unwind: Next): Val =
+    let(Op.Method(obj, name), unwind)
+  def dynmethod(obj: Val, signature: String, unwind: Next): Val =
+    let(Op.Dynmethod(obj, signature), unwind)
   def module(name: Global, unwind: Next): Val =
-    let(Op.Module(name, unwind))
-  def as(ty: Type, obj: Val): Val =
-    let(Op.As(ty, obj))
-  def is(ty: Type, obj: Val): Val =
-    let(Op.Is(ty, obj))
-  def copy(value: Val): Val =
-    let(Op.Copy(value))
-  def sizeof(ty: Type): Val =
-    let(Op.Sizeof(ty))
-  def closure(ty: Type, fun: Val, captures: Seq[Val]): Val =
-    let(Op.Closure(ty, fun, captures))
-  def box(ty: Type, obj: Val): Val =
-    let(Op.Box(ty, obj))
-  def unbox(ty: Type, obj: Val): Val =
-    let(Op.Unbox(ty, obj))
+    let(Op.Module(name), unwind)
+  def as(ty: Type, obj: Val, unwind: Next): Val =
+    let(Op.As(ty, obj), unwind)
+  def is(ty: Type, obj: Val, unwind: Next): Val =
+    let(Op.Is(ty, obj), unwind)
+  def copy(value: Val, unwind: Next): Val =
+    let(Op.Copy(value), unwind)
+  def sizeof(ty: Type, unwind: Next): Val =
+    let(Op.Sizeof(ty), unwind)
+  def closure(ty: Type, fun: Val, captures: Seq[Val], unwind: Next): Val =
+    let(Op.Closure(ty, fun, captures), unwind)
+  def box(ty: Type, obj: Val, unwind: Next): Val =
+    let(Op.Box(ty, obj), unwind)
+  def unbox(ty: Type, obj: Val, unwind: Next): Val =
+    let(Op.Unbox(ty, obj), unwind)
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
@@ -18,7 +18,7 @@ object Fresh {
   def apply(insts: Seq[Inst]): Fresh = {
     var max = -1
     insts.foreach {
-      case Inst.Let(local, _) =>
+      case Inst.Let(local, _, _) =>
         max = Math.max(max, local.id)
       case Inst.Label(local, params) =>
         max = Math.max(max, local.id)

--- a/nir/src/main/scala/scala/scalanative/nir/Insts.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Insts.scala
@@ -8,9 +8,10 @@ sealed abstract class Inst {
 object Inst {
   final case object None                                      extends Inst
   final case class Label(name: Local, params: Seq[Val.Local]) extends Inst
-  final case class Let(name: Local, op: Op)                   extends Inst
+  final case class Let(name: Local, op: Op, unwind: Next)     extends Inst
   object Let {
-    def apply(op: Op)(implicit fresh: Fresh): Let = Let(fresh(), op)
+    def apply(op: Op, unwind: Next)(implicit fresh: Fresh): Let =
+      Let(fresh(), op, unwind)
   }
 
   sealed abstract class Cf                                  extends Inst

--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -5,24 +5,24 @@ import util.unreachable
 
 sealed abstract class Op {
   final def resty: Type = this match {
-    case Op.Call(Type.Function(_, ret), _, _, _) => ret
-    case Op.Call(_, _, _, _)                     => unreachable
-    case Op.Load(ty, _, _)                       => ty
-    case Op.Store(_, _, _, _)                    => Type.Unit
-    case Op.Elem(_, _, _)                        => Type.Ptr
-    case Op.Extract(aggr, indexes)               => aggr.ty.elemty(indexes.map(Val.Int(_)))
-    case Op.Insert(aggr, _, _)                   => aggr.ty
-    case Op.Stackalloc(ty, _)                    => Type.Ptr
-    case Op.Bin(_, ty, _, _)                     => ty
-    case Op.Comp(_, _, _, _)                     => Type.Bool
-    case Op.Conv(_, ty, _)                       => ty
-    case Op.Select(_, v, _)                      => v.ty
+    case Op.Call(Type.Function(_, ret), _, _) => ret
+    case Op.Call(_, _, _)                     => unreachable
+    case Op.Load(ty, _, _)                    => ty
+    case Op.Store(_, _, _, _)                 => Type.Unit
+    case Op.Elem(_, _, _)                     => Type.Ptr
+    case Op.Extract(aggr, indexes)            => aggr.ty.elemty(indexes.map(Val.Int(_)))
+    case Op.Insert(aggr, _, _)                => aggr.ty
+    case Op.Stackalloc(ty, _)                 => Type.Ptr
+    case Op.Bin(_, ty, _, _)                  => ty
+    case Op.Comp(_, _, _, _)                  => Type.Bool
+    case Op.Conv(_, ty, _)                    => ty
+    case Op.Select(_, v, _)                   => v.ty
 
     case Op.Classalloc(n)     => Type.Class(n)
     case Op.Field(_, _)       => Type.Ptr
     case Op.Method(_, _)      => Type.Ptr
     case Op.Dynmethod(_, _)   => Type.Ptr
-    case Op.Module(n, _)      => Type.Module(n)
+    case Op.Module(n)         => Type.Module(n)
     case Op.As(ty, _)         => ty
     case Op.Is(_, _)          => Type.Bool
     case Op.Copy(v)           => v.ty
@@ -36,13 +36,9 @@ sealed abstract class Op {
 }
 object Op {
   sealed abstract class Pure extends Op
-  sealed abstract class Unwind extends Op {
-    def unwind: Next
-  }
 
   // low-level
-  final case class Call(ty: Type, ptr: Val, args: Seq[Val], unwind: Next)
-      extends Unwind
+  final case class Call(ty: Type, ptr: Val, args: Seq[Val])      extends Op
   final case class Load(ty: Type, ptr: Val, isVolatile: Boolean) extends Op
   final case class Store(ty: Type, ptr: Val, value: Val, isVolatile: Boolean)
       extends Op
@@ -65,7 +61,7 @@ object Op {
   final case class Field(obj: Val, name: Global)                   extends Op
   final case class Method(obj: Val, name: Global)                  extends Op
   final case class Dynmethod(obj: Val, signature: String)          extends Op
-  final case class Module(name: Global, unwind: Next)              extends Unwind
+  final case class Module(name: Global)                            extends Op
   final case class As(ty: Type, obj: Val)                          extends Op
   final case class Is(ty: Type, obj: Val)                          extends Op
   final case class Copy(value: Val)                                extends Op

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -125,10 +125,14 @@ object Show {
           str(")")
         }
         str(":")
-      case Inst.Let(name, op) =>
+      case Inst.Let(name, op, unwind) =>
         local_(name)
         str(" = ")
         op_(op)
+        if (unwind ne Next.None) {
+          str(" ")
+          next_(unwind)
+        }
       case Inst.Unreachable =>
         str("unreachable")
       case Inst.Ret(Val.None) =>
@@ -171,7 +175,7 @@ object Show {
     }
 
     def op_(op: Op): Unit = op match {
-      case Op.Call(ty, f, args, unwind) =>
+      case Op.Call(ty, f, args) =>
         str("call[")
         type_(ty)
         str("] ")
@@ -179,10 +183,6 @@ object Show {
         str("(")
         rep(args, sep = ", ")(val_)
         str(")")
-        if (unwind ne Next.None) {
-          str(" ")
-          next_(unwind)
-        }
       case Op.Load(ty, ptr, isVolatile) =>
         str(if (isVolatile) "volatile load[" else "load[")
         type_(ty)
@@ -271,13 +271,9 @@ object Show {
         str(", \"")
         str(escapeQuotes(signature))
         str("\"")
-      case Op.Module(name, unwind) =>
+      case Op.Module(name) =>
         str("module ")
         global_(name)
-        if (unwind ne Next.None) {
-          str(" ")
-          next_(unwind)
-        }
       case Op.As(ty, v) =>
         str("as[")
         type_(ty)

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -35,8 +35,8 @@ trait Transform {
         Val.Local(param.name, onType(param.ty))
       }
       Inst.Label(n, newparams)
-    case Inst.Let(n, op) =>
-      Inst.Let(n, onOp(op))
+    case Inst.Let(n, op, unwind) =>
+      Inst.Let(n, onOp(op), onNext(unwind))
 
     case Inst.Unreachable =>
       Inst.Unreachable
@@ -53,8 +53,8 @@ trait Transform {
   }
 
   def onOp(op: Op): Op = op match {
-    case Op.Call(ty, ptrv, argvs, unwind) =>
-      Op.Call(onType(ty), onVal(ptrv), argvs.map(onVal), onNext(unwind))
+    case Op.Call(ty, ptrv, argvs) =>
+      Op.Call(onType(ty), onVal(ptrv), argvs.map(onVal))
     case Op.Load(ty, ptrv, isVolatile) =>
       Op.Load(onType(ty), onVal(ptrv), isVolatile)
     case Op.Store(ty, ptrv, v, isVolatile) =>
@@ -84,8 +84,8 @@ trait Transform {
       Op.Method(onVal(v), n)
     case Op.Dynmethod(obj, signature) =>
       Op.Dynmethod(onVal(obj), signature)
-    case Op.Module(n, unwind) =>
-      Op.Module(n, onNext(unwind))
+    case Op.Module(n) =>
+      Op.Module(n)
     case Op.As(ty, v) =>
       Op.As(onType(ty), onVal(v))
     case Op.Is(ty, v) =>

--- a/nir/src/main/scala/scala/scalanative/nir/Versions.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Versions.scala
@@ -21,8 +21,8 @@ object Versions {
    * when 2.3-based release happens all of the code needs to recompiled with
    * new version of the toolchain.
    */
-  final val compat: Int   = 3
-  final val revision: Int = 5
+  final val compat: Int   = 4
+  final val revision: Int = 6
 
   /* Current public release version of Scala Native. */
   final val current: String = "0.3.9-SNAPSHOT"

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -131,7 +131,8 @@ final class BinaryDeserializer(_buffer: => ByteBuffer) {
   private def getInst(): Inst = getInt match {
     case T.NoneInst        => Inst.None
     case T.LabelInst       => Inst.Label(getLocal, getParams)
-    case T.LetInst         => Inst.Let(getLocal, getOp)
+    case T.LetInst         => Inst.Let(getLocal, getOp, Next.None)
+    case T.LetUnwindInst   => Inst.Let(getLocal, getOp, getNext)
     case T.UnreachableInst => Inst.Unreachable
     case T.RetInst         => Inst.Ret(getVal)
     case T.JumpInst        => Inst.Jump(getNext)
@@ -235,7 +236,7 @@ final class BinaryDeserializer(_buffer: => ByteBuffer) {
   }
 
   private def getOp(): Op = getInt match {
-    case T.CallOp       => Op.Call(getType, getVal, getVals, getNext)
+    case T.CallOp       => Op.Call(getType, getVal, getVals)
     case T.LoadOp       => Op.Load(getType, getVal, isVolatile = false)
     case T.StoreOp      => Op.Store(getType, getVal, getVal, isVolatile = false)
     case T.ElemOp       => Op.Elem(getType, getVal, getVals)
@@ -254,7 +255,7 @@ final class BinaryDeserializer(_buffer: => ByteBuffer) {
       val dynmethod = Op.Dynmethod(getVal, getString)
       dyns += dynmethod.signature
       dynmethod
-    case T.ModuleOp  => Op.Module(getGlobal, getNext)
+    case T.ModuleOp  => Op.Module(getGlobal)
     case T.AsOp      => Op.As(getType, getVal)
     case T.IsOp      => Op.Is(getType, getVal)
     case T.CopyOp    => Op.Copy(getVal)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -118,10 +118,16 @@ final class BinarySerializer(buffer: ByteBuffer) {
       putLocal(name)
       putParams(params)
 
-    case Inst.Let(name, op) =>
+    case Inst.Let(name, op, Next.None) =>
       putInt(T.LetInst)
       putLocal(name)
       putOp(op)
+
+    case Inst.Let(name, op, unwind) =>
+      putInt(T.LetUnwindInst)
+      putLocal(name)
+      putOp(op)
+      putNext(unwind)
 
     case Inst.Unreachable =>
       putInt(T.UnreachableInst)
@@ -267,12 +273,11 @@ final class BinarySerializer(buffer: ByteBuffer) {
   }
 
   private def putOp(op: Op) = op match {
-    case Op.Call(ty, v, args, unwind) =>
+    case Op.Call(ty, v, args) =>
       putInt(T.CallOp)
       putType(ty)
       putVal(v)
       putVals(args)
-      putNext(unwind)
 
     case Op.Load(ty, ptr, isVolatile) =>
       assert(!isVolatile, "volatile loads are not serializable")
@@ -354,10 +359,9 @@ final class BinarySerializer(buffer: ByteBuffer) {
       putVal(obj)
       putString(sign)
 
-    case Op.Module(name, unwind) =>
+    case Op.Module(name) =>
       putInt(T.ModuleOp)
       putGlobal(name)
-      putNext(unwind)
 
     case Op.As(ty, v) =>
       putInt(T.AsOp)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -114,6 +114,7 @@ object Tags {
   final val IfInst          = 1 + JumpInst
   final val SwitchInst      = 1 + IfInst
   final val ThrowInst       = 1 + SwitchInst
+  final val LetUnwindInst   = 1 + ThrowInst
 
   // Globals
 

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Inst.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Inst.scala
@@ -16,8 +16,8 @@ object Inst extends Base[nir.Inst] {
       case (name, params) => nir.Inst.Label(name, params getOrElse Seq())
     })
   val Let =
-    P(Local.parser ~ "=" ~ Op.parser map {
-      case (name, op) => nir.Inst.Let(name, op)
+    P(Local.parser ~ "=" ~ Op.parser ~ unwind map {
+      case (name, op, unwind) => nir.Inst.Let(name, op, unwind)
     })
   val Unreachable = P("unreachable".! map (_ => nir.Inst.Unreachable))
   val Ret =

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Op.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Op.scala
@@ -9,14 +9,11 @@ object Op extends Base[nir.Op] {
 
   import Base.IgnoreWhitespace._
 
-  private val unwind: P[Next] =
-    P(Next.parser.?).map(_.getOrElse(nir.Next.None))
-
   val Call =
     P(
       "call[" ~ Type.parser ~ "]" ~ Val.parser ~ "(" ~ Val.parser
-        .rep(sep = ",") ~ ")" ~ unwind).map {
-      case (ty, f, args, unwind) => nir.Op.Call(ty, f, args, unwind)
+        .rep(sep = ",") ~ ")").map {
+      case (ty, f, args) => nir.Op.Call(ty, f, args)
     }
   val Load =
     P("volatile".!.? ~ "load[" ~ Type.parser ~ "]" ~ Val.parser map {
@@ -75,9 +72,8 @@ object Op extends Base[nir.Op] {
     P("dynmethod" ~ Val.parser ~ "," ~ Base.stringLit map {
       case (obj, signature) => nir.Op.Dynmethod(obj, signature)
     })
-  val Module = P("module" ~ Global.parser ~ unwind).map {
-    case (name, unwind) =>
-      nir.Op.Module(name, unwind)
+  val Module = P("module" ~ Global.parser).map {
+    case name => nir.Op.Module(name)
   }
   val As =
     P("as[" ~ Type.parser ~ "]" ~ Val.parser map {

--- a/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
@@ -22,8 +22,15 @@ class InstParserTest extends FlatSpec with Matchers {
     result should be(label)
   }
 
-  it should "parse `Inst.Let`" in {
-    val let: Inst                 = Inst.Let(local, Op.As(noTpe, Val.None))
+  it should "parse `Inst.Let` without unwind" in {
+    val let: Inst                 = Inst.Let(local, Op.As(noTpe, Val.None), Next.None)
+    val Parsed.Success(result, _) = parser.Inst.Let.parse(let.show)
+    result should be(let)
+  }
+
+  it should "parse `Inst.Let` with unwind" in {
+    val let: Inst =
+      Inst.Let(local, Op.As(noTpe, Val.None), Next.Unwind(Local(0)))
     val Parsed.Success(result, _) = parser.Inst.Let.parse(let.show)
     result should be(let)
   }

--- a/nirparser/src/test/scala/scala/scalanative/nir/OpParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/OpParserTest.scala
@@ -9,15 +9,8 @@ class OpParserTest extends FlatSpec with Matchers {
   val global = Global.Top("test")
   val noTpe  = Type.None
 
-  "The NIR parser" should "parse `Op.Call` without unwind" in {
-    val call: Op                  = Op.Call(noTpe, Val.None, Seq.empty, Next.None)
-    val Parsed.Success(result, _) = parser.Op.Call.parse(call.show)
-    result should be(call)
-  }
-
-  "The NIR parser" should "parse `Op.Call` with unwind" in {
-    val call: Op =
-      Op.Call(noTpe, Val.None, Seq.empty, Next.Unwind(Local(0)))
+  "The NIR parser" should "parse `Op.Call`" in {
+    val call: Op                  = Op.Call(noTpe, Val.None, Seq.empty)
     val Parsed.Success(result, _) = parser.Op.Call.parse(call.show)
     result should be(call)
   }
@@ -120,14 +113,8 @@ class OpParserTest extends FlatSpec with Matchers {
       parser.Op.Dynmethod.parse(dynmethod.show)
     result should be(dynmethod)
   }
-  it should "parse `Op.Module` without unwind" in {
-    val module: Op                = Op.Module(global, Next.None)
-    val Parsed.Success(result, _) = parser.Op.Module.parse(module.show)
-    result should be(module)
-  }
-
-  it should "parse `Op.Module` with unwind" in {
-    val module: Op                = Op.Module(global, Next.Unwind(Local(0)))
+  it should "parse `Op.Module`" in {
+    val module: Op                = Op.Module(global)
     val Parsed.Success(result, _) = parser.Op.Module.parse(module.show)
     result should be(module)
   }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -38,6 +38,9 @@ abstract class NirGenPhase
   protected val curUnwind     = new util.ScopedVar[nir.Next]
   protected val curStatBuffer = new util.ScopedVar[StatBuffer]
 
+  protected def unwind: Next =
+    curUnwind.get
+
   protected def lazyAnonDefs =
     curLazyAnonDefs.get
   protected def consumeLazyAnonDef(sym: Symbol): ClassDef = {

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -350,7 +350,7 @@ trait NirGenStat { self: NirGenPhase =>
         buf.label(fresh(), params)
         vars.foreach { sym =>
           val ty    = genType(sym.info, box = false)
-          val alloc = buf.stackalloc(ty, Val.None)
+          val alloc = buf.stackalloc(ty, Val.None, unwind)
           curMethodEnv.enter(sym, alloc)
         }
       }

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -62,8 +62,9 @@ object Generate {
           Inst.Let(boolptr.name,
                    Op.Elem(meta.tables.classHasTraitTy,
                            meta.tables.classHasTraitVal,
-                           Seq(Val.Int(0), classid, traitid))),
-          Inst.Let(result.name, Op.Load(Type.Bool, boolptr)),
+                           Seq(Val.Int(0), classid, traitid)),
+                   Next.None),
+          Inst.Let(result.name, Op.Load(Type.Bool, boolptr), Next.None),
           Inst.Ret(result)
         )
       )
@@ -92,8 +93,9 @@ object Generate {
           Inst.Let(boolptr.name,
                    Op.Elem(meta.tables.traitHasTraitTy,
                            meta.tables.traitHasTraitVal,
-                           Seq(Val.Int(0), leftid, rightid))),
-          Inst.Let(result.name, Op.Load(Type.Bool, boolptr)),
+                           Seq(Val.Int(0), leftid, rightid)),
+                   Next.None),
+          Inst.Let(result.name, Op.Load(Type.Bool, boolptr), Next.None),
           Inst.Ret(result)
         )
       )
@@ -123,22 +125,25 @@ object Generate {
         MainSig,
         Seq(
           Inst.Label(fresh(), Seq(argc, argv)),
-          Inst.Let(stackBottom.name, Op.Stackalloc(Type.Ptr, Val.Long(0))),
-          Inst.Let(
-            Op.Store(Type.Ptr,
-                     Val.Global(stackBottomName, Type.Ptr),
-                     stackBottom)),
-          Inst.Let(Op.Call(InitSig, Init, Seq(), unwind)),
-          Inst.Let(rt.name, Op.Module(Rt.name, unwind)),
+          Inst.Let(stackBottom.name,
+                   Op.Stackalloc(Type.Ptr, Val.Long(0)),
+                   unwind),
+          Inst.Let(Op.Store(Type.Ptr,
+                            Val.Global(stackBottomName, Type.Ptr),
+                            stackBottom),
+                   unwind),
+          Inst.Let(Op.Call(InitSig, Init, Seq()), unwind),
+          Inst.Let(rt.name, Op.Module(Rt.name), unwind),
           Inst.Let(arr.name,
-                   Op.Call(RtInitSig, RtInit, Seq(rt, argc, argv), unwind)),
-          Inst.Let(module.name, Op.Module(entry.top, unwind)),
-          Inst.Let(Op.Call(entryMainTy, entryMain, Seq(module, arr), unwind)),
-          Inst.Let(Op.Call(RtLoopSig, RtLoop, Seq(module), unwind)),
+                   Op.Call(RtInitSig, RtInit, Seq(rt, argc, argv)),
+                   unwind),
+          Inst.Let(module.name, Op.Module(entry.top), unwind),
+          Inst.Let(Op.Call(entryMainTy, entryMain, Seq(module, arr)), unwind),
+          Inst.Let(Op.Call(RtLoopSig, RtLoop, Seq(module)), unwind),
           Inst.Ret(Val.Int(0)),
           Inst.Label(unwind.name, Seq(exc)),
-          Inst.Let(
-            Op.Call(PrintStackTraceSig, PrintStackTrace, Seq(exc), Next.None)),
+          Inst.Let(Op.Call(PrintStackTraceSig, PrintStackTrace, Seq(exc)),
+                   Next.None),
           Inst.Ret(Val.Int(1))
         )
       )
@@ -169,7 +174,7 @@ object Generate {
           val initSig = Type.Function(Seq(clsTy), Type.Void)
           val init    = Val.Global(name member "init", Type.Ptr)
 
-          Inst.Let(Op.Call(initSig, init, Seq(alloc), Next.None))
+          Inst.Let(Op.Call(initSig, init, Seq(alloc)), Next.None)
         }
 
         val loadName = name member "load"
@@ -183,16 +188,18 @@ object Generate {
             Inst.Let(slot.name,
                      Op.Elem(Type.Ptr,
                              Val.Global(Global.Top("__modules"), Type.Ptr),
-                             Seq(Val.Int(meta.moduleArray.index(cls))))),
-            Inst.Let(self.name, Op.Load(clsTy, slot)),
+                             Seq(Val.Int(meta.moduleArray.index(cls)))),
+                     Next.None),
+            Inst.Let(self.name, Op.Load(clsTy, slot), Next.None),
             Inst.Let(cond.name,
-                     Op.Comp(Comp.Ine, nir.Rt.Object, self, Val.Null)),
+                     Op.Comp(Comp.Ine, nir.Rt.Object, self, Val.Null),
+                     Next.None),
             Inst.If(cond, Next(existing), Next(initialize)),
             Inst.Label(existing, Seq()),
             Inst.Ret(self),
             Inst.Label(initialize, Seq()),
-            Inst.Let(alloc.name, Op.Classalloc(name)),
-            Inst.Let(Op.Store(clsTy, slot, alloc)),
+            Inst.Let(alloc.name, Op.Classalloc(name), Next.None),
+            Inst.Let(Op.Store(clsTy, slot, alloc), Next.None),
             initCall,
             Inst.Ret(alloc)
           )

--- a/tools/src/main/scala/scala/scalanative/linker/ReflectiveProxy.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ReflectiveProxy.scala
@@ -19,7 +19,7 @@ object ReflectiveProxy {
 
     val label      = genProxyLabel(proxyArgs)
     val unboxInsts = genArgUnboxes(label)
-    val method     = Inst.Let(Op.Method(label.params.head, defn.name))
+    val method     = Inst.Let(Op.Method(label.params.head, defn.name), Next.None)
     val call       = genCall(defnType, method, label.params, unboxInsts)
     val box        = genRetValBox(call.name, defnType.ret, proxyTy.ret)
     val retInst    = genRet(box.name, proxyTy.ret)
@@ -55,9 +55,9 @@ object ReflectiveProxy {
   private def genArgUnboxes(label: Inst.Label) =
     label.params.tail.map {
       case local: Val.Local if Type.unbox.contains(local.ty) =>
-        Inst.Let(Op.Unbox(local.ty, local))
+        Inst.Let(Op.Unbox(local.ty, local), Next.None)
       case local: Val.Local =>
-        Inst.Let(Op.Copy(local))
+        Inst.Let(Op.Copy(local), Next.None)
     }
 
   private def genCall(defnTy: Type.Function,
@@ -74,16 +74,16 @@ object ReflectiveProxy {
         }
         .toList
 
-    Inst.Let(
-      Op.Call(defnTy, Val.Local(method.name, Type.Ptr), callParams, Next.None))
+    Inst.Let(Op.Call(defnTy, Val.Local(method.name, Type.Ptr), callParams),
+             Next.None)
   }
 
   private def genRetValBox(callName: Local, defnRetTy: Type, proxyRetTy: Type) =
     Type.box.get(defnRetTy) match {
       case Some(boxTy) =>
-        Inst.Let(Op.Box(boxTy, Val.Local(callName, defnRetTy)))
+        Inst.Let(Op.Box(boxTy, Val.Local(callName, defnRetTy)), Next.None)
       case None =>
-        Inst.Let(Op.Copy(Val.Local(callName, defnRetTy)))
+        Inst.Let(Op.Copy(Val.Local(callName, defnRetTy)), Next.None)
     }
 
   private def genRet(retValBoxName: Local, proxyRetTy: Type) =

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/BasicBlocksFusion.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/BasicBlocksFusion.scala
@@ -58,7 +58,7 @@ class BasicBlocksFusion extends Pass {
         // Replace the parameters of the fused block with the supplied arguments
         val paramDef = params.zip(args).map {
           case (param, arg) =>
-            Let(param, Op.Copy(arg))
+            Let(param, Op.Copy(arg), Next.None)
         }
 
         // need to drop the first instruction of recCode, as it is the block label

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/BlockParamReduction.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/BlockParamReduction.scala
@@ -36,7 +36,7 @@ object BlockParamReduction extends PassCompanion {
         }
         val argCopies = params.zip(paramVals).collect {
           case (param, Some(value)) =>
-            Let(param.name, Op.Copy(value))
+            Let(param.name, Op.Copy(value), Next.None)
         }
 
         val newLabel = Inst.Label(name, newParams)

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/Canonicalization.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/Canonicalization.scala
@@ -14,13 +14,13 @@ object Canonicalization extends PassCompanion {
 
   private object Canonicalize extends Transform {
     override def onInst(inst: Inst): Inst = inst match {
-      case Let(n, Op.Bin(bin, ty, lhs, rhs))
+      case Let(n, Op.Bin(bin, ty, lhs, rhs), unwind)
           if (commutativeBin(bin) && scalarValue(lhs)) =>
-        Let(n, Op.Bin(bin, ty, rhs, lhs))
+        Let(n, Op.Bin(bin, ty, rhs, lhs), unwind)
 
-      case Let(n, Op.Comp(comp, ty, lhs, rhs))
+      case Let(n, Op.Comp(comp, ty, lhs, rhs), unwind)
           if (commutativeComp(comp) && scalarValue(lhs)) =>
-        Let(n, Op.Comp(comp, ty, rhs, lhs))
+        Let(n, Op.Comp(comp, ty, rhs, lhs), unwind)
 
       case _ =>
         inst

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/CfChainsSimplification.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/CfChainsSimplification.scala
@@ -126,8 +126,9 @@ class CfChainsSimplification(implicit top: sema.Top) extends Pass {
             .zip(elseArgs)
             .map {
               case (thenV, elseV) =>
-                val freshVar   = fresh()
-                val selectInst = Let(freshVar, Op.Select(cond, thenV, elseV))
+                val freshVar = fresh()
+                val selectInst =
+                  Let(freshVar, Op.Select(cond, thenV, elseV), Next.None)
                 (Val.Local(freshVar, thenV.ty), selectInst)
             }
             .unzip

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/ConstantFolding.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/ConstantFolding.scala
@@ -125,9 +125,9 @@ class ConstantFolding extends Pass {
   }
 
   override def onInsts(insts: Seq[Inst]): Seq[Inst] = insts.map {
-    case inst @ Inst.Let(n, op) =>
+    case inst @ Inst.Let(n, op, unwind) =>
       emulate.lift(op) match {
-        case Some(newVal) => Let(n, Op.Copy(newVal))
+        case Some(newVal) => Let(n, Op.Copy(newVal), unwind)
         case None         => inst
       }
 

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/DeadCodeElimination.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/DeadCodeElimination.scala
@@ -24,7 +24,7 @@ class DeadCodeElimination(implicit top: sema.Top) extends Pass {
         }
         buf += block.label.copy(params = newParams)
         block.insts.foreach {
-          case inst @ Inst.Let(n, op) =>
+          case inst @ Inst.Let(n, _, _) =>
             if (usedef(n).alive) buf += inst
           case inst: Inst.Cf =>
             buf += removeArgs.onInst(inst)

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/PartialEvaluation.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/PartialEvaluation.scala
@@ -17,215 +17,221 @@ class PartialEvaluation extends Pass {
   override def onInsts(insts: Seq[Inst]): Seq[Inst] = insts.map {
 
     /* Iadd */
-    case Let(n, Op.Bin(Iadd, ty, lhs, IVal(0))) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Iadd, ty, lhs, IVal(0)), unwind) =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Iadd, ty, lhs, rhs)) if (lhs == rhs) =>
-      Let(n, Op.Bin(Imul, ty, lhs, IVal(2, ty)))
+    case Let(n, Op.Bin(Iadd, ty, lhs, rhs), unwind) if lhs == rhs =>
+      Let(n, Op.Bin(Imul, ty, lhs, IVal(2, ty)), unwind)
 
     /* Isub */
-    case Let(n, Op.Bin(Isub, ty, lhs, IVal(0))) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Isub, ty, lhs, IVal(0)), unwind) =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Isub, ty, lhs, IVal(i))) if (i < 0) =>
-      Let(n, Op.Bin(Iadd, ty, lhs, IVal(-i, ty)))
+    case Let(n, Op.Bin(Isub, ty, lhs, IVal(i)), unwind) if i < 0 =>
+      Let(n, Op.Bin(Iadd, ty, lhs, IVal(-i, ty)), unwind)
 
-    case Let(n, Op.Bin(Isub, ty, lhs, rhs)) if (lhs == rhs) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Isub, ty, lhs, rhs), unwind) if lhs == rhs =>
+      copy(n, IVal(0, ty), unwind)
 
     /* Imul */
-    case Let(n, Op.Bin(Imul, ty, lhs, IVal(0))) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Imul, ty, lhs, IVal(0)), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
-    case Let(n, Op.Bin(Imul, ty, lhs, IVal(1))) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Imul, ty, lhs, IVal(1)), unwind) =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Imul, ty, lhs, IVal(-1))) =>
-      Let(n, Op.Bin(Isub, ty, IVal(0, ty), lhs))
+    case Let(n, Op.Bin(Imul, ty, lhs, IVal(-1)), unwind) =>
+      Let(n, Op.Bin(Isub, ty, IVal(0, ty), lhs), unwind)
 
-    case Let(n, Op.Bin(Imul, ty, lhs, PowerOf2(shift))) =>
-      Let(n, Op.Bin(Shl, ty, lhs, shift))
+    case Let(n, Op.Bin(Imul, ty, lhs, PowerOf2(shift)), unwind) =>
+      Let(n, Op.Bin(Shl, ty, lhs, shift), unwind)
 
     /* Sdiv */
-    case Let(n, Op.Bin(Sdiv, ty, _, IVal(0))) =>
-      copy(n, Val.Undef(ty))
+    case Let(n, Op.Bin(Sdiv, ty, _, IVal(0)), unwind) =>
+      copy(n, Val.Undef(ty), unwind)
 
-    case Let(n, Op.Bin(Sdiv, ty, lhs, IVal(1))) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Sdiv, ty, lhs, IVal(1)), unwind) =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Sdiv, ty, lhs, IVal(-1))) =>
-      Let(n, Op.Bin(Isub, ty, IVal(0, ty), lhs))
+    case Let(n, Op.Bin(Sdiv, ty, lhs, IVal(-1)), unwind) =>
+      Let(n, Op.Bin(Isub, ty, IVal(0, ty), lhs), unwind)
 
-    case Let(n, Op.Bin(Sdiv, ty, IVal(0), _)) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Sdiv, ty, IVal(0), _), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
     /* Udiv */
-    case Let(n, Op.Bin(Udiv, ty, _, IVal(0))) =>
-      copy(n, Val.Undef(ty))
+    case Let(n, Op.Bin(Udiv, ty, _, IVal(0)), unwind) =>
+      copy(n, Val.Undef(ty), unwind)
 
-    case Let(n, Op.Bin(Udiv, ty, lhs, IVal(1))) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Udiv, ty, lhs, IVal(1)), unwind) =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Udiv, ty, IVal(0), _)) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Udiv, ty, IVal(0), _), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
-    case Let(n, Op.Bin(Udiv, ty, lhs, PowerOf2(shift))) =>
-      Let(n, Op.Bin(Lshr, ty, lhs, shift))
+    case Let(n, Op.Bin(Udiv, ty, lhs, PowerOf2(shift)), unwind) =>
+      Let(n, Op.Bin(Lshr, ty, lhs, shift), unwind)
 
     /* Srem */
-    case Let(n, Op.Bin(Srem, ty, lhs, IVal(0))) =>
-      copy(n, Val.Undef(ty))
+    case Let(n, Op.Bin(Srem, ty, lhs, IVal(0)), unwind) =>
+      copy(n, Val.Undef(ty), unwind)
 
-    case Let(n, Op.Bin(Srem, ty, lhs, IVal(1))) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Srem, ty, lhs, IVal(1)), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
-    case Let(n, Op.Bin(Srem, ty, lhs, IVal(-1))) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Srem, ty, lhs, IVal(-1)), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
-    case Let(n, Op.Bin(Srem, ty, IVal(0), rhs)) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Srem, ty, IVal(0), rhs), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
     /* Urem */
-    case Let(n, Op.Bin(Urem, ty, lhs, IVal(0))) =>
-      copy(n, Val.Undef(ty))
+    case Let(n, Op.Bin(Urem, ty, lhs, IVal(0)), unwind) =>
+      copy(n, Val.Undef(ty), unwind)
 
-    case Let(n, Op.Bin(Urem, ty, lhs, IVal(1))) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Urem, ty, lhs, IVal(1)), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
-    case Let(n, Op.Bin(Urem, ty, IVal(0), rhs)) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Urem, ty, IVal(0), rhs), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
     /* Shl */
-    case Let(n, Op.Bin(Shl, Type.Int, lhs, Val.Int(a))) if ((a & 31) == 0) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Shl, Type.Int, lhs, Val.Int(a)), unwind)
+        if (a & 31) == 0 =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Shl, Type.Long, lhs, Val.Long(a))) if ((a & 63) == 0) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Shl, Type.Long, lhs, Val.Long(a)), unwind)
+        if (a & 63) == 0 =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Shl, ty, IVal(0), _)) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Shl, ty, IVal(0), _), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
     /* Lshr */
-    case Let(n, Op.Bin(Lshr, Type.Int, lhs, Val.Int(a))) if ((a & 31) == 0) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Lshr, Type.Int, lhs, Val.Int(a)), unwind)
+        if (a & 31) == 0 =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Lshr, Type.Long, lhs, Val.Long(a))) if ((a & 63) == 0) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Lshr, Type.Long, lhs, Val.Long(a)), unwind)
+        if (a & 63) == 0 =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Lshr, ty, IVal(0), rhs)) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Lshr, ty, IVal(0), rhs), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
     /* Ashr */
-    case Let(n, Op.Bin(Ashr, Type.Int, lhs, Val.Int(a))) if ((a & 31) == 0) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Ashr, Type.Int, lhs, Val.Int(a)), unwind)
+        if (a & 31) == 0 =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Ashr, Type.Long, lhs, Val.Long(a))) if ((a & 63) == 0) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Ashr, Type.Long, lhs, Val.Long(a)), unwind)
+        if (a & 63) == 0 =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Ashr, ty, IVal(0), rhs)) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Ashr, ty, IVal(0), rhs), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
-    case Let(n, Op.Bin(Ashr, ty, IVal(-1), rhs)) =>
-      copy(n, IVal(-1, ty))
+    case Let(n, Op.Bin(Ashr, ty, IVal(-1), rhs), unwind) =>
+      copy(n, IVal(-1, ty), unwind)
 
     /* And */
-    case Let(n, Op.Bin(And, ty, lhs, rhs)) if (lhs == rhs) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(And, ty, lhs, rhs), unwind) if lhs == rhs =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(And, ty, lhs, IVal(0))) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(And, ty, lhs, IVal(0)), unwind) =>
+      copy(n, IVal(0, ty), unwind)
 
-    case Let(n, Op.Bin(And, ty, lhs, IVal(-1))) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(And, ty, lhs, IVal(-1)), unwind) =>
+      copy(n, lhs, unwind)
 
     /* Or */
-    case Let(n, Op.Bin(Or, ty, lhs, rhs)) if (lhs == rhs) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Or, ty, lhs, rhs), unwind) if lhs == rhs =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Or, ty, lhs, IVal(0))) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Or, ty, lhs, IVal(0)), unwind) =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Bin(Or, ty, lhs, IVal(-1))) =>
-      copy(n, IVal(-1, ty))
+    case Let(n, Op.Bin(Or, ty, lhs, IVal(-1)), unwind) =>
+      copy(n, IVal(-1, ty), unwind)
 
     /* Xor */
-    case Let(n, Op.Bin(Xor, ty, lhs, rhs)) if (lhs == rhs) =>
-      copy(n, IVal(0, ty))
+    case Let(n, Op.Bin(Xor, ty, lhs, rhs), unwind) if lhs == rhs =>
+      copy(n, IVal(0, ty), unwind)
 
-    case Let(n, Op.Bin(Xor, ty, lhs, IVal(0))) =>
-      copy(n, lhs)
+    case Let(n, Op.Bin(Xor, ty, lhs, IVal(0)), unwind) =>
+      copy(n, lhs, unwind)
 
     /* Ieq */
-    case Let(n, Op.Comp(Ieq, ty, lhs, rhs)) if (lhs == rhs) =>
-      copy(n, Val.True)
+    case Let(n, Op.Comp(Ieq, ty, lhs, rhs), unwind) if lhs == rhs =>
+      copy(n, Val.True, unwind)
 
-    case Let(n, Op.Comp(Ieq, ty, lhs, Val.True)) =>
-      copy(n, lhs)
+    case Let(n, Op.Comp(Ieq, ty, lhs, Val.True), unwind) =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Comp(Ieq, ty, lhs, Val.False)) =>
-      neg(n, lhs)
+    case Let(n, Op.Comp(Ieq, ty, lhs, Val.False), unwind) =>
+      neg(n, lhs, unwind)
 
     /* Ine */
-    case Let(n, Op.Comp(Ine, ty, lhs, rhs)) if (lhs == rhs) =>
-      copy(n, Val.False)
+    case Let(n, Op.Comp(Ine, ty, lhs, rhs), unwind) if lhs == rhs =>
+      copy(n, Val.False, unwind)
 
-    case Let(n, Op.Comp(Ine, ty, lhs, Val.False)) =>
-      copy(n, lhs)
+    case Let(n, Op.Comp(Ine, ty, lhs, Val.False), unwind) =>
+      copy(n, lhs, unwind)
 
-    case Let(n, Op.Comp(Ine, ty, lhs, Val.True)) =>
-      neg(n, lhs)
+    case Let(n, Op.Comp(Ine, ty, lhs, Val.True), unwind) =>
+      neg(n, lhs, unwind)
 
     /* Ugt */
-    case Let(n, Op.Comp(Ugt, ty, lhs, IVal(a))) if (a == umaxValue(ty)) =>
-      copy(n, Val.False)
+    case Let(n, Op.Comp(Ugt, ty, lhs, IVal(a)), unwind) if a == umaxValue(ty) =>
+      copy(n, Val.False, unwind)
 
     /* Uge */
-    case Let(n, Op.Comp(Uge, ty, lhs, IVal(a))) if (a == uminValue(ty)) =>
-      copy(n, Val.True)
+    case Let(n, Op.Comp(Uge, ty, lhs, IVal(a)), unwind) if a == uminValue(ty) =>
+      copy(n, Val.True, unwind)
 
     /* Ult */
-    case Let(n, Op.Comp(Ult, ty, lhs, IVal(a))) if (a == uminValue(ty)) =>
-      copy(n, Val.False)
+    case Let(n, Op.Comp(Ult, ty, lhs, IVal(a)), unwind) if a == uminValue(ty) =>
+      copy(n, Val.False, unwind)
 
     /* Ule */
-    case Let(n, Op.Comp(Ule, ty, lhs, IVal(a))) if (a == umaxValue(ty)) =>
-      copy(n, Val.True)
+    case Let(n, Op.Comp(Ule, ty, lhs, IVal(a)), unwind) if a == umaxValue(ty) =>
+      copy(n, Val.True, unwind)
 
     /* Sgt */
-    case Let(n, Op.Comp(Sgt, ty, lhs, IVal(a))) if (a == maxValue(ty)) =>
-      copy(n, Val.False)
+    case Let(n, Op.Comp(Sgt, ty, lhs, IVal(a)), unwind) if a == maxValue(ty) =>
+      copy(n, Val.False, unwind)
 
     /* Sge */
-    case Let(n, Op.Comp(Sge, ty, lhs, IVal(a))) if (a == minValue(ty)) =>
-      copy(n, Val.True)
+    case Let(n, Op.Comp(Sge, ty, lhs, IVal(a)), unwind) if a == minValue(ty) =>
+      copy(n, Val.True, unwind)
 
     /* Slt */
-    case Let(n, Op.Comp(Slt, ty, lhs, IVal(a))) if (a == minValue(ty)) =>
-      copy(n, Val.False)
+    case Let(n, Op.Comp(Slt, ty, lhs, IVal(a)), unwind) if a == minValue(ty) =>
+      copy(n, Val.False, unwind)
 
     /* Sle */
-    case Let(n, Op.Comp(Sle, ty, lhs, IVal(a))) if (a == maxValue(ty)) =>
-      copy(n, Val.True)
+    case Let(n, Op.Comp(Sle, ty, lhs, IVal(a)), unwind) if a == maxValue(ty) =>
+      copy(n, Val.True, unwind)
 
     /* Select */
-    case Let(n, Op.Select(cond, thenv, elsev)) if (thenv == elsev) =>
-      copy(n, thenv)
+    case Let(n, Op.Select(cond, thenv, elsev), unwind) if thenv == elsev =>
+      copy(n, thenv, unwind)
 
-    case Let(n, Op.Select(cond, Val.True, Val.False)) =>
-      copy(n, cond)
+    case Let(n, Op.Select(cond, Val.True, Val.False), unwind) =>
+      copy(n, cond, unwind)
 
-    case Let(n, Op.Select(cond, Val.False, Val.True)) =>
-      neg(n, cond)
+    case Let(n, Op.Select(cond, Val.False, Val.True), unwind) =>
+      neg(n, cond, unwind)
 
     case inst =>
       inst
   }
 
-  private def copy(n: Local, value: Val): Inst =
-    Let(n, Op.Copy(value))
+  private def copy(n: Local, value: Val, unwind: Next): Inst =
+    Let(n, Op.Copy(value), unwind)
 
-  private def neg(n: Local, value: Val): Inst =
-    Let(n, Op.Bin(Xor, Type.Bool, value, Val.True))
+  private def neg(n: Local, value: Val, unwind: Next): Inst =
+    Let(n, Op.Bin(Xor, Type.Bool, value, Val.True), unwind)
 }
 
 object PartialEvaluation extends PassCompanion {

--- a/tools/src/main/scala/scala/scalanative/sema/ControlFlow.scala
+++ b/tools/src/main/scala/scala/scalanative/sema/ControlFlow.scala
@@ -24,7 +24,7 @@ object ControlFlow {
     lazy val splitCount: Int = {
       var count = 0
       insts.foreach {
-        case Inst.Let(_, call: Op.Call) if call.unwind ne Next.None =>
+        case Inst.Let(_, call: Op.Call, unwind) if unwind ne Next.None =>
           count += 1
         case _ =>
           ()
@@ -108,8 +108,8 @@ object ControlFlow {
       def visit(node: Block): Unit = {
         val insts :+ cf = node.insts
         insts.foreach {
-          case Inst.Let(_, op: Op.Unwind) if op.unwind ne Next.None =>
-            edge(node, block(op.unwind.name), op.unwind)
+          case Inst.Let(_, op, unwind) if unwind ne Next.None =>
+            edge(node, block(unwind.name), unwind)
           case _ =>
             ()
         }

--- a/tools/src/main/scala/scala/scalanative/sema/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/sema/UseDef.scala
@@ -55,11 +55,11 @@ object UseDef {
   }
 
   private def isPure(inst: Inst)(implicit top: Top) = inst match {
-    case Inst.Let(_, Op.Call(_, Val.Global(Ref(node), _), _, _)) =>
+    case Inst.Let(_, Op.Call(_, Val.Global(Ref(node), _), _), _) =>
       node.attrs.isPure
-    case Inst.Let(_, Op.Module(Ref(node), _)) =>
+    case Inst.Let(_, Op.Module(Ref(node)), _) =>
       node.attrs.isPure
-    case Inst.Let(_, _: Op.Pure) =>
+    case Inst.Let(_, _: Op.Pure, _) =>
       true
     case _ =>
       false
@@ -99,8 +99,8 @@ object UseDef {
     blocks.foreach { block =>
       enterBlock(block.name, block.params.map(_.name))
       block.insts.foreach {
-        case Inst.Let(n, _) => enterInst(n)
-        case _              => ()
+        case Inst.Let(n, _, _) => enterInst(n)
+        case _                 => ()
       }
     }
 


### PR DESCRIPTION
Previously, we only stored them in calls and
module accessors. This is a breaking NIR change.