### PR TITLE
Interflow: canonicalize constants to be on the right

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -84,6 +84,26 @@ sealed abstract class Op {
     case _ =>
       false
   }
+
+  final def isCommutative: Boolean = this match {
+    case Op.Bin(bin, _, _, _) =>
+      import Bin._
+      bin match {
+        case Iadd | Imul | And | Or | Xor =>
+          true
+        case Fadd | Isub | Fsub | Fmul | Sdiv | Udiv | Fdiv | Srem | Urem | Frem |
+            Shl | Lshr | Ashr =>
+          false
+      }
+    case Op.Comp(comp, _, _, _) =>
+      import Comp._
+      comp match {
+        case Ieq | Ine => true
+        case _         => false
+      }
+    case _ =>
+      false
+  }
 }
 object Op {
   // low-level

--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -89,10 +89,10 @@ sealed abstract class Op {
     case Op.Bin(bin, _, _, _) =>
       import Bin._
       bin match {
-        case Iadd | Imul | And | Or | Xor =>
+        case Iadd | Imul | And | Or | Xor | Fadd | Fmul =>
           true
-        case Fadd | Isub | Fsub | Fmul | Sdiv | Udiv | Fdiv | Srem | Urem | Frem |
-            Shl | Lshr | Ashr =>
+        case Isub | Fsub | Sdiv | Udiv | Fdiv | Srem | Urem | Frem | Shl |
+            Lshr | Ashr =>
           false
       }
     case Op.Comp(comp, _, _, _) =>


### PR DESCRIPTION
Cannonicalize constants to always go on the right of the
commutative binary and comparisons ops.