### PR TITLE
Update sbt.version to 1.2.6 in docs

### DIFF
--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -20,7 +20,7 @@ This generates the following files:
 
 * ``project/build.properties`` to specify the sbt version::
 
-    sbt.version = 0.13.17
+    sbt.version = 1.2.6
 
 * ``build.sbt`` to enable the plugin and specify Scala version::
 


### PR DESCRIPTION
The suggested sbt setup contains, as `sbt.version`, the last `0.13.x`. Scala Native works great on sbt `1.2.x` which is newer and better.
So it is better to change the suggested version.