### PR TITLE
Make NIR's unreachable defined behavior

### DIFF
--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -1,6 +1,6 @@
 package java.lang
 
-import scalanative.runtime.{divULong, remULong, undefined, Intrinsics}
+import scalanative.runtime.{divULong, remULong, Intrinsics}
 
 final class Long(val _value: scala.Long) extends Number with Comparable[Long] {
   @inline def this(s: String) =

--- a/nativelib/src/main/scala/scala/scalanative/native/CField.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/CField.scala
@@ -2,7 +2,7 @@
 package scala.scalanative
 package native
 
-import scalanative.runtime.undefined
+import scalanative.runtime.intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 7)
 
@@ -10,75 +10,75 @@ final abstract class CField1[P, F]
 
 object CField1 {
 
-  implicit def array[T, N <: Nat]: CField1[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField1[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
-  implicit def struct1[F1]: CField1[CStruct1[F1], F1] = undefined
+  implicit def struct1[F1]: CField1[CStruct1[F1], F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
-  implicit def struct2[F1, F2]: CField1[CStruct2[F1, F2], F1] = undefined
+  implicit def struct2[F1, F2]: CField1[CStruct2[F1, F2], F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct3[F1, F2, F3]: CField1[CStruct3[F1, F2, F3], F1] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct4[F1, F2, F3, F4]: CField1[CStruct4[F1, F2, F3, F4], F1] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct5[F1, F2, F3, F4, F5]
-    : CField1[CStruct5[F1, F2, F3, F4, F5], F1] = undefined
+    : CField1[CStruct5[F1, F2, F3, F4, F5], F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct6[F1, F2, F3, F4, F5, F6]
-    : CField1[CStruct6[F1, F2, F3, F4, F5, F6], F1] = undefined
+    : CField1[CStruct6[F1, F2, F3, F4, F5, F6], F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct7[F1, F2, F3, F4, F5, F6, F7]
-    : CField1[CStruct7[F1, F2, F3, F4, F5, F6, F7], F1] = undefined
+    : CField1[CStruct7[F1, F2, F3, F4, F5, F6, F7], F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct8[F1, F2, F3, F4, F5, F6, F7, F8]
-    : CField1[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F1] = undefined
+    : CField1[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct9[F1, F2, F3, F4, F5, F6, F7, F8, F9]
-    : CField1[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F1] = undefined
+    : CField1[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]
     : CField1[CStruct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], F1] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]
     : CField1[CStruct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11], F1] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField1[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
               F1] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField1[CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-              F1] = undefined
+              F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -97,7 +97,7 @@ object CField1 {
                         F13,
                         F14]: CField1[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F1] = undefined
+    F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -117,7 +117,7 @@ object CField1 {
                         F14,
                         F15]: CField1[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F1] = undefined
+    F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -152,7 +152,7 @@ object CField1 {
                                                 F14,
                                                 F15,
                                                 F16],
-                                      F1] = undefined
+                                      F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -189,7 +189,7 @@ object CField1 {
                                                 F15,
                                                 F16,
                                                 F17],
-                                      F1] = undefined
+                                      F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -228,7 +228,7 @@ object CField1 {
                                                 F16,
                                                 F17,
                                                 F18],
-                                      F1] = undefined
+                                      F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -269,7 +269,7 @@ object CField1 {
                                                 F17,
                                                 F18,
                                                 F19],
-                                      F1] = undefined
+                                      F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -312,7 +312,7 @@ object CField1 {
                                                 F18,
                                                 F19,
                                                 F20],
-                                      F1] = undefined
+                                      F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -357,7 +357,7 @@ object CField1 {
                                                 F19,
                                                 F20,
                                                 F21],
-                                      F1] = undefined
+                                      F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -404,7 +404,7 @@ object CField1 {
                                                 F20,
                                                 F21,
                                                 F22],
-                                      F1] = undefined
+                                      F1] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -416,71 +416,71 @@ final abstract class CField2[P, F]
 
 object CField2 {
 
-  implicit def array[T, N <: Nat]: CField2[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField2[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
-  implicit def struct2[F1, F2]: CField2[CStruct2[F1, F2], F2] = undefined
+  implicit def struct2[F1, F2]: CField2[CStruct2[F1, F2], F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct3[F1, F2, F3]: CField2[CStruct3[F1, F2, F3], F2] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct4[F1, F2, F3, F4]: CField2[CStruct4[F1, F2, F3, F4], F2] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct5[F1, F2, F3, F4, F5]
-    : CField2[CStruct5[F1, F2, F3, F4, F5], F2] = undefined
+    : CField2[CStruct5[F1, F2, F3, F4, F5], F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct6[F1, F2, F3, F4, F5, F6]
-    : CField2[CStruct6[F1, F2, F3, F4, F5, F6], F2] = undefined
+    : CField2[CStruct6[F1, F2, F3, F4, F5, F6], F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct7[F1, F2, F3, F4, F5, F6, F7]
-    : CField2[CStruct7[F1, F2, F3, F4, F5, F6, F7], F2] = undefined
+    : CField2[CStruct7[F1, F2, F3, F4, F5, F6, F7], F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct8[F1, F2, F3, F4, F5, F6, F7, F8]
-    : CField2[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F2] = undefined
+    : CField2[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct9[F1, F2, F3, F4, F5, F6, F7, F8, F9]
-    : CField2[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F2] = undefined
+    : CField2[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]
     : CField2[CStruct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], F2] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]
     : CField2[CStruct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11], F2] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField2[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
               F2] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField2[CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-              F2] = undefined
+              F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -499,7 +499,7 @@ object CField2 {
                         F13,
                         F14]: CField2[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F2] = undefined
+    F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -519,7 +519,7 @@ object CField2 {
                         F14,
                         F15]: CField2[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F2] = undefined
+    F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -554,7 +554,7 @@ object CField2 {
                                                 F14,
                                                 F15,
                                                 F16],
-                                      F2] = undefined
+                                      F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -591,7 +591,7 @@ object CField2 {
                                                 F15,
                                                 F16,
                                                 F17],
-                                      F2] = undefined
+                                      F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -630,7 +630,7 @@ object CField2 {
                                                 F16,
                                                 F17,
                                                 F18],
-                                      F2] = undefined
+                                      F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -671,7 +671,7 @@ object CField2 {
                                                 F17,
                                                 F18,
                                                 F19],
-                                      F2] = undefined
+                                      F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -714,7 +714,7 @@ object CField2 {
                                                 F18,
                                                 F19,
                                                 F20],
-                                      F2] = undefined
+                                      F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -759,7 +759,7 @@ object CField2 {
                                                 F19,
                                                 F20,
                                                 F21],
-                                      F2] = undefined
+                                      F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -806,7 +806,7 @@ object CField2 {
                                                 F20,
                                                 F21,
                                                 F22],
-                                      F2] = undefined
+                                      F2] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -818,67 +818,67 @@ final abstract class CField3[P, F]
 
 object CField3 {
 
-  implicit def array[T, N <: Nat]: CField3[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField3[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct3[F1, F2, F3]: CField3[CStruct3[F1, F2, F3], F3] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct4[F1, F2, F3, F4]: CField3[CStruct4[F1, F2, F3, F4], F3] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct5[F1, F2, F3, F4, F5]
-    : CField3[CStruct5[F1, F2, F3, F4, F5], F3] = undefined
+    : CField3[CStruct5[F1, F2, F3, F4, F5], F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct6[F1, F2, F3, F4, F5, F6]
-    : CField3[CStruct6[F1, F2, F3, F4, F5, F6], F3] = undefined
+    : CField3[CStruct6[F1, F2, F3, F4, F5, F6], F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct7[F1, F2, F3, F4, F5, F6, F7]
-    : CField3[CStruct7[F1, F2, F3, F4, F5, F6, F7], F3] = undefined
+    : CField3[CStruct7[F1, F2, F3, F4, F5, F6, F7], F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct8[F1, F2, F3, F4, F5, F6, F7, F8]
-    : CField3[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F3] = undefined
+    : CField3[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct9[F1, F2, F3, F4, F5, F6, F7, F8, F9]
-    : CField3[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F3] = undefined
+    : CField3[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]
     : CField3[CStruct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], F3] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]
     : CField3[CStruct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11], F3] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField3[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
               F3] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField3[CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-              F3] = undefined
+              F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -897,7 +897,7 @@ object CField3 {
                         F13,
                         F14]: CField3[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F3] = undefined
+    F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -917,7 +917,7 @@ object CField3 {
                         F14,
                         F15]: CField3[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F3] = undefined
+    F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -952,7 +952,7 @@ object CField3 {
                                                 F14,
                                                 F15,
                                                 F16],
-                                      F3] = undefined
+                                      F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -989,7 +989,7 @@ object CField3 {
                                                 F15,
                                                 F16,
                                                 F17],
-                                      F3] = undefined
+                                      F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1028,7 +1028,7 @@ object CField3 {
                                                 F16,
                                                 F17,
                                                 F18],
-                                      F3] = undefined
+                                      F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1069,7 +1069,7 @@ object CField3 {
                                                 F17,
                                                 F18,
                                                 F19],
-                                      F3] = undefined
+                                      F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1112,7 +1112,7 @@ object CField3 {
                                                 F18,
                                                 F19,
                                                 F20],
-                                      F3] = undefined
+                                      F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1157,7 +1157,7 @@ object CField3 {
                                                 F19,
                                                 F20,
                                                 F21],
-                                      F3] = undefined
+                                      F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1204,7 +1204,7 @@ object CField3 {
                                                 F20,
                                                 F21,
                                                 F22],
