### PR TITLE
Fix #1345 "j.u.TimeZone#getAvailableIDs is Not Yet Implemented", now returns useful empty Array 

### DIFF
--- a/javalib/src/main/scala/java/util/TimeZone.scala
+++ b/javalib/src/main/scala/java/util/TimeZone.scala
@@ -10,7 +10,7 @@ class TimeZone extends Serializable with Cloneable {
 object TimeZone {
   val SHORT: Int = 0
 
-  def getAvailableIDs(): Array[String] = ???
+  def getAvailableIDs(): Array[String] = Array.empty[String]
 
   def getTimeZone(ID: String): TimeZone = ???
 

--- a/unit-tests/src/test/scala/java/util/FormatterSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterSuite.scala
@@ -3897,8 +3897,17 @@ object FormatterSuite extends tests.Suite {
    * Regression test for Harmony-5845
    * test the short name for timezone whether uses DaylightTime or not
    */
-  testFails("DaylightTime", 0) { // issue not filed yet
-    // java.util.TimeZone$.getAvailableIDs throws NotImplementedError
+  test("DaylightTime") {
+    // 2018-09-05 Implementation note:
+    // The TimeZone.getAvailableIDs() now stub returns an empty array,
+    // no longer throwing NotImplementedError.That allows his test to be
+    // enabled.
+    //
+    // This test now passes, but the success is may be vacuous/deceiving.
+    // The actual "America" conditions below will not get executed until
+    // getAvailableIDs() is more fully implemented and reports those TimeZones
+    // as available. When that happens, this test may start failing for
+    // "mysterious" but valid reasons.
     val c1: Calendar = new GregorianCalendar(2007, 0, 1)
     val c2: Calendar = new GregorianCalendar(2007, 7, 1)
     for (tz <- TimeZone.getAvailableIDs) {

--- a/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
@@ -3471,8 +3471,17 @@ object FormatterUSSuite extends tests.Suite {
    * Regression test for Harmony-5845
    * test the short name for timezone whether uses DaylightTime or not
    */
-  testFails("DaylightTime", 0) { // issue not filed yet
-    // java.util.TimeZone$.getAvailableIDs throws NotImplementedError
+  test("DaylightTime") {
+    // 2018-09-05 Implementation note:
+    // The TimeZone.getAvailableIDs() now stub returns an empty array,
+    // no longer throwing NotImplementedError.That allows his test to be
+    // enabled.
+    //
+    // This test now passes, but the success is may be vacuous/deceiving.
+    // The actual "America" conditions below will not get executed until
+    // getAvailableIDs() is more fully implemented and reports those TimeZones
+    // as available. When that happens, this test may start failing for
+    // "mysterious" but valid reasons.
     val c1: Calendar = new GregorianCalendar(2007, 0, 1)
     val c2: Calendar = new GregorianCalendar(2007, 7, 1)
     for (tz <- TimeZone.getAvailableIDs) {


### PR DESCRIPTION
  * The presenting problem was described in issue #1345.
    "j.u.TimeZone#getAvailableIDs is Not Yet Implemented"
    This issue is now fixed.

  * j.u.TimeZone#getAvailableIDs is implemented but it returns
    an empty Array because no TimeZones are currently implemented.

    While the new behavior is correct and true, it would appear to
    be less than useful and not worth the cost of processing this
    pull request.

    The motivation for this PR is that it allows the second to last
    "testFail" in the two java.util.Formatter*Suite files to be converted
    to "test". Once the PR queue drains to this point, there will be only
    one remaining "testFail"; the same condition in each of two files.
    The goal is to make it easier to reason about and quantify what
    is actually working and what work remains to be done.

  * This j.u.TimeZone fix was designed to be a first evolution, "femto" level
    fix, not a "fix everything' mega-fix.. I needed to complete it,
    and complete it correctly, with limited available time.

    TimeZone.Scala is doing its intended work as a stub, but needs further
    implementation.

    In particular, it is now defined as a concrete class when it should be
    abstract, with a concrete implementation.  All good things in time.

64/32 bit issues:

      None known.

Documentation:

      None needed. unit-test is for developers and there is no
      visible Aristotelean distinction between a "testFails" enveloping
      actually failing statements and a "test" of successful statements.

Testing:

  * Built and tested ("test-all") on X86_64. All tests passed.