### PR TITLE
Fix #1296 "non-0 digits for Float/Double", requires PR #1436

### DIFF
--- a/javalib/src/main/scala/java/text/DecimalFormat.scala
+++ b/javalib/src/main/scala/java/text/DecimalFormat.scala
@@ -207,8 +207,12 @@ class DecimalFormat extends NumberFormat {
 
     private[this] def getDoubleDigits(number: Double): DoubleDigits = {
       // regular expressions (regex) are a good Computer Science candidate
-      // here. This is essential low level code and the implementation
-      // of regex may not be robust enough.
+      // here but are not used.
+      // This is essential low level code. I doubt the current
+      // implementation of regex is either robust or perfomant enough.
+      // I do not have time to benchmark alternate implementations, so
+      // I go for an implementation I believe I can both do quickly
+      // and get correct.
 
       val (wdPrefix, suffix) = number.toString.span(_ != '.')
 

--- a/unit-tests/src/test/scala/java/util/FormatterSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterSuite.scala
@@ -3,12 +3,12 @@ package java.util
 // Ported from Harmony
 
 /* Design Note:   Lee Tibbert 2018-12-03
- * 
+ *
  * Kudos to the original scala implementation for finding a way through an
  * thicket of implementation difficulties!
- * 
+ *
  * A bread crumb for future maintainers:
- * 
+ *
  *   If you are attempting the understand the use of Locale in this file
  *   and its companion, FormatterUSSuite.scala, the important thing to know
  *   is that ScalaNative is currently explicitly documented as supporting
@@ -17,10 +17,10 @@ package java.util
  *   A number of tests in this file are disabled because they critically depend
  *   upon a Locale other than Locale.US.  The file FormatterUSSuite.scala
  *   runs many of those tests in Locale.US.
- * 
+ *
  *   Ideally, when more inclusive Locale support is implemented, the file
  *   FormatterUSsuite.scala can go away and tests in this file enabled.
- * 
+ *
  *   The astute reader will notice that a number of tests _enabled_ in
  *   this file appear to use a Locale other than Locale.US. Tracing and/or
  *   executing the test will show that the property being tested is Locale
@@ -28,7 +28,7 @@ package java.util
  *   time here on wonderment, to little or no profit.
  *
  * Status:
- * 
+ *
  *   After this and several other relevant PRs in the queue are accepted &
  *   the dust settles, I believe only one test will remain disabled.  That
  *   test relies upon Locale.GERMAN.

--- a/unit-tests/src/test/scala/java/util/FormatterSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterSuite.scala
@@ -2,6 +2,38 @@ package java.util
 
 // Ported from Harmony
 
+/* Design Note:   Lee Tibbert 2018-12-03
+ * 
+ * Kudos to the original scala implementation for finding a way through an
+ * thicket of implementation difficulties!
+ * 
+ * A bread crumb for future maintainers:
+ * 
+ *   If you are attempting the understand the use of Locale in this file
+ *   and its companion, FormatterUSSuite.scala, the important thing to know
+ *   is that ScalaNative is currently explicitly documented as supporting
+ *   _only_ Locale.US.
+ *
+ *   A number of tests in this file are disabled because they critically depend
+ *   upon a Locale other than Locale.US.  The file FormatterUSSuite.scala
+ *   runs many of those tests in Locale.US.
+ * 
+ *   Ideally, when more inclusive Locale support is implemented, the file
+ *   FormatterUSsuite.scala can go away and tests in this file enabled.
+ * 
+ *   The astute reader will notice that a number of tests _enabled_ in
+ *   this file appear to use a Locale other than Locale.US. Tracing and/or
+ *   executing the test will show that the property being tested is Locale
+ *   independent. From repeated experience I can say than one can waste much
+ *   time here on wonderment, to little or no profit.
+ *
+ * Status:
+ * 
+ *   After this and several other relevant PRs in the queue are accepted &
+ *   the dust settles, I believe only one test will remain disabled.  That
+ *   test relies upon Locale.GERMAN.
+ */
+
 import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.Closeable
@@ -2912,14 +2944,6 @@ object FormatterSuite extends tests.Suite {
       assertEquals("9.00000e-05", f.toString())
     }
   }
-
-  // Next test uses, by design, Locale.GERMAN and will continue to fail
-  // even after PR #1298 and this PR for issue ##1296 are merged.
-  // Tests in FormatterSuite.scala using Locale.US should pass as
-  // those PRs are merged.
-  //
-  // This test can be enabled as part of verifying Locale.GERMAN
-  // support. It should pass then.
 
   testFails(
     "format(String, Array[Object]) for Float/Double conversion type 'f'",

--- a/unit-tests/src/test/scala/java/util/FormatterSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterSuite.scala
@@ -2,38 +2,6 @@ package java.util
 
 // Ported from Harmony
 
-/* Design Note:   Lee Tibbert 2018-12-03
- *
- * Kudos to the original scala implementation for finding a way through an
- * thicket of implementation difficulties!
- *
- * A bread crumb for future maintainers:
- *
- *   If you are attempting the understand the use of Locale in this file
- *   and its companion, FormatterUSSuite.scala, the important thing to know
- *   is that ScalaNative is currently explicitly documented as supporting
- *   _only_ Locale.US.
- *
- *   A number of tests in this file are disabled because they critically depend
- *   upon a Locale other than Locale.US.  The file FormatterUSSuite.scala
- *   runs many of those tests in Locale.US.
- *
- *   Ideally, when more inclusive Locale support is implemented, the file
- *   FormatterUSsuite.scala can go away and tests in this file enabled.
- *
- *   The astute reader will notice that a number of tests _enabled_ in
- *   this file appear to use a Locale other than Locale.US. Tracing and/or
- *   executing the test will show that the property being tested is Locale
- *   independent. From repeated experience I can say than one can waste much
- *   time here on wonderment, to little or no profit.
- *
- * Status:
- *
- *   After this and several other relevant PRs in the queue are accepted &
- *   the dust settles, I believe only one test will remain disabled.  That
- *   test relies upon Locale.GERMAN.
- */
-
 import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.Closeable

--- a/unit-tests/src/test/scala/java/util/FormatterSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterSuite.scala
@@ -2913,6 +2913,14 @@ object FormatterSuite extends tests.Suite {
     }
   }
 
+  // Next test uses, by design, Locale.GERMAN and will continue to fail
+  // even after PR #1298 and this PR for issue ##1296 are merged.
+  // Tests in FormatterSuite.scala using Locale.US should pass as
+  // those PRs are merged.
+  //
+  // This test can be enabled as part of verifying Locale.GERMAN
+  // support. It should pass then.
+
   testFails(
     "format(String, Array[Object]) for Float/Double conversion type 'f'",
     1443) {

--- a/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
@@ -2446,10 +2446,11 @@ object FormatterUSSuite extends tests.Suite {
     }
   }
 
-  testFails(
-    "format(String, Array[Object]) for java.lang.Float/Double.MAX_VALUE conversion type 'f'",
-    0) { // issue not filed yet
-    // These need a way to reproduce the same decimal representation of extreme values as JVM.
+  test(
+    "format(String, Array[Object]) for java.lang.Float/Double.MAX_VALUE " +
+      "conversion type 'f'") {
+    // These need a way to reproduce the same decimal representation of
+    // extreme values as JVM.
     val tripleF = Array(
       Array(-1234567890.012345678d, "% 0#(9.8f", "(1234567890.01234580)"),
       Array(

--- a/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
@@ -1,7 +1,8 @@
 package java.util
 
 // Ported from Harmony
-// Modified to test Locale.US only. Please see FormatterSuite.scala for the original port
+// Modified to test Locale.US only. Please see FormatterSuite.scala for
+// the original port.
 
 import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream


### PR DESCRIPTION
  * The presenting problem was described in issue #1296
    "j.t.DecimalFormat is generating non-0 non-significant digits for
    Float/Double". This issue is now fixed.

  * This pull request will _FAIL_ Travis CI until after PR #1298
    "Fix Issue #481 "java.lang.{Float, Double}::toString is inconsistent
    with Scala JVM" is merged.

  * I did a visual inspection of the digit generation of the other
    numeric types, especially BigDecimal. They appeared to not
    have the issue of #1296.  They pass the unit-tests, but I did
    not check of those unit-tests tested MAX_VALUE.

  * DecimalFormat is almost certainly a performance pig. This code
    path is used by printf() so every person and their dog goes down it
    and expects good performance. The BigMath conversions probably
    require handling as character-by-character. Given the reasonably
    fast Double.toString of PR #1298 a clever person could probably
    come up with code which is faster yet still meets the constraints
    of DecimalFormat.  It would probably test for grouping being inactive
    and the min & max number of digits, using a fast path if possible,
    otherwise (grouping, weird rounding) falling back to the existing code.

64/32 bit issues:

      None known.

Documentation:

      A release note is requested.

Testing:

  * Built and tested ("test-all") on X86 private environment with PR1298
    active. All tests passed.

  * Built and tested ("test-all") on X86_64, no PR #1298.
    Six tests involving floating point conversions failed.
    I understand why they failed and expect these failures to
    cease once PR #1340 is merged.