### PR TITLE
Add four Java 8 API methods: {Long, Int, Short, Byte}ValueExact.

### DIFF
--- a/javalib/src/main/scala/java/math/BigInteger.scala
+++ b/javalib/src/main/scala/java/math/BigInteger.scala
@@ -333,6 +333,13 @@ class BigInteger extends Number with Comparable[BigInteger] {
 
   def bitLength(): Int = BitLevel.bitLength(this)
 
+  def byteValueExact(): Byte = {
+    if ((numberLength > 1) || (bitLength() >= java.lang.Byte.SIZE)) {
+      throw new ArithmeticException("BigInteger out of byte range")
+    }
+    byteValue()
+  }
+
   def clearBit(n: Int): BigInteger = {
     if (testBit(n)) BitLevel.flipBit(this, n)
     else this
@@ -514,6 +521,13 @@ class BigInteger extends Number with Comparable[BigInteger] {
 
   override def intValue(): Int = sign * digits(0)
 
+  def intValueExact(): Int = {
+    if ((numberLength > 1) || (bitLength() >= java.lang.Integer.SIZE)) {
+      throw new ArithmeticException("BigInteger out of int range")
+    }
+    intValue()
+  }
+
   def isProbablePrime(certainty: Int): Boolean =
     Primality.isProbablePrime(abs(), certainty)
 
@@ -523,6 +537,13 @@ class BigInteger extends Number with Comparable[BigInteger] {
         (digits(1).toLong << 32) | (digits(0) & 0xFFFFFFFFL)
       else digits(0) & 0xFFFFFFFFL
     sign * value
+  }
+
+  def longValueExact(): Long = {
+    if ((numberLength > 2) || (bitLength() >= java.lang.Long.SIZE)) {
+      throw new ArithmeticException("BigInteger out of long range")
+    }
+    longValue()
   }
 
   def max(bi: BigInteger): BigInteger = {
@@ -677,6 +698,13 @@ class BigInteger extends Number with Comparable[BigInteger] {
     if (n == 0 || sign == 0) this
     else if (n > 0) BitLevel.shiftRight(this, n)
     else BitLevel.shiftLeft(this, -n)
+  }
+
+  def shortValueExact(): Short = {
+    if ((numberLength > 1) || (bitLength() >= java.lang.Short.SIZE)) {
+      throw new ArithmeticException("BigInteger out of short range")
+    }
+    shortValue()
   }
 
   def signum(): Int = sign

--- a/unit-tests/src/test/scala/java/math/BigIntegerSuite.scala
+++ b/unit-tests/src/test/scala/java/math/BigIntegerSuite.scala
@@ -1,0 +1,113 @@
+package java.math
+
+object BigIntegerSuite extends tests.Suite {
+
+// byteValueExact
+
+  val byteMaxBi = new BigInteger(java.lang.Byte.MAX_VALUE.toString)
+  val byteMinBi = new BigInteger(java.lang.Byte.MIN_VALUE.toString)
+
+  test("byteValueExact with BigInteger > Byte.MAX_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = byteMaxBi.add(BigInteger.ONE)
+      bi.byteValueExact()
+    }
+  }
+
+  test("byteValueExact with BigInteger == Byte.MAX_VALUE should not throw") {
+    assert(byteMaxBi.byteValueExact() == java.lang.Byte.MAX_VALUE)
+  }
+
+  test("byteValueExact with BigInteger == Byte.MIN_VALUE should not throw") {
+    assert(byteMinBi.byteValueExact() == java.lang.Byte.MIN_VALUE)
+  }
+
+  test("byteValueExact with BigInteger < Byte.MIN_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = byteMinBi.subtract(BigInteger.ONE)
+      bi.byteValueExact()
+    }
+  }
+
+// intValueExact
+
+  val intMaxBi = new BigInteger(java.lang.Integer.MAX_VALUE.toString)
+  val intMinBi = new BigInteger(java.lang.Integer.MIN_VALUE.toString)
+
+  test("intValueExact with BigInteger > Integer.MAX_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = intMaxBi.add(BigInteger.ONE)
+      bi.intValueExact()
+    }
+  }
+
+  test("intValueExact with BigInteger == Integer.MAX_VALUE should not throw") {
+    assert(intMaxBi.intValueExact() == java.lang.Integer.MAX_VALUE)
+  }
+
+  test("intValueExact with BigInteger == Integer.MIN_VALUE should not throw") {
+    assert(intMinBi.intValueExact() == java.lang.Integer.MIN_VALUE)
+  }
+
+  test("intValueExact with BigInteger < Integer.MIN_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = intMinBi.subtract(BigInteger.ONE)
+      bi.intValueExact()
+    }
+  }
+
+// longValueExact
+
+  val longMaxBi = new BigInteger(java.lang.Long.MAX_VALUE.toString)
+  val longMinBi = new BigInteger(java.lang.Long.MIN_VALUE.toString)
+
+  test("longValueExact with BigInteger > Long.MAX_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = longMaxBi.add(BigInteger.ONE)
+      bi.longValueExact()
+    }
+  }
+
+  test("longValueExact with BigInteger == Long.MAX_VALUE should not throw") {
+    assert(longMaxBi.longValueExact() == java.lang.Long.MAX_VALUE)
+  }
+
+  test("longValueExact with BigInteger == Long.MIN_VALUE should not throw") {
+    assert(longMinBi.longValueExact() == java.lang.Long.MIN_VALUE)
+  }
+
+  test("longValueExact with BigInteger < Long.MIN_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = longMinBi.subtract(BigInteger.ONE)
+      bi.longValueExact()
+    }
+  }
+
+// shortValueExact
+
+  val shortMaxBi = new BigInteger(java.lang.Short.MAX_VALUE.toString)
+  val shortMinBi = new BigInteger(java.lang.Short.MIN_VALUE.toString)
+
+  test("shortValueExact with BigInteger > Short.MAX_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = shortMaxBi.add(BigInteger.ONE)
+      bi.shortValueExact()
+    }
+  }
+
+  test("shortValueExact with BigInteger == Short.MAX_VALUE should not throw") {
+    assert(shortMaxBi.shortValueExact() == java.lang.Short.MAX_VALUE)
+  }
+
+  test("shortValueExact with BigInteger == Short.MIN_VALUE should not throw") {
+    assert(shortMinBi.shortValueExact() == java.lang.Short.MIN_VALUE)
+  }
+
+  test("shortValueExact with BigInteger < Short.MIN_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = shortMinBi.subtract(BigInteger.ONE)
+      bi.shortValueExact()
+    }
+  }
+
+}


### PR DESCRIPTION
* This pull request adds four missing Java 8 API routines. These
  routines throw exceptions if the BigInteger does not fit into
  the destination type.

* I worked around the absence of these routines when I ported the
  Google Ryu double/float toString code to ScalaNative.
  Having these routines available will ease the re-port of Ryu I am about
  to do.

64/32 bit issues:

      None known

Documentation:

      Deserves a release note.

Testing:

* Passes test-all on both X86_64 & X86 systems.