### PR TITLE
Implement BigMath arbitrary precision square root & Java API 9/1O features.

### DIFF
--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -21,6 +21,9 @@
  *  limitations under the License.
  */
 
+/* Modified for ScalaNative. sqrt() added. See git commit comments.
+ */
+
 package java.math
 
 import java.util.Arrays
@@ -110,9 +113,11 @@ object BigDecimal {
     new BigDecimal(d.toString)
   }
 
-  private def addAndMult10(thisValue: BigDecimal,
-                           augend: BigDecimal,
-                           diffScale: Int): BigDecimal = {
+  private def addAndMult10(
+      thisValue: BigDecimal,
+      augend: BigDecimal,
+      diffScale: Int
+  ): BigDecimal = {
     def powLen           = LongTenPowsBitLength(diffScale)
     def augPlusPowLength = augend._bitLength + powLen
     def maxLen           = Math.max(thisValue._bitLength, augPlusPowLength) + 1
@@ -128,10 +133,12 @@ object BigDecimal {
     }
   }
 
-  private def divideBigIntegers(scaledDividend: BigInteger,
-                                scaledDivisor: BigInteger,
-                                scale: Int,
-                                roundingMode: RoundingMode): BigDecimal = {
+  private def divideBigIntegers(
+      scaledDividend: BigInteger,
+      scaledDivisor: BigInteger,
+      scale: Int,
+      roundingMode: RoundingMode
+  ): BigDecimal = {
     val qr = scaledDividend.divideAndRemainderImpl(scaledDivisor)
     // If after division there is a remainder...
 
@@ -171,10 +178,12 @@ object BigDecimal {
     }
   }
 
-  private def dividePrimitiveLongs(scaledDividend: Long,
-                                   scaledDivisor: Long,
-                                   scale: Int,
-                                   roundingMode: RoundingMode): BigDecimal = {
+  private def dividePrimitiveLongs(
+      scaledDividend: Long,
+      scaledDivisor: Long,
+      scale: Int,
+      roundingMode: RoundingMode
+  ): BigDecimal = {
     import java.lang.{Long => JLong}
 
     val remainder = scaledDividend % scaledDivisor
@@ -212,9 +221,11 @@ object BigDecimal {
    *  @param roundingMode the type of rounding
    *  @return the carry propagated after rounding.
    */
-  private def roundingBehavior(parityBit: Int,
-                               fraction: Int,
-                               roundingMode: RoundingMode): Int = {
+  private def roundingBehavior(
+      parityBit: Int,
+      fraction: Int,
+      roundingMode: RoundingMode
+  ): Int = {
     import RoundingMode._
 
     val absFraction = Math.abs(fraction)
@@ -285,11 +296,13 @@ object BigDecimal {
     s.substring(0, pos) + s2 + s.substring(pos)
 
   @inline
-  private def insertString(s: String,
-                           pos: Int,
-                           s2: String,
-                           s2Start: Int,
-                           s2Len: Int): String = {
+  private def insertString(
+      s: String,
+      pos: Int,
+      s2: String,
+      s2Start: Int,
+      s2Len: Int
+  ): String = {
     insertString(s, pos, s2.substring(s2Start, s2Start + s2Len))
   }
 
@@ -367,7 +380,8 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
 
     if (last >= in.length || offset < 0 || len <= 0 || last < 0) {
       throw new NumberFormatException(
-        s"Bad offset/length: offset=${offset} len=$len in.length=${in.length}")
+        s"Bad offset/length: offset=${offset} len=$len in.length=${in.length}"
+      )
     }
 
     var index = offset
@@ -479,8 +493,8 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     _scale = 1075 - ((bits >> 52) & 2047).toInt
     // Extracting the 52 bits of the mantissa.
     val mantissa =
-      if (_scale == 1075) (bits & 0xFFFFFFFFFFFFFL) << 1
-      else (bits & 0xFFFFFFFFFFFFFL) | 0x10000000000000L
+      if (_scale == 1075) (bits & 0XFFFFFFFFFFFFFL) << 1
+      else (bits & 0XFFFFFFFFFFFFFL) | 0X10000000000000L
 
     if (mantissa == 0) {
       _scale = 0
@@ -514,7 +528,8 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
         _bitLength = bitLength(_smallValue)
       } else {
         setUnscaledValue(
-          multiplyByFivePow(BigInteger.valueOf(mantissa3), _scale))
+          multiplyByFivePow(BigInteger.valueOf(mantissa3), _scale)
+        )
       }
     } else {
       _smallValue = mantissa3
@@ -579,8 +594,10 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
       if (Math.max(this._bitLength, augend._bitLength) + 1 < 64)
         valueOf(this._smallValue + augend._smallValue, this._scale)
       else
-        new BigDecimal(this.getUnscaledValue.add(augend.getUnscaledValue),
-                       this._scale)
+        new BigDecimal(
+          this.getUnscaledValue.add(augend.getUnscaledValue),
+          this._scale
+        )
     } else if (diffScale > 0) {
       addAndMult10(this, augend, diffScale)
     } else {
@@ -612,7 +629,8 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
         } else {
           val tempBI2 = larger.getUnscaledValue.subtract(biLarger)
           multiplyByPosInt(tempBI2, 10).add(
-            BigInteger.valueOf(largerSignum * 9))
+            BigInteger.valueOf(largerSignum * 9)
+          )
         }
       }
       // Rounding the improved adding
@@ -634,8 +652,10 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
       if (Math.max(this._bitLength, subtrahend._bitLength) + 1 < 64)
         valueOf(this._smallValue - subtrahend._smallValue, this._scale)
       else
-        new BigDecimal(getUnscaledValue.subtract(subtrahend.getUnscaledValue),
-                       _scale)
+        new BigDecimal(
+          getUnscaledValue.subtract(subtrahend.getUnscaledValue),
+          _scale
+        )
     } else if (diffScale > 0) {
       def powTenLen = LongTenPowsBitLength(diffScale)
       def maxLen =
@@ -656,8 +676,10 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
 
       if (negDiffScale < LongTenPows.length && maxLen < 64) {
         val powTen = LongTenPows(negDiffScale)
-        valueOf(_smallValue * powTen - subtrahend._smallValue,
-                subtrahend._scale)
+        valueOf(
+          _smallValue * powTen - subtrahend._smallValue,
+          subtrahend._scale
+        )
       } else {
         val mult    = multiplyByTenPow(this.getUnscaledValue, negDiffScale)
         val multSub = mult.subtract(subtrahend.getUnscaledValue)
@@ -696,8 +718,10 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     if (this.isZero || multiplicand.isZero) {
       zeroScaledBy(newScale)
     } else if (this._bitLength + multiplicand._bitLength < 64) {
-      valueOf(this._smallValue * multiplicand._smallValue,
-              safeLongToInt(newScale))
+      valueOf(
+        this._smallValue * multiplicand._smallValue,
+        safeLongToInt(newScale)
+      )
     } else {
       val unscaled =
         this.getUnscaledValue.multiply(multiplicand.getUnscaledValue)
@@ -714,9 +738,11 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
   def divide(divisor: BigDecimal, scale: Int, roundingMode: Int): BigDecimal =
     divide(divisor, scale, RoundingMode.valueOf(roundingMode))
 
-  def divide(divisor: BigDecimal,
-             scale: Int,
-             roundingMode: RoundingMode): BigDecimal = {
+  def divide(
+      divisor: BigDecimal,
+      scale: Int,
+      roundingMode: RoundingMode
+  ): BigDecimal = {
     if (roundingMode == null)
       throw new NullPointerException("roundingMode == null")
     else if (divisor.isZero)
@@ -816,7 +842,8 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
       // If  abs(q) != 1  then the quotient is periodic
       if (q.abs() != BigInteger.ONE) {
         throw new ArithmeticException(
-          "Non-terminating decimal expansion; no exact representable decimal result")
+          "Non-terminating decimal expansion; no exact representable decimal result"
+        )
       }
 
       // The sign of the is fixed and the quotient will be saved in 'p2'
@@ -941,8 +968,10 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     else new BigDecimal(integralValue, safeLongToInt(varScale))
   }
 
-  def divideToIntegralValue(divisor: BigDecimal,
-                            mc: MathContext): BigDecimal = {
+  def divideToIntegralValue(
+      divisor: BigDecimal,
+      mc: MathContext
+  ): BigDecimal = {
     // scalastyle:off return
     val mcPrecision   = mc.precision
     val diffPrecision = this.precision() - divisor.precision()
@@ -1004,10 +1033,12 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     // To strip trailing zeros until the specified precision is reached
     @inline
     @tailrec
-    def loop(i: Int,
-             ns: Long,
-             q: BigInteger,
-             prec: Int): (Long, BigInteger, Int) = {
+    def loop(
+        i: Int,
+        ns: Long,
+        q: BigInteger,
+        prec: Int
+    ): (Long, BigInteger, Int) = {
       if (!q.testBit(0)) {
         val qr = q.divideAndRemainderImpl(BigTenPows(i))
         val cond1 = {
@@ -1046,8 +1077,10 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
   def divideAndRemainder(divisor: BigDecimal): Array[BigDecimal] =
     divideAndRemainderImpl(divisor).toArray()
 
-  def divideAndRemainder(divisor: BigDecimal,
-                         mc: MathContext): Array[BigDecimal] =
+  def divideAndRemainder(
+      divisor: BigDecimal,
+      mc: MathContext
+  ): Array[BigDecimal] =
     divideAndRemainderImpl(divisor, mc).toArray()
 
   def pow(n: Int): BigDecimal = {
@@ -1177,8 +1210,10 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
       if (diffScale < LongTenPows.length && cmp < 64) {
         valueOf(this._smallValue * LongTenPows(diffScale.toInt), newScale)
       } else {
-        new BigDecimal(multiplyByTenPow(getUnscaledValue, diffScale.toInt),
-                       newScale)
+        new BigDecimal(
+          multiplyByTenPow(getUnscaledValue, diffScale.toInt),
+          newScale
+        )
       }
     } else if (this._bitLength < 64 && -diffScale < LongTenPows.length) {
       val lpt = LongTenPows(-diffScale.toInt)
@@ -1223,9 +1258,11 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
       // while the number is even...
       @inline
       @tailrec
-      def loop(i: Int,
-               strippedBI: BigInteger,
-               scale: Long): (BigInteger, Long) = {
+      def loop(
+          i: Int,
+          strippedBI: BigInteger,
+          scale: Long
+      ): (BigInteger, Long) = {
         if (!strippedBI.testBit(0)) {
           // To divide by 10^i
           val qr = strippedBI.divideAndRemainderImpl(BigTenPows(i))
@@ -1585,7 +1622,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
           bits += 2
       }
       // Testing bit 54 to check if the carry creates a new binary digit
-      if ((bits & 0x40000000000000L) == 0) {
+      if ((bits & 0X40000000000000L) == 0) {
         // To drop the last bit of mantissa (first discarded)
         bits >>= 1
         exponent += discardedSize
@@ -1616,15 +1653,98 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
 
         // Construct the 64 double bits: [sign(1), exponent(11), mantissa(52)]
         val resultBits =
-          (sign & 0x8000000000000000L) |
+          (sign & 0X8000000000000000L) |
             (exponent.toLong << 52) |
-            (bits & 0xFFFFFFFFFFFFFL)
+            (bits & 0XFFFFFFFFFFFFFL)
         java.lang.Double.longBitsToDouble(resultBits)
       }
     }
   }
 
   def ulp(): BigDecimal = valueOf(1, _scale)
+
+  def sqrt(mc: MathContext): BigDecimal = {
+
+    if (mc == null)
+      throw new NullPointerException("MathContext == null")
+
+    val sgn = this.signum
+
+    if (sgn < 0)
+      throw new ArithmeticException("sqrt of negative number")
+    else if (sgn == 0) {
+      val newScale = this.scale / 2
+      BigDecimal.valueOf(0L, newScale)
+    } else {
+
+      // Babylonian or Newton's method.
+
+      val radicand = this
+
+      // To avoid least significant digit rounding issues, do sqrt math
+      // with one additional guard digit of precision. Just before returning
+      // the result drop that digit by rounding using the MathContext
+      // passed in.
+
+      val workMc = new MathContext(mc.getPrecision + 1, mc.getRoundingMode)
+
+      val bdTWO = new BigDecimal("2.0", workMc)
+      @tailrec
+      def loop(x: BigDecimal): BigDecimal = {
+
+        val y = (radicand
+          .divide(x, workMc))
+          .add(x)
+          .divide(bdTWO, workMc)
+
+        // Important note on loop/recursion termination.
+        //
+        // Math theory guarantees that a correct implementation will
+        // converge. That is, the difference between two iterations
+        // will become less than epsilon or tolerance, for a suitable
+        // definition of epsilon.
+        //
+        // Using the workMc, with its guard digit, in the subtraction drops
+        // digits to_the_right_of or smaller_than workMc.getPrecision defines
+        // such an epsilon. Digits to_the_right_of or smaller_than
+        // workMc.getPrecison are dropped, allowing a direct comparison to
+        // BigDecimal.ZERO and eventual loop/recursion termination.
+
+        val delta = y.subtract(x, workMc)
+        val done  = (delta.compareTo(ZERO) == 0)
+
+        if (done) y else loop(y)
+
+      }
+
+      def guess(): BigDecimal = {
+
+        // Try for a guess better than a hardcoded 1 or this/2 without
+        // expending lots of CPU cycles. A reasonably good initial guess
+        // saves many trips through the loop, with its division and general
+        // BigDecimal math.
+        //
+        // Can not simply bitshift a BigDecimal. A math.pow() of a double
+        // by power of two is not all that expensive.
+        //
+        // Bet that most BigDecimals will have whole integer portions
+        // larger than 10 or so.  For small radicands, this algorithm
+        // is slightly expensive and yields an OK but not superior guess.
+        // It comes onto its own with larger radicands and amply repays
+        // the cost of the Math.pow() by its much better guess saving many
+        // trips through the loop.
+        //
+        // Improvements are left to the Gentle Reader.
+
+        val powerOfTwo = (this._bitLength) - (_scale / Log2).toLong
+
+        new BigDecimal(Math.pow(2, powerOfTwo / 2))
+      }
+
+      loop(guess()).round(mc) // drop method-internal extra digit of precision.
+
+    }
+  }
 
   private def decimalDigitsInLong(value: Long): Int = {
     if (value == Long.MinValue) {
@@ -1644,8 +1764,10 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
   }
 
   @inline
-  private def divideAndRemainderImpl(divisor: BigDecimal,
-                                     mc: MathContext): QuotAndRem = {
+  private def divideAndRemainderImpl(
+      divisor: BigDecimal,
+      mc: MathContext
+  ): QuotAndRem = {
     val quot = this.divideToIntegralValue(divisor, mc)
     val rem  = this.subtract(quot.multiply(divisor))
     new QuotAndRem(quot, rem)
@@ -1725,7 +1847,8 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     } else {
       new BigDecimal(
         multiplyByTenPow(getUnscaledValue, safeLongToInt(-newScale)),
-        0)
+        0
+      )
     }
   }
 

--- a/javalib/src/main/scala/java/math/BigInteger.scala
+++ b/javalib/src/main/scala/java/math/BigInteger.scala
@@ -333,6 +333,13 @@ class BigInteger extends Number with Comparable[BigInteger] {
 
   def bitLength(): Int = BitLevel.bitLength(this)
 
+  def byteValueExact(): Byte = {
+    if ((numberLength > 1) || (bitLength() >= java.lang.Byte.SIZE)) {
+      throw new ArithmeticException("BigInteger out of byte range")
+    }
+    byteValue()
+  }
+
   def clearBit(n: Int): BigInteger = {
     if (testBit(n)) BitLevel.flipBit(this, n)
     else this
@@ -514,6 +521,13 @@ class BigInteger extends Number with Comparable[BigInteger] {
 
   override def intValue(): Int = sign * digits(0)
 
+  def intValueExact(): Int = {
+    if ((numberLength > 1) || (bitLength() >= java.lang.Integer.SIZE)) {
+      throw new ArithmeticException("BigInteger out of int range")
+    }
+    intValue()
+  }
+
   def isProbablePrime(certainty: Int): Boolean =
     Primality.isProbablePrime(abs(), certainty)
 
@@ -523,6 +537,13 @@ class BigInteger extends Number with Comparable[BigInteger] {
         (digits(1).toLong << 32) | (digits(0) & 0xFFFFFFFFL)
       else digits(0) & 0xFFFFFFFFL
     sign * value
+  }
+
+  def longValueExact(): Long = {
+    if ((numberLength > 2) || (bitLength() >= java.lang.Long.SIZE)) {
+      throw new ArithmeticException("BigInteger out of long range")
+    }
+    longValue()
   }
 
   def max(bi: BigInteger): BigInteger = {
@@ -677,6 +698,13 @@ class BigInteger extends Number with Comparable[BigInteger] {
     if (n == 0 || sign == 0) this
     else if (n > 0) BitLevel.shiftRight(this, n)
     else BitLevel.shiftLeft(this, -n)
+  }
+
+  def shortValueExact(): Short = {
+    if ((numberLength > 1) || (bitLength() >= java.lang.Short.SIZE)) {
+      throw new ArithmeticException("BigInteger out of short range")
+    }
+    shortValue()
   }
 
   def signum(): Int = sign

--- a/javalib/src/main/scala/java/math/BigInteger.scala
+++ b/javalib/src/main/scala/java/math/BigInteger.scala
@@ -39,6 +39,10 @@
  * INCLUDES MODIFICATIONS BY RICHARD ZSCHECH AS WELL AS GOOGLE.
  */
 
+/* Modified for ScalaNative. sqrt() and Java 9 API features added. See
+ * git commit comments.
+ */
+
 package java.math
 
 import java.util.Random
@@ -49,6 +53,8 @@ object BigInteger {
   final val ONE = new BigInteger(1, 1)
 
   final val TEN = new BigInteger(1, 10)
+
+  final val TWO = new BigInteger(1, 2)
 
   final val ZERO = new BigInteger(0, 0)
 
@@ -70,7 +76,7 @@ object BigInteger {
   private final val SMALL_VALUES = Array(
     ZERO,
     ONE,
-    new BigInteger(1, 2),
+    TWO,
     new BigInteger(1, 3),
     new BigInteger(1, 4),
     new BigInteger(1, 5),
@@ -169,10 +175,7 @@ class BigInteger extends Number with Comparable[BigInteger] {
   /** Cache for the hash code. */
   private var _hashCode: Int = 0
 
-  def this(byteArray: Array[Byte]) = {
-    this()
-    if (byteArray.length == 0)
-      throw new NumberFormatException("Zero length BigInteger")
+  private[this] def byteArrayConstructorImpl(byteArray: Array[Byte]) {
 
     if (byteArray(0) < 0) {
       sign = -1
@@ -185,14 +188,40 @@ class BigInteger extends Number with Comparable[BigInteger] {
     this.cutOffLeadingZeroes()
   }
 
-  def this(signum: Int, magnitude: Array[Byte]) = {
+  def this(byteArray: Array[Byte]) = {
     this()
-    checkNotNull(magnitude)
-    if ((signum < -1) || (signum > 1))
-      throw new NumberFormatException("Invalid signum value")
-    if (signum == 0 && magnitude.exists(_ != 0))
-      throw new NumberFormatException("signum-magnitude mismatch")
+    checkNotNull(byteArray)
 
+    if (byteArray.length == 0)
+      throw new NumberFormatException("Zero length BigInteger")
+
+    byteArrayConstructorImpl(byteArray)
+  }
+
+  def this(byteArray: Array[Byte], off: Int, len: Int) = {
+    this()
+    checkNotNull(byteArray)
+
+    // verbosity is the price of descriptive error messages, well paid!
+    if (byteArray.length == 0)
+      throw new NumberFormatException("Zero length BigInteger")
+
+    if (off < 0)
+      throw new IndexOutOfBoundsException("off < 0")
+
+    if (len < 0)
+      throw new IndexOutOfBoundsException("len < 0")
+
+    val until = off + len
+    if (until > byteArray.length)
+      throw new IndexOutOfBoundsException("off + len > byteArray.length")
+
+    byteArrayConstructorImpl(byteArray.slice(off, until))
+
+  }
+
+  private[this] def signumMagnitudeConstructorImpl(signum: Int,
+                                                   magnitude: Array[Byte]) {
     if (magnitude.length == 0) {
       sign = 0
       numberLength = 1
@@ -202,6 +231,55 @@ class BigInteger extends Number with Comparable[BigInteger] {
       this.putBytesPositiveToIntegers(magnitude)
       this.cutOffLeadingZeroes()
     }
+  }
+
+  def this(signum: Int, magnitude: Array[Byte]) = {
+    this()
+    checkNotNull(magnitude)
+    if ((signum < -1) || (signum > 1))
+      throw new NumberFormatException("Invalid signum value")
+    if (signum == 0 && magnitude.exists(_ != 0))
+      throw new NumberFormatException("signum-magnitude mismatch")
+
+    signumMagnitudeConstructorImpl(signum, magnitude)
+  }
+
+  def this(signum: Int, magnitude: Array[Byte], off: Int, len: Int) = {
+    this()
+    checkNotNull(magnitude)
+    if ((signum < -1) || (signum > 1))
+      throw new NumberFormatException("Invalid signum value")
+    if (signum == 0 && magnitude.exists(_ != 0))
+      throw new NumberFormatException("signum-magnitude mismatch")
+
+    // verbosity is the price of descriptive error messages, well paid!
+
+    // API for long extant Java constructor
+    // public BigInteger​(int signum, byte[] magnitude)
+    // explicitly allows zero length magnitude array, so allow that here also.
+    //
+    // API for this constructor explicitly states that various conditions
+    // (off < 0 etc) are not checked and allowed if magnitude.length == 0.
+
+    val slice =
+      if (magnitude.length == 0) {
+        magnitude
+      } else {
+        if (off < 0)
+          throw new IndexOutOfBoundsException("off < 0")
+
+        if (len < 0)
+          throw new IndexOutOfBoundsException("len < 0")
+
+        val until = off + len
+        if (until > magnitude.length)
+          throw new IndexOutOfBoundsException("off + len > magnitude.length")
+
+        magnitude.slice(off, until)
+      }
+
+    signumMagnitudeConstructorImpl(signum, slice)
+
   }
 
   def this(bitLength: Int, certainty: Int, rnd: Random) = {
@@ -708,6 +786,41 @@ class BigInteger extends Number with Comparable[BigInteger] {
   }
 
   def signum(): Int = sign
+
+  def sqrt(): BigInteger = {
+    // Babylonian or Newton's method.
+    // See https://en.wikipedia.org/wiki/Integer_square_root, especially
+    // for termination condition.
+    //
+    // Ideas & proofs from https://www.akalin.com/computing-isqrt
+    // were also useful, especially for initial guess.
+
+    @tailrec
+    def loop(x: BigInteger): BigInteger = {
+
+      val y     = (this.divide(x)).add(x).shiftRight(1)
+      val delta = y.subtract(x)
+      val done  = ((delta.compareTo(ZERO) == 0) || (delta.compareTo(ONE) == 0))
+
+      if (done) x else loop(y)
+    }
+
+    if (this.compareTo(BigInteger.ZERO) < 0)
+      throw new ArithmeticException("sqrt of negative number")
+
+    // Intentionally a slight overestimate of true root.
+    val initialGuess = (1 << Math.ceil(this.bitLength / 2.0).toInt)
+
+    loop(BigInteger.valueOf(initialGuess))
+  }
+
+  def sqrtAndRemainder(): Array[BigInteger] = {
+
+    val root      = this.sqrt()
+    val remainder = this.subtract(root.multiply(root))
+
+    Array[BigInteger](root, remainder)
+  }
 
   def subtract(bi: BigInteger): BigInteger = Elementary.subtract(this, bi)
 

--- a/unit-tests/src/test/scala/java/math/BigDecimalSuite.scala
+++ b/unit-tests/src/test/scala/java/math/BigDecimalSuite.scala
@@ -1,0 +1,263 @@
+package java.math
+
+object BigDecimalSuite extends tests.Suite {
+
+  // Editorial comment:
+  //
+  // You may think now that this file is excessively commented.
+  // The author of those comments agrees. Any file requiring this
+  // much commenting means that you are entering the land of deep
+  // sneakers and exceedingly bad fortune!
+  //
+  // Wait until you have to chase accuracy issues, such as  "least
+  // significant digits differing by one". You might want to consider again.
+
+// sqrt
+
+  test("Testing sqrt") {}
+
+  test("* null MathContext should throw NPE") {
+    assertThrows[NullPointerException] {
+      val bd = BigDecimal.ONE.negate
+      bd.sqrt(null: MathContext)
+    }
+  }
+
+  test("* of negative value should throw") {
+    assertThrows[ArithmeticException] {
+      val bd = BigDecimal.ONE.negate
+      bd.sqrt(MathContext.DECIMAL64)
+    }
+  }
+
+  test("* of 0 should reduce scale to floor(original/2.0)") {
+
+    val scale    = 9
+    val expected = scale / 2 // expect 4, integer division.
+
+    val bd = BigDecimal.ZERO
+      .setScale(scale, MathContext.DECIMAL64.getRoundingMode)
+
+    val result = bd.sqrt(MathContext.DECIMAL64).scale
+
+    assert(
+      result == expected,
+      s"sqrt ${0} scale: ${scale} " +
+        s"result: ${result} != expected: ${expected}"
+    )
+  }
+
+  test("* of 2.0 should be correct to 16 decimal places") {
+
+    // Why is precision 17, not 16 decimal places in test title"
+    // A number comments in tests below refer to this comment for
+    // the answer.
+    //
+    // By observation, not any deep understanding Scala JVM and
+    // perhaps Java seem to count the inferred 0 or 1 in an IEEE754
+    // float as part of the precision. Thus to get what the rest
+    // of the world would call 16 digits of decimal precision, one must
+    // add one. But Yes, you say, we are dealing with BigDecimal here,
+    // not IEEE754 floats. Same behavior seems to rule, for consistency?
+
+    val precision = 17
+
+    val startWith = "2.0"
+
+    val radicand: BigDecimal = new BigDecimal(
+      startWith,
+      new MathContext(precision, RoundingMode.HALF_UP)
+    )
+
+    // URL: http://www.cs.utsa.edu/~wagner/CS3343/newton/sqrt.html
+    // reference value:             1.41421356237309504880
+    // Java 10:                     1.41421356237309505  // precision 18
+    // Scala REPL Java8 math.sqrt   1.4142135623730951
+    val expected = new BigDecimal(
+      "1.4142135623730951", // Scala REPL/JVM
+      new MathContext(precision, RoundingMode.HALF_UP)
+    )
+
+    val root: BigDecimal =
+      radicand.sqrt(new MathContext(precision, RoundingMode.HALF_UP))
+
+    assert(
+      root.compareTo(expected) == 0,
+      s"root: |${root}| != expected: |${expected}|"
+    )
+  }
+
+  test("* of e (2.7) should be correct to 100 decimal places, HALF_EVEN") {
+
+    val precision = 100
+
+    // format: off
+    val startWith = "2.7182818284590452353602874713526624977572470936999" +
+                      "59574966967627724076630353547594571382178525166427"
+    // format: on
+
+    val radicand: BigDecimal = new BigDecimal(
+      startWith,
+      new MathContext(precision, RoundingMode.HALF_EVEN)
+    )
+
+    // With thanks to http://www.wolframalpha.com for results of query:
+    // ""square root of base of natural logarithm to 100 digits""
+    //
+    // "square root of  to 100 digits". 10 * sqrt(10) is:
+    //
+    // reference value:
+    // 1.648721270700128146848650787814163571653776100710148
+    //   011575079311640661021194215608632776520056366643
+    // Java 10:                     Available but not calculated
+    // Scala REPL Java8 math.sqrt   Not Available.
+
+    // format: off
+    val reference = "1.648721270700128146848650787814163571653776100710148" +
+                      "011575079311640661021194215608632776520056366643"
+    // format: on
+
+    val expected = new BigDecimal(
+      reference,
+      new MathContext(precision, RoundingMode.HALF_EVEN)
+    )
+
+    val root: BigDecimal =
+      radicand.sqrt(new MathContext(precision, RoundingMode.HALF_EVEN))
+
+    assert(
+      root.compareTo(expected) == 0,
+      s"root: |${root}| != expected: |${expected}|"
+    )
+  }
+
+  test("* of 3.0 should be correct to 16 decimal places") {
+
+    // see comment in test of sqrt(2) for why this is 17, not 16.
+    val precision = 17
+
+    val startWith = "3.0"
+
+    val radicand: BigDecimal = new BigDecimal(
+      startWith,
+      new MathContext(precision, RoundingMode.HALF_UP)
+    )
+
+    // Digits of square root of three, April 1994  URL:
+    //   https://apod.nasa.gov/htmltest/gifcity/sqrt3.1mil
+    //
+    // reference value:             1.7320508075688772935
+    // Java 10:                     1.73205080756887729 // precision 18
+    // Java 10:                     1.7320508075688773  // precision 17
+    // Scala REPL Java8 math.sqrt   1.7320508075688772
+
+    val expected = new BigDecimal(
+      "1.7320508075688773",
+      new MathContext(precision, RoundingMode.HALF_UP)
+    )
+
+    val root: BigDecimal =
+      radicand.sqrt(new MathContext(precision, RoundingMode.HALF_UP))
+
+    assert(
+      root.compareTo(expected) == 0,
+      s"root: |${root}| != expected: |${expected}|"
+    )
+
+  }
+
+  test("* of 1000.0 (negative scale) should be correct, HALF_UP") {
+    // This tests both having digits to the left of the decimal point
+    // (negative scale) and sqrt(5).
+    // sqrt(100) * sqrt(10) == 100 * sqrt(2) * sqrt(5)
+
+    // see comment in test of sqrt(2) for why this is 17, not 16.
+    val precision = 17
+
+    val startWith = "1000.0"
+
+    val radicand: BigDecimal = new BigDecimal(
+      startWith,
+      new MathContext(precision, RoundingMode.HALF_UP)
+    )
+
+    // With thanks to http://www.wolframalpha.com for results of query:
+    // "square root of 1000 to 100 digits". Only a few of those digit are
+    // used here.
+    //
+    // reference value:             31.62277660168379332
+    // Java 10:                     31.622776601683793  // precision 17
+    // Scala REPL Java8 math.sqrt   31.622776601683793
+
+    val expected = new BigDecimal(
+      "31.622776601683793",
+      new MathContext(precision, RoundingMode.HALF_UP)
+    )
+
+    val root: BigDecimal =
+      radicand.sqrt(new MathContext(precision, RoundingMode.HALF_UP))
+
+    assert(
+      root.compareTo(expected) == 0,
+      s"root: |${root}| != expected: |${expected}|"
+    )
+
+  }
+
+  test("* of 1000.0 (negative scale) should be correct, HALF_EVEN") {
+
+    // see comment in test of sqrt(2) for why this is 17, not 16.
+    val precision = 17
+
+    val startWith = "1000.0"
+    val radicand: BigDecimal = new BigDecimal(
+      startWith,
+      new MathContext(precision, RoundingMode.HALF_UP)
+    )
+
+    // reference value:             31.62277660168379332
+    // Java 10:                     31.622776601683793  // precision 17
+    // Scala REPL Java8 math.sqrt   31.622776601683793
+
+    val expected = new BigDecimal(
+      "31.622776601683793",
+      new MathContext(precision, RoundingMode.HALF_EVEN)
+    )
+
+    val root: BigDecimal =
+      radicand.sqrt(new MathContext(precision, RoundingMode.HALF_EVEN))
+
+    assert(
+      root.compareTo(expected) == 0,
+      s"root: |${root}| != expected: |${expected}|"
+    )
+
+  }
+
+  test("* of 1000000.0 (large number) should be correct") {
+
+    // see comment in test of sqrt(2) for why this is 17, not 16.
+    val precision = 17
+
+    val startWith = "1000000.0"
+
+    val radicand: BigDecimal = new BigDecimal(
+      startWith,
+      new MathContext(precision, RoundingMode.HALF_UP)
+    )
+
+    // reference value:             1000.00, by simple math.
+
+    val expected =
+      new BigDecimal("1000.0", new MathContext(precision, RoundingMode.HALF_UP))
+
+    val root: BigDecimal =
+      radicand.sqrt(new MathContext(precision, RoundingMode.HALF_UP))
+
+    assert(
+      root.compareTo(expected) == 0,
+      s"root: |${root}| != expected: |${expected}|"
+    )
+  }
+
+}

--- a/unit-tests/src/test/scala/java/math/BigIntegerSuite.scala
+++ b/unit-tests/src/test/scala/java/math/BigIntegerSuite.scala
@@ -1,0 +1,113 @@
+package java.math
+
+object BigIntegerSuite extends tests.Suite {
+
+// byteValueExact
+
+  val byteMaxBi = new BigInteger(java.lang.Byte.MAX_VALUE.toString)
+  val byteMinBi = new BigInteger(java.lang.Byte.MIN_VALUE.toString)
+
+  test("byteValueExact with BigInteger > Byte.MAX_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = byteMaxBi.add(BigInteger.ONE)
+      bi.byteValueExact()
+    }
+  }
+
+  test("byteValueExact with BigInteger == Byte.MAX_VALUE should not throw") {
+    assert(byteMaxBi.byteValueExact() == java.lang.Byte.MAX_VALUE)
+  }
+
+  test("byteValueExact with BigInteger == Byte.MIN_VALUE should not throw") {
+    assert(byteMinBi.byteValueExact() == java.lang.Byte.MIN_VALUE)
+  }
+
+  test("byteValueExact with BigInteger < Byte.MIN_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = byteMinBi.subtract(BigInteger.ONE)
+      bi.byteValueExact()
+    }
+  }
+
+// intValueExact
+
+  val intMaxBi = new BigInteger(java.lang.Integer.MAX_VALUE.toString)
+  val intMinBi = new BigInteger(java.lang.Integer.MIN_VALUE.toString)
+
+  test("intValueExact with BigInteger > Integer.MAX_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = intMaxBi.add(BigInteger.ONE)
+      bi.intValueExact()
+    }
+  }
+
+  test("intValueExact with BigInteger == Integer.MAX_VALUE should not throw") {
+    assert(intMaxBi.intValueExact() == java.lang.Integer.MAX_VALUE)
+  }
+
+  test("intValueExact with BigInteger == Integer.MIN_VALUE should not throw") {
+    assert(intMinBi.intValueExact() == java.lang.Integer.MIN_VALUE)
+  }
+
+  test("intValueExact with BigInteger < Integer.MIN_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = intMinBi.subtract(BigInteger.ONE)
+      bi.intValueExact()
+    }
+  }
+
+// longValueExact
+
+  val longMaxBi = new BigInteger(java.lang.Long.MAX_VALUE.toString)
+  val longMinBi = new BigInteger(java.lang.Long.MIN_VALUE.toString)
+
+  test("longValueExact with BigInteger > Long.MAX_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = longMaxBi.add(BigInteger.ONE)
+      bi.longValueExact()
+    }
+  }
+
+  test("longValueExact with BigInteger == Long.MAX_VALUE should not throw") {
+    assert(longMaxBi.longValueExact() == java.lang.Long.MAX_VALUE)
+  }
+
+  test("longValueExact with BigInteger == Long.MIN_VALUE should not throw") {
+    assert(longMinBi.longValueExact() == java.lang.Long.MIN_VALUE)
+  }
+
+  test("longValueExact with BigInteger < Long.MIN_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = longMinBi.subtract(BigInteger.ONE)
+      bi.longValueExact()
+    }
+  }
+
+// shortValueExact
+
+  val shortMaxBi = new BigInteger(java.lang.Short.MAX_VALUE.toString)
+  val shortMinBi = new BigInteger(java.lang.Short.MIN_VALUE.toString)
+
+  test("shortValueExact with BigInteger > Short.MAX_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = shortMaxBi.add(BigInteger.ONE)
+      bi.shortValueExact()
+    }
+  }
+
+  test("shortValueExact with BigInteger == Short.MAX_VALUE should not throw") {
+    assert(shortMaxBi.shortValueExact() == java.lang.Short.MAX_VALUE)
+  }
+
+  test("shortValueExact with BigInteger == Short.MIN_VALUE should not throw") {
+    assert(shortMinBi.shortValueExact() == java.lang.Short.MIN_VALUE)
+  }
+
+  test("shortValueExact with BigInteger < Short.MIN_VALUE should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = shortMinBi.subtract(BigInteger.ONE)
+      bi.shortValueExact()
+    }
+  }
+
+}

--- a/unit-tests/src/test/scala/java/math/BigIntegerSuite.scala
+++ b/unit-tests/src/test/scala/java/math/BigIntegerSuite.scala
@@ -2,27 +2,262 @@ package java.math
 
 object BigIntegerSuite extends tests.Suite {
 
+// BigInteger.TWO
+
+  test("BigInteger.TWO should exist") {
+    val bi       = BigInteger.TWO
+    val expected = 2
+    val result   = bi.intValue
+    assert(
+      result == expected,
+      s"BigInteger.TWO result: ${result} != expected: ${expected}"
+    )
+  }
+
+// Constructors
+
+  test("Testing constructor BigInteger(byteArray)") {}
+
+  test("* null byteArray should throw NPE") {
+    assertThrows[NullPointerException] {
+      val bi = new BigInteger(null: Array[Byte])
+    }
+  }
+
+  test("* empty byteArray should throw") {
+    assertThrows[NumberFormatException] {
+      val byteArr = Array.empty[Byte]
+      val bi      = new BigInteger(byteArr)
+    }
+  }
+
+  test("* with valid arguments should create expected") {
+    val byteArr  = Array[Byte](2, 1)
+    val expected = 513
+    val bi       = new BigInteger(byteArr)
+    val result   = bi.intValueExact()
+
+    assert(
+      result == expected,
+      s"BigInteger(${byteArr}) " +
+        s"result: ${result} != expected: ${expected}"
+    )
+  }
+
+  test("Testing constructor BigInteger(byteArray, off, len)") {}
+
+  test("* null byteArray should throw NPE") {
+    assertThrows[NullPointerException] {
+      val bi = new BigInteger(null: Array[Byte], 0, 10)
+    }
+  }
+
+  test("* empty byteArray should throw") {
+    assertThrows[NumberFormatException] {
+      val byteArr = Array.empty[Byte]
+      val bi      = new BigInteger(byteArr, 1, 10)
+    }
+  }
+
+  test("* off < 0 should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val byteArr = Array[Byte](9, 8, 4, 5)
+      val bi      = new BigInteger(byteArr, -1, 10)
+    }
+  }
+
+  test("* len < 0 should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val byteArr = Array[Byte](9, 8, 4, 5)
+      val bi      = new BigInteger(byteArr, 0, -2)
+    }
+  }
+
+  test("* off + len too big should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val byteArr = Array[Byte](9, 8, 4, 5)
+      val bi      = new BigInteger(byteArr, 2, 5)
+    }
+  }
+
+  test("* with valid arguments should create expected") {
+    val byteArr  = Array[Byte](9, 8, 4, 5)
+    val expected = 1029
+    val bi       = new BigInteger(byteArr, 2, 2)
+    val result   = bi.intValueExact()
+
+    assert(
+      result == expected,
+      s"BigInteger(${byteArr}) " +
+        s"result: ${result} != expected: ${expected}"
+    )
+  }
+
+  test("Testing constructor BigInteger(signum, null, off, len)") {}
+
+  test("* null magnitude array should throw NPE") {
+    assertThrows[NullPointerException] {
+      val bi = new BigInteger(0, null: Array[Byte], 1, 6)
+    }
+  }
+
+  test("* empty magnitude array should create BigInteger(0)") {
+    val expected = BigInteger.ZERO
+    val result   = new BigInteger(0, Array.empty[Byte], -1, -2)
+  }
+
+  test("* signum < -1 should throw") {
+    assertThrows[NumberFormatException] {
+      val bi = new BigInteger(-2, Array[Byte](1), 2, 7)
+    }
+  }
+
+  test("* signum > 1 should throw") {
+    assertThrows[NumberFormatException] {
+      val bi = new BigInteger(2, Array[Byte](99), 1, 3)
+    }
+  }
+
+  test("* empty array, with any valid signum should create BigInteger(0)") {
+    val expected     = BigInteger.ZERO
+    val result_plus  = new BigInteger(1, Array.empty[Byte], -1, -2)
+    val result_zero  = new BigInteger(0, Array.empty[Byte], -3, -4)
+    val result_minus = new BigInteger(-1, Array.empty[Byte], -5, 6)
+
+    assert(result_plus.compareTo(expected) == 0,
+           s"signum == 1 result: ${result_plus} != expected: ${expected}")
+
+    assert(result_zero.compareTo(expected) == 0,
+           s"signum == 0 result: ${result_zero} != expected: ${expected}")
+
+    assert(result_minus.compareTo(expected) == 0,
+           s"signum == -1 result: ${result_minus} != expected: ${expected}")
+  }
+
+  test("* signum == 0 with one or more non-zero array bytes should throw") {
+    assertThrows[NumberFormatException] {
+      val bi = new BigInteger(0, Array[Byte](0, 1, 0), -1, -2)
+    }
+  }
+
+  test("* signum == 0 with valid array bytes should create BigInteger(0)") {
+    val expected = BigInteger.ZERO
+    val result   = new BigInteger(0, Array[Byte](0, 0, 0), 2, 1)
+
+    assert(result.compareTo(expected) == 0,
+           s"result: ${result} != expected: ${expected}")
+  }
+
+  test("* len == 0, with valid signum & bytes should create BigInteger(0)") {
+    val expected = BigInteger.ZERO
+
+    val result_plus  = new BigInteger(1, Array[Byte](1, 0), 0, 0)
+    val result_zero  = new BigInteger(0, Array[Byte](0, 0), 1, 0)
+    val result_minus = new BigInteger(-1, Array[Byte](0, 1), 0, 0)
+
+    assert(result_plus.compareTo(expected) == 0,
+           s"signum == 1 result: ${result_plus} != expected: ${expected}")
+
+    assert(result_zero.compareTo(expected) == 0,
+           s"signum == 0 result: ${result_zero} != expected: ${expected}")
+
+    assert(result_minus.compareTo(expected) == 0,
+           s"signum == -1 result: ${result_minus} != expected: ${expected}")
+  }
+
+  test("* off < 0, signum == 1 with non-empty magnitude should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val bi = new BigInteger(1, Array[Byte](0, 1, 0), -1, 4)
+    }
+  }
+
+  test("* off < 0, signum == 0 with non-empty magnitude should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val bi = new BigInteger(0, Array[Byte](0, 0), -1, 2)
+    }
+  }
+
+  test("* off < 0, signum == -1 with non-empty magnitude should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val bi = new BigInteger(-1, Array[Byte](8, 4, 1), -5, 4)
+    }
+  }
+
+  test("* len < 0, signum == 1 with non-empty magnitude should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val bi = new BigInteger(1, Array[Byte](0, 1, 0), 1, -3)
+    }
+  }
+
+  test("* len < 0, signum == 0 with non-empty magnitude should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val bi = new BigInteger(0, Array[Byte](0, 0), 0, -4)
+    }
+  }
+
+  test("* len < 0, signum == -1 with non-empty magnitude should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val bi = new BigInteger(-1, Array[Byte](8, 4, 1), 2, -2)
+    }
+  }
+
+  test("* off + len > magnitude.length, signum == 1 should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val bi = new BigInteger(1, Array[Byte](3, 2, 4, 9), 3, 2)
+    }
+  }
+
+  test("* off + len > magnitude.length, signum == 0 should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val bi = new BigInteger(0, Array[Byte](0, 0, 0, 0), 2, 3)
+    }
+  }
+
+  test("* off + len > magnitude.length, signum == -1 should throw") {
+    assertThrows[IndexOutOfBoundsException] {
+      val bi = new BigInteger(-1, Array[Byte](1, 2, 3, 5), 2, 7)
+    }
+  }
+
+// ---
+  test("* valid arguments should create expected") {
+
+    val expected_plus = new BigInteger(1, Array[Byte](3, 9))
+    val result_plus   = new BigInteger(1, Array[Byte](3, 9, 7), 0, 2)
+
+    assert(result_plus.compareTo(expected_plus) == 0,
+           s"result: ${result_plus} != expected: ${expected_plus}")
+
+    val expected_minus = new BigInteger(-1, Array[Byte](9, 7))
+    val result_minus   = new BigInteger(-1, Array[Byte](3, 9, 7), 1, 2)
+
+    assert(result_minus.compareTo(expected_minus) == 0,
+           s"result: ${result_minus} != expected: ${expected_minus}")
+  }
+
 // byteValueExact
+
+  test("Testing byteValueExact") {}
 
   val byteMaxBi = new BigInteger(java.lang.Byte.MAX_VALUE.toString)
   val byteMinBi = new BigInteger(java.lang.Byte.MIN_VALUE.toString)
 
-  test("byteValueExact with BigInteger > Byte.MAX_VALUE should throw") {
+  test("* BigInteger > Byte.MAX_VALUE should throw") {
     assertThrows[ArithmeticException] {
       val bi = byteMaxBi.add(BigInteger.ONE)
       bi.byteValueExact()
     }
   }
 
-  test("byteValueExact with BigInteger == Byte.MAX_VALUE should not throw") {
+  test("* BigInteger == Byte.MAX_VALUE should not throw") {
     assert(byteMaxBi.byteValueExact() == java.lang.Byte.MAX_VALUE)
   }
 
-  test("byteValueExact with BigInteger == Byte.MIN_VALUE should not throw") {
+  test("* BigInteger == Byte.MIN_VALUE should not throw") {
     assert(byteMinBi.byteValueExact() == java.lang.Byte.MIN_VALUE)
   }
 
-  test("byteValueExact with BigInteger < Byte.MIN_VALUE should throw") {
+  test("* BigInteger < Byte.MIN_VALUE should throw") {
     assertThrows[ArithmeticException] {
       val bi = byteMinBi.subtract(BigInteger.ONE)
       bi.byteValueExact()
@@ -31,25 +266,27 @@ object BigIntegerSuite extends tests.Suite {
 
 // intValueExact
 
+  test("Testing intValueExact") {}
+
   val intMaxBi = new BigInteger(java.lang.Integer.MAX_VALUE.toString)
   val intMinBi = new BigInteger(java.lang.Integer.MIN_VALUE.toString)
 
-  test("intValueExact with BigInteger > Integer.MAX_VALUE should throw") {
+  test("* BigInteger > Integer.MAX_VALUE should throw") {
     assertThrows[ArithmeticException] {
       val bi = intMaxBi.add(BigInteger.ONE)
       bi.intValueExact()
     }
   }
 
-  test("intValueExact with BigInteger == Integer.MAX_VALUE should not throw") {
+  test("* BigInteger == Integer.MAX_VALUE should not throw") {
     assert(intMaxBi.intValueExact() == java.lang.Integer.MAX_VALUE)
   }
 
-  test("intValueExact with BigInteger == Integer.MIN_VALUE should not throw") {
+  test("* BigInteger == Integer.MIN_VALUE should not throw") {
     assert(intMinBi.intValueExact() == java.lang.Integer.MIN_VALUE)
   }
 
-  test("intValueExact with BigInteger < Integer.MIN_VALUE should throw") {
+  test("* BigInteger < Integer.MIN_VALUE should throw") {
     assertThrows[ArithmeticException] {
       val bi = intMinBi.subtract(BigInteger.ONE)
       bi.intValueExact()
@@ -58,25 +295,27 @@ object BigIntegerSuite extends tests.Suite {
 
 // longValueExact
 
+  test("Testing longValueExact") {}
+
   val longMaxBi = new BigInteger(java.lang.Long.MAX_VALUE.toString)
   val longMinBi = new BigInteger(java.lang.Long.MIN_VALUE.toString)
 
-  test("longValueExact with BigInteger > Long.MAX_VALUE should throw") {
+  test("* BigInteger > Long.MAX_VALUE should throw") {
     assertThrows[ArithmeticException] {
       val bi = longMaxBi.add(BigInteger.ONE)
       bi.longValueExact()
     }
   }
 
-  test("longValueExact with BigInteger == Long.MAX_VALUE should not throw") {
+  test("* BigInteger == Long.MAX_VALUE should not throw") {
     assert(longMaxBi.longValueExact() == java.lang.Long.MAX_VALUE)
   }
 
-  test("longValueExact with BigInteger == Long.MIN_VALUE should not throw") {
+  test("* BigInteger == Long.MIN_VALUE should not throw") {
     assert(longMinBi.longValueExact() == java.lang.Long.MIN_VALUE)
   }
 
-  test("longValueExact with BigInteger < Long.MIN_VALUE should throw") {
+  test("* BigInteger < Long.MIN_VALUE should throw") {
     assertThrows[ArithmeticException] {
       val bi = longMinBi.subtract(BigInteger.ONE)
       bi.longValueExact()
@@ -85,29 +324,149 @@ object BigIntegerSuite extends tests.Suite {
 
 // shortValueExact
 
+  test("Testing shortValueExact") {}
+
   val shortMaxBi = new BigInteger(java.lang.Short.MAX_VALUE.toString)
   val shortMinBi = new BigInteger(java.lang.Short.MIN_VALUE.toString)
 
-  test("shortValueExact with BigInteger > Short.MAX_VALUE should throw") {
+  test("* BigInteger > Short.MAX_VALUE should throw") {
     assertThrows[ArithmeticException] {
       val bi = shortMaxBi.add(BigInteger.ONE)
       bi.shortValueExact()
     }
   }
 
-  test("shortValueExact with BigInteger == Short.MAX_VALUE should not throw") {
+  test("* BigInteger == Short.MAX_VALUE should not throw") {
     assert(shortMaxBi.shortValueExact() == java.lang.Short.MAX_VALUE)
   }
 
-  test("shortValueExact with BigInteger == Short.MIN_VALUE should not throw") {
+  test("* BigInteger == Short.MIN_VALUE should not throw") {
     assert(shortMinBi.shortValueExact() == java.lang.Short.MIN_VALUE)
   }
 
-  test("shortValueExact with BigInteger < Short.MIN_VALUE should throw") {
+  test("* BigInteger < Short.MIN_VALUE should throw") {
     assertThrows[ArithmeticException] {
       val bi = shortMinBi.subtract(BigInteger.ONE)
       bi.shortValueExact()
     }
+  }
+
+// sqrt
+
+  test("Testing sqrt") {}
+
+  test("* of negative value should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = BigInteger.ONE.negate
+      bi.sqrt
+    }
+  }
+
+  test("* of one below power-of-2 perfect square should be correct") {
+    val n        = 63
+    val bi       = BigInteger.valueOf(n)
+    val expected = 7
+    val result   = bi.sqrt.intValueExact
+
+    assert(
+      result == expected,
+      s"sqrt ${n} result: ${result} != expected: ${expected}"
+    )
+  }
+
+  test("* of power-of-2 perfect square should be correct") {
+    val n        = 64
+    val bi       = BigInteger.valueOf(n)
+    val expected = 8
+    val result   = bi.sqrt.intValueExact
+
+    assert(
+      result == expected,
+      s"sqrt ${n} result: ${result} != expected: ${expected}"
+    )
+  }
+
+  test("* of one above power-of-2 perfect square should be correct") {
+    val n        = 65
+    val bi       = BigInteger.valueOf(n)
+    val expected = 8
+    val result   = bi.sqrt.intValueExact
+
+    assert(
+      result == expected,
+      s"sqrt ${n} result: ${result} != expected: ${expected}"
+    )
+  }
+
+// sqrtAndRemainder
+
+  test("Testing sqrtAndRemainder") {}
+
+  test("* of negative value should throw") {
+    assertThrows[ArithmeticException] {
+      val bi = BigInteger.ONE.negate
+      bi.sqrtAndRemainder
+    }
+  }
+
+  test("* of one below perfect square should be correct") {
+    val n                 = 99
+    val bi                = BigInteger.valueOf(n)
+    val expectedWhole     = BigInteger.valueOf(9)
+    val expectedRemainder = BigInteger.valueOf(18)
+    val result            = bi.sqrtAndRemainder
+
+    assert(
+      result(0).compareTo(expectedWhole) == 0,
+      s"sqrtAndRemainder ${n} " +
+        s"whole: ${result(0)} != expected: ${expectedWhole}"
+    )
+
+    assert(
+      result(1).compareTo(expectedRemainder) == 0,
+      s"sqrtAndRemainder ${n} " +
+        s"remainder: ${result(1)} != expected: ${expectedRemainder}"
+    )
+  }
+
+  test("* of perfect square should be correct") {
+    val n                 = 100
+    val bi                = BigInteger.valueOf(n)
+    val expectedWhole     = BigInteger.TEN
+    val expectedRemainder = BigInteger.ZERO
+    val result            = bi.sqrtAndRemainder
+
+    assert(
+      result(0).compareTo(expectedWhole) == 0,
+      s"sqrtAndRemainder ${n} " +
+        s"whole: ${result(0)} != expected: ${expectedWhole}"
+    )
+
+    assert(
+      result(1).compareTo(expectedRemainder) == 0,
+      s"sqrtAndRemainder ${n} " +
+        s"remainder: ${result(1)} != expected: ${expectedRemainder}"
+    )
+  }
+
+  test("* of one above perfect square should be correct") {
+    val n                 = 101
+    val bi                = BigInteger.valueOf(n)
+    val expectedWhole     = BigInteger.TEN
+    val expectedRemainder = BigInteger.ONE
+    val result            = bi.sqrtAndRemainder
+
+    assert(
+      result(0).compareTo(expectedWhole) == 0,
+      s"sqrtAndRemainder ${n} " +
+        s"whole: ${result(0)} != expected: ${expectedWhole}"
+    )
+
+    assert(
+      result(1).compareTo(expectedRemainder) == 0,
+      s"sqrtAndRemainder ${n} " +
+        s"remainder: ${result(1)} != expected: ${expectedRemainder}"
+    )
   }
 
 }


### PR DESCRIPTION
Implement BigMath arbitrary precision square root & Java API 9/1O features.
    
    * This pull request adds Java API 9 methods to BigInteger.scala and
      BigDecimal.scala. For these files, the Java API is unchanged for
      Java 10, so they now meet that specification also.
    
    * Have you ever wanted to know the value of the square root of e,
      base of the natural logarithms, to 100 or more decimal places?
      Now you can realize your dreams and live large with arbitrary precision
      square root methods.
    
    * The motivating change was to add API square root methods to BigInteger
      and BigDecimal while I still understood the initial guess and
      recursion terminating conditions.
    
    * As long as I was editing & testing BigInteger.scala, it made sense to
      add the constant BigInteger.TWO and the two new constructors.
    
    64/32 bit issues:
    
          None known.
    
    Documentation:
    
          Deserves a release note.
    
    Testing:
    
    * Passes test-all on both X86_64.
    
    * Untested on X86, because of link issues in the now ancient
      ScalaNative on that system.
