### PR TITLE
Don't rely on recursion in legacy dce

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
@@ -104,11 +104,16 @@ object UseDef {
         ndef.deps += ddef
       }
     }
-    def alive(ndef: Def): Unit =
-      if (!ndef.alive) {
-        ndef.alive = true
-        ndef.deps.foreach(alive)
+    def traceAlive(ndef: Def): Unit = {
+      val todo = mutable.Queue(ndef)
+      while (todo.nonEmpty) {
+        val ndef = todo.dequeue()
+        if (!ndef.alive) {
+          ndef.alive = true
+          todo ++= ndef.deps
+        }
       }
+    }
 
     // enter definitions
     blocks.foreach { block =>
@@ -146,8 +151,7 @@ object UseDef {
       }
     }
 
-    // trace live code
-    alive(defs(cfg.entry.name))
+    traceAlive(defs(cfg.entry.name))
 
     defs.toMap
   }


### PR DESCRIPTION
This PR removes recursion from legacy UseDef analysis and replaces it with a work queue. This minimizes the risk of getting a stack overflow in methods with long dependency chains (i.e., PR #1436).