### PR TITLE
Bump snapshot version to 0.4.0

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Versions.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Versions.scala
@@ -25,5 +25,5 @@ object Versions {
   final val revision: Int = 6
 
   /* Current public release version of Scala Native. */
-  final val current: String = "0.3.9-SNAPSHOT"
+  final val current: String = "0.4.0-SNAPSHOT"
 }


### PR DESCRIPTION
Next release is going be 0.4.0, not 0.3.9. 