### PR TITLE
Immix: Fix conservative marking confuses an empty chunk with an object.

### DIFF
--- a/nativelib/src/main/resources/gc/immix/Object.c
+++ b/nativelib/src/main/resources/gc/immix/Object.c
@@ -111,8 +111,8 @@ Object *Object_getLargeInnerPointer(LargeAllocator *allocator, word_t *word) {
     }
 
     Object *object = (Object *)current;
-    if (word < (word_t *)object + Object_ChunkSize(object) / WORD_SIZE &&
-        object->rtti != NULL) {
+    if (Object_IsAllocated(&object->header) &&
+        word < (word_t *)object + Object_ChunkSize(object) / WORD_SIZE) {
 #ifdef DEBUG_PRINT
         printf("large inner pointer: %p, object: %p\n", word, objectHeader);
         fflush(stdout);


### PR DESCRIPTION
Conservative marking scans the stack for things that could be a pointer.

Scenario:
1. Stack contains something that looks like an inner pointer to large heap.
2. It actually points inside an empty chunk, that was previously a large object.
3. It finds the start and checks the `object->rtti != NULL` See `Object_getLargeInnerPointer`. This is true, because this was not cleared when sweeping. See the relevant part of `LargeAllocator_AddChunk`.
```c
        Chunk *currentChunk = (Chunk *)current;
        LargeAllocator_freeListAddBlockLast(&allocator->freeLists[listIndex],
                                            (Chunk *)current);
        LargeAllocator_setChunkSize(currentChunk, chunkSize);
        currentChunk->header.type = object_large;
        Object_SetFree(&((Object *)currentChunk)->header);
        Bitmap_SetBit(allocator->bitmap, current);
```

This is extremely rare, but I have seen it overriding the `FreeLineHeader` which then causes allocating outside the heap.