### PR TITLE
Fix #1275 "Silently failing to readAllBytes of 2+GB files"

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -1,6 +1,7 @@
 package java.nio.file
 
 import java.lang.Iterable
+import java.lang.OutOfMemoryError
 
 import java.io.{
   BufferedReader,
@@ -430,7 +431,11 @@ object Files {
     !exists(path, options)
 
   def readAllBytes(path: Path): Array[Byte] = Zone { implicit z =>
-    val len   = size(path).toInt
+    val pathSize: Long = size(path)
+    if (!pathSize.isValidInt) {
+      throw new OutOfMemoryError("Required array size too large")
+    }
+    val len   = pathSize.toInt
     val bytes = scala.scalanative.runtime.ByteArray.alloc(len)
     val fd    = fcntl.open(toCString(path.toString), fcntl.O_RDONLY)
     try {


### PR DESCRIPTION
  * The presenting problem was expressed in issue #1275
    "javalib/src/main/scala/java/nio/file/Files.scala __silently__
    fails to read all bytes of files sizes > 32 bits".
    This issue is now fixed.

  * Files.scala method readAllBytes() now throws
    `java.lang.OutOfMemoryError: Required array size too large.`
    when attempting to read a file with size greater that Int.MaxValue,
    This is the same Error thrown by Scala JVM and Java itself
    in the same case.

64/32 bit issues:

      None known.

Documentation:

      Deserves a release note.

Testing:

	* Built and tested ("test-all") on X86_64.

	* The readAllBytes test in FilesSuite.scala checks that the
	  current edit works with small, 3 byte, files. This test passes.

	* I created a private test file which checked that the current
	  edit works with small, 200 byte, files. This was just a
	  "belt & suspenders" test to assure myself that I was reading
	  a file correctly.

	* The second part of the private test file checked if readAllBytes()
	  would throw the expected error when attempting to read all
	  the bytes of a 3GB file, where the system itself had 7GB of
	  free memory. That is, the OOM not caused by the system itself
	  running out of memory.

	  Because this second test requires a 3GB date file, it is not a
	  candidate for inclusion in a test suite. Either storing a
	  3GB file, even compressed, or generating it at each CI run
	  is probably not a reasonable thing to do.