### PR TITLE
Automatically discover clang 7 and 8 

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -132,7 +132,8 @@ object Discover {
 
   /** Versions of clang which are known to work with Scala Native. */
   private[scalanative] val clangVersions =
-    Seq(("7", ""),
+    Seq(("8", ""),
+        ("7", ""),
         ("6", "0"),
         ("5", "0"),
         ("4", "0"),

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -133,7 +133,9 @@ object Discover {
   /** Versions of clang which are known to work with Scala Native. */
   private[scalanative] val clangVersions =
     Seq(("8", ""),
+        ("8", "0"),
         ("7", ""),
+        ("7", "0"), // LLVM changed version numbering scheme, try both.
         ("6", "0"),
         ("5", "0"),
         ("4", "0"),

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -132,7 +132,13 @@ object Discover {
 
   /** Versions of clang which are known to work with Scala Native. */
   private[scalanative] val clangVersions =
-    Seq(("6", "0"), ("5", "0"), ("4", "0"), ("3", "9"), ("3", "8"), ("3", "7"))
+    Seq(("7", ""),
+        ("6", "0"),
+        ("5", "0"),
+        ("4", "0"),
+        ("3", "9"),
+        ("3", "8"),
+        ("3", "7"))
 
   /** Discover concrete binary path using command name and
    *  a sequence of potential supported versions.
@@ -153,7 +159,8 @@ object Discover {
       case None => {
         val binaryNames = binaryVersions.flatMap {
           case (major, minor) =>
-            Seq(s"$binaryName$major$minor", s"$binaryName-$major.$minor")
+            val sep = if (minor == "") "" else "."
+            Seq(s"$binaryName$major$minor", s"$binaryName-$major${sep}$minor")
         } :+ binaryName
 
         Process("which" +: binaryNames)


### PR DESCRIPTION
  * clang-7 will soon become available. This pull request allows
    Scala-Native to be built using Clang-7.

  * clang-7, when present, is used in preference to any lower clang
    version. In particular, Discover.scala _does_not_ use the
    update-alternative mechanism present on some (Ubuntu) systems.

  * LLVM and Clang are being released with executable files using a
    new version scheme. These files now have a major
    version, but no minor version.

64/32 bit issues:

      None known

Documentation:

      Deserves a release note.

Testing:

 * All testing done on Ubuntu 16.04 systems.

* Manually tested with clang-7 not present on X86.

* Manually tested with both clang-7 & clang-6 present on X86_64.

* Manually tested with only clang-7 present on X86_64.