### PR TITLE
Fix #1445: scripted link-order fails to compile in some environments

### DIFF
--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -17,8 +17,9 @@ compile in Compile := {
     path.getAbsolutePath
 
   def run(command: Seq[String]): Int = {
+    import scala.sys.process._
     log.info("Running " + command.mkString(" "))
-    scala.sys.process.Process(command, cwd) ! log
+    Process(command, cwd) ! log
   }
 
   val opaths = cpaths.map { cpath =>

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -7,7 +7,7 @@ scalaVersion := "2.11.12"
 nativeLinkingOptions in Compile += s"-L${target.value.getAbsoluteFile}"
 
 compile in Compile := {
-
+  val log            = streams.value.log
   val cwd            = target.value
   val compileOptions = nativeCompileOptions.value
   val cpaths         = (baseDirectory.value.getAbsoluteFile * "*.c").get
@@ -19,7 +19,6 @@ compile in Compile := {
     path.getAbsolutePath
 
   def run(command: Seq[String]): Int = {
-    val log = streams.value.log
     log.info("Running " + command.mkString(" "))
 
     // Use a Process() idiom that works with both sbt 0.13.n & 1.n.

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -18,7 +18,7 @@ compile in Compile := {
 
   def run(command: Seq[String]): Int = {
     log.info("Running " + command.mkString(" "))
-    Process(command, cwd) ! log
+    scala.sys.process.Process(command, cwd) ! log
   }
 
   val opaths = cpaths.map { cpath =>


### PR DESCRIPTION
The presenting issue was described in issue #1445, link-order failed to compile. 
That issue is now fixed.

*  sbt changed the way it handles Process() between version 0.13.n and 1.N.
   The earlier version defines implicit conversions for, among other things,
   converting an sbt logger to a scala Process logger.  These implicits
   were removed in sbt 1.?, which documents the use of bog standard
   `scala.sys.process.Process`. 

    The challenge is to write code which runs with both versions. The solution
    is to explicitly convert the sbt logger to scala ProcessLogger.  

*    With the changes of this PR,  the link-order test continues to succeed in Travis CI.
     In addition, link-order now passes in interactive mode on my system for both sbt versions.

* The following anomalies disturb my tranquility:

  -  Inquiring minds will ask `Why did this issue not show up in Travis CI'.  Sorry but
    after much study I still can not answer that.  It seems that scripted-tests runs
    sbt 1.2.6 twice, with differing garbage collectors. I would have expected both
    of those to fail link-order with the code prior to this PR. I saw no evidence of such
    a failure.

  - I am also not sure why other people are not experiencing this issue.  The underlying
    defect looked pretty bold to me and I have not been able to isolate anything special
    about my system.

  - I wish I were more clever and could track these down.

* I think it is safe to merge this PR and it has value even with these anomalies unresolved. 
This PR makes the link-order test more robust to further sbt change and provides a model or
existence proof for future developers of other scripted tests.

Documentation:

* None needed.

Testing:

  * Built and tested ("test-all") on X86_64 only . All tests pass.

```