### PR TITLE
Add support for first-class values of native.Tag

### DIFF
--- a/nativelib/src/main/resources/posix/netinet/in.h
+++ b/nativelib/src/main/resources/posix/netinet/in.h
@@ -25,8 +25,6 @@ struct scalanative_sockaddr_in6 {
     in_port_t sin6_port;
     uint32_t sin6_flowinfo;
     uint32_t sin6_scope_id;
-    uint32_t padding; // So that the struct has the same
-                      // size in C and in Native.
 };
 
 void scalanative_convert_in_addr(struct scalanative_in_addr *in,

--- a/nativelib/src/main/scala/scala/scalanative/native/Tag.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Tag.scala
@@ -1,515 +1,7953 @@
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 1)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 1)
 package scala.scalanative
 package native
 
 import scala.reflect.ClassTag
-import scalanative.runtime.intrinsic
+import scalanative.runtime.{intrinsic, throwUndefined}
 
-final abstract class Tag[P]
+sealed abstract class Tag[P] {
+  def size: Int
+  def alignment: Int
+  def offset(idx: Int): Int = throwUndefined()
+}
 
 object Tag {
-  implicit val Unit: Tag[Unit]                    = intrinsic
-  implicit val Boolean: Tag[Boolean]              = intrinsic
-  implicit val Char: Tag[Char]                    = intrinsic
-  implicit val Byte: Tag[Byte]                    = intrinsic
-  implicit val UByte: Tag[UByte]                  = intrinsic
-  implicit val Short: Tag[Short]                  = intrinsic
-  implicit val UShort: Tag[UShort]                = intrinsic
-  implicit val Int: Tag[Int]                      = intrinsic
-  implicit val UInt: Tag[UInt]                    = intrinsic
-  implicit val Long: Tag[Long]                    = intrinsic
-  implicit val ULong: Tag[ULong]                  = intrinsic
-  implicit val Float: Tag[Float]                  = intrinsic
-  implicit val Double: Tag[Double]                = intrinsic
-  implicit def Ptr[T: Tag]: Tag[Ptr[T]]           = intrinsic
-  implicit def Ref[T <: AnyRef: ClassTag]: Tag[T] = intrinsic
+  final case class Ptr[T](of: Tag[T]) extends Tag[native.Ptr[T]] {
+    @inline final def size: Int      = 8
+    @inline final def alignment: Int = 8
+  }
 
-  implicit def Nat0: Tag[Nat._0] = intrinsic
-  implicit def Nat1: Tag[Nat._1] = intrinsic
-  implicit def Nat2: Tag[Nat._2] = intrinsic
-  implicit def Nat3: Tag[Nat._3] = intrinsic
-  implicit def Nat4: Tag[Nat._4] = intrinsic
-  implicit def Nat5: Tag[Nat._5] = intrinsic
-  implicit def Nat6: Tag[Nat._6] = intrinsic
-  implicit def Nat7: Tag[Nat._7] = intrinsic
-  implicit def Nat8: Tag[Nat._8] = intrinsic
-  implicit def Nat9: Tag[Nat._9] = intrinsic
-  implicit def NatDigit[N <: Nat.Base: Tag, M <: Nat: Tag]
-    : Tag[Nat.Digit[N, M]] =
-    intrinsic
+  final case class Class[T <: AnyRef](of: java.lang.Class[T]) extends Tag[T] {
+    @inline final def size: Int      = 8
+    @inline final def alignment: Int = 8
+  }
 
-  implicit def CArray[T: Tag, N <: Nat: Tag]: Tag[CArray[T, N]] = intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object Unit extends Tag[scala.Unit] {
+    @inline final def size: Int      = 8
+    @inline final def alignment: Int = 8
+  }
 
-  implicit def CStruct0: Tag[CStruct0] = intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object Boolean extends Tag[scala.Boolean] {
+    @inline final def size: Int      = 1
+    @inline final def alignment: Int = 1
+  }
 
-  implicit def CStruct1[T1: Tag]: Tag[CStruct1[T1]] = intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object Char extends Tag[scala.Char] {
+    @inline final def size: Int      = 2
+    @inline final def alignment: Int = 2
+  }
 
-  implicit def CStruct2[T1: Tag, T2: Tag]: Tag[CStruct2[T1, T2]] = intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object Byte extends Tag[scala.Byte] {
+    @inline final def size: Int      = 1
+    @inline final def alignment: Int = 1
+  }
 
-  implicit def CStruct3[T1: Tag, T2: Tag, T3: Tag]: Tag[CStruct3[T1, T2, T3]] =
-    intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object UByte extends Tag[native.UByte] {
+    @inline final def size: Int      = 1
+    @inline final def alignment: Int = 1
+  }
 
-  implicit def CStruct4[T1: Tag, T2: Tag, T3: Tag, T4: Tag]
-    : Tag[CStruct4[T1, T2, T3, T4]] = intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object Short extends Tag[scala.Short] {
+    @inline final def size: Int      = 2
+    @inline final def alignment: Int = 2
+  }
 
-  implicit def CStruct5[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag]
-    : Tag[CStruct5[T1, T2, T3, T4, T5]] = intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object UShort extends Tag[native.UShort] {
+    @inline final def size: Int      = 2
+    @inline final def alignment: Int = 2
+  }
 
-  implicit def CStruct6[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag]
-    : Tag[CStruct6[T1, T2, T3, T4, T5, T6]] = intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object Int extends Tag[scala.Int] {
+    @inline final def size: Int      = 4
+    @inline final def alignment: Int = 4
+  }
 
-  implicit def CStruct7[T1: Tag,
-                        T2: Tag,
-                        T3: Tag,
-                        T4: Tag,
-                        T5: Tag,
-                        T6: Tag,
-                        T7: Tag]: Tag[CStruct7[T1, T2, T3, T4, T5, T6, T7]] =
-    intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object UInt extends Tag[native.UInt] {
+    @inline final def size: Int      = 4
+    @inline final def alignment: Int = 4
+  }
 
-  implicit def CStruct8[T1: Tag,
-                        T2: Tag,
-                        T3: Tag,
-                        T4: Tag,
-                        T5: Tag,
-                        T6: Tag,
-                        T7: Tag,
-                        T8: Tag]
-    : Tag[CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]] = intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object Long extends Tag[scala.Long] {
+    @inline final def size: Int      = 8
+    @inline final def alignment: Int = 8
+  }
 
-  implicit def CStruct9[T1: Tag,
-                        T2: Tag,
-                        T3: Tag,
-                        T4: Tag,
-                        T5: Tag,
-                        T6: Tag,
-                        T7: Tag,
-                        T8: Tag,
-                        T9: Tag]
-    : Tag[CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] = intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object ULong extends Tag[native.ULong] {
+    @inline final def size: Int      = 8
+    @inline final def alignment: Int = 8
+  }
 
-  implicit def CStruct10[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag]
-    : Tag[CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] = intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object Float extends Tag[scala.Float] {
+    @inline final def size: Int      = 4
+    @inline final def alignment: Int = 4
+  }
 
-  implicit def CStruct11[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag]
-    : Tag[CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] = intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 40)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+  object Double extends Tag[scala.Double] {
+    @inline final def size: Int      = 8
+    @inline final def alignment: Int = 8
+  }
 
-  implicit def CStruct12[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag,
-                         T12: Tag]
-    : Tag[CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] =
-    intrinsic
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 47)
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
 
-  implicit def CStruct13[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag,
-                         T12: Tag,
-                         T13: Tag]
-    : Tag[CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] =
-    intrinsic
+  object Nat0 extends Tag[native.Nat._0] {
+    @noinline final def size: Int      = throwUndefined()
+    @noinline final def alignment: Int = throwUndefined()
+  }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
 
-  implicit def CStruct14[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag,
-                         T12: Tag,
-                         T13: Tag,
-                         T14: Tag]: Tag[
-    CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]] =
-    intrinsic
+  object Nat1 extends Tag[native.Nat._1] {
+    @noinline final def size: Int      = throwUndefined()
+    @noinline final def alignment: Int = throwUndefined()
+  }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
 
-  implicit def CStruct15[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag,
-                         T12: Tag,
-                         T13: Tag,
-                         T14: Tag,
-                         T15: Tag]: Tag[
-    CStruct15[T1,
-              T2,
-              T3,
-              T4,
-              T5,
-              T6,
-              T7,
-              T8,
-              T9,
-              T10,
-              T11,
-              T12,
-              T13,
-              T14,
-              T15]] = intrinsic
+  object Nat2 extends Tag[native.Nat._2] {
+    @noinline final def size: Int      = throwUndefined()
+    @noinline final def alignment: Int = throwUndefined()
+  }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
 
-  implicit def CStruct16[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag,
-                         T12: Tag,
-                         T13: Tag,
-                         T14: Tag,
-                         T15: Tag,
-                         T16: Tag]: Tag[
-    CStruct16[T1,
-              T2,
-              T3,
-              T4,
-              T5,
-              T6,
-              T7,
-              T8,
-              T9,
-              T10,
-              T11,
-              T12,
-              T13,
-              T14,
-              T15,
-              T16]] = intrinsic
+  object Nat3 extends Tag[native.Nat._3] {
+    @noinline final def size: Int      = throwUndefined()
+    @noinline final def alignment: Int = throwUndefined()
+  }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
 
-  implicit def CStruct17[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag,
-                         T12: Tag,
-                         T13: Tag,
-                         T14: Tag,
-                         T15: Tag,
-                         T16: Tag,
-                         T17: Tag]: Tag[
-    CStruct17[T1,
-              T2,
-              T3,
-              T4,
-              T5,
-              T6,
-              T7,
-              T8,
-              T9,
-              T10,
-              T11,
-              T12,
-              T13,
-              T14,
-              T15,
-              T16,
-              T17]] = intrinsic
+  object Nat4 extends Tag[native.Nat._4] {
+    @noinline final def size: Int      = throwUndefined()
+    @noinline final def alignment: Int = throwUndefined()
+  }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
 
-  implicit def CStruct18[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag,
-                         T12: Tag,
-                         T13: Tag,
-                         T14: Tag,
-                         T15: Tag,
-                         T16: Tag,
-                         T17: Tag,
-                         T18: Tag]: Tag[
-    CStruct18[T1,
-              T2,
-              T3,
-              T4,
-              T5,
-              T6,
-              T7,
-              T8,
-              T9,
-              T10,
-              T11,
-              T12,
-              T13,
-              T14,
-              T15,
-              T16,
-              T17,
-              T18]] = intrinsic
+  object Nat5 extends Tag[native.Nat._5] {
+    @noinline final def size: Int      = throwUndefined()
+    @noinline final def alignment: Int = throwUndefined()
+  }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
 
