### PR TITLE
  Interflow: initial infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - java -version
   - if [ "$MODE" == "source-checks" ]; then ./scripts/source-checks; fi
   - if [ "$MODE" == "test-tools" ]; then
-      sbt "-no-colors" "-J-Xmx2G" "^^ $SBT_VERSION" nscplugin/publishLocal sbtScalaNative/publishLocal test-tools;
+      sbt "-no-colors" "-J-Xmx3G" "^^ $SBT_VERSION" nscplugin/publishLocal sbtScalaNative/publishLocal test-tools;
     fi
   - if [ "$MODE" == "test-runtime" ]; then
       ./ci-docker/load-cached-images.sh

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -47,4 +47,4 @@ USER scala-native
 
 WORKDIR /home/scala-native/scala-native
 
-CMD sbt -no-colors -J-Xmx2G "^^ $SBT_VERSION" rebuild "set scriptedBufferLog in sbtScalaNative := false" "$TEST_COMMAND"
+CMD sbt -no-colors -J-Xmx3G "^^ $SBT_VERSION" rebuild "set scriptedBufferLog in sbtScalaNative := false" "$TEST_COMMAND"

--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -5,14 +5,34 @@ import Type._
 
 object Rt {
   val Object    = Ref(Global.Top("java.lang.Object"))
+  val Class     = Ref(Global.Top("java.lang.Class"))
   val String    = Ref(Global.Top("java.lang.String"))
   val BoxedUnit = Ref(Global.Top("scala.runtime.BoxedUnit"))
   val Type      = StructValue(Seq(Int, Int, Ptr, Byte))
 
-  val JavaEqualsSig    = Sig.Method("equals", Seq(Object, Bool))
-  val JavaHashCodeSig  = Sig.Method("hashCode", Seq(Int))
-  val ScalaEqualsSig   = Sig.Method("scala_==", Seq(Object, Bool))
-  val ScalaHashCodeSig = Sig.Method("scala_##", Seq(Int))
+  val JavaEqualsSig       = Sig.Method("equals", Seq(Object, Bool))
+  val JavaHashCodeSig     = Sig.Method("hashCode", Seq(Int))
+  val ScalaEqualsSig      = Sig.Method("scala_==", Seq(Object, Bool))
+  val ScalaHashCodeSig    = Sig.Method("scala_##", Seq(Int))
+  val GetClassSig         = Sig.Method("getClass", Seq(Class))
+  val IsArraySig          = Sig.Method("isArray", Seq(Bool))
+  val IsAssignableFromSig = Sig.Method("isAssignableFrom", Seq(Class, Bool))
+  val GetNameSig          = Sig.Method("getName", Seq(String))
+  val BitCountSig         = Sig.Method("bitCount", Seq(Int, Int))
+  val ReverseBytesSig     = Sig.Method("reverseBytes", Seq(Int, Int))
+  val NumberOfLeadingZerosSig =
+    Sig.Method("numberOfLeadingZeros", Seq(Int, Int))
+  val CosSig  = Sig.Method("cos", Seq(Double, Double))
+  val SinSig  = Sig.Method("sin", Seq(Double, Double))
+  val PowSig  = Sig.Method("pow", Seq(Double, Double, Double))
+  val MaxSig  = Sig.Method("max", Seq(Double, Double, Double))
+  val SqrtSig = Sig.Method("sqrt", Seq(Double, Double))
+
+  val StringName               = String.name
+  val StringValueName          = StringName member Sig.Field("value")
+  val StringOffsetName         = StringName member Sig.Field("offset")
+  val StringCountName          = StringName member Sig.Field("count")
+  val StringCachedHashCodeName = StringName member Sig.Field("cachedHashCode")
 
   val arrayAlloc: Map[Sig, Global] = Seq(
     "BooleanArray",

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -32,6 +32,18 @@ object Show {
   def apply(v: Type): String  = { val b = newBuilder; b.type_(v); b.toString }
   def apply(v: Val): String   = { val b = newBuilder; b.val_(v); b.toString }
 
+  def dump(defns: Seq[Defn], fileName: String): Unit = {
+    val pw = new java.io.PrintWriter(fileName)
+    try {
+      defns.foreach { defn =>
+        pw.write(defn.show)
+        pw.write("\n")
+      }
+    } finally {
+      pw.close()
+    }
+  }
+
   final class NirShowBuilder(val builder: ShowBuilder) extends AnyVal {
     import builder._
 

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -72,7 +72,7 @@ object Build {
       ScalaNative.optimize(config, linked, driver)
 
     IO.getAll(config.workdir, "glob:**.ll").foreach(Files.delete)
-    ScalaNative.codegen(config, linked, optimized)
+    ScalaNative.codegen(config, optimized)
     val generated = IO.getAll(config.workdir, "glob:**.ll")
 
     val unpackedLib = LLVM.unpackNativelib(config.nativelib, config.workdir)

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -35,17 +35,15 @@ private[scalanative] object ScalaNative {
   /** Optimizer high-level NIR under closed-world assumption. */
   def optimize(config: Config,
                linked: linker.Result,
-               driver: optimizer.Driver): Seq[nir.Defn] =
+               driver: optimizer.Driver): linker.Result =
     config.logger.time(s"Optimizing (${config.mode} mode)") {
       Optimizer(config, linked, driver)
     }
 
   /** Given low-level assembly, emit LLVM IR for it to the buildDirectory. */
-  def codegen(config: Config,
-              linked: linker.Result,
-              optimized: Seq[nir.Defn]): Seq[Path] = {
+  def codegen(config: Config, linked: linker.Result): Seq[Path] = {
     config.logger.time("Generating intermediate code") {
-      CodeGen(config, linked, optimized)
+      CodeGen(config, linked)
     }
     val produced = IO.getAll(config.workdir, "glob:**.ll")
     config.logger.info(s"Produced ${produced.length} files")

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -15,9 +15,8 @@ import scalanative.util.Stats
 object CodeGen {
 
   /** Lower and generate code for given assembly. */
-  def apply(config: build.Config,
-            linked: linker.Result,
-            defns: Seq[Defn]): Unit = {
+  def apply(config: build.Config, linked: linker.Result): Unit = {
+    val defns   = linked.defns
     val proxies = GenerateReflectiveProxies(linked.dynimpls, defns)
 
     implicit val meta = new Metadata(linked, proxies)

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -437,6 +437,9 @@ object Lower {
       import buf._
 
       op match {
+        case Op.As(ty: Type.RefKind, v) if v.ty == Type.Null =>
+          let(n, Op.Copy(Val.Null), unwind)
+
         case Op.As(ty: Type.RefKind, v) if v.ty.isInstanceOf[Type.RefKind] =>
           val checkIfIsInstanceOfL, castL, failL = fresh()
 
@@ -800,22 +803,22 @@ object Lower {
 
       Val.Const(Val.StructValue(rtti(StringCls).const +: fieldValues))
     }
-
-    // Update java.lang.String::hashCode whenever you change this method.
-    def stringHashCode(s: String): Int =
-      if (s.length == 0) {
-        0
-      } else {
-        val value = s.toCharArray
-        var hash  = 0
-        var i     = 0
-        while (i < value.length) {
-          hash = value(i) + ((hash << 5) - hash)
-          i += 1
-        }
-        hash
-      }
   }
+
+  // Update java.lang.String::hashCode whenever you change this method.
+  def stringHashCode(s: String): Int =
+    if (s.length == 0) {
+      0
+    } else {
+      val value = s.toCharArray
+      var hash  = 0
+      var i     = 0
+      while (i < value.length) {
+        hash = value(i) + ((hash << 5) - hash)
+        i += 1
+      }
+      hash
+    }
 
   val LARGE_OBJECT_MIN_SIZE = 8192
 

--- a/tools/src/main/scala/scala/scalanative/interflow/BailOut.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/BailOut.scala
@@ -1,0 +1,4 @@
+package scala.scalanative
+package interflow
+
+final case class BailOut(val msg: String) extends Exception(msg)

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -1,0 +1,754 @@
+package scala.scalanative
+package interflow
+
+import scala.collection.mutable
+import scalanative.nir._
+import scalanative.linker._
+import scalanative.codegen.MemoryLayout
+import scalanative.util.unreachable
+import scalanative.interflow.Sema._
+
+trait Eval { self: Interflow =>
+  def run(insts: Array[Inst],
+          offsets: Map[Local, Int],
+          from: Local,
+          blockFresh: Fresh)(implicit state: State): Inst.Cf = {
+    var pc = offsets(from) + 1
+
+    while (true) {
+      val inst = insts(pc)
+      def bailOut =
+        throw BailOut("can't eval inst: " + inst.show)
+      inst match {
+        case Inst.None =>
+          unreachable
+        case _: Inst.Label =>
+          unreachable
+        case Inst.Let(local, op, unwind) =>
+          val value = eval(local, op, unwind, blockFresh)
+          if (value.ty == Type.Nothing) {
+            return Inst.Unreachable(unwind)
+          } else {
+            val shortUnitValue =
+              if (value.ty == Type.Unit) Val.Unit else value
+            state.storeLocal(local, shortUnitValue)
+            pc += 1
+          }
+        case Inst.Ret(v) =>
+          return Inst.Ret(eval(v))
+        case Inst.Jump(Next.Label(target, args)) =>
+          val evalArgs = args.map(eval)
+          return Inst.Jump(Next.Label(target, evalArgs))
+        case Inst.If(cond,
+                     Next.Label(thenTarget, thenArgs),
+                     Next.Label(elseTarget, elseArgs)) =>
+          def thenNext =
+            Next.Label(thenTarget, thenArgs.map(eval))
+          def elseNext =
+            Next.Label(elseTarget, elseArgs.map(eval))
+          val next = eval(cond) match {
+            case Val.True =>
+              return Inst.Jump(thenNext)
+            case Val.False =>
+              return Inst.Jump(elseNext)
+            case cond =>
+              return Inst.If(cond, thenNext, elseNext)
+          }
+        case Inst.Switch(scrut,
+                         Next.Label(defaultTarget, defaultArgs),
+                         cases) =>
+          def defaultNext =
+            Next.Label(defaultTarget, defaultArgs.map(eval))
+          eval(scrut) match {
+            case value if value.isCanonical =>
+              cases
+                .collectFirst {
+                  case Next.Case(caseValue, Next.Label(caseTarget, caseArgs))
+                      if caseValue == value =>
+                    val evalArgs = caseArgs.map(eval)
+                    return Inst.Jump(Next.Label(caseTarget, evalArgs))
+                }
+                .getOrElse {
+                  return Inst.Jump(defaultNext)
+                }
+            case scrut =>
+              return Inst.Switch(scrut, defaultNext, cases)
+          }
+        case Inst.Throw(v, unwind) =>
+          val excv = eval(v)
+          unwind match {
+            case Next.None =>
+              return Inst.Throw(excv, Next.None)
+            case Next.Unwind(Val.Local(exc, _), Next.Label(name, args)) =>
+              state.storeLocal(exc, excv)
+              val eargs = args.map(eval)
+              return Inst.Jump(Next.Label(name, eargs))
+            case _ =>
+              unreachable
+          }
+        case Inst.Unreachable(unwind) =>
+          unwind match {
+            case Next.None =>
+              return Inst.Unreachable(unwind)
+            case Next.Unwind(Val.Local(exc, _), Next.Label(name, args)) =>
+              val eexc = Val.Local(state.fresh(), Rt.Object)
+              state.storeLocal(exc, eexc)
+              val eargs = args.map(eval)
+              return Inst.Unreachable(
+                Next.Unwind(eexc, Next.Label(name, eargs)))
+            case _ =>
+              unreachable
+          }
+      }
+    }
+
+    unreachable
+  }
+
+  def eval(local: Local, op: Op, unwind: Next, blockFresh: Fresh)(
+      implicit state: State): Val = {
+    import state.materialize
+    def emit = {
+      if (unwind ne Next.None) {
+        throw BailOut("try-catch")
+      }
+      state.emit
+    }
+    def bailOut =
+      throw BailOut("can't eval op: " + op.show)
+    op match {
+      case Op.Call(sig, meth, args) =>
+        val emeth = eval(meth)
+        val eargs = args.map(eval)
+
+        emeth match {
+          case Val.Global(name, _) if intrinsics.contains(name) =>
+            intrinsic(local, sig, name, eargs, unwind)
+          case _ =>
+            val mmeth   = materialize(emeth)
+            val margs   = eargs.map(materialize(_))
+            val margtys = margs.map(_.ty)
+
+            val (msig, mtarget) = mmeth match {
+              case Val.Global(name, _) =>
+                visitDuplicate(name, margtys)
+                  .map { defn =>
+                    (defn.ty, Val.Global(defn.name, Type.Ptr))
+                  }
+                  .getOrElse {
+                    (sig, mmeth)
+                  }
+              case _ =>
+                (sig, mmeth)
+            }
+
+            emit.call(msig, mtarget, margs, unwind)
+        }
+      case _: Op.Load =>
+        bailOut
+      case _: Op.Store =>
+        bailOut
+      case _: Op.Elem =>
+        bailOut
+      case _: Op.Extract =>
+        bailOut
+      case _: Op.Insert =>
+        bailOut
+      case _: Op.Stackalloc =>
+        bailOut
+      case Op.Bin(bin, ty, l, r) =>
+        (eval(l), eval(r)) match {
+          case (l, r) if l.isCanonical && r.isCanonical =>
+            eval(bin, ty, l, r)
+          case (l, r) =>
+            emit.bin(bin, ty, materialize(l), materialize(r), unwind)
+        }
+      case Op.Comp(comp, ty, l, r) =>
+        (comp, eval(l), eval(r)) match {
+          case (_, l, r) if l.isCanonical && r.isCanonical =>
+            eval(comp, ty, l, r)
+          case (Comp.Ieq, Val.Virtual(addr), r) if !r.isCanonical =>
+            Val.False
+          case (Comp.Ieq, l, Val.Virtual(addr)) if !r.isCanonical =>
+            Val.False
+          case (Comp.Ine, Val.Virtual(addr), r) if !r.isCanonical =>
+            Val.True
+          case (Comp.Ine, l, Val.Virtual(addr)) if !r.isCanonical =>
+            Val.True
+          case (_, l, r) =>
+            emit.comp(comp, ty, materialize(l), materialize(r), unwind)
+        }
+      case Op.Conv(conv, ty, value) =>
+        eval(value) match {
+          case value if value.isCanonical =>
+            eval(conv, ty, value)
+          case value =>
+            emit.conv(conv, ty, materialize(value), unwind)
+        }
+      case Op.Classalloc(ClassRef(cls)) =>
+        Val.Virtual(state.allocClass(cls))
+      case Op.Fieldload(ty, obj, name @ FieldRef(cls, fld)) =>
+        eval(obj) match {
+          case Val.Virtual(addr) =>
+            val instance = state.derefVirtual(addr)
+            instance.values(fld.index)
+          case obj =>
+            emit.fieldload(ty, materialize(obj), name, unwind)
+        }
+      case Op.Fieldstore(ty, obj, name @ FieldRef(cls, fld), value) =>
+        eval(obj) match {
+          case Val.Virtual(addr) =>
+            val instance = state.derefVirtual(addr)
+            instance.values(fld.index) = eval(value)
+            Val.Unit
+          case obj =>
+            emit.fieldstore(ty,
+                            materialize(obj),
+                            name,
+                            materialize(eval(value)),
+                            unwind)
+        }
+      case Op.Method(obj, sig) =>
+        def resolved(reason: String) = {
+          log(s"resolved sig $sig: $reason")
+        }
+        eval(obj) match {
+          case Val.Virtual(addr) =>
+            val cls = state.deref(addr).cls
+            resolved(s"virtual value of type ${cls.name}")
+            Val.Global(resolve(cls, sig), Type.Ptr)
+          case obj if obj.ty == Type.Null =>
+            emit.method(materialize(obj), sig, unwind)
+          case obj =>
+            targets(obj.ty, sig).toSeq match {
+              case Seq() =>
+                resolved(s"no possible targets on ${obj.ty.show}")
+                Val.Zero(Type.Nothing)
+              case Seq(meth) =>
+                resolved(
+                  s"single possible target ${meth.show} for ${obj.ty.show}")
+                Val.Global(meth, Type.Ptr)
+              case meths =>
+                meths.foreach(visitRoot)
+                emit.method(materialize(obj), sig, unwind)
+            }
+        }
+      case _: Op.Dynmethod =>
+        bailOut
+      case Op.Module(clsName) =>
+        val init = clsName member Sig.Ctor(Seq.empty)
+        if (originals.contains(init)) {
+          visitRoot(init)
+        }
+        emit.module(clsName, unwind)
+      case Op.As(ty: Type.RefKind, obj) =>
+        eval(obj) match {
+          case obj @ Val.Virtual(addr) if is(state.deref(addr).cls, ty) =>
+            obj
+          case obj if obj.ty == Type.Null =>
+            obj
+          case obj =>
+            obj.ty match {
+              case ClassRef(cls) if is(cls, ty) =>
+                obj
+              case _ =>
+                emit.as(ty, materialize(obj), unwind)
+            }
+        }
+      case Op.Is(ty, obj) =>
+        val refty = ty match {
+          case ty: Type.RefKind => ty
+          case _                => bailOut
+        }
+        eval(obj) match {
+          case Val.Null =>
+            Val.False
+          case Val.Virtual(addr) =>
+            Val.Bool(is(state.deref(addr).cls, refty))
+          case obj =>
+            obj.ty match {
+              case ExactClassRef(cls, nullable) =>
+                val isStatically = is(cls, refty)
+                val res = if (!isStatically) {
+                  Val.False
+                } else if (!nullable) {
+                  Val.True
+                } else {
+                  emit.comp(Comp.Ine, Type.Ptr, obj, Val.Null, unwind)
+                }
+                log(
+                  s"isinstanceof ${obj.ty.show} a ${cls.ty.show} ? ${res.show}")
+                res
+              case _ =>
+                emit.is(refty, materialize(obj), unwind)
+            }
+        }
+      case Op.Copy(v) =>
+        eval(v)
+      case Op.Sizeof(ty) =>
+        Val.Long(MemoryLayout.sizeOf(ty))
+      case Op.Box(Type.Ref(boxname, _, _), value) =>
+        Val.Virtual(state.allocBox(boxname, eval(value)))
+      case Op.Unbox(boxty @ Type.Ref(boxname, _, _), value) =>
+        eval(value) match {
+          case Val.Virtual(addr) =>
+            val instance = state.derefVirtual(addr)
+            if (boxname == instance.cls.name) {
+              instance.values(0)
+            } else {
+              Val.Zero(Type.Nothing)
+            }
+          case value =>
+            emit.unbox(boxty, materialize(value), unwind)
+        }
+      case Op.Arrayalloc(ty, init) =>
+        eval(init) match {
+          case Val.Int(count) if count < 4096 =>
+            Val.Virtual(state.allocArray(ty, count))
+          case Val.ArrayValue(_, values) if values.size < 4096 =>
+            val addr     = state.allocArray(ty, values.size)
+            val instance = state.derefVirtual(addr)
+            values.zipWithIndex.foreach {
+              case (v, idx) =>
+                instance.values(idx) = v
+            }
+            Val.Virtual(addr)
+          case init =>
+            emit.arrayalloc(ty, materialize(init), unwind)
+        }
+      case Op.Arrayload(ty, arr, idx) =>
+        (eval(arr), eval(idx)) match {
+          case (Val.Virtual(addr), Val.Int(offset)) =>
+            val instance = state.derefVirtual(addr)
+            instance.values(offset)
+          case (arr, idx) =>
+            emit.arrayload(ty, materialize(arr), materialize(idx), unwind)
+        }
+      case Op.Arraystore(ty, arr, idx, value) =>
+        (eval(arr), eval(idx)) match {
+          case (Val.Virtual(addr), Val.Int(offset)) =>
+            val instance = state.derefVirtual(addr)
+            instance.values(offset) = eval(value)
+            Val.Unit
+          case (arr, idx) =>
+            def fallback =
+              emit.arraystore(ty,
+                              materialize(arr),
+                              materialize(idx),
+                              materialize(eval(value)),
+                              unwind)
+            eval(value) match {
+              case Val.Virtual(addr) =>
+                arr.ty match {
+                  case ArrayRef(elemty, _) =>
+                    state.deref(addr).cls.ty match {
+                      case BoxRef(boxty) if elemty == boxty =>
+                        val boxvalue = state.derefVirtual(addr).values(0)
+                        emit.arraystore(elemty,
+                                        materialize(arr),
+                                        materialize(idx),
+                                        materialize(boxvalue),
+                                        unwind)
+                      case _ =>
+                        fallback
+                    }
+                  case _ =>
+                    fallback
+                }
+              case _ =>
+                fallback
+            }
+        }
+      case Op.Arraylength(arr) =>
+        eval(arr) match {
+          case Val.Virtual(addr) =>
+            val instance = state.derefVirtual(addr)
+            Val.Int(instance.values.length)
+          case arr =>
+            emit.arraylength(materialize(arr), unwind)
+        }
+      case Op.Var(ty) =>
+        Val.Local(state.newVar(ty), Type.Var(ty))
+      case Op.Varload(slot) =>
+        val Val.Local(local, _) = eval(slot)
+        state.loadVar(local)
+      case Op.Varstore(slot, value) =>
+        val Val.Local(local, _) = eval(slot)
+        state.storeVar(local, eval(value))
+        Val.Unit
+    }
+  }
+
+  def eval(bin: Bin, ty: Type, l: Val, r: Val)(implicit state: State): Val = {
+    def bailOut =
+      throw BailOut(s"can't eval bin op: $bin[${ty.show}] ${l.show}, ${r.show}")
+    bin match {
+      case Bin.Iadd =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r))   => Val.Int(l + r)
+          case (Val.Long(l), Val.Long(r)) => Val.Long(l + r)
+          case _                          => bailOut
+        }
+      case Bin.Fadd =>
+        (l, r) match {
+          case (Val.Float(l), Val.Float(r))   => Val.Float(l + r)
+          case (Val.Double(l), Val.Double(r)) => Val.Double(l + r)
+          case _                              => bailOut
+        }
+      case Bin.Isub =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r))   => Val.Int(l - r)
+          case (Val.Long(l), Val.Long(r)) => Val.Long(l - r)
+          case _                          => bailOut
+        }
+      case Bin.Fsub =>
+        (l, r) match {
+          case (Val.Float(l), Val.Float(r))   => Val.Float(l - r)
+          case (Val.Double(l), Val.Double(r)) => Val.Double(l - r)
+          case _                              => bailOut
+        }
+      case Bin.Imul =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r))   => Val.Int(l * r)
+          case (Val.Long(l), Val.Long(r)) => Val.Long(l * r)
+          case _                          => bailOut
+        }
+      case Bin.Fmul =>
+        (l, r) match {
+          case (Val.Float(l), Val.Float(r))   => Val.Float(l * r)
+          case (Val.Double(l), Val.Double(r)) => Val.Double(l * r)
+          case _                              => bailOut
+        }
+      case Bin.Sdiv =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r)) if r != 0 =>
+            Val.Int(l / r)
+          case (Val.Long(l), Val.Long(r)) if r != 0L =>
+            Val.Long(l / r)
+          case _ =>
+            bailOut
+        }
+      case Bin.Udiv =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r)) if r != 0 =>
+            Val.Int(java.lang.Integer.divideUnsigned(l, r))
+          case (Val.Long(l), Val.Long(r)) if r != 0 =>
+            Val.Long(java.lang.Long.divideUnsigned(l, r))
+          case _ =>
+            bailOut
+        }
+      case Bin.Fdiv =>
+        (l, r) match {
+          case (Val.Float(l), Val.Float(r))   => Val.Float(l / r)
+          case (Val.Double(l), Val.Double(r)) => Val.Double(l / r)
+          case _                              => bailOut
+        }
+      case Bin.Srem =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r)) if r != 0 =>
+            Val.Int(l % r)
+          case (Val.Long(l), Val.Long(r)) if r != 0L =>
+            Val.Long(l % r)
+          case _ =>
+            bailOut
+        }
+      case Bin.Urem =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r)) if r != 0 =>
+            Val.Int(java.lang.Integer.remainderUnsigned(l, r))
+          case (Val.Long(l), Val.Long(r)) if r != 0L =>
+            Val.Long(java.lang.Long.remainderUnsigned(l, r))
+          case _ =>
+            bailOut
+        }
+      case Bin.Frem =>
+        (l, r) match {
+          case (Val.Float(l), Val.Float(r))   => Val.Float(l % r)
+          case (Val.Double(l), Val.Double(r)) => Val.Double(l % r)
+          case _                              => bailOut
+        }
+      case Bin.Shl =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r))   => Val.Int(l << r)
+          case (Val.Long(l), Val.Long(r)) => Val.Long(l << r)
+          case _                          => bailOut
+        }
+      case Bin.Lshr =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r))   => Val.Int(l >>> r)
+          case (Val.Long(l), Val.Long(r)) => Val.Long(l >>> r)
+          case _                          => bailOut
+        }
+      case Bin.Ashr =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r))   => Val.Int(l >> r)
+          case (Val.Long(l), Val.Long(r)) => Val.Long(l >> r)
+          case _                          => bailOut
+        }
+      case Bin.And =>
+        (l, r) match {
+          case (Val.Bool(l), Val.Bool(r)) => Val.Bool(l & r)
+          case (Val.Int(l), Val.Int(r))   => Val.Int(l & r)
+          case (Val.Long(l), Val.Long(r)) => Val.Long(l & r)
+          case _                          => bailOut
+        }
+      case Bin.Or =>
+        (l, r) match {
+          case (Val.Bool(l), Val.Bool(r)) => Val.Bool(l | r)
+          case (Val.Int(l), Val.Int(r))   => Val.Int(l | r)
+          case (Val.Long(l), Val.Long(r)) => Val.Long(l | r)
+          case _                          => bailOut
+        }
+      case Bin.Xor =>
+        (l, r) match {
+          case (Val.Bool(l), Val.Bool(r)) => Val.Bool(l ^ r)
+          case (Val.Int(l), Val.Int(r))   => Val.Int(l ^ r)
+          case (Val.Long(l), Val.Long(r)) => Val.Long(l ^ r)
+          case _                          => bailOut
+        }
+    }
+  }
+
+  def eval(comp: Comp, ty: Type, l: Val, r: Val)(implicit state: State): Val = {
+    def bailOut =
+      throw BailOut(
+        s"can't eval comp op: $comp[${ty.show}] ${l.show}, ${r.show}")
+    comp match {
+      case Comp.Ieq =>
+        (l, r) match {
+          case (Val.Bool(l), Val.Bool(r))           => Val.Bool(l == r)
+          case (Val.Int(l), Val.Int(r))             => Val.Bool(l == r)
+          case (Val.Long(l), Val.Long(r))           => Val.Bool(l == r)
+          case (Val.Null, Val.Null)                 => Val.True
+          case (Val.Virtual(l), Val.Virtual(r))     => Val.Bool(l == r)
+          case (Val.Global(l, _), Val.Global(r, _)) => Val.Bool(l == r)
+          case (Val.Null | _: Val.Virtual | _: Val.Global,
+                Val.Null | _: Val.Virtual | _: Val.Global) =>
+            Val.False
+          case _ => bailOut
+        }
+      case Comp.Ine =>
+        (l, r) match {
+          case (Val.Bool(l), Val.Bool(r))           => Val.Bool(l != r)
+          case (Val.Int(l), Val.Int(r))             => Val.Bool(l != r)
+          case (Val.Long(l), Val.Long(r))           => Val.Bool(l != r)
+          case (Val.Null, Val.Null)                 => Val.False
+          case (Val.Virtual(l), Val.Virtual(r))     => Val.Bool(l != r)
+          case (Val.Global(l, _), Val.Global(r, _)) => Val.Bool(l != r)
+          case (Val.Null | _: Val.Virtual | _: Val.Global,
+                Val.Null | _: Val.Virtual | _: Val.Global) =>
+            Val.True
+          case _ => bailOut
+        }
+      case Comp.Ugt =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r)) =>
+            Val.Bool(java.lang.Integer.compareUnsigned(l, r) > 0)
+          case (Val.Long(l), Val.Long(r)) =>
+            Val.Bool(java.lang.Long.compareUnsigned(l, r) > 0)
+          case _ =>
+            bailOut
+        }
+      case Comp.Uge =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r)) =>
+            Val.Bool(java.lang.Integer.compareUnsigned(l, r) >= 0)
+          case (Val.Long(l), Val.Long(r)) =>
+            Val.Bool(java.lang.Long.compareUnsigned(l, r) >= 0)
+          case _ =>
+            bailOut
+        }
+      case Comp.Ult =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r)) =>
+            Val.Bool(java.lang.Integer.compareUnsigned(l, r) < 0)
+          case (Val.Long(l), Val.Long(r)) =>
+            Val.Bool(java.lang.Long.compareUnsigned(l, r) < 0)
+          case _ =>
+            bailOut
+        }
+      case Comp.Ule =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r)) =>
+            Val.Bool(java.lang.Integer.compareUnsigned(l, r) <= 0)
+          case (Val.Long(l), Val.Long(r)) =>
+            Val.Bool(java.lang.Long.compareUnsigned(l, r) <= 0)
+          case _ =>
+            bailOut
+        }
+      case Comp.Sgt =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r))   => Val.Bool(l > r)
+          case (Val.Long(l), Val.Long(r)) => Val.Bool(l > r)
+          case _                          => bailOut
+        }
+      case Comp.Sge =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r))   => Val.Bool(l >= r)
+          case (Val.Long(l), Val.Long(r)) => Val.Bool(l >= r)
+          case _                          => bailOut
+        }
+      case Comp.Slt =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r))   => Val.Bool(l < r)
+          case (Val.Long(l), Val.Long(r)) => Val.Bool(l < r)
+          case _                          => bailOut
+        }
+      case Comp.Sle =>
+        (l, r) match {
+          case (Val.Int(l), Val.Int(r))   => Val.Bool(l <= r)
+          case (Val.Long(l), Val.Long(r)) => Val.Bool(l <= r)
+          case _                          => bailOut
+        }
+      case Comp.Feq =>
+        (l, r) match {
+          case (Val.Float(l), Val.Float(r))   => Val.Bool(l == r)
+          case (Val.Double(l), Val.Double(r)) => Val.Bool(l == r)
+          case _                              => bailOut
+        }
+      case Comp.Fne =>
+        (l, r) match {
+          case (Val.Float(l), Val.Float(r))   => Val.Bool(l != r)
+          case (Val.Double(l), Val.Double(r)) => Val.Bool(l != r)
+          case _                              => bailOut
+        }
+      case Comp.Fgt =>
+        (l, r) match {
+          case (Val.Float(l), Val.Float(r))   => Val.Bool(l > r)
+          case (Val.Double(l), Val.Double(r)) => Val.Bool(l > r)
+          case _                              => bailOut
+        }
+      case Comp.Fge =>
+        (l, r) match {
+          case (Val.Float(l), Val.Float(r))   => Val.Bool(l >= r)
+          case (Val.Double(l), Val.Double(r)) => Val.Bool(l >= r)
+          case _                              => bailOut
+        }
+      case Comp.Flt =>
+        (l, r) match {
+          case (Val.Float(l), Val.Float(r))   => Val.Bool(l < r)
+          case (Val.Double(l), Val.Double(r)) => Val.Bool(l < r)
+          case _                              => bailOut
+        }
+      case Comp.Fle =>
+        (l, r) match {
+          case (Val.Float(l), Val.Float(r))   => Val.Bool(l <= r)
+          case (Val.Double(l), Val.Double(r)) => Val.Bool(l <= r)
+          case _                              => bailOut
+        }
+    }
+  }
+
+  def eval(conv: Conv, ty: Type, value: Val)(implicit state: State): Val = {
+    def bailOut =
+      throw BailOut(s"can't eval conv op: $conv[${ty.show}] ${value.show}")
+    conv match {
+      case _ if ty == value.ty =>
+        value
+      case Conv.Trunc =>
+        (value, ty) match {
+          case (Val.Short(v), Type.Byte) => Val.Byte(v.toByte)
+          case (Val.Int(v), Type.Byte)   => Val.Byte(v.toByte)
+          case (Val.Int(v), Type.Short)  => Val.Short(v.toShort)
+          case (Val.Int(v), Type.Char)   => Val.Short(v.toChar.toShort)
+          case (Val.Long(v), Type.Byte)  => Val.Int(v.toByte)
+          case (Val.Long(v), Type.Short) => Val.Int(v.toShort)
+          case (Val.Long(v), Type.Int)   => Val.Int(v.toInt)
+          case (Val.Long(v), Type.Char)  => Val.Short(v.toChar.toShort)
+          case _                         => bailOut
+        }
+      case Conv.Zext =>
+        (value, ty) match {
+          case (Val.Short(v), Type.Int) =>
+            Val.Int(v.toChar.toInt)
+          case (Val.Short(v), Type.Long) =>
+            Val.Long(v.toChar.toLong)
+          case (Val.Int(v), Type.Long) =>
+            Val.Long(java.lang.Integer.toUnsignedLong(v))
+          case _ =>
+            bailOut
+        }
+      case Conv.Sext =>
+        (value, ty) match {
+          case (Val.Byte(v), Type.Short) => Val.Short(v.toShort)
+          case (Val.Byte(v), Type.Int)   => Val.Int(v.toInt)
+          case (Val.Byte(v), Type.Long)  => Val.Long(v.toLong)
+          case (Val.Short(v), Type.Int)  => Val.Int(v.toInt)
+          case (Val.Short(v), Type.Long) => Val.Long(v.toLong)
+          case (Val.Int(v), Type.Long)   => Val.Long(v.toLong)
+          case _                         => bailOut
+        }
+      case Conv.Fptrunc =>
+        (value, ty) match {
+          case (Val.Double(v), Type.Float) => Val.Float(v.toFloat)
+          case _                           => bailOut
+        }
+      case Conv.Fpext =>
+        (value, ty) match {
+          case (Val.Float(v), Type.Double) => Val.Double(v.toDouble)
+          case _                           => bailOut
+        }
+      case Conv.Fptoui =>
+        bailOut
+      case Conv.Fptosi =>
+        (value, ty) match {
+          case (Val.Float(v), Type.Int)   => Val.Int(v.toInt)
+          case (Val.Double(v), Type.Int)  => Val.Int(v.toInt)
+          case (Val.Float(v), Type.Long)  => Val.Long(v.toLong)
+          case (Val.Double(v), Type.Long) => Val.Long(v.toLong)
+          case _                          => bailOut
+        }
+      case Conv.Uitofp =>
+        bailOut
+      case Conv.Sitofp =>
+        (value, ty) match {
+          case (Val.Int(v), Type.Float)   => Val.Float(v.toFloat)
+          case (Val.Int(v), Type.Double)  => Val.Double(v.toDouble)
+          case (Val.Long(v), Type.Float)  => Val.Float(v.toFloat)
+          case (Val.Long(v), Type.Double) => Val.Double(v.toDouble)
+          case _                          => bailOut
+        }
+      case Conv.Ptrtoint =>
+        (value, ty) match {
+          case (Val.Null, Type.Long) => Val.Long(0L)
+          case _                     => bailOut
+        }
+      case Conv.Inttoptr =>
+        (value, ty) match {
+          case (Val.Long(0L), Type.Ptr) => Val.Null
+          case _                        => bailOut
+        }
+      case Conv.Bitcast =>
+        (value, ty) match {
+          case (value, ty) if value.ty == ty =>
+            value
+          case (Val.Int(value), Type.Float) =>
+            Val.Float(java.lang.Float.intBitsToFloat(value))
+          case (Val.Long(value), Type.Double) =>
+            Val.Double(java.lang.Double.longBitsToDouble(value))
+          case (Val.Float(value), Type.Int) =>
+            Val.Int(java.lang.Float.floatToRawIntBits(value))
+          case (Val.Double(value), Type.Long) =>
+            Val.Long(java.lang.Double.doubleToRawLongBits(value))
+          case _ =>
+            bailOut
+        }
+    }
+  }
+
+  def eval(value: Val)(implicit state: State): Val = value match {
+    case Val.Local(local, _) if local.id >= 0 =>
+      state.loadLocal(local) match {
+        case value: Val.Virtual =>
+          eval(value)
+        case value =>
+          value
+      }
+    case Val.Virtual(addr) if state.escaped(addr) =>
+      state.derefEscaped(addr).escapedValue
+    case Val.String(value) =>
+      Val.Virtual(state.allocString(value))
+    case _ =>
+      value.canonicalize
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
@@ -1,0 +1,46 @@
+package scala.scalanative
+package interflow
+
+import java.util.Arrays
+import scalanative.nir.Val
+import scalanative.linker.Class
+
+sealed abstract class Instance extends Cloneable {
+  def cls: Class
+
+  override def clone(): Instance = this match {
+    case EscapedInstance(cls, escapedValue) =>
+      EscapedInstance(cls, escapedValue)
+    case VirtualInstance(kind, cls, values) =>
+      VirtualInstance(kind, cls, values.clone())
+  }
+
+  override def toString: String = this match {
+    case EscapedInstance(cls, escapedValue) =>
+      s"EscapedInstance(${cls.name.show}, ${escapedValue.show})"
+    case VirtualInstance(kind, cls, values) =>
+      s"VirtualInstance($kind, $cls, ${values.map(_.show)})"
+  }
+}
+
+final case class EscapedInstance(val cls: Class, val escapedValue: Val)
+    extends Instance {
+  assert(!escapedValue.isVirtual)
+}
+
+final case class VirtualInstance(val kind: Kind,
+                                 val cls: Class,
+                                 var values: Array[Val])
+    extends Instance {
+  // We can't use case class generated equals, due to the fact
+  // that equals on arrays does reference equality by default.
+  override def equals(other: Any): Boolean = other match {
+    case other: VirtualInstance =>
+      kind == other.kind &&
+        cls == other.cls &&
+        Arrays.equals(values.asInstanceOf[Array[Object]],
+                      other.values.asInstanceOf[Array[Object]])
+    case _ =>
+      false
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -1,0 +1,56 @@
+package scala.scalanative
+package interflow
+
+import scala.collection.mutable
+import scalanative.nir._
+import scalanative.linker._
+
+class Interflow(val originals: Map[Global, Defn.Define])(
+    implicit val linked: linker.Result)
+    extends Visit
+    with Eval
+    with Intrinsics
+    with Log {
+  val todo      = mutable.Queue.empty[Global]
+  val done      = mutable.Map.empty[Global, Defn.Define]
+  val started   = mutable.Set.empty[Global]
+  val blacklist = mutable.Set.empty[Global]
+  var context   = List.empty[String]
+}
+
+object Interflow {
+  def apply(config: build.Config,
+            linked: linker.Result,
+            defns: Seq[Defn]): Seq[Defn] = {
+    val defnsMap = defns.collect {
+      case defn: Defn.Define =>
+        defn.name -> defn
+    }.toMap
+    val interflow = new Interflow(defnsMap)(linked)
+    linked.entries.foreach { entry =>
+      linked.infos(entry) match {
+        case info: Method =>
+          interflow.visitRoot(entry)
+        case _ =>
+          ()
+      }
+    }
+    interflow.visitLoop()
+    val done = interflow.done.values.map { defn =>
+      defn.name -> defn
+    }.toMap
+    val result = mutable.UnrolledBuffer.empty[Defn]
+    result ++= done.values
+    result ++= defns.iterator.filterNot(defn => done.contains(defn.name))
+    result.sortBy { defn =>
+      defn.name match {
+        case Global.Member(Global.Top(id), sig) =>
+          (id, sig.mangle)
+        case Global.Top(id) =>
+          (id, "")
+        case _ =>
+          ("", "")
+      }
+    }
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
@@ -1,0 +1,142 @@
+package scala.scalanative
+package interflow
+
+import java.util.Arrays
+import scalanative.nir._
+import scalanative.linker._
+
+trait Intrinsics { self: Interflow =>
+  val intrinsics = Set[Global](
+    Global.Member(Global.Top("java.lang.Object"), Rt.GetClassSig),
+    Global.Member(Global.Top("java.lang.Class"), Rt.IsArraySig),
+    Global.Member(Global.Top("java.lang.Class"), Rt.IsAssignableFromSig),
+    Global.Member(Global.Top("java.lang.Class"), Rt.GetNameSig),
+    Global.Member(Global.Top("java.lang.Integer$"), Rt.BitCountSig),
+    Global.Member(Global.Top("java.lang.Integer$"), Rt.ReverseBytesSig),
+    Global.Member(Global.Top("java.lang.Integer$"), Rt.NumberOfLeadingZerosSig),
+    Global.Member(Global.Top("java.lang.Math$"), Rt.CosSig),
+    Global.Member(Global.Top("java.lang.Math$"), Rt.SinSig),
+    Global.Member(Global.Top("java.lang.Math$"), Rt.PowSig),
+    Global.Member(Global.Top("java.lang.Math$"), Rt.MaxSig),
+    Global.Member(Global.Top("java.lang.Math$"), Rt.SqrtSig)
+  )
+
+  def intrinsic(local: Local,
+                ty: Type,
+                name: Global,
+                args: Seq[Val],
+                unwind: Next)(implicit state: State): Val = {
+    val Global.Member(_, sig) = name
+
+    def emit = {
+      if (unwind ne Next.None) {
+        throw BailOut("try-catch")
+      }
+      state.emit.call(ty,
+                      Val.Global(name, Type.Ptr),
+                      args.map(state.materialize(_)),
+                      unwind)
+    }
+
+    sig match {
+      case Rt.GetClassSig =>
+        args match {
+          case Seq(Val.Virtual(thisAddr)) =>
+            val cls = state.deref(thisAddr).cls
+            val addr =
+              state.allocClass(
+                linked.infos(Global.Top("java.lang.Class")).asInstanceOf[Class])
+            val instance = state.derefVirtual(addr)
+            instance.values(0) = Val.Global(cls.name, Type.Ptr)
+            Val.Virtual(addr)
+          case _ =>
+            emit
+        }
+      case Rt.IsArraySig =>
+        args match {
+          case Seq(Val.Virtual(addr)) =>
+            val Val.Global(clsName, _) = state.derefVirtual(addr).values(0)
+            Val.Bool(Type.isArray(clsName))
+          case _ =>
+            emit
+        }
+      case Rt.IsAssignableFromSig =>
+        args match {
+          case Seq(Val.Virtual(leftAddr), Val.Virtual(rightAddr)) =>
+            val Val.Global(leftName, _) = state.derefVirtual(leftAddr).values(0)
+            val Val.Global(rightName, _) =
+              state.derefVirtual(rightAddr).values(0)
+            val left  = linked.infos(leftName).asInstanceOf[Class]
+            val right = linked.infos(rightName).asInstanceOf[Class]
+            Val.Bool(right.subclasses.contains(left))
+          case _ =>
+            emit
+        }
+      case Rt.GetNameSig =>
+        args match {
+          case Seq(Val.Virtual(addr)) =>
+            val Val.Global(name: Global.Top, _) =
+              state.derefVirtual(addr).values(0)
+            eval(Val.String(name.id))(state)
+          case _ =>
+            emit
+        }
+      case Rt.BitCountSig =>
+        args match {
+          case Seq(_, Val.Int(v)) =>
+            Val.Int(java.lang.Integer.bitCount(v))
+          case _ =>
+            emit
+        }
+      case Rt.ReverseBytesSig =>
+        args match {
+          case Seq(_, Val.Int(v)) =>
+            Val.Int(java.lang.Integer.reverseBytes(v))
+          case _ =>
+            emit
+        }
+      case Rt.NumberOfLeadingZerosSig =>
+        args match {
+          case Seq(_, Val.Int(v)) =>
+            Val.Int(java.lang.Integer.numberOfLeadingZeros(v))
+          case _ =>
+            emit
+        }
+      case Rt.CosSig =>
+        args match {
+          case Seq(_, Val.Double(v)) =>
+            Val.Double(java.lang.Math.cos(v))
+          case _ =>
+            emit
+        }
+      case Rt.SinSig =>
+        args match {
+          case Seq(_, Val.Double(v)) =>
+            Val.Double(java.lang.Math.sin(v))
+          case _ =>
+            emit
+        }
+      case Rt.PowSig =>
+        args match {
+          case Seq(_, Val.Double(v1), Val.Double(v2)) =>
+            Val.Double(java.lang.Math.pow(v1, v2))
+          case _ =>
+            emit
+        }
+      case Rt.SqrtSig =>
+        args match {
+          case Seq(_, Val.Double(v)) =>
+            Val.Double(java.lang.Math.sqrt(v))
+          case _ =>
+            emit
+        }
+      case Rt.MaxSig =>
+        args match {
+          case Seq(_, Val.Double(v1), Val.Double(v2)) =>
+            Val.Double(java.lang.Math.max(v1, v2))
+          case _ =>
+            emit
+        }
+    }
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/Kind.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Kind.scala
@@ -1,0 +1,8 @@
+package scala.scalanative
+package interflow
+
+sealed abstract class Kind
+final object ClassKind  extends Kind
+final object ArrayKind  extends Kind
+final object BoxKind    extends Kind
+final object StringKind extends Kind

--- a/tools/src/main/scala/scala/scalanative/interflow/Log.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Log.scala
@@ -1,0 +1,37 @@
+package scala.scalanative
+package interflow
+
+trait Log { self: Interflow =>
+  private def show: Boolean =
+    false
+
+  def in[T](msg: String)(f: => T): T = {
+    if (show) { log(msg) }
+    context ::= msg
+    try {
+      val start = System.nanoTime
+      val res   = f
+      val end   = System.nanoTime
+      if (show) { log(s"done $msg (${(end - start) / 1000000D})") }
+      res
+    } catch {
+      case e: Throwable =>
+        log("unwinding " + msg)
+        throw e
+    } finally {
+      context = context.tail
+    }
+  }
+
+  def log(msg: String): Unit =
+    if (show) {
+      println("  " * context.size + msg)
+    }
+
+  def debug[T](msg: String)(f: => T): T = {
+    log(s"computing $msg")
+    val res = f
+    log(s"debug $msg = $res")
+    res
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
@@ -1,0 +1,59 @@
+package scala.scalanative
+package interflow
+
+import scala.collection.mutable
+import scalanative.nir._
+
+final class MergeBlock(val label: Inst.Label, val name: Local) {
+  val incoming            = mutable.Map.empty[Local, (Seq[Val], State)]
+  val outgoing            = mutable.Map.empty[Local, MergeBlock]
+  var phis: Seq[MergePhi] = _
+  var start: State        = _
+  var end: State          = _
+  var cf: Inst.Cf         = _
+  var invalidations: Int  = 0
+
+  def toInsts(): Seq[Inst] = {
+    val block  = this
+    val result = new nir.Buffer()(Fresh(0))
+    def mergeNext(next: Next.Label): Next.Label = {
+      val nextBlock = outgoing(next.name)
+      val mergeValues = nextBlock.phis.flatMap {
+        case MergePhi(_, incoming) =>
+          incoming.collect {
+            case (name, value) if name == block.label.name =>
+              value
+          }
+      }
+      Next.Label(nextBlock.name, mergeValues)
+    }
+    def mergeUnwind(next: Next): Next = next match {
+      case Next.None =>
+        next
+      case Next.Unwind(exc, next: Next.Label) =>
+        Next.Unwind(exc, mergeNext(next))
+    }
+    val params = block.phis.map(_.param)
+    result.label(block.name, params)
+    result ++= block.end.emit
+    block.cf match {
+      case ret: Inst.Ret =>
+        result += ret
+      case Inst.Jump(next: Next.Label) =>
+        result.jump(mergeNext(next))
+      case Inst.If(cond, thenNext: Next.Label, elseNext: Next.Label) =>
+        result.branch(cond, mergeNext(thenNext), mergeNext(elseNext))
+      case Inst.Switch(scrut, defaultNext: Next.Label, cases) =>
+        val mergeCases = cases.map {
+          case Next.Case(v, next: Next.Label) =>
+            Next.Case(v, mergeNext(next))
+        }
+        result.switch(scrut, mergeNext(defaultNext), mergeCases)
+      case Inst.Throw(v, unwind) =>
+        result.raise(v, mergeUnwind(unwind))
+      case Inst.Unreachable(unwind) =>
+        result.unreachable(mergeUnwind(unwind))
+    }
+    result.toSeq
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/MergePhi.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergePhi.scala
@@ -1,0 +1,6 @@
+package scala.scalanative
+package interflow
+
+import scalanative.nir._
+
+final case class MergePhi(param: Val.Local, incoming: Seq[(Local, Val)])

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -1,0 +1,372 @@
+package scala.scalanative
+package interflow
+
+import scala.collection.mutable
+import scalanative.util.unreachable
+import scalanative.nir._
+import scalanative.linker._
+import scalanative.interflow.Sema._
+
+final class MergeProcessor(insts: Array[Inst],
+                           blockFresh: Fresh,
+                           inline: Boolean,
+                           eval: Eval)(implicit linked: linker.Result) {
+  val offsets =
+    insts.zipWithIndex.collect {
+      case (Inst.Label(local, _), offset) =>
+        local -> offset
+    }.toMap
+  val blocks = mutable.Map.empty[Local, MergeBlock]
+  var todo   = mutable.Set.empty[Local]
+
+  def findMergeBlock(name: Local): MergeBlock = {
+    def newMergeBlock = {
+      val label = insts(offsets(name)).asInstanceOf[Inst.Label]
+      new MergeBlock(label, Local(blockFresh().id * 10000))
+    }
+    blocks.getOrElseUpdate(name, newMergeBlock)
+  }
+
+  def merge(block: MergeBlock)(
+      implicit linked: linker.Result): (Seq[MergePhi], State) = {
+    val params   = block.label.params
+    val incoming = block.incoming.toSeq.sortBy(_._1.id)
+
+    incoming match {
+      case Seq() =>
+        unreachable
+      case Seq((Local(id), (values, state))) =>
+        val newstate = state.fullClone(block.name)
+        params.zip(values).foreach {
+          case (param, value) =>
+            newstate.storeLocal(param.name, value)
+        }
+        val phis =
+          if (id == -1 && !inline) {
+            values.zipWithIndex.map {
+              case (param: Val.Local, i) =>
+                MergePhi(param, Seq.empty[(Local, Val)])
+            }
+          } else {
+            Seq.empty
+          }
+        (phis, newstate)
+      case _ =>
+        val names     = incoming.map { case (n, (_, _)) => n }
+        val states    = incoming.map { case (_, (_, s)) => s }
+        val headState = states.head
+
+        var mergeFresh  = Fresh(block.name.id)
+        val mergeLocals = mutable.Map.empty[Local, Val]
+        val mergeHeap   = mutable.Map.empty[Addr, Instance]
+        val mergePhis   = mutable.UnrolledBuffer.empty[MergePhi]
+        val newEscapes  = mutable.Set.empty[Addr]
+
+        def mergePhi(values: Seq[Val]): Val =
+          if (values.distinct.size == 1) {
+            values.head
+          } else {
+            val materialized = states.zip(values).map {
+              case (s, v @ Val.Virtual(addr)) if !s.escaped(addr) =>
+                newEscapes += addr
+                s.materialize(v)
+              case (s, v) =>
+                s.materialize(v)
+            }
+            val name    = mergeFresh()
+            val paramty = lub(materialized.map(_.ty))
+            val param   = Val.Local(name, paramty)
+            mergePhis += MergePhi(param, names.zip(materialized))
+            param
+          }
+
+        def computeMerge(): Unit = {
+
+          // 1. Merge locals
+          def includeLocal(local: Local): Boolean =
+            states.forall(_.locals.contains(local))
+          val locals =
+            headState.locals.keysIterator
+              .filter(includeLocal)
+              .toArray
+              .sortBy(_.id)
+          locals.foreach { local =>
+            val values = states.map(_.locals(local))
+            mergeLocals(local) = mergePhi(values)
+          }
+
+          // 2. Merge heap
+
+          def includeAddr(addr: Addr): Boolean =
+            states.forall { state =>
+              state.heap.contains(addr) &&
+              (state.deref(addr).cls eq states.head.deref(addr).cls)
+            }
+          def escapes(addr: Addr): Boolean =
+            states.exists(_.escaped(addr))
+          val addrs =
+            states.head.heap.keys.filter(includeAddr).toArray.sorted
+          addrs.foreach { addr =>
+            val headInstance = states.head.deref(addr)
+            if (escapes(addr)) {
+              val values = states.map { s =>
+                s.deref(addr) match {
+                  case _: VirtualInstance        => Val.Virtual(addr)
+                  case EscapedInstance(_, value) => value
+                }
+              }
+              val param = mergePhi(values)
+              mergeHeap(addr) = EscapedInstance(headInstance.cls, param)
+            } else {
+              val VirtualInstance(headKind, _, headValues) = headInstance
+              val mergeValues = headValues.zipWithIndex.map {
+                case (_, idx) =>
+                  val values = states.map { state =>
+                    if (state.escaped(addr)) restart()
+                    state.derefVirtual(addr).values(idx)
+                  }
+                  mergePhi(values)
+              }
+              mergeHeap(addr) =
+                VirtualInstance(headKind, headInstance.cls, mergeValues)
+            }
+          }
+
+          // 3. Merge params
+
+          params.zipWithIndex.foreach {
+            case (param, idx) =>
+              val values = incoming.map {
+                case (_, (values, _)) =>
+                  values(idx)
+              }
+              mergeLocals(param.name) = mergePhi(values)
+          }
+        }
+
+        def restart(): Nothing =
+          throw MergeProcessor.Restart
+
+        // Retry until no new escapes are found
+
+        var retries = 0
+        do {
+          retries += 1
+          mergeFresh = Fresh(block.name.id)
+          mergeLocals.clear()
+          mergeHeap.clear()
+          mergePhis.clear()
+          newEscapes.clear()
+          try {
+            computeMerge()
+          } catch {
+            case MergeProcessor.Restart =>
+              ()
+          }
+          if (retries > 128) {
+            throw BailOut("too many state merge retries")
+          }
+        } while (newEscapes.nonEmpty)
+
+        // Wrap up anre rturn a new merge state
+
+        val mergeState = new State(block.name)
+        mergeState.emit = new nir.Buffer()(mergeFresh)
+        mergeState.fresh = mergeFresh
+        mergeState.locals = mergeLocals
+        mergeState.heap = mergeHeap
+
+        (mergePhis, mergeState)
+    }
+  }
+
+  def done(): Boolean =
+    todo.isEmpty
+
+  def snapshot(): String = {
+    val sb = new StringBuilder
+    def println(msg: String) = {
+      sb.append(msg)
+      sb.append('\n')
+    }
+    blocks.values.toSeq.sortBy(_.name.id).foreach { block =>
+      println("-- block " + block.label.show)
+      println("name " + block.name.show)
+      if (block.phis != null) {
+        block.phis.foreach {
+          case MergePhi(name, incoming) =>
+            println(
+              s"phi " + name.show + " = " + incoming
+                .map {
+                  case (from, value) => s"(${from.show}, ${value.show})"
+                }
+                .mkString("{ ", ", ", "}"))
+        }
+      } else {
+        println("phis = null")
+      }
+      if (block.end != null) {
+        block.end.emit.toSeq.foreach(i => println(i.show))
+      } else {
+        println("insts = null")
+      }
+      if (block.cf != null) {
+        println(block.cf.show)
+      } else {
+        println("cf = null")
+      }
+    }
+    sb.toString
+  }
+
+  var cnt = 0
+
+  def advance(): Unit = {
+    val sortedTodo = todo.toArray.sortBy(_.id)
+    val block      = findMergeBlock(sortedTodo.head)
+    todo.clear()
+    todo ++= sortedTodo.tail
+
+    val (newPhis, newState) = merge(block)
+    block.phis = newPhis
+
+    if (newState != block.start) {
+      if (block.invalidations > 128) {
+        throw BailOut("too many block invalidations")
+      } else {
+        block.invalidations += 1
+      }
+
+      def nextLabel(next: Next.Label): Unit = {
+        val nextMergeBlock = findMergeBlock(next.name)
+        block.outgoing(next.name) = nextMergeBlock
+        nextMergeBlock.incoming(block.label.name) = ((next.args, block.end))
+        todo += next.name
+      }
+      def nextUnwind(next: Next): Unit = next match {
+        case Next.None =>
+          ()
+        case Next.Unwind(_, next: Next.Label) =>
+          nextLabel(next)
+        case _ =>
+          util.unreachable
+      }
+
+      block.start = newState.fullClone(block.name)
+      block.end = newState
+      block.cf =
+        eval.run(insts, offsets, block.label.name, blockFresh)(block.end)
+      block.outgoing.clear()
+      block.cf match {
+        case _: Inst.Ret =>
+          ()
+        case Inst.Jump(next: Next.Label) =>
+          nextLabel(next)
+        case Inst.If(_, thenNext: Next.Label, elseNext: Next.Label) =>
+          nextLabel(thenNext)
+          nextLabel(elseNext)
+        case Inst.Switch(_, defaultNext: Next.Label, cases) =>
+          nextLabel(defaultNext)
+          cases.foreach {
+            case Next.Case(_, caseNext: Next.Label) =>
+              nextLabel(caseNext)
+          }
+        case Inst.Throw(_, next) =>
+          nextUnwind(next)
+        case Inst.Unreachable(next) =>
+          nextUnwind(next)
+        case _ =>
+          unreachable
+      }
+    }
+  }
+
+  def toSeq(): Seq[MergeBlock] = {
+    val retMergeBlocks = blocks.values.collect {
+      case block if block.cf.isInstanceOf[Inst.Ret] =>
+        block
+    }.toSeq
+
+    // Inlining expects at most one block that returns.
+    // If the discovered blocks contain more than one,
+    // we must merge them together using a synthetic block.
+    if (inline && retMergeBlocks.size > 1) {
+      val retTy = lub(retMergeBlocks.map { block =>
+        val Inst.Ret(v) = block.cf
+        v match {
+          case Val.Virtual(addr) => block.end.deref(addr).cls.ty
+          case _                 => v.ty
+        }
+      })
+
+      // Create synthetic label and block where all returning blocks
+      // are going tojump to. Synthetics names must be fresh relative
+      // to the source instructions, not relative to generated ones.
+      val syntheticFresh = Fresh(insts)
+      val syntheticParam = Val.Local(syntheticFresh(), retTy)
+      val syntheticLabel = Inst.Label(syntheticFresh(), Seq(syntheticParam))
+      val resultMergeBlock =
+        new MergeBlock(syntheticLabel, Local(blockFresh().id * 10000))
+      blocks(syntheticLabel.name) = resultMergeBlock
+
+      // Update all returning blocks to jump to result block,
+      // and update incoming/outgoing edges to include result block.
+      retMergeBlocks.foreach { block =>
+        val Inst.Ret(v) = block.cf
+        block.cf = Inst.Jump(Next.Label(syntheticLabel.name, Seq(v)))
+        block.outgoing(syntheticLabel.name) = resultMergeBlock
+        resultMergeBlock.incoming(block.label.name) = ((Seq(v), block.end))
+      }
+
+      // Perform merge of all incoming edges to compute
+      // state and phis in the resulting block. Synthetic
+      // param value must be evaluated in end state as it
+      // might be eliminated after merge processing.
+      val (phis, state) = merge(resultMergeBlock)
+      resultMergeBlock.phis = phis
+      resultMergeBlock.start = state
+      resultMergeBlock.end = state
+      resultMergeBlock.cf = Inst.Ret(eval.eval(syntheticParam)(state))
+    }
+
+    blocks.values.toSeq.sortBy(_.label.name.id)
+  }
+}
+
+object MergeProcessor {
+  final case object Restart
+      extends Exception
+      with scala.util.control.NoStackTrace
+
+  def fromEntry(insts: Array[Inst],
+                args: Seq[Val],
+                state: State,
+                blockFresh: Fresh,
+                inline: Boolean,
+                eval: Eval)(implicit linked: linker.Result): MergeProcessor = {
+    val builder         = new MergeProcessor(insts, blockFresh, inline, eval)
+    val entryName       = insts.head.asInstanceOf[Inst.Label].name
+    val entryMergeBlock = builder.findMergeBlock(entryName)
+    val entryState      = new State(entryMergeBlock.name)
+    entryState.inherit(state)
+    entryMergeBlock.incoming(Local(-1)) = ((args, entryState))
+    builder.todo += entryName
+    builder
+  }
+
+  def process(insts: Array[Inst],
+              args: Seq[Val],
+              state: State,
+              blockFresh: Fresh,
+              inline: Boolean,
+              eval: Eval)(implicit linked: linker.Result): Seq[MergeBlock] = {
+    val builder =
+      MergeProcessor.fromEntry(insts, args, state, blockFresh, inline, eval)
+
+    while (!builder.done()) {
+      builder.advance()
+    }
+
+    builder.toSeq()
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/Sema.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Sema.scala
@@ -1,0 +1,134 @@
+package scala.scalanative
+package interflow
+
+import scala.collection.mutable
+import scalanative.nir._
+import scalanative.linker._
+import scalanative.util.unreachable
+
+object Sema {
+
+  def is(cls: Class, ty: Type.RefKind)(
+      implicit linked: linker.Result): Boolean = {
+    ty match {
+      case ExactClassRef(othercls, _) =>
+        cls == othercls
+      case ClassRef(othercls) =>
+        cls.is(othercls)
+      case TraitRef(trt) =>
+        cls.is(trt)
+      case _ =>
+        util.unreachable
+    }
+  }
+
+  def lub(tys: Seq[Type])(implicit linked: linker.Result): Type = tys match {
+    case Seq() =>
+      unreachable
+    case head +: tail =>
+      tail.foldLeft[Type](head)(lub)
+  }
+
+  def lub(lty: Type, rty: Type)(implicit linked: linker.Result): Type =
+    (lty, rty) match {
+      case _ if lty == rty =>
+        lty
+      case (ClassRef(lcls), ClassRef(rcls)) =>
+        if (rcls.is(lcls)) {
+          lcls.ty
+        } else {
+          val lparent =
+            lcls.parent.getOrElse(
+              linked.infos(Rt.Object.name).asInstanceOf[Class])
+          lub(lparent.ty, rty)
+        }
+      case (ClassRef(cls), TraitRef(trt)) =>
+        if (cls.is(trt)) {
+          Type.Ref(trt.name)
+        } else {
+          Rt.Object
+        }
+      case (TraitRef(trt), ClassRef(cls)) =>
+        lub(rty, lty)
+      case (TraitRef(ltrt), TraitRef(rtrt)) =>
+        if (ltrt.is(rtrt)) {
+          Type.Ref(rtrt.name)
+        } else if (rtrt.is(ltrt)) {
+          Type.Ref(ltrt.name)
+        } else {
+          Rt.Object
+        }
+      case (lty @ (_: Type.RefKind | Type.Ptr), Type.Null) =>
+        lty
+      case (Type.Null, rty @ (_: Type.RefKind | Type.Ptr)) =>
+        rty
+      case (ty, Type.Nothing) =>
+        ty
+      case (Type.Nothing, ty) =>
+        ty
+      case (Type.Short, Type.Char) | (Type.Char, Type.Short) =>
+        Type.Short
+      case _ =>
+        util.unsupported(s"lub(${lty.show}, ${rty.show})")
+    }
+
+  def glb(tys: (Type, Type))(implicit linked: linker.Result): Option[Type] =
+    glb(tys._1, tys._2)
+
+  def glb(lty: Type, rty: Type)(implicit linked: linker.Result): Option[Type] =
+    (lty, rty) match {
+      case _ if lty == rty =>
+        Some(lty)
+      case (ClassRef(lcls), ClassRef(rcls)) =>
+        if (lcls.is(rcls)) {
+          Some(lcls.ty)
+        } else if (rcls.is(lcls)) {
+          Some(rcls.ty)
+        } else {
+          None
+        }
+      case (ClassRef(cls), TraitRef(trt)) =>
+        if (cls.is(trt)) {
+          Some(cls.ty)
+        } else if (cls.ty == Rt.Object) {
+          Some(Type.Ref(trt.name))
+        } else {
+          None
+        }
+      case (TraitRef(trt), ClassRef(cls)) =>
+        glb(rty, lty)
+      case (TraitRef(ltrt), TraitRef(rtrt)) =>
+        if (ltrt.is(rtrt)) {
+          Some(Type.Ref(ltrt.name))
+        } else if (rtrt.is(ltrt)) {
+          Some(Type.Ref(rtrt.name))
+        } else {
+          None
+        }
+      case (_: Type.RefKind | Type.Ptr, Type.Null) |
+          (Type.Null, _: Type.RefKind | Type.Ptr) =>
+        Some(Type.Null)
+      case (_, Type.Nothing) | (Type.Nothing, _) =>
+        Some(Type.Nothing)
+      case (Type.Short, Type.Char) | (Type.Char, Type.Short) =>
+        Some(Type.Short)
+      case _ =>
+        util.unsupported(s"glb(${lty.show}, ${rty.show})")
+    }
+
+  def resolve(cls: Class, sig: Sig)(implicit linked: linker.Result): Global =
+    cls.resolve(sig).get
+
+  def targets(ty: Type, sig: Sig)(
+      implicit linked: linker.Result): mutable.Set[Global] =
+    ty match {
+      case ExactClassRef(cls, _) =>
+        val out = mutable.Set.empty[Global]
+        out ++= cls.resolve(sig)
+        out
+      case ScopeRef(scope) =>
+        scope.targets(sig)
+      case _ =>
+        mutable.Set.empty
+    }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -1,0 +1,266 @@
+package scala.scalanative
+package interflow
+
+import scala.collection.mutable
+import scalanative.util.unreachable
+import scalanative.nir._
+import scalanative.linker._
+import scalanative.codegen.Lower
+
+final class State(block: Local) {
+  var fresh  = Fresh(block.id)
+  var heap   = mutable.Map.empty[Addr, Instance]
+  var locals = mutable.Map.empty[Local, Val]
+  var emit   = new nir.Buffer()(fresh)
+
+  private def alloc(kind: Kind, cls: Class, values: Array[Val]): Addr = {
+    val addr = fresh().id
+    heap(addr) = VirtualInstance(kind, cls, values)
+    addr
+  }
+  def allocClass(cls: Class): Addr = {
+    val fields = cls.fields.map(fld => Val.Zero(fld.ty).canonicalize)
+    alloc(ClassKind, cls, fields.toArray[Val])
+  }
+  def allocArray(elemty: Type, count: Int)(
+      implicit linked: linker.Result): Addr = {
+    val zero   = Val.Zero(elemty).canonicalize
+    val values = Array.fill[Val](count)(zero)
+    val cls    = linked.infos(Type.toArrayClass(elemty)).asInstanceOf[Class]
+    alloc(ArrayKind, cls, values)
+  }
+  def allocBox(boxname: Global, value: Val)(
+      implicit linked: linker.Result): Addr = {
+    val boxcls = linked.infos(boxname).asInstanceOf[Class]
+    alloc(BoxKind, boxcls, Array(value))
+  }
+  def allocString(value: String)(implicit linked: linker.Result): Addr = {
+    val charsArray = value.toArray
+    val charsAddr  = allocArray(Type.Char, charsArray.length)
+    val chars      = derefVirtual(charsAddr)
+    charsArray.zipWithIndex.foreach {
+      case (value, idx) =>
+        chars.values(idx) = Val.Short(value.toShort)
+    }
+    val values = new Array[Val](4)
+    values(linked.StringValueField.index) = Val.Virtual(charsAddr)
+    values(linked.StringOffsetField.index) = Val.Int(0)
+    values(linked.StringCountField.index) = Val.Int(charsArray.length)
+    values(linked.StringCachedHashCodeField.index) =
+      Val.Int(Lower.stringHashCode(value))
+    alloc(StringKind, linked.StringClass, values)
+  }
+  def deref(addr: Addr): Instance =
+    heap(addr)
+  def derefVirtual(addr: Addr): VirtualInstance =
+    heap(addr).asInstanceOf[VirtualInstance]
+  def derefEscaped(addr: Addr): EscapedInstance =
+    heap(addr).asInstanceOf[EscapedInstance]
+  def escaped(addr: Addr): Boolean =
+    deref(addr).isInstanceOf[EscapedInstance]
+  def escaped(value: Val): Boolean = value match {
+    case Val.Virtual(addr) => escaped(addr)
+    case _                 => false
+  }
+  def loadLocal(local: Local): Val =
+    locals(local)
+  def storeLocal(local: Local, value: Val): Unit = {
+    locals(local) = value
+  }
+  def newVar(ty: Type): Local = {
+    val local = Local(-fresh().id)
+    locals(local) = Val.Zero(ty).canonicalize
+    local
+  }
+  def loadVar(local: Local): Val = {
+    assert(local.id < 0)
+    locals(local)
+  }
+  def storeVar(local: Local, value: Val): Unit = {
+    assert(local.id < 0)
+    locals(local) = value
+  }
+  def materialize(value: Val)(implicit linked: linker.Result): Val =
+    value match {
+      case Val.Virtual(addr) =>
+        materialize(addr)
+      case _ =>
+        value
+    }
+  def materialize(addr: Long)(implicit linked: linker.Result): Val = {
+    val reachable = mutable.Set.empty[Addr]
+    val addrs     = mutable.UnrolledBuffer.empty[Addr]
+    def markValue(v: Val): Unit = v match {
+      case Val.Virtual(addr) =>
+        markAddr(addr)
+      case _ =>
+        ()
+    }
+    def markAddr(addr: Addr): Unit = {
+      if (!reachable.contains(addr)) {
+        def markCurrentAddr() = {
+          reachable += addr
+          addrs += addr
+        }
+        deref(addr) match {
+          case VirtualInstance(BoxKind, _, _) =>
+            markCurrentAddr()
+          case VirtualInstance(StringKind, _, values) =>
+            markCurrentAddr()
+            if (escaped(values(linked.StringValueField.index))) {
+              values.foreach(markValue)
+            }
+          case VirtualInstance(_, _, values) =>
+            markCurrentAddr()
+            values.foreach(markValue)
+          case _: EscapedInstance =>
+            ()
+        }
+      }
+    }
+    markAddr(addr)
+
+    val locals = addrs.map { addr =>
+      val local = deref(addr) match {
+        case VirtualInstance(ArrayKind, cls, values) =>
+          val ArrayRef(elemty, _) = cls.ty
+          val init =
+            if (!elemty.isInstanceOf[Type.RefKind]
+                && values.forall(_.isCanonical)
+                && values.exists(v => !v.isDefault)) {
+              Val.ArrayValue(elemty, values)
+            } else {
+              Val.Int(values.length)
+            }
+          emit.arrayalloc(elemty, init, Next.None)
+        case VirtualInstance(BoxKind, cls, Array(value)) =>
+          emit.box(Type.Ref(cls.name), value, Next.None)
+        case VirtualInstance(StringKind, _, values)
+            if !escaped(values(linked.StringValueField.index)) =>
+          val Val.Virtual(charsAddr) = values(linked.StringValueField.index)
+          val chars = derefVirtual(charsAddr).values
+            .map {
+              case Val.Short(v) => v.toChar
+            }
+            .toArray[Char]
+          Val.String(new java.lang.String(chars))
+        case VirtualInstance(_, cls, _) =>
+          emit.classalloc(cls.name, Next.None)
+        case _: EscapedInstance =>
+          unreachable
+      }
+      addr -> local
+    }.toMap
+
+    def escapedValueOf(addr: Addr): Val =
+      if (locals.contains(addr)) {
+        locals(addr)
+      } else {
+        derefEscaped(addr).escapedValue
+      }
+
+    addrs.foreach { addr =>
+      val local = locals(addr)
+      deref(addr) match {
+        case VirtualInstance(ArrayKind, cls, values) =>
+          val ArrayRef(elemty, _) = cls.ty
+          if (!elemty.isInstanceOf[Type.RefKind]
+              && values.forall(_.isCanonical)
+              && values.exists(v => !v.isDefault)) {
+            ()
+          } else {
+            values.zipWithIndex.foreach {
+              case (value, idx) if value.isDefault =>
+                // fields are initialied to default value
+                ()
+              case (Val.Virtual(addr), idx) =>
+                val value = escapedValueOf(addr)
+                assert(!value.isVirtual)
+                emit.arraystore(elemty, local, Val.Int(idx), value, Next.None)
+              case (value, idx) =>
+                emit.arraystore(elemty, local, Val.Int(idx), value, Next.None)
+            }
+          }
+        case VirtualInstance(BoxKind, _, _) =>
+          ()
+        case VirtualInstance(StringKind, _, values)
+            if !escaped(values(linked.StringValueField.index)) =>
+          ()
+        case VirtualInstance(_, cls, values) =>
+          cls.fields.zip(values).foreach {
+            case (fld, value) if value.isDefault =>
+              // fields are initialied to default value
+              ()
+            case (fld, Val.Virtual(addr)) =>
+              val value = escapedValueOf(addr)
+              assert(!value.isVirtual)
+              emit.fieldstore(fld.ty, local, fld.name, value, Next.None)
+            case (fld, value) =>
+              emit.fieldstore(fld.ty, local, fld.name, value, Next.None)
+          }
+        case _: EscapedInstance =>
+          unreachable
+      }
+      heap(addr) = new EscapedInstance(heap(addr).cls, local)
+    }
+
+    escapedValueOf(addr)
+  }
+  def inherit(other: State): Unit = {
+    this.heap = other.heap.map { case (k, v) => (k, v.clone()) }
+  }
+  def fullClone(block: Local): State = {
+    val newstate = new State(block)
+    newstate.heap = heap.map { case (k, v) => (k, v.clone()) }
+    newstate.locals = locals.clone()
+    newstate
+  }
+  override def equals(other: Any): Boolean = other match {
+    case other: State =>
+      other.heap == this.heap && other.locals == this.locals
+    case _ =>
+      false
+  }
+  def diff(other: State): String = {
+    val builder = new StringBuilder
+    def println(msg: String): Unit = {
+      builder.append(msg)
+      builder.append("\n")
+    }
+    if (other == null) {
+      println("right is null")
+    } else {
+      heap.foreach {
+        case (addr, instance) =>
+          if (!other.heap.contains(addr)) {
+            println(s"addr $addr is only present in left")
+          } else if (other.heap(addr) != instance) {
+            println(
+              s"different value for $addr: left = $instance, right = ${other.heap(addr)}")
+          }
+      }
+      other.heap.foreach {
+        case (addr, instance) =>
+          if (!heap.contains(addr)) {
+            println(s"addr $addr is only present in right")
+          }
+      }
+      locals.foreach {
+        case (id, value) =>
+          if (!other.locals.contains(id)) {
+            println(s"local ${id.show} is only present in left")
+          } else if (other.locals(id) != value) {
+            println(
+              s"different value for local ${id.show}: left = ${value.show}, right = ${other.locals(id).show}")
+          }
+      }
+      other.locals.foreach {
+        case (id, value) =>
+          if (!locals.contains(id)) {
+            println(s"local ${id.show} is only present in right")
+          }
+      }
+    }
+    builder.toString
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -1,0 +1,152 @@
+package scala.scalanative
+package interflow
+
+import scalanative.nir._
+import scalanative.linker._
+import scalanative.optimizer.pass.DeadCodeElimination
+import scalanative.interflow.Sema._
+
+trait Visit { self: Interflow =>
+  def shallVisit(name: Global): Boolean =
+    originals
+      .get(originalName(name))
+      .fold {
+        false
+      } { defn =>
+        val notExtern = !defn.attrs.isExtern
+        val hasInsts  = defn.insts.size > 0
+        val hasSema   = linked.infos.contains(defn.name)
+
+        notExtern && hasInsts && hasSema
+      }
+
+  def visitRoot(name: Global): Unit =
+    if (shallVisit(name)) {
+      todo.enqueue(name)
+    }
+
+  def visitDuplicate(name: Global, argtys: Seq[Type]): Option[Defn.Define] = {
+    val dup = duplicateName(name, argtys)
+    if (shallVisit(dup)) {
+      if (!done.contains(dup)) {
+        visitMethod(dup)
+      }
+      done.get(dup)
+    } else {
+      None
+    }
+  }
+
+  def visitLoop(): Unit = {
+    while (todo.nonEmpty) {
+      val name = todo.dequeue()
+      if (!done.contains(name)) {
+        visitMethod(name)
+      }
+    }
+  }
+
+  def visitMethod(name: Global): Unit =
+    if (!started.contains(name)) {
+      started += name
+      try {
+        done(name) = visitInsts(name)
+      } catch {
+        case exc: BailOut =>
+          blacklist += name
+          log(s"failed to expand ${name.show}: ${exc.toString}")
+          done(name) = originals(originalName(name))
+      }
+    }
+
+  def visitInsts(name: Global): Defn.Define = in(s"visit ${name.show}") {
+    val orig     = originalName(name)
+    val origtys  = argumentTypes(orig)
+    val origdefn = originals(orig)
+    val argtys   = argumentTypes(name)
+
+    // Wrap up the result.
+    def result(retty: Type, insts: Seq[Inst]) =
+      origdefn.copy(name = name,
+                    ty = Type.Function(argtys, retty),
+                    insts = insts)
+
+    // Create new fresh and state for the first basic block.
+    val fresh = Fresh(0)
+    val state = new State(Local(0))
+
+    // Compute argument values that are typed as an
+    // intersection of duplicate argument type and original
+    // declared argument type.
+    val args = argtys.zip(origtys).map {
+      case (argty, origty) =>
+        val paramty = glb(argty, origty).getOrElse(origty)
+        Val.Local(fresh(), paramty)
+    }
+
+    // If any of the argument types is nothing, this method
+    // is never going to be called, so we don't have to visit it.
+    if (args.exists(_.ty == Type.Nothing)) {
+      val insts = Seq(Inst.Label(Local(0), args), Inst.Unreachable(Next.None))
+      return result(Type.Nothing, insts)
+    }
+
+    // Run a merge processor starting from the entry basic block.
+    val blocks =
+      MergeProcessor.process(origdefn.insts.toArray,
+                             args,
+                             state,
+                             fresh,
+                             inline = false,
+                             this)
+
+    // Collect instructions, materialize all returned values
+    // and compute the result type.
+    val insts = blocks.flatMap { block =>
+      block.cf = block.cf match {
+        case Inst.Ret(retv) =>
+          Inst.Ret(block.end.materialize(retv))
+        case Inst.Throw(excv, unwind) =>
+          Inst.Throw(block.end.materialize(excv), unwind)
+        case cf =>
+          cf
+      }
+      block.toInsts()
+    }
+    val rets = insts.collect {
+      case Inst.Ret(v) => v.ty
+    }
+    val retty = rets match {
+      case Seq()   => Type.Nothing
+      case Seq(ty) => ty
+      case tys     => lub(tys)
+    }
+
+    result(retty, insts)
+  }
+
+  def originalName(name: Global): Global = name match {
+    case Global.Member(owner, Sig.Duplicate(origSig, argtys)) =>
+      originalName(Global.Member(owner, origSig))
+    case _ =>
+      name
+  }
+
+  def duplicateName(name: Global, argtys: Seq[Type]): Global = {
+    val orig = originalName(name)
+    if (argumentTypes(orig) == argtys) {
+      orig
+    } else {
+      val Global.Member(top, sig) = orig
+      Global.Member(top, Sig.Duplicate(sig, argtys))
+    }
+  }
+
+  def argumentTypes(name: Global): Seq[Type] = name match {
+    case Global.Member(_, Sig.Duplicate(_, argtys)) =>
+      argtys
+    case _ =>
+      val Type.Function(argtys, _) = linked.infos(name).asInstanceOf[Method].ty
+      argtys
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/package.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/package.scala
@@ -1,0 +1,7 @@
+package scala.scalanative
+
+import scalanative.nir._
+
+package object interflow {
+  type Addr = Long
+}

--- a/tools/src/main/scala/scala/scalanative/linker/Extractors.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Extractors.scala
@@ -52,3 +52,50 @@ object FieldRef extends Extractor[(Info, Field)] {
       case node: Field => (node.owner, node)
     }
 }
+
+object ArrayRef {
+  def unapply(ty: Type): Option[(Type, Boolean)] = ty match {
+    case Type.Array(ty, nullable) =>
+      Some((ty, nullable))
+    case Type.Ref(name, _, nullable) =>
+      Type.fromArrayClass(name).map(ty => (ty, nullable))
+    case _ =>
+      None
+  }
+}
+
+object ExactClassRef {
+  def unapply(ty: Type)(implicit linked: Result): Option[(Class, Boolean)] =
+    ty match {
+      case Type.Ref(ClassRef(cls), exact, nullable)
+          if exact || cls.subclasses.isEmpty =>
+        Some((cls, nullable))
+      case UnitRef(nullable) =>
+        Some((linked.infos(Rt.BoxedUnit.name).asInstanceOf[Class], nullable))
+      case Type.Array(ty, nullable) =>
+        Some(
+          (linked.infos(Type.toArrayClass(ty)).asInstanceOf[Class], nullable))
+      case _ =>
+        None
+    }
+}
+
+object UnitRef {
+  def unapply(ty: Type): Option[Boolean] = ty match {
+    case Type.Unit =>
+      Some(false)
+    case Type.Ref(name, _, nullable) if name == Rt.BoxedUnit.name =>
+      Some(nullable)
+    case _ =>
+      None
+  }
+}
+
+object BoxRef {
+  def unapply(ty: Type): Option[(Type, Boolean)] = ty match {
+    case Type.Ref(name, _, nullable) =>
+      Type.unbox.get(Type.Ref(name)).map(ty => (ty, nullable))
+    case _ =>
+      None
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/linker/Link.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Link.scala
@@ -11,4 +11,10 @@ object Link {
     Scope { implicit in =>
       Reach(config, entries, ClassLoader.fromDisk(config))
     }
+
+  /** Run reachability analysis on already loaded methods. */
+  def apply(config: build.Config,
+            entries: Seq[Global],
+            defns: Seq[Defn]): Result =
+    Reach(config, entries, ClassLoader.fromMemory(defns))
 }

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -167,6 +167,12 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
           case _ =>
             ()
         }
+      case info: Trait =>
+        def loopTraits(traitInfo: Trait): Unit = {
+          traitInfo.subtraits += info
+          traitInfo.traits.foreach(loopTraits)
+        }
+        info.traits.foreach(loopTraits)
       case info: Class =>
         // Register given class as a subclass of all
         // transitive parents and as an implementation
@@ -356,17 +362,23 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
   }
 
   def reachDeclare(defn: Defn.Declare): Unit = {
-    val Defn.Declare(attrs, name, sig) = defn
-    newInfo(new Method(attrs, scopeInfoOrUnavailable(name.top), name, Seq()))
+    val Defn.Declare(attrs, name, ty) = defn
+    newInfo(
+      new Method(attrs, scopeInfoOrUnavailable(name.top), name, ty, Array()))
     reachAttrs(attrs)
-    reachType(sig)
+    reachType(ty)
   }
 
   def reachDefine(defn: Defn.Define): Unit = {
-    val Defn.Define(attrs, name, sig, insts) = defn
-    newInfo(new Method(attrs, scopeInfoOrUnavailable(name.top), name, insts))
+    val Defn.Define(attrs, name, ty, insts) = defn
+    newInfo(
+      new Method(attrs,
+                 scopeInfoOrUnavailable(name.top),
+                 name,
+                 ty,
+                 insts.toArray))
     reachAttrs(attrs)
-    reachType(sig)
+    reachType(ty)
     reachInsts(insts)
   }
 

--- a/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
@@ -17,15 +17,15 @@ abstract class OptimizerSpec extends LinkerSpec {
    * @param fn      A function to apply to the products of the compilation.
    * @return The result of applying `fn` to the resulting definitions.
    */
-  def optimize[T](entry: String,
-                  sources: Map[String, String],
-                  driver: Option[Driver] = None)(
-      fn: (Config, linker.Result, Seq[nir.Defn]) => T): T =
+  def optimize[T](
+      entry: String,
+      sources: Map[String, String],
+      driver: Option[Driver] = None)(fn: (Config, linker.Result) => T): T =
     link(entry, sources, driver = driver) {
       case (config, linked) =>
-        val driver_ = driver.getOrElse(Driver.default(Mode.default))
-        val opt     = ScalaNative.optimize(config, linked, driver_)
-        fn(config, linked, opt)
+        val driver_   = driver.getOrElse(Driver.default(Mode.default))
+        val optimized = ScalaNative.optimize(config, linked, driver_)
+        fn(config, optimized)
     }
 
 }

--- a/tools/src/test/scala/scala/scalanative/codegen/CodeGenSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/codegen/CodeGenSpec.scala
@@ -25,15 +25,15 @@ abstract class CodeGenSpec extends OptimizerSpec {
       sources: Map[String, String],
       driver: Option[Driver] = None)(f: (Config, linker.Result, Path) => T): T =
     optimize(entry, sources, driver) {
-      case (config, linked, optimized) =>
+      case (config, optimized) =>
         Scope { implicit in =>
-          ScalaNative.codegen(config, linked, optimized)
+          ScalaNative.codegen(config, optimized)
           val workdir = VirtualDirectory.real(config.workdir)
           val outfile = Paths.get("out.ll")
 
           assert(workdir.contains(outfile), "out.ll not found.")
 
-          f(config, linked, outfile)
+          f(config, optimized, outfile)
         }
     }
 


### PR DESCRIPTION
This pr introduces preliminary infrastructure for Interflow (#1278).  

In the first part, we focus on type inference and method duplication. Partial evaluation and partial escape analysis are included as well but they are mostly inactive until we add inlining (in one of the next PRs). 

Apart from the new code that runs before the old optimizer, there are a few more NIR changes included here aswell:

1. minor changes to box and unbox ops.
1. minor changes to case node.
1. all reference types track 'nullability' (i.e., can this reference be a null).
1. class types track 'exactness' (i.e., is it only this class, or class and all subclasses). 

We leave interflow enabled at all times on master to catch potential bugs early. Due to added compile time cost, it's likely we'll make it a release mode only feature in the future. 