### PR TITLE
Fix heap growth in Heap_allocSmallSlow for Immix

### DIFF
--- a/nativelib/src/main/resources/gc/immix/Heap.c
+++ b/nativelib/src/main/resources/gc/immix/Heap.c
@@ -129,6 +129,8 @@ NOINLINE word_t *Heap_allocSmallSlow(Heap *heap, uint32_t size) {
     if (object != NULL)
         goto done;
 
+    // A small object can always fit in a single free block
+    // because it is no larger than 8K while the block is 32K.
     Heap_Grow(heap, WORDS_IN_BLOCK);
     object = (Object *)Allocator_Alloc(&allocator, size);
 

--- a/nativelib/src/main/resources/gc/immix/Heap.c
+++ b/nativelib/src/main/resources/gc/immix/Heap.c
@@ -129,7 +129,7 @@ NOINLINE word_t *Heap_allocSmallSlow(Heap *heap, uint32_t size) {
     if (object != NULL)
         goto done;
 
-    Heap_Grow(heap, size);
+    Heap_Grow(heap, WORDS_IN_BLOCK);
     object = (Object *)Allocator_Alloc(&allocator, size);
 
 done:


### PR DESCRIPTION
In the unlikely case when that it fails to allocated after a full garbage collection, `Heap_allocSmallSlow` attempts to grow the heap by **the size of the object**. `Heap_Grow` can only handle multiples of `WORDS_IN_BLOCK`. See the assert in its first line of `Heap_Grow`:
```c
assert(increment % WORDS_IN_BLOCK == 0);
```
That is why it will now try to grow the heap by a full block.