### PR TITLE
Remove none and void from NIR

### DIFF
--- a/docs/contrib/mangling.rst
+++ b/docs/contrib/mangling.rst
@@ -24,8 +24,7 @@ that uses a notation inspired by
         K <sig-name> <type-name>+ E    // duplicate name
 
     <type-name> ::=
-        v                              // c void
-        g                              // c vararg
+        v                              // c vararg
         R _                            // c pointer type-name
         R <type-name>+ E               // c function type-name
         S <type-name>+ E               // c anonymous struct type-name

--- a/nir/src/main/scala/scala/scalanative/nir/Insts.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Insts.scala
@@ -6,7 +6,6 @@ sealed abstract class Inst {
 }
 
 object Inst {
-  final case object None                                      extends Inst
   final case class Label(name: Local, params: Seq[Val.Local]) extends Inst
   final case class Let(name: Local, op: Op, unwind: Next)     extends Inst
   object Let {

--- a/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
@@ -72,8 +72,7 @@ object Mangle {
     }
 
     def mangleType(ty: Type): Unit = ty match {
-      case Type.Void         => str("v")
-      case Type.Vararg       => str("g")
+      case Type.Vararg       => str("v")
       case Type.Ptr          => str("R_")
       case Type.I(8, false)  => str("Ub")
       case Type.I(16, false) => str("Us")

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -126,8 +126,6 @@ object Show {
           str(" ")
           next_(unwind)
         }
-      case Inst.Ret(Val.None) =>
-        str("ret")
       case Inst.Ret(value) =>
         str("ret ")
         val_(value)
@@ -215,10 +213,8 @@ object Show {
         str("stackalloc[")
         type_(ty)
         str("]")
-        if (n ne Val.None) {
-          str(" ")
-          val_(n)
-        }
+        str(" ")
+        val_(n)
       case Op.Bin(bin, ty, l, r) =>
         bin_(bin)
         str("[")
@@ -397,8 +393,6 @@ object Show {
     }
 
     def val_(value: Val): Unit = value match {
-      case Val.None =>
-        str("none")
       case Val.True =>
         str("true")
       case Val.False =>
@@ -476,20 +470,16 @@ object Show {
         global_(name)
         str(" : ")
         type_(ty)
-        if (v ne Val.None) {
-          str(" = ")
-          val_(v)
-        }
+        str(" = ")
+        val_(v)
       case Defn.Const(attrs, name, ty, v) =>
         attrs_(attrs)
         str("const ")
         global_(name)
         str(" : ")
         type_(ty)
-        if (v ne Val.None) {
-          str(" = ")
-          val_(v)
-        }
+        str(" = ")
+        val_(v)
       case Defn.Declare(attrs, name, ty) =>
         attrs_(attrs)
         str("decl ")
@@ -544,7 +534,6 @@ object Show {
     }
 
     def type_(ty: Type): Unit = ty match {
-      case Type.None   => str("none")
       case Type.Vararg => str("...")
       case Type.Bool   => str("bool")
       case Type.Ptr    => str("ptr")

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -101,8 +101,6 @@ object Show {
     }
 
     def inst_(inst: Inst): Unit = inst match {
-      case Inst.None =>
-        str("none")
       case Inst.Label(name, params) =>
         local_(name)
         if (params.isEmpty) {

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -545,7 +545,6 @@ object Show {
 
     def type_(ty: Type): Unit = ty match {
       case Type.None   => str("none")
-      case Type.Void   => str("void")
       case Type.Vararg => str("...")
       case Type.Bool   => str("bool")
       case Type.Ptr    => str("ptr")

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -26,8 +26,6 @@ trait Transform {
     insts.map(onInst)
 
   def onInst(inst: Inst): Inst = inst match {
-    case Inst.None =>
-      inst
     case Inst.Label(n, params) =>
       val newparams = params.map { param =>
         Val.Local(param.name, onType(param.ty))

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -25,7 +25,6 @@ object Type {
 
   // low-level second-class types
 
-  final case object Void   extends Type
   final case object Vararg extends Type
 
   // low-level primitive types

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -21,7 +21,6 @@ sealed abstract class Type {
 }
 
 object Type {
-  final case object None extends Type
 
   // low-level second-class types
 

--- a/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
@@ -39,9 +39,6 @@ object Unmangle {
     def readType(): Type = peek() match {
       case 'v' =>
         next()
-        Type.Void
-      case 'g' =>
-        next()
         Type.Vararg
       case 'R' =>
         next()

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -7,7 +7,6 @@ import scala.annotation.tailrec
 
 sealed abstract class Val {
   final def ty: Type = this match {
-    case Val.None                 => Type.None
     case Val.Null                 => Type.Null
     case Val.Zero(ty)             => ty
     case Val.True | Val.False     => Type.Bool
@@ -126,7 +125,6 @@ sealed abstract class Val {
 }
 object Val {
   // low-level
-  final case object None  extends Val
   final case object True  extends Val
   final case object False extends Val
   object Bool extends (Boolean => Val) {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -231,7 +231,6 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
 
   private def getTypes(): Seq[Type] = getSeq(getType)
   private def getType(): Type = getInt match {
-    case T.NoneType        => Type.None
     case T.VarargType      => Type.Vararg
     case T.PtrType         => Type.Ptr
     case T.BoolType        => Type.Bool
@@ -261,7 +260,6 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
 
   private def getVals(): Seq[Val] = getSeq(getVal)
   private def getVal(): Val = getInt match {
-    case T.NoneVal        => Val.None
     case T.TrueVal        => Val.True
     case T.FalseVal       => Val.False
     case T.NullVal        => Val.Null

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -232,7 +232,6 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
   private def getTypes(): Seq[Type] = getSeq(getType)
   private def getType(): Type = getInt match {
     case T.NoneType        => Type.None
-    case T.VoidType        => Type.Void
     case T.VarargType      => Type.Vararg
     case T.PtrType         => Type.Ptr
     case T.BoolType        => Type.Bool

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -90,7 +90,6 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
 
   private def getInsts(): Seq[Inst] = getSeq(getInst)
   private def getInst(): Inst = getInt match {
-    case T.NoneInst        => Inst.None
     case T.LabelInst       => Inst.Label(getLocal, getParams)
     case T.LetInst         => Inst.Let(getLocal, getOp, Next.None)
     case T.LetUnwindInst   => Inst.Let(getLocal, getOp, getNext)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -94,9 +94,6 @@ final class BinarySerializer(buffer: ByteBuffer) {
 
   private def putInsts(insts: Seq[Inst]) = putSeq(insts)(putInst)
   private def putInst(cf: Inst) = cf match {
-    case Inst.None =>
-      putInt(T.NoneInst)
-
     case Inst.Label(name, params) =>
       putInt(T.LabelInst)
       putLocal(name)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -446,7 +446,6 @@ final class BinarySerializer(buffer: ByteBuffer) {
 
   private def putTypes(tys: Seq[Type]): Unit = putSeq(tys)(putType)
   private def putType(ty: Type): Unit = ty match {
-    case Type.None   => putInt(T.NoneType)
     case Type.Vararg => putInt(T.VarargType)
     case Type.Ptr    => putInt(T.PtrType)
     case Type.Bool   => putInt(T.BoolType)
@@ -486,7 +485,6 @@ final class BinarySerializer(buffer: ByteBuffer) {
 
   private def putVals(values: Seq[Val]): Unit = putSeq(values)(putVal)
   private def putVal(value: Val): Unit = value match {
-    case Val.None            => putInt(T.NoneVal)
     case Val.True            => putInt(T.TrueVal)
     case Val.False           => putInt(T.FalseVal)
     case Val.Null            => putInt(T.NullVal)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -447,7 +447,6 @@ final class BinarySerializer(buffer: ByteBuffer) {
   private def putTypes(tys: Seq[Type]): Unit = putSeq(tys)(putType)
   private def putType(ty: Type): Unit = ty match {
     case Type.None   => putInt(T.NoneType)
-    case Type.Void   => putInt(T.VoidType)
     case Type.Vararg => putInt(T.VarargType)
     case Type.Ptr    => putInt(T.PtrType)
     case Type.Bool   => putInt(T.BoolType)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -99,8 +99,7 @@ object Tags {
 
   final val Inst = Defn + 32
 
-  final val NoneInst        = 1 + Inst
-  final val LabelInst       = 1 + NoneInst
+  final val LabelInst       = 1 + Inst
   final val LetInst         = 1 + LabelInst
   final val LetUnwindInst   = 1 + LetInst
   final val RetInst         = 1 + LetUnwindInst

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -177,8 +177,7 @@ object Tags {
 
   final val Type = Op + 32
 
-  final val NoneType        = 1 + Type
-  final val VarargType      = 1 + NoneType
+  final val VarargType      = 1 + Type
   final val BoolType        = 1 + VarargType
   final val PtrType         = 1 + BoolType
   final val CharType        = 1 + PtrType
@@ -207,8 +206,7 @@ object Tags {
 
   final val Val = Type + 32
 
-  final val NoneVal        = 1 + Val
-  final val TrueVal        = 1 + NoneVal
+  final val TrueVal        = 1 + Val
   final val FalseVal       = 1 + TrueVal
   final val NullVal        = 1 + FalseVal
   final val ZeroVal        = 1 + NullVal

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -178,8 +178,7 @@ object Tags {
   final val Type = Op + 32
 
   final val NoneType        = 1 + Type
-  final val VoidType        = 1 + NoneType
-  final val VarargType      = 1 + VoidType
+  final val VarargType      = 1 + NoneType
   final val BoolType        = 1 + VarargType
   final val PtrType         = 1 + BoolType
   final val CharType        = 1 + PtrType

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Defn.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Defn.scala
@@ -9,14 +9,14 @@ object Defn extends Base[nir.Defn] {
   import Base.IgnoreWhitespace._
 
   val Var =
-    P(Attrs.parser ~ "var" ~ Global.parser ~ ":" ~ Type.parser ~ ("=" ~ Val.parser).? map {
+    P(Attrs.parser ~ "var" ~ Global.parser ~ ":" ~ Type.parser ~ "=" ~ Val.parser map {
       case (attrs, name, ty, v) =>
-        nir.Defn.Var(attrs, name, ty, v getOrElse nir.Val.None)
+        nir.Defn.Var(attrs, name, ty, v)
     })
   val Const =
-    P(Attrs.parser ~ "const" ~ Global.parser ~ ":" ~ Type.parser ~ ("=" ~ Val.parser).? map {
+    P(Attrs.parser ~ "const" ~ Global.parser ~ ":" ~ Type.parser ~ "=" ~ Val.parser map {
       case (attrs, name, ty, v) =>
-        nir.Defn.Const(attrs, name, ty, v getOrElse nir.Val.None)
+        nir.Defn.Const(attrs, name, ty, v)
     })
   val Declare =
     P(Attrs.parser ~ "decl" ~ Global.parser ~ ":" ~ Type.parser map {
@@ -38,7 +38,8 @@ object Defn extends Base[nir.Defn] {
     P(
       Attrs.parser ~ "class" ~ Global.parser ~ (":" ~ Global.parser.rep(
         sep = ",")).? map {
-        case (attrs, name, None) => nir.Defn.Class(attrs, name, None, Seq())
+        case (attrs, name, None) =>
+          nir.Defn.Class(attrs, name, None, Seq())
         case (attrs, name, Some(inherits)) =>
           nir.Defn.Class(attrs, name, inherits.headOption, inherits.tail)
       })
@@ -46,7 +47,8 @@ object Defn extends Base[nir.Defn] {
     P(
       Attrs.parser ~ "module" ~ Global.parser ~ (":" ~ Global.parser.rep(
         sep = ",")).? map {
-        case (attrs, name, None) => nir.Defn.Module(attrs, name, None, Seq())
+        case (attrs, name, None) =>
+          nir.Defn.Module(attrs, name, None, Seq())
         case (attrs, name, Some(inherits)) =>
           nir.Defn.Module(attrs, name, inherits.headOption, inherits.tail)
       })

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Inst.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Inst.scala
@@ -10,7 +10,6 @@ object Inst extends Base[nir.Inst] {
   private val unwind: P[Next] =
     P(Next.parser.?).map(_.getOrElse(nir.Next.None))
 
-  val None = P("none".! map (_ => nir.Inst.None))
   val Label =
     P(Local.parser ~ ("(" ~ Val.Local.rep(sep = ",") ~ ")").? ~ ":" map {
       case (name, params) => nir.Inst.Label(name, params getOrElse Seq())
@@ -20,7 +19,7 @@ object Inst extends Base[nir.Inst] {
       case (name, op, unwind) => nir.Inst.Let(name, op, unwind)
     })
   val Ret =
-    P("ret" ~ Val.parser.? map (v => nir.Inst.Ret(v.getOrElse(nir.Val.None))))
+    P("ret" ~ Val.parser map (nir.Inst.Ret(_)))
   val Jump = P("jump" ~ Next.parser map (nir.Inst.Jump(_)))
   val If =
     P("if" ~ Val.parser ~ "then" ~ Next.parser ~ "else" ~ Next.parser map {
@@ -37,5 +36,5 @@ object Inst extends Base[nir.Inst] {
     P("unreachable" ~ unwind map (nir.Inst.Unreachable(_)))
 
   override val parser: P[nir.Inst] =
-    None | Label | Let | Ret | Jump | If | Switch | Throw | Unreachable
+    Label | Let | Ret | Jump | If | Switch | Throw | Unreachable
 }

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Op.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Op.scala
@@ -40,8 +40,8 @@ object Op extends Base[nir.Op] {
       case (aggr, value, indices) => nir.Op.Insert(aggr, value, indices)
     })
   val Stackalloc =
-    P("stackalloc[" ~ Type.parser ~ "]" ~ Val.parser.? map {
-      case (ty, n) => nir.Op.Stackalloc(ty, n getOrElse nir.Val.None)
+    P("stackalloc[" ~ Type.parser ~ "]" ~ Val.parser map {
+      case (ty, n) => nir.Op.Stackalloc(ty, n)
     })
   val Bin =
     P(nir.parser.Bin.parser ~ "[" ~ Type.parser ~ "]" ~ Val.parser ~ "," ~ Val.parser map {

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Type.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Type.scala
@@ -9,8 +9,6 @@ object Type extends Base[nir.Type] {
   import Base._
   import IgnoreWhitespace._
 
-  val None   = P("none".! map (_ => nir.Type.None))
-  val Void   = P("void".! map (_ => nir.Type.Void))
   val Vararg = P("...".! map (_ => nir.Type.Vararg))
   val Ptr    = P("ptr".! map (_ => nir.Type.Ptr))
   val Bool   = P("bool".! map (_ => nir.Type.Bool))
@@ -41,5 +39,5 @@ object Type extends Base[nir.Type] {
   val Ref     = Global.parser.map(nir.Type.Ref(_))
 
   override val parser: P[nir.Type] =
-    None | Void | Vararg | Ptr | Bool | UByte | UShort | UInt | ULong | Byte | Short | Int | Long | Float | Double | ArrayValue | Function | StructValue | Nothing | Var | Unit | Array | Ref
+    Vararg | Ptr | Bool | UByte | UShort | UInt | ULong | Byte | Short | Int | Long | Float | Double | ArrayValue | Function | StructValue | Nothing | Var | Unit | Array | Ref
 }

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Val.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Val.scala
@@ -9,7 +9,6 @@ object Val extends Base[nir.Val] {
   import Base._
   import IgnoreWhitespace._
 
-  val None   = P("none".! map (_ => nir.Val.None))
   val True   = P("true".! map (_ => nir.Val.True))
   val False  = P("false".! map (_ => nir.Val.False))
   val Null   = P("null".! map (_ => nir.Val.Null))
@@ -42,6 +41,6 @@ object Val extends Base[nir.Val] {
   val String = P(stringLit map (nir.Val.String(_)))
 
   override val parser: P[nir.Val] =
-    None | True | False | Null | Zero | Long | Int | Short | Byte | Double | Float | StructValue | ArrayValue | Chars | Local | Global | Unit | Const | String
+    True | False | Null | Zero | Long | Int | Short | Byte | Double | Float | StructValue | ArrayValue | Chars | Local | Global | Unit | Const | String
 
 }

--- a/nirparser/src/test/scala/scala/scalanative/nir/DefnParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/DefnParserTest.scala
@@ -9,8 +9,8 @@ class DefnParserTest extends FunSuite {
   val global = Global.Top("global")
 
   Seq[Defn](
-    Defn.Var(Attrs.None, global, ty, Val.None),
-    Defn.Const(Attrs.None, global, ty, Val.None),
+    Defn.Var(Attrs.None, global, ty, Val.Zero(ty)),
+    Defn.Const(Attrs.None, global, ty, Val.Zero(ty)),
     Defn.Declare(Attrs.None, global, ty),
     Defn.Define(Attrs.None, global, ty, Seq.empty),
     Defn.Trait(Attrs.None, global, Seq.empty),

--- a/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
@@ -7,20 +7,18 @@ import org.scalatest._
 class InstParserTest extends FunSuite {
   val local  = Local(1)
   val next   = Next(local)
-  val noTpe  = Type.None
+  val noTpe  = Type.Unit
   val value  = Val.Int(42)
   val unwind = Next.Unwind(Val.Local(local, nir.Rt.Object), next)
 
   Seq[Inst](
-    Inst.None,
     Inst.Label(local, Seq.empty),
     Inst.Let(local, Op.As(noTpe, value), Next.None),
     Inst.Let(local, Op.As(noTpe, value), unwind),
-    Inst.Ret(Val.None),
     Inst.Ret(value),
     Inst.Jump(next),
-    Inst.If(Val.None, next, next),
-    Inst.Switch(Val.None, next, Seq.empty),
+    Inst.If(value, next, next),
+    Inst.Switch(value, next, Seq.empty),
     Inst.Throw(Val.Zero(Type.Ptr), Next.None),
     Inst.Throw(Val.Zero(Type.Ptr), unwind),
     Inst.Unreachable(Next.None),

--- a/nirparser/src/test/scala/scala/scalanative/nir/NextParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/NextParserTest.scala
@@ -13,9 +13,9 @@ class NextParserTest extends FunSuite {
     Next.Unwind(exc, Next.Label(local, Seq.empty)),
     Next.Unwind(exc, Next.Label(local, Seq(value))),
     Next.Unwind(exc, Next.Label(local, Seq(value, value))),
-    Next.Case(Val.None, Next.Label(local, Seq.empty)),
-    Next.Case(Val.None, Next.Label(local, Seq(value))),
-    Next.Case(Val.None, Next.Label(local, Seq(value, value))),
+    Next.Case(value, Next.Label(local, Seq.empty)),
+    Next.Case(value, Next.Label(local, Seq(value))),
+    Next.Case(value, Next.Label(local, Seq(value, value))),
     Next.Label(local, Seq.empty),
     Next.Label(local, Seq(value)),
     Next.Label(local, Seq(value, value))

--- a/nirparser/src/test/scala/scala/scalanative/nir/OpParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/OpParserTest.scala
@@ -23,7 +23,6 @@ class OpParserTest extends FunSuite {
     Op.Insert(local, local, Seq(0)),
     Op.Insert(local, local, Seq(0, 1)),
     Op.Insert(local, local, Seq(0, 1, 2)),
-    Op.Stackalloc(ty, Val.None),
     Op.Stackalloc(ty, Val.Int(32)),
     Op.Bin(Bin.Iadd, ty, local, local),
     Op.Comp(Comp.Ieq, ty, local, local),

--- a/nirparser/src/test/scala/scala/scalanative/nir/TypeParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/TypeParserTest.scala
@@ -8,8 +8,6 @@ class TypeParserTest extends FunSuite {
   val global = Global.Top("global")
 
   Seq[Type](
-    Type.None,
-    Type.Void,
     Type.Vararg,
     Type.Ptr,
     Type.Bool,
@@ -29,7 +27,7 @@ class TypeParserTest extends FunSuite {
     Type.StructValue(Seq(Type.Int)),
     Type.StructValue(Seq(Type.Int, Type.Ptr)),
     Type.Function(Seq.empty, Type.Unit),
-    Type.Function(Seq(Type.Int), Type.Void),
+    Type.Function(Seq(Type.Int), Type.Unit),
     Type.Function(Seq(Type.Int, Type.Long), Type.Nothing),
     Type.Nothing,
     Type.Var(Type.Int),

--- a/nirparser/src/test/scala/scala/scalanative/nir/ValParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/ValParserTest.scala
@@ -6,10 +6,8 @@ import org.scalatest._
 
 class ValParserTest extends FunSuite {
   val global = Global.Top("test")
-  val noTpe  = Type.None
 
   Seq[Val](
-    Val.None,
     Val.True,
     Val.False,
     Val.Null,

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1268,7 +1268,7 @@ trait NirGenExpr { self: NirGenPhase =>
           (Some(sizep), tagp)
       }
       val ty   = genType(unwrapTag(tagp), box = false)
-      val size = sizeopt.fold[Val](Val.None)(genExpr(_))
+      val size = sizeopt.fold[Val](Val.Int(1))(genExpr(_))
 
       buf.stackalloc(ty, size, unwind)
     }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -138,7 +138,7 @@ trait NirGenStat { self: NirGenPhase =>
         val ty   = genType(f.tpe, box = false)
         val name = genFieldName(f)
 
-        buf += Defn.Var(attrs, name, ty, Val.None)
+        buf += Defn.Var(attrs, name, ty, Val.Zero(ty))
       }
     }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -649,9 +649,6 @@ object CodeGen {
         newline()
         str("]")
 
-      case Inst.None =>
-        ()
-
       case cf =>
         unsupported(cf)
     }

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -113,9 +113,9 @@ object CodeGen {
         genDefn {
           env(n) match {
             case defn @ Defn.Var(attrs, _, _, _) =>
-              defn.copy(attrs.copy(isExtern = true), rhs = Val.None)
+              defn.copy(attrs.copy(isExtern = true))
             case defn @ Defn.Const(attrs, _, ty, _) =>
-              defn.copy(attrs.copy(isExtern = true), rhs = Val.None)
+              defn.copy(attrs.copy(isExtern = true))
             case defn @ Defn.Declare(attrs, _, _) =>
               defn.copy(attrs.copy(isExtern = true))
             case defn @ Defn.Define(attrs, name, ty, _) =>
@@ -215,9 +215,10 @@ object CodeGen {
       str(if (attrs.isExtern) "external " else "hidden ")
       str(if (isConst) "constant" else "global")
       str(" ")
-      rhs match {
-        case Val.None => genType(ty)
-        case rhs      => genVal(rhs)
+      if (attrs.isExtern) {
+        genType(ty)
+      } else {
+        genVal(rhs)
       }
     }
 
@@ -586,10 +587,6 @@ object CodeGen {
         newline()
         str("unreachable")
 
-      case Inst.Ret(Val.None) =>
-        newline()
-        str("ret void")
-
       case Inst.Ret(value) =>
         newline()
         str("ret ")
@@ -764,10 +761,8 @@ object CodeGen {
           genLocal(pointee)
           str(" = alloca ")
           genType(ty)
-          if (n ne Val.None) {
-            str(", ")
-            genVal(n)
-          }
+          str(", ")
+          genVal(n)
 
           newline()
           genBind()

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -401,7 +401,6 @@ object CodeGen {
     }
 
     def genType(ty: Type): Unit = ty match {
-      case Type.Void                                             => str("void")
       case Type.Vararg                                           => str("...")
       case _: Type.RefKind | Type.Ptr | Type.Null | Type.Nothing => str("i8*")
       case Type.Bool                                             => str("i1")
@@ -662,7 +661,7 @@ object CodeGen {
 
     def genLet(inst: Inst.Let)(implicit fresh: Fresh): Unit = {
       def isVoid(ty: Type): Boolean =
-        ty == Type.Void || ty == Type.Unit || ty == Type.Nothing
+        ty == Type.Unit || ty == Type.Nothing
 
       val op     = inst.op
       val name   = inst.name

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -117,7 +117,7 @@ object Generate {
     def genMain(): Unit = {
       implicit val fresh = Fresh()
       val entryMainTy =
-        Type.Function(Seq(Type.Ref(entry.top), ObjectArray), Type.Void)
+        Type.Function(Seq(Type.Ref(entry.top), ObjectArray), Type.Unit)
       val entryMainName =
         Global.Member(
           entry,
@@ -191,7 +191,7 @@ object Generate {
           val initCall = if (cls.isStaticModule) {
             Inst.None
           } else {
-            val initSig = Type.Function(Seq(clsTy), Type.Void)
+            val initSig = Type.Function(Seq(clsTy), Type.Unit)
             val init    = Val.Global(name.member(Sig.Ctor(Seq())), Type.Ptr)
 
             Inst.Let(Op.Call(initSig, init, Seq(alloc)), Next.None)

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -189,12 +189,12 @@ object Generate {
           val alloc = Val.Local(fresh(), clsTy)
 
           val initCall = if (cls.isStaticModule) {
-            Inst.None
+            Seq()
           } else {
             val initSig = Type.Function(Seq(clsTy), Type.Unit)
             val init    = Val.Global(name.member(Sig.Ctor(Seq())), Type.Ptr)
 
-            Inst.Let(Op.Call(initSig, init, Seq(alloc)), Next.None)
+            Seq(Inst.Let(Op.Call(initSig, init, Seq(alloc)), Next.None))
           }
 
           val loadName = name.member(Sig.Generated("load"))
@@ -219,8 +219,8 @@ object Generate {
               Inst.Ret(self),
               Inst.Label(initialize, Seq()),
               Inst.Let(alloc.name, Op.Classalloc(name), Next.None),
-              Inst.Let(Op.Store(clsTy, slot, alloc), Next.None),
-              initCall,
+              Inst.Let(Op.Store(clsTy, slot, alloc), Next.None)
+            ) ++ initCall ++ Seq(
               Inst.Ret(alloc)
             )
           )

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -933,7 +933,7 @@ object Lower {
   val unitValue = Val.StructValue(Seq(unitConst))
 
   val throwName = extern("scalanative_throw")
-  val throwSig  = Type.Function(Seq(Type.Ptr), Type.Void)
+  val throwSig  = Type.Function(Seq(Type.Ptr), Type.Nothing)
   val throw_    = Val.Global(throwName, Type.Ptr)
 
   val arrayAlloc = Type.typeToArray.map {

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -99,7 +99,7 @@ object Lower {
 
       insts.foreach {
         case Inst.Let(n, Op.Var(ty), unwind) =>
-          buf.let(n, Op.Stackalloc(ty, Val.None), unwind)
+          buf.let(n, Op.Stackalloc(ty, Val.Int(1)), unwind)
         case _ =>
           ()
       }

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -20,8 +20,6 @@ trait Eval { self: Interflow =>
       def bailOut =
         throw BailOut("can't eval inst: " + inst.show)
       inst match {
-        case Inst.None =>
-          unreachable
         case _: Inst.Label =>
           unreachable
         case Inst.Let(local, op, unwind) =>

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -453,8 +453,6 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
     insts.foreach(reachInst)
 
   def reachInst(inst: Inst): Unit = inst match {
-    case Inst.None =>
-      ()
     case Inst.Label(n, params) =>
       params.foreach(p => reachType(p.ty))
     case Inst.Let(n, op, unwind) =>

--- a/tools/src/main/scala/scala/scalanative/sema/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/sema/UseDef.scala
@@ -140,8 +140,6 @@ object UseDef {
           if (!isPure(inst)) deps(block.name, Seq(inst.name))
         case inst: Inst.Cf =>
           deps(block.name, collect(inst))
-        case Inst.None =>
-          ()
         case inst =>
           unreachable
       }

--- a/tools/src/test/scala/scala/scalanative/nir/TypeManglingSuite.scala
+++ b/tools/src/test/scala/scala/scalanative/nir/TypeManglingSuite.scala
@@ -5,7 +5,6 @@ import org.scalatest._
 
 class TypeManglingSuite extends FunSuite {
   Seq(
-    Type.Void,
     Type.Vararg,
     Type.Ptr,
     Type.Byte,


### PR DESCRIPTION
They are non-essential and redundant and therefore can be removed.