-  implicit def CStruct19[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag,
-                         T12: Tag,
-                         T13: Tag,
-                         T14: Tag,
-                         T15: Tag,
-                         T16: Tag,
-                         T17: Tag,
-                         T18: Tag,
-                         T19: Tag]: Tag[
-    CStruct19[T1,
-              T2,
-              T3,
-              T4,
-              T5,
-              T6,
-              T7,
-              T8,
-              T9,
-              T10,
-              T11,
-              T12,
-              T13,
-              T14,
-              T15,
-              T16,
-              T17,
-              T18,
-              T19]] = intrinsic
+  object Nat6 extends Tag[native.Nat._6] {
+    @noinline final def size: Int      = throwUndefined()
+    @noinline final def alignment: Int = throwUndefined()
+  }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
 
-  implicit def CStruct20[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag,
-                         T12: Tag,
-                         T13: Tag,
-                         T14: Tag,
-                         T15: Tag,
-                         T16: Tag,
-                         T17: Tag,
-                         T18: Tag,
-                         T19: Tag,
-                         T20: Tag]: Tag[
-    CStruct20[T1,
-              T2,
-              T3,
-              T4,
-              T5,
-              T6,
-              T7,
-              T8,
-              T9,
-              T10,
-              T11,
-              T12,
-              T13,
-              T14,
-              T15,
-              T16,
-              T17,
-              T18,
-              T19,
-              T20]] = intrinsic
+  object Nat7 extends Tag[native.Nat._7] {
+    @noinline final def size: Int      = throwUndefined()
+    @noinline final def alignment: Int = throwUndefined()
+  }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
 
-  implicit def CStruct21[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag,
-                         T12: Tag,
-                         T13: Tag,
-                         T14: Tag,
-                         T15: Tag,
-                         T16: Tag,
-                         T17: Tag,
-                         T18: Tag,
-                         T19: Tag,
-                         T20: Tag,
-                         T21: Tag]: Tag[
-    CStruct21[T1,
-              T2,
-              T3,
-              T4,
-              T5,
-              T6,
-              T7,
-              T8,
-              T9,
-              T10,
-              T11,
-              T12,
-              T13,
-              T14,
-              T15,
-              T16,
-              T17,
-              T18,
-              T19,
-              T20,
-              T21]] = intrinsic
+  object Nat8 extends Tag[native.Nat._8] {
+    @noinline final def size: Int      = throwUndefined()
+    @noinline final def alignment: Int = throwUndefined()
+  }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 45)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
 
-  implicit def CStruct22[T1: Tag,
-                         T2: Tag,
-                         T3: Tag,
-                         T4: Tag,
-                         T5: Tag,
-                         T6: Tag,
-                         T7: Tag,
-                         T8: Tag,
-                         T9: Tag,
-                         T10: Tag,
-                         T11: Tag,
-                         T12: Tag,
-                         T13: Tag,
-                         T14: Tag,
-                         T15: Tag,
-                         T16: Tag,
-                         T17: Tag,
-                         T18: Tag,
-                         T19: Tag,
-                         T20: Tag,
-                         T21: Tag,
-                         T22: Tag]: Tag[
-    CStruct22[T1,
-              T2,
-              T3,
-              T4,
-              T5,
-              T6,
-              T7,
-              T8,
-              T9,
-              T10,
-              T11,
-              T12,
-              T13,
-              T14,
-              T15,
-              T16,
-              T17,
-              T18,
-              T19,
-              T20,
-              T21,
-              T22]] = intrinsic
+  object Nat9 extends Tag[native.Nat._9] {
+    @noinline final def size: Int      = throwUndefined()
+    @noinline final def alignment: Int = throwUndefined()
+  }
 
