### PR TITLE
Don't publish docs and sources if SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,10 @@ lazy val mavenPublishSettings = Seq(
 lazy val publishSettings = Seq(
   publishArtifact in Compile := true,
   publishArtifact in Test := false,
+  publishArtifact in (Compile, packageDoc) :=
+    !version.value.contains("SNAPSHOT"),
+  publishArtifact in (Compile, packageSrc) :=
+    !version.value.contains("SNAPSHOT"),
   homepage := Some(url("http://www.scala-native.org")),
   startYear := Some(2015),
   licenses := Seq(


### PR DESCRIPTION
Publishing sources and docs is not required for local versions and slows
down the workflow cycle when doing `rebuild` or depending on `package`
in the compilation of certain Scala Native modules.

To speed up the `publishLocal`/`publish` workflow, we don't package
source and doc classifiers, meaning there will be no -src and -doc jars
published in the local repository if the version is a SNAPSHOT.