### PR TITLE
 Bug compatibility with scala/bug/issues/11253 

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -985,6 +985,9 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def binaryOperationType(lty: nir.Type, rty: nir.Type) = (lty, rty) match {
+      // Bug compatibility with scala/bug/issues/11253
+      case (Type.Long, Type.Float) =>
+        Type.Double
       case (nir.Type.Ptr, _: nir.Type.RefKind) =>
         lty
       case (_: nir.Type.RefKind, nir.Type.Ptr) =>

--- a/unit-tests/src/test/scala/scala/bugcompat/LongFloatPrimitiveSuite.scala
+++ b/unit-tests/src/test/scala/scala/bugcompat/LongFloatPrimitiveSuite.scala
@@ -1,0 +1,17 @@
+package scala
+
+object LongFloatPrimitiveSuite extends tests.Suite {
+  @inline def inlineFloat(): Float =
+    java.lang.Float.intBitsToFloat(1079290514)
+  @noinline def noinlineFloat(): Float =
+    java.lang.Float.intBitsToFloat(1079290514)
+  @inline def inlineLong(): Long =
+    1412906027847L
+  @noinline def noinlineLong(): Long =
+    1412906027847L
+
+  test("scala/bug/issues/11253") {
+    assert(noinlineLong % noinlineFloat == 2.3242621F)
+    assert(inlineLong   % inlineFloat == 2.3242621F)
+  }
+}


### PR DESCRIPTION
Scalac mistakingly uses Double precision when performing
primitive binary operations on Long that take a Float
argument. Once this bug is fixed upstream we can conditionally
enable the workaround only on affected versions.