-// ###sourceLocation(file: "/Users/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 49)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 56)
+
+  final case class Digit[N <: native.Nat.Base, M <: native.Nat](n: Tag[N],
+                                                                m: Tag[M])
+      extends Tag[native.Nat.Digit[N, M]] {
+    @inline final def size: Int      = throwUndefined()
+    @inline final def alignment: Int = throwUndefined()
+  }
+
+  final case class CArray[T, N <: native.Nat](of: Tag[T], n: Tag[N])
+      extends Tag[native.CArray[T, N]] {
+    final def size: Int = {
+      var mul = 1
+      def natToInt(tag: Tag[_]): Int = tag match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 69)
+        case Tag.Nat0 => 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 69)
+        case Tag.Nat1 => 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 69)
+        case Tag.Nat2 => 2
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 69)
+        case Tag.Nat3 => 3
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 69)
+        case Tag.Nat4 => 4
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 69)
+        case Tag.Nat5 => 5
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 69)
+        case Tag.Nat6 => 6
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 69)
+        case Tag.Nat7 => 7
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 69)
+        case Tag.Nat8 => 8
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 69)
+        case Tag.Nat9 => 9
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 71)
+        case Tag.Digit(n, m) =>
+          val mint = natToInt(m)
+          mul *= 10
+          natToInt(n) * mul + mint
+        case _ =>
+          throwUndefined()
+      }
+      of.size * natToInt(n)
+    }
+    @inline final def alignment: Int           = of.alignment
+    @inline override def offset(idx: Int): Int = of.size * idx
+  }
+
+  private[scalanative] sealed trait CStruct
+
+  @inline private[scalanative] def align(offset: Int, alignment: Int) = {
+    val alignmentMask = alignment - 1
+    val padding =
+      if ((offset & alignmentMask) == 0) 0
+      else alignment - (offset & alignmentMask)
+    offset + padding
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct0() extends Tag[native.CStruct0] with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct1[T1](_1: Tag[T1])
+      extends Tag[native.CStruct1[T1]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct2[T1, T2](_1: Tag[T1], _2: Tag[T2])
+      extends Tag[native.CStruct2[T1, T2]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct3[T1, T2, T3](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3])
+      extends Tag[native.CStruct3[T1, T2, T3]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct4[T1, T2, T3, T4](_1: Tag[T1],
+                                            _2: Tag[T2],
+                                            _3: Tag[T3],
+                                            _4: Tag[T4])
+      extends Tag[native.CStruct4[T1, T2, T3, T4]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct5[T1, T2, T3, T4, T5](_1: Tag[T1],
+                                                _2: Tag[T2],
+                                                _3: Tag[T3],
+                                                _4: Tag[T4],
+                                                _5: Tag[T5])
+      extends Tag[native.CStruct5[T1, T2, T3, T4, T5]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct6[T1, T2, T3, T4, T5, T6](_1: Tag[T1],
+                                                    _2: Tag[T2],
+                                                    _3: Tag[T3],
+                                                    _4: Tag[T4],
+                                                    _5: Tag[T5],
+                                                    _6: Tag[T6])
+      extends Tag[native.CStruct6[T1, T2, T3, T4, T5, T6]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct7[T1, T2, T3, T4, T5, T6, T7](_1: Tag[T1],
+                                                        _2: Tag[T2],
+                                                        _3: Tag[T3],
+                                                        _4: Tag[T4],
+                                                        _5: Tag[T5],
+                                                        _6: Tag[T6],
+                                                        _7: Tag[T7])
+      extends Tag[native.CStruct7[T1, T2, T3, T4, T5, T6, T7]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8](_1: Tag[T1],
+                                                            _2: Tag[T2],
+                                                            _3: Tag[T3],
+                                                            _4: Tag[T4],
+                                                            _5: Tag[T5],
+                                                            _6: Tag[T6],
+                                                            _7: Tag[T7],
+                                                            _8: Tag[T8])
+      extends Tag[native.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9](_1: Tag[T1],
+                                                                _2: Tag[T2],
+                                                                _3: Tag[T3],
+                                                                _4: Tag[T4],
+                                                                _5: Tag[T5],
+                                                                _6: Tag[T6],
+                                                                _7: Tag[T7],
+                                                                _8: Tag[T8],
+                                                                _9: Tag[T9])
+      extends Tag[native.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](
+      _1: Tag[T1],
+      _2: Tag[T2],
+      _3: Tag[T3],
+      _4: Tag[T4],
+      _5: Tag[T5],
+      _6: Tag[T6],
+      _7: Tag[T7],
+      _8: Tag[T8],
+      _9: Tag[T9],
+      _10: Tag[T10])
+      extends Tag[native.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](
+      _1: Tag[T1],
+      _2: Tag[T2],
+      _3: Tag[T3],
+      _4: Tag[T4],
+      _5: Tag[T5],
+      _6: Tag[T6],
+      _7: Tag[T7],
+      _8: Tag[T8],
+      _9: Tag[T9],
+      _10: Tag[T10],
+      _11: Tag[T11])
+      extends Tag[
+        native.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](
+      _1: Tag[T1],
+      _2: Tag[T2],
+      _3: Tag[T3],
+      _4: Tag[T4],
+      _5: Tag[T5],
+      _6: Tag[T6],
+      _7: Tag[T7],
+      _8: Tag[T8],
+      _9: Tag[T9],
+      _10: Tag[T10],
+      _11: Tag[T11],
+      _12: Tag[T12])
+      extends Tag[
+        native.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _12.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 11 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _12.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct13[T1,
+                             T2,
+                             T3,
+                             T4,
+                             T5,
+                             T6,
+                             T7,
+                             T8,
+                             T9,
+                             T10,
+                             T11,
+                             T12,
+                             T13](_1: Tag[T1],
+                                  _2: Tag[T2],
+                                  _3: Tag[T3],
+                                  _4: Tag[T4],
+                                  _5: Tag[T5],
+                                  _6: Tag[T6],
+                                  _7: Tag[T7],
+                                  _8: Tag[T8],
+                                  _9: Tag[T9],
+                                  _10: Tag[T10],
+                                  _11: Tag[T11],
+                                  _12: Tag[T12],
+                                  _13: Tag[T13])
+      extends Tag[
+        native.CStruct13[T1,
+                         T2,
+                         T3,
+                         T4,
+                         T5,
+                         T6,
+                         T7,
+                         T8,
+                         T9,
+                         T10,
+                         T11,
+                         T12,
+                         T13]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _12.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _13.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 11 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _12.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 12 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _13.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct14[T1,
+                             T2,
+                             T3,
+                             T4,
+                             T5,
+                             T6,
+                             T7,
+                             T8,
+                             T9,
+                             T10,
+                             T11,
+                             T12,
+                             T13,
+                             T14](_1: Tag[T1],
+                                  _2: Tag[T2],
+                                  _3: Tag[T3],
+                                  _4: Tag[T4],
+                                  _5: Tag[T5],
+                                  _6: Tag[T6],
+                                  _7: Tag[T7],
+                                  _8: Tag[T8],
+                                  _9: Tag[T9],
+                                  _10: Tag[T10],
+                                  _11: Tag[T11],
+                                  _12: Tag[T12],
+                                  _13: Tag[T13],
+                                  _14: Tag[T14])
+      extends Tag[
+        native.CStruct14[T1,
+                         T2,
+                         T3,
+                         T4,
+                         T5,
+                         T6,
+                         T7,
+                         T8,
+                         T9,
+                         T10,
+                         T11,
+                         T12,
+                         T13,
+                         T14]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _12.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _13.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _14.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 11 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _12.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 12 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _13.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 13 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _14.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct15[T1,
+                             T2,
+                             T3,
+                             T4,
+                             T5,
+                             T6,
+                             T7,
+                             T8,
+                             T9,
+                             T10,
+                             T11,
+                             T12,
+                             T13,
+                             T14,
+                             T15](_1: Tag[T1],
+                                  _2: Tag[T2],
+                                  _3: Tag[T3],
+                                  _4: Tag[T4],
+                                  _5: Tag[T5],
+                                  _6: Tag[T6],
+                                  _7: Tag[T7],
+                                  _8: Tag[T8],
+                                  _9: Tag[T9],
+                                  _10: Tag[T10],
+                                  _11: Tag[T11],
+                                  _12: Tag[T12],
+                                  _13: Tag[T13],
+                                  _14: Tag[T14],
+                                  _15: Tag[T15])
+      extends Tag[
+        native.CStruct15[T1,
+                         T2,
+                         T3,
+                         T4,
+                         T5,
+                         T6,
+                         T7,
+                         T8,
+                         T9,
+                         T10,
+                         T11,
+                         T12,
+                         T13,
+                         T14,
+                         T15]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _12.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _13.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _14.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _15.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 11 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _12.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 12 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _13.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 13 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _14.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 14 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _15.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct16[T1,
+                             T2,
+                             T3,
+                             T4,
+                             T5,
+                             T6,
+                             T7,
+                             T8,
+                             T9,
+                             T10,
+                             T11,
+                             T12,
+                             T13,
+                             T14,
+                             T15,
+                             T16](_1: Tag[T1],
+                                  _2: Tag[T2],
+                                  _3: Tag[T3],
+                                  _4: Tag[T4],
+                                  _5: Tag[T5],
+                                  _6: Tag[T6],
+                                  _7: Tag[T7],
+                                  _8: Tag[T8],
+                                  _9: Tag[T9],
+                                  _10: Tag[T10],
+                                  _11: Tag[T11],
+                                  _12: Tag[T12],
+                                  _13: Tag[T13],
+                                  _14: Tag[T14],
+                                  _15: Tag[T15],
+                                  _16: Tag[T16])
+      extends Tag[
+        native.CStruct16[T1,
+                         T2,
+                         T3,
+                         T4,
+                         T5,
+                         T6,
+                         T7,
+                         T8,
+                         T9,
+                         T10,
+                         T11,
+                         T12,
+                         T13,
+                         T14,
+                         T15,
+                         T16]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _12.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _13.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _14.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _15.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _16.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 11 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _12.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 12 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _13.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 13 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _14.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 14 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _15.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 15 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _16.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct17[T1,
+                             T2,
+                             T3,
+                             T4,
+                             T5,
+                             T6,
+                             T7,
+                             T8,
+                             T9,
+                             T10,
+                             T11,
+                             T12,
+                             T13,
+                             T14,
+                             T15,
+                             T16,
+                             T17](_1: Tag[T1],
+                                  _2: Tag[T2],
+                                  _3: Tag[T3],
+                                  _4: Tag[T4],
+                                  _5: Tag[T5],
+                                  _6: Tag[T6],
+                                  _7: Tag[T7],
+                                  _8: Tag[T8],
+                                  _9: Tag[T9],
+                                  _10: Tag[T10],
+                                  _11: Tag[T11],
+                                  _12: Tag[T12],
+                                  _13: Tag[T13],
+                                  _14: Tag[T14],
+                                  _15: Tag[T15],
+                                  _16: Tag[T16],
+                                  _17: Tag[T17])
+      extends Tag[
+        native.CStruct17[T1,
+                         T2,
+                         T3,
+                         T4,
+                         T5,
+                         T6,
+                         T7,
+                         T8,
+                         T9,
+                         T10,
+                         T11,
+                         T12,
+                         T13,
+                         T14,
+                         T15,
+                         T16,
+                         T17]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _12.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _13.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _14.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _15.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _16.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _17.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 11 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _12.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 12 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _13.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 13 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _14.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 14 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _15.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 15 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _16.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 16 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _17.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct18[T1,
+                             T2,
+                             T3,
+                             T4,
+                             T5,
+                             T6,
+                             T7,
+                             T8,
+                             T9,
+                             T10,
+                             T11,
+                             T12,
+                             T13,
+                             T14,
+                             T15,
+                             T16,
+                             T17,
+                             T18](_1: Tag[T1],
+                                  _2: Tag[T2],
+                                  _3: Tag[T3],
+                                  _4: Tag[T4],
+                                  _5: Tag[T5],
+                                  _6: Tag[T6],
+                                  _7: Tag[T7],
+                                  _8: Tag[T8],
+                                  _9: Tag[T9],
+                                  _10: Tag[T10],
+                                  _11: Tag[T11],
+                                  _12: Tag[T12],
+                                  _13: Tag[T13],
+                                  _14: Tag[T14],
+                                  _15: Tag[T15],
+                                  _16: Tag[T16],
+                                  _17: Tag[T17],
+                                  _18: Tag[T18])
+      extends Tag[
+        native.CStruct18[T1,
+                         T2,
+                         T3,
+                         T4,
+                         T5,
+                         T6,
+                         T7,
+                         T8,
+                         T9,
+                         T10,
+                         T11,
+                         T12,
+                         T13,
+                         T14,
+                         T15,
+                         T16,
+                         T17,
+                         T18]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _12.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _13.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _14.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _15.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _16.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _17.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _18.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 11 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _12.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 12 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _13.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 13 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _14.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 14 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _15.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 15 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _16.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 16 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _17.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 17 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _18.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct19[T1,
+                             T2,
+                             T3,
+                             T4,
+                             T5,
+                             T6,
+                             T7,
+                             T8,
+                             T9,
+                             T10,
+                             T11,
+                             T12,
+                             T13,
+                             T14,
+                             T15,
+                             T16,
+                             T17,
+                             T18,
+                             T19](_1: Tag[T1],
+                                  _2: Tag[T2],
+                                  _3: Tag[T3],
+                                  _4: Tag[T4],
+                                  _5: Tag[T5],
+                                  _6: Tag[T6],
+                                  _7: Tag[T7],
+                                  _8: Tag[T8],
+                                  _9: Tag[T9],
+                                  _10: Tag[T10],
+                                  _11: Tag[T11],
+                                  _12: Tag[T12],
+                                  _13: Tag[T13],
+                                  _14: Tag[T14],
+                                  _15: Tag[T15],
+                                  _16: Tag[T16],
+                                  _17: Tag[T17],
+                                  _18: Tag[T18],
+                                  _19: Tag[T19])
+      extends Tag[
+        native.CStruct19[T1,
+                         T2,
+                         T3,
+                         T4,
+                         T5,
+                         T6,
+                         T7,
+                         T8,
+                         T9,
+                         T10,
+                         T11,
+                         T12,
+                         T13,
+                         T14,
+                         T15,
+                         T16,
+                         T17,
+                         T18,
+                         T19]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _19.alignment) + _19.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _12.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _13.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _14.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _15.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _16.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _17.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _18.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _19.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 11 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _12.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 12 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _13.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 13 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _14.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 14 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _15.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 15 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _16.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 16 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _17.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 17 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _18.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 18 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _19.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct20[T1,
+                             T2,
+                             T3,
+                             T4,
+                             T5,
+                             T6,
+                             T7,
+                             T8,
+                             T9,
+                             T10,
+                             T11,
+                             T12,
+                             T13,
+                             T14,
+                             T15,
+                             T16,
+                             T17,
+                             T18,
+                             T19,
+                             T20](_1: Tag[T1],
+                                  _2: Tag[T2],
+                                  _3: Tag[T3],
+                                  _4: Tag[T4],
+                                  _5: Tag[T5],
+                                  _6: Tag[T6],
+                                  _7: Tag[T7],
+                                  _8: Tag[T8],
+                                  _9: Tag[T9],
+                                  _10: Tag[T10],
+                                  _11: Tag[T11],
+                                  _12: Tag[T12],
+                                  _13: Tag[T13],
+                                  _14: Tag[T14],
+                                  _15: Tag[T15],
+                                  _16: Tag[T16],
+                                  _17: Tag[T17],
+                                  _18: Tag[T18],
+                                  _19: Tag[T19],
+                                  _20: Tag[T20])
+      extends Tag[
+        native.CStruct20[T1,
+                         T2,
+                         T3,
+                         T4,
+                         T5,
+                         T6,
+                         T7,
+                         T8,
+                         T9,
+                         T10,
+                         T11,
+                         T12,
+                         T13,
+                         T14,
+                         T15,
+                         T16,
+                         T17,
+                         T18,
+                         T19,
+                         T20]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _19.alignment) + _19.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _20.alignment) + _20.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _12.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _13.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _14.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _15.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _16.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _17.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _18.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _19.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _20.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 11 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _12.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 12 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _13.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 13 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _14.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 14 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _15.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 15 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _16.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 16 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _17.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 17 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _18.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 18 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _19.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 19 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _19.alignment) + _19.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _20.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct21[T1,
+                             T2,
+                             T3,
+                             T4,
+                             T5,
+                             T6,
+                             T7,
+                             T8,
+                             T9,
+                             T10,
+                             T11,
+                             T12,
+                             T13,
+                             T14,
+                             T15,
+                             T16,
+                             T17,
+                             T18,
+                             T19,
+                             T20,
+                             T21](_1: Tag[T1],
+                                  _2: Tag[T2],
+                                  _3: Tag[T3],
+                                  _4: Tag[T4],
+                                  _5: Tag[T5],
+                                  _6: Tag[T6],
+                                  _7: Tag[T7],
+                                  _8: Tag[T8],
+                                  _9: Tag[T9],
+                                  _10: Tag[T10],
+                                  _11: Tag[T11],
+                                  _12: Tag[T12],
+                                  _13: Tag[T13],
+                                  _14: Tag[T14],
+                                  _15: Tag[T15],
+                                  _16: Tag[T16],
+                                  _17: Tag[T17],
+                                  _18: Tag[T18],
+                                  _19: Tag[T19],
+                                  _20: Tag[T20],
+                                  _21: Tag[T21])
+      extends Tag[
+        native.CStruct21[T1,
+                         T2,
+                         T3,
+                         T4,
+                         T5,
+                         T6,
+                         T7,
+                         T8,
+                         T9,
+                         T10,
+                         T11,
+                         T12,
+                         T13,
+                         T14,
+                         T15,
+                         T16,
+                         T17,
+                         T18,
+                         T19,
+                         T20,
+                         T21]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _19.alignment) + _19.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _20.alignment) + _20.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _21.alignment) + _21.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _12.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _13.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _14.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _15.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _16.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _17.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _18.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _19.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _20.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _21.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 11 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _12.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 12 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _13.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 13 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _14.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 14 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _15.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 15 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _16.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 16 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _17.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 17 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _18.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 18 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _19.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 19 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _19.alignment) + _19.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _20.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 20 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _19.alignment) + _19.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _20.alignment) + _20.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _21.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 99)
+
+  final case class CStruct22[T1,
+                             T2,
+                             T3,
+                             T4,
+                             T5,
+                             T6,
+                             T7,
+                             T8,
+                             T9,
+                             T10,
+                             T11,
+                             T12,
+                             T13,
+                             T14,
+                             T15,
+                             T16,
+                             T17,
+                             T18,
+                             T19,
+                             T20,
+                             T21,
+                             T22](_1: Tag[T1],
+                                  _2: Tag[T2],
+                                  _3: Tag[T3],
+                                  _4: Tag[T4],
+                                  _5: Tag[T5],
+                                  _6: Tag[T6],
+                                  _7: Tag[T7],
+                                  _8: Tag[T8],
+                                  _9: Tag[T9],
+                                  _10: Tag[T10],
+                                  _11: Tag[T11],
+                                  _12: Tag[T12],
+                                  _13: Tag[T13],
+                                  _14: Tag[T14],
+                                  _15: Tag[T15],
+                                  _16: Tag[T16],
+                                  _17: Tag[T17],
+                                  _18: Tag[T18],
+                                  _19: Tag[T19],
+                                  _20: Tag[T20],
+                                  _21: Tag[T21],
+                                  _22: Tag[T22])
+      extends Tag[
+        native.CStruct22[T1,
+                         T2,
+                         T3,
+                         T4,
+                         T5,
+                         T6,
+                         T7,
+                         T8,
+                         T9,
+                         T10,
+                         T11,
+                         T12,
+                         T13,
+                         T14,
+                         T15,
+                         T16,
+                         T17,
+                         T18,
+                         T19,
+                         T20,
+                         T21,
+                         T22]]
+      with CStruct {
+    final def size: Int = {
+      var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _19.alignment) + _19.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _20.alignment) + _20.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _21.alignment) + _21.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 104)
+      res = align(res, _22.alignment) + _22.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 106)
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _1.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _2.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _3.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _4.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _5.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _6.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _7.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _8.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _9.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _10.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _11.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _12.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _13.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _14.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _15.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _16.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _17.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _18.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _19.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _20.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _21.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 111)
+      res = res max _22.alignment
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 113)
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 0 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _1.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 1 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _2.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 2 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _3.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 3 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _4.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 4 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _5.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 5 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _6.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 6 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _7.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 7 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _8.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 8 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _9.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 9 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _10.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 10 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _11.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 11 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _12.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 12 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _13.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 13 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _14.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 14 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _15.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 15 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _16.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 16 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _17.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 17 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _18.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 18 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _19.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 19 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _19.alignment) + _19.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _20.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 20 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _19.alignment) + _19.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _20.alignment) + _20.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _21.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 117)
+      case 21 =>
+        var res = 0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _1.alignment) + _1.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _2.alignment) + _2.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _3.alignment) + _3.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _4.alignment) + _4.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _5.alignment) + _5.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _6.alignment) + _6.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _7.alignment) + _7.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _8.alignment) + _8.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _9.alignment) + _9.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _10.alignment) + _10.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _11.alignment) + _11.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _12.alignment) + _12.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _13.alignment) + _13.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _14.alignment) + _14.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _15.alignment) + _15.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _16.alignment) + _16.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _17.alignment) + _17.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _18.alignment) + _18.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _19.alignment) + _19.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _20.alignment) + _20.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 120)
+        res = align(res, _21.alignment) + _21.size
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 122)
+        align(res, _22.alignment)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 124)
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 130)
+
+  implicit def materializePtrTag[T](implicit tag: Tag[T]): Tag[native.Ptr[T]] =
+    Tag.Ptr(tag)
+  implicit def materializeClassTag[T <: AnyRef: ClassTag]: Tag[T] =
+    Tag.Class(
+      implicitly[ClassTag[T]].runtimeClass.asInstanceOf[java.lang.Class[T]])
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeUnitTag: Tag[scala.Unit] =
+    Unit
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeBooleanTag: Tag[scala.Boolean] =
+    Boolean
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeCharTag: Tag[scala.Char] =
+    Char
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeByteTag: Tag[scala.Byte] =
+    Byte
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeUByteTag: Tag[native.UByte] =
+    UByte
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeShortTag: Tag[scala.Short] =
+    Short
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeUShortTag: Tag[native.UShort] =
+    UShort
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeIntTag: Tag[scala.Int] =
+    Int
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeUIntTag: Tag[native.UInt] =
+    UInt
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeLongTag: Tag[scala.Long] =
+    Long
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeULongTag: Tag[native.ULong] =
+    ULong
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeFloatTag: Tag[scala.Float] =
+    Float
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 136)
+  implicit def materializeDoubleTag: Tag[scala.Double] =
+    Double
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 140)
+  implicit def materializeNat0Tag: Tag[native.Nat._0] =
+    Nat0
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 140)
+  implicit def materializeNat1Tag: Tag[native.Nat._1] =
+    Nat1
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 140)
+  implicit def materializeNat2Tag: Tag[native.Nat._2] =
+    Nat2
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 140)
+  implicit def materializeNat3Tag: Tag[native.Nat._3] =
+    Nat3
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 140)
+  implicit def materializeNat4Tag: Tag[native.Nat._4] =
+    Nat4
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 140)
+  implicit def materializeNat5Tag: Tag[native.Nat._5] =
+    Nat5
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 140)
+  implicit def materializeNat6Tag: Tag[native.Nat._6] =
+    Nat6
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 140)
+  implicit def materializeNat7Tag: Tag[native.Nat._7] =
+    Nat7
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 140)
+  implicit def materializeNat8Tag: Tag[native.Nat._8] =
+    Nat8
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 140)
+  implicit def materializeNat9Tag: Tag[native.Nat._9] =
+    Nat9
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 143)
+  implicit def materializeNatDigitTag[N <: native.Nat.Base: Tag,
+                                      M <: native.Nat: Tag]
+    : Tag[native.Nat.Digit[N, M]] =
+    Tag.Digit(implicitly[Tag[N]], implicitly[Tag[M]])
+  implicit def materializeCArrayTag[T: Tag, N <: native.Nat: Tag]
+    : Tag[native.CArray[T, N]] =
+    Tag.CArray(implicitly[Tag[T]], implicitly[Tag[N]])
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct0Tag: Tag[native.CStruct0] =
+    Tag.CStruct0()
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct1Tag[T1: Tag]: Tag[native.CStruct1[T1]] =
+    Tag.CStruct1(implicitly[Tag[T1]])
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct2Tag[T1: Tag, T2: Tag]
+    : Tag[native.CStruct2[T1, T2]] =
+    Tag.CStruct2(implicitly[Tag[T1]], implicitly[Tag[T2]])
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct3Tag[T1: Tag, T2: Tag, T3: Tag]
+    : Tag[native.CStruct3[T1, T2, T3]] =
+    Tag.CStruct3(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]])
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct4Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag]
+    : Tag[native.CStruct4[T1, T2, T3, T4]] =
+    Tag.CStruct4(implicitly[Tag[T1]],
+                 implicitly[Tag[T2]],
+                 implicitly[Tag[T3]],
+                 implicitly[Tag[T4]])
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct5Tag[T1: Tag,
+                                      T2: Tag,
+                                      T3: Tag,
+                                      T4: Tag,
+                                      T5: Tag]
+    : Tag[native.CStruct5[T1, T2, T3, T4, T5]] =
+    Tag.CStruct5(implicitly[Tag[T1]],
+                 implicitly[Tag[T2]],
+                 implicitly[Tag[T3]],
+                 implicitly[Tag[T4]],
+                 implicitly[Tag[T5]])
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct6Tag[T1: Tag,
+                                      T2: Tag,
+                                      T3: Tag,
+                                      T4: Tag,
+                                      T5: Tag,
+                                      T6: Tag]
+    : Tag[native.CStruct6[T1, T2, T3, T4, T5, T6]] =
+    Tag.CStruct6(implicitly[Tag[T1]],
+                 implicitly[Tag[T2]],
+                 implicitly[Tag[T3]],
+                 implicitly[Tag[T4]],
+                 implicitly[Tag[T5]],
+                 implicitly[Tag[T6]])
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct7Tag[T1: Tag,
+                                      T2: Tag,
+                                      T3: Tag,
+                                      T4: Tag,
+                                      T5: Tag,
+                                      T6: Tag,
+                                      T7: Tag]
+    : Tag[native.CStruct7[T1, T2, T3, T4, T5, T6, T7]] =
+    Tag.CStruct7(implicitly[Tag[T1]],
+                 implicitly[Tag[T2]],
+                 implicitly[Tag[T3]],
+                 implicitly[Tag[T4]],
+                 implicitly[Tag[T5]],
+                 implicitly[Tag[T6]],
+                 implicitly[Tag[T7]])
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct8Tag[T1: Tag,
+                                      T2: Tag,
+                                      T3: Tag,
+                                      T4: Tag,
+                                      T5: Tag,
+                                      T6: Tag,
+                                      T7: Tag,
+                                      T8: Tag]
+    : Tag[native.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]] =
+    Tag.CStruct8(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct9Tag[T1: Tag,
+                                      T2: Tag,
+                                      T3: Tag,
+                                      T4: Tag,
+                                      T5: Tag,
+                                      T6: Tag,
+                                      T7: Tag,
+                                      T8: Tag,
+                                      T9: Tag]
+    : Tag[native.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] =
+    Tag.CStruct9(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct10Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag]
+    : Tag[native.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] =
+    Tag.CStruct10(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct11Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag]
+    : Tag[native.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] =
+    Tag.CStruct11(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct12Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag,
+                                       T12: Tag]
+    : Tag[native.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] =
+    Tag.CStruct12(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]],
+      implicitly[Tag[T12]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct13Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag,
+                                       T12: Tag,
+                                       T13: Tag]: Tag[
+    native.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] =
+    Tag.CStruct13(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]],
+      implicitly[Tag[T12]],
+      implicitly[Tag[T13]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct14Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag,
+                                       T12: Tag,
+                                       T13: Tag,
+                                       T14: Tag]: Tag[
+    native.CStruct14[T1,
+                     T2,
+                     T3,
+                     T4,
+                     T5,
+                     T6,
+                     T7,
+                     T8,
+                     T9,
+                     T10,
+                     T11,
+                     T12,
+                     T13,
+                     T14]] =
+    Tag.CStruct14(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]],
+      implicitly[Tag[T12]],
+      implicitly[Tag[T13]],
+      implicitly[Tag[T14]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct15Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag,
+                                       T12: Tag,
+                                       T13: Tag,
+                                       T14: Tag,
+                                       T15: Tag]: Tag[
+    native.CStruct15[T1,
+                     T2,
+                     T3,
+                     T4,
+                     T5,
+                     T6,
+                     T7,
+                     T8,
+                     T9,
+                     T10,
+                     T11,
+                     T12,
+                     T13,
+                     T14,
+                     T15]] =
+    Tag.CStruct15(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]],
+      implicitly[Tag[T12]],
+      implicitly[Tag[T13]],
+      implicitly[Tag[T14]],
+      implicitly[Tag[T15]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct16Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag,
+                                       T12: Tag,
+                                       T13: Tag,
+                                       T14: Tag,
+                                       T15: Tag,
+                                       T16: Tag]: Tag[
+    native.CStruct16[T1,
+                     T2,
+                     T3,
+                     T4,
+                     T5,
+                     T6,
+                     T7,
+                     T8,
+                     T9,
+                     T10,
+                     T11,
+                     T12,
+                     T13,
+                     T14,
+                     T15,
+                     T16]] =
+    Tag.CStruct16(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]],
+      implicitly[Tag[T12]],
+      implicitly[Tag[T13]],
+      implicitly[Tag[T14]],
+      implicitly[Tag[T15]],
+      implicitly[Tag[T16]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct17Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag,
+                                       T12: Tag,
+                                       T13: Tag,
+                                       T14: Tag,
+                                       T15: Tag,
+                                       T16: Tag,
+                                       T17: Tag]: Tag[
+    native.CStruct17[T1,
+                     T2,
+                     T3,
+                     T4,
+                     T5,
+                     T6,
+                     T7,
+                     T8,
+                     T9,
+                     T10,
+                     T11,
+                     T12,
+                     T13,
+                     T14,
+                     T15,
+                     T16,
+                     T17]] =
+    Tag.CStruct17(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]],
+      implicitly[Tag[T12]],
+      implicitly[Tag[T13]],
+      implicitly[Tag[T14]],
+      implicitly[Tag[T15]],
+      implicitly[Tag[T16]],
+      implicitly[Tag[T17]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct18Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag,
+                                       T12: Tag,
+                                       T13: Tag,
+                                       T14: Tag,
+                                       T15: Tag,
+                                       T16: Tag,
+                                       T17: Tag,
+                                       T18: Tag]: Tag[
+    native.CStruct18[T1,
+                     T2,
+                     T3,
+                     T4,
+                     T5,
+                     T6,
+                     T7,
+                     T8,
+                     T9,
+                     T10,
+                     T11,
+                     T12,
+                     T13,
+                     T14,
+                     T15,
+                     T16,
+                     T17,
+                     T18]] =
+    Tag.CStruct18(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]],
+      implicitly[Tag[T12]],
+      implicitly[Tag[T13]],
+      implicitly[Tag[T14]],
+      implicitly[Tag[T15]],
+      implicitly[Tag[T16]],
+      implicitly[Tag[T17]],
+      implicitly[Tag[T18]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct19Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag,
+                                       T12: Tag,
+                                       T13: Tag,
+                                       T14: Tag,
+                                       T15: Tag,
+                                       T16: Tag,
+                                       T17: Tag,
+                                       T18: Tag,
+                                       T19: Tag]: Tag[
+    native.CStruct19[T1,
+                     T2,
+                     T3,
+                     T4,
+                     T5,
+                     T6,
+                     T7,
+                     T8,
+                     T9,
+                     T10,
+                     T11,
+                     T12,
+                     T13,
+                     T14,
+                     T15,
+                     T16,
+                     T17,
+                     T18,
+                     T19]] =
+    Tag.CStruct19(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]],
+      implicitly[Tag[T12]],
+      implicitly[Tag[T13]],
+      implicitly[Tag[T14]],
+      implicitly[Tag[T15]],
+      implicitly[Tag[T16]],
+      implicitly[Tag[T17]],
+      implicitly[Tag[T18]],
+      implicitly[Tag[T19]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct20Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag,
+                                       T12: Tag,
+                                       T13: Tag,
+                                       T14: Tag,
+                                       T15: Tag,
+                                       T16: Tag,
+                                       T17: Tag,
+                                       T18: Tag,
+                                       T19: Tag,
+                                       T20: Tag]: Tag[
+    native.CStruct20[T1,
+                     T2,
+                     T3,
+                     T4,
+                     T5,
+                     T6,
+                     T7,
+                     T8,
+                     T9,
+                     T10,
+                     T11,
+                     T12,
+                     T13,
+                     T14,
+                     T15,
+                     T16,
+                     T17,
+                     T18,
+                     T19,
+                     T20]] =
+    Tag.CStruct20(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]],
+      implicitly[Tag[T12]],
+      implicitly[Tag[T13]],
+      implicitly[Tag[T14]],
+      implicitly[Tag[T15]],
+      implicitly[Tag[T16]],
+      implicitly[Tag[T17]],
+      implicitly[Tag[T18]],
+      implicitly[Tag[T19]],
+      implicitly[Tag[T20]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct21Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag,
+                                       T12: Tag,
+                                       T13: Tag,
+                                       T14: Tag,
+                                       T15: Tag,
+                                       T16: Tag,
+                                       T17: Tag,
+                                       T18: Tag,
+                                       T19: Tag,
+                                       T20: Tag,
+                                       T21: Tag]: Tag[
+    native.CStruct21[T1,
+                     T2,
+                     T3,
+                     T4,
+                     T5,
+                     T6,
+                     T7,
+                     T8,
+                     T9,
+                     T10,
+                     T11,
+                     T12,
+                     T13,
+                     T14,
+                     T15,
+                     T16,
+                     T17,
+                     T18,
+                     T19,
+                     T20,
+                     T21]] =
+    Tag.CStruct21(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]],
+      implicitly[Tag[T12]],
+      implicitly[Tag[T13]],
+      implicitly[Tag[T14]],
+      implicitly[Tag[T15]],
+      implicitly[Tag[T16]],
+      implicitly[Tag[T17]],
+      implicitly[Tag[T18]],
+      implicitly[Tag[T19]],
+      implicitly[Tag[T20]],
+      implicitly[Tag[T21]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 152)
+  implicit def materializeCStruct22Tag[T1: Tag,
+                                       T2: Tag,
+                                       T3: Tag,
+                                       T4: Tag,
+                                       T5: Tag,
+                                       T6: Tag,
+                                       T7: Tag,
+                                       T8: Tag,
+                                       T9: Tag,
+                                       T10: Tag,
+                                       T11: Tag,
+                                       T12: Tag,
+                                       T13: Tag,
+                                       T14: Tag,
+                                       T15: Tag,
+                                       T16: Tag,
+                                       T17: Tag,
+                                       T18: Tag,
+                                       T19: Tag,
+                                       T20: Tag,
+                                       T21: Tag,
+                                       T22: Tag]: Tag[
+    native.CStruct22[T1,
+                     T2,
+                     T3,
+                     T4,
+                     T5,
+                     T6,
+                     T7,
+                     T8,
+                     T9,
+                     T10,
+                     T11,
+                     T12,
+                     T13,
+                     T14,
+                     T15,
+                     T16,
+                     T17,
+                     T18,
+                     T19,
+                     T20,
+                     T21,
+                     T22]] =
+    Tag.CStruct22(
+      implicitly[Tag[T1]],
+      implicitly[Tag[T2]],
+      implicitly[Tag[T3]],
+      implicitly[Tag[T4]],
+      implicitly[Tag[T5]],
+      implicitly[Tag[T6]],
+      implicitly[Tag[T7]],
+      implicitly[Tag[T8]],
+      implicitly[Tag[T9]],
+      implicitly[Tag[T10]],
+      implicitly[Tag[T11]],
+      implicitly[Tag[T12]],
+      implicitly[Tag[T13]],
+      implicitly[Tag[T14]],
+      implicitly[Tag[T15]],
+      implicitly[Tag[T16]],
+      implicitly[Tag[T17]],
+      implicitly[Tag[T18]],
+      implicitly[Tag[T19]],
+      implicitly[Tag[T20]],
+      implicitly[Tag[T21]],
+      implicitly[Tag[T22]]
+    )
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb", line: 155)
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/native/Tag.scala.gyb
@@ -2,48 +2,154 @@ package scala.scalanative
 package native
 
 import scala.reflect.ClassTag