-                                      F3] = undefined
+                                      F3] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -1216,62 +1216,62 @@ final abstract class CField4[P, F]
 
 object CField4 {
 
-  implicit def array[T, N <: Nat]: CField4[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField4[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct4[F1, F2, F3, F4]: CField4[CStruct4[F1, F2, F3, F4], F4] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct5[F1, F2, F3, F4, F5]
-    : CField4[CStruct5[F1, F2, F3, F4, F5], F4] = undefined
+    : CField4[CStruct5[F1, F2, F3, F4, F5], F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct6[F1, F2, F3, F4, F5, F6]
-    : CField4[CStruct6[F1, F2, F3, F4, F5, F6], F4] = undefined
+    : CField4[CStruct6[F1, F2, F3, F4, F5, F6], F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct7[F1, F2, F3, F4, F5, F6, F7]
-    : CField4[CStruct7[F1, F2, F3, F4, F5, F6, F7], F4] = undefined
+    : CField4[CStruct7[F1, F2, F3, F4, F5, F6, F7], F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct8[F1, F2, F3, F4, F5, F6, F7, F8]
-    : CField4[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F4] = undefined
+    : CField4[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct9[F1, F2, F3, F4, F5, F6, F7, F8, F9]
-    : CField4[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F4] = undefined
+    : CField4[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]
     : CField4[CStruct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], F4] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]
     : CField4[CStruct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11], F4] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField4[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
               F4] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField4[CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-              F4] = undefined
+              F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1290,7 +1290,7 @@ object CField4 {
                         F13,
                         F14]: CField4[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F4] = undefined
+    F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1310,7 +1310,7 @@ object CField4 {
                         F14,
                         F15]: CField4[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F4] = undefined
+    F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1345,7 +1345,7 @@ object CField4 {
                                                 F14,
                                                 F15,
                                                 F16],
-                                      F4] = undefined
+                                      F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1382,7 +1382,7 @@ object CField4 {
                                                 F15,
                                                 F16,
                                                 F17],
-                                      F4] = undefined
+                                      F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1421,7 +1421,7 @@ object CField4 {
                                                 F16,
                                                 F17,
                                                 F18],
-                                      F4] = undefined
+                                      F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1462,7 +1462,7 @@ object CField4 {
                                                 F17,
                                                 F18,
                                                 F19],
-                                      F4] = undefined
+                                      F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1505,7 +1505,7 @@ object CField4 {
                                                 F18,
                                                 F19,
                                                 F20],
-                                      F4] = undefined
+                                      F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1550,7 +1550,7 @@ object CField4 {
                                                 F19,
                                                 F20,
                                                 F21],
-                                      F4] = undefined
+                                      F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1597,7 +1597,7 @@ object CField4 {
                                                 F20,
                                                 F21,
                                                 F22],
-                                      F4] = undefined
+                                      F4] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -1609,57 +1609,57 @@ final abstract class CField5[P, F]
 
 object CField5 {
 
-  implicit def array[T, N <: Nat]: CField5[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField5[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct5[F1, F2, F3, F4, F5]
-    : CField5[CStruct5[F1, F2, F3, F4, F5], F5] = undefined
+    : CField5[CStruct5[F1, F2, F3, F4, F5], F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct6[F1, F2, F3, F4, F5, F6]
-    : CField5[CStruct6[F1, F2, F3, F4, F5, F6], F5] = undefined
+    : CField5[CStruct6[F1, F2, F3, F4, F5, F6], F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct7[F1, F2, F3, F4, F5, F6, F7]
-    : CField5[CStruct7[F1, F2, F3, F4, F5, F6, F7], F5] = undefined
+    : CField5[CStruct7[F1, F2, F3, F4, F5, F6, F7], F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct8[F1, F2, F3, F4, F5, F6, F7, F8]
-    : CField5[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F5] = undefined
+    : CField5[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct9[F1, F2, F3, F4, F5, F6, F7, F8, F9]
-    : CField5[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F5] = undefined
+    : CField5[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]
     : CField5[CStruct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], F5] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]
     : CField5[CStruct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11], F5] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField5[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
               F5] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField5[CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-              F5] = undefined
+              F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1678,7 +1678,7 @@ object CField5 {
                         F13,
                         F14]: CField5[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F5] = undefined
+    F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1698,7 +1698,7 @@ object CField5 {
                         F14,
                         F15]: CField5[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F5] = undefined
+    F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1733,7 +1733,7 @@ object CField5 {
                                                 F14,
                                                 F15,
                                                 F16],
-                                      F5] = undefined
+                                      F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1770,7 +1770,7 @@ object CField5 {
                                                 F15,
                                                 F16,
                                                 F17],
-                                      F5] = undefined
+                                      F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1809,7 +1809,7 @@ object CField5 {
                                                 F16,
                                                 F17,
                                                 F18],
-                                      F5] = undefined
+                                      F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1850,7 +1850,7 @@ object CField5 {
                                                 F17,
                                                 F18,
                                                 F19],
-                                      F5] = undefined
+                                      F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1893,7 +1893,7 @@ object CField5 {
                                                 F18,
                                                 F19,
                                                 F20],
-                                      F5] = undefined
+                                      F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1938,7 +1938,7 @@ object CField5 {
                                                 F19,
                                                 F20,
                                                 F21],
-                                      F5] = undefined
+                                      F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -1985,7 +1985,7 @@ object CField5 {
                                                 F20,
                                                 F21,
                                                 F22],
-                                      F5] = undefined
+                                      F5] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -1997,52 +1997,52 @@ final abstract class CField6[P, F]
 
 object CField6 {
 
-  implicit def array[T, N <: Nat]: CField6[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField6[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct6[F1, F2, F3, F4, F5, F6]
-    : CField6[CStruct6[F1, F2, F3, F4, F5, F6], F6] = undefined
+    : CField6[CStruct6[F1, F2, F3, F4, F5, F6], F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct7[F1, F2, F3, F4, F5, F6, F7]
-    : CField6[CStruct7[F1, F2, F3, F4, F5, F6, F7], F6] = undefined
+    : CField6[CStruct7[F1, F2, F3, F4, F5, F6, F7], F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct8[F1, F2, F3, F4, F5, F6, F7, F8]
-    : CField6[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F6] = undefined
+    : CField6[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct9[F1, F2, F3, F4, F5, F6, F7, F8, F9]
-    : CField6[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F6] = undefined
+    : CField6[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]
     : CField6[CStruct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], F6] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]
     : CField6[CStruct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11], F6] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField6[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
               F6] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField6[CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-              F6] = undefined
+              F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2061,7 +2061,7 @@ object CField6 {
                         F13,
                         F14]: CField6[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F6] = undefined
+    F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2081,7 +2081,7 @@ object CField6 {
                         F14,
                         F15]: CField6[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F6] = undefined
+    F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2116,7 +2116,7 @@ object CField6 {
                                                 F14,
                                                 F15,
                                                 F16],
-                                      F6] = undefined
+                                      F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2153,7 +2153,7 @@ object CField6 {
                                                 F15,
                                                 F16,
                                                 F17],
-                                      F6] = undefined
+                                      F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2192,7 +2192,7 @@ object CField6 {
                                                 F16,
                                                 F17,
                                                 F18],
-                                      F6] = undefined
+                                      F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2233,7 +2233,7 @@ object CField6 {
                                                 F17,
                                                 F18,
                                                 F19],
-                                      F6] = undefined
+                                      F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2276,7 +2276,7 @@ object CField6 {
                                                 F18,
                                                 F19,
                                                 F20],
-                                      F6] = undefined
+                                      F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2321,7 +2321,7 @@ object CField6 {
                                                 F19,
                                                 F20,
                                                 F21],
-                                      F6] = undefined
+                                      F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2368,7 +2368,7 @@ object CField6 {
                                                 F20,
                                                 F21,
                                                 F22],
-                                      F6] = undefined
+                                      F6] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -2380,47 +2380,47 @@ final abstract class CField7[P, F]
 
 object CField7 {
 
-  implicit def array[T, N <: Nat]: CField7[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField7[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct7[F1, F2, F3, F4, F5, F6, F7]
-    : CField7[CStruct7[F1, F2, F3, F4, F5, F6, F7], F7] = undefined
+    : CField7[CStruct7[F1, F2, F3, F4, F5, F6, F7], F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct8[F1, F2, F3, F4, F5, F6, F7, F8]
-    : CField7[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F7] = undefined
+    : CField7[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct9[F1, F2, F3, F4, F5, F6, F7, F8, F9]
-    : CField7[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F7] = undefined
+    : CField7[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]
     : CField7[CStruct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], F7] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]
     : CField7[CStruct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11], F7] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField7[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
               F7] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField7[CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-              F7] = undefined
+              F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2439,7 +2439,7 @@ object CField7 {
                         F13,
                         F14]: CField7[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F7] = undefined
+    F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2459,7 +2459,7 @@ object CField7 {
                         F14,
                         F15]: CField7[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F7] = undefined
+    F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2494,7 +2494,7 @@ object CField7 {
                                                 F14,
                                                 F15,
                                                 F16],
-                                      F7] = undefined
+                                      F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2531,7 +2531,7 @@ object CField7 {
                                                 F15,
                                                 F16,
                                                 F17],
-                                      F7] = undefined
+                                      F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2570,7 +2570,7 @@ object CField7 {
                                                 F16,
                                                 F17,
                                                 F18],
-                                      F7] = undefined
+                                      F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2611,7 +2611,7 @@ object CField7 {
                                                 F17,
                                                 F18,
                                                 F19],
-                                      F7] = undefined
+                                      F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2654,7 +2654,7 @@ object CField7 {
                                                 F18,
                                                 F19,
                                                 F20],
-                                      F7] = undefined
+                                      F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2699,7 +2699,7 @@ object CField7 {
                                                 F19,
                                                 F20,
                                                 F21],
-                                      F7] = undefined
+                                      F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2746,7 +2746,7 @@ object CField7 {
                                                 F20,
                                                 F21,
                                                 F22],
-                                      F7] = undefined
+                                      F7] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -2758,42 +2758,42 @@ final abstract class CField8[P, F]
 
 object CField8 {
 
-  implicit def array[T, N <: Nat]: CField8[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField8[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct8[F1, F2, F3, F4, F5, F6, F7, F8]
-    : CField8[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F8] = undefined
+    : CField8[CStruct8[F1, F2, F3, F4, F5, F6, F7, F8], F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct9[F1, F2, F3, F4, F5, F6, F7, F8, F9]
-    : CField8[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F8] = undefined
+    : CField8[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]
     : CField8[CStruct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], F8] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]
     : CField8[CStruct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11], F8] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField8[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
               F8] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField8[CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-              F8] = undefined
+              F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2812,7 +2812,7 @@ object CField8 {
                         F13,
                         F14]: CField8[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F8] = undefined
+    F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2832,7 +2832,7 @@ object CField8 {
                         F14,
                         F15]: CField8[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F8] = undefined
+    F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2867,7 +2867,7 @@ object CField8 {
                                                 F14,
                                                 F15,
                                                 F16],
-                                      F8] = undefined
+                                      F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2904,7 +2904,7 @@ object CField8 {
                                                 F15,
                                                 F16,
                                                 F17],
-                                      F8] = undefined
+                                      F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2943,7 +2943,7 @@ object CField8 {
                                                 F16,
                                                 F17,
                                                 F18],
-                                      F8] = undefined
+                                      F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -2984,7 +2984,7 @@ object CField8 {
                                                 F17,
                                                 F18,
                                                 F19],
-                                      F8] = undefined
+                                      F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3027,7 +3027,7 @@ object CField8 {
                                                 F18,
                                                 F19,
                                                 F20],
