### PR TITLE
Elide null checks for non-nullable values

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -225,6 +225,30 @@ trait Eval { self: Interflow =>
             Val.True
           case (Comp.Ine, l, Val.Virtual(addr)) if !r.isCanonical =>
             Val.True
+          case (Comp.Ieq, v @ Of(ty: Type.RefKind), Val.Null)
+              if !ty.isNullable =>
+            Val.False
+          case (Comp.Ieq, Val.Null, v @ Of(ty: Type.RefKind))
+              if !ty.isNullable =>
+            Val.False
+          case (Comp.Ine, v @ Of(ty: Type.RefKind), Val.Null)
+              if !ty.isNullable =>
+            Val.True
+          case (Comp.Ine, Val.Null, v @ Of(ty: Type.RefKind))
+              if !ty.isNullable =>
+            Val.True
+          case (Comp.Ieq,
+                l @ Of2(lty: Type.RefKind, ClassRef(lcls)),
+                r @ Of2(rty: Type.RefKind, ClassRef(rcls)))
+              if !lty.isNullable && lty.isExact && lcls.isModule
+                && !rty.isNullable && rty.isExact && rcls.isModule =>
+            Val.Bool(lcls.name == rcls.name)
+          case (Comp.Ine,
+                l @ Of2(lty: Type.RefKind, ClassRef(lcls)),
+                r @ Of2(rty: Type.RefKind, ClassRef(rcls)))
+              if !lty.isNullable && lty.isExact && lcls.isModule
+                && !rty.isNullable && rty.isExact && rcls.isModule =>
+            Val.Bool(lcls.name != rcls.name)
           case (_, l, r) =>
             emit.comp(comp, ty, materialize(l), materialize(r), unwind)
         }

--- a/tools/src/main/scala/scala/scalanative/interflow/Of.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Of.scala
@@ -1,0 +1,14 @@
+package scala.scalanative
+package interflow
+
+import scalanative.nir._
+
+object Of {
+  def unapply(value: Val): Some[Type] =
+    Some(value.ty)
+}
+
+object Of2 {
+  def unapply(value: Val): Some[(Type, Type)] =
+    Some((value.ty, value.ty))
+}

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -14,7 +14,7 @@ sealed abstract class ScopeInfo extends Info {
   val calls   = mutable.Set.empty[Sig]
 
   def isClass: Boolean = this.isInstanceOf[Class]
-  def isTrait: Boolean = this.isInstanceOf[Class]
+  def isTrait: Boolean = this.isInstanceOf[Trait]
   def is(info: ScopeInfo): Boolean
   def targets(sig: Sig): mutable.Set[Global]
   def implementors: mutable.Set[Class]
@@ -206,6 +206,7 @@ final class Result(val infos: mutable.Map[Global, Info],
                    val defns: Seq[Defn],
                    val dynsigs: Seq[Sig],
                    val dynimpls: Seq[Global]) {
+  lazy val ObjectClass       = infos(Rt.Object.name).asInstanceOf[Class]
   lazy val StringClass       = infos(Rt.StringName).asInstanceOf[Class]
   lazy val StringValueField  = infos(Rt.StringValueName).asInstanceOf[Field]
   lazy val StringOffsetField = infos(Rt.StringOffsetName).asInstanceOf[Field]


### PR DESCRIPTION
This PR uses Interflow's nullability information to elide null checks.
Previously we would unconditionally check if an object is null for
any object or array access. 