### PR TITLE
Make division by zero defined behaviour

### DIFF
--- a/docs/user/lang.rst
+++ b/docs/user/lang.rst
@@ -34,7 +34,6 @@ A number of error conditions which are well-defined on JVM are undefined
 behavior:
 
 1. Dereferencing null.
-2. Division by zero.
 3. Stack overflows.
 
 Those typically crash application with a segfault on the supported architectures.

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -89,5 +89,10 @@ package object runtime {
   /** Run the runtime's event loop. The method is called from the
    *  generated C-style after the application's main method terminates.
    */
-  def loop(): Unit = ExecutionContext.loop()
+  def loop(): Unit =
+    ExecutionContext.loop()
+
+  /** Called by the compiler in case of division by zero. */
+  def throwDivisionByZero(): Nothing =
+    throw new java.lang.ArithmeticException("/ by zero")
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -41,23 +41,33 @@ sealed abstract class Op {
   }
 
   final def show: String = nir.Show(this)
+
+  final def isPure: Boolean = this match {
+    case _: Op.Elem | _: Op.Extract | _: Op.Insert | _: Op.Comp | _: Op.Conv |
+        _: Op.Select =>
+      true
+    case Op.Bin(Bin.Sdiv | Bin.Udiv | Bin.Srem | Bin.Urem, _, _, _) =>
+      false
+    case _: Op.Bin =>
+      true
+    case _ =>
+      false
+  }
 }
 object Op {
-  sealed abstract class Pure extends Op
-
   // low-level
   final case class Call(ty: Type, ptr: Val, args: Seq[Val])      extends Op
   final case class Load(ty: Type, ptr: Val, isVolatile: Boolean) extends Op
   final case class Store(ty: Type, ptr: Val, value: Val, isVolatile: Boolean)
       extends Op
-  final case class Elem(ty: Type, ptr: Val, indexes: Seq[Val])      extends Pure
-  final case class Extract(aggr: Val, indexes: Seq[Int])            extends Pure
-  final case class Insert(aggr: Val, value: Val, indexes: Seq[Int]) extends Pure
+  final case class Elem(ty: Type, ptr: Val, indexes: Seq[Val])      extends Op
+  final case class Extract(aggr: Val, indexes: Seq[Int])            extends Op
+  final case class Insert(aggr: Val, value: Val, indexes: Seq[Int]) extends Op
   final case class Stackalloc(ty: Type, n: Val)                     extends Op
-  final case class Bin(bin: nir.Bin, ty: Type, l: Val, r: Val)      extends Pure
-  final case class Comp(comp: nir.Comp, ty: Type, l: Val, r: Val)   extends Pure
-  final case class Conv(conv: nir.Conv, ty: Type, value: Val)       extends Pure
-  final case class Select(cond: Val, thenv: Val, elsev: Val)        extends Pure
+  final case class Bin(bin: nir.Bin, ty: Type, l: Val, r: Val)      extends Op
+  final case class Comp(comp: nir.Comp, ty: Type, l: Val, r: Val)   extends Op
+  final case class Conv(conv: nir.Conv, ty: Type, value: Val)       extends Op
+  final case class Select(cond: Val, thenv: Val, elsev: Val)        extends Op
 
   def Load(ty: Type, ptr: Val): Load =
     Load(ty, ptr, isVolatile = false)

--- a/tools/src/main/scala/scala/scalanative/optimizer/pass/GlobalValueNumbering.scala
+++ b/tools/src/main/scala/scala/scalanative/optimizer/pass/GlobalValueNumbering.scala
@@ -101,8 +101,10 @@ object GlobalValueNumbering extends PassCompanion {
     import Op._
     op match {
       // Always idempotent:
-      case (_: Pure | _: Method | _: Dynmethod | _: As | _: Is | _: Copy |
-          _: Sizeof | _: Module | _: Box | _: Unbox | _: Arraylength) =>
+      case (_: Method | _: Dynmethod | _: As | _: Is | _: Copy | _: Sizeof |
+          _: Module | _: Box | _: Unbox | _: Arraylength) =>
+        true
+      case op if op.isPure =>
         true
 
       // Never idempotent:

--- a/tools/src/main/scala/scala/scalanative/sema/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/sema/UseDef.scala
@@ -72,7 +72,7 @@ object UseDef {
       pureWhitelist.contains(name)
     case Inst.Let(_, Op.Module(name), _) =>
       pureWhitelist.contains(name)
-    case Inst.Let(_, _: Op.Pure, _) =>
+    case Inst.Let(_, op, _) if op.isPure =>
       true
     case _ =>
       false

--- a/unit-tests/src/test/scala/scala/DivisionByZeroSuite.scala
+++ b/unit-tests/src/test/scala/scala/DivisionByZeroSuite.scala
@@ -1,0 +1,94 @@
+package scala
+
+object DivisionByZeroSuite extends tests.Suite {
+  @noinline def byte1  = 1.toByte
+  @noinline def char1  = 1.toChar
+  @noinline def short1 = 1.toShort
+  @noinline def int1   = 1
+  @noinline def long1  = 1L
+  @noinline def byte0  = 0.toByte
+  @noinline def char0  = 0.toChar
+  @noinline def short0 = 0.toShort
+  @noinline def int0   = 0
+  @noinline def long0  = 0L
+
+  test("byte / zero") {
+    assertThrows[ArithmeticException](byte1 / byte0)
+    assertThrows[ArithmeticException](byte1 / short0)
+    assertThrows[ArithmeticException](byte1 / char0)
+    assertThrows[ArithmeticException](byte1 / int0)
+    assertThrows[ArithmeticException](byte1 / long0)
+  }
+
+  test("byte % zero") {
+    assertThrows[ArithmeticException](byte1 / byte0)
+    assertThrows[ArithmeticException](byte1 / short0)
+    assertThrows[ArithmeticException](byte1 / char0)
+    assertThrows[ArithmeticException](byte1 / int0)
+    assertThrows[ArithmeticException](byte1 / long0)
+  }
+
+  test("short / zero") {
+    assertThrows[ArithmeticException](short1 / byte0)
+    assertThrows[ArithmeticException](short1 / short0)
+    assertThrows[ArithmeticException](short1 / char0)
+    assertThrows[ArithmeticException](short1 / int0)
+    assertThrows[ArithmeticException](short1 / long0)
+  }
+
+  test("short % zero") {
+    assertThrows[ArithmeticException](short1 / byte0)
+    assertThrows[ArithmeticException](short1 / short0)
+    assertThrows[ArithmeticException](short1 / char0)
+    assertThrows[ArithmeticException](short1 / int0)
+    assertThrows[ArithmeticException](short1 / long0)
+  }
+
+  test("char / zero") {
+    assertThrows[ArithmeticException](char1 / byte0)
+    assertThrows[ArithmeticException](char1 / short0)
+    assertThrows[ArithmeticException](char1 / char0)
+    assertThrows[ArithmeticException](char1 / int0)
+    assertThrows[ArithmeticException](char1 / long0)
+  }
+
+  test("char % zero") {
+    assertThrows[ArithmeticException](char1 / byte0)
+    assertThrows[ArithmeticException](char1 / short0)
+    assertThrows[ArithmeticException](char1 / char0)
+    assertThrows[ArithmeticException](char1 / int0)
+    assertThrows[ArithmeticException](char1 / long0)
+  }
+
+  test("int / zero") {
+    assertThrows[ArithmeticException](int1 / byte0)
+    assertThrows[ArithmeticException](int1 / short0)
+    assertThrows[ArithmeticException](int1 / char0)
+    assertThrows[ArithmeticException](int1 / int0)
+    assertThrows[ArithmeticException](int1 / long0)
+  }
+
+  test("int % zero") {
+    assertThrows[ArithmeticException](int1 / byte0)
+    assertThrows[ArithmeticException](int1 / short0)
+    assertThrows[ArithmeticException](int1 / char0)
+    assertThrows[ArithmeticException](int1 / int0)
+    assertThrows[ArithmeticException](int1 / long0)
+  }
+
+  test("long / zero") {
+    assertThrows[ArithmeticException](long1 / byte0)
+    assertThrows[ArithmeticException](long1 / short0)
+    assertThrows[ArithmeticException](long1 / char0)
+    assertThrows[ArithmeticException](long1 / int0)
+    assertThrows[ArithmeticException](long1 / long0)
+  }
+
+  test("long % zero") {
+    assertThrows[ArithmeticException](long1 / byte0)
+    assertThrows[ArithmeticException](long1 / short0)
+    assertThrows[ArithmeticException](long1 / char0)
+    assertThrows[ArithmeticException](long1 / int0)
+    assertThrows[ArithmeticException](long1 / long0)
+  }
+}

--- a/unit-tests/src/test/scala/scala/DivisionOverflowSuite.scala
+++ b/unit-tests/src/test/scala/scala/DivisionOverflowSuite.scala
@@ -1,0 +1,23 @@
+package scala
+
+object DivisionOverflowSuite extends tests.Suite {
+  @noinline def intMinus1  = -1
+  @noinline def longMinus1 = -1L
+
+  test("Integer.MIN_VALUE / -1") {
+    assert(
+      (java.lang.Integer.MIN_VALUE / intMinus1) == java.lang.Integer.MIN_VALUE)
+  }
+
+  test("Integer.MIN_VALUE % -1") {
+    assert((java.lang.Integer.MIN_VALUE % intMinus1) == 0)
+  }
+
+  test("Long.MIN_VALUE / -1") {
+    assert((java.lang.Long.MIN_VALUE / longMinus1) == java.lang.Long.MIN_VALUE)
+  }
+
+  test("Long.MIN_VALUE % -1") {
+    assert((java.lang.Long.MIN_VALUE % longMinus1) == 0)
+  }
+}

--- a/unit-tests/src/test/scala/scala/scalanative/IssuesSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/IssuesSuite.scala
@@ -49,15 +49,14 @@ object IssuesSuite extends tests.Suite {
   }
 
   test("#314") {
-    // Division by zero is undefined behavior in production mode.
-    // Optimizer can assume it never happens and remove unused result.
+    // Division by zero is defined behavior.
     assert {
       try {
         5 / 0
-        true
+        false
       } catch {
-        case _: Throwable =>
-          false
+        case _: ArithmeticException =>
+          true
       }
     }
   }


### PR DESCRIPTION
This change makes integer division behave the same as on JVM:

1. Division by 0 throws an ArithmeticException.
2. Division that overflows wraps around.

Previously these two cases were undefined. While integer segfaults
are relatively easy to debug, the problem gets worse once LLVM
starts optimizing assuming undefined behaviour (by removing said
segfaults and replacing ops with 0).