### PR TITLE
Make unwind handler blocks first class

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Fresh.scala
@@ -18,6 +18,9 @@ object Fresh {
   def apply(insts: Seq[Inst]): Fresh = {
     var max = -1L
     insts.foreach {
+      case Inst.Let(local, _, Next.Unwind(Val.Local(exc, _), _)) =>
+        max = Math.max(max, local.id)
+        max = Math.max(max, exc.id)
       case Inst.Let(local, _, _) =>
         max = Math.max(max, local.id)
       case Inst.Label(local, params) =>
@@ -25,6 +28,10 @@ object Fresh {
         params.foreach { param =>
           max = Math.max(max, param.name.id)
         }
+      case Inst.Throw(_, Next.Unwind(Val.Local(exc, _), _)) =>
+        max = Math.max(max, exc.id)
+      case Inst.Unreachable(Next.Unwind(Val.Local(exc, _), _)) =>
+        max = Math.max(max, exc.id)
       case _ =>
         ()
     }

--- a/nir/src/main/scala/scala/scalanative/nir/Next.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Next.scala
@@ -11,7 +11,9 @@ object Next {
     def name: Local =
       throw new UnsupportedOperationException
   }
-  final case class Unwind(name: Local) extends Next
+  final case class Unwind(exc: Val.Local, next: Next) extends Next {
+    def name: Local = next.name
+  }
   final case class Case(value: Val, next: Next) extends Next {
     def name: Local = next.name
   }

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -71,19 +71,21 @@ object Show {
     def next_(next: Next): Unit = next match {
       case Next.Label(name, Seq()) =>
         local_(name)
-      case Next.Label(name, args) =>
-        local_(name)
-        str("(")
-        rep(args, sep = ", ")(val_)
-        str(")")
-      case Next.Unwind(name) =>
+      case Next.Unwind(exc, next) =>
         str("unwind ")
-        local_(name)
+        val_(exc)
+        str(" to ")
+        next_(next)
       case Next.Case(v, next) =>
         str("case ")
         val_(v)
         str(" => ")
         next_(next)
+      case Next.Label(name, args) =>
+        local_(name)
+        str("(")
+        rep(args, sep = ", ")(val_)
+        str(")")
     }
 
     def inst_(inst: Inst): Unit = inst match {

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -139,9 +139,9 @@ trait Transform {
   }
 
   def onNext(next: Next): Next = next match {
-    case Next.None           => Next.None
-    case unwind: Next.Unwind => unwind
-    case Next.Label(n, args) => Next.Label(n, args.map(onVal))
-    case Next.Case(v, n)     => Next.Case(onVal(v), n)
+    case Next.None            => Next.None
+    case Next.Case(v, n)      => Next.Case(onVal(v), n)
+    case Next.Unwind(n, next) => Next.Unwind(n, onNext(next))
+    case Next.Label(n, args)  => Next.Label(n, args.map(onVal))
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -188,9 +188,9 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
   private def getNexts(): Seq[Next] = getSeq(getNext)
   private def getNext(): Next = getInt match {
     case T.NoneNext   => Next.None
-    case T.UnwindNext => Next.Unwind(getLocal)
-    case T.LabelNext  => Next.Label(getLocal, getVals)
+    case T.UnwindNext => Next.Unwind(getParam, getNext)
     case T.CaseNext   => Next.Case(getVal, getNext)
+    case T.LabelNext  => Next.Label(getLocal, getVals)
   }
 
   private def getOp(): Op = getInt match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -278,9 +278,9 @@ final class BinarySerializer(buffer: ByteBuffer) {
   private def putNexts(nexts: Seq[Next]) = putSeq(nexts)(putNext)
   private def putNext(next: Next): Unit = next match {
     case Next.None         => putInt(T.NoneNext)
-    case Next.Unwind(n)    => putInt(T.UnwindNext); putLocal(n)
-    case Next.Label(n, vs) => putInt(T.LabelNext); putLocal(n); putVals(vs)
+    case Next.Unwind(e, n) => putInt(T.UnwindNext); putParam(e); putNext(n)
     case Next.Case(v, n)   => putInt(T.CaseNext); putVal(v); putNext(n)
+    case Next.Label(n, vs) => putInt(T.LabelNext); putLocal(n); putVals(vs)
   }
 
   private def putOp(op: Op) = op match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -136,8 +136,8 @@ object Tags {
 
   final val NoneNext   = 1 + Next
   final val UnwindNext = 1 + NoneNext
-  final val LabelNext  = 1 + UnwindNext
-  final val CaseNext   = 1 + LabelNext
+  final val CaseNext   = 1 + UnwindNext
+  final val LabelNext  = 1 + CaseNext
 
   // Ops
 

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Next.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Next.scala
@@ -12,10 +12,13 @@ object Next extends Base[nir.Next] {
     P(Local.parser ~ ("(" ~ Val.parser.rep(sep = ",") ~ ")").? map {
       case (name, args) => nir.Next.Label(name, args getOrElse Seq())
     })
-  val Unwind = P("unwind" ~ Local.parser map (nir.Next.Unwind(_)))
+  val Unwind = P("unwind" ~ Val.Local ~ "to" ~ Label map {
+    case (name, next) =>
+      nir.Next.Unwind(name, next)
+  })
   val Case =
-    P("case" ~ Val.parser ~ "=>" ~ Local.parser map {
-      case (value, name) => nir.Next.Case(value, name)
+    P("case" ~ Val.parser ~ "=>" ~ Label map {
+      case (value, next) => nir.Next.Case(value, next)
     })
   override val parser: P[nir.Next] = Label | Unwind | Case
 }

--- a/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
@@ -5,23 +5,26 @@ import fastparse.all.Parsed
 import org.scalatest._
 
 class InstParserTest extends FunSuite {
-  val local = Local(1)
-  val next  = Next(local)
-  val noTpe = Type.None
+  val local  = Local(1)
+  val next   = Next(local)
+  val noTpe  = Type.None
+  val value  = Val.Int(42)
+  val unwind = Next.Unwind(Val.Local(local, nir.Rt.Object), next)
 
   Seq[Inst](
     Inst.None,
     Inst.Label(local, Seq.empty),
-    Inst.Let(local, Op.As(noTpe, Val.None), Next.None),
-    Inst.Let(local, Op.As(noTpe, Val.None), Next.Unwind(Local(0))),
+    Inst.Let(local, Op.As(noTpe, value), Next.None),
+    Inst.Let(local, Op.As(noTpe, value), unwind),
     Inst.Ret(Val.None),
+    Inst.Ret(value),
     Inst.Jump(next),
     Inst.If(Val.None, next, next),
     Inst.Switch(Val.None, next, Seq.empty),
-    Inst.Throw(Val.Zero(Type.Ptr), Next.Unwind(Local(0))),
     Inst.Throw(Val.Zero(Type.Ptr), Next.None),
-    Inst.Unreachable(Next.Unwind(Local(0))),
-    Inst.Unreachable(Next.None)
+    Inst.Throw(Val.Zero(Type.Ptr), unwind),
+    Inst.Unreachable(Next.None),
+    Inst.Unreachable(unwind)
   ).foreach { inst =>
     test(s"parse inst `${inst.show}`") {
       val Parsed.Success(result, _) = parser.Inst.parser.parse(inst.show)

--- a/nirparser/src/test/scala/scala/scalanative/nir/NextParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/NextParserTest.scala
@@ -6,11 +6,19 @@ import org.scalatest._
 
 class NextParserTest extends FunSuite {
   val local = Local(1)
+  val value = Val.Int(42)
+  val exc   = Val.Local(local, nir.Rt.Object)
 
   Seq[Next](
-    Next.Unwind(local),
-    Next.Case(Val.None, local),
-    Next.Label(local, Seq.empty)
+    Next.Unwind(exc, Next.Label(local, Seq.empty)),
+    Next.Unwind(exc, Next.Label(local, Seq(value))),
+    Next.Unwind(exc, Next.Label(local, Seq(value, value))),
+    Next.Case(Val.None, Next.Label(local, Seq.empty)),
+    Next.Case(Val.None, Next.Label(local, Seq(value))),
+    Next.Case(Val.None, Next.Label(local, Seq(value, value))),
+    Next.Label(local, Seq.empty),
+    Next.Label(local, Seq(value)),
+    Next.Label(local, Seq(value, value))
   ).zipWithIndex.foreach {
     case (next, idx) =>
       test(s"parse next `${next.show}`") {

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -274,7 +274,7 @@ trait NirGenExpr { self: NirGenPhase =>
                expr: Tree,
                catches: List[Tree],
                finallyp: Tree): Val = {
-      val unwind = fresh()
+      val handler = fresh()
       val excn    = fresh()
       val normaln = fresh()
       val mergen  = fresh()
@@ -284,14 +284,14 @@ trait NirGenExpr { self: NirGenPhase =>
       // Nested code gen to separate out try/catch-related instructions.
       val nested = new ExprBuffer
       locally {
-        scoped(curUnwind := Next.Unwind(unwind)) {
+        scoped(curUnwindHandler := Some(handler)) {
           nested.label(normaln)
           val res = nested.genExpr(expr)
           nested.jump(mergen, Seq(res))
         }
       }
       locally {
-        nested.label(unwind, Seq(excv))
+        nested.label(handler, Seq(excv))
         val res = nested.genTryCatch(retty, excv, mergen, catches)
         nested.jump(mergen, Seq(res))
       }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -29,17 +29,20 @@ abstract class NirGenPhase
 
   protected val curLazyAnonDefs =
     new util.ScopedVar[mutable.Map[Symbol, ClassDef]]
-  protected val curClassSym   = new util.ScopedVar[Symbol]
-  protected val curMethodSym  = new util.ScopedVar[Symbol]
-  protected val curMethodInfo = new util.ScopedVar[CollectMethodInfo]
-  protected val curMethodEnv  = new util.ScopedVar[MethodEnv]
-  protected val curMethodThis = new util.ScopedVar[Option[Val]]
-  protected val curFresh      = new util.ScopedVar[nir.Fresh]
-  protected val curUnwind     = new util.ScopedVar[nir.Next]
-  protected val curStatBuffer = new util.ScopedVar[StatBuffer]
+  protected val curClassSym      = new util.ScopedVar[Symbol]
+  protected val curMethodSym     = new util.ScopedVar[Symbol]
+  protected val curMethodInfo    = new util.ScopedVar[CollectMethodInfo]
+  protected val curMethodEnv     = new util.ScopedVar[MethodEnv]
+  protected val curMethodThis    = new util.ScopedVar[Option[Val]]
+  protected val curFresh         = new util.ScopedVar[nir.Fresh]
+  protected val curUnwindHandler = new util.ScopedVar[Option[nir.Local]]
+  protected val curStatBuffer    = new util.ScopedVar[StatBuffer]
 
-  protected def unwind: Next =
-    curUnwind.get
+  protected def unwind(implicit fresh: Fresh): Next =
+    curUnwindHandler.get.fold[Next](Next.None) { handler =>
+      val exc = Val.Local(fresh(), nir.Rt.Object)
+      Next.Unwind(exc, Next.Label(handler, Seq(exc)))
+    }
 
   protected def lazyAnonDefs =
     curLazyAnonDefs.get

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -159,7 +159,7 @@ trait NirGenStat { self: NirGenPhase =>
         curMethodEnv := env,
         curMethodInfo := (new CollectMethodInfo).collect(dd.rhs),
         curFresh := fresh,
-        curUnwind := Next.None
+        curUnwindHandler := None
       ) {
         val sym      = dd.symbol
         val owner    = curClassSym.get
@@ -272,7 +272,7 @@ trait NirGenStat { self: NirGenPhase =>
         buf.label(fresh(), params)
         vars.foreach { sym =>
           val ty   = genType(sym.info, box = false)
-          val slot = buf.var_(ty, unwind)
+          val slot = buf.var_(ty, unwind(fresh))
           curMethodEnv.enter(sym, slot)
         }
       }

--- a/tools/src/main/scala/scala/scalanative/sema/ControlFlow.scala
+++ b/tools/src/main/scala/scala/scalanative/sema/ControlFlow.scala
@@ -36,19 +36,6 @@ object ControlFlow {
     def succ  = outEdges.map(_.to)
     def label = Inst.Label(name, params)
     def show  = name.show
-
-    def isRegular: Boolean =
-      inEdges.forall {
-        case Edge(_, _, _: Next.Case)  => true
-        case Edge(_, _, _: Next.Label) => true
-        case _                         => false
-      }
-
-    def isExceptionHandler: Boolean =
-      inEdges.forall {
-        case Edge(_, _, _: Next.Unwind) => true
-        case _                          => false
-      }
   }
 
   final class Graph(val entry: Block,


### PR DESCRIPTION
Previously, unwind handlers were rather second class and slightly magical:

```
...
%y = call %f(%x) unwind %handle
...
%handle(%e):
...
```
Here `%handle` is a an exception handling block that may only be used as target for unwind jumps. Value for `%e` appears magically through mapping to [LLVM's landingpads](https://llvm.org/docs/ExceptionHandling.html) in codegen. This makes regular jumps to unwind handler blocks ill-behaved as they would hit a landing pad that's inserted in the block prologue.

Instead, this PR changes them to be more uniform with normal control-flow. In particular, unwind jumps now define a value (that corresponds to the caught exception) together with conventional parametrized jump. For example:
```
...
%y = call %f(%x) unwind %e to %handle(%e)
...
%handle(%e):
...
```
The handler block doesn't need to differentiate unwind and non-unwind incoming edges any more, it only cares about the regular parametrized jump with an exception as an argument. The landing pads are generated for each unwind definition. It's impossible to accidentally jump to landingpad in any way except for genuine unwind handling case.

This opens the door for exception handler blocks to be usable as targets for regular jumps in combination with exceptional unwind jumps at the same time. This is important to enable Interflow transform exceptional control-flow into regular control-flow (which is in turn is necessary to optimize non-local returns).