-                                      F8] = undefined
+                                      F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3072,7 +3072,7 @@ object CField8 {
                                                 F19,
                                                 F20,
                                                 F21],
-                                      F8] = undefined
+                                      F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3119,7 +3119,7 @@ object CField8 {
                                                 F20,
                                                 F21,
                                                 F22],
-                                      F8] = undefined
+                                      F8] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -3131,37 +3131,37 @@ final abstract class CField9[P, F]
 
 object CField9 {
 
-  implicit def array[T, N <: Nat]: CField9[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField9[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct9[F1, F2, F3, F4, F5, F6, F7, F8, F9]
-    : CField9[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F9] = undefined
+    : CField9[CStruct9[F1, F2, F3, F4, F5, F6, F7, F8, F9], F9] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]
     : CField9[CStruct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], F9] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]
     : CField9[CStruct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11], F9] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField9[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
               F9] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField9[CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-              F9] = undefined
+              F9] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3180,7 +3180,7 @@ object CField9 {
                         F13,
                         F14]: CField9[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F9] = undefined
+    F9] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3200,7 +3200,7 @@ object CField9 {
                         F14,
                         F15]: CField9[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F9] = undefined
+    F9] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3235,7 +3235,7 @@ object CField9 {
                                                 F14,
                                                 F15,
                                                 F16],
-                                      F9] = undefined
+                                      F9] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3272,7 +3272,7 @@ object CField9 {
                                                 F15,
                                                 F16,
                                                 F17],
-                                      F9] = undefined
+                                      F9] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3311,7 +3311,7 @@ object CField9 {
                                                 F16,
                                                 F17,
                                                 F18],
-                                      F9] = undefined
+                                      F9] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3352,7 +3352,7 @@ object CField9 {
                                                 F17,
                                                 F18,
                                                 F19],
-                                      F9] = undefined
+                                      F9] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3395,7 +3395,7 @@ object CField9 {
                                                 F18,
                                                 F19,
                                                 F20],
-                                      F9] = undefined
+                                      F9] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3440,7 +3440,7 @@ object CField9 {
                                                 F19,
                                                 F20,
                                                 F21],
-                                      F9] = undefined
+                                      F9] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3487,7 +3487,7 @@ object CField9 {
                                                 F20,
                                                 F21,
                                                 F22],
-                                      F9] = undefined
+                                      F9] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -3499,32 +3499,32 @@ final abstract class CField10[P, F]
 
 object CField10 {
 
-  implicit def array[T, N <: Nat]: CField10[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField10[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]
     : CField10[CStruct10[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], F10] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]
     : CField10[CStruct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11], F10] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField10[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
-               F10] = undefined
+               F10] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField10[
       CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-      F10] = undefined
+      F10] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3543,7 +3543,7 @@ object CField10 {
                         F13,
                         F14]: CField10[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F10] = undefined
+    F10] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3563,7 +3563,7 @@ object CField10 {
                         F14,
                         F15]: CField10[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F10] = undefined
+    F10] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3598,7 +3598,7 @@ object CField10 {
                                                  F14,
                                                  F15,
                                                  F16],
-                                       F10] = undefined
+                                       F10] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3635,7 +3635,7 @@ object CField10 {
                                                  F15,
                                                  F16,
                                                  F17],
-                                       F10] = undefined
+                                       F10] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3674,7 +3674,7 @@ object CField10 {
                                                  F16,
                                                  F17,
                                                  F18],
-                                       F10] = undefined
+                                       F10] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3715,7 +3715,7 @@ object CField10 {
                                                  F17,
                                                  F18,
                                                  F19],
-                                       F10] = undefined
+                                       F10] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3758,7 +3758,7 @@ object CField10 {
                                                  F18,
                                                  F19,
                                                  F20],
-                                       F10] = undefined
+                                       F10] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3803,7 +3803,7 @@ object CField10 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F10] = undefined
+                                       F10] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3850,7 +3850,7 @@ object CField10 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F10] = undefined
+                                       F10] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -3862,26 +3862,26 @@ final abstract class CField11[P, F]
 
 object CField11 {
 
-  implicit def array[T, N <: Nat]: CField11[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField11[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]
     : CField11[CStruct11[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11], F11] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField11[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
-               F11] = undefined
+               F11] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField11[
       CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-      F11] = undefined
+      F11] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3900,7 +3900,7 @@ object CField11 {
                         F13,
                         F14]: CField11[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F11] = undefined
+    F11] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3920,7 +3920,7 @@ object CField11 {
                         F14,
                         F15]: CField11[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F11] = undefined
+    F11] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3955,7 +3955,7 @@ object CField11 {
                                                  F14,
                                                  F15,
                                                  F16],
-                                       F11] = undefined
+                                       F11] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -3992,7 +3992,7 @@ object CField11 {
                                                  F15,
                                                  F16,
                                                  F17],
-                                       F11] = undefined
+                                       F11] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4031,7 +4031,7 @@ object CField11 {
                                                  F16,
                                                  F17,
                                                  F18],
-                                       F11] = undefined
+                                       F11] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4072,7 +4072,7 @@ object CField11 {
                                                  F17,
                                                  F18,
                                                  F19],
-                                       F11] = undefined
+                                       F11] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4115,7 +4115,7 @@ object CField11 {
                                                  F18,
                                                  F19,
                                                  F20],
-                                       F11] = undefined
+                                       F11] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4160,7 +4160,7 @@ object CField11 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F11] = undefined
+                                       F11] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4207,7 +4207,7 @@ object CField11 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F11] = undefined
+                                       F11] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -4219,20 +4219,20 @@ final abstract class CField12[P, F]
 
 object CField12 {
 
-  implicit def array[T, N <: Nat]: CField12[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField12[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]
     : CField12[CStruct12[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12],
-               F12] = undefined
+               F12] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField12[
       CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-      F12] = undefined
+      F12] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4251,7 +4251,7 @@ object CField12 {
                         F13,
                         F14]: CField12[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F12] = undefined
+    F12] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4271,7 +4271,7 @@ object CField12 {
                         F14,
                         F15]: CField12[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F12] = undefined
+    F12] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4306,7 +4306,7 @@ object CField12 {
                                                  F14,
                                                  F15,
                                                  F16],
-                                       F12] = undefined
+                                       F12] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4343,7 +4343,7 @@ object CField12 {
                                                  F15,
                                                  F16,
                                                  F17],
-                                       F12] = undefined
+                                       F12] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4382,7 +4382,7 @@ object CField12 {
                                                  F16,
                                                  F17,
                                                  F18],
-                                       F12] = undefined
+                                       F12] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4423,7 +4423,7 @@ object CField12 {
                                                  F17,
                                                  F18,
                                                  F19],
-                                       F12] = undefined
+                                       F12] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4466,7 +4466,7 @@ object CField12 {
                                                  F18,
                                                  F19,
                                                  F20],
-                                       F12] = undefined
+                                       F12] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4511,7 +4511,7 @@ object CField12 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F12] = undefined
+                                       F12] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4558,7 +4558,7 @@ object CField12 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F12] = undefined
+                                       F12] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -4570,14 +4570,14 @@ final abstract class CField13[P, F]
 
 object CField13 {
 
-  implicit def array[T, N <: Nat]: CField13[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField13[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
   implicit def struct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]
     : CField13[
       CStruct13[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13],
-      F13] = undefined
+      F13] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4596,7 +4596,7 @@ object CField13 {
                         F13,
                         F14]: CField13[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F13] = undefined
+    F13] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4616,7 +4616,7 @@ object CField13 {
                         F14,
                         F15]: CField13[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F13] = undefined
+    F13] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4651,7 +4651,7 @@ object CField13 {
                                                  F14,
                                                  F15,
                                                  F16],
-                                       F13] = undefined
+                                       F13] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4688,7 +4688,7 @@ object CField13 {
                                                  F15,
                                                  F16,
                                                  F17],
-                                       F13] = undefined
+                                       F13] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4727,7 +4727,7 @@ object CField13 {
                                                  F16,
                                                  F17,
                                                  F18],
-                                       F13] = undefined
+                                       F13] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4768,7 +4768,7 @@ object CField13 {
                                                  F17,
                                                  F18,
                                                  F19],
-                                       F13] = undefined
+                                       F13] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4811,7 +4811,7 @@ object CField13 {
                                                  F18,
                                                  F19,
                                                  F20],
-                                       F13] = undefined
+                                       F13] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4856,7 +4856,7 @@ object CField13 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F13] = undefined
+                                       F13] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4903,7 +4903,7 @@ object CField13 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F13] = undefined
+                                       F13] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -4915,7 +4915,7 @@ final abstract class CField14[P, F]
 
 object CField14 {
 
-  implicit def array[T, N <: Nat]: CField14[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField14[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4934,7 +4934,7 @@ object CField14 {
                         F13,
                         F14]: CField14[
     CStruct14[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14],
-    F14] = undefined
+    F14] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4954,7 +4954,7 @@ object CField14 {
                         F14,
                         F15]: CField14[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F14] = undefined
+    F14] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -4989,7 +4989,7 @@ object CField14 {
                                                  F14,
                                                  F15,
                                                  F16],
-                                       F14] = undefined
+                                       F14] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5026,7 +5026,7 @@ object CField14 {
                                                  F15,
                                                  F16,
                                                  F17],
-                                       F14] = undefined
+                                       F14] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5065,7 +5065,7 @@ object CField14 {
                                                  F16,
                                                  F17,
                                                  F18],
-                                       F14] = undefined
+                                       F14] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5106,7 +5106,7 @@ object CField14 {
                                                  F17,
                                                  F18,
                                                  F19],
-                                       F14] = undefined
+                                       F14] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5149,7 +5149,7 @@ object CField14 {
                                                  F18,
                                                  F19,
                                                  F20],
-                                       F14] = undefined
+                                       F14] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5194,7 +5194,7 @@ object CField14 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F14] = undefined
+                                       F14] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5241,7 +5241,7 @@ object CField14 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F14] = undefined
+                                       F14] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -5253,7 +5253,7 @@ final abstract class CField15[P, F]
 
 object CField15 {
 
-  implicit def array[T, N <: Nat]: CField15[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField15[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5273,7 +5273,7 @@ object CField15 {
                         F14,
                         F15]: CField15[
     CStruct15[F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15],
-    F15] = undefined
+    F15] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5308,7 +5308,7 @@ object CField15 {
                                                  F14,
                                                  F15,
                                                  F16],
-                                       F15] = undefined
+                                       F15] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5345,7 +5345,7 @@ object CField15 {
                                                  F15,
                                                  F16,
                                                  F17],
