### PR TITLE
Fix regression due to new implemetation of sizeof

### DIFF
--- a/javalib/src/main/scala/java/lang/reflect/Array.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Array.scala
@@ -7,14 +7,22 @@ object Array {
   def newInstance(componentType: _Class[_], length: Int): AnyRef = {
     val rawty = componentType.rawty
 
-    if (rawty == typeof[PrimitiveBoolean]) new scala.Array[Boolean](length)
-    else if (rawty == typeof[PrimitiveChar]) new scala.Array[Char](length)
-    else if (rawty == typeof[PrimitiveByte]) new scala.Array[Byte](length)
-    else if (rawty == typeof[PrimitiveShort]) new scala.Array[Short](length)
-    else if (rawty == typeof[PrimitiveInt]) new scala.Array[Int](length)
-    else if (rawty == typeof[PrimitiveLong]) new scala.Array[Long](length)
-    else if (rawty == typeof[PrimitiveFloat]) new scala.Array[Float](length)
-    else if (rawty == typeof[PrimitiveDouble]) new scala.Array[Double](length)
+    if (rawty == getRawType(classOf[PrimitiveBoolean]))
+      new scala.Array[Boolean](length)
+    else if (rawty == getRawType(classOf[PrimitiveChar]))
+      new scala.Array[Char](length)
+    else if (rawty == getRawType(classOf[PrimitiveByte]))
+      new scala.Array[Byte](length)
+    else if (rawty == getRawType(classOf[PrimitiveShort]))
+      new scala.Array[Short](length)
+    else if (rawty == getRawType(classOf[PrimitiveInt]))
+      new scala.Array[Int](length)
+    else if (rawty == getRawType(classOf[PrimitiveLong]))
+      new scala.Array[Long](length)
+    else if (rawty == getRawType(classOf[PrimitiveFloat]))
+      new scala.Array[Float](length)
+    else if (rawty == getRawType(classOf[PrimitiveDouble]))
+      new scala.Array[Double](length)
     else new scala.Array[Object](length)
   }
 

--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -25,14 +25,14 @@ final class _Class[A](val rawty: RawPtr) {
     obj.asInstanceOf[A]
 
   def getComponentType(): _Class[_] = {
-    if (rawty == typeof[BooleanArray]) classOf[scala.Boolean]
-    else if (rawty == typeof[CharArray]) classOf[scala.Char]
-    else if (rawty == typeof[ByteArray]) classOf[scala.Byte]
-    else if (rawty == typeof[ShortArray]) classOf[scala.Short]
-    else if (rawty == typeof[IntArray]) classOf[scala.Int]
-    else if (rawty == typeof[LongArray]) classOf[scala.Long]
-    else if (rawty == typeof[FloatArray]) classOf[scala.Float]
-    else if (rawty == typeof[DoubleArray]) classOf[scala.Double]
+    if (rawty == toRawType(classOf[BooleanArray])) classOf[scala.Boolean]
+    else if (rawty == toRawType(classOf[CharArray])) classOf[scala.Char]
+    else if (rawty == toRawType(classOf[ByteArray])) classOf[scala.Byte]
+    else if (rawty == toRawType(classOf[ShortArray])) classOf[scala.Short]
+    else if (rawty == toRawType(classOf[IntArray])) classOf[scala.Int]
+    else if (rawty == toRawType(classOf[LongArray])) classOf[scala.Long]
+    else if (rawty == toRawType(classOf[FloatArray])) classOf[scala.Float]
+    else if (rawty == toRawType(classOf[DoubleArray])) classOf[scala.Double]
     else classOf[java.lang.Object]
   }
 
@@ -53,15 +53,15 @@ final class _Class[A](val rawty: RawPtr) {
     ???
 
   def isArray(): scala.Boolean =
-    (rawty == typeof[BooleanArray] ||
-      rawty == typeof[CharArray] ||
-      rawty == typeof[ByteArray] ||
-      rawty == typeof[ShortArray] ||
-      rawty == typeof[IntArray] ||
-      rawty == typeof[LongArray] ||
-      rawty == typeof[FloatArray] ||
-      rawty == typeof[DoubleArray] ||
-      rawty == typeof[ObjectArray])
+    (rawty == toRawType(classOf[BooleanArray]) ||
+      rawty == toRawType(classOf[CharArray]) ||
+      rawty == toRawType(classOf[ByteArray]) ||
+      rawty == toRawType(classOf[ShortArray]) ||
+      rawty == toRawType(classOf[IntArray]) ||
+      rawty == toRawType(classOf[LongArray]) ||
+      rawty == toRawType(classOf[FloatArray]) ||
+      rawty == toRawType(classOf[DoubleArray]) ||
+      rawty == toRawType(classOf[ObjectArray]))
 
   def isAssignableFrom(that: Class[_]): scala.Boolean =
     is(that.asInstanceOf[_Class[_]].ty, ty)
@@ -111,15 +111,15 @@ final class _Class[A](val rawty: RawPtr) {
     ty.kind == TRAIT_KIND
 
   def isPrimitive(): scala.Boolean =
-    (rawty == typeof[PrimitiveBoolean] ||
-      rawty == typeof[PrimitiveChar] ||
-      rawty == typeof[PrimitiveByte] ||
-      rawty == typeof[PrimitiveShort] ||
-      rawty == typeof[PrimitiveInt] ||
-      rawty == typeof[PrimitiveLong] ||
-      rawty == typeof[PrimitiveFloat] ||
-      rawty == typeof[PrimitiveDouble] ||
-      rawty == typeof[PrimitiveUnit])
+    (rawty == toRawType(classOf[PrimitiveBoolean]) ||
+      rawty == toRawType(classOf[PrimitiveChar]) ||
+      rawty == toRawType(classOf[PrimitiveByte]) ||
+      rawty == toRawType(classOf[PrimitiveShort]) ||
+      rawty == toRawType(classOf[PrimitiveInt]) ||
+      rawty == toRawType(classOf[PrimitiveLong]) ||
+      rawty == toRawType(classOf[PrimitiveFloat]) ||
+      rawty == toRawType(classOf[PrimitiveDouble]) ||
+      rawty == toRawType(classOf[PrimitiveUnit]))
 
   override def equals(other: Any): scala.Boolean =
     other match {

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -19,7 +19,7 @@ class _Object {
     getClass.getName + "@" + Integer.toHexString(hashCode)
 
   @inline def __getClass(): _Class[_] =
-    new _Class(runtime.getType(this))
+    new _Class(runtime.getRawType(this))
 
   @inline def __notify(): Unit =
     runtime.getMonitor(this)._notify
@@ -52,9 +52,9 @@ class _Object {
   }
 
   protected def __clone(): _Object = {
-    val ty    = runtime.getType(this)
-    val size  = loadLong(elemRawPtr(ty, sizeof[runtime.Type]))
-    val clone = runtime.GC.alloc(ty, size)
+    val rawty = runtime.getRawType(this)
+    val size  = loadLong(elemRawPtr(rawty, sizeof[runtime.Type]))
+    val clone = runtime.GC.alloc(rawty, size)
     val src   = castObjectToRawPtr(this)
     libc.memcpy(clone, src, size)
     castRawPtrToObject(clone).asInstanceOf[_Object]

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -6,6 +6,8 @@ import scalanative.native._
 import scalanative.runtime.Intrinsics._
 import scalanative.runtime.LLVMIntrinsics._
 
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 10)
+
 sealed abstract class Array[T]
     extends java.io.Serializable
     with java.lang.Cloneable {
@@ -37,8 +39,6 @@ sealed abstract class Array[T]
 }
 
 object Array {
-  final val HeaderSize = 16
-
   @noinline def throwIndexOutOfBoundsException(i: Int): Nothing =
     throw new IndexOutOfBoundsException(i.toString)
 
@@ -69,7 +69,7 @@ object Array {
            len: Int): Unit = {
     if (from == null || to == null) {
       throw new NullPointerException()
-    } else if (getType(from) != getType(to)) {
+    } else if (getRawType(from) != getRawType(to)) {
       throw new ArrayStoreException("Invalid array copy.")
     } else if (len < 0) {
       throw new IndexOutOfBoundsException("length is negative")
@@ -114,7 +114,7 @@ object Array {
               len: Int): Int = {
     if (left == null || right == null) {
       throw new NullPointerException()
-    } else if (getType(left) != getType(right)) {
+    } else if (getRawType(left) != getRawType(right)) {
       throw new ArrayStoreException("Invalid array copy.")
     } else if (len < 0) {
       throw new IndexOutOfBoundsException("length is negative")
@@ -132,166 +132,24 @@ object Array {
   }
 }
 
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 138)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 139)
 
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 140)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 141)
 
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 144)
-
-final class UnitArray private () extends Array[Unit] {
-  import Array._
-
-  @inline def stride: CSize =
-    sizeof[Unit]
-
-  @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, HeaderSize + stride * i)
-    }
-
-  @inline def apply(i: Int): Unit =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 168)
-      loadObject(ith).asInstanceOf[Unit]
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-    }
-
-  @inline def update(i: Int, value: Unit): Unit =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 181)
-      storeObject(ith, value.asInstanceOf[Object])
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 183)
-    }
-
-  @inline override def clone(): UnitArray = {
-    val arrinfo = typeof[UnitArray]
-    val arrsize = HeaderSize + sizeof[Unit] * length
-    val arr     = GC.alloc(arrinfo, arrsize)
-    val src     = castObjectToRawPtr(this)
-    libc.memcpy(arr, src, arrsize)
-    castRawPtrToObject(arr).asInstanceOf[UnitArray]
-  }
-}
-
-object UnitArray {
-  import Array._
-
-  @inline def alloc(length: Int): UnitArray = {
-    val arrinfo = typeof[UnitArray]
-    val arrsize = HeaderSize + sizeof[Unit] * length
-    val arr     = GC.alloc(arrinfo, arrsize)
-    storeInt(elemRawPtr(arr, 8), length)
-    storeInt(elemRawPtr(arr, 12), sizeof[Unit].toInt)
-    castRawPtrToObject(arr).asInstanceOf[UnitArray]
-  }
-
-  @inline def snapshot(length: Int, data: RawPtr): UnitArray = {
-    val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = castObjectToRawPtr(data)
-    val size = sizeof[Unit] * length
-    libc.memcpy(dst, src, size)
-    arr
-  }
-}
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 140)
-
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 144)
-
-final class BooleanArray private () extends Array[Boolean] {
-  import Array._
-
-  @inline def stride: CSize =
-    sizeof[Boolean]
-
-  @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, HeaderSize + stride * i)
-    }
-
-  @inline def apply(i: Int): Boolean =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 166)
-      loadBoolean(ith)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-    }
-
-  @inline def update(i: Int, value: Boolean): Unit =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 179)
-      storeBoolean(ith, value)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 183)
-    }
-
-  @inline override def clone(): BooleanArray = {
-    val arrinfo = typeof[BooleanArray]
-    val arrsize = HeaderSize + sizeof[Boolean] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    val src     = castObjectToRawPtr(this)
-    libc.memcpy(arr, src, arrsize)
-    castRawPtrToObject(arr).asInstanceOf[BooleanArray]
-  }
-}
-
-object BooleanArray {
-  import Array._
-
-  @inline def alloc(length: Int): BooleanArray = {
-    val arrinfo = typeof[BooleanArray]
-    val arrsize = HeaderSize + sizeof[Boolean] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    storeInt(elemRawPtr(arr, 8), length)
-    storeInt(elemRawPtr(arr, 12), sizeof[Boolean].toInt)
-    castRawPtrToObject(arr).asInstanceOf[BooleanArray]
-  }
-
-  @inline def snapshot(length: Int, data: RawPtr): BooleanArray = {
-    val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = castObjectToRawPtr(data)
-    val size = sizeof[Boolean] * length
-    libc.memcpy(dst, src, size)
-    arr
-  }
-}
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 140)
-
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 144)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 145)
 
 final class CharArray private () extends Array[Char] {
   import Array._
 
   @inline def stride: CSize =
-    sizeof[Char]
+    2
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
       throwIndexOutOfBoundsException(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, HeaderSize + stride * i)
+      elemRawPtr(rawptr, 16 + 2 * i)
     }
 
   @inline def apply(i: Int): Char =
