### PR TITLE
Fix #1341 "Double.toHexString returns one too few zeros for Double.MIN_VALUE

### DIFF
--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -285,11 +285,8 @@ object Double {
 
           val hexSignificand = java.lang.Long.toHexString(significand)
           if (significand != 0 && fractionDigits > hexSignificand.length) {
-            var digitDiff = fractionDigits - hexSignificand.length - 1
-            while (digitDiff != 0) {
-              hexString.append('0')
-              digitDiff -= 1
-            }
+            val digitDiff = fractionDigits - hexSignificand.length
+            hexString.append("0" * digitDiff)
           }
 
           hexString.append(hexSignificand)
@@ -304,11 +301,8 @@ object Double {
 
           val hexSignificand = java.lang.Long.toHexString(significand)
           if (significand != 0 && fractionDigits > hexSignificand.length) {
-            var digitDiff = fractionDigits - hexSignificand.length - 1
-            while (digitDiff != 0) {
-              hexString.append('0')
-              digitDiff -= 1
-            }
+            var digitDiff = fractionDigits - hexSignificand.length
+            hexString.append("0" * digitDiff)
           }
 
           hexString.append(hexSignificand)

--- a/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
@@ -3,7 +3,8 @@ package java.lang
 import java.lang.Double.{
   doubleToLongBits,
   doubleToRawLongBits,
-  longBitsToDouble
+  longBitsToDouble,
+  toHexString
 }
 
 object DoubleSuite extends tests.Suite {
@@ -210,4 +211,22 @@ object DoubleSuite extends tests.Suite {
     assert(Double.toString(Double.NEGATIVE_INFINITY).equals("-Infinity"))
     assert(Double.toString(Double.NaN).equals("NaN"))
   }
+
+  test("toHexString - MIN_VALUE, Issue #1341") {
+    assert(
+      toHexString(java.lang.Double.MIN_VALUE).equals("0x0.0000000000001p-1022"))
+  }
+
+  test("toHexString - assorted other values") {
+
+    assert(
+      toHexString(java.lang.Double.MAX_VALUE).equals("0x1.fffffffffffffp1023"))
+
+    // A value > 1.0 requiring lots of, but not all,  zeros.
+    assert(toHexString(1.00000000000003).equals("0x1.0000000000087p0"))
+
+    // An arbitrary but negative value.
+    assert(java.lang.Double.toHexString(-31.0).equals("-0x1.fp4"))
+  }
+
 }

--- a/unit-tests/src/test/scala/java/util/FormatterSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterSuite.scala
@@ -3171,9 +3171,8 @@ object FormatterSuite extends tests.Suite {
     }
   }
 
-  testFails(
-    "format(String, Array[Object]) for Float/Double conversion type 'a' and 'A'",
-    0) { // issue not filed yet
+  test(
+    "format(String, Array[Object]) for Float/Double conversion type 'a' and 'A'") {
     val tripleA: Array[Array[Any]] = Array(
       Array(-0f, "%a", "-0x0.0p0"),
       Array(-0f, "%#.3a", "-0x0.000p0"),

--- a/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
@@ -2718,10 +2718,9 @@ object FormatterUSSuite extends tests.Suite {
     }
   }
 
-  testFails(
-    "format(String, Array[Object]) for java.lang.Double.MIN_VALUE conversion type 'a' and 'A'",
-    0) { // issue not filed yet
-    // it is java.lang.Double.toHexString in Formatter.FloatUtil.transform_a that throws NumberFormatException.
+  test(
+    "format(String, Array[Object]) for java.lang.Double.MIN_VALUE conversion type 'a' and 'A'") {
+
     val tripleA: Array[Array[Any]] = Array(
       Array(java.lang.Double.MIN_VALUE, "%a", "0x0.0000000000001p-1022"),
       Array(java.lang.Double.MIN_VALUE, "%5a", "0x0.0000000000001p-1022")


### PR DESCRIPTION

  * The presenting problem was described in issue #1341
    "Double.toHexString returns one too few zeros for Double.MIN_VALUE"
    This issue is now fixed.

  * The toHexString method on other Numeric types needs checking. They
    are not covered by this pull request.

  * The original failing test was in java.util.FormatterUSSuite.scala.
    I changed "testFails" to "test" in that file.

  * Since the failing method was in Double.scala, I added a few toHexString
    tests to java.lang.DoubleSuite.scala. This puts at least some
    tests closer in cognitive space to the source of the method they
    are testing.

64/32 bit issues:

      None known.

Documentation:

      A release note is requested.

Testing:

  * Built and tested ("test-all") on X86 and X86_64.
    All tests passed.