### PR TITLE
[0.3.x] Add forwarders to support sconfig/scalafmt

### DIFF
--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -154,6 +154,7 @@ class ArrayList[E] private (private[this] var inner: Array[Any],
     _size = 0
   }
 
+  // TODO: remove forwarders - 0.3.8 workaround
   override def addAll(c: Collection[_ <: E]): Boolean =
     super.addAll(c)
 
@@ -162,6 +163,9 @@ class ArrayList[E] private (private[this] var inner: Array[Any],
 
   override def iterator(): java.util.Iterator[E] =
     super.iterator()
+
+  override def listIterator(index: Int): ListIterator[E] =
+    super.listIterator(index)
 
   // TODO: JDK 1.8
   // def forEach(action: Consumer[_ >: E]): Unit =

--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -154,7 +154,7 @@ class ArrayList[E] private (private[this] var inner: Array[Any],
     _size = 0
   }
 
-  // TODO: remove forwarders - 0.3.8 workaround
+  // forwarders - https://github.com/scala-native/scala-native/issues/375
   override def addAll(c: Collection[_ <: E]): Boolean =
     super.addAll(c)
 

--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -19,9 +19,9 @@ trait List[E] extends Collection[E] {
   def contains(o: Any): Boolean
   def size(): Int
   // TODO: remove forwarders - 0.3.8 workaround
-  override def containsAll(c: Collection[_]): Boolean
-  override def equals(o: Any): Boolean
-  override def hashCode(): Int
-  override def removeAll(c: Collection[_]): Boolean
-  override def remove(o: Any): Boolean
+  def containsAll(c: Collection[_]): Boolean
+  def equals(o: Any): Boolean
+  def hashCode(): Int
+  def removeAll(c: Collection[_]): Boolean
+  def remove(o: Any): Boolean
 }

--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -18,7 +18,7 @@ trait List[E] extends Collection[E] {
   def iterator(): Iterator[E]
   def contains(o: Any): Boolean
   def size(): Int
-  //  TODO: remove forwarders - 0.3.8 workaround
+  // TODO: remove forwarders - 0.3.8 workaround
   override def containsAll(c: Collection[_]): Boolean
   override def equals(o: Any): Boolean
   override def hashCode(): Int

--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -18,4 +18,10 @@ trait List[E] extends Collection[E] {
   def iterator(): Iterator[E]
   def contains(o: Any): Boolean
   def size(): Int
+  // forwarders - 0.3.8 workaround
+  override def containsAll(c: Collection[_]): Boolean
+  override def equals(o: Any): Boolean
+  override def hashCode(): Int
+  override def removeAll(c: Collection[_]): Boolean
+  override def remove(o: Any): Boolean
 }

--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -18,7 +18,6 @@ trait List[E] extends Collection[E] {
   def iterator(): Iterator[E]
   def contains(o: Any): Boolean
   def size(): Int
-  // TODO: remove forwarders - 0.3.8 workaround
   def containsAll(c: Collection[_]): Boolean
   def equals(o: Any): Boolean
   def hashCode(): Int

--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -18,7 +18,7 @@ trait List[E] extends Collection[E] {
   def iterator(): Iterator[E]
   def contains(o: Any): Boolean
   def size(): Int
-  // forwarders - 0.3.8 workaround
+  //  TODO: remove forwarders - 0.3.8 workaround
   override def containsAll(c: Collection[_]): Boolean
   override def equals(o: Any): Boolean
   override def hashCode(): Int

--- a/javalib/src/main/scala/java/util/Set.scala
+++ b/javalib/src/main/scala/java/util/Set.scala
@@ -11,12 +11,5 @@ trait Set[E] extends Collection[E] {
   def remove(obj: Any): scala.Boolean
   def removeAll(c: Collection[_]): Boolean
   def retainAll(c: Collection[_]): Boolean
-  // TODO: remove forwarders - 0.3.8 workaround
   def addAll(coll: Collection[_ <: E]): Boolean
-  //TODO:
-  //def hashCode(): scala.Int
-  //def toArray(): Array[Any]
-  //def toArray[T](array: Array[T]): Array[T]
-  //def contains(coll: Collection[_]): scala.Boolean
-  //def equals(obj: Any): scala.Boolean
 }

--- a/javalib/src/main/scala/java/util/Set.scala
+++ b/javalib/src/main/scala/java/util/Set.scala
@@ -11,9 +11,9 @@ trait Set[E] extends Collection[E] {
   def remove(obj: Any): scala.Boolean
   def removeAll(c: Collection[_]): Boolean
   def retainAll(c: Collection[_]): Boolean
-
+  // TODO: remove forwarders - 0.3.8 workaround
+  def addAll(coll: Collection[_ <: E]): Boolean
   //TODO:
-  //def addAll(coll: Collection[_ <: E]): scala.Boolean
   //def hashCode(): scala.Int
   //def toArray(): Array[Any]
   //def toArray[T](array: Array[T]): Array[T]


### PR DESCRIPTION
This is the first PR in a series to support a Scala Native version of `scalafmt` that needs not be applied to master.