### PR TITLE
Make boolean to be a non-integer type in NIR

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -29,6 +29,7 @@ object Type {
   // low-level primitive types
 
   sealed abstract class Primitive(val width: Int) extends Type
+  final case object Bool                          extends Primitive(1)
   final case object Ptr                           extends Primitive(64)
 
   sealed abstract class I(width: Int, val signed: Boolean)
@@ -36,7 +37,6 @@ object Type {
   object I {
     def unapply(i: I): Some[(Int, Boolean)] = Some((i.width, i.signed))
   }
-  final case object Bool   extends I(1, signed = false)
   final case object Char   extends I(16, signed = false)
   final case object Byte   extends I(8, signed = true)
   final case object UByte  extends I(8, signed = false)

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -793,7 +793,7 @@ trait NirGenExpr { self: NirGenPhase =>
         case (_: Type.I, NOT)             => negateBits(coerced)
         case (_: Type.F, NEG)             => negateFloat(coerced)
         case (_: Type.I, NEG)             => negateInt(coerced)
-        case (_: Type.I, ZNOT)            => negateBool(coerced)
+        case (Type.Bool, ZNOT)            => negateBool(coerced)
         case _                            => abort("Unknown unary operation code: " + code)
       }
     }
@@ -846,7 +846,7 @@ trait NirGenExpr { self: NirGenPhase =>
                 "Unknown floating point type binary operation code: " + code)
           }
 
-        case _: Type.I =>
+        case Type.Bool | _: Type.I =>
           code match {
             case ADD =>
               genBinaryOp(Op.Bin(Bin.Iadd, _, _, _), left, right, opty)


### PR DESCRIPTION
Previously we treated boolean as a integer type
due to mapping to LLVM's i1 which is effectively
a single-bit integer. This change makes it a non-
integer value type instead.