### PR TITLE
Add char literal value to NIR

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -401,6 +401,9 @@ object Show {
         str("zero[")
         type_(ty)
         str("]")
+      case Val.Char(value) =>
+        str("char ")
+        str(value.toInt)
       case Val.Byte(value) =>
         str("byte ")
         str(value)

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -10,6 +10,7 @@ sealed abstract class Val {
     case Val.Null                 => Type.Null
     case Val.Zero(ty)             => ty
     case Val.True | Val.False     => Type.Bool
+    case Val.Char(_)              => Type.Char
     case Val.Byte(_)              => Type.Byte
     case Val.Short(_)             => Type.Short
     case Val.Int(_)               => Type.Int
@@ -77,6 +78,8 @@ sealed abstract class Val {
   final def isCanonical: Boolean = this match {
     case Val.True | Val.False =>
       true
+    case _: Val.Char =>
+      true
     case _: Val.Byte | _: Val.Short | _: Val.Int | _: Val.Long =>
       true
     case _: Val.Float | _: Val.Double =>
@@ -90,6 +93,7 @@ sealed abstract class Val {
   final def isDefault: Boolean = this match {
     case Val.False      => true
     case Val.Zero(_)    => true
+    case Val.Char('\0') => true
     case Val.Byte(0)    => true
     case Val.Short(0)   => true
     case Val.Int(0)     => true
@@ -104,7 +108,7 @@ sealed abstract class Val {
     case Val.Zero(Type.Bool) =>
       Val.False
     case Val.Zero(Type.Char) =>
-      Val.Short(0.toShort)
+      Val.Char('\0')
     case Val.Zero(Type.Byte) =>
       Val.Byte(0.toByte)
     case Val.Zero(Type.Short) =>
@@ -138,6 +142,7 @@ object Val {
   }
   final case object Null                     extends Val
   final case class Zero(of: nir.Type)        extends Val
+  final case class Char(value: scala.Char)   extends Val
   final case class Byte(value: scala.Byte)   extends Val
   final case class Short(value: scala.Short) extends Val
   final case class Int(value: scala.Int)     extends Val

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -263,6 +263,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
     case T.FalseVal       => Val.False
     case T.NullVal        => Val.Null
     case T.ZeroVal        => Val.Zero(getType)
+    case T.CharVal        => Val.Char(getShort.toChar)
     case T.ByteVal        => Val.Byte(get)
     case T.ShortVal       => Val.Short(getShort)
     case T.IntVal         => Val.Int(getInt)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -486,6 +486,7 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Val.False           => putInt(T.FalseVal)
     case Val.Null            => putInt(T.NullVal)
     case Val.Zero(ty)        => putInt(T.ZeroVal); putType(ty)
+    case Val.Char(v)         => putInt(T.CharVal); putShort(v.toShort)
     case Val.Byte(v)         => putInt(T.ByteVal); put(v)
     case Val.Short(v)        => putInt(T.ShortVal); putShort(v)
     case Val.Int(v)          => putInt(T.IntVal); putInt(v)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -209,7 +209,8 @@ object Tags {
   final val FalseVal       = 1 + TrueVal
   final val NullVal        = 1 + FalseVal
   final val ZeroVal        = 1 + NullVal
-  final val ByteVal        = 1 + ZeroVal
+  final val CharVal        = 1 + ZeroVal
+  final val ByteVal        = 1 + CharVal
   final val ShortVal       = 1 + ByteVal
   final val IntVal         = 1 + ShortVal
   final val LongVal        = 1 + IntVal

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Val.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Val.scala
@@ -9,6 +9,7 @@ object Val extends Base[nir.Val] {
   import Base._
   import IgnoreWhitespace._
 
+  val Char   = P("char" ~ Base.Int map (i => nir.Val.Char(i.toChar)))
   val True   = P("true".! map (_ => nir.Val.True))
   val False  = P("false".! map (_ => nir.Val.False))
   val Null   = P("null".! map (_ => nir.Val.Null))
@@ -41,6 +42,6 @@ object Val extends Base[nir.Val] {
   val String = P(stringLit map (nir.Val.String(_)))
 
   override val parser: P[nir.Val] =
-    True | False | Null | Zero | Long | Int | Short | Byte | Double | Float | StructValue | ArrayValue | Chars | Local | Global | Unit | Const | String
+    Char | True | False | Null | Zero | Long | Int | Short | Byte | Double | Float | StructValue | ArrayValue | Chars | Local | Global | Unit | Const | String
 
 }

--- a/nirparser/src/test/scala/scala/scalanative/nir/ValParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/ValParserTest.scala
@@ -12,6 +12,7 @@ class ValParserTest extends FunSuite {
     Val.False,
     Val.Null,
     Val.Zero(Type.Int),
+    Val.Char('0'),
     Val.Byte(0),
     Val.Short(0),
     Val.Int(0),

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -432,8 +432,10 @@ trait NirGenExpr { self: NirGenPhase =>
           if (value.booleanValue) Val.True else Val.False
         case ByteTag =>
           Val.Byte(value.intValue.toByte)
-        case ShortTag | CharTag =>
+        case ShortTag =>
           Val.Short(value.intValue.toShort)
+        case CharTag =>
+          Val.Char(value.intValue.toChar)
         case IntTag =>
           Val.Int(value.intValue)
         case LongTag =>

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -459,6 +459,7 @@ object CodeGen {
       case Val.Null      => str("null")
       case Val.Zero(ty)  => str("zeroinitializer")
       case Val.Byte(v)   => str(v)
+      case Val.Char(v)   => str(v.toInt)
       case Val.Short(v)  => str(v)
       case Val.Int(v)    => str(v)
       case Val.Long(v)   => str(v)

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -789,7 +789,7 @@ object Lower {
             rtti(CharArrayCls).const,
             charsLength,
             Val.Int(0), // padding to get next field aligned properly
-            Val.ArrayValue(Type.Short, chars.map(c => Val.Short(c.toShort)))
+            Val.ArrayValue(Type.Char, chars.map(Val.Char))
           )
         ))
 

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -40,7 +40,7 @@ final class State(block: Local) {
     val chars      = derefVirtual(charsAddr)
     charsArray.zipWithIndex.foreach {
       case (value, idx) =>
-        chars.values(idx) = Val.Short(value.toShort)
+        chars.values(idx) = Val.Char(value)
     }
     val values = new Array[Val](4)
     values(linked.StringValueField.index) = Val.Virtual(charsAddr)
@@ -140,7 +140,7 @@ final class State(block: Local) {
           val Val.Virtual(charsAddr) = values(linked.StringValueField.index)
           val chars = derefVirtual(charsAddr).values
             .map {
-              case Val.Short(v) => v.toChar
+              case Val.Char(v) => v
             }
             .toArray[Char]
           Val.String(new java.lang.String(chars))


### PR DESCRIPTION
Previously we used Short literals interchangeably with
Chars because they both map to LLVM's i16 but it's not
correct with respect to NIR's type system (char and short
are unrelated value types that require explicit conversion).