### PR TITLE
Interflow: code motion

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -54,10 +54,14 @@ sealed abstract class Op {
     case _: Op.Elem | _: Op.Extract | _: Op.Insert | _: Op.Comp | _: Op.Conv |
         _: Op.Is | _: Op.Copy | _: Op.Sizeof =>
       true
-    // Division and modulo on integers are not pure as
-    // they may throw if the divisor is zero.
-    case Op.Bin(Bin.Sdiv | Bin.Udiv | Bin.Srem | Bin.Urem, _: Type.I, _, _) =>
-      false
+    // Division and modulo on integers is only pure if
+    // divisor is a canonical non-zero value.
+    case Op.Bin(Bin.Sdiv | Bin.Udiv | Bin.Srem | Bin.Urem, _: Type.I, _, div) =>
+      if (div.isCanonical && !div.isZero) {
+        true
+      } else {
+        false
+      }
     case _: Op.Bin =>
       true
     case _ =>

--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -27,15 +27,17 @@ sealed abstract class Op {
     case Op.Is(_, _)                => Type.Bool
     case Op.Copy(v)                 => v.ty
     case Op.Sizeof(_)               => Type.Long
-    case Op.Box(ty, _)              => ty
-    case Op.Unbox(ty, _)            => Type.unbox(ty)
-    case Op.Var(ty)                 => Type.Var(ty)
-    case Op.Varload(slot)           => val Type.Var(ty) = slot.ty; ty
-    case Op.Varstore(slot, _)       => Type.Unit
-    case Op.Arrayalloc(ty, _)       => Type.Array(ty, nullable = false)
-    case Op.Arrayload(ty, _, _)     => ty
-    case Op.Arraystore(_, _, _, _)  => Type.Unit
-    case Op.Arraylength(_)          => Type.Int
+    case Op.Box(refty: Type.RefKind, _) =>
+      Type.Ref(refty.className, exact = true, nullable = false)
+    case Op.Unbox(ty, _)      => Type.unbox(ty)
+    case Op.Var(ty)           => Type.Var(ty)
+    case Op.Varload(slot)     => val Type.Var(ty) = slot.ty; ty
+    case Op.Varstore(slot, _) => Type.Unit
+    case Op.Arrayalloc(ty, _) =>
+      Type.Ref(Type.toArrayClass(ty), exact = true, nullable = false)
+    case Op.Arrayload(ty, _, _)    => ty
+    case Op.Arraystore(_, _, _, _) => Type.Unit
+    case Op.Arraylength(_)         => Type.Int
   }
 
   final def show: String = nir.Show(this)

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -50,9 +50,9 @@ sealed abstract class Val {
       false
   }
 
-  final def isDefault: Boolean = this match {
-    case Val.False      => true
+  final def isZero: Boolean = this match {
     case Val.Zero(_)    => true
+    case Val.False      => true
     case Val.Char('\0') => true
     case Val.Byte(0)    => true
     case Val.Short(0)   => true

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -23,9 +23,10 @@ sealed abstract class Val {
     case Val.Local(_, ty)         => ty
     case Val.Global(_, ty)        => ty
 
-    case Val.Unit       => Type.Unit
-    case Val.Const(_)   => Type.Ptr
-    case Val.String(_)  => Rt.String
+    case Val.Unit     => Type.Unit
+    case Val.Const(_) => Type.Ptr
+    case Val.String(_) =>
+      Type.Ref(Rt.String.name, exact = true, nullable = false)
     case Val.Virtual(_) => Type.Virtual
   }
 

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -122,8 +122,8 @@ trait Eval { self: Interflow =>
           case emeth =>
             val eargs = args.map(eval)
             val argtys = eargs.map {
-              case Val.Virtual(addr) =>
-                state.deref(addr).cls.ty
+              case InstanceRef(refty: Type.RefKind) =>
+                Type.Ref(refty.className)
               case value =>
                 value.ty
             }

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -363,7 +363,11 @@ trait Eval { self: Interflow =>
         val canDelay =
           emptyCtor || isWhitelisted
 
-        emit.module(clsName, unwind)
+        if (canDelay) {
+          Val.Virtual(delay(Op.Module(clsName)))
+        } else {
+          emit.module(clsName, unwind)
+        }
       case Op.As(ty, rawObj) =>
         val refty = ty match {
           case ty: Type.RefKind => ty

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -192,17 +192,11 @@ trait Eval { self: Interflow =>
       case Op.Store(ty, ptr, value) =>
         emit.store(ty, materialize(eval(ptr)), materialize(eval(value)), unwind)
       case Op.Elem(ty, ptr, indexes) =>
-        emit.elem(ty,
-                  materialize(eval(ptr)),
-                  indexes.map(i => materialize(eval(i))),
-                  unwind)
+        Val.Virtual(delay(Op.Elem(ty, eval(ptr), indexes.map(eval))))
       case Op.Extract(aggr, indexes) =>
-        emit.extract(materialize(eval(aggr)), indexes, unwind)
+        Val.Virtual(delay(Op.Extract(eval(aggr), indexes)))
       case Op.Insert(aggr, value, indexes) =>
-        emit.insert(materialize(eval(aggr)),
-                    materialize(eval(value)),
-                    indexes,
-                    unwind)
+        Val.Virtual(delay(Op.Insert(eval(aggr), eval(value), indexes)))
       case Op.Stackalloc(ty, n) =>
         emit.stackalloc(ty, materialize(eval(n)), unwind)
       case op @ Op.Bin(bin, ty, l, r) =>

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -269,7 +269,7 @@ trait Eval { self: Interflow =>
             Val.Bool(lcls.name != rcls.name)
 
           case (_, l, r) =>
-            emit.comp(comp, ty, materialize(l), materialize(r), unwind)
+            Val.Virtual(delay(Op.Comp(comp, ty, l, r)))
         }
       case Op.Conv(conv, ty, value) =>
         eval(value) match {
@@ -391,9 +391,9 @@ trait Eval { self: Interflow =>
         }
         val obj = eval(rawObj)
         def fallback =
-          emit.is(refty, materialize(obj), unwind)
+          Val.Virtual(delay(Op.Is(refty, obj)))
         def objNotNull =
-          emit.comp(Comp.Ine, Rt.Object, materialize(obj), Val.Null, unwind)
+          Val.Virtual(delay(Op.Comp(Comp.Ine, Rt.Object, obj, Val.Null)))
         val objty = obj match {
           case InstanceRef(ty) =>
             ty

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -276,17 +276,15 @@ trait Eval { self: Interflow =>
         Val.Virtual(state.allocClass(cls))
       case Op.Fieldload(ty, obj, name @ FieldRef(cls, fld)) =>
         eval(obj) match {
-          case Val.Virtual(addr) =>
-            val instance = state.derefVirtual(addr)
-            instance.values(fld.index)
+          case VirtualRef(_, _, values) =>
+            values(fld.index)
           case obj =>
             emit.fieldload(ty, materialize(obj), name, unwind)
         }
       case Op.Fieldstore(ty, obj, name @ FieldRef(cls, fld), value) =>
         eval(obj) match {
-          case Val.Virtual(addr) =>
-            val instance = state.derefVirtual(addr)
-            instance.values(fld.index) = eval(value)
+          case VirtualRef(_, _, values) =>
+            values(fld.index) = eval(value)
             Val.Unit
           case obj =>
             emit.fieldstore(ty,

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -170,7 +170,7 @@ trait Eval { self: Interflow =>
                   margs.zip(sigtys).map {
                     case (marg, ty) =>
                       if (!Sub.is(marg.ty, ty)) {
-                        emit.conv(Conv.Bitcast, ty, marg, unwind)
+                        Val.Virtual(delay(Op.Conv(Conv.Bitcast, ty, marg)))
                       } else {
                         marg
                       }
@@ -276,7 +276,7 @@ trait Eval { self: Interflow =>
           case value if value.isCanonical =>
             eval(conv, ty, value)
           case value =>
-            emit.conv(conv, ty, materialize(value), unwind)
+            Val.Virtual(delay(Op.Conv(conv, ty, value)))
         }
       case Op.Classalloc(ClassRef(cls)) =>
         Val.Virtual(state.allocClass(cls))

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -205,10 +205,12 @@ trait Eval { self: Interflow =>
                     unwind)
       case Op.Stackalloc(ty, n) =>
         emit.stackalloc(ty, materialize(eval(n)), unwind)
-      case Op.Bin(bin, ty, l, r) =>
+      case op @ Op.Bin(bin, ty, l, r) =>
         (eval(l), eval(r)) match {
           case (l, r) if l.isCanonical && r.isCanonical =>
             eval(bin, ty, l, r, unwind)
+          case (l, r) if op.isPure =>
+            Val.Virtual(delay(Op.Bin(bin, ty, l, r)))
           case (l, r) =>
             emit.bin(bin, ty, materialize(l), materialize(r), unwind)
         }

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -215,21 +215,23 @@ trait Eval { self: Interflow =>
 
           // Two virtual allocations will compare equal if
           // and only if they have the same virtual address.
-          case (Comp.Ieq, Val.Virtual(l), Val.Virtual(r)) =>
+          case (Comp.Ieq, Val.Virtual(l), Val.Virtual(r))
+              if state.isVirtual(l) && state.isVirtual(r) =>
             Val.Bool(l == r)
-          case (Comp.Ine, Val.Virtual(l), Val.Virtual(r)) =>
+          case (Comp.Ine, Val.Virtual(l), Val.Virtual(r))
+              if state.isVirtual(l) && state.isVirtual(r) =>
             Val.Bool(l != r)
 
           // Not-yet-materialized virtual allocation will never be
           // the same as already existing allocation (be it null
           // or any other value).
-          case (Comp.Ieq, Val.Virtual(addr), r) =>
+          case (Comp.Ieq, Val.Virtual(addr), r) if state.isVirtual(addr) =>
             Val.False
-          case (Comp.Ieq, l, Val.Virtual(addr)) =>
+          case (Comp.Ieq, l, Val.Virtual(addr)) if state.isVirtual(addr) =>
             Val.False
-          case (Comp.Ine, Val.Virtual(addr), r) =>
+          case (Comp.Ine, Val.Virtual(addr), r) if state.isVirtual(addr) =>
             Val.True
-          case (Comp.Ine, l, Val.Virtual(addr)) =>
+          case (Comp.Ine, l, Val.Virtual(addr)) if state.isVirtual(addr) =>
             Val.True
 
           // Comparing non-nullable value with null will always

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -881,7 +881,7 @@ trait Eval { self: Interflow =>
           case value =>
             value
         }
-      case Val.Virtual(addr) if state.escaped(addr) =>
+      case Val.Virtual(addr) if state.hasEscaped(addr) =>
         state.derefEscaped(addr).escapedValue
       case Val.String(value) =>
         Val.Virtual(state.allocString(value))

--- a/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Instance.scala
@@ -9,6 +9,8 @@ sealed abstract class Instance extends Cloneable {
   def ty: Type = this match {
     case EscapedInstance(value) =>
       value.ty
+    case DelayedInstance(op) =>
+      op.resty
     case VirtualInstance(_, cls, _) =>
       Type.Ref(cls.name, exact = true, nullable = false)
   }
@@ -16,6 +18,8 @@ sealed abstract class Instance extends Cloneable {
   override def clone(): Instance = this match {
     case EscapedInstance(value) =>
       EscapedInstance(value)
+    case DelayedInstance(op) =>
+      DelayedInstance(op)
     case VirtualInstance(kind, cls, values) =>
       VirtualInstance(kind, cls, values.clone())
   }
@@ -23,12 +27,16 @@ sealed abstract class Instance extends Cloneable {
   override def toString: String = this match {
     case EscapedInstance(value) =>
       s"EscapedInstance(${value.show})"
+    case DelayedInstance(op) =>
+      s"DelayedInstance(${op.show})"
     case VirtualInstance(kind, cls, values) =>
       s"VirtualInstance($kind, ${cls.name.show}, Array(${values.map(_.show)}))"
   }
 }
 
 final case class EscapedInstance(val escapedValue: Val) extends Instance
+
+final case class DelayedInstance(val delayedOp: Op) extends Instance
 
 final case class VirtualInstance(val kind: Kind,
                                  val cls: Class,

--- a/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
@@ -9,8 +9,7 @@ object InstanceRef {
     unapply(Val.Virtual(addr))
   def unapply(value: Val)(implicit state: State): Option[Type] = value match {
     case Val.Virtual(addr) =>
-      val cls = state.deref(addr).cls
-      Some(Type.Ref(cls.name, exact = true, nullable = false))
+      Some(state.deref(addr).ty)
     case _ =>
       None
   }
@@ -40,7 +39,7 @@ object EscapedRef {
   def unapply(value: Val)(implicit state: State): Option[Val] = value match {
     case Val.Virtual(addr) =>
       state.deref(addr) match {
-        case EscapedInstance(_, value) =>
+        case EscapedInstance(value) =>
           Some(value)
         case _ =>
           None

--- a/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
@@ -1,0 +1,51 @@
+package scala.scalanative
+package interflow
+
+import scalanative.nir.{Type, Val}
+import scalanative.linker.Class
+
+object InstanceRef {
+  def unapply(addr: Addr)(implicit state: State): Option[Type] =
+    unapply(Val.Virtual(addr))
+  def unapply(value: Val)(implicit state: State): Option[Type] = value match {
+    case Val.Virtual(addr) =>
+      val cls = state.deref(addr).cls
+      Some(Type.Ref(cls.name, exact = true, nullable = false))
+    case _ =>
+      None
+  }
+}
+
+object VirtualRef {
+  def unapply(addr: Addr)(
+      implicit state: State): Option[(Kind, Class, Array[Val])] =
+    unapply(Val.Virtual(addr))
+  def unapply(value: Val)(
+      implicit state: State): Option[(Kind, Class, Array[Val])] = value match {
+    case Val.Virtual(addr) =>
+      state.deref(addr) match {
+        case VirtualInstance(kind, cls, values) =>
+          Some((kind, cls, values))
+        case _ =>
+          None
+      }
+    case _ =>
+      None
+  }
+}
+
+object EscapedRef {
+  def unapply(addr: Addr)(implicit state: State): Option[Val] =
+    unapply(Val.Virtual(addr))
+  def unapply(value: Val)(implicit state: State): Option[Val] = value match {
+    case Val.Virtual(addr) =>
+      state.deref(addr) match {
+        case EscapedInstance(_, value) =>
+          Some(value)
+        case _ =>
+          None
+      }
+    case _ =>
+      None
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/InstanceRef.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package interflow
 
-import scalanative.nir.{Type, Val}
+import scalanative.nir.{Op, Type, Val}
 import scalanative.linker.Class
 
 object InstanceRef {
@@ -25,6 +25,22 @@ object VirtualRef {
       state.deref(addr) match {
         case VirtualInstance(kind, cls, values) =>
           Some((kind, cls, values))
+        case _ =>
+          None
+      }
+    case _ =>
+      None
+  }
+}
+
+object DelayedRef {
+  def unapply(addr: Addr)(implicit state: State): Option[Op] =
+    unapply(Val.Virtual(addr))
+  def unapply(value: Val)(implicit state: State): Option[Op] = value match {
+    case Val.Virtual(addr) =>
+      state.deref(addr) match {
+        case DelayedInstance(op) =>
+          Some(op)
         case _ =>
           None
       }

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
@@ -5,8 +5,8 @@ import scala.collection.mutable
 import scalanative.nir._
 
 final class MergeBlock(val label: Inst.Label, val name: Local) {
-  val incoming            = mutable.Map.empty[Local, (Seq[Val], State)]
-  val outgoing            = mutable.Map.empty[Local, MergeBlock]
+  var incoming            = mutable.Map.empty[Local, (Seq[Val], State)]
+  var outgoing            = mutable.Map.empty[Local, MergeBlock]
   var phis: Seq[MergePhi] = _
   var start: State        = _
   var end: State          = _
@@ -32,6 +32,8 @@ final class MergeBlock(val label: Inst.Label, val name: Local) {
         next
       case Next.Unwind(exc, next: Next.Label) =>
         Next.Unwind(exc, mergeNext(next))
+      case _ =>
+        util.unreachable
     }
     val params = block.phis.map(_.param)
     result.label(block.name, params)
@@ -47,6 +49,8 @@ final class MergeBlock(val label: Inst.Label, val name: Local) {
         val mergeCases = cases.map {
           case Next.Case(v, next: Next.Label) =>
             Next.Case(v, mergeNext(next))
+          case _ =>
+            util.unreachable
         }
         result.switch(scrut, mergeNext(defaultNext), mergeCases)
       case Inst.Throw(v, unwind) =>

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -363,8 +363,8 @@ final class MergeProcessor(insts: Array[Inst],
         val Inst.Ret(v)    = block.cf
         implicit val state = block.end
         v match {
-          case Val.Virtual(addr) => block.end.deref(addr).cls.ty
-          case _                 => v.ty
+          case InstanceRef(ty) => ty
+          case _               => v.ty
         }
       })
 

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -135,6 +135,10 @@ final class MergeProcessor(insts: Array[Inst],
                   }
                   mergeHeap(addr) =
                     VirtualInstance(headKind, headCls, mergeValues)
+                case DelayedInstance(op) =>
+                  assert(
+                    states.forall(s => s.derefDelayed(addr).delayedOp == op))
+                  mergeHeap(addr) = DelayedInstance(op)
               }
             }
             out

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -71,7 +71,7 @@ final class MergeProcessor(insts: Array[Inst],
             values.head
           } else {
             val materialized = states.zip(values).map {
-              case (s, v @ Val.Virtual(addr)) if !s.escaped(addr) =>
+              case (s, v @ Val.Virtual(addr)) if !s.hasEscaped(addr) =>
                 newEscapes += addr
                 s.materialize(v)
               case (s, v) =>
@@ -110,7 +110,7 @@ final class MergeProcessor(insts: Array[Inst],
               (state.deref(addr).cls eq states.head.deref(addr).cls)
             }
           def escapes(addr: Addr): Boolean =
-            states.exists(_.escaped(addr))
+            states.exists(_.hasEscaped(addr))
           val addrs = {
             val out =
               states.head.heap.keys.filter(includeAddr).toArray.sorted
@@ -130,7 +130,7 @@ final class MergeProcessor(insts: Array[Inst],
                 val mergeValues = headValues.zipWithIndex.map {
                   case (_, idx) =>
                     val values = states.map { state =>
-                      if (state.escaped(addr)) restart()
+                      if (state.hasEscaped(addr)) restart()
                       state.derefVirtual(addr).values(idx)
                     }
                     mergePhi(values)

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -119,12 +119,11 @@ final class MergeProcessor(insts: Array[Inst],
                 case _ if escapes(addr) =>
                   val values = states.map { s =>
                     s.deref(addr) match {
-                      case EscapedInstance(_, value) => value
-                      case _                         => Val.Virtual(addr)
+                      case EscapedInstance(value) => value
+                      case _                      => Val.Virtual(addr)
                     }
                   }
-                  mergeHeap(addr) =
-                    EscapedInstance(headInstance.cls, mergePhi(values))
+                  mergeHeap(addr) = EscapedInstance(mergePhi(values))
                 case VirtualInstance(headKind, headCls, headValues) =>
                   val mergeValues = headValues.zipWithIndex.map {
                     case (_, idx) =>

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -206,7 +206,7 @@ final class State(block: Local) {
         val canConstantInit =
           (!elemty.isInstanceOf[Type.RefKind]
             && values.forall(_.isCanonical)
-            && values.exists(v => !v.isDefault))
+            && values.exists(v => !v.isZero))
         val init =
           if (canConstantInit) {
             Val.ArrayValue(elemty, values)
@@ -242,11 +242,11 @@ final class State(block: Local) {
         val canConstantInit =
           (!elemty.isInstanceOf[Type.RefKind]
             && values.forall(_.isCanonical)
-            && values.exists(v => !v.isDefault))
+            && values.exists(v => !v.isZero))
         if (!canConstantInit) {
           values.zipWithIndex.foreach {
             case (value, idx) =>
-              if (!value.isDefault) {
+              if (!value.isZero) {
                 reachVal(value)
                 emit.arraystore(elemty,
                                 local,
@@ -264,7 +264,7 @@ final class State(block: Local) {
       case VirtualInstance(_, cls, vals) =>
         cls.fields.zip(vals).foreach {
           case (fld, value) =>
-            if (!value.isDefault) {
+            if (!value.isZero) {
               reachVal(value)
               emit.fieldstore(fld.ty,
                               local,

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -67,11 +67,18 @@ final class State(block: Local) {
         false
     }
   }
-  def escaped(addr: Addr): Boolean = {
-    deref(addr).isInstanceOf[EscapedInstance]
+  def isVirtual(addr: Addr): Boolean = {
+    heap(addr).isInstanceOf[VirtualInstance]
   }
-  def escaped(value: Val): Boolean = value match {
-    case Val.Virtual(addr) => escaped(addr)
+  def isVirtual(value: Val): Boolean = value match {
+    case Val.Virtual(addr) => isVirtual(addr)
+    case _                 => false
+  }
+  def hasEscaped(addr: Addr): Boolean = {
+    heap(addr).isInstanceOf[EscapedInstance]
+  }
+  def hasEscaped(value: Val): Boolean = value match {
+    case Val.Virtual(addr) => hasEscaped(addr)
     case _                 => false
   }
   def loadLocal(local: Local): Val = {
@@ -93,132 +100,6 @@ final class State(block: Local) {
     assert(local.id < 0)
     locals(local) = value
   }
-  def materialize(value: Val)(implicit linked: linker.Result): Val =
-    value match {
-      case Val.Virtual(addr) =>
-        materialize(addr)
-      case _ =>
-        value
-    }
-  def materialize(addr: Long)(implicit linked: linker.Result): Val = {
-    val reachable = mutable.Set.empty[Addr]
-    val addrs     = mutable.UnrolledBuffer.empty[Addr]
-    def markValue(v: Val): Unit = v match {
-      case Val.Virtual(addr) =>
-        markAddr(addr)
-      case _ =>
-        ()
-    }
-    def markAddr(addr: Addr): Unit = {
-      if (!reachable.contains(addr)) {
-        def markCurrentAddr() = {
-          reachable += addr
-          addrs += addr
-        }
-        deref(addr) match {
-          case VirtualInstance(BoxKind, _, _) =>
-            markCurrentAddr()
-          case VirtualInstance(StringKind, _, values) =>
-            markCurrentAddr()
-            if (escaped(values(linked.StringValueField.index))) {
-              values.foreach(markValue)
-            }
-          case VirtualInstance(_, _, values) =>
-            markCurrentAddr()
-            values.foreach(markValue)
-          case _: EscapedInstance =>
-            ()
-        }
-      }
-    }
-    markAddr(addr)
-
-    val locals = addrs.map { addr =>
-      val local = deref(addr) match {
-        case VirtualInstance(ArrayKind, cls, values) =>
-          val ArrayRef(elemty, _) = cls.ty
-          val init =
-            if (!elemty.isInstanceOf[Type.RefKind]
-                && values.forall(_.isCanonical)
-                && values.exists(v => !v.isDefault)) {
-              Val.ArrayValue(elemty, values)
-            } else {
-              Val.Int(values.length)
-            }
-          emit.arrayalloc(elemty, init, Next.None)
-        case VirtualInstance(BoxKind, cls, Array(value)) =>
-          emit.box(Type.Ref(cls.name), value, Next.None)
-        case VirtualInstance(StringKind, _, values)
-            if !escaped(values(linked.StringValueField.index)) =>
-          val Val.Virtual(charsAddr) = values(linked.StringValueField.index)
-          val chars = derefVirtual(charsAddr).values
-            .map {
-              case Val.Char(v) => v
-            }
-            .toArray[Char]
-          Val.String(new java.lang.String(chars))
-        case VirtualInstance(_, cls, _) =>
-          emit.classalloc(cls.name, Next.None)
-        case _: EscapedInstance =>
-          unreachable
-      }
-      addr -> local
-    }.toMap
-
-    def escapedValueOf(addr: Addr): Val =
-      if (locals.contains(addr)) {
-        locals(addr)
-      } else {
-        derefEscaped(addr).escapedValue
-      }
-
-    addrs.foreach { addr =>
-      val local = locals(addr)
-      deref(addr) match {
-        case VirtualInstance(ArrayKind, cls, values) =>
-          val ArrayRef(elemty, _) = cls.ty
-          if (!elemty.isInstanceOf[Type.RefKind]
-              && values.forall(_.isCanonical)
-              && values.exists(v => !v.isDefault)) {
-            ()
-          } else {
-            values.zipWithIndex.foreach {
-              case (value, idx) if value.isDefault =>
-                // fields are initialied to default value
-                ()
-              case (Val.Virtual(addr), idx) =>
-                val value = escapedValueOf(addr)
-                assert(!value.isVirtual)
-                emit.arraystore(elemty, local, Val.Int(idx), value, Next.None)
-              case (value, idx) =>
-                emit.arraystore(elemty, local, Val.Int(idx), value, Next.None)
-            }
-          }
-        case VirtualInstance(BoxKind, _, _) =>
-          ()
-        case VirtualInstance(StringKind, _, values)
-            if !escaped(values(linked.StringValueField.index)) =>
-          ()
-        case VirtualInstance(_, cls, values) =>
-          cls.fields.zip(values).foreach {
-            case (fld, value) if value.isDefault =>
-              // fields are initialied to default value
-              ()
-            case (fld, Val.Virtual(addr)) =>
-              val value = escapedValueOf(addr)
-              assert(!value.isVirtual)
-              emit.fieldstore(fld.ty, local, fld.name, value, Next.None)
-            case (fld, value) =>
-              emit.fieldstore(fld.ty, local, fld.name, value, Next.None)
-          }
-        case _: EscapedInstance =>
-          unreachable
-      }
-      heap(addr) = new EscapedInstance(heap(addr).cls, local)
-    }
-
-    escapedValueOf(addr)
-  }
   def inherit(other: State, roots: Seq[Val]): Unit = {
     val closure = heapClosure(roots) ++ other.heapClosure(roots)
 
@@ -232,7 +113,7 @@ final class State(block: Local) {
     def reachAddr(addr: Addr): Unit = {
       if (heap.contains(addr) && !reachable.contains(addr)) {
         reachable += addr
-        deref(addr) match {
+        heap(addr) match {
           case VirtualInstance(_, _, vals) =>
             vals.foreach(reachVal)
           case EscapedInstance(_, value) =>
@@ -264,46 +145,107 @@ final class State(block: Local) {
     case _ =>
       false
   }
-  def diff(other: State): String = {
-    val builder = new StringBuilder
-    def println(msg: String): Unit = {
-      builder.append(msg)
-      builder.append("\n")
-    }
-    if (other == null) {
-      println("right is null")
-    } else {
-      heap.foreach {
-        case (addr, instance) =>
-          if (!other.heap.contains(addr)) {
-            println(s"addr $addr is only present in left")
-          } else if (other.heap(addr) != instance) {
-            println(
-              s"different value for $addr: left = $instance, right = ${other.heap(addr)}")
-          }
-      }
-      other.heap.foreach {
-        case (addr, instance) =>
-          if (!heap.contains(addr)) {
-            println(s"addr $addr is only present in right")
-          }
-      }
-      locals.foreach {
-        case (id, value) =>
-          if (!other.locals.contains(id)) {
-            println(s"local ${id.show} is only present in left")
-          } else if (other.locals(id) != value) {
-            println(
-              s"different value for local ${id.show}: left = ${value.show}, right = ${other.locals(id).show}")
-          }
-      }
-      other.locals.foreach {
-        case (id, value) =>
-          if (!locals.contains(id)) {
-            println(s"local ${id.show} is only present in right")
-          }
+  def materialize(rootValue: Val)(implicit linked: linker.Result): Val = {
+    val locals = mutable.Map.empty[Addr, Val]
+
+    def reachAddr(addr: Addr): Unit = {
+      if (!locals.contains(addr)) {
+        val local = reachAlloc(addr)
+        locals(addr) = local
+        reachInit(local, addr)
+        heap(addr) = EscapedInstance(heap(addr).cls, local)
       }
     }
-    builder.toString
+
+    def reachAlloc(addr: Addr): Val = heap(addr) match {
+      case VirtualInstance(ArrayKind, cls, values) =>
+        val ArrayRef(elemty, _) = cls.ty
+        val canConstantInit =
+          (!elemty.isInstanceOf[Type.RefKind]
+            && values.forall(_.isCanonical)
+            && values.exists(v => !v.isDefault))
+        val init =
+          if (canConstantInit) {
+            Val.ArrayValue(elemty, values)
+          } else {
+            Val.Int(values.length)
+          }
+        emit.arrayalloc(elemty, init, Next.None)
+      case VirtualInstance(BoxKind, cls, Array(value)) =>
+        reachVal(value)
+        emit.let(Op.Box(Type.Ref(cls.name), escapedVal(value)), Next.None)
+      case VirtualInstance(StringKind, _, values)
+          if !hasEscaped(values(linked.StringValueField.index)) =>
+        val Val.Virtual(charsAddr) = values(linked.StringValueField.index)
+        val chars = derefVirtual(charsAddr).values
+          .map {
+            case Val.Char(v) => v
+          }
+          .toArray[Char]
+        Val.String(new java.lang.String(chars))
+      case VirtualInstance(_, cls, values) =>
+        emit.classalloc(cls.name, Next.None)
+      case EscapedInstance(_, value) =>
+        reachVal(value)
+        escapedVal(value)
+    }
+
+    def reachInit(local: Val, addr: Addr): Unit = heap(addr) match {
+      case VirtualInstance(ArrayKind, cls, values) =>
+        val ArrayRef(elemty, _) = cls.ty
+        val canConstantInit =
+          (!elemty.isInstanceOf[Type.RefKind]
+            && values.forall(_.isCanonical)
+            && values.exists(v => !v.isDefault))
+        if (!canConstantInit) {
+          values.zipWithIndex.foreach {
+            case (value, idx) =>
+              if (!value.isDefault) {
+                reachVal(value)
+                emit.arraystore(elemty,
+                                local,
+                                Val.Int(idx),
+                                escapedVal(value),
+                                Next.None)
+              }
+          }
+        }
+      case VirtualInstance(BoxKind, cls, Array(value)) =>
+        ()
+      case VirtualInstance(StringKind, _, values)
+          if !hasEscaped(values(linked.StringValueField.index)) =>
+        ()
+      case VirtualInstance(_, cls, vals) =>
+        cls.fields.zip(vals).foreach {
+          case (fld, value) =>
+            if (!value.isDefault) {
+              reachVal(value)
+              emit.fieldstore(fld.ty,
+                              local,
+                              fld.name,
+                              escapedVal(value),
+                              Next.None)
+            }
+        }
+      case EscapedInstance(_, value) =>
+        ()
+    }
+
+    def reachVal(v: Val): Unit = v match {
+      case Val.Virtual(addr)       => reachAddr(addr)
+      case Val.ArrayValue(_, vals) => vals.foreach(reachVal)
+      case Val.StructValue(vals)   => vals.foreach(reachVal)
+      case _                       => ()
+    }
+
+    def escapedVal(v: Val): Val = v match {
+      case Val.Virtual(addr) =>
+        locals(addr)
+      case _ =>
+        v
+    }
+
+    reachVal(rootValue)
+    escapedVal(rootValue)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -116,7 +116,7 @@ final class State(block: Local) {
         heap(addr) match {
           case VirtualInstance(_, _, vals) =>
             vals.foreach(reachVal)
-          case EscapedInstance(_, value) =>
+          case EscapedInstance(value) =>
             reachVal(value)
         }
       }
@@ -153,7 +153,7 @@ final class State(block: Local) {
         val local = reachAlloc(addr)
         locals(addr) = local
         reachInit(local, addr)
-        heap(addr) = EscapedInstance(heap(addr).cls, local)
+        heap(addr) = EscapedInstance(local)
       }
     }
 
@@ -185,7 +185,7 @@ final class State(block: Local) {
         Val.String(new java.lang.String(chars))
       case VirtualInstance(_, cls, values) =>
         emit.classalloc(cls.name, Next.None)
-      case EscapedInstance(_, value) =>
+      case EscapedInstance(value) =>
         reachVal(value)
         escapedVal(value)
     }
@@ -227,7 +227,7 @@ final class State(block: Local) {
                               Next.None)
             }
         }
-      case EscapedInstance(_, value) =>
+      case EscapedInstance(value) =>
         ()
     }
 

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -59,14 +59,6 @@ final class State(block: Local) {
   def derefEscaped(addr: Addr): EscapedInstance = {
     heap(addr).asInstanceOf[EscapedInstance]
   }
-  def inBounds(addr: Addr, offset: Int): Boolean = {
-    heap(addr) match {
-      case VirtualInstance(_, _, v) =>
-        offset >= 0 && offset < v.length
-      case _ =>
-        false
-    }
-  }
   def isVirtual(addr: Addr): Boolean = {
     heap(addr).isInstanceOf[VirtualInstance]
   }

--- a/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
@@ -55,7 +55,7 @@ object UseDef {
     collector.deps.distinct
   }
 
-  private val pureWhitelist = {
+  val pureWhitelist = {
     val out = mutable.Set.empty[Global]
     out += Global.Top("scala.Predef$")
     out += Global.Top("scala.runtime.BoxesRunTime$")

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -82,10 +82,10 @@ trait Visit { self: Interflow =>
     val argtys   = argumentTypes(name)
 
     // Wrap up the result.
-    def result(retty: Type, insts: Seq[Inst]) =
+    def result(retty: Type, rawInsts: Seq[Inst]) =
       origdefn.copy(name = name,
                     ty = Type.Function(argtys, retty),
-                    insts = eliminateDeadCode(insts))
+                    insts = ControlFlow.removeDeadBlocks(rawInsts))
 
     // Create new fresh and state for the first basic block.
     val fresh = Fresh(0)


### PR DESCRIPTION
This PR introduces one more optimization as a part of the Interflow's main pass: code motion. Previously we never reordered operations in the original code, they could either be partially evaluated or where emitted into the optimized output in the same order as they were defined originally. We used to run DCE in a separate pass to remove pure operations whose result was never used. Instead, we add support for "delayed" ops into Interflow's optimizer state. 

For example:
```
%entry:
   %x = add[Int] %y, 3
   %cond = gt[Int] %y, 0 
   if %cond then %ifTrue else %ifFalse
%ifTrue:
   %z = mul[Int] %x, 42
   jump %merge(%z)
%ifFalse:
   jump %merge(%y)
%merge(result: Int):
   ...
```

Here `%x` is defined in `%entry` but only used in `%ifTrue`. Interflow now can sink the definition of `%x` into the `%ifTrue` branch, and completely eliminate it from other branches:
```
%entry:
   %cond = gt[Int] %y, 0 
   if %cond then %ifTrue else %ifFalse
%ifTrue:
   %x = add[Int] %y, 3
   %z = mul[Int] %x, 42
   jump %merge(%z)
%ifFalse:
   jump %merge(%y)
%merge(result: Int):
   ...
```
The optimization extends infrastructure for Partial Escape Analysis: pure operations are removed from the code when they are visited, and later materialized when the virtual value escapes (i.e. used by other emitted op). This turns materialization into a graph scheduling problem, so state materialization and block invalidation had to be improved a bit to support this use case. 
