### PR TITLE
Interflow: infer module constructor purity

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -949,6 +949,7 @@ trait Eval { self: Interflow =>
       def canStoreValue(v: Val): Boolean = v match {
         case _ if v.isCanonical => true
         case Val.Local(n, _)    => canStoreTo.contains(n)
+        case _: Val.String      => true
         case _                  => false
       }
 

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -20,6 +20,7 @@ class Interflow(val mode: build.Mode, val originals: Map[Global, Defn.Define])(
 
   val mergeProcessor = new util.ScopedVar[MergeProcessor]
   val blockFresh     = new util.ScopedVar[Fresh]
+  val modulePurity   = mutable.Map.empty[Global, Boolean]
 }
 
 object Interflow {


### PR DESCRIPTION
This change relaxes the definition of "pure" module constructor to allow the following inside the module constructor:

1. Any non-throwing control-flow instructions
1. Any pure `let n = op` instructions
1. Loads and stores to currently accessed module
1. Loads and stores to any values allocated inside the module constructor
1. Access to other pure modules

This also allows for modules which store other modules values as "optimization" (i.e. many modules in standard library do this).