### PR TITLE
Interflow: fix trait method devirtualization

### DIFF
--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -105,7 +105,7 @@ final class _Class[A](val rawty: RawPtr) {
       rawty == toRawType(classOf[PrimitiveDouble]) ||
       rawty == toRawType(classOf[PrimitiveUnit]))
 
-  override def equals(other: Any): scala.Boolean =
+  @inline override def equals(other: Any): scala.Boolean =
     other match {
       case other: _Class[_] =>
         rawty == other.rawty
@@ -113,7 +113,7 @@ final class _Class[A](val rawty: RawPtr) {
         false
     }
 
-  override def hashCode: Int =
+  @inline override def hashCode: Int =
     Intrinsics.castRawPtrToLong(rawty).##
 
   override def toString = {

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -399,20 +399,23 @@ final class Check(implicit linked: linker.Result) {
                    obj: Val,
                    name: Global,
                    value: Option[Val]): Unit = {
+
     obj.ty match {
-      case ClassRef(cls) =>
-        cls.fields.collectFirst {
-          case fld: Field if fld.name == name =>
-            in("field declared type") {
-              expect(ty, fld.ty)
-            }
-            value.foreach { v =>
-              in("stored value") {
-                expect(fld.ty, v)
+      case ScopeRef(scope) =>
+        scope.implementors.foreach { cls =>
+          cls.fields.collectFirst {
+            case fld: Field if fld.name == name =>
+              in("field declared type") {
+                expect(ty, fld.ty)
               }
-            }
+              value.foreach { v =>
+                in("stored value") {
+                  expect(fld.ty, v)
+                }
+              }
+          }
         }
-      case _ =>
+      case ty =>
         error(s"can't access fields of a non-class type ${ty.show}")
     }
   }

--- a/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
@@ -29,7 +29,7 @@ trait Intrinsics { self: Interflow =>
     Global.Member(Global.Top("java.lang.Math$"), Rt.SqrtSig)
   ) ++ arrayIntrinsics
 
-  def intrinsic(local: Local, ty: Type, name: Global, rawArgs: Seq[Val])(
+  def intrinsic(ty: Type, name: Global, rawArgs: Seq[Val])(
       implicit state: State): Val = {
     val Global.Member(_, sig) = name
 
@@ -133,14 +133,14 @@ trait Intrinsics { self: Interflow =>
       case _ if arrayApplyIntrinsics.contains(name) =>
         val Seq(arr, idx)            = rawArgs
         val Type.Function(_, elemty) = ty
-        eval(local, Op.Arrayload(elemty, arr, idx))
+        eval(Op.Arrayload(elemty, arr, idx))
       case _ if arrayUpdateIntrinsics.contains(name) =>
         val Seq(arr, idx, value)                = rawArgs
         val Type.Function(Seq(_, _, elemty), _) = ty
-        eval(local, Op.Arraystore(elemty, arr, idx, value))
+        eval(Op.Arraystore(elemty, arr, idx, value))
       case _ if name == arrayLengthIntrinsic =>
         val Seq(arr) = rawArgs
-        eval(local, Op.Arraylength(arr))
+        eval(Op.Arraylength(arr))
     }
   }
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -212,8 +212,15 @@ trait Visit { self: Interflow =>
     if (!shallDuplicate(orig, argtys)) {
       orig
     } else {
+      val origargtys = argumentTypes(name)
+      val dupargtys = argtys.zip(origargtys).map {
+        case (argty, origty) =>
+          // Duplicate argument type should not be
+          // less specific than the original declare type.
+          if (!Sub.is(argty, origty)) origty else argty
+      }
       val Global.Member(top, sig) = orig
-      Global.Member(top, Sig.Duplicate(sig, argtys))
+      Global.Member(top, Sig.Duplicate(sig, dupargtys))
     }
   }
 


### PR DESCRIPTION
This fixes an implementation bug that made interflow unintentionally devirtualize
purely based on exact class types. This excluded trait/class methods which are statically
known to have a single implementation. Improves throughput on deltablue, tracer, 
sudoku and brainfuck benchmarks.