@@ -299,10 +157,10 @@ final class CharArray private () extends Array[Char] {
       throwIndexOutOfBoundsException(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 166)
+      val ith    = elemRawPtr(rawptr, 16 + 2 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 167)
       loadChar(ith)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 171)
     }
 
   @inline def update(i: Int, value: Char): Unit =
@@ -310,16 +168,16 @@ final class CharArray private () extends Array[Char] {
       throwIndexOutOfBoundsException(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 179)
+      val ith    = elemRawPtr(rawptr, 16 + 2 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 180)
       storeChar(ith, value)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 183)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 184)
     }
 
   @inline override def clone(): CharArray = {
-    val arrinfo = typeof[CharArray]
-    val arrsize = HeaderSize + sizeof[Char] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
+    val arrty   = toRawType(classOf[CharArray])
+    val arrsize = 16 + 2 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[CharArray]
@@ -330,9 +188,9 @@ object CharArray {
   import Array._
 
   @inline def alloc(length: Int): CharArray = {
-    val arrinfo = typeof[CharArray]
-    val arrsize = HeaderSize + sizeof[Char] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
+    val arrty   = toRawType(classOf[CharArray])
+    val arrsize = 16 + 2 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), sizeof[Char].toInt)
     castRawPtrToObject(arr).asInstanceOf[CharArray]
@@ -341,454 +199,28 @@ object CharArray {
   @inline def snapshot(length: Int, data: RawPtr): CharArray = {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
-    val src  = castObjectToRawPtr(data)
+    val src  = data
     val size = sizeof[Char] * length
     libc.memcpy(dst, src, size)
     arr
   }
 }
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 140)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 141)
 
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 144)
-
-final class ByteArray private () extends Array[Byte] {
-  import Array._
-
-  @inline def stride: CSize =
-    sizeof[Byte]
-
-  @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, HeaderSize + stride * i)
-    }
-
-  @inline def apply(i: Int): Byte =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 166)
-      loadByte(ith)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-    }
-
-  @inline def update(i: Int, value: Byte): Unit =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 179)
-      storeByte(ith, value)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 183)
-    }
-
-  @inline override def clone(): ByteArray = {
-    val arrinfo = typeof[ByteArray]
-    val arrsize = HeaderSize + sizeof[Byte] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    val src     = castObjectToRawPtr(this)
-    libc.memcpy(arr, src, arrsize)
-    castRawPtrToObject(arr).asInstanceOf[ByteArray]
-  }
-}
-
-object ByteArray {
-  import Array._
-
-  @inline def alloc(length: Int): ByteArray = {
-    val arrinfo = typeof[ByteArray]
-    val arrsize = HeaderSize + sizeof[Byte] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    storeInt(elemRawPtr(arr, 8), length)
-    storeInt(elemRawPtr(arr, 12), sizeof[Byte].toInt)
-    castRawPtrToObject(arr).asInstanceOf[ByteArray]
-  }
-
-  @inline def snapshot(length: Int, data: RawPtr): ByteArray = {
-    val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = castObjectToRawPtr(data)
-    val size = sizeof[Byte] * length
-    libc.memcpy(dst, src, size)
-    arr
-  }
-}
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 140)
-
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 144)
-
-final class ShortArray private () extends Array[Short] {
-  import Array._
-
-  @inline def stride: CSize =
-    sizeof[Short]
-
-  @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, HeaderSize + stride * i)
-    }
-
-  @inline def apply(i: Int): Short =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 166)
-      loadShort(ith)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-    }
-
-  @inline def update(i: Int, value: Short): Unit =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 179)
-      storeShort(ith, value)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 183)
-    }
-
-  @inline override def clone(): ShortArray = {
-    val arrinfo = typeof[ShortArray]
-    val arrsize = HeaderSize + sizeof[Short] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    val src     = castObjectToRawPtr(this)
-    libc.memcpy(arr, src, arrsize)
-    castRawPtrToObject(arr).asInstanceOf[ShortArray]
-  }
-}
-
-object ShortArray {
-  import Array._
-
-  @inline def alloc(length: Int): ShortArray = {
-    val arrinfo = typeof[ShortArray]
-    val arrsize = HeaderSize + sizeof[Short] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    storeInt(elemRawPtr(arr, 8), length)
-    storeInt(elemRawPtr(arr, 12), sizeof[Short].toInt)
-    castRawPtrToObject(arr).asInstanceOf[ShortArray]
-  }
-
-  @inline def snapshot(length: Int, data: RawPtr): ShortArray = {
-    val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = castObjectToRawPtr(data)
-    val size = sizeof[Short] * length
-    libc.memcpy(dst, src, size)
-    arr
-  }
-}
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 140)
-
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 144)
-
-final class IntArray private () extends Array[Int] {
-  import Array._
-
-  @inline def stride: CSize =
-    sizeof[Int]
-
-  @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, HeaderSize + stride * i)
-    }
-
-  @inline def apply(i: Int): Int =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 166)
-      loadInt(ith)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-    }
-
-  @inline def update(i: Int, value: Int): Unit =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 179)
-      storeInt(ith, value)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 183)
-    }
-
-  @inline override def clone(): IntArray = {
-    val arrinfo = typeof[IntArray]
-    val arrsize = HeaderSize + sizeof[Int] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    val src     = castObjectToRawPtr(this)
-    libc.memcpy(arr, src, arrsize)
-    castRawPtrToObject(arr).asInstanceOf[IntArray]
-  }
-}
-
-object IntArray {
-  import Array._
-
-  @inline def alloc(length: Int): IntArray = {
-    val arrinfo = typeof[IntArray]
-    val arrsize = HeaderSize + sizeof[Int] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    storeInt(elemRawPtr(arr, 8), length)
-    storeInt(elemRawPtr(arr, 12), sizeof[Int].toInt)
-    castRawPtrToObject(arr).asInstanceOf[IntArray]
-  }
-
-  @inline def snapshot(length: Int, data: RawPtr): IntArray = {
-    val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = castObjectToRawPtr(data)
-    val size = sizeof[Int] * length
-    libc.memcpy(dst, src, size)
-    arr
-  }
-}
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 140)
-
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 144)
-
-final class LongArray private () extends Array[Long] {
-  import Array._
-
-  @inline def stride: CSize =
-    sizeof[Long]
-
-  @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, HeaderSize + stride * i)
-    }
-
-  @inline def apply(i: Int): Long =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 166)
-      loadLong(ith)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-    }
-
-  @inline def update(i: Int, value: Long): Unit =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 179)
-      storeLong(ith, value)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 183)
-    }
-
-  @inline override def clone(): LongArray = {
-    val arrinfo = typeof[LongArray]
-    val arrsize = HeaderSize + sizeof[Long] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    val src     = castObjectToRawPtr(this)
-    libc.memcpy(arr, src, arrsize)
-    castRawPtrToObject(arr).asInstanceOf[LongArray]
-  }
-}
-
-object LongArray {
-  import Array._
-
-  @inline def alloc(length: Int): LongArray = {
-    val arrinfo = typeof[LongArray]
-    val arrsize = HeaderSize + sizeof[Long] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    storeInt(elemRawPtr(arr, 8), length)
-    storeInt(elemRawPtr(arr, 12), sizeof[Long].toInt)
-    castRawPtrToObject(arr).asInstanceOf[LongArray]
-  }
-
-  @inline def snapshot(length: Int, data: RawPtr): LongArray = {
-    val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = castObjectToRawPtr(data)
-    val size = sizeof[Long] * length
-    libc.memcpy(dst, src, size)
-    arr
-  }
-}
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 140)
-
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 144)
-
-final class FloatArray private () extends Array[Float] {
-  import Array._
-
-  @inline def stride: CSize =
-    sizeof[Float]
-
-  @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, HeaderSize + stride * i)
-    }
-
-  @inline def apply(i: Int): Float =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 166)
-      loadFloat(ith)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-    }
-
-  @inline def update(i: Int, value: Float): Unit =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 179)
-      storeFloat(ith, value)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 183)
-    }
-
-  @inline override def clone(): FloatArray = {
-    val arrinfo = typeof[FloatArray]
-    val arrsize = HeaderSize + sizeof[Float] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    val src     = castObjectToRawPtr(this)
-    libc.memcpy(arr, src, arrsize)
-    castRawPtrToObject(arr).asInstanceOf[FloatArray]
-  }
-}
-
-object FloatArray {
-  import Array._
-
-  @inline def alloc(length: Int): FloatArray = {
-    val arrinfo = typeof[FloatArray]
-    val arrsize = HeaderSize + sizeof[Float] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    storeInt(elemRawPtr(arr, 8), length)
-    storeInt(elemRawPtr(arr, 12), sizeof[Float].toInt)
-    castRawPtrToObject(arr).asInstanceOf[FloatArray]
-  }
-
-  @inline def snapshot(length: Int, data: RawPtr): FloatArray = {
-    val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = castObjectToRawPtr(data)
-    val size = sizeof[Float] * length
-    libc.memcpy(dst, src, size)
-    arr
-  }
-}
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 140)
-
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 144)
-
-final class DoubleArray private () extends Array[Double] {
-  import Array._
-
-  @inline def stride: CSize =
-    sizeof[Double]
-
-  @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, HeaderSize + stride * i)
-    }
-
-  @inline def apply(i: Int): Double =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 166)
-      loadDouble(ith)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-    }
-
-  @inline def update(i: Int, value: Double): Unit =
-    if (i < 0 || i >= length) {
-      throwIndexOutOfBoundsException(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 179)
-      storeDouble(ith, value)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 183)
-    }
-
-  @inline override def clone(): DoubleArray = {
-    val arrinfo = typeof[DoubleArray]
-    val arrsize = HeaderSize + sizeof[Double] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    val src     = castObjectToRawPtr(this)
-    libc.memcpy(arr, src, arrsize)
-    castRawPtrToObject(arr).asInstanceOf[DoubleArray]
-  }
-}
-
-object DoubleArray {
-  import Array._
-
-  @inline def alloc(length: Int): DoubleArray = {
-    val arrinfo = typeof[DoubleArray]
-    val arrsize = HeaderSize + sizeof[Double] * length
-    val arr     = GC.alloc_atomic(arrinfo, arrsize)
-    storeInt(elemRawPtr(arr, 8), length)
-    storeInt(elemRawPtr(arr, 12), sizeof[Double].toInt)
-    castRawPtrToObject(arr).asInstanceOf[DoubleArray]
-  }
-
-  @inline def snapshot(length: Int, data: RawPtr): DoubleArray = {
-    val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = castObjectToRawPtr(data)
-    val size = sizeof[Double] * length
-    libc.memcpy(dst, src, size)
-    arr
-  }
-}
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 140)
-
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 144)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 145)
 
 final class ObjectArray private () extends Array[Object] {
   import Array._
 
   @inline def stride: CSize =
-    sizeof[Object]
+    8
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
       throwIndexOutOfBoundsException(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, HeaderSize + stride * i)
+      elemRawPtr(rawptr, 16 + 8 * i)
     }
 
   @inline def apply(i: Int): Object =
