### PR TITLE
Fix #202: Support assignment to extern variables

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -24,6 +24,7 @@ C Header          Scala Native Module
 `fmtmsg.h`_       N/A
 `fnmatch.h`_      N/A
 `ftw.h`_          N/A
+`getopt.h`_       scala.scalanative.posix.getopt_
 `glob.h`_         N/A
 `grp.h`_          scala.scalanative.posix.grp_
 `iconv.h`_        N/A
@@ -108,6 +109,7 @@ C Header          Scala Native Module
 .. _fmtmsg.h: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/fmtmsg.h.html
 .. _fnmatch.h: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/fnmatch.h.html
 .. _ftw.h: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/ftw.h.html
+.. _getopt.h: http://pubs.opengroup.org/onlinepubs/9699919799/functions/getopt.html
 .. _glob.h: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/glob.h.html
 .. _grp.h: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/grp.h.html
 .. _iconv.h: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/iconv.h.html
@@ -182,6 +184,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.dirent: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/dirent.scala
 .. _scala.scalanative.posix.errno: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/errno.scala
 .. _scala.scalanative.posix.fcntl: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/fcntl.scala
+.. _scala.scalanative.posix.getopt: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/getopt.scala
 .. _scala.scalanative.posix.grp: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/grp.scala
 .. _scala.scalanative.posix.inttypes: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/inttypes.scala
 .. _scala.scalanative.posix.limits: https://github.com/scala-native/scala-native/blob/master/nativelib/src/main/scala/scala/scalanative/posix/limits.scala

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1535,7 +1535,7 @@ trait NirGenExpr { self: NirGenPhase =>
                       statically: Boolean,
                       selfp: Tree,
                       argsp: Seq[Tree]): Val = {
-      if (sym.owner.isExternModule && sym.hasFlag(ACCESSOR)) {
+      if (sym.owner.isExternModule && sym.isAccessor) {
         genApplyExternAccessor(sym, argsp)
       } else {
         val self = genExpr(selfp)
@@ -1551,8 +1551,10 @@ trait NirGenExpr { self: NirGenPhase =>
           val elem = Val.Global(name, Type.Ptr)
           buf.load(ty, elem, unwind)
 
-        case Seq(value) =>
-          unsupported(argsp)
+        case Seq(valuep) =>
+          val name  = genMethodName(sym)
+          val value = genExpr(valuep)
+          buf.store(value.ty, Val.Global(name, Type.Ptr), value, unwind)
       }
     }
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
@@ -78,7 +78,12 @@ trait NirGenName { self: NirGenPhase =>
     if (sym == String_+) {
       genMethodName(StringConcatMethod)
     } else if (sym.owner.isExternModule) {
-      owner member id tag "extern"
+      if (sym.isSetter) {
+        val id0 = sym.name.dropSetter.decoded.toString
+        owner member id0 tag "extern"
+      } else {
+        owner member id tag "extern"
+      }
     } else if (sym.name == nme.CONSTRUCTOR) {
       owner member ("init" +: mangledParams).mkString("_")
     } else {

--- a/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
@@ -1,0 +1,14 @@
+package scala.scalanative
+package posix
+
+import scalanative.native._
+
+@extern
+object getopt {
+  var optarg: CString = extern
+  var opterr: CInt    = extern
+  var optind: CInt    = extern
+  var optopt: CInt    = extern
+
+  def getopt(argc: CInt, argv: Ptr[CString], optstring: CString): CInt = extern
+}

--- a/unit-tests/src/test/scala/scala/scalanative/native/CInteropSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/native/CInteropSuite.scala
@@ -38,4 +38,30 @@ object CInteropSuite extends tests.Suite {
     val wrongRand = randFunc.cast[CFunctionPtr1[Int, Int]] // wrong signature
     wrongRand(42) // no argument declared
   }
+
+  test("extern variable read and assign") {
+    import scala.scalanative.posix.getopt
+
+    val args = Seq("skipped", "skipped", "skipped", "-b", "-f", "farg")
+
+    Zone { implicit z =>
+      val argv = stackalloc[CString](args.length)
+
+      for ((arg, i) <- args.zipWithIndex) {
+        argv(i) = toCString(arg)
+        ()
+      }
+
+      // Skip first 3 arguments
+      getopt.optind = 3
+
+      val bOpt = getopt.getopt(args.length, argv, c"bf:")
+      assert(bOpt == 'b')
+
+      val fOpt = getopt.getopt(args.length, argv, c"bf:")
+      assert(fOpt == 'f')
+      val fArg = fromCString(getopt.optarg)
+      assert(fArg == "farg")
+    }
+  }
 }


### PR DESCRIPTION
Implement the unsupported assignment case in
NirGetnExpr.genApplyExternAccessor. As a bonus, add bindings for
getopt.h and use it to test the interoperability.

---

This is only tested with the example from #202, that is assignment of primitive types.