### PR TITLE
Downgrade to sbt-pgp 1.0.0

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
 addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-dirty-money"   % "0.2.0")
 addSbtPlugin("org.foundweekends"  % "sbt-bintray"       % "0.5.4")
-addSbtPlugin("com.jsuereth"       % "sbt-pgp"           % "1.1.1")
+addSbtPlugin("com.jsuereth"       % "sbt-pgp"           % "1.0.0")
 addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"   % "0.3.0")
 
 scalacOptions ++= Seq(


### PR DESCRIPTION
In #1375 @ekrich bumped sbt-pgp version 1.0.0 but it made `sandbox/run` to run the code on the JVM instead of SN which shouldn't happen. 