### PR TITLE
Refactor intrinsics modules

### DIFF
--- a/javalib/src/main/scala/java/lang/Byte.scala
+++ b/javalib/src/main/scala/java/lang/Byte.scala
@@ -1,6 +1,6 @@
 package java.lang
 
-import scalanative.runtime.{byteToUInt, byteToULong}
+import scalanative.runtime.Intrinsics.{byteToUInt, byteToULong}
 
 final class Byte(val _value: scala.Byte) extends Number with Comparable[Byte] {
   @inline def this(s: String) =

--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -1,6 +1,6 @@
 package java.lang
 
-import scalanative.runtime.{divUInt, remUInt, intToULong, Intrinsics}
+import scalanative.runtime.{divUInt, remUInt, intToULong, LLVMIntrinsics}
 
 final class Integer(val _value: scala.Int)
     extends Number
@@ -187,7 +187,7 @@ object Integer {
     100000000, 10000000, 1000000, 100000, 10000, 1000, 100, 10, 1)
 
   @inline def bitCount(i: scala.Int): scala.Int =
-    Intrinsics.`llvm.ctpop.i32`(i)
+    LLVMIntrinsics.`llvm.ctpop.i32`(i)
 
   @inline def byteValue(i: scala.Int): scala.Byte =
     i.toByte
@@ -278,10 +278,10 @@ object Integer {
     Math.min(a, b)
 
   @inline def numberOfLeadingZeros(i: scala.Int): scala.Int =
-    Intrinsics.`llvm.ctlz.i32`(i, iszeroundef = false)
+    LLVMIntrinsics.`llvm.ctlz.i32`(i, iszeroundef = false)
 
   @inline def numberOfTrailingZeros(i: scala.Int): scala.Int =
-    Intrinsics.`llvm.cttz.i32`(i, iszeroundef = false)
+    LLVMIntrinsics.`llvm.cttz.i32`(i, iszeroundef = false)
 
   @inline def parseInt(s: String): scala.Int =
     parseInt(s, 10)
@@ -340,10 +340,10 @@ object Integer {
     remUInt(dividend, divisor)
 
   @inline def reverse(i: scala.Int): scala.Int =
-    Intrinsics.`llvm.bitreverse.i32`(i)
+    LLVMIntrinsics.`llvm.bitreverse.i32`(i)
 
   @inline def reverseBytes(i: scala.Int): scala.Int =
-    Intrinsics.`llvm.bswap.i32`(i)
+    LLVMIntrinsics.`llvm.bswap.i32`(i)
 
   @inline def rotateLeft(i: scala.Int, distance: scala.Int): scala.Int =
     (i << distance) | (i >>> -distance)

--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -1,6 +1,7 @@
 package java.lang
 
-import scalanative.runtime.{divUInt, remUInt, intToULong, LLVMIntrinsics}
+import scalanative.runtime.Intrinsics.{divUInt, remUInt, intToULong}
+import scalanative.runtime.LLVMIntrinsics
 
 final class Integer(val _value: scala.Int)
     extends Number

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -1,6 +1,6 @@
 package java.lang
 
-import scalanative.runtime.{divULong, remULong, Intrinsics}
+import scalanative.runtime.{divULong, remULong, LLVMIntrinsics}
 
 final class Long(val _value: scala.Long) extends Number with Comparable[Long] {
   @inline def this(s: String) =
@@ -189,7 +189,7 @@ object Long {
   final val BYTES     = 8
 
   @inline def bitCount(l: scala.Long): scala.Int =
-    Intrinsics.`llvm.ctpop.i64`(l).toInt
+    LLVMIntrinsics.`llvm.ctpop.i64`(l).toInt
 
   @inline def compare(x: scala.Long, y: scala.Long): scala.Int =
     if (x == y) 0
@@ -292,10 +292,10 @@ object Long {
     Math.min(a, b)
 
   @inline def numberOfLeadingZeros(l: scala.Long): Int =
-    Intrinsics.`llvm.ctlz.i64`(l, iszeroundef = false).toInt
+    LLVMIntrinsics.`llvm.ctlz.i64`(l, iszeroundef = false).toInt
 
   @inline def numberOfTrailingZeros(l: scala.Long): Int =
-    Intrinsics.`llvm.cttz.i64`(l, iszeroundef = false).toInt
+    LLVMIntrinsics.`llvm.cttz.i64`(l, iszeroundef = false).toInt
 
   @inline def parseLong(s: String): scala.Long =
     parseLong(s, 10)
@@ -352,10 +352,10 @@ object Long {
     remULong(dividend, divisor)
 
   @inline def reverse(l: scala.Long): scala.Long =
-    Intrinsics.`llvm.bitreverse.i64`(l)
+    LLVMIntrinsics.`llvm.bitreverse.i64`(l)
 
   @inline def reverseBytes(l: scala.Long): scala.Long =
-    Intrinsics.`llvm.bswap.i64`(l)
+    LLVMIntrinsics.`llvm.bswap.i64`(l)
 
   @inline def rotateLeft(i: scala.Long, distance: scala.Int): scala.Long =
     (i << distance) | (i >>> -distance)

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -1,6 +1,7 @@
 package java.lang
 
-import scalanative.runtime.{divULong, remULong, LLVMIntrinsics}
+import scalanative.runtime.Intrinsics.{divULong, remULong}
+import scalanative.runtime.LLVMIntrinsics
 
 final class Long(val _value: scala.Long) extends Number with Comparable[Long] {
   @inline def this(s: String) =

--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -1,6 +1,6 @@
 package java.lang
 
-import scalanative.runtime.Intrinsics._
+import scalanative.runtime.LLVMIntrinsics._
 import scalanative.libc.{math => cmath}
 
 object Math {

--- a/javalib/src/main/scala/java/lang/Short.scala
+++ b/javalib/src/main/scala/java/lang/Short.scala
@@ -1,6 +1,7 @@
 package java.lang
 
-import scalanative.runtime.{shortToUInt, shortToULong, LLVMIntrinsics}
+import scalanative.runtime.Intrinsics.{shortToUInt, shortToULong}
+import scalanative.runtime.LLVMIntrinsics
 
 final class Short(val _value: scala.Short)
     extends Number

--- a/javalib/src/main/scala/java/lang/Short.scala
+++ b/javalib/src/main/scala/java/lang/Short.scala
@@ -1,6 +1,6 @@
 package java.lang
 
-import scalanative.runtime.{shortToUInt, shortToULong, Intrinsics}
+import scalanative.runtime.{shortToUInt, shortToULong, LLVMIntrinsics}
 
 final class Short(val _value: scala.Short)
     extends Number
@@ -217,7 +217,7 @@ object Short {
   }
 
   @inline def reverseBytes(i: scala.Short): scala.Short =
-    Intrinsics.`llvm.bswap.i16`(i)
+    LLVMIntrinsics.`llvm.bswap.i16`(i)
 
   @inline def toString(s: scala.Short): String =
     Integer.toString(s)

--- a/nativelib/src/main/scala/scala/scalanative/native/UInt.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/UInt.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package native
 
-import scalanative.runtime.{divUInt, remUInt}
+import scalanative.runtime.Intrinsics.{divUInt, remUInt}
 import java.lang.{Integer => JInteger}
 
 /** `UInt`, a 32-bit unsigned integer. */

--- a/nativelib/src/main/scala/scala/scalanative/native/ULong.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/ULong.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package native
 
-import scalanative.runtime.{divULong, remULong}
+import scalanative.runtime.Intrinsics.{divULong, remULong}
 import java.lang.{Long => JLong}
 
 /** `ULong`, a 64-bit unsigned integer. */

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -3,7 +3,7 @@ package scala.scalanative
 package runtime
 
 import scalanative.native._
-import scalanative.runtime.Intrinsics._
+import scalanative.runtime.LLVMIntrinsics._
 
 sealed abstract class Array[T]
     extends java.io.Serializable

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -2,7 +2,7 @@ package scala.scalanative
 package runtime
 
 import scalanative.native._
-import scalanative.runtime.Intrinsics._
+import scalanative.runtime.LLVMIntrinsics._
 
 sealed abstract class Array[T]
     extends java.io.Serializable

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -1,0 +1,32 @@
+package scala.scalanative
+package runtime
+
+object Intrinsics {
+
+  /** Intrinsified unsigned devision on ints. */
+  def divUInt(l: Int, r: Int): Int = intrinsic
+
+  /** Intrinsified unsigned devision on longs. */
+  def divULong(l: Long, r: Long): Long = intrinsic
+
+  /** Intrinsified unsigned remainder on ints. */
+  def remUInt(l: Int, r: Int): Int = intrinsic
+
+  /** Intrinsified unsigned remainder on longs. */
+  def remULong(l: Long, r: Long): Long = intrinsic
+
+  /** Intrinsified byte to unsigned int converstion. */
+  def byteToUInt(b: Byte): Int = intrinsic
+
+  /** Intrinsified byte to unsigned long conversion. */
+  def byteToULong(b: Byte): Long = intrinsic
+
+  /** Intrinsified short to unsigned int conversion. */
+  def shortToUInt(v: Short): Int = intrinsic
+
+  /** Intrinsified short to unsigned long conversion. */
+  def shortToULong(v: Short): Long = intrinsic
+
+  /** Intrinsified int to unsigned long conversion. */
+  def intToULong(v: Int): Long = intrinsic
+}

--- a/nativelib/src/main/scala/scala/scalanative/runtime/LLVMIntrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/LLVMIntrinsics.scala
@@ -7,7 +7,7 @@ import native._
  * @see [[http://llvm.org/releases/3.7.0/docs/LangRef.html#intrinsic-functions LLVM intrinsics functions]]
  */
 @extern
-object Intrinsics {
+object LLVMIntrinsics {
   @struct class IntOverflow(val value: Int, val flag: Boolean)
   @struct class LongOverflow(val value: Long, val flag: Boolean)
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 
 import native._
-import runtime.Intrinsics._
+import runtime.LLVMIntrinsics._
 
 package object runtime {
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -36,33 +36,6 @@ package object runtime {
   /** Returns info pointer for given type. */
   def typeof[T](implicit tag: Tag[T]): Ptr[Type] = intrinsic
 
-  /** Intrinsified unsigned devision on ints. */
-  def divUInt(l: Int, r: Int): Int = intrinsic
-
-  /** Intrinsified unsigned devision on longs. */
-  def divULong(l: Long, r: Long): Long = intrinsic
-
-  /** Intrinsified unsigned remainder on ints. */
-  def remUInt(l: Int, r: Int): Int = intrinsic
-
-  /** Intrinsified unsigned remainder on longs. */
-  def remULong(l: Long, r: Long): Long = intrinsic
-
-  /** Intrinsified byte to unsigned int converstion. */
-  def byteToUInt(b: Byte): Int = intrinsic
-
-  /** Intrinsified byte to unsigned long conversion. */
-  def byteToULong(b: Byte): Long = intrinsic
-
-  /** Intrinsified short to unsigned int conversion. */
-  def shortToUInt(v: Short): Int = intrinsic
-
-  /** Intrinsified short to unsigned long conversion. */
-  def shortToULong(v: Short): Long = intrinsic
-
-  /** Intrinsified int to unsigned long conversion. */
-  def intToULong(v: Int): Long = intrinsic
-
   /** Read type information of given object. */
   def getType(obj: Object): Ptr[ClassType] = !obj.cast[Ptr[Ptr[ClassType]]]
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -132,20 +132,23 @@ trait NirDefinitions { self: NirGlobalAddons =>
     lazy val TypeofMethod = getMember(RuntimeModule, TermName("typeof"))
     lazy val GetMonitorMethod =
       getMember(RuntimeModule, TermName("getMonitor"))
-    lazy val DivUIntMethod  = getMember(RuntimeModule, TermName("divUInt"))
-    lazy val DivULongMethod = getMember(RuntimeModule, TermName("divULong"))
-    lazy val RemUIntMethod  = getMember(RuntimeModule, TermName("remUInt"))
-    lazy val RemULongMethod = getMember(RuntimeModule, TermName("remULong"))
+
+    lazy val IntrinsicsModule = getRequiredModule(
+      "scala.scalanative.runtime.Intrinsics")
+    lazy val DivUIntMethod  = getMember(IntrinsicsModule, TermName("divUInt"))
+    lazy val DivULongMethod = getMember(IntrinsicsModule, TermName("divULong"))
+    lazy val RemUIntMethod  = getMember(IntrinsicsModule, TermName("remUInt"))
+    lazy val RemULongMethod = getMember(IntrinsicsModule, TermName("remULong"))
     lazy val ByteToUIntMethod =
-      getMember(RuntimeModule, TermName("byteToUInt"))
+      getMember(IntrinsicsModule, TermName("byteToUInt"))
     lazy val ByteToULongMethod =
-      getMember(RuntimeModule, TermName("byteToULong"))
+      getMember(IntrinsicsModule, TermName("byteToULong"))
     lazy val ShortToUIntMethod =
-      getMember(RuntimeModule, TermName("shortToUInt"))
+      getMember(IntrinsicsModule, TermName("shortToUInt"))
     lazy val ShortToULongMethod =
-      getMember(RuntimeModule, TermName("shortToULong"))
+      getMember(IntrinsicsModule, TermName("shortToULong"))
     lazy val IntToULongMethod =
-      getMember(RuntimeModule, TermName("intToULong"))
+      getMember(IntrinsicsModule, TermName("intToULong"))
 
     lazy val RuntimePrimitive: Map[Char, Symbol] = Map(
       'B' -> getRequiredClass("scala.scalanative.runtime.PrimitiveBoolean"),


### PR DESCRIPTION
This change renames `runtime.Intrinsics` to `runtime.LLVMIntrinsics` and uses `runtime.Intrinsics` for our own primitive operations instead. 