### PR TITLE
Fix #1342 "Four (2x2) 'segfaults for unknown reason' "

### DIFF
--- a/javalib/src/main/scala/java/util/Formatter.scala
+++ b/javalib/src/main/scala/java/util/Formatter.scala
@@ -21,27 +21,9 @@ class Formatter(
     private var _locale: Locale
 ) extends Closeable
     with Flushable {
+
   if (_out == null)
     _out = new StringBuilder()
-
-  final class BigDecimalLayoutForm private (name: String, ordinal: Int)
-      extends Enum[BigDecimalLayoutForm](name, ordinal)
-
-  object BigDecimalLayoutForm {
-    final val SCIENTIFIC    = new BigDecimalLayoutForm("SCIENTIFIC", 0)
-    final val DECIMAL_FLOAT = new BigDecimalLayoutForm("DECIMAL_FLOAT", 1)
-
-    def valueOf(name: String): BigDecimalLayoutForm =
-      _values.find(_.name == name).getOrElse {
-        throw new IllegalArgumentException(
-          "No enum constant java.util.Formatter.BigDecimalLayoutForm." + name)
-      }
-
-    private val _values: Array[BigDecimalLayoutForm] =
-      Array(SCIENTIFIC, DECIMAL_FLOAT)
-
-    def values(): Array[BigDecimalLayoutForm] = _values.clone()
-  }
 
   private var closed: Boolean = false
 
@@ -224,6 +206,27 @@ class Formatter(
 }
 
 object Formatter {
+
+  final class BigDecimalLayoutForm private (name: String, ordinal: Int)
+      extends Enum[BigDecimalLayoutForm](name, ordinal)
+
+  object BigDecimalLayoutForm {
+
+    final val SCIENTIFIC    = new BigDecimalLayoutForm("SCIENTIFIC", 0)
+    final val DECIMAL_FLOAT = new BigDecimalLayoutForm("DECIMAL_FLOAT", 1)
+
+    def valueOf(name: String): BigDecimalLayoutForm =
+      _values.find(_.name == name).getOrElse {
+        throw new IllegalArgumentException(
+          "No enum constant java.util.Formatter.BigDecimalLayoutForm." + name)
+      }
+
+    private val _values: Array[BigDecimalLayoutForm] =
+      Array(SCIENTIFIC, DECIMAL_FLOAT)
+
+    def values(): Array[BigDecimalLayoutForm] = _values.clone()
+  }
+
   private def closeOutputStream(os: OutputStream): Unit = {
     if (null == os)
       return

--- a/unit-tests/src/test/scala/java/util/FormatterSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterSuite.scala
@@ -3872,9 +3872,7 @@ object FormatterSuite extends tests.Suite {
     }
   }
 
-  testFails("Formatter.BigDecimalLayoutForm.values()", 0) { // issue not filed yet
-    // BigDecimalLayoutForm.values() segfaults for unknown reason.
-    throw new NullPointerException() // to prevent segfault
+  test("Formatter.BigDecimalLayoutForm.values()") {
     import Formatter.BigDecimalLayoutForm
     val vals: Array[BigDecimalLayoutForm] = BigDecimalLayoutForm.values()
     assertEquals(2, vals.length)
@@ -3882,9 +3880,7 @@ object FormatterSuite extends tests.Suite {
     assertEquals(BigDecimalLayoutForm.DECIMAL_FLOAT, vals(1))
   }
 
-  testFails("Formatter.BigDecimalLayoutForm.valueOf(String)", 0) { // issue not filed yet
-    // the line `val sci: ...` segfaults for unknown reason.
-    throw new NullPointerException() // to prevent segfault
+  test("Formatter.BigDecimalLayoutForm.valueOf(String)") {
     import Formatter.BigDecimalLayoutForm
     val sci: BigDecimalLayoutForm = BigDecimalLayoutForm.valueOf("SCIENTIFIC")
     assertEquals(BigDecimalLayoutForm.SCIENTIFIC, sci)

--- a/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
@@ -3446,9 +3446,7 @@ object FormatterUSSuite extends tests.Suite {
     }
   }
 
-  testFails("Formatter.BigDecimalLayoutForm.values()", 0) { // issue not filed yet
-    // BigDecimalLayoutForm.values() segfaults for unknown reason.
-    throw new NullPointerException() // to prevent segfault
+  test("Formatter.BigDecimalLayoutForm.values()") {
     import Formatter.BigDecimalLayoutForm
     val vals: Array[BigDecimalLayoutForm] = BigDecimalLayoutForm.values()
     assertEquals(2, vals.length)
@@ -3456,9 +3454,7 @@ object FormatterUSSuite extends tests.Suite {
     assertEquals(BigDecimalLayoutForm.DECIMAL_FLOAT, vals(1))
   }
 
-  testFails("Formatter.BigDecimalLayoutForm.valueOf(String)", 0) { // issue not filed yet
-    // the line `val sci: ...` segfaults for unknown reason.
-    throw new NullPointerException() // to prevent segfault
+  test("Formatter.BigDecimalLayoutForm.valueOf(String)") {
     import Formatter.BigDecimalLayoutForm
     val sci: BigDecimalLayoutForm = BigDecimalLayoutForm.valueOf("SCIENTIFIC")
     assertEquals(BigDecimalLayoutForm.SCIENTIFIC, sci)


### PR DESCRIPTION
  * The presenting problem was described in issue #1342.
    "Four (2x2) 'segfaults for unknown reason' in Formatter*Suite.scala
    BigDecimal tests".
    This issue is now fixed.

  * The comments left by @matil019, the original author, were
    essential in figuring this out. They helped me rapidly figure
    out why the test was marked "testFailed" and helped me
    zoom in on Formatter.BigDecimalLayoutForm.  Thank you, @matil019.

  * The underlying problem was in the declaration of
    Formatter.BigDecimalLayoutForm as an object within a class.
    The class later got instantiated. The compiler had no problem,
    but, it appears, memory for the inner object was never allocated.
    When the Suite code attempted to access that unallocated
    memory, NullPointerException, as it should be.  Reading the
    code, all appeared just fine. Obviously the compiler thought so.
    The missing memory allocation was pretty hidden & hard to find.

    Studying the Java 8 API with an eye to what might have gone wrong
    with the java-to-scala translation lead to re-arranging the
    code so that the BigDecimalLayoutForm object declared to more
    closely match the specification.

    With this change, FormatterSuite.scala and its sororital/fraternal
    twin FormatterUSSuite.scala now pass the BigDecimal value() &
    valueOf() tests.

    Without those careful tests, this defect would never have been found
    & fixed.

64/32 bit issues:

      None known.

Documentation:

      A release note is requested.

Testing:

  * Built and tested ("test-all") on X86_64 & X86. All tests passed.