### PR TITLE
Reduce binary size overhead of the new floating point to string conversion

### DIFF
--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -319,7 +319,7 @@ object Double {
   }
 
   @inline def toString(d: scala.Double): String = {
-    RyuDouble.doubleToString(d, RyuRoundingMode.CONSERVATIVE)
+    RyuDouble.doubleToString(d, RyuRoundingMode.Conservative)
   }
 
   @inline def valueOf(d: scala.Double): Double =

--- a/javalib/src/main/scala/java/lang/Float.scala
+++ b/javalib/src/main/scala/java/lang/Float.scala
@@ -321,7 +321,7 @@ object Float {
     }
 
   def toString(f: scala.Float): String = {
-    RyuFloat.floatToString(f, RyuRoundingMode.CONSERVATIVE)
+    RyuFloat.floatToString(f, RyuRoundingMode.Conservative)
   }
 
   @inline def valueOf(s: String): Float =

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuDouble.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuDouble.scala
@@ -694,7 +694,8 @@ object RyuDouble {
 
   // format: on
 
-  def doubleToString(value: Double, roundingMode: RyuRoundingMode): String = {
+  @noinline def doubleToString(value: Double,
+                               roundingMode: RyuRoundingMode): String = {
 
     // Step 1: Decode the floating point number, and unify normalized and
     // subnormal cases.

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuDouble.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuDouble.scala
@@ -865,7 +865,7 @@ object RyuDouble {
 
     // Step 5: Print the decimal representation.
     // We follow Double.toString semantics here.
-    val result = scala.Array.ofDim[Char](24)
+    val result = new scala.Array[Char](24)
     var index  = 0
     if (sign) {
       result(index) = '-'

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
@@ -172,7 +172,8 @@ object RyuFloat {
 
 // format: on
 
-  def floatToString(value: Float, roundingMode: RyuRoundingMode): String = {
+  @noinline def floatToString(value: Float,
+                              roundingMode: RyuRoundingMode): String = {
 
     // Step 1: Decode the floating point number, and unify normalized and
     // subnormal cases.

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
@@ -326,7 +326,7 @@ object RyuFloat {
 
     // Step 5: Print the decimal representation.
     // We follow Float.toString semantics here.
-    val result = scala.Array.ofDim[Char](15)
+    val result = new scala.Array[Char](15)
     var index  = 0
     if (sign) {
       result(index) = '-'

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuRoundingMode.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuRoundingMode.scala
@@ -35,34 +35,19 @@ package scala.scalanative
 package runtime
 package ieee754tostring.ryu
 
-object RyuRoundingMode extends Enumeration {
+abstract class RyuRoundingMode {
+  def acceptUpperBound(even: Boolean): Boolean
+  def acceptLowerBound(even: Boolean): Boolean
+}
 
-  val CONSERVATIVE: RyuRoundingMode = new conservativeRM()
-
-  val ROUND_EVEN: RyuRoundingMode = new roundEvenRM()
-
-  abstract class RyuRoundingMode {
-
-    def acceptUpperBound(even: Boolean): Boolean
-
-    def acceptLowerBound(even: Boolean): Boolean
-
-  }
-
-  private[this] class conservativeRM extends RyuRoundingMode {
-
+object RyuRoundingMode {
+  object Conservative extends RyuRoundingMode {
     def acceptUpperBound(even: Boolean): Boolean = false
-
     def acceptLowerBound(even: Boolean): Boolean = false
-
   }
 
-  private[this] class roundEvenRM extends RyuRoundingMode {
-
+  object RoundEven extends RyuRoundingMode {
     def acceptUpperBound(even: Boolean): Boolean = even
-
     def acceptLowerBound(even: Boolean): Boolean = even
-
   }
-
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -863,8 +863,8 @@ object Lower {
                   Op.Call(sig, Val.Global(func, Type.Ptr), Seq(Val.Null, len)),
                   unwind)
         case arrval: Val.ArrayValue =>
-          val sig  = arraySnapshotSig.getOrElse(ty, arrayAllocSig(Rt.Object))
-          val func = arraySnapshot.getOrElse(ty, arrayAlloc(Rt.Object))
+          val sig  = arraySnapshotSig.getOrElse(ty, arraySnapshotSig(Rt.Object))
+          val func = arraySnapshot.getOrElse(ty, arraySnapshot(Rt.Object))
           val len  = Val.Int(arrval.values.length)
           val init = Val.Const(arrval)
           buf.let(


### PR DESCRIPTION
This PR adds a few minor changes that shrink down the binary size overhead of the #1436 to around 25k (split roughly in half between code and data for the arrays). 