### PR TITLE
Fix #1330 "SocketSuite buffer size tests failing on WSL"

### DIFF
--- a/unit-tests/src/test/scala/java/net/SocketSuite.scala
+++ b/unit-tests/src/test/scala/java/net/SocketSuite.scala
@@ -97,9 +97,9 @@ object SocketSuite extends tests.Suite {
     val s = new Socket()
 
     try {
-      val prevValue = s.getReceiveBufferSize
+      val prevValue = s.getSendBufferSize
       assert(prevValue > 0)
-      s.setReceiveBufferSize(prevValue + 100)
+      s.setSendBufferSize(prevValue + 100)
     } finally {
       s.close()
     }


### PR DESCRIPTION
  * The presenting problem was expressed in issue #1330
    "SocketSuite buffer size tests failing on WSL".
    This issue is now fixed.

  * The underlying issue was a conceptual problem in the two tests
    "receiveBufferSize" & "sendBufferSize".

    The Java 8 API documentation for methods setReceiveBufferSize & and
    setSendBufferSize at URL
        https://docs.oracle.com/javase/8/docs/api/java/net/
	      Socket.html#setReceiveBufferSize-int- // yes, trailing dash!

    describes the argument to the calls as a _hint_ which the Operating
    System (OS) can ignore.  There are several valid reasons why the OS can
    choose to do so. Changing the buffer size, even before a bind() call
    may not be supported. The buffer size may already be at its maximum.

    The result is that a call to get*BufferSize after the set call may
    return almost any strictly positive value. It makes no sense testing
    it.  That test has been removed.

  * Previously the two changed tests could leave a socket open (no close())
    if the assertion failed. This is potential leak of a limited resource.
    The code in this pull request does not have this potential leak.

64/32 bit issues:

      None known.

Documentation:

       None required. The comments in the Suite itself should suffice.

Testing:

	* Built and tested ("test-all") on X86_64. All tests passed.

	* I do not have access to a WSL system but will ask the original
	  poster to exercise the change.