### PR TITLE
Add dedicated instructions for field load/store

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -69,8 +69,14 @@ class Buffer(implicit fresh: Fresh) {
     let(Op.Select(cond, thenv, elsev), unwind)
   def classalloc(name: Global, unwind: Next): Val =
     let(Op.Classalloc(name), unwind)
-  def field(obj: Val, name: Global, unwind: Next): Val =
-    let(Op.Field(obj, name), unwind)
+  def fieldload(ty: Type, obj: Val, name: Global, unwind: Next): Val =
+    let(Op.Fieldload(ty, obj, name), unwind)
+  def fieldstore(ty: Type,
+                 obj: Val,
+                 name: Global,
+                 value: Val,
+                 unwind: Next): Val =
+    let(Op.Fieldstore(ty, obj, name, value), unwind)
   def method(obj: Val, signature: String, unwind: Next): Val =
     let(Op.Method(obj, signature), unwind)
   def dynmethod(obj: Val, signature: String, unwind: Next): Val =

--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -18,18 +18,19 @@ sealed abstract class Op {
     case Op.Conv(_, ty, _)                    => ty
     case Op.Select(_, v, _)                   => v.ty
 
-    case Op.Classalloc(n)     => Type.Class(n)
-    case Op.Field(_, _)       => Type.Ptr
-    case Op.Method(_, _)      => Type.Ptr
-    case Op.Dynmethod(_, _)   => Type.Ptr
-    case Op.Module(n)         => Type.Module(n)
-    case Op.As(ty, _)         => ty
-    case Op.Is(_, _)          => Type.Bool
-    case Op.Copy(v)           => v.ty
-    case Op.Sizeof(_)         => Type.Long
-    case Op.Closure(ty, _, _) => ty
-    case Op.Box(ty, _)        => ty
-    case Op.Unbox(ty, _)      => Type.unbox(ty)
+    case Op.Classalloc(n)           => Type.Class(n)
+    case Op.Fieldload(ty, _, _)     => ty
+    case Op.Fieldstore(ty, _, _, _) => Type.Unit
+    case Op.Method(_, _)            => Type.Ptr
+    case Op.Dynmethod(_, _)         => Type.Ptr
+    case Op.Module(n)               => Type.Module(n)
+    case Op.As(ty, _)               => ty
+    case Op.Is(_, _)                => Type.Bool
+    case Op.Copy(v)                 => v.ty
+    case Op.Sizeof(_)               => Type.Long
+    case Op.Closure(ty, _, _)       => ty
+    case Op.Box(ty, _)              => ty
+    case Op.Unbox(ty, _)            => Type.unbox(ty)
   }
 
   final def show: String = nir.Show(this)
@@ -57,8 +58,10 @@ object Op {
     Store(ty, ptr, value, isVolatile = false)
 
   // high-level
-  final case class Classalloc(name: Global)                        extends Op
-  final case class Field(obj: Val, name: Global)                   extends Op
+  final case class Classalloc(name: Global)                    extends Op
+  final case class Fieldload(ty: Type, obj: Val, name: Global) extends Op
+  final case class Fieldstore(ty: Type, obj: Val, name: Global, value: Val)
+      extends Op
   final case class Method(obj: Val, signature: String)             extends Op
   final case class Dynmethod(obj: Val, signature: String)          extends Op
   final case class Module(name: Global)                            extends Op

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -237,11 +237,22 @@ object Show {
       case Op.Classalloc(name) =>
         str("classalloc ")
         global_(name)
-      case Op.Field(value, name) =>
-        str("field ")
-        val_(value)
+      case Op.Fieldload(ty, obj, name) =>
+        str("fieldload[")
+        type_(ty)
+        str("] ")
+        val_(obj)
         str(", ")
         global_(name)
+      case Op.Fieldstore(ty, obj, name, value) =>
+        str("fieldstore[")
+        type_(ty)
+        str("] ")
+        val_(obj)
+        str(", ")
+        global_(name)
+        str(", ")
+        val_(value)
       case Op.Method(value, signature) =>
         str("method ")
         val_(value)

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -78,8 +78,10 @@ trait Transform {
 
     case Op.Classalloc(n) =>
       Op.Classalloc(n)
-    case Op.Field(v, n) =>
-      Op.Field(onVal(v), n)
+    case Op.Fieldload(ty, v, n) =>
+      Op.Fieldload(onType(ty), onVal(v), n)
+    case Op.Fieldstore(ty, v1, n, v2) =>
+      Op.Fieldstore(onType(ty), onVal(v1), n, onVal(v2))
     case Op.Method(v, n) =>
       Op.Method(onVal(v), n)
     case Op.Dynmethod(obj, signature) =>

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -207,7 +207,8 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
     case T.SelectOp     => Op.Select(getVal, getVal, getVal)
 
     case T.ClassallocOp => Op.Classalloc(getGlobal)
-    case T.FieldOp      => Op.Field(getVal, getGlobal)
+    case T.FieldloadOp  => Op.Fieldload(getType, getVal, getGlobal)
+    case T.FieldstoreOp => Op.Fieldstore(getType, getVal, getGlobal, getVal)
     case T.MethodOp     => Op.Method(getVal, getString)
     case T.DynmethodOp  => Op.Dynmethod(getVal, getString)
     case T.ModuleOp     => Op.Module(getGlobal)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -339,10 +339,18 @@ final class BinarySerializer(buffer: ByteBuffer) {
       putInt(T.ClassallocOp)
       putGlobal(n)
 
-    case Op.Field(v, name) =>
-      putInt(T.FieldOp)
-      putVal(v)
+    case Op.Fieldload(ty, obj, name) =>
+      putInt(T.FieldloadOp)
+      putType(ty)
+      putVal(obj)
       putGlobal(name)
+
+    case Op.Fieldstore(ty, obj, name, value) =>
+      putInt(T.FieldstoreOp)
+      putType(ty)
+      putVal(obj)
+      putGlobal(name)
+      putVal(value)
 
     case Op.Method(v, signature) =>
       putInt(T.MethodOp)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -145,8 +145,9 @@ object Tags {
   final val ConvOp       = 1 + CompOp
   final val SelectOp     = 1 + ConvOp
   final val ClassallocOp = 1 + SelectOp
-  final val FieldOp      = 1 + ClassallocOp
-  final val MethodOp     = 1 + FieldOp
+  final val FieldloadOp  = 1 + ClassallocOp
+  final val FieldstoreOp = 1 + FieldloadOp
+  final val MethodOp     = 1 + FieldstoreOp
   final val ModuleOp     = 1 + MethodOp
   final val AsOp         = 1 + ModuleOp
   final val IsOp         = 1 + AsOp

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Op.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Op.scala
@@ -60,9 +60,13 @@ object Op extends Base[nir.Op] {
       case (cond, thenp, elsep) => nir.Op.Select(cond, thenp, elsep)
     })
   val Classalloc = P("classalloc" ~ Global.parser map (nir.Op.Classalloc(_)))
-  val Field =
-    P("field" ~ Val.parser ~ "," ~ Global.parser map {
-      case (value, name) => nir.Op.Field(value, name)
+  val Fieldload =
+    P("fieldload" ~ "[" ~ Type.parser ~ "]" ~ Val.parser ~ "," ~ Global.parser map {
+      case (ty, value, name) => nir.Op.Fieldload(ty, value, name)
+    })
+  val Fieldstore =
+    P("fieldstore" ~ "[" ~ Type.parser ~ "]" ~ Val.parser ~ "," ~ Global.parser ~ "," ~ Val.parser map {
+      case (ty, obj, name, value) => nir.Op.Fieldstore(ty, obj, name, value)
     })
   val Method =
     P("method" ~ Val.parser ~ "," ~ Base.stringLit map {
@@ -96,5 +100,5 @@ object Op extends Base[nir.Op] {
     case (ty, obj) => nir.Op.Unbox(ty, obj)
   })
   override val parser: P[nir.Op] =
-    Call | Load | Store | Elem | Extract | Insert | Stackalloc | Bin | Comp | Conv | Select | Classalloc | Field | Method | Module | As | Is | Copy | Sizeof | Closure | Box | Unbox
+    Call | Load | Store | Elem | Extract | Insert | Stackalloc | Bin | Comp | Conv | Select | Classalloc | Fieldload | Fieldstore | Method | Module | As | Is | Copy | Sizeof | Closure | Box | Unbox
 }

--- a/nirparser/src/test/scala/scala/scalanative/nir/OpParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/OpParserTest.scala
@@ -93,10 +93,17 @@ class OpParserTest extends FlatSpec with Matchers {
     result should be(classalloc)
   }
 
-  it should "parse `Op.Field`" in {
-    val field: Op = Op.Field(Val.None, global)
+  it should "parse `Op.Fieldload`" in {
+    val field: Op = Op.Fieldload(Type.Int, Val.None, global)
     val Parsed.Success(result, _) =
-      parser.Op.Field.parse(field.show)
+      parser.Op.Fieldload.parse(field.show)
+    result should be(field)
+  }
+
+  it should "parse `Op.Fieldstore`" in {
+    val field: Op = Op.Fieldstore(Type.Int, Val.None, global, Val.None)
+    val Parsed.Success(result, _) =
+      parser.Op.Fieldstore.parse(field.show)
     result should be(field)
   }
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -515,13 +515,11 @@ trait NirGenExpr { self: NirGenPhase =>
         val ty   = genType(tree.symbol.tpe, box = false)
         val qual = genExpr(qualp)
         val name = genFieldName(tree.symbol)
-        val elem =
-          if (sym.owner.isExternModule) {
-            Val.Global(name, Type.Ptr)
-          } else {
-            buf.field(qual, name, unwind)
-          }
-        buf.load(ty, elem, unwind)
+        if (sym.owner.isExternModule) {
+          buf.load(ty, Val.Global(name, Type.Ptr), unwind)
+        } else {
+          buf.fieldload(ty, qual, name, unwind)
+        }
       }
     }
 
@@ -544,13 +542,11 @@ trait NirGenExpr { self: NirGenPhase =>
           val qual = genExpr(qualp)
           val rhs  = genExpr(rhsp)
           val name = genFieldName(sel.symbol)
-          val elem =
-            if (sel.symbol.owner.isExternModule) {
-              Val.Global(name, Type.Ptr)
-            } else {
-              buf.field(qual, name, unwind)
-            }
-          buf.store(ty, elem, rhs, unwind)
+          if (sel.symbol.owner.isExternModule) {
+            buf.store(ty, Val.Global(name, Type.Ptr), rhs, unwind)
+          } else {
+            buf.fieldstore(ty, qual, name, rhs, unwind)
+          }
 
         case id: Ident =>
           val ty  = genType(id.tpe, box = false)

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -511,9 +511,15 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
     case Op.Classalloc(n) =>
       classInfo(n).foreach(reachAllocation)
-    case Op.Field(v, n) =>
+    case Op.Fieldload(ty, v, n) =>
+      reachType(ty)
       reachVal(v)
       reachGlobal(n)
+    case Op.Fieldstore(ty, v1, n, v2) =>
+      reachType(ty)
+      reachVal(v1)
+      reachGlobal(n)
+      reachVal(v2)
     case Op.Method(obj, sig) =>
       reachVal(obj)
       reachMethodTargets(obj.ty, sig)

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/GlobalValueNumbering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/GlobalValueNumbering.scala
@@ -102,12 +102,12 @@ object GlobalValueNumbering extends PassCompanion {
     op match {
       // Always idempotent:
       case (_: Pure | _: Method | _: Dynmethod | _: As | _: Is | _: Copy |
-          _: Sizeof | _: Module | _: Field | _: Box | _: Unbox) =>
+          _: Sizeof | _: Module | _: Box | _: Unbox) =>
         true
 
       // Never idempotent:
       case (_: Load | _: Store | _: Stackalloc | _: Classalloc | _: Call |
-          _: Closure) =>
+          _: Closure | _: Fieldload | _: Fieldstore) =>
         false
     }
   }
@@ -151,8 +151,14 @@ object GlobalValueNumbering extends PassCompanion {
           case (Select(condA, thenvA, elsevA), Select(condB, thenvB, elsevB)) =>
             eqVals(Seq(condA, thenvA, elsevA), Seq(condB, thenvB, elsevB))
 
-          case (Field(objA, nameA), Field(objB, nameB)) =>
-            eqVal(objA, objB) && eqGlobal(nameA, nameB)
+          case (Fieldload(tyA, objA, nameA), Fieldload(tyB, objB, nameB)) =>
+            eqType(tyA, tyB) && eqVal(objA, objB) && eqGlobal(nameA, nameB)
+
+          case (Fieldstore(tyA, objA, nameA, vA),
+                Fieldstore(tyB, objB, nameB, vB)) =>
+            eqType(tyA, tyB) && eqVal(objA, objB) && eqGlobal(nameA, nameB) && eqVal(
+              vA,
+              vB)
 
           case (Method(objA, signatureA), Method(objB, signatureB)) =>
             eqVal(objA, objB) && signatureA == signatureB
@@ -288,7 +294,9 @@ object GlobalValueNumbering extends PassCompanion {
         case Conv(conv, ty, value)      => Seq("Conv", ty, value)
         case Select(cond, thenv, elsev) => Seq("Select", cond, thenv, elsev)
 
-        case Field(obj, name)           => Seq("Field", obj, name)
+        case Fieldload(ty, obj, name) => Seq("Fieldload", ty, obj, name)
+        case Fieldstore(ty, obj, name, value) =>
+          Seq("Fieldstore", ty, obj, name, value)
         case Method(obj, name)          => Seq("Method", obj, name)
         case Dynmethod(obj, signature)  => Seq("Dynmethod", obj, signature)
         case As(ty, obj)                => Seq("As", ty, obj)


### PR DESCRIPTION
Previously we represented field operations through a mix of `Op.Field` and `Op.Load`/`Op.Store`. The semantics of `Op.Field` was to return an inner pointer that points directly to the field within a class, and then subsequent load and stores would perform an operation through that pointer. This encoding turned out to be tricky to optimize as a high-level operation in Interflow (#1278) because we also use load and store for C's unsafe memory operations. 

This pr introduces two dedicated instructions `Op.Fieldload` and `Op.Fieldstore`. Unlike the previous encoding these are only used for high-level Scala and are never emitted for C-style memory accesses. This makes it easier to optimize the away without doing any additional analysis.