-                                       F15] = undefined
+                                       F15] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5384,7 +5384,7 @@ object CField15 {
                                                  F16,
                                                  F17,
                                                  F18],
-                                       F15] = undefined
+                                       F15] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5425,7 +5425,7 @@ object CField15 {
                                                  F17,
                                                  F18,
                                                  F19],
-                                       F15] = undefined
+                                       F15] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5468,7 +5468,7 @@ object CField15 {
                                                  F18,
                                                  F19,
                                                  F20],
-                                       F15] = undefined
+                                       F15] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5513,7 +5513,7 @@ object CField15 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F15] = undefined
+                                       F15] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5560,7 +5560,7 @@ object CField15 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F15] = undefined
+                                       F15] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -5572,7 +5572,7 @@ final abstract class CField16[P, F]
 
 object CField16 {
 
-  implicit def array[T, N <: Nat]: CField16[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField16[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5607,7 +5607,7 @@ object CField16 {
                                                  F14,
                                                  F15,
                                                  F16],
-                                       F16] = undefined
+                                       F16] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5644,7 +5644,7 @@ object CField16 {
                                                  F15,
                                                  F16,
                                                  F17],
-                                       F16] = undefined
+                                       F16] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5683,7 +5683,7 @@ object CField16 {
                                                  F16,
                                                  F17,
                                                  F18],
-                                       F16] = undefined
+                                       F16] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5724,7 +5724,7 @@ object CField16 {
                                                  F17,
                                                  F18,
                                                  F19],
-                                       F16] = undefined
+                                       F16] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5767,7 +5767,7 @@ object CField16 {
                                                  F18,
                                                  F19,
                                                  F20],
-                                       F16] = undefined
+                                       F16] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5812,7 +5812,7 @@ object CField16 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F16] = undefined
+                                       F16] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5859,7 +5859,7 @@ object CField16 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F16] = undefined
+                                       F16] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -5871,7 +5871,7 @@ final abstract class CField17[P, F]
 
 object CField17 {
 
-  implicit def array[T, N <: Nat]: CField17[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField17[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5908,7 +5908,7 @@ object CField17 {
                                                  F15,
                                                  F16,
                                                  F17],
-                                       F17] = undefined
+                                       F17] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5947,7 +5947,7 @@ object CField17 {
                                                  F16,
                                                  F17,
                                                  F18],
-                                       F17] = undefined
+                                       F17] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -5988,7 +5988,7 @@ object CField17 {
                                                  F17,
                                                  F18,
                                                  F19],
-                                       F17] = undefined
+                                       F17] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6031,7 +6031,7 @@ object CField17 {
                                                  F18,
                                                  F19,
                                                  F20],
-                                       F17] = undefined
+                                       F17] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6076,7 +6076,7 @@ object CField17 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F17] = undefined
+                                       F17] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6123,7 +6123,7 @@ object CField17 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F17] = undefined
+                                       F17] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -6135,7 +6135,7 @@ final abstract class CField18[P, F]
 
 object CField18 {
 
-  implicit def array[T, N <: Nat]: CField18[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField18[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6174,7 +6174,7 @@ object CField18 {
                                                  F16,
                                                  F17,
                                                  F18],
-                                       F18] = undefined
+                                       F18] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6215,7 +6215,7 @@ object CField18 {
                                                  F17,
                                                  F18,
                                                  F19],
-                                       F18] = undefined
+                                       F18] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6258,7 +6258,7 @@ object CField18 {
                                                  F18,
                                                  F19,
                                                  F20],
-                                       F18] = undefined
+                                       F18] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6303,7 +6303,7 @@ object CField18 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F18] = undefined
+                                       F18] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6350,7 +6350,7 @@ object CField18 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F18] = undefined
+                                       F18] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -6362,7 +6362,7 @@ final abstract class CField19[P, F]
 
 object CField19 {
 
-  implicit def array[T, N <: Nat]: CField19[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField19[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6403,7 +6403,7 @@ object CField19 {
                                                  F17,
                                                  F18,
                                                  F19],
-                                       F19] = undefined
+                                       F19] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6446,7 +6446,7 @@ object CField19 {
                                                  F18,
                                                  F19,
                                                  F20],
-                                       F19] = undefined
+                                       F19] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6491,7 +6491,7 @@ object CField19 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F19] = undefined
+                                       F19] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6538,7 +6538,7 @@ object CField19 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F19] = undefined
+                                       F19] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -6550,7 +6550,7 @@ final abstract class CField20[P, F]
 
 object CField20 {
 
-  implicit def array[T, N <: Nat]: CField20[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField20[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6593,7 +6593,7 @@ object CField20 {
                                                  F18,
                                                  F19,
                                                  F20],
-                                       F20] = undefined
+                                       F20] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6638,7 +6638,7 @@ object CField20 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F20] = undefined
+                                       F20] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6685,7 +6685,7 @@ object CField20 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F20] = undefined
+                                       F20] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -6697,7 +6697,7 @@ final abstract class CField21[P, F]
 
 object CField21 {
 
-  implicit def array[T, N <: Nat]: CField21[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField21[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6742,7 +6742,7 @@ object CField21 {
                                                  F19,
                                                  F20,
                                                  F21],
-                                       F21] = undefined
+                                       F21] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6789,7 +6789,7 @@ object CField21 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F21] = undefined
+                                       F21] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 
@@ -6801,7 +6801,7 @@ final abstract class CField22[P, F]
 
 object CField22 {
 
-  implicit def array[T, N <: Nat]: CField22[CArray[T, N], T] = undefined
+  implicit def array[T, N <: Nat]: CField22[CArray[T, N], T] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 17)
 
@@ -6848,7 +6848,7 @@ object CField22 {
                                                  F20,
                                                  F21,
                                                  F22],
-                                       F22] = undefined
+                                       F22] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CField.scala.gyb", line: 21)
 

--- a/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala
@@ -2,7 +2,7 @@
 package scala.scalanative
 package native
 
-import scalanative.runtime.undefined
+import scalanative.runtime.intrinsic
 
 /** C-style function pointer. */
 sealed abstract class CFunctionPtr
@@ -11,71 +11,71 @@ object CFunctionPtr {
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
-  implicit def fromFunction0[R](f: Function0[R]): CFunctionPtr0[R] = undefined
+  implicit def fromFunction0[R](f: Function0[R]): CFunctionPtr0[R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction1[T1, R](f: Function1[T1, R]): CFunctionPtr1[T1, R] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction2[T1, T2, R](
-      f: Function2[T1, T2, R]): CFunctionPtr2[T1, T2, R] = undefined
+      f: Function2[T1, T2, R]): CFunctionPtr2[T1, T2, R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction3[T1, T2, T3, R](
-      f: Function3[T1, T2, T3, R]): CFunctionPtr3[T1, T2, T3, R] = undefined
+      f: Function3[T1, T2, T3, R]): CFunctionPtr3[T1, T2, T3, R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction4[T1, T2, T3, T4, R](
       f: Function4[T1, T2, T3, T4, R]): CFunctionPtr4[T1, T2, T3, T4, R] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction5[T1, T2, T3, T4, T5, R](
       f: Function5[T1, T2, T3, T4, T5, R])
-    : CFunctionPtr5[T1, T2, T3, T4, T5, R] = undefined
+    : CFunctionPtr5[T1, T2, T3, T4, T5, R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction6[T1, T2, T3, T4, T5, T6, R](
       f: Function6[T1, T2, T3, T4, T5, T6, R])
-    : CFunctionPtr6[T1, T2, T3, T4, T5, T6, R] = undefined
+    : CFunctionPtr6[T1, T2, T3, T4, T5, T6, R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction7[T1, T2, T3, T4, T5, T6, T7, R](
       f: Function7[T1, T2, T3, T4, T5, T6, T7, R])
-    : CFunctionPtr7[T1, T2, T3, T4, T5, T6, T7, R] = undefined
+    : CFunctionPtr7[T1, T2, T3, T4, T5, T6, T7, R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](
       f: Function8[T1, T2, T3, T4, T5, T6, T7, T8, R])
-    : CFunctionPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] = undefined
+    : CFunctionPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](
       f: Function9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R])
-    : CFunctionPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = undefined
+    : CFunctionPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](
       f: Function10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R])
-    : CFunctionPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = undefined
+    : CFunctionPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
   implicit def fromFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](
       f: Function11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R])
     : CFunctionPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
@@ -94,7 +94,7 @@ object CFunctionPtr {
                               R](
       f: Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R])
     : CFunctionPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
@@ -127,7 +127,7 @@ object CFunctionPtr {
                      T12,
                      T13,
                      R] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
@@ -174,7 +174,7 @@ object CFunctionPtr {
                                         T12,
                                         T13,
                                         T14,
-                                        R] = undefined
+                                        R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
@@ -224,7 +224,7 @@ object CFunctionPtr {
                                         T13,
                                         T14,
                                         T15,
-                                        R] = undefined
+                                        R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
@@ -277,7 +277,7 @@ object CFunctionPtr {
                                         T14,
                                         T15,
                                         T16,
-                                        R] = undefined
+                                        R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
@@ -333,7 +333,7 @@ object CFunctionPtr {
                                         T15,
                                         T16,
                                         T17,
-                                        R] = undefined
+                                        R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
@@ -392,7 +392,7 @@ object CFunctionPtr {
                                         T16,
                                         T17,
                                         T18,
-                                        R] = undefined
+                                        R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
@@ -454,7 +454,7 @@ object CFunctionPtr {
                                         T17,
                                         T18,
                                         T19,
-                                        R] = undefined
+                                        R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
@@ -519,7 +519,7 @@ object CFunctionPtr {
                                         T18,
                                         T19,
                                         T20,
-                                        R] = undefined
+                                        R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
@@ -587,7 +587,7 @@ object CFunctionPtr {
                                         T19,
                                         T20,
                                         T21,
-                                        R] = undefined
+                                        R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 13)
 
@@ -658,7 +658,7 @@ object CFunctionPtr {
                                         T20,
                                         T21,
                                         T22,
-                                        R] = undefined
+                                        R] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 17)
 