-import scalanative.runtime.intrinsic
+import scalanative.runtime.{intrinsic, throwUndefined}
 
-final abstract class Tag[P]
+sealed abstract class Tag[P] {
+  def size: Int
+  def alignment: Int
+  def offset(idx: Int): Int = throwUndefined()
+}
 
 object Tag {
-  implicit val Unit: Tag[Unit]                    = intrinsic
-  implicit val Boolean: Tag[Boolean]              = intrinsic
-  implicit val Char: Tag[Char]                    = intrinsic
-  implicit val Byte: Tag[Byte]                    = intrinsic
-  implicit val UByte: Tag[UByte]                  = intrinsic
-  implicit val Short: Tag[Short]                  = intrinsic
-  implicit val UShort: Tag[UShort]                = intrinsic
-  implicit val Int: Tag[Int]                      = intrinsic
-  implicit val UInt: Tag[UInt]                    = intrinsic
-  implicit val Long: Tag[Long]                    = intrinsic
-  implicit val ULong: Tag[ULong]                  = intrinsic
-  implicit val Float: Tag[Float]                  = intrinsic
-  implicit val Double: Tag[Double]                = intrinsic
-  implicit def Ptr[T: Tag]: Tag[Ptr[T]]           = intrinsic
-  implicit def Ref[T <: AnyRef: ClassTag]: Tag[T] = intrinsic
+  final case class Ptr[T](of: Tag[T])
+      extends Tag[native.Ptr[T]] {
+    @inline final def size: Int = 8
+    @inline final def alignment: Int = 8
+  }
 
-  implicit def Nat0: Tag[Nat._0] = intrinsic
-  implicit def Nat1: Tag[Nat._1] = intrinsic
-  implicit def Nat2: Tag[Nat._2] = intrinsic
-  implicit def Nat3: Tag[Nat._3] = intrinsic
-  implicit def Nat4: Tag[Nat._4] = intrinsic
-  implicit def Nat5: Tag[Nat._5] = intrinsic
-  implicit def Nat6: Tag[Nat._6] = intrinsic
-  implicit def Nat7: Tag[Nat._7] = intrinsic
-  implicit def Nat8: Tag[Nat._8] = intrinsic
-  implicit def Nat9: Tag[Nat._9] = intrinsic
-  implicit def NatDigit[N <: Nat.Base: Tag, M <: Nat: Tag]: Tag[Nat.Digit[N, M]] =
-    intrinsic
+  final case class Class[T <: AnyRef](of: java.lang.Class[T])
+      extends Tag[T] {
+    @inline final def size: Int = 8
+    @inline final def alignment: Int = 8
+  }
 
-  implicit def CArray[T: Tag, N <: Nat: Tag]: Tag[CArray[T, N]] = intrinsic
+  % prims = [('Unit', 'scala.Unit', 8),
+  %          ('Boolean', 'scala.Boolean', 1),
+  %          ('Char', 'scala.Char', 2),
+  %          ('Byte', 'scala.Byte', 1),
+  %          ('UByte', 'native.UByte', 1),
+  %          ('Short', 'scala.Short', 2),
+  %          ('UShort', 'native.UShort', 2),
+  %          ('Int', 'scala.Int', 4),
+  %          ('UInt', 'native.UInt', 4),
+  %          ('Long', 'scala.Long', 8),
+  %          ('ULong', 'native.ULong', 8),
+  %          ('Float', 'scala.Float', 4),
+  %          ('Double', 'scala.Double', 8)]
+  % for (name, T, size) in prims:
 
+  object ${name} extends Tag[${T}] {
+    @inline final def size: Int = ${size}
+    @inline final def alignment: Int = ${size}
+  }
+
+  % end
+
+  % for N in range(0, 10):
+
+  object Nat${N} extends Tag[native.Nat._${N}] {
+    @noinline final def size: Int = throwUndefined()
+    @noinline final def alignment: Int = throwUndefined()
+  }
+
+  % end
+
+  final case class Digit[N <: native.Nat.Base, M <: native.Nat](n: Tag[N], m: Tag[M])
+      extends Tag[native.Nat.Digit[N, M]] {
+    @inline final def size: Int = throwUndefined()
+    @inline final def alignment: Int = throwUndefined()
+  }
+
+  final case class CArray[T, N <: native.Nat](of: Tag[T], n: Tag[N])
+      extends Tag[native.CArray[T, N]] {
+    final def size: Int = {
+      var mul = 1
+      def natToInt(tag: Tag[_]): Int = tag match {
+        % for N in range(0, 10):
+        case Tag.Nat${N} => ${N}
+        % end
+        case Tag.Digit(n, m) =>
+          val mint = natToInt(m)
+          mul *= 10
+          natToInt(n) * mul + mint
+        case _ =>
+          throwUndefined()
+      }
+      of.size * natToInt(n)
+    }
+    @inline final def alignment: Int = of.alignment
+    @inline override def offset(idx: Int): Int = of.size * idx
+  }
+
+  private[scalanative] sealed trait CStruct
+
+  @inline private[scalanative] def align(offset: Int, alignment: Int) = {
+    val alignmentMask = alignment - 1
+    val padding =
+      if ((offset & alignmentMask) == 0) 0
+      else alignment - (offset & alignmentMask)
+    offset + padding
+  }
+
+  % for N in range(0, 23):
+  %   Ts      = ["T" + str(i) for i in range(1, N + 1)]
+  %   JustTs  = "" if N == 0 else "[" + ", ".join(Ts) + "]"
+  %   TagTs   = ["Tag[{}]".format(T) for T in Ts]
+  %   args    = ", ".join("_{}: {}".format(i + 1, T) for (i, T) in enumerate(TagTs))
+
+  final case class CStruct${N}${JustTs}(${args}) extends Tag[native.CStruct${N}${JustTs}] with CStruct {
+    final def size: Int = {
+      var res = 0
+      % for i in range(1, N + 1):
+      res = align(res, _${i}.alignment) + _${i}.size
+      % end
+      align(res, alignment)
+    }
+    final def alignment: Int = {
+      var res = 1
+      % for i in range(1, N + 1):
+      res = res max _${i}.alignment
+      % end
+      res
+    }
+    override def offset(idx: Int): Int = idx match {
+      % for fld in range(1, N + 1):
+      case ${fld - 1} =>
+        var res = 0
+        % for i in range(1, fld):
+        res = align(res, _${i}.alignment) + _${i}.size
+        % end
+        align(res, _${fld}.alignment)
+      % end
+      case _ =>
+        throwUndefined()
+    }
+  }
+
+  % end
+
+  implicit def materializePtrTag[T](implicit tag: Tag[T]): Tag[native.Ptr[T]] =
+    Tag.Ptr(tag)
+  implicit def materializeClassTag[T <: AnyRef: ClassTag]: Tag[T] =
+    Tag.Class(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[java.lang.Class[T]])
+  % for (name, T, _) in prims:
+  implicit def materialize${name}Tag: Tag[${T}] =
+    ${name}
+  % end
+  % for N in range(0, 10):
+  implicit def materializeNat${N}Tag: Tag[native.Nat._${N}] =
+    Nat${N}
+  %end
+  implicit def materializeNatDigitTag[N <: native.Nat.Base: Tag, M <: native.Nat: Tag]: Tag[native.Nat.Digit[N, M]] =
+    Tag.Digit(implicitly[Tag[N]], implicitly[Tag[M]])
+  implicit def materializeCArrayTag[T: Tag, N <: native.Nat: Tag]: Tag[native.CArray[T, N]] =
+    Tag.CArray(implicitly[Tag[T]], implicitly[Tag[N]])
   % for N in range(0, 23):
   %   Ts      = ["T" + str(i) for i in range(1, N + 1)]
   %   BoundTs = "" if N == 0 else "[" + ", ".join(map(lambda T: T + ": Tag", Ts)) + "]"
   %   JustTs  = "" if N == 0 else "[" + ", ".join(Ts) + "]"
-
-  implicit def CStruct${N}${BoundTs}: Tag[CStruct${N}${JustTs}] = intrinsic
-
+  %   tags    = ", ".join("implicitly[Tag[{}]]".format(T) for T in Ts)
+  implicit def materializeCStruct${N}Tag${BoundTs}: Tag[native.CStruct${N}${JustTs}] =
+    Tag.CStruct${N}(${tags})
   % end
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/package.scala
@@ -81,8 +81,14 @@ package object native {
   /** C-style string with trailing 0. */
   type CString = Ptr[CChar]
 
+  /** Materialize tag for given type. */
+  def tagof[T](implicit tag: Tag[T]): Tag[T] = tag
+
   /** The C 'sizeof' operator. */
   def sizeof[T](implicit tag: Tag[T]): CSize = intrinsic
+
+  /** C-style alignment operator. */
+  def alignmentof[T](implicit tag: Tag[T]): CSize = tag.alignment
 
   /** Heap allocate and zero-initialize a value
    *  using current implicit allocator.

--- a/nativelib/src/main/scala/scala/scalanative/native/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/package.scala
@@ -85,7 +85,7 @@ package object native {
   def tagof[T](implicit tag: Tag[T]): Tag[T] = tag
 
   /** The C 'sizeof' operator. */
-  def sizeof[T](implicit tag: Tag[T]): CSize = intrinsic
+  def sizeof[T](implicit tag: Tag[T]): CSize = tag.size
 
   /** C-style alignment operator. */
   def alignmentof[T](implicit tag: Tag[T]): CSize = tag.alignment

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -34,10 +34,12 @@ package object runtime {
   def intrinsic: Nothing = throwUndefined()
 
   /** Returns info pointer for given type. */
-  def typeof[T](implicit tag: Tag[T]): Ptr[Type] = intrinsic
+  def typeof[T](implicit ct: scala.reflect.ClassTag[T]): Ptr[Type] =
+    ct.runtimeClass.asInstanceOf[java.lang._Class[_]].ty
 
   /** Read type information of given object. */
-  def getType(obj: Object): Ptr[ClassType] = !obj.cast[Ptr[Ptr[ClassType]]]
+  def getType(obj: Object): Ptr[ClassType] =
+    !obj.cast[Ptr[Ptr[ClassType]]]
 
   /** Get monitor for given object. */
   def getMonitor(obj: Object): Monitor = Monitor.dummy

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -41,7 +41,6 @@ trait NirDefinitions { self: NirGlobalAddons =>
       "scala.scalanative.native.package")
     lazy val CastMethod   = getMember(NativeModule, TermName("cast"))
     lazy val ExternMethod = getMember(NativeModule, TermName("extern"))
-    lazy val SizeofMethod = getMember(NativeModule, TermName("sizeof"))
     lazy val StackallocMethods =
       getMember(NativeModule, TermName("stackalloc")).alternatives
 
@@ -139,7 +138,6 @@ trait NirDefinitions { self: NirGlobalAddons =>
 
     lazy val RuntimeModule = getRequiredModule(
       "scala.scalanative.runtime.package")
-    lazy val TypeofMethod = getMember(RuntimeModule, TermName("typeof"))
     lazy val GetMonitorMethod =
       getMember(RuntimeModule, TermName("getMonitor"))
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -79,29 +79,39 @@ trait NirDefinitions { self: NirGlobalAddons =>
     lazy val NatDigitClass =
       getRequiredClass("scala.scalanative.native.Nat$Digit")
 
-    lazy val TagModule        = getRequiredModule("scala.scalanative.native.Tag")
-    lazy val UnitTagMethod    = getDecl(TagModule, TermName("Unit"))
-    lazy val BooleanTagMethod = getDecl(TagModule, TermName("Boolean"))
-    lazy val CharTagMethod    = getDecl(TagModule, TermName("Char"))
-    lazy val ByteTagMethod    = getDecl(TagModule, TermName("Byte"))
-    lazy val UByteTagMethod   = getDecl(TagModule, TermName("UByte"))
-    lazy val ShortTagMethod   = getDecl(TagModule, TermName("Short"))
-    lazy val UShortTagMethod  = getDecl(TagModule, TermName("UShort"))
-    lazy val IntTagMethod     = getDecl(TagModule, TermName("Int"))
-    lazy val UIntTagMethod    = getDecl(TagModule, TermName("UInt"))
-    lazy val LongTagMethod    = getDecl(TagModule, TermName("Long"))
-    lazy val ULongTagMethod   = getDecl(TagModule, TermName("ULong"))
-    lazy val FloatTagMethod   = getDecl(TagModule, TermName("Float"))
-    lazy val DoubleTagMethod  = getDecl(TagModule, TermName("Double"))
-    lazy val PtrTagMethod     = getDecl(TagModule, TermName("Ptr"))
-    lazy val RefTagMethod     = getDecl(TagModule, TermName("Ref"))
+    lazy val TagModule     = getRequiredModule("scala.scalanative.native.Tag")
+    lazy val UnitTagMethod = getDecl(TagModule, TermName("materializeUnitTag"))
+    lazy val BooleanTagMethod =
+      getDecl(TagModule, TermName("materializeBooleanTag"))
+    lazy val CharTagMethod = getDecl(TagModule, TermName("materializeCharTag"))
+    lazy val ByteTagMethod = getDecl(TagModule, TermName("materializeByteTag"))
+    lazy val UByteTagMethod =
+      getDecl(TagModule, TermName("materializeUByteTag"))
+    lazy val ShortTagMethod =
+      getDecl(TagModule, TermName("materializeShortTag"))
+    lazy val UShortTagMethod =
+      getDecl(TagModule, TermName("materializeUShortTag"))
+    lazy val IntTagMethod  = getDecl(TagModule, TermName("materializeIntTag"))
+    lazy val UIntTagMethod = getDecl(TagModule, TermName("materializeUIntTag"))
+    lazy val LongTagMethod = getDecl(TagModule, TermName("materializeLongTag"))
+    lazy val ULongTagMethod =
+      getDecl(TagModule, TermName("materializeULongTag"))
+    lazy val FloatTagMethod =
+      getDecl(TagModule, TermName("materializeFloatTag"))
+    lazy val DoubleTagMethod =
+      getDecl(TagModule, TermName("materializeDoubleTag"))
+    lazy val PtrTagMethod = getDecl(TagModule, TermName("materializePtrTag"))
+    lazy val ClassTagMethod =
+      getDecl(TagModule, TermName("materializeClassTag"))
     lazy val NatBaseTagMethod = (0 to 9).map { n =>
-      getDecl(TagModule, TermName("Nat" + n))
+      getDecl(TagModule, TermName("materializeNat" + n + "Tag"))
     }
-    lazy val NatDigitTagMethod = getDecl(TagModule, TermName("NatDigit"))
-    lazy val CArrayTagMethod   = getDecl(TagModule, TermName("CArray"))
+    lazy val NatDigitTagMethod =
+      getDecl(TagModule, TermName("materializeNatDigitTag"))
+    lazy val CArrayTagMethod =
+      getDecl(TagModule, TermName("materializeCArrayTag"))
     lazy val CStructTagMethod = (0 to 22).map { n =>
-      getDecl(TagModule, TermName("CStruct" + n))
+      getDecl(TagModule, TermName("materializeCStruct" + n + "Tag"))
     }
 
     // scala names

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -732,8 +732,6 @@ trait NirGenExpr { self: NirGenPhase =>
         genSynchronized(app)
       } else if (code == CCAST) {
         genCastOp(app)
-      } else if (code == SIZEOF || code == TYPEOF) {
-        genOfOp(app, code)
       } else if (code == STACKALLOC) {
         genStackalloc(app)
       } else if (code == CQUOTE) {
@@ -1265,18 +1263,6 @@ trait NirGenExpr { self: NirGenPhase =>
 
     def genCastOp(fromty: nir.Type, toty: nir.Type, value: Val): Val =
       castConv(fromty, toty).fold(value)(buf.conv(_, toty, value, unwind))
-
-    def genOfOp(app: Apply, code: Int): Val = {
-      val Apply(_, Seq(tagp)) = app
-
-      val st = unwrapTag(tagp)
-
-      code match {
-        case SIZEOF => buf.sizeof(genType(st, box = false), unwind)
-        case TYPEOF => genTypeValue(st)
-        case _      => util.unreachable
-      }
-    }
 
     def genStackalloc(app: Apply): Val = {
       val (sizeopt, tagp) = app match {

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -71,7 +71,7 @@ trait NirGenUtil { self: NirGenPhase =>
           case FloatTagMethod   => just(FloatClass)
           case DoubleTagMethod  => just(DoubleClass)
           case PtrTagMethod     => just(PtrClass)
-          case RefTagMethod     => just(unwrapClassTagOption(args.head).get)
+          case ClassTagMethod   => just(unwrapClassTagOption(args.head).get)
           case sym if NatBaseTagMethod.contains(sym) =>
             just(NatBaseClass(NatBaseTagMethod.indexOf(sym)))
           case NatDigitTagMethod =>

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirPrimitives.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirPrimitives.scala
@@ -19,9 +19,7 @@ object NirPrimitives {
   final val FUN_PTR_CALL = 1 + PTR_FIELD
   final val FUN_PTR_FROM = 1 + FUN_PTR_CALL
 
-  final val SIZEOF     = 1 + FUN_PTR_FROM
-  final val TYPEOF     = 1 + SIZEOF
-  final val CQUOTE     = 1 + TYPEOF
+  final val CQUOTE     = 1 + FUN_PTR_FROM
   final val CCAST      = 1 + CQUOTE
   final val STACKALLOC = 1 + CCAST
 
@@ -87,8 +85,6 @@ abstract class NirPrimitives {
     PtrFieldMethod.foreach(addPrimitive(_, PTR_FIELD))
     CFunctionPtrApply.foreach(addPrimitive(_, FUN_PTR_CALL))
     CFunctionPtrFrom.foreach(addPrimitive(_, FUN_PTR_FROM))
-    addPrimitive(SizeofMethod, SIZEOF)
-    addPrimitive(TypeofMethod, TYPEOF)
     addPrimitive(CQuoteMethod, CQUOTE)
     addPrimitive(CCastMethod, CCAST)
     StackallocMethods.foreach(addPrimitive(_, STACKALLOC))

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -761,6 +761,7 @@ object CodeGen {
           genType(ty)
           str(", ")
           genVal(n)
+          str(", align 8")
 
           newline()
           genBind()

--- a/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
@@ -1,17 +1,19 @@
 package scala.scalanative
 package codegen
 
+import scala.collection.mutable
 import scalanative.nir.Type.RefKind
 import scalanative.nir.{Type, Val}
 import scalanative.util.unsupported
 import scalanative.codegen.MemoryLayout.PositionedType
 
-final case class MemoryLayout(size: Long, tys: List[PositionedType]) {
+final case class MemoryLayout(size: Long,
+                              tys: Seq[MemoryLayout.PositionedType]) {
   lazy val offsetArray: Seq[Val] = {
     val ptrOffsets =
       tys.collect {
         // offset in words without rtti
-        case MemoryLayout.Tpe(_, offset, _: RefKind) =>
+        case MemoryLayout.PositionedType(_: RefKind, offset) =>
           Val.Long(offset / MemoryLayout.WORD_SIZE - 1)
       }
 
@@ -20,84 +22,58 @@ final case class MemoryLayout(size: Long, tys: List[PositionedType]) {
 }
 
 object MemoryLayout {
+  final val WORD_SIZE = 8
 
-  val WORD_SIZE = 8
-
-  sealed abstract class PositionedType {
-    def size: Long
-    def offset: Long
-  }
-  final case class Tpe(size: Long, offset: Long, ty: Type)
-      extends PositionedType
-  final case class Padding(size: Long, offset: Long) extends PositionedType
+  final case class PositionedType(ty: Type, offset: Long)
 
   def sizeOf(ty: Type): Long = ty match {
     case primitive: Type.PrimitiveKind =>
       math.max(primitive.width / WORD_SIZE, 1)
-    case Type.ArrayValue(arrTy, n) =>
-      sizeOf(arrTy) * n
+    case Type.ArrayValue(ty, n) =>
+      sizeOf(ty) * n
     case Type.StructValue(tys) =>
       MemoryLayout(tys).size
     case Type.Nothing | Type.Ptr | _: Type.RefKind =>
       8
     case _ =>
-      unsupported(s"sizeOf $ty")
+      unsupported(s"sizeof $ty")
+  }
+
+  def alignmentOf(ty: Type): Long = ty match {
+    case primitive: Type.PrimitiveKind =>
+      math.max(primitive.width / WORD_SIZE, 1)
+    case Type.ArrayValue(ty, n) =>
+      alignmentOf(ty)
+    case Type.StructValue(Seq()) =>
+      1
+    case Type.StructValue(tys) =>
+      tys.map(alignmentOf).max
+    case Type.Nothing | Type.Ptr | _: Type.RefKind =>
+      8
+    case _ =>
+      unsupported(s"alignment $ty")
+  }
+
+  def align(offset: Long, alignment: Long): Long = {
+    val alignmentMask = alignment - 1L
+    val padding =
+      if ((offset & alignmentMask) == 0L) 0L
+      else alignment - (offset & alignmentMask)
+    offset + padding
   }
 
   def apply(tys: Seq[Type]): MemoryLayout = {
-    val (size, potys) = impl(tys, 0)
+    val pos    = mutable.UnrolledBuffer.empty[PositionedType]
+    var offset = 0L
 
-    MemoryLayout(size, potys.reverse)
-  }
-
-  private def impl(tys: Seq[Type],
-                   offset: Long): (Long, List[PositionedType]) = {
-    if (tys.isEmpty) {
-      return (0, List())
+    tys.foreach { ty =>
+      offset = align(offset, alignmentOf(ty))
+      pos += PositionedType(ty, offset)
+      offset += sizeOf(ty)
     }
 
-    val sizes = tys.map(sizeOf)
+    val alignment = if (tys.isEmpty) 1 else tys.map(alignmentOf).max
 
-    def findMax(tys: Seq[Type]): Long = tys.foldLeft(0L) {
-      case (acc, Type.StructValue(innerTy)) =>
-        math.max(acc, findMax(innerTy))
-      case (acc, ty) => math.max(acc, sizeOf(ty))
-    }
-
-    val maxSize = findMax(tys)
-
-    val (size, positionedTypes) =
-      (tys zip sizes).foldLeft((offset, List[PositionedType]())) {
-        case ((index, potys), (ty, size)) if size > 0 =>
-          ty match {
-            case Type.StructValue(stys) =>
-              val innerAlignment = findMax(stys)
-              val pad =
-                if (index                    % innerAlignment == 0) 0
-                else innerAlignment - (index % innerAlignment)
-              val (innerSize, innerTys) = impl(stys, index + pad)
-
-              (index + pad + innerSize,
-               innerTys ::: Padding(pad, index) :: potys)
-
-            case _ =>
-              val pad = if (index % size == 0) 0 else size - (index % size)
-              (index + pad + size,
-               Tpe(size, index + pad, ty) :: Padding(pad, index) :: potys)
-
-          }
-        case ((index, potys), _) => (index, potys)
-
-      }
-
-    val finalPad = if (size % maxSize == 0) 0 else maxSize - (size % maxSize)
-    val potys =
-      if (finalPad > 0) {
-        Padding(finalPad, size) :: positionedTypes
-      } else {
-        positionedTypes
-      }
-
-    (potys.foldLeft(0L) { case (acc, poty) => acc + poty.size }, potys)
+    MemoryLayout(align(offset, alignment), pos)
   }
 }

--- a/unit-tests/src/test/scala/scala/scalanative/native/TagSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/native/TagSuite.scala
@@ -1,0 +1,204 @@
+package scala.scalanative.native
+
+object TagSuite extends tests.Suite {
+
+  test("tag size") {
+    assert(tagof[Ptr[_]].size == 8)
+    assert(tagof[Object].size == 8)
+    assert(tagof[Array[_]].size == 8)
+    assert(tagof[Unit].size == 8)
+    assert(tagof[Boolean].size == 1)
+    assert(tagof[Char].size == 2)
+    assert(tagof[Byte].size == 1)
+    assert(tagof[UByte].size == 1)
+    assert(tagof[Short].size == 2)
+    assert(tagof[UShort].size == 2)
+    assert(tagof[Int].size == 4)
+    assert(tagof[UInt].size == 4)
+    assert(tagof[Long].size == 8)
+    assert(tagof[ULong].size == 8)
+    assert(tagof[Float].size == 4)
+    assert(tagof[Double].size == 8)
+    assert(tagof[CArray[Int, Nat._0]].size == 0)
+    assert(tagof[CArray[Int, Nat._3]].size == 4 * 3)
+    assert(tagof[CArray[Int, Nat._9]].size == 4 * 9)
+    assert(tagof[CStruct0].size == 0)
+    assert(tagof[CStruct1[Int]].size == 4)
+    assert(tagof[CStruct2[Byte, Int]].size == 8)
+    assert(tagof[CStruct3[Byte, Byte, Int]].size == 8)
+  }
+
+  test("tag size should be consistent with sizeof") {
+    assert(tagof[Ptr[_]].size == sizeof[Ptr[_]])
+    assert(tagof[Object].size == sizeof[Object])
+    assert(tagof[Array[_]].size == sizeof[Array[_]])
+    assert(tagof[Unit].size == sizeof[Unit])
+    assert(tagof[Boolean].size == sizeof[Boolean])
+    assert(tagof[Char].size == sizeof[Char])
+    assert(tagof[Byte].size == sizeof[Byte])
+    assert(tagof[UByte].size == sizeof[UByte])
+    assert(tagof[Short].size == sizeof[Short])
+    assert(tagof[UShort].size == sizeof[UShort])
+    assert(tagof[Int].size == sizeof[Int])
+    assert(tagof[UInt].size == sizeof[UInt])
+    assert(tagof[Long].size == sizeof[Long])
+    assert(tagof[ULong].size == sizeof[ULong])
+    assert(tagof[Float].size == sizeof[Float])
+    assert(tagof[Double].size == sizeof[Double])
+    assert(tagof[CArray[Int, Nat._0]].size == sizeof[CArray[Int, Nat._0]])
+    assert(tagof[CArray[Int, Nat._3]].size == sizeof[CArray[Int, Nat._3]])
+    assert(tagof[CArray[Int, Nat._9]].size == sizeof[CArray[Int, Nat._9]])
+    assert(tagof[CStruct0].size == sizeof[CStruct0])
+    assert(tagof[CStruct1[Int]].size == sizeof[CStruct1[Int]])
+    assert(tagof[CStruct2[Byte, Int]].size == sizeof[CStruct2[Byte, Int]])
+    assert(
+      tagof[CStruct3[Byte, Byte, Int]].size == sizeof[CStruct3[Byte,
+                                                               Byte,
+                                                               Int]])
+  }
+
+  test("tag alignment") {
+    assert(tagof[Ptr[_]].alignment == 8)
+    assert(tagof[Object].alignment == 8)
+    assert(tagof[Array[_]].alignment == 8)
+    assert(tagof[Unit].alignment == 8)
+    assert(tagof[Boolean].alignment == 1)
+    assert(tagof[Char].alignment == 2)
+    assert(tagof[Byte].alignment == 1)
+    assert(tagof[UByte].alignment == 1)
+    assert(tagof[Short].alignment == 2)
+    assert(tagof[UShort].alignment == 2)
+    assert(tagof[Int].alignment == 4)
+    assert(tagof[UInt].alignment == 4)
+    assert(tagof[Long].alignment == 8)
+    assert(tagof[ULong].alignment == 8)
+    assert(tagof[Float].alignment == 4)
+    assert(tagof[Double].alignment == 8)
+    assert(tagof[CArray[Int, Nat._0]].alignment == 4)
+    assert(tagof[CArray[Int, Nat._3]].alignment == 4)
+    assert(tagof[CArray[Int, Nat._9]].alignment == 4)
+    assert(tagof[CStruct0].alignment == 1)
+    assert(tagof[CStruct1[Int]].alignment == 4)
+    assert(tagof[CStruct2[Byte, Int]].alignment == 4)
+    assert(tagof[CStruct3[Byte, Byte, Int]].alignment == 4)
+  }
+
+  test("tag alignment should be consistent with alignmentof") {
+    assert(tagof[Ptr[_]].alignment == alignmentof[Ptr[_]])
+    assert(tagof[Object].alignment == alignmentof[Object])
+    assert(tagof[Array[_]].alignment == alignmentof[Array[_]])
+    assert(tagof[Unit].alignment == alignmentof[Unit])
+    assert(tagof[Boolean].alignment == alignmentof[Boolean])
+    assert(tagof[Char].alignment == alignmentof[Char])
+    assert(tagof[Byte].alignment == alignmentof[Byte])
+    assert(tagof[UByte].alignment == alignmentof[UByte])
+    assert(tagof[Short].alignment == alignmentof[Short])
+    assert(tagof[UShort].alignment == alignmentof[UShort])
+    assert(tagof[Int].alignment == alignmentof[Int])
+    assert(tagof[UInt].alignment == alignmentof[UInt])
+    assert(tagof[Long].alignment == alignmentof[Long])
+    assert(tagof[ULong].alignment == alignmentof[ULong])
+    assert(tagof[Float].alignment == alignmentof[Float])
+    assert(tagof[Double].alignment == alignmentof[Double])
+    assert(
+      tagof[CArray[Int, Nat._0]].alignment == alignmentof[CArray[Int, Nat._0]])
+    assert(
+      tagof[CArray[Int, Nat._3]].alignment == alignmentof[CArray[Int, Nat._3]])
+    assert(
+      tagof[CArray[Int, Nat._9]].alignment == alignmentof[CArray[Int, Nat._9]])
+    assert(tagof[CStruct0].alignment == alignmentof[CStruct0])
+    assert(tagof[CStruct1[Int]].alignment == alignmentof[CStruct1[Int]])
+    assert(
+      tagof[CStruct2[Byte, Int]].alignment == alignmentof[CStruct2[Byte, Int]])
+    assert(
+      tagof[CStruct3[Byte, Byte, Int]].alignment == alignmentof[CStruct3[Byte,
+                                                                         Byte,
+                                                                         Int]])
+  }
+
+  test("tag offset") {
+    assert(tagof[CArray[Byte, Nat._0]].offset(0) == 0)
+    assert(tagof[CArray[Byte, Nat._0]].offset(1) == 1)
+    assert(tagof[CArray[Byte, Nat._0]].offset(42) == 42)
+    assert(tagof[CArray[Int, Nat._0]].offset(0) == 0)
+    assert(tagof[CArray[Int, Nat._0]].offset(1) == 4)
+    assert(tagof[CArray[Int, Nat._0]].offset(42) == 4 * 42)
+    assert(tagof[CStruct1[Int]].offset(0) == 0)
+    assert(tagof[CStruct2[Byte, Int]].offset(0) == 0)
+    assert(tagof[CStruct2[Byte, Int]].offset(1) == 4)
+    assert(tagof[CStruct3[Byte, Byte, Int]].offset(0) == 0)
+    assert(tagof[CStruct3[Byte, Byte, Int]].offset(1) == 1)
+    assert(tagof[CStruct3[Byte, Byte, Int]].offset(2) == 4)
+    assert(tagof[CStruct2[Byte, CStruct2[Byte, Int]]].offset(0) == 0)
+    assert(tagof[CStruct2[Byte, CStruct2[Byte, Int]]].offset(1) == 4)
+  }
+
+  type uint8_t  = UByte
+  type uint16_t = UShort
+  type uint32_t = UInt
+  type uint64_t = ULong
+
+  type iovec = CStruct2[Ptr[Byte], // iov_base
+                        CSize] // iov_len
+
+  type socklen_t   = CUnsignedInt
+  type sa_family_t = CUnsignedShort
+  type _14         = Nat.Digit[Nat._1, Nat._4]
+  type sockaddr =
+    CStruct2[sa_family_t, // sa_family
+             CArray[CChar, _14]] // sa_data, size = 14 in OS X and Linux
+  type sockaddr_storage = CStruct1[sa_family_t] // ss_family
+  type msghdr = CStruct7[Ptr[Byte], // msg_name
+                         socklen_t, // msg_namelen
+                         Ptr[iovec], // msg_iov
+                         CInt, // msg_iovlen
+                         Ptr[Byte], // msg_control
+                         socklen_t, // msg_crontrollen
+                         CInt] // msg_flags
+  type cmsghdr = CStruct3[socklen_t, // cmsg_len
+                          CInt, // cmsg_level
+                          CInt] // cmsg_type
+  type linger = CStruct2[CInt, // l_onoff
+                         CInt] // l_linger
+
+  type in_port_t = uint16_t
+  type in_addr_t = uint32_t
+  type _16       = Nat.Digit[Nat._1, Nat._6]
+
+  type in_addr = CStruct1[in_addr_t] // s_addr
+  type sockaddr_in = CStruct3[sa_family_t, // sin_family
+                              in_port_t, // sin_port
+                              in_addr] // sin_addr
+
+  type in6_addr = CStruct1[CArray[uint8_t, _16]] // s6_addr
+  type sockaddr_in6 = CStruct5[in6_addr, // sin6_addr
+                               sa_family_t, // sin6_family
+                               in_port_t, // sin6_port
+                               uint32_t, // sin6_flowinfo
+                               uint32_t] // sin6_scope_id
+
+  type ipv6_mreq = CStruct2[in6_addr, // ipv6mr_multiaddr
+                            CUnsignedInt] // ipv6mr_interface
+
+  test("socket size") {
+    assert(tagof[uint8_t].size == sizeof[uint8_t])
+    assert(tagof[uint16_t].size == sizeof[uint16_t])
+    assert(tagof[uint32_t].size == sizeof[uint32_t])
+    assert(tagof[uint64_t].size == sizeof[uint64_t])
+    assert(tagof[iovec].size == sizeof[iovec])
+    assert(tagof[socklen_t].size == sizeof[socklen_t])
+    assert(tagof[sa_family_t].size == sizeof[sa_family_t])
+    assert(tagof[sockaddr].size == sizeof[sockaddr])
+    assert(tagof[sockaddr_storage].size == sizeof[sockaddr_storage])
+    assert(tagof[msghdr].size == sizeof[msghdr])
+    assert(tagof[cmsghdr].size == sizeof[cmsghdr])
+    assert(tagof[linger].size == sizeof[linger])
+    assert(tagof[in_port_t].size == sizeof[in_port_t])
+    assert(tagof[in_addr_t].size == sizeof[in_addr_t])
+    assert(tagof[in_addr].size == sizeof[in_addr])
+    assert(tagof[sockaddr_in].size == sizeof[sockaddr_in])
+    assert(tagof[in6_addr].size == sizeof[in6_addr])
+    assert(tagof[sockaddr_in6].size == sizeof[sockaddr_in6])
+    assert(tagof[ipv6_mreq].size == sizeof[ipv6_mreq])
+  }
+}


### PR DESCRIPTION
Currently tags are special because they must be interpreted
at compile-time by the scalac plugin and it is undefined otherwise.
This change introduces first-class value equivalent for tags so
that operations that depend on tags can provide a generic implementation
based on it (this includes sizeof, typeof, pointer operations etc).