@@ -796,10 +228,10 @@ final class ObjectArray private () extends Array[Object] {
       throwIndexOutOfBoundsException(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 166)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 167)
       loadObject(ith)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 171)
     }
 
   @inline def update(i: Int, value: Object): Unit =
@@ -807,16 +239,16 @@ final class ObjectArray private () extends Array[Object] {
       throwIndexOutOfBoundsException(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 179)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 180)
       storeObject(ith, value)
-// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 183)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 184)
     }
 
   @inline override def clone(): ObjectArray = {
-    val arrinfo = typeof[ObjectArray]
-    val arrsize = HeaderSize + sizeof[Object] * length
-    val arr     = GC.alloc(arrinfo, arrsize)
+    val arrty   = toRawType(classOf[ObjectArray])
+    val arrsize = 16 + 8 * length
+    val arr     = GC.alloc(arrty, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[ObjectArray]
@@ -827,9 +259,9 @@ object ObjectArray {
   import Array._
 
   @inline def alloc(length: Int): ObjectArray = {
-    val arrinfo = typeof[ObjectArray]
-    val arrsize = HeaderSize + sizeof[Object] * length
-    val arr     = GC.alloc(arrinfo, arrsize)
+    val arrty   = toRawType(classOf[ObjectArray])
+    val arrsize = 16 + 8 * length
+    val arr     = GC.alloc(arrty, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), sizeof[Object].toInt)
     castRawPtrToObject(arr).asInstanceOf[ObjectArray]
@@ -838,8 +270,576 @@ object ObjectArray {
   @inline def snapshot(length: Int, data: RawPtr): ObjectArray = {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
-    val src  = castObjectToRawPtr(data)
+    val src  = data
     val size = sizeof[Object] * length
+    libc.memcpy(dst, src, size)
+    arr
+  }
+}
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 141)
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 145)
+
+final class BooleanArray private () extends Array[Boolean] {
+  import Array._
+
+  @inline def stride: CSize =
+    1
+
+  @inline def atRaw(i: Int): RawPtr =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      elemRawPtr(rawptr, 16 + 1 * i)
+    }
+
+  @inline def apply(i: Int): Boolean =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 1 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 167)
+      loadBoolean(ith)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 171)
+    }
+
+  @inline def update(i: Int, value: Boolean): Unit =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 1 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 180)
+      storeBoolean(ith, value)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 184)
+    }
+
+  @inline override def clone(): BooleanArray = {
+    val arrty   = toRawType(classOf[BooleanArray])
+    val arrsize = 16 + 1 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    val src     = castObjectToRawPtr(this)
+    libc.memcpy(arr, src, arrsize)
+    castRawPtrToObject(arr).asInstanceOf[BooleanArray]
+  }
+}
+
+object BooleanArray {
+  import Array._
+
+  @inline def alloc(length: Int): BooleanArray = {
+    val arrty   = toRawType(classOf[BooleanArray])
+    val arrsize = 16 + 1 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    storeInt(elemRawPtr(arr, 8), length)
+    storeInt(elemRawPtr(arr, 12), sizeof[Boolean].toInt)
+    castRawPtrToObject(arr).asInstanceOf[BooleanArray]
+  }
+
+  @inline def snapshot(length: Int, data: RawPtr): BooleanArray = {
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
+    val size = sizeof[Boolean] * length
+    libc.memcpy(dst, src, size)
+    arr
+  }
+}
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 141)
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 145)
+
+final class LongArray private () extends Array[Long] {
+  import Array._
+
+  @inline def stride: CSize =
+    8
+
+  @inline def atRaw(i: Int): RawPtr =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      elemRawPtr(rawptr, 16 + 8 * i)
+    }
+
+  @inline def apply(i: Int): Long =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 167)
+      loadLong(ith)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 171)
+    }
+
+  @inline def update(i: Int, value: Long): Unit =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 180)
+      storeLong(ith, value)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 184)
+    }
+
+  @inline override def clone(): LongArray = {
+    val arrty   = toRawType(classOf[LongArray])
+    val arrsize = 16 + 8 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    val src     = castObjectToRawPtr(this)
+    libc.memcpy(arr, src, arrsize)
+    castRawPtrToObject(arr).asInstanceOf[LongArray]
+  }
+}
+
+object LongArray {
+  import Array._
+
+  @inline def alloc(length: Int): LongArray = {
+    val arrty   = toRawType(classOf[LongArray])
+    val arrsize = 16 + 8 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    storeInt(elemRawPtr(arr, 8), length)
+    storeInt(elemRawPtr(arr, 12), sizeof[Long].toInt)
+    castRawPtrToObject(arr).asInstanceOf[LongArray]
+  }
+
+  @inline def snapshot(length: Int, data: RawPtr): LongArray = {
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
+    val size = sizeof[Long] * length
+    libc.memcpy(dst, src, size)
+    arr
+  }
+}
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 141)
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 145)
+
+final class ShortArray private () extends Array[Short] {
+  import Array._
+
+  @inline def stride: CSize =
+    2
+
+  @inline def atRaw(i: Int): RawPtr =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      elemRawPtr(rawptr, 16 + 2 * i)
+    }
+
+  @inline def apply(i: Int): Short =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 2 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 167)
+      loadShort(ith)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 171)
+    }
+
+  @inline def update(i: Int, value: Short): Unit =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 2 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 180)
+      storeShort(ith, value)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 184)
+    }
+
+  @inline override def clone(): ShortArray = {
+    val arrty   = toRawType(classOf[ShortArray])
+    val arrsize = 16 + 2 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    val src     = castObjectToRawPtr(this)
+    libc.memcpy(arr, src, arrsize)
+    castRawPtrToObject(arr).asInstanceOf[ShortArray]
+  }
+}
+
+object ShortArray {
+  import Array._
+
+  @inline def alloc(length: Int): ShortArray = {
+    val arrty   = toRawType(classOf[ShortArray])
+    val arrsize = 16 + 2 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    storeInt(elemRawPtr(arr, 8), length)
+    storeInt(elemRawPtr(arr, 12), sizeof[Short].toInt)
+    castRawPtrToObject(arr).asInstanceOf[ShortArray]
+  }
+
+  @inline def snapshot(length: Int, data: RawPtr): ShortArray = {
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
+    val size = sizeof[Short] * length
+    libc.memcpy(dst, src, size)
+    arr
+  }
+}
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 141)
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 145)
+
+final class IntArray private () extends Array[Int] {
+  import Array._
+
+  @inline def stride: CSize =
+    4
+
+  @inline def atRaw(i: Int): RawPtr =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      elemRawPtr(rawptr, 16 + 4 * i)
+    }
+
+  @inline def apply(i: Int): Int =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 4 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 167)
+      loadInt(ith)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 171)
+    }
+
+  @inline def update(i: Int, value: Int): Unit =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 4 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 180)
+      storeInt(ith, value)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 184)
+    }
+
+  @inline override def clone(): IntArray = {
+    val arrty   = toRawType(classOf[IntArray])
+    val arrsize = 16 + 4 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    val src     = castObjectToRawPtr(this)
+    libc.memcpy(arr, src, arrsize)
+    castRawPtrToObject(arr).asInstanceOf[IntArray]
+  }
+}
+
+object IntArray {
+  import Array._
+
+  @inline def alloc(length: Int): IntArray = {
+    val arrty   = toRawType(classOf[IntArray])
+    val arrsize = 16 + 4 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    storeInt(elemRawPtr(arr, 8), length)
+    storeInt(elemRawPtr(arr, 12), sizeof[Int].toInt)
+    castRawPtrToObject(arr).asInstanceOf[IntArray]
+  }
+
+  @inline def snapshot(length: Int, data: RawPtr): IntArray = {
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
+    val size = sizeof[Int] * length
+    libc.memcpy(dst, src, size)
+    arr
+  }
+}
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 141)
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 145)
+
+final class DoubleArray private () extends Array[Double] {
+  import Array._
+
+  @inline def stride: CSize =
+    8
+
+  @inline def atRaw(i: Int): RawPtr =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      elemRawPtr(rawptr, 16 + 8 * i)
+    }
+
+  @inline def apply(i: Int): Double =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 167)
+      loadDouble(ith)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 171)
+    }
+
+  @inline def update(i: Int, value: Double): Unit =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 180)
+      storeDouble(ith, value)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 184)
+    }
+
+  @inline override def clone(): DoubleArray = {
+    val arrty   = toRawType(classOf[DoubleArray])
+    val arrsize = 16 + 8 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    val src     = castObjectToRawPtr(this)
+    libc.memcpy(arr, src, arrsize)
+    castRawPtrToObject(arr).asInstanceOf[DoubleArray]
+  }
+}
+
+object DoubleArray {
+  import Array._
+
+  @inline def alloc(length: Int): DoubleArray = {
+    val arrty   = toRawType(classOf[DoubleArray])
+    val arrsize = 16 + 8 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    storeInt(elemRawPtr(arr, 8), length)
+    storeInt(elemRawPtr(arr, 12), sizeof[Double].toInt)
+    castRawPtrToObject(arr).asInstanceOf[DoubleArray]
+  }
+
+  @inline def snapshot(length: Int, data: RawPtr): DoubleArray = {
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
+    val size = sizeof[Double] * length
+    libc.memcpy(dst, src, size)
+    arr
+  }
+}
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 141)
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 145)
+
+final class ByteArray private () extends Array[Byte] {
+  import Array._
+
+  @inline def stride: CSize =
+    1
+
+  @inline def atRaw(i: Int): RawPtr =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      elemRawPtr(rawptr, 16 + 1 * i)
+    }
+
+  @inline def apply(i: Int): Byte =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 1 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 167)
+      loadByte(ith)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 171)
+    }
+
+  @inline def update(i: Int, value: Byte): Unit =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 1 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 180)
+      storeByte(ith, value)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 184)
+    }
+
+  @inline override def clone(): ByteArray = {
+    val arrty   = toRawType(classOf[ByteArray])
+    val arrsize = 16 + 1 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    val src     = castObjectToRawPtr(this)
+    libc.memcpy(arr, src, arrsize)
+    castRawPtrToObject(arr).asInstanceOf[ByteArray]
+  }
+}
+
+object ByteArray {
+  import Array._
+
+  @inline def alloc(length: Int): ByteArray = {
+    val arrty   = toRawType(classOf[ByteArray])
+    val arrsize = 16 + 1 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    storeInt(elemRawPtr(arr, 8), length)
+    storeInt(elemRawPtr(arr, 12), sizeof[Byte].toInt)
+    castRawPtrToObject(arr).asInstanceOf[ByteArray]
+  }
+
+  @inline def snapshot(length: Int, data: RawPtr): ByteArray = {
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
+    val size = sizeof[Byte] * length
+    libc.memcpy(dst, src, size)
+    arr
+  }
+}
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 141)
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 145)
+
+final class FloatArray private () extends Array[Float] {
+  import Array._
+
+  @inline def stride: CSize =
+    4
+
+  @inline def atRaw(i: Int): RawPtr =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      elemRawPtr(rawptr, 16 + 4 * i)
+    }
+
+  @inline def apply(i: Int): Float =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 4 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 167)
+      loadFloat(ith)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 171)
+    }
+
+  @inline def update(i: Int, value: Float): Unit =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 4 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 180)
+      storeFloat(ith, value)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 184)
+    }
+
+  @inline override def clone(): FloatArray = {
+    val arrty   = toRawType(classOf[FloatArray])
+    val arrsize = 16 + 4 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    val src     = castObjectToRawPtr(this)
+    libc.memcpy(arr, src, arrsize)
+    castRawPtrToObject(arr).asInstanceOf[FloatArray]
+  }
+}
+
+object FloatArray {
+  import Array._
+
+  @inline def alloc(length: Int): FloatArray = {
+    val arrty   = toRawType(classOf[FloatArray])
+    val arrsize = 16 + 4 * length
+    val arr     = GC.alloc_atomic(arrty, arrsize)
+    storeInt(elemRawPtr(arr, 8), length)
+    storeInt(elemRawPtr(arr, 12), sizeof[Float].toInt)
+    castRawPtrToObject(arr).asInstanceOf[FloatArray]
+  }
+
+  @inline def snapshot(length: Int, data: RawPtr): FloatArray = {
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
+    val size = sizeof[Float] * length
+    libc.memcpy(dst, src, size)
+    arr
+  }
+}
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 141)
+
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 145)
+
+final class UnitArray private () extends Array[Unit] {
+  import Array._
+
+  @inline def stride: CSize =
+    8
+
+  @inline def atRaw(i: Int): RawPtr =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      elemRawPtr(rawptr, 16 + 8 * i)
+    }
+
+  @inline def apply(i: Int): Unit =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 169)
+      loadObject(ith).asInstanceOf[Unit]
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 171)
+    }
+
+  @inline def update(i: Int, value: Unit): Unit =
+    if (i < 0 || i >= length) {
+      throwIndexOutOfBoundsException(i)
+    } else {
+      val rawptr = castObjectToRawPtr(this)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 182)
+      storeObject(ith, value.asInstanceOf[Object])
+// ###sourceLocation(file: "/home/denys/.src/native/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 184)
+    }
+
+  @inline override def clone(): UnitArray = {
+    val arrty   = toRawType(classOf[UnitArray])
+    val arrsize = 16 + 8 * length
+    val arr     = GC.alloc(arrty, arrsize)
+    val src     = castObjectToRawPtr(this)
+    libc.memcpy(arr, src, arrsize)
+    castRawPtrToObject(arr).asInstanceOf[UnitArray]
+  }
+}
+
+object UnitArray {
+  import Array._
+
+  @inline def alloc(length: Int): UnitArray = {
+    val arrty   = toRawType(classOf[UnitArray])
+    val arrsize = 16 + 8 * length
+    val arr     = GC.alloc(arrty, arrsize)
+    storeInt(elemRawPtr(arr, 8), length)
+    storeInt(elemRawPtr(arr, 12), sizeof[Unit].toInt)
+    castRawPtrToObject(arr).asInstanceOf[UnitArray]
+  }
+
+  @inline def snapshot(length: Int, data: RawPtr): UnitArray = {
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
+    val size = sizeof[Unit] * length
     libc.memcpy(dst, src, size)
     arr
   }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -5,6 +5,9 @@ import scalanative.native._
 import scalanative.runtime.Intrinsics._
 import scalanative.runtime.LLVMIntrinsics._
 
+% sizePtr = 8
+% sizeHeader = 16
+
 sealed abstract class Array[T]
     extends java.io.Serializable
     with java.lang.Cloneable {
@@ -36,8 +39,6 @@ sealed abstract class Array[T]
 }
 
 object Array {
-  final val HeaderSize = 16
-
   @noinline def throwIndexOutOfBoundsException(i: Int): Nothing =
     throw new IndexOutOfBoundsException(i.toString)
 
@@ -68,7 +69,7 @@ object Array {
            len: Int): Unit = {
     if (from == null || to == null) {
       throw new NullPointerException()
-    } else if (getType(from) != getType(to)) {
+    } else if (getRawType(from) != getRawType(to)) {
       throw new ArrayStoreException("Invalid array copy.")
     } else if (len < 0) {
       throw new IndexOutOfBoundsException("length is negative")
@@ -113,7 +114,7 @@ object Array {
               len: Int): Int = {
     if (left == null || right == null) {
       throw new NullPointerException()
-    } else if (getType(left) != getType(right)) {
+    } else if (getRawType(left) != getRawType(right)) {
       throw new ArrayStoreException("Invalid array copy.")
     } else if (len < 0) {
       throw new IndexOutOfBoundsException("length is negative")
@@ -132,11 +133,11 @@ object Array {
 }
 
 %{
-   types = ['Unit', 'Boolean', 'Char', 'Byte', 'Short',
-            'Int', 'Long', 'Float', 'Double', 'Object']
+   types = {'Unit': sizePtr, 'Boolean': 1, 'Char': 2, 'Byte': 1, 'Short': 2,
+            'Int': 4, 'Long': 8, 'Float': 4, 'Double': 8, 'Object': sizePtr}
 }%
 
-% for T in types:
+% for T, sizeT in types.iteritems():
 
 %{
    alloc = 'GC.alloc_atomic' if T != 'Object' and T != 'Unit' else 'GC.alloc'
@@ -146,14 +147,14 @@ final class ${T}Array private () extends Array[${T}] {
   import Array._
 
   @inline def stride: CSize =
-    sizeof[${T}]
+    ${sizeT}
 
   @inline def atRaw(i: Int): RawPtr =
     if (i < 0 || i >= length) {
       throwIndexOutOfBoundsException(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, HeaderSize + stride * i)
+      elemRawPtr(rawptr, ${sizeHeader} + ${sizeT} * i)
     }
 
   @inline def apply(i: Int): ${T} =
@@ -161,7 +162,7 @@ final class ${T}Array private () extends Array[${T}] {
       throwIndexOutOfBoundsException(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
+      val ith    = elemRawPtr(rawptr, ${sizeHeader} + ${sizeT} * i)
       % if T != 'Unit':
       load${T}(ith)
       % else:
@@ -174,7 +175,7 @@ final class ${T}Array private () extends Array[${T}] {
       throwIndexOutOfBoundsException(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, HeaderSize + stride * i)
+      val ith    = elemRawPtr(rawptr, ${sizeHeader} + ${sizeT} * i)
       % if T != 'Unit':
       store${T}(ith, value)
       % else:
@@ -183,9 +184,9 @@ final class ${T}Array private () extends Array[${T}] {
     }
 
   @inline override def clone(): ${T}Array = {
-    val arrinfo = typeof[${T}Array]
-    val arrsize = HeaderSize + sizeof[${T}] * length
-    val arr     = ${alloc}(arrinfo, arrsize)
+    val arrty   = toRawType(classOf[${T}Array])
+    val arrsize = ${sizeHeader} + ${sizeT} * length
+    val arr     = ${alloc}(arrty, arrsize)
     val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[${T}Array]
@@ -196,9 +197,9 @@ object ${T}Array {
   import Array._
 
   @inline def alloc(length: Int): ${T}Array = {
-    val arrinfo = typeof[${T}Array]
-    val arrsize = HeaderSize + sizeof[${T}] * length
-    val arr     = ${alloc}(arrinfo, arrsize)
+    val arrty   = toRawType(classOf[${T}Array])
+    val arrsize = ${sizeHeader} + ${sizeT} * length
+    val arr     = ${alloc}(arrty, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), sizeof[${T}].toInt)
     castRawPtrToObject(arr).asInstanceOf[${T}Array]
@@ -207,7 +208,7 @@ object ${T}Array {
   @inline def snapshot(length: Int, data: RawPtr): ${T}Array = {
     val arr  = alloc(length)
     val dst  = arr.atRaw(0)
-    val src  = castObjectToRawPtr(data)
+    val src  = data
     val size = sizeof[${T}] * length
     libc.memcpy(dst, src, size)
     arr

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -11,9 +11,9 @@ import native._
 @extern
 object GC {
   @name("scalanative_alloc")
-  def alloc(info: RawPtr, size: CSize): RawPtr = extern
+  def alloc(rawty: RawPtr, size: CSize): RawPtr = extern
   @name("scalanative_alloc_atomic")
-  def alloc_atomic(info: RawPtr, size: CSize): RawPtr = extern
+  def alloc_atomic(rawty: RawPtr, size: CSize): RawPtr = extern
   @name("scalanative_collect")
   def collect(): Unit = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -35,18 +35,17 @@ package object runtime {
   /** Used as a stub right hand of intrinsified methods. */
   def intrinsic: Nothing = throwUndefined()
 
-  /** Returns info pointer for given type. */
-  def typeof[T](implicit ct: scala.reflect.ClassTag[T]): RawPtr =
-    ct.runtimeClass.asInstanceOf[java.lang._Class[_]].rawty
+  @inline def toRawType(cls: Class[_]): RawPtr =
+    cls.asInstanceOf[java.lang._Class[_]].rawty
 
   /** Read type information of given object. */
-  def getType(obj: Object): RawPtr = {
+  @inline def getRawType(obj: Object): RawPtr = {
     val rawptr = Intrinsics.castObjectToRawPtr(obj)
     Intrinsics.loadRawPtr(rawptr)
   }
 
   /** Get monitor for given object. */
-  def getMonitor(obj: Object): Monitor = Monitor.dummy
+  @inline def getMonitor(obj: Object): Monitor = Monitor.dummy
 
   /** Initialize runtime with given arguments and return the
    *  rest as Java-style array.

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -71,7 +71,7 @@ object Build {
       s"Discovered ${classCount} classes and ${methodCount} methods")
 
     val optimized = ScalaNative.optimize(config, linked)
-    nir.Show.dump(linked.defns, "optimized.hnir")
+    nir.Show.dump(optimized.defns, "optimized.hnir")
     ScalaNative.check(config, optimized)
 
     IO.getAll(config.workdir, "glob:**.ll").foreach(Files.delete)


### PR DESCRIPTION
In #1424, we unintrinsified sizeof and typeof,
now they are implemented as regular library code.
This regressed some benchmarks due to them not
being perfectly optimized away in some cases.
To fix this we avoid using sizeof in the Arrays
implementation and change typeof to not use ClassTag
but rather use java.lang.Class directly.