### PR TITLE
 Fix undefined behaviour in float to integer conversions

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1376,9 +1376,17 @@ trait NirGenExpr { self: NirGenPhase =>
             Conv.Sitofp
           case (nir.Type.I(_, false), _: nir.Type.F) =>
             Conv.Uitofp
-          case (_: nir.Type.F, nir.Type.I(_, true)) =>
+          case (_: nir.Type.F, nir.Type.I(iwidth, true)) =>
+            if (iwidth < 32) {
+              val ivalue = genCoercion(value, fromty, Type.Int)
+              return genCoercion(ivalue, Type.Int, toty)
+            }
             Conv.Fptosi
-          case (_: nir.Type.F, nir.Type.I(_, false)) =>
+          case (_: nir.Type.F, nir.Type.I(iwidth, false)) =>
+            if (iwidth < 32) {
+              val ivalue = genCoercion(value, fromty, Type.Int)
+              return genCoercion(ivalue, Type.Int, toty)
+            }
             Conv.Fptoui
           case (nir.Type.Double, nir.Type.Float) =>
             Conv.Fptrunc

--- a/unit-tests/src/test/scala/scala/FloatingToIntegerOverflow.scala
+++ b/unit-tests/src/test/scala/scala/FloatingToIntegerOverflow.scala
@@ -1,0 +1,42 @@
+package scala
+
+object FloatingToIntegerOverflowSuite extends tests.Suite {
+  @noinline def tooSmallFloatToInt   = java.lang.Integer.MIN_VALUE.toFloat - 42
+  @noinline def tooSmallDoubleToLong = java.lang.Long.MIN_VALUE.toDouble - 42
+  @noinline def tooBigFloatToInt     = java.lang.Integer.MAX_VALUE.toFloat + 42
+  @noinline def tooBigDoubleToLong   = java.lang.Long.MAX_VALUE.toDouble + 42
+  @noinline def floatNaN             = java.lang.Float.NaN
+  @noinline def doubleNaN            = java.lang.Double.NaN
+
+  test("nan float to int") {
+    assert(floatNaN.toInt == 0)
+  }
+
+  test("nan float to long") {
+    assert(floatNaN.toLong == 0L)
+  }
+
+  test("nan double to int") {
+    assert(doubleNaN.toInt == 0)
+  }
+
+  test("nan double to long") {
+    assert(doubleNaN.toLong == 0L)
+  }
+
+  test("float too small to fit in int") {
+    assert(tooSmallFloatToInt.toInt == java.lang.Integer.MIN_VALUE)
+  }
+
+  test("float too small to fit in long") {
+    assert(tooSmallDoubleToLong.toLong == java.lang.Long.MIN_VALUE)
+  }
+
+  test("float too big to fit in int") {
+    assert(tooBigFloatToInt.toInt == java.lang.Integer.MAX_VALUE)
+  }
+
+  test("float too small to fit in long") {
+    assert(tooBigDoubleToLong.toLong == java.lang.Long.MAX_VALUE)
+  }
+}


### PR DESCRIPTION
On LLVM fptosi is undefined behaviour in cases when
the resulting float to integer is effectively out of bounds.
We insert extra checks to ensure that semantics is consistent
with Scala on the JVM.