### PR TITLE
Change to allow experimenting with Metals

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,16 @@ def projectName(project: sbt.ResolvedProject): String = {
   convertCamelKebab(project.id)
 }
 
+lazy val startupTransition: State => State = { s: State =>
+  if (System.getProperty("METALS_ENABLED") != null) "^^1.2.6" :: s
+  else s
+}
+
+onLoad in Global := {
+  val old = (onLoad in Global).value
+  startupTransition compose old
+}
+
 // Provide consistent project name pattern.
 lazy val nameSettings = Seq(
   normalizedName := projectName(thisProject.value), // Maven <artifactId>


### PR DESCRIPTION
This change allows experimenting with Metals and your choice of editor. See https://scalameta.org/metals/

This should only change the build when using with Metals by changing the build to sbt 1.2.6. I think this is a great opportunity to get ahead of the curve and help shape the direction of these new tools. This will also help when we get a Dotty front end as well.

Since the Metals system does not index Scala 2.10 files, this allows most everything to compile with 2.12 so things get indexed. I was able to get "go to definition" to work somewhat with the `javalib` which was cool since it navigated to Scala Native `javalib` code.

There is still a bit you need to do locally. Then develop as you normally do in Scala Native.
```
$ sbt
> ^^1.2.6
> rebuild
```
After this is complete and after changes you can do the following:
https://scalameta.org/metals/docs/editors/vscode.html#manually-trigger-build-import