@@ -667,13 +667,13 @@ object CFunctionPtr {
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
 
 final abstract class CFunctionPtr0[R] extends CFunctionPtr {
-  def apply()(implicit tag1: Tag[R]): R = undefined
+  def apply()(implicit tag1: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
 
 final abstract class CFunctionPtr1[T1, R] extends CFunctionPtr {
-  def apply(arg1: T1)(implicit tag1: Tag[T1], tag2: Tag[R]): R = undefined
+  def apply(arg1: T1)(implicit tag1: Tag[T1], tag2: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -681,7 +681,7 @@ final abstract class CFunctionPtr1[T1, R] extends CFunctionPtr {
 final abstract class CFunctionPtr2[T1, T2, R] extends CFunctionPtr {
   def apply(arg1: T1,
             arg2: T2)(implicit tag1: Tag[T1], tag2: Tag[T2], tag3: Tag[R]): R =
-    undefined
+    intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -690,7 +690,7 @@ final abstract class CFunctionPtr3[T1, T2, T3, R] extends CFunctionPtr {
   def apply(arg1: T1, arg2: T2, arg3: T3)(implicit tag1: Tag[T1],
                                           tag2: Tag[T2],
                                           tag3: Tag[T3],
-                                          tag4: Tag[R]): R = undefined
+                                          tag4: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -701,7 +701,7 @@ final abstract class CFunctionPtr4[T1, T2, T3, T4, R] extends CFunctionPtr {
                                                     tag3: Tag[T3],
                                                     tag4: Tag[T4],
                                                     tag5: Tag[R]): R =
-    undefined
+    intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -713,7 +713,7 @@ final abstract class CFunctionPtr5[T1, T2, T3, T4, T5, R] extends CFunctionPtr {
       tag3: Tag[T3],
       tag4: Tag[T4],
       tag5: Tag[T5],
-      tag6: Tag[R]): R = undefined
+      tag6: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -727,7 +727,7 @@ final abstract class CFunctionPtr6[T1, T2, T3, T4, T5, T6, R]
       tag4: Tag[T4],
       tag5: Tag[T5],
       tag6: Tag[T6],
-      tag7: Tag[R]): R = undefined
+      tag7: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -747,7 +747,7 @@ final abstract class CFunctionPtr7[T1, T2, T3, T4, T5, T6, T7, R]
                       tag5: Tag[T5],
                       tag6: Tag[T6],
                       tag7: Tag[T7],
-                      tag8: Tag[R]): R = undefined
+                      tag8: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -769,7 +769,7 @@ final abstract class CFunctionPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R]
                       tag6: Tag[T6],
                       tag7: Tag[T7],
                       tag8: Tag[T8],
-                      tag9: Tag[R]): R = undefined
+                      tag9: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -793,7 +793,7 @@ final abstract class CFunctionPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
                       tag7: Tag[T7],
                       tag8: Tag[T8],
                       tag9: Tag[T9],
-                      tag10: Tag[R]): R = undefined
+                      tag10: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -819,7 +819,7 @@ final abstract class CFunctionPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
                         tag8: Tag[T8],
                         tag9: Tag[T9],
                         tag10: Tag[T10],
-                        tag11: Tag[R]): R = undefined
+                        tag11: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -848,7 +848,7 @@ final abstract class CFunctionPtr11[
                         tag9: Tag[T9],
                         tag10: Tag[T10],
                         tag11: Tag[T11],
-                        tag12: Tag[R]): R = undefined
+                        tag12: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -879,7 +879,7 @@ final abstract class CFunctionPtr12[
                         tag10: Tag[T10],
                         tag11: Tag[T11],
                         tag12: Tag[T12],
-                        tag13: Tag[R]): R = undefined
+                        tag13: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -912,7 +912,7 @@ final abstract class CFunctionPtr13[
                         tag11: Tag[T11],
                         tag12: Tag[T12],
                         tag13: Tag[T13],
-                        tag14: Tag[R]): R = undefined
+                        tag14: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -947,7 +947,7 @@ final abstract class CFunctionPtr14[
                         tag12: Tag[T12],
                         tag13: Tag[T13],
                         tag14: Tag[T14],
-                        tag15: Tag[R]): R = undefined
+                        tag15: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -984,7 +984,7 @@ final abstract class CFunctionPtr15[
                         tag13: Tag[T13],
                         tag14: Tag[T14],
                         tag15: Tag[T15],
-                        tag16: Tag[R]): R = undefined
+                        tag16: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -1023,7 +1023,7 @@ final abstract class CFunctionPtr16[
                         tag14: Tag[T14],
                         tag15: Tag[T15],
                         tag16: Tag[T16],
-                        tag17: Tag[R]): R = undefined
+                        tag17: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -1080,7 +1080,7 @@ final abstract class CFunctionPtr17[T1,
                         tag15: Tag[T15],
                         tag16: Tag[T16],
                         tag17: Tag[T17],
-                        tag18: Tag[R]): R = undefined
+                        tag18: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -1140,7 +1140,7 @@ final abstract class CFunctionPtr18[T1,
                         tag16: Tag[T16],
                         tag17: Tag[T17],
                         tag18: Tag[T18],
-                        tag19: Tag[R]): R = undefined
+                        tag19: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -1203,7 +1203,7 @@ final abstract class CFunctionPtr19[T1,
                         tag17: Tag[T17],
                         tag18: Tag[T18],
                         tag19: Tag[T19],
-                        tag20: Tag[R]): R = undefined
+                        tag20: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -1269,7 +1269,7 @@ final abstract class CFunctionPtr20[T1,
                         tag18: Tag[T18],
                         tag19: Tag[T19],
                         tag20: Tag[T20],
-                        tag21: Tag[R]): R = undefined
+                        tag21: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -1338,7 +1338,7 @@ final abstract class CFunctionPtr21[T1,
                         tag19: Tag[T19],
                         tag20: Tag[T20],
                         tag21: Tag[T21],
-                        tag22: Tag[R]): R = undefined
+                        tag22: Tag[R]): R = intrinsic
 }
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb", line: 24)
@@ -1410,5 +1410,5 @@ final abstract class CFunctionPtr22[T1,
                         tag20: Tag[T20],
                         tag21: Tag[T21],
                         tag22: Tag[T22],
-                        tag23: Tag[R]): R = undefined
+                        tag23: Tag[R]): R = intrinsic
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/native/CFunctionPtr.scala.gyb
@@ -1,7 +1,7 @@
 package scala.scalanative
 package native
 
-import scalanative.runtime.undefined
+import scalanative.runtime.intrinsic
 
 /** C-style function pointer. */
 sealed abstract class CFunctionPtr
