### PR TITLE
Fix #1335 "Potential socket leak in *SocketSuite.scala"

### DIFF
--- a/unit-tests/src/test/scala/java/net/ServerSocketSuite.scala
+++ b/unit-tests/src/test/scala/java/net/ServerSocketSuite.scala
@@ -3,74 +3,100 @@ package java.net
 object ServerSocketSuite extends tests.Suite {
 
   test("bind") {
-    val s1   = new ServerSocket
-    val addr = new InetSocketAddress(InetAddress.getLoopbackAddress, 0)
+    val s1 = new ServerSocket
+    try {
+      val addr = new InetSocketAddress(InetAddress.getLoopbackAddress, 0)
 
-    s1.bind(addr)
-    val port = s1.getLocalPort
+      s1.bind(addr)
+      val port = s1.getLocalPort
 
-    assertEquals(s1.getLocalSocketAddress,
-                 new InetSocketAddress(InetAddress.getLoopbackAddress, port))
-    assert(s1.isBound)
+      assertEquals(s1.getLocalSocketAddress,
+                   new InetSocketAddress(InetAddress.getLoopbackAddress, port))
+      assert(s1.isBound)
 
-    val s2 = new ServerSocket
-    val s3 = new ServerSocket
-    s2.bind(addr)
-
-    assertThrows[BindException] { s3.bind(s2.getLocalSocketAddress) }
+      val s2 = new ServerSocket
+      val s3 = new ServerSocket // creating new socket unlikely to throw.
+      try {
+        s2.bind(addr)
+        assertThrows[BindException] { s3.bind(s2.getLocalSocketAddress) }
+      } finally {
+        s3.close()
+        s2.close()
+      }
+    } finally {
+      s1.close()
+    }
 
     val s4 = new ServerSocket
-    assertThrows[BindException] {
-      s4.bind(new InetSocketAddress(InetAddress.getByName("101.0.0.0"), 0))
+    try {
+      assertThrows[BindException] {
+        s4.bind(new InetSocketAddress(InetAddress.getByName("101.0.0.0"), 0))
+      }
+    } finally {
+      s4.close()
     }
 
     class UnsupportedSocketAddress extends SocketAddress {}
 
     val s5 = new ServerSocket
-    assertThrows[IllegalArgumentException] {
-      s5.bind(new UnsupportedSocketAddress)
+    try {
+      assertThrows[IllegalArgumentException] {
+        s5.bind(new UnsupportedSocketAddress)
+      }
+    } finally {
+      s5.close()
     }
-
-    s1.close
-    s2.close
-    s3.close
-    s4.close
-    s5.close
   }
 
   test("accept") {
     val s = new ServerSocket(0)
-    s.setSoTimeout(1)
-    assertThrows[SocketTimeoutException] { s.accept }
+    try {
+      s.setSoTimeout(1)
+      assertThrows[SocketTimeoutException] { s.accept }
+    } finally {
+      s.close()
+    }
   }
 
   test("close") {
     val s = new ServerSocket(0)
     s.close
     assertThrows[SocketException] { s.accept }
+    // socket already closed, all paths.
   }
 
   test("soTimeout") {
     val s = new ServerSocket(0)
-
-    val prevValue = s.getSoTimeout
-    s.setSoTimeout(prevValue + 100)
-    assertEquals(prevValue + 100, s.getSoTimeout)
+    try {
+      val prevValue = s.getSoTimeout
+      s.setSoTimeout(prevValue + 100)
+      assertEquals(prevValue + 100, s.getSoTimeout)
+    } finally {
+      s.close()
+    }
   }
 
   test("toString") {
-    val s1    = new ServerSocket(0)
-    val port1 = s1.getLocalPort
-    assertEquals("ServerSocket[addr=0.0.0.0/0.0.0.0,localport=" + port1 + "]",
-                 s1.toString)
+    val s1 = new ServerSocket(0)
+    try {
+      val port1 = s1.getLocalPort
+      assertEquals("ServerSocket[addr=0.0.0.0/0.0.0.0,localport="
+                     + port1 + "]",
+                   s1.toString)
 
-    val s2 = new ServerSocket
-    assertEquals("ServerSocket[unbound]", s2.toString)
+      val s2 = new ServerSocket
+      try {
+        assertEquals("ServerSocket[unbound]", s2.toString)
 
-    s2.bind(new InetSocketAddress("127.0.0.1", 0))
-    val port2 = s2.getLocalPort
-    assertEquals("ServerSocket[addr=/127.0.0.1,localport=" + port2 + "]",
-                 s2.toString)
+        s2.bind(new InetSocketAddress("127.0.0.1", 0))
+        val port2 = s2.getLocalPort
+        assertEquals("ServerSocket[addr=/127.0.0.1,localport=" + port2 + "]",
+                     s2.toString)
+      } finally {
+        s2.close()
+      }
+    } finally {
+      s1.close()
+    }
   }
-
 }

--- a/unit-tests/src/test/scala/java/net/SocketSuite.scala
+++ b/unit-tests/src/test/scala/java/net/SocketSuite.scala
@@ -115,9 +115,9 @@ object SocketSuite extends tests.Suite {
     val s = new Socket()
 
     try {
-      val prevValue = s.getReceiveBufferSize
+      val prevValue = s.getSendBufferSize
       assert(prevValue > 0)
-      s.setReceiveBufferSize(prevValue + 100)
+      s.setSendBufferSize(prevValue + 100)
     } finally {
       s.close()
     }

--- a/unit-tests/src/test/scala/java/net/SocketSuite.scala
+++ b/unit-tests/src/test/scala/java/net/SocketSuite.scala
@@ -5,121 +5,195 @@ import java.io.IOException
 object SocketSuite extends tests.Suite {
 
   test("keepAlive") {
-    val s         = new Socket()
-    val prevValue = s.getKeepAlive
-    s.setKeepAlive(!prevValue)
-    assertEquals(s.getKeepAlive, !prevValue)
-    s.close()
+    val s = new Socket()
+    try {
+      val prevValue = s.getKeepAlive
+      s.setKeepAlive(!prevValue)
+      assertEquals(s.getKeepAlive, !prevValue)
+    } finally {
+      s.close()
+    }
   }
 
   test("reuseAddr") {
-    val s         = new Socket()
-    val prevValue = s.getReuseAddress
-    s.setReuseAddress(!prevValue)
-    assertEquals(s.getReuseAddress, !prevValue)
-    s.close()
+    val s = new Socket()
+    try {
+      val prevValue = s.getReuseAddress
+      s.setReuseAddress(!prevValue)
+      assertEquals(s.getReuseAddress, !prevValue)
+    } finally {
+      s.close()
+    }
   }
 
   test("OOBInline") {
-    val s         = new Socket()
-    val prevValue = s.getOOBInline
-    s.setOOBInline(!prevValue)
-    assertEquals(s.getOOBInline, !prevValue)
-    s.close()
+    val s = new Socket()
+    try {
+      val prevValue = s.getOOBInline
+      s.setOOBInline(!prevValue)
+      assertEquals(s.getOOBInline, !prevValue)
+    } finally {
+      s.close()
+    }
   }
 
   test("tcpNoDelay") {
-    val s         = new Socket()
-    val prevValue = s.getTcpNoDelay
-    s.setTcpNoDelay(!prevValue)
-    assertEquals(s.getTcpNoDelay, !prevValue)
-    s.close()
+    val s = new Socket()
+    try {
+      val prevValue = s.getTcpNoDelay
+      s.setTcpNoDelay(!prevValue)
+      assertEquals(s.getTcpNoDelay, !prevValue)
+    } finally {
+      s.close()
+    }
   }
 
   test("soLinger") {
     val s = new Socket()
-    s.setSoLinger(true, 100)
-    assertEquals(s.getSoLinger, 100)
-    s.setSoLinger(false, 50000000)
-    assertEquals(s.getSoLinger, -1)
-    s.close()
+    try {
+      s.setSoLinger(true, 100)
+      assertEquals(s.getSoLinger, 100)
+      s.setSoLinger(false, 50000000)
+      assertEquals(s.getSoLinger, -1)
+    } finally {
+      s.close()
+    }
   }
 
   test("soTimeout") {
-    val s         = new Socket()
-    val prevValue = s.getSoTimeout
-    s.setSoTimeout(prevValue + 1000)
-    assertEquals(s.getSoTimeout, prevValue + 1000)
-    s.close()
+    val s = new Socket()
+    try {
+      val prevValue = s.getSoTimeout
+      s.setSoTimeout(prevValue + 1000)
+      assertEquals(s.getSoTimeout, prevValue + 1000)
+    } finally {
+      s.close()
+    }
   }
 
   test("receiveBufferSize") {
-    val s         = new Socket()
-    val prevValue = s.getReceiveBufferSize
-    s.setReceiveBufferSize(prevValue + 100)
-    // On linux the size is actually set to the double of given parameter
-    // so we don't test if it's equal
-    assert(s.getReceiveBufferSize >= prevValue + 100)
-    s.close()
+    // This test basically checks that getReceiveBufferSize &
+    // setReceiveBufferSize do not unexpectedly throw and that the former
+    // returns a minimally sane value.
+    //
+    // The Java 8 documentation at URL
+    // https://docs.oracle.com/javase/8/docs/api/java/net/\
+    //     Socket.html#setReceiveBufferSize-int- [sic trailing dash]
+    // describes the argument for setReceiveBufferSize(int) &
+    // setSendBufferSize(int) as a _hint_ to the operating system, _not_
+    // a requirement or demand.  This description is basically unaltered
+    // in Java 10.
+    //
+    // There are a number of reasons the operating system can choose to
+    // ignore the hint. Changing the buffer size, even before a bind() call,
+    // may not be implemented. The buffer size may already be at its
+    // maximum.
+    //
+    // Since, by definition, the OS can ignore the hint, it makes no
+    // sense to set the size, then re-read it and see if it changed.
+    //
+    // The sendBuffersize test refers to this comment.
+    // Please keep both tests synchronized.
+
+    val s = new Socket()
+
+    try {
+      val prevValue = s.getReceiveBufferSize
+      assert(prevValue > 0)
+      s.setReceiveBufferSize(prevValue + 100)
+    } finally {
+      s.close()
+    }
   }
 
   test("sendBufferSize") {
-    val s         = new Socket()
-    val prevValue = s.getSendBufferSize
-    s.setSendBufferSize(prevValue + 100)
-    // On linux the size is actually set to the double of given parameter
-    // so we don't test if it's equal
-    assert(s.getSendBufferSize >= prevValue + 100)
-    s.close()
+    // This test basically checks that getSendBufferSize &
+    // setSendBufferSize do not unexpectedly throw and that the former
+    // returns a minimally sane value.
+    // See more extensive comments in setBufferSize test.
+
+    val s = new Socket()
+
+    try {
+      val prevValue = s.getReceiveBufferSize
+      assert(prevValue > 0)
+      s.setReceiveBufferSize(prevValue + 100)
+    } finally {
+      s.close()
+    }
   }
 
   test("trafficClass") {
     val s = new Socket()
-    s.setTrafficClass(0x28)
-    assertEquals(s.getTrafficClass, 0x28)
-    s.close()
+    try {
+      s.setTrafficClass(0x28)
+      assertEquals(s.getTrafficClass, 0x28)
+    } finally {
+      s.close()
+    }
   }
 
   test("connect with timeout") {
     val s = new Socket()
-    assertThrows[SocketTimeoutException] {
-      s.connect(new InetSocketAddress("123.123.123.123", 12341), 100)
+    try {
+      assertThrows[SocketTimeoutException] {
+        s.connect(new InetSocketAddress("123.123.123.123", 12341), 100)
+      }
+    } finally {
+      s.close()
     }
-    s.close()
   }
 
   test("bind") {
     val s1 = new Socket
-    val nonLocalAddr =
-      new InetSocketAddress(InetAddress.getByName("123.123.123.123"), 0)
-    assertThrows[BindException] { s1.bind(nonLocalAddr) }
-    s1.close()
+    try {
+      val nonLocalAddr =
+        new InetSocketAddress(InetAddress.getByName("123.123.123.123"), 0)
+      assertThrows[BindException] { s1.bind(nonLocalAddr) }
+    } finally {
+      s1.close()
+    }
 
     val s2 = new Socket
-    s2.bind(new InetSocketAddress(InetAddress.getLoopbackAddress, 0))
-    val port = s2.getLocalPort
-    assertEquals(new InetSocketAddress(InetAddress.getLoopbackAddress, port),
-                 s2.getLocalSocketAddress)
-    s2.close()
+    try {
+      s2.bind(new InetSocketAddress(InetAddress.getLoopbackAddress, 0))
+      val port = s2.getLocalPort
+      assertEquals(new InetSocketAddress(InetAddress.getLoopbackAddress, port),
+                   s2.getLocalSocketAddress)
+    } finally {
+      s2.close()
+    }
 
     val s3 = new Socket
-    s3.bind(null)
-    assert(s3.getLocalSocketAddress != null)
-    s3.close()
+    try {
+      s3.bind(null)
+      assert(s3.getLocalSocketAddress != null)
+    } finally {
+      s3.close()
+    }
 
     val s4 = new Socket
-    s4.bind(new InetSocketAddress(InetAddress.getLoopbackAddress, 0))
-    val s5 = new Socket
-    assertThrows[BindException] { s5.bind(s4.getLocalSocketAddress) }
-    s4.close()
-    s5.close()
+    try {
+      s4.bind(new InetSocketAddress(InetAddress.getLoopbackAddress, 0))
+      val s5 = new Socket
+      try {
+        assertThrows[BindException] { s5.bind(s4.getLocalSocketAddress) }
+      } finally {
+        s5.close()
+      }
+    } finally {
+      s4.close()
+    }
 
     class UnsupportedSocketAddress extends SocketAddress
     val s6 = new Socket
-    assertThrows[IllegalArgumentException] {
-      s6.bind(new UnsupportedSocketAddress)
+    try {
+      assertThrows[IllegalArgumentException] {
+        s6.bind(new UnsupportedSocketAddress)
+      }
+    } finally {
+      s6.close()
     }
-    s6.close()
   }
 
 }


### PR DESCRIPTION
  * The presenting problem was expressed in issue #1335
    "Potential socket leak in *SocketSuite.scala"
    This issue is now fixed.

  * The fix is to allocate the socket then execute all code, especially
    assertions, within try/finally blocks to ensure that the socket
    gets closed on all paths, happy or sad.

  * I could not prove to myself, within the time allowed, that a leak existed,
    but it sure looked like it could. Without proof that it existed,
    I can not prove that it is now gone.  At the very least, the
    testing code looks more believably correct and does not rely for a
    assurance of correctness on arcane, changeable knowledge.

64/32 bit issues:

      None known.

Documentation:

      None required. This is an internal interface. The Suite code
      itself is lightly commented, say where a try block is un-needed.

Testing:

	* Built and tested ("test-all") on X86_64. All tests passed.