### PR TITLE
Make field access on null throw NullPointerException

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
+++ b/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
@@ -34,7 +34,9 @@ object SocketHelpers {
         return false
       }
 
-      val sock = socket((!ret).ai_family, SOCK_STREAM, (!ret).ai_protocol)
+      val res = !ret
+
+      val sock = socket(res.ai_family, SOCK_STREAM, res.ai_protocol)
       try {
         if (sock < 0) {
           return false
@@ -50,7 +52,7 @@ object SocketHelpers {
         time.tv_sec = timeout / 1000
         time.tv_usec = (timeout % 1000) * 1000
 
-        connect(sock, (!ret).ai_addr, (!ret).ai_addrlen)
+        connect(sock, res.ai_addr, res.ai_addrlen)
 
         if (select(sock + 1, null, fdset, null, time) == 1) {
           val so_error = stackalloc[CInt].cast[Ptr[Byte]]
@@ -82,7 +84,7 @@ object SocketHelpers {
         case e: Throwable => e
       } finally {
         close(sock)
-        freeaddrinfo(!ret)
+        freeaddrinfo(res)
       }
     }
     true

--- a/unit-tests/src/test/scala/scala/FieldSuite.scala
+++ b/unit-tests/src/test/scala/scala/FieldSuite.scala
@@ -1,0 +1,27 @@
+package scala.scalanative.native
+
+object FieldSuite extends tests.Suite {
+
+  class C { var x: Int = 42 }
+
+  @noinline def nullC: C    = null
+  @noinline def notNullC: C = new C
+
+  test("load non-null object field") {
+    assert(notNullC.x == 42)
+  }
+
+  test("load null object field") {
+    assertThrows[NullPointerException](nullC.x)
+  }
+
+  test("store non-null object field") {
+    val c = notNullC
+    c.x = 84
+    assert(c.x == 84)
+  }
+
+  test("store null object field") {
+    assertThrows[NullPointerException](nullC.x = 84)
+  }
+}


### PR DESCRIPTION
Previously field operations on null were undefined behavior.
This change makes it consistent with the reference implementation
on top of the JVM.