@@ -11,7 +11,7 @@ object CFunctionPtr {
 % for N in range(0, 23):
 %    Ts = ", ".join(["T" + str(i) for i in range(1, N + 1)] + ["R"])
 
-  implicit def fromFunction${N}[${Ts}](f: Function${N}[${Ts}]): CFunctionPtr${N}[${Ts}] = undefined
+  implicit def fromFunction${N}[${Ts}](f: Function${N}[${Ts}]): CFunctionPtr${N}[${Ts}] = intrinsic
 
 % end
 
@@ -23,7 +23,7 @@ object CFunctionPtr {
 %   tagargs = ", ".join("tag" + str(i+1) + ": Tag[" + ty + "]" for (i, ty) in enumerate(tagtys))
 
 final abstract class CFunctionPtr${N}[${", ".join(["T" + str(i) for i in range(1, N+1)] + ["R"])}] extends CFunctionPtr {
-  def apply(${args})(implicit ${tagargs}): R = undefined
+  def apply(${args})(implicit ${tagargs}): R = intrinsic
 }
 
 % end

--- a/nativelib/src/main/scala/scala/scalanative/native/CVararg.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/CVararg.scala
@@ -2,11 +2,11 @@ package scala.scalanative
 package native
 
 import scala.language.implicitConversions
-import runtime.undefined
+import runtime.intrinsic
 
 /** Type of a C-style vararg in an extern method. */
 final abstract class CVararg
 
 object CVararg {
-  implicit def apply[T](value: T)(implicit tag: Tag[T]): CVararg = undefined
+  implicit def apply[T](value: T)(implicit tag: Tag[T]): CVararg = intrinsic
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala
@@ -8,135 +8,135 @@ import runtime._
 final abstract class Ptr[T] {
 
   /** Dereference a pointer. */
-  def unary_!(implicit tag: Tag[T]): T = undefined
+  def unary_!(implicit tag: Tag[T]): T = intrinsic
 
   /** Store a value to the address pointed at by a pointer. */
-  def `unary_!_=`(value: T)(implicit tag: Tag[T]): Unit = undefined
+  def `unary_!_=`(value: T)(implicit tag: Tag[T]): Unit = intrinsic
 
   /** Compute a derived pointer by adding given offset. */
-  def +(offset: Word)(implicit tag: Tag[T]): Ptr[T] = undefined
+  def +(offset: Word)(implicit tag: Tag[T]): Ptr[T] = intrinsic
 
   /** Compute a derived pointer by subtracting given offset. */
-  def -(offset: Word)(implicit tag: Tag[T]): Ptr[T] = undefined
+  def -(offset: Word)(implicit tag: Tag[T]): Ptr[T] = intrinsic
 
   /** Compute the offset between two pointers. */
-  def -(ptr: Ptr[T])(implicit tag: Tag[T]): CPtrDiff = undefined
+  def -(ptr: Ptr[T])(implicit tag: Tag[T]): CPtrDiff = intrinsic
 
   /** Read a value at given offset. Equivalent to !(offset + word). */
-  def apply(offset: Word)(implicit tag: Tag[T]): T = undefined
+  def apply(offset: Word)(implicit tag: Tag[T]): T = intrinsic
 
   /** Store a value to given offset. Equivalent to !(offset + word) = value. */
-  def update(offset: Word, value: T)(implicit tag: Tag[T]): T = undefined
+  def update(offset: Word, value: T)(implicit tag: Tag[T]): T = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 1-th field of the struct. */
-  def _1[F](implicit T: Tag[T], F: CField1[T, F]): Ptr[F] = undefined
+  def _1[F](implicit T: Tag[T], F: CField1[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 2-th field of the struct. */
-  def _2[F](implicit T: Tag[T], F: CField2[T, F]): Ptr[F] = undefined
+  def _2[F](implicit T: Tag[T], F: CField2[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 3-th field of the struct. */
-  def _3[F](implicit T: Tag[T], F: CField3[T, F]): Ptr[F] = undefined
+  def _3[F](implicit T: Tag[T], F: CField3[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 4-th field of the struct. */
-  def _4[F](implicit T: Tag[T], F: CField4[T, F]): Ptr[F] = undefined
+  def _4[F](implicit T: Tag[T], F: CField4[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 5-th field of the struct. */
-  def _5[F](implicit T: Tag[T], F: CField5[T, F]): Ptr[F] = undefined
+  def _5[F](implicit T: Tag[T], F: CField5[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 6-th field of the struct. */
-  def _6[F](implicit T: Tag[T], F: CField6[T, F]): Ptr[F] = undefined
+  def _6[F](implicit T: Tag[T], F: CField6[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 7-th field of the struct. */
-  def _7[F](implicit T: Tag[T], F: CField7[T, F]): Ptr[F] = undefined
+  def _7[F](implicit T: Tag[T], F: CField7[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 8-th field of the struct. */
-  def _8[F](implicit T: Tag[T], F: CField8[T, F]): Ptr[F] = undefined
+  def _8[F](implicit T: Tag[T], F: CField8[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 9-th field of the struct. */
-  def _9[F](implicit T: Tag[T], F: CField9[T, F]): Ptr[F] = undefined
+  def _9[F](implicit T: Tag[T], F: CField9[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 10-th field of the struct. */
-  def _10[F](implicit T: Tag[T], F: CField10[T, F]): Ptr[F] = undefined
+  def _10[F](implicit T: Tag[T], F: CField10[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 11-th field of the struct. */
-  def _11[F](implicit T: Tag[T], F: CField11[T, F]): Ptr[F] = undefined
+  def _11[F](implicit T: Tag[T], F: CField11[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 12-th field of the struct. */
-  def _12[F](implicit T: Tag[T], F: CField12[T, F]): Ptr[F] = undefined
+  def _12[F](implicit T: Tag[T], F: CField12[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 13-th field of the struct. */
-  def _13[F](implicit T: Tag[T], F: CField13[T, F]): Ptr[F] = undefined
+  def _13[F](implicit T: Tag[T], F: CField13[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 14-th field of the struct. */
-  def _14[F](implicit T: Tag[T], F: CField14[T, F]): Ptr[F] = undefined
+  def _14[F](implicit T: Tag[T], F: CField14[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 15-th field of the struct. */
-  def _15[F](implicit T: Tag[T], F: CField15[T, F]): Ptr[F] = undefined
+  def _15[F](implicit T: Tag[T], F: CField15[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 16-th field of the struct. */
-  def _16[F](implicit T: Tag[T], F: CField16[T, F]): Ptr[F] = undefined
+  def _16[F](implicit T: Tag[T], F: CField16[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 17-th field of the struct. */
-  def _17[F](implicit T: Tag[T], F: CField17[T, F]): Ptr[F] = undefined
+  def _17[F](implicit T: Tag[T], F: CField17[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 18-th field of the struct. */
-  def _18[F](implicit T: Tag[T], F: CField18[T, F]): Ptr[F] = undefined
+  def _18[F](implicit T: Tag[T], F: CField18[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 19-th field of the struct. */
-  def _19[F](implicit T: Tag[T], F: CField19[T, F]): Ptr[F] = undefined
+  def _19[F](implicit T: Tag[T], F: CField19[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 20-th field of the struct. */
-  def _20[F](implicit T: Tag[T], F: CField20[T, F]): Ptr[F] = undefined
+  def _20[F](implicit T: Tag[T], F: CField20[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 21-th field of the struct. */
-  def _21[F](implicit T: Tag[T], F: CField21[T, F]): Ptr[F] = undefined
+  def _21[F](implicit T: Tag[T], F: CField21[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 28)
 
   /** Get a derived pointer to the 22-th field of the struct. */
-  def _22[F](implicit T: Tag[T], F: CField22[T, F]): Ptr[F] = undefined
+  def _22[F](implicit T: Tag[T], F: CField22[T, F]): Ptr[F] = intrinsic
 
 // ###sourceLocation(file: "/Users/Denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb", line: 33)
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/native/Ptr.scala.gyb
@@ -7,30 +7,30 @@ import runtime._
 final abstract class Ptr[T] {
 
   /** Dereference a pointer. */
-  def unary_!(implicit tag: Tag[T]): T = undefined
+  def unary_!(implicit tag: Tag[T]): T = intrinsic
 
   /** Store a value to the address pointed at by a pointer. */
-  def `unary_!_=`(value: T)(implicit tag: Tag[T]): Unit = undefined
+  def `unary_!_=`(value: T)(implicit tag: Tag[T]): Unit = intrinsic
 
   /** Compute a derived pointer by adding given offset. */
-  def +(offset: Word)(implicit tag: Tag[T]): Ptr[T] = undefined
+  def +(offset: Word)(implicit tag: Tag[T]): Ptr[T] = intrinsic
 
   /** Compute a derived pointer by subtracting given offset. */
-  def -(offset: Word)(implicit tag: Tag[T]): Ptr[T] = undefined
+  def -(offset: Word)(implicit tag: Tag[T]): Ptr[T] = intrinsic
 
   /** Compute the offset between two pointers. */
-  def -(ptr: Ptr[T])(implicit tag: Tag[T]): CPtrDiff = undefined
+  def -(ptr: Ptr[T])(implicit tag: Tag[T]): CPtrDiff = intrinsic
 
   /** Read a value at given offset. Equivalent to !(offset + word). */
-  def apply(offset: Word)(implicit tag: Tag[T]): T = undefined
+  def apply(offset: Word)(implicit tag: Tag[T]): T = intrinsic
 
   /** Store a value to given offset. Equivalent to !(offset + word) = value. */
-  def update(offset: Word, value: T)(implicit tag: Tag[T]): T = undefined
+  def update(offset: Word, value: T)(implicit tag: Tag[T]): T = intrinsic
 
 % for N in range(1, 23):
 
   /** Get a derived pointer to the ${N}-th field of the struct. */
-  def _${N}[F](implicit T: Tag[T], F: CField${N}[T, F]): Ptr[F] = undefined
+  def _${N}[F](implicit T: Tag[T], F: CField${N}[T, F]): Ptr[F] = intrinsic
 
 % end
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/Tag.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Tag.scala
@@ -3,74 +3,74 @@ package scala.scalanative
 package native
 
 import scala.reflect.ClassTag
-import scalanative.runtime.undefined
+import scalanative.runtime.intrinsic
 
 final abstract class Tag[P]
 
 object Tag {
-  implicit val Unit: Tag[Unit]                    = undefined
-  implicit val Boolean: Tag[Boolean]              = undefined
-  implicit val Char: Tag[Char]                    = undefined
-  implicit val Byte: Tag[Byte]                    = undefined
-  implicit val UByte: Tag[UByte]                  = undefined
-  implicit val Short: Tag[Short]                  = undefined
-  implicit val UShort: Tag[UShort]                = undefined
-  implicit val Int: Tag[Int]                      = undefined
-  implicit val UInt: Tag[UInt]                    = undefined
-  implicit val Long: Tag[Long]                    = undefined
-  implicit val ULong: Tag[ULong]                  = undefined
-  implicit val Float: Tag[Float]                  = undefined
-  implicit val Double: Tag[Double]                = undefined
-  implicit def Ptr[T: Tag]: Tag[Ptr[T]]           = undefined
-  implicit def Ref[T <: AnyRef: ClassTag]: Tag[T] = undefined
+  implicit val Unit: Tag[Unit]                    = intrinsic
+  implicit val Boolean: Tag[Boolean]              = intrinsic
+  implicit val Char: Tag[Char]                    = intrinsic
+  implicit val Byte: Tag[Byte]                    = intrinsic
+  implicit val UByte: Tag[UByte]                  = intrinsic
+  implicit val Short: Tag[Short]                  = intrinsic
+  implicit val UShort: Tag[UShort]                = intrinsic
+  implicit val Int: Tag[Int]                      = intrinsic
+  implicit val UInt: Tag[UInt]                    = intrinsic
+  implicit val Long: Tag[Long]                    = intrinsic
+  implicit val ULong: Tag[ULong]                  = intrinsic
+  implicit val Float: Tag[Float]                  = intrinsic
+  implicit val Double: Tag[Double]                = intrinsic
+  implicit def Ptr[T: Tag]: Tag[Ptr[T]]           = intrinsic
+  implicit def Ref[T <: AnyRef: ClassTag]: Tag[T] = intrinsic
 
-  implicit def Nat0: Tag[Nat._0] = undefined
-  implicit def Nat1: Tag[Nat._1] = undefined
-  implicit def Nat2: Tag[Nat._2] = undefined
-  implicit def Nat3: Tag[Nat._3] = undefined
-  implicit def Nat4: Tag[Nat._4] = undefined
-  implicit def Nat5: Tag[Nat._5] = undefined
-  implicit def Nat6: Tag[Nat._6] = undefined
-  implicit def Nat7: Tag[Nat._7] = undefined
-  implicit def Nat8: Tag[Nat._8] = undefined
-  implicit def Nat9: Tag[Nat._9] = undefined
+  implicit def Nat0: Tag[Nat._0] = intrinsic
+  implicit def Nat1: Tag[Nat._1] = intrinsic
+  implicit def Nat2: Tag[Nat._2] = intrinsic
+  implicit def Nat3: Tag[Nat._3] = intrinsic
+  implicit def Nat4: Tag[Nat._4] = intrinsic
+  implicit def Nat5: Tag[Nat._5] = intrinsic
+  implicit def Nat6: Tag[Nat._6] = intrinsic
+  implicit def Nat7: Tag[Nat._7] = intrinsic
+  implicit def Nat8: Tag[Nat._8] = intrinsic
+  implicit def Nat9: Tag[Nat._9] = intrinsic
   implicit def NatDigit[N <: Nat.Base: Tag, M <: Nat: Tag]
     : Tag[Nat.Digit[N, M]] =
-    undefined
+    intrinsic
 
-  implicit def CArray[T: Tag, N <: Nat: Tag]: Tag[CArray[T, N]] = undefined
-
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
-
-  implicit def CStruct0: Tag[CStruct0] = undefined
+  implicit def CArray[T: Tag, N <: Nat: Tag]: Tag[CArray[T, N]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
-  implicit def CStruct1[T1: Tag]: Tag[CStruct1[T1]] = undefined
+  implicit def CStruct0: Tag[CStruct0] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
-  implicit def CStruct2[T1: Tag, T2: Tag]: Tag[CStruct2[T1, T2]] = undefined
+  implicit def CStruct1[T1: Tag]: Tag[CStruct1[T1]] = intrinsic
+
+// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+
+  implicit def CStruct2[T1: Tag, T2: Tag]: Tag[CStruct2[T1, T2]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
   implicit def CStruct3[T1: Tag, T2: Tag, T3: Tag]: Tag[CStruct3[T1, T2, T3]] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
   implicit def CStruct4[T1: Tag, T2: Tag, T3: Tag, T4: Tag]
-    : Tag[CStruct4[T1, T2, T3, T4]] = undefined
+    : Tag[CStruct4[T1, T2, T3, T4]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
   implicit def CStruct5[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag]
-    : Tag[CStruct5[T1, T2, T3, T4, T5]] = undefined
+    : Tag[CStruct5[T1, T2, T3, T4, T5]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
   implicit def CStruct6[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag]
-    : Tag[CStruct6[T1, T2, T3, T4, T5, T6]] = undefined
+    : Tag[CStruct6[T1, T2, T3, T4, T5, T6]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -81,7 +81,7 @@ object Tag {
                         T5: Tag,
                         T6: Tag,
                         T7: Tag]: Tag[CStruct7[T1, T2, T3, T4, T5, T6, T7]] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -93,7 +93,7 @@ object Tag {
                         T6: Tag,
                         T7: Tag,
                         T8: Tag]
-    : Tag[CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]] = undefined
+    : Tag[CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -106,7 +106,7 @@ object Tag {
                         T7: Tag,
                         T8: Tag,
                         T9: Tag]
-    : Tag[CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] = undefined
+    : Tag[CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -120,7 +120,7 @@ object Tag {
                          T8: Tag,
                          T9: Tag,
                          T10: Tag]
-    : Tag[CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] = undefined
+    : Tag[CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -135,7 +135,7 @@ object Tag {
                          T9: Tag,
                          T10: Tag,
                          T11: Tag]
-    : Tag[CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] = undefined
+    : Tag[CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -152,7 +152,7 @@ object Tag {
                          T11: Tag,
                          T12: Tag]
     : Tag[CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -170,7 +170,7 @@ object Tag {
                          T12: Tag,
                          T13: Tag]
     : Tag[CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -189,7 +189,7 @@ object Tag {
                          T13: Tag,
                          T14: Tag]: Tag[
     CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]] =
-    undefined
+    intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -222,7 +222,7 @@ object Tag {
               T12,
               T13,
               T14,
-              T15]] = undefined
+              T15]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -257,7 +257,7 @@ object Tag {
               T13,
               T14,
               T15,
-              T16]] = undefined
+              T16]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -294,7 +294,7 @@ object Tag {
               T14,
               T15,
               T16,
-              T17]] = undefined
+              T17]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -333,7 +333,7 @@ object Tag {
               T15,
               T16,
               T17,
-              T18]] = undefined
+              T18]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -374,7 +374,7 @@ object Tag {
               T16,
               T17,
               T18,
-              T19]] = undefined
+              T19]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -417,7 +417,7 @@ object Tag {
               T17,
               T18,
               T19,
-              T20]] = undefined
+              T20]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -462,7 +462,7 @@ object Tag {
               T18,
               T19,
               T20,
-              T21]] = undefined
+              T21]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
 
@@ -509,7 +509,7 @@ object Tag {
               T19,
               T20,
               T21,
-              T22]] = undefined
+              T22]] = intrinsic
 
 // ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb
@@ -2,48 +2,48 @@ package scala.scalanative
 package native
 
 import scala.reflect.ClassTag
-import scalanative.runtime.undefined
+import scalanative.runtime.intrinsic
 
 final abstract class Tag[P]
 
 object Tag {
-  implicit val Unit: Tag[Unit]                    = undefined
-  implicit val Boolean: Tag[Boolean]              = undefined
-  implicit val Char: Tag[Char]                    = undefined
-  implicit val Byte: Tag[Byte]                    = undefined
-  implicit val UByte: Tag[UByte]                  = undefined
-  implicit val Short: Tag[Short]                  = undefined
-  implicit val UShort: Tag[UShort]                = undefined
-  implicit val Int: Tag[Int]                      = undefined
-  implicit val UInt: Tag[UInt]                    = undefined
-  implicit val Long: Tag[Long]                    = undefined
-  implicit val ULong: Tag[ULong]                  = undefined
-  implicit val Float: Tag[Float]                  = undefined
-  implicit val Double: Tag[Double]                = undefined
-  implicit def Ptr[T: Tag]: Tag[Ptr[T]]           = undefined
-  implicit def Ref[T <: AnyRef: ClassTag]: Tag[T] = undefined
+  implicit val Unit: Tag[Unit]                    = intrinsic
+  implicit val Boolean: Tag[Boolean]              = intrinsic
+  implicit val Char: Tag[Char]                    = intrinsic
+  implicit val Byte: Tag[Byte]                    = intrinsic
+  implicit val UByte: Tag[UByte]                  = intrinsic
+  implicit val Short: Tag[Short]                  = intrinsic
+  implicit val UShort: Tag[UShort]                = intrinsic
+  implicit val Int: Tag[Int]                      = intrinsic
+  implicit val UInt: Tag[UInt]                    = intrinsic
+  implicit val Long: Tag[Long]                    = intrinsic
+  implicit val ULong: Tag[ULong]                  = intrinsic
+  implicit val Float: Tag[Float]                  = intrinsic
+  implicit val Double: Tag[Double]                = intrinsic
+  implicit def Ptr[T: Tag]: Tag[Ptr[T]]           = intrinsic
+  implicit def Ref[T <: AnyRef: ClassTag]: Tag[T] = intrinsic
 
-  implicit def Nat0: Tag[Nat._0] = undefined
-  implicit def Nat1: Tag[Nat._1] = undefined
-  implicit def Nat2: Tag[Nat._2] = undefined
-  implicit def Nat3: Tag[Nat._3] = undefined
-  implicit def Nat4: Tag[Nat._4] = undefined
-  implicit def Nat5: Tag[Nat._5] = undefined
-  implicit def Nat6: Tag[Nat._6] = undefined
-  implicit def Nat7: Tag[Nat._7] = undefined
-  implicit def Nat8: Tag[Nat._8] = undefined
-  implicit def Nat9: Tag[Nat._9] = undefined
+  implicit def Nat0: Tag[Nat._0] = intrinsic
+  implicit def Nat1: Tag[Nat._1] = intrinsic
+  implicit def Nat2: Tag[Nat._2] = intrinsic
+  implicit def Nat3: Tag[Nat._3] = intrinsic
+  implicit def Nat4: Tag[Nat._4] = intrinsic
+  implicit def Nat5: Tag[Nat._5] = intrinsic
+  implicit def Nat6: Tag[Nat._6] = intrinsic
+  implicit def Nat7: Tag[Nat._7] = intrinsic
+  implicit def Nat8: Tag[Nat._8] = intrinsic
+  implicit def Nat9: Tag[Nat._9] = intrinsic
   implicit def NatDigit[N <: Nat.Base: Tag, M <: Nat: Tag]: Tag[Nat.Digit[N, M]] =
-    undefined
+    intrinsic
 
-  implicit def CArray[T: Tag, N <: Nat: Tag]: Tag[CArray[T, N]] = undefined
+  implicit def CArray[T: Tag, N <: Nat: Tag]: Tag[CArray[T, N]] = intrinsic
 
   % for N in range(0, 23):
   %   Ts      = ["T" + str(i) for i in range(1, N + 1)]
   %   BoundTs = "" if N == 0 else "[" + ", ".join(map(lambda T: T + ": Tag", Ts)) + "]"
   %   JustTs  = "" if N == 0 else "[" + ", ".join(Ts) + "]"
 
-  implicit def CStruct${N}${BoundTs}: Tag[CStruct${N}${JustTs}] = undefined
+  implicit def CStruct${N}${BoundTs}: Tag[CStruct${N}${JustTs}] = intrinsic
 
   % end
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/package.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 
 import java.nio.charset.Charset
 import scala.language.experimental.macros
-import scalanative.runtime.{libc, undefined}
+import scalanative.runtime.{libc, intrinsic}
 
 package object native {
 
@@ -82,7 +82,7 @@ package object native {
   type CString = Ptr[CChar]
 
   /** The C 'sizeof' operator. */
-  def sizeof[T](implicit tag: Tag[T]): CSize = undefined
+  def sizeof[T](implicit tag: Tag[T]): CSize = intrinsic
 
   /** Heap allocate and zero-initialize a value
    *  using current implicit allocator.
@@ -100,26 +100,26 @@ package object native {
    *
    *  Note: unlike alloc, the memory is not zero-initialized.
    */
-  def stackalloc[T](implicit tag: Tag[T]): Ptr[T] = undefined
+  def stackalloc[T](implicit tag: Tag[T]): Ptr[T] = intrinsic
 
   /** Stack allocate n values of given type.
    *
    *  Note: unlike alloc, the memory is not zero-initialized.
    */
-  def stackalloc[T](n: CSize)(implicit tag: Tag[T]): Ptr[T] = undefined
+  def stackalloc[T](n: CSize)(implicit tag: Tag[T]): Ptr[T] = intrinsic
 
   /** Used as right hand side of external method and field declarations. */
-  def extern: Nothing = undefined
+  def extern: Nothing = intrinsic
 
   /** C-style string literal. */
   implicit class CQuote(val ctx: StringContext) {
-    def c(): CString = undefined
+    def c(): CString = intrinsic
   }
 
   /** C-style unchecked cast. */
   implicit class CCast[From](val from: From) {
     def cast[To](implicit fromtag: Tag[From], totag: Tag[To]): To =
-      undefined
+      intrinsic
   }
 
   /** Scala Native extensions to the standard Byte. */

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -31,37 +31,37 @@ package object runtime {
   final val STRUCT_KIND = 2
 
   /** Used as a stub right hand of intrinsified methods. */
-  def undefined: Nothing = throw new UndefinedBehaviorError
+  def intrinsic: Nothing = throwUndefined()
 
   /** Returns info pointer for given type. */
-  def typeof[T](implicit tag: Tag[T]): Ptr[Type] = undefined
+  def typeof[T](implicit tag: Tag[T]): Ptr[Type] = intrinsic
 
   /** Intrinsified unsigned devision on ints. */
-  def divUInt(l: Int, r: Int): Int = undefined
+  def divUInt(l: Int, r: Int): Int = intrinsic
 
   /** Intrinsified unsigned devision on longs. */
-  def divULong(l: Long, r: Long): Long = undefined
+  def divULong(l: Long, r: Long): Long = intrinsic
 
   /** Intrinsified unsigned remainder on ints. */
-  def remUInt(l: Int, r: Int): Int = undefined
+  def remUInt(l: Int, r: Int): Int = intrinsic
 
   /** Intrinsified unsigned remainder on longs. */
-  def remULong(l: Long, r: Long): Long = undefined
+  def remULong(l: Long, r: Long): Long = intrinsic
 
   /** Intrinsified byte to unsigned int converstion. */
-  def byteToUInt(b: Byte): Int = undefined
+  def byteToUInt(b: Byte): Int = intrinsic
 
   /** Intrinsified byte to unsigned long conversion. */
-  def byteToULong(b: Byte): Long = undefined
+  def byteToULong(b: Byte): Long = intrinsic
 
   /** Intrinsified short to unsigned int conversion. */
-  def shortToUInt(v: Short): Int = undefined
+  def shortToUInt(v: Short): Int = intrinsic
 
   /** Intrinsified short to unsigned long conversion. */
-  def shortToULong(v: Short): Long = undefined
+  def shortToULong(v: Short): Long = intrinsic
 
   /** Intrinsified int to unsigned long conversion. */
-  def intToULong(v: Int): Long = undefined
+  def intToULong(v: Int): Long = intrinsic
 
   /** Read type information of given object. */
   def getType(obj: Object): Ptr[ClassType] = !obj.cast[Ptr[Ptr[ClassType]]]
@@ -104,4 +104,8 @@ package object runtime {
   /** Called by the generated code in case of operations on null. */
   @noinline def throwNullPointer(): Nothing =
     throw new NullPointerException()
+
+  /** Called by the generated code in case of unexpected condition. */
+  @noinline def throwUndefined(): Nothing =
+    throw new UndefinedBehaviorError
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -19,8 +19,8 @@ class Buffer(implicit fresh: Fresh) {
     this += Inst.Label(name, Seq.empty)
   def label(name: Local, params: Seq[Val.Local]): Unit =
     this += Inst.Label(name, params)
-  def unreachable: Unit =
-    this += Inst.Unreachable
+  def unreachable(unwind: Next): Unit =
+    this += Inst.Unreachable(unwind)
   def ret(value: Val): Unit =
     this += Inst.Ret(value)
   def jump(next: Next): Unit =

--- a/nir/src/main/scala/scala/scalanative/nir/Insts.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Insts.scala
@@ -15,11 +15,11 @@ object Inst {
   }
 
   sealed abstract class Cf                                  extends Inst
-  final case object Unreachable                             extends Cf
   final case class Ret(value: Val)                          extends Cf
   final case class Jump(next: Next)                         extends Cf
   final case class If(value: Val, thenp: Next, elsep: Next) extends Cf
   final case class Switch(value: Val, default: Next, cases: Seq[Next])
       extends Cf
   final case class Throw(value: Val, unwind: Next) extends Cf
+  final case class Unreachable(unwind: Next)       extends Cf
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -112,8 +112,6 @@ object Show {
           str(" ")
           next_(unwind)
         }
-      case Inst.Unreachable =>
-        str("unreachable")
       case Inst.Ret(Val.None) =>
         str("ret")
       case Inst.Ret(value) =>
@@ -147,6 +145,12 @@ object Show {
       case Inst.Throw(v, unwind) =>
         str("throw ")
         val_(v)
+        if (unwind ne Next.None) {
+          str(" ")
+          next_(unwind)
+        }
+      case Inst.Unreachable(unwind) =>
+        str("unreachable")
         if (unwind ne Next.None) {
           str(" ")
           next_(unwind)

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -36,8 +36,6 @@ trait Transform {
     case Inst.Let(n, op, unwind) =>
       Inst.Let(n, onOp(op), onNext(unwind))
 
-    case Inst.Unreachable =>
-      Inst.Unreachable
     case Inst.Ret(v) =>
       Inst.Ret(onVal(v))
     case Inst.Jump(next) =>
@@ -48,6 +46,8 @@ trait Transform {
       Inst.Switch(onVal(v), onNext(default), cases.map(onNext))
     case Inst.Throw(v, unwind) =>
       Inst.Throw(onVal(v), onNext(unwind))
+    case Inst.Unreachable(unwind) =>
+      Inst.Unreachable(onNext(unwind))
   }
 
   def onOp(op: Op): Op = op match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -94,12 +94,12 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
     case T.LabelInst       => Inst.Label(getLocal, getParams)
     case T.LetInst         => Inst.Let(getLocal, getOp, Next.None)
     case T.LetUnwindInst   => Inst.Let(getLocal, getOp, getNext)
-    case T.UnreachableInst => Inst.Unreachable
     case T.RetInst         => Inst.Ret(getVal)
     case T.JumpInst        => Inst.Jump(getNext)
     case T.IfInst          => Inst.If(getVal, getNext, getNext)
     case T.SwitchInst      => Inst.Switch(getVal, getNext, getNexts)
     case T.ThrowInst       => Inst.Throw(getVal, getNext)
+    case T.UnreachableInst => Inst.Unreachable(getNext)
   }
 
   private def getComp(): Comp = getInt match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -117,9 +117,6 @@ final class BinarySerializer(buffer: ByteBuffer) {
       putOp(op)
       putNext(unwind)
 
-    case Inst.Unreachable =>
-      putInt(T.UnreachableInst)
-
     case Inst.Ret(v) =>
       putInt(T.RetInst)
       putVal(v)
@@ -143,6 +140,10 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Inst.Throw(v, unwind) =>
       putInt(T.ThrowInst)
       putVal(v)
+      putNext(unwind)
+
+    case Inst.Unreachable(unwind) =>
+      putInt(T.UnreachableInst)
       putNext(unwind)
   }
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -102,13 +102,13 @@ object Tags {
   final val NoneInst        = 1 + Inst
   final val LabelInst       = 1 + NoneInst
   final val LetInst         = 1 + LabelInst
-  final val UnreachableInst = 1 + LetInst
-  final val RetInst         = 1 + UnreachableInst
+  final val LetUnwindInst   = 1 + LetInst
+  final val RetInst         = 1 + LetUnwindInst
   final val JumpInst        = 1 + RetInst
   final val IfInst          = 1 + JumpInst
   final val SwitchInst      = 1 + IfInst
   final val ThrowInst       = 1 + SwitchInst
-  final val LetUnwindInst   = 1 + ThrowInst
+  final val UnreachableInst = 1 + ThrowInst
 
   // Globals
 

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Inst.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Inst.scala
@@ -19,7 +19,6 @@ object Inst extends Base[nir.Inst] {
     P(Local.parser ~ "=" ~ Op.parser ~ unwind map {
       case (name, op, unwind) => nir.Inst.Let(name, op, unwind)
     })
-  val Unreachable = P("unreachable".! map (_ => nir.Inst.Unreachable))
   val Ret =
     P("ret" ~ Val.parser.? map (v => nir.Inst.Ret(v.getOrElse(nir.Val.None))))
   val Jump = P("jump" ~ Next.parser map (nir.Inst.Jump(_)))
@@ -34,6 +33,9 @@ object Inst extends Base[nir.Inst] {
   val Throw = P("throw" ~ Val.parser ~ unwind).map {
     case (value, unwind) => nir.Inst.Throw(value, unwind)
   }
+  val Unreachable =
+    P("unreachable" ~ unwind map (nir.Inst.Unreachable(_)))
+
   override val parser: P[nir.Inst] =
-    None | Label | Let | Unreachable | Ret | Jump | If | Switch | Throw
+    None | Label | Let | Ret | Jump | If | Switch | Throw | Unreachable
 }

--- a/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
@@ -14,13 +14,14 @@ class InstParserTest extends FunSuite {
     Inst.Label(local, Seq.empty),
     Inst.Let(local, Op.As(noTpe, Val.None), Next.None),
     Inst.Let(local, Op.As(noTpe, Val.None), Next.Unwind(Local(0))),
-    Inst.Unreachable,
     Inst.Ret(Val.None),
     Inst.Jump(next),
     Inst.If(Val.None, next, next),
     Inst.Switch(Val.None, next, Seq.empty),
     Inst.Throw(Val.Zero(Type.Ptr), Next.Unwind(Local(0))),
-    Inst.Throw(Val.Zero(Type.Ptr), Next.None)
+    Inst.Throw(Val.Zero(Type.Ptr), Next.None),
+    Inst.Unreachable(Next.Unwind(Local(0))),
+    Inst.Unreachable(Next.None)
   ).foreach { inst =>
     test(s"parse inst `${inst.show}`") {
       val Parsed.Success(result, _) = parser.Inst.parser.parse(inst.show)

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -26,7 +26,7 @@ trait NirGenExpr { self: NirGenPhase =>
       inst match {
         case inst: nir.Inst.Label =>
           if (labeled) {
-            unreachable
+            unreachable(unwind)
           }
           labeled = true
         case _ =>

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -90,7 +90,7 @@ object Lower {
               let(n, Op.Copy(unit), unwind)
             case Type.Nothing =>
               genOp(buf, fresh(), op, unwind)
-              unreachable
+              unreachable(unwind)
               label(fresh(), Seq(Val.Local(n, op.resty)))
             case _ =>
               genOp(buf, n, op, unwind)
@@ -127,11 +127,11 @@ object Lower {
 
       label(isNullL)
       call(throwNullPointerTy, throwNullPointerVal, Seq(Val.Null), unwind)
-      unreachable
+      unreachable(unwind)
 
       label(notNullL)
       genOp(buf, fresh(), Op.Call(throwSig, throw_, Seq(exc)), unwind)
-      unreachable
+      unreachable(unwind)
     }
 
     def genOp(buf: Buffer, n: Local, op: Op, unwind: Next): Unit = op match {
@@ -411,7 +411,7 @@ object Lower {
                throwClassCastVal,
                Seq(Val.Null, fromTy, toTy),
                unwind)
-          unreachable
+          unreachable(unwind)
 
           label(castL)
           let(n, Op.Conv(Conv.Bitcast, ty, v), unwind)
@@ -550,7 +550,7 @@ object Lower {
              throwDivisionByZeroVal,
              Seq(Val.Null),
              unwind)
-        unreachable
+        unreachable(unwind)
 
         label(elseL)
         if (bin == Bin.Srem || bin == Bin.Sdiv) {

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -443,7 +443,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
     insts.foreach(reachInst)
 
   def reachInst(inst: Inst): Unit = inst match {
-    case Inst.None | Inst.Unreachable =>
+    case Inst.None =>
       ()
     case Inst.Label(n, params) =>
       params.foreach(p => reachType(p.ty))
@@ -464,6 +464,8 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
       cases.foreach(reachNext)
     case Inst.Throw(v, unwind) =>
       reachVal(v)
+      reachNext(unwind)
+    case Inst.Unreachable(unwind) =>
       reachNext(unwind)
   }
 

--- a/tools/src/main/scala/scala/scalanative/sema/ControlFlow.scala
+++ b/tools/src/main/scala/scala/scalanative/sema/ControlFlow.scala
@@ -114,7 +114,7 @@ object ControlFlow {
             ()
         }
         cf match {
-          case Inst.Unreachable | _: Inst.Ret =>
+          case _: Inst.Ret =>
             ()
           case Inst.Jump(next) =>
             edge(node, block(next.name), next)
@@ -127,6 +127,10 @@ object ControlFlow {
               edge(node, block(case_.name), case_)
             }
           case Inst.Throw(_, next) =>
+            if (next ne Next.None) {
+              edge(node, block(next.name), next)
+            }
+          case Inst.Unreachable(next) =>
             if (next ne Next.None) {
               edge(node, block(next.name), next)
             }


### PR DESCRIPTION
Previously it mapped to LLVM's unreachable which is
undefined behavior. Instead, we change its semantics
to throw an UndefinedBehaviorError instead.