### PR TITLE
Reduce size overhead of runtime type information

### DIFF
--- a/nativelib/src/main/resources/gc/immix/headers/ObjectHeader.h
+++ b/nativelib/src/main/resources/gc/immix/headers/ObjectHeader.h
@@ -19,19 +19,9 @@ typedef struct {
         int32_t id;
         int32_t tid;
         word_t *name;
-        int8_t kind;
     } rt;
-    int64_t size;
-    struct {
-        int32_t from;
-        int32_t to;
-    } range;
-    struct {
-        int32_t dyn_method_count;
-        word_t *dyn_method_salt;
-        word_t *dyn_method_keys;
-        word_t *dyn_methods;
-    } dynDispatchTable;
+    int32_t size;
+    int32_t idRangeUntil;
     int64_t *refMapStruct;
 } Rtti;
 

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -53,7 +53,7 @@ class _Object {
 
   protected def __clone(): _Object = {
     val rawty = runtime.getRawType(this)
-    val size  = loadLong(elemRawPtr(rawty, sizeof[runtime.Type]))
+    val size  = loadInt(elemRawPtr(rawty, sizeof[runtime.Type]))
     val clone = runtime.GC.alloc(rawty, size)
     val src   = castObjectToRawPtr(this)
     libc.memcpy(clone, src, size)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -8,29 +8,23 @@ import scalanative.runtime.LLVMIntrinsics._
 package object runtime {
 
   /** Runtime Type Information. */
-  type Type = CStruct3[Int, String, Byte]
+  type Type = CStruct2[Int, String]
 
   implicit class TypeOps(val self: Ptr[Type]) extends AnyVal {
-    def id: Int      = !(self._1)
-    def name: String = !(self._2)
-    def kind: Long   = !(self._3)
+    def id: Int          = !(self._1)
+    def name: String     = !(self._2)
+    def isClass: Boolean = id >= 0
   }
 
   /** Class runtime type information. */
-  type ClassType = CStruct3[Type, Long, CStruct2[Int, Int]]
+  type ClassType = CStruct3[Type, Int, Int]
 
   implicit class ClassTypeOps(val self: Ptr[ClassType]) extends AnyVal {
-    def id: Int           = self._1.id
-    def name: String      = self._1.name
-    def kind: Long        = self._1.kind
-    def size: Long        = !(self._2)
-    def idRangeFrom: Long = !(self._3._1)
-    def idRangeTo: Long   = !(self._3._2)
+    def id: Int            = self._1.id
+    def name: String       = self._1.name
+    def size: Int          = !(self._2)
+    def idRangeUntil: Long = !(self._3)
   }
-
-  final val CLASS_KIND  = 0
-  final val TRAIT_KIND  = 1
-  final val STRUCT_KIND = 2
 
   /** Used as a stub right hand of intrinsified methods. */
   def intrinsic: Nothing = throwUndefined()
@@ -100,4 +94,8 @@ package object runtime {
   /** Called by the generated code in case of out of bounds on array access. */
   @noinline def throwOutOfBounds(i: Int): Nothing =
     throw new IndexOutOfBoundsException(i.toString)
+
+  /** Called by the generated code in case of missing method on reflective call. */
+  @noinline def throwNoSuchMethod(sig: String): Nothing =
+    throw new NoSuchMethodException(sig)
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -7,7 +7,7 @@ object Rt {
   val Object = Ref(Global.Top("java.lang.Object"))
   val Class  = Ref(Global.Top("java.lang.Class"))
   val String = Ref(Global.Top("java.lang.String"))
-  val Type   = StructValue(Seq(Int, Int, Ptr, Byte))
+  val Type   = StructValue(Seq(Int, Int, Ptr))
 
   val BoxedNull       = Ref(Global.Top("scala.runtime.Null$"))
   val BoxedUnit       = Ref(Global.Top("scala.runtime.BoxedUnit"))

--- a/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/DynamicHashMap.scala
@@ -16,7 +16,7 @@ class DynamicHashMap(meta: Metadata, cls: Class, proxies: Seq[Defn]) {
       .filterNot(m => sigs.contains(m.sig)) ++ own
   }
   val ty: Type =
-    Type.StructValue(Seq(Type.Int, Type.Ptr, Type.Ptr, Type.Ptr))
+    Type.Ptr
   val value: Val =
     DynmethodPerfectHashMap(methods, meta.linked.dynsigs)
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -19,6 +19,9 @@ class Metadata(val linked: linker.Result, proxies: Seq[Defn]) {
   val dispatchTable  = new TraitDispatchTable(this)
   val hasTraitTables = new HasTraitTables(this)
 
+  val dynmapIndex = Val.Int(if (linked.dynsigs.isEmpty) -1 else 4)
+  val vtableIndex = Val.Int(if (linked.dynsigs.isEmpty) 4 else 5)
+
   initClassMetadata()
   initTraitMetadata()
 
@@ -62,7 +65,9 @@ class Metadata(val linked: linker.Result, proxies: Seq[Defn]) {
     classes.foreach { node =>
       vtable(node) = new VirtualTable(this, node)
       layout(node) = new FieldLayout(this, node)
-      dynmap(node) = new DynamicHashMap(this, node, proxies)
+      if (linked.dynsigs.nonEmpty) {
+        dynmap(node) = new DynamicHashMap(this, node, proxies)
+      }
       rtti(node) = new RuntimeTypeInformation(this, node)
     }
   }

--- a/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
@@ -158,8 +158,7 @@ class PerfectHashMap[K, V](val keys: Seq[Int],
 }
 
 object DynmethodPerfectHashMap {
-  def apply(dynmethods: Seq[Global.Member],
-            allSignatures: Seq[Sig]): Val.StructValue = {
+  def apply(dynmethods: Seq[Global.Member], allSignatures: Seq[Sig]): Val = {
 
     val signaturesWithIndex =
       allSignatures.zipWithIndex.foldLeft(Map[Sig, Int]()) {
@@ -179,20 +178,21 @@ object DynmethodPerfectHashMap {
       case None         => (Val.Int(-1), Val.Null)
     }.unzip
 
-    Val.StructValue(
-      Val.Int(perfectHashMap.size) ::
-        (perfectHashMap.size match {
-        case 0 =>
-          List(Val.Null, Val.Null, Val.Null)
-        case _ =>
+    if (perfectHashMap.size == 0) {
+      Val.Null
+    } else {
+      Val.Const(
+        Val.StructValue(
           List(
+            Val.Int(perfectHashMap.size),
             Val.Const(
               Val.ArrayValue(Type.Int, perfectHashMap.keys.map(Val.Int))),
             Val.Const(Val.ArrayValue(Type.Int, keys)),
             Val.Const(Val.ArrayValue(Type.Ptr, values))
           )
-      })
-    )
+        )
+      )
+    }
   }
 
   def hash(key: Int, salt: Int): Int = {


### PR DESCRIPTION
This PR reduces binary size overhead of dynamic hash maps (underlying data structure used for the implementation of the Scala's reflective method calls). Additionally, the desugaring of reflective calls uses similar pattern introduced in #1432 by delaying the slow path until the end of the method and sharing it as long as unwind handler is the same. 