### PR TITLE
Whitelist scala.collection.immutable.Range as pure

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
@@ -62,6 +62,7 @@ object UseDef {
     out += Global.Top("scala.scalanative.runtime.Boxes$")
     out += Global.Top("scala.scalanative.runtime.package$")
     out += Global.Top("scala.scalanative.native.package$")
+    out += Global.Top("scala.collection.immutable.Range$")
     out ++= codegen.Lower.BoxTo.values
     out
   }


### PR DESCRIPTION
This effectively makes `for (x <- 1 to N) ...` loops completely free after Interflow. For example:
```
object Test {
  @noinline def f(i: Int) = println(i)
  @noinline def loop(): Unit = {
    for (i <- 1 to 10) {
      f(i)
    }
  }
  def main(args: Array[String]): Unit = {
    loop()
  }
}
```
Here loop is turned into a regular while loop without any OO overhead:
```

noinline def @"M5Test$D4loopuE" : (@"T5Test$") => unit {
%20000(%1 : @"T5Test$"):
  jump %340000(int 1)
%340000(%340001 : int):
  %340003 = module @"T5Test$"
  %340004 = call[(!?@"T5Test$", int) => unit] @"M5Test$KD1fiuEX5Test$iE" : ptr(%340003 : !?@"T5Test$", %340001 : int)
  %340006 = ieq[int] %340001 : int, int 10
  if %340006 : bool then %370000 else %350000
%350000:
  %360002 = iadd[int] %340001 : int, int 1
  jump %340000(%360002 : int)
%370000:
  ret unit
}