### PR TITLE
[0.3.x] Add java.util.IdentityHashMap

### DIFF
--- a/javalib/src/main/scala/java/util/IdentityHashMap.scala
+++ b/javalib/src/main/scala/java/util/IdentityHashMap.scala
@@ -1,0 +1,19 @@
+package java.util
+
+class IdentityHashMap[K, V] extends HashMap[K, V] {
+
+  override def boxKey(key: K): AnyRef =
+    IdentityBox(key)
+  override def unboxKey(box: AnyRef): K =
+    box match {
+      case IdentityBox(value) => value.asInstanceOf[K]
+      case _                  => null.asInstanceOf[K]
+    }
+
+  // forwarders - https://github.com/scala-native/scala-native/issues/375
+  override def containsKey(key: Any): Boolean     = super.containsKey(key)
+  override def containsValue(value: Any): Boolean = super.containsValue(value)
+  override def get(key: Any): V                   = super.get(key)
+  override def put(key: K, value: V): V           = super.put(key, value)
+  override def remove(key: Any): V                = super.remove(key)
+}

--- a/javalib/src/main/scala/java/util/IdentityHashMap.scala
+++ b/javalib/src/main/scala/java/util/IdentityHashMap.scala
@@ -17,4 +17,5 @@ class IdentityHashMap[K, V] extends HashMap[K, V] {
   override def put(key: K, value: V): V           = super.put(key, value)
   override def remove(key: Any): V                = super.remove(key)
   override def clear(): Unit                      = super.clear()
+  override def size(): Int                        = super.size()
 }

--- a/javalib/src/main/scala/java/util/IdentityHashMap.scala
+++ b/javalib/src/main/scala/java/util/IdentityHashMap.scala
@@ -16,4 +16,5 @@ class IdentityHashMap[K, V] extends HashMap[K, V] {
   override def get(key: Any): V                   = super.get(key)
   override def put(key: K, value: V): V           = super.put(key, value)
   override def remove(key: Any): V                = super.remove(key)
+  override def clear(): Unit                      = super.clear()
 }

--- a/javalib/src/main/scala/java/util/package.scala
+++ b/javalib/src/main/scala/java/util/package.scala
@@ -8,6 +8,14 @@ package object util {
     def ===(that: Any): Boolean =
       if (self.asInstanceOf[AnyRef] eq null) that.asInstanceOf[AnyRef] eq null
       else self.equals(that)
+
+    @inline
+    def =:=(that: Any): Boolean = {
+      val aself = self.asInstanceOf[AnyRef]
+      val athat = that.asInstanceOf[AnyRef]
+      if (aself eq null) athat eq null
+      else aself eq athat
+    }
   }
 
   private[util] final case class Box[+K](inner: K) {
@@ -23,6 +31,21 @@ package object util {
     override def hashCode(): Int =
       if (inner == null) 0
       else inner.hashCode
+  }
+
+  private[util] final case class IdentityBox[+K](inner: K) {
+    def apply(): K = inner
+
+    override def equals(o: Any): Boolean = {
+      o match {
+        case o: IdentityBox[_] => inner =:= o.inner
+        case _                 => false
+      }
+    }
+
+    override def hashCode(): Int =
+      System.identityHashCode(inner.asInstanceOf[AnyRef])
+
   }
 
   private[util] def defaultOrdering[E]: Ordering[E] = {

--- a/unit-tests/src/test/scala/java/util/IdentityHashMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/IdentityHashMapSuite.scala
@@ -2,7 +2,6 @@ package java.util
 
 // Ported from Scala.js
 
-import java.{util => ju}
 import scala.reflect.ClassTag
 
 object IdentityHashMapSuite extends MapSuite {
@@ -58,14 +57,51 @@ object IdentityHashMapSuite extends MapSuite {
     assertNull(map.get(null))
   }
 
+  test("check put, null key, null value") {
+    val map   = factory.empty[AnyRef, AnyRef]
+    val value = "Some value"
+    map.put(null, value)
+    assertEquals(value, map.get(null))
+    val key = "Some key"
+    map.put(key, null)
+    assertNull(map.get(key))
+  }
+
+  test("check remove") {
+    val map = factory.empty[AnyRef, AnyRef]
+    map.put(null, null)
+    map.put("key1", "value1")
+    map.put("key2", "value2")
+    map.remove("key1")
+    assertTrue(!map.containsKey("key1"))                                 // Did not remove key1
+    assertTrue(!map.containsValue("value1"))                             // Did not remove the value for key
+    assertTrue(map.get("key2") != null && (map.get("key2") eq "value2")) // Modified key2
+    assertNull(map.get(null))                                            // Modified null entry
+  }
+
+  test("Regression for HARMONY-37") {
+    // problem with size
+    // cannot link: @java.util.IdentityHashMap::field.size
+    val map = factory.empty[String, String]
+    map.remove("absent")
+    //assertEquals(0, map.size) // Size is incorrect
+    map.put("key", "value")
+    map.remove("key")
+    //assertEquals(0, map.size) // After removing non-null element size is incorrect
+    map.put(null, null)
+    //assertEquals(1, map.size) // adding literal null failed
+    map.remove(null)
+    //assertEquals(0, map.size) // After removing null element size is incorrect
+  }
+  // other Harmony tests available
 }
 
 class IdentityMapSuiteFactory extends AbstractMapSuiteFactory {
   override def implementationName: String =
     "java.util.IdentityHashMap"
 
-  override def empty[K: ClassTag, V: ClassTag]: ju.IdentityHashMap[K, V] =
-    new ju.IdentityHashMap[K, V]
+  override def empty[K: ClassTag, V: ClassTag]: IdentityHashMap[K, V] =
+    new IdentityHashMap[K, V]
 
   def allowsNullKeys: Boolean                   = true
   def allowsNullValues: Boolean                 = true

--- a/unit-tests/src/test/scala/java/util/IdentityHashMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/IdentityHashMapSuite.scala
@@ -5,29 +5,12 @@ package java.util
 import java.{util => ju}
 import scala.reflect.ClassTag
 
-//object IdentityHashMapSuite extends MapSuite {
-//  def factory(): IdentityHashMapSuite = new IdentityHashMapSuite
-//}
-//
-//class IdentityHashMapSuite extends AbstractMapSuiteFactory {
-//  override def implementationName: String =
-//    "java.util.IdentityHashMap"
-//
-//  override def empty[K: ClassTag, V: ClassTag]: ju.IdentityHashMap[K, V] =
-//    new ju.IdentityHashMap[K, V]
-//
-//  def allowsNullKeys: Boolean   = true
-//  def allowsNullValues: Boolean = true
-//
-//}
+object IdentityHashMapSuite extends MapSuite {
+  override def factory: IdentityMapSuiteFactory = new IdentityMapSuiteFactory
 
-object IdentityHashMapSuite extends tests.Suite {
-
-  def empty[K: ClassTag, V: ClassTag]: ju.IdentityHashMap[K, V] =
-    new ju.IdentityHashMap[K, V]
-
+  // tests from Harmony
   // tests with null keys and values
-  val map                  = empty[AnyRef, AnyRef]
+  val map                  = factory.empty[AnyRef, AnyRef]
   var result: AnyRef       = _
   var value: AnyRef        = _
   var anothervalue: AnyRef = _
@@ -74,4 +57,18 @@ object IdentityHashMapSuite extends tests.Suite {
     assertTrue(!map.containsValue(anothervalue))
     assertNull(map.get(null))
   }
+
+}
+
+class IdentityMapSuiteFactory extends AbstractMapSuiteFactory {
+  override def implementationName: String =
+    "java.util.IdentityHashMap"
+
+  override def empty[K: ClassTag, V: ClassTag]: ju.IdentityHashMap[K, V] =
+    new ju.IdentityHashMap[K, V]
+
+  def allowsNullKeys: Boolean                   = true
+  def allowsNullValues: Boolean                 = true
+  override def allowsIdentityBasedKeys: Boolean = true
+
 }

--- a/unit-tests/src/test/scala/java/util/IdentityHashMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/IdentityHashMapSuite.scala
@@ -1,0 +1,77 @@
+package java.util
+
+// Ported from Scala.js
+
+import java.{util => ju}
+import scala.reflect.ClassTag
+
+//object IdentityHashMapSuite extends MapSuite {
+//  def factory(): IdentityHashMapSuite = new IdentityHashMapSuite
+//}
+//
+//class IdentityHashMapSuite extends AbstractMapSuiteFactory {
+//  override def implementationName: String =
+//    "java.util.IdentityHashMap"
+//
+//  override def empty[K: ClassTag, V: ClassTag]: ju.IdentityHashMap[K, V] =
+//    new ju.IdentityHashMap[K, V]
+//
+//  def allowsNullKeys: Boolean   = true
+//  def allowsNullValues: Boolean = true
+//
+//}
+
+object IdentityHashMapSuite extends tests.Suite {
+
+  def empty[K: ClassTag, V: ClassTag]: ju.IdentityHashMap[K, V] =
+    new ju.IdentityHashMap[K, V]
+
+  // tests with null keys and values
+  val map                  = empty[AnyRef, AnyRef]
+  var result: AnyRef       = _
+  var value: AnyRef        = _
+  var anothervalue: AnyRef = _
+
+  test("null key and value") { //
+    result = map.put(null, null)
+    assertTrue(map.containsKey(null))
+    assertTrue(map.containsValue(null))
+    assertNull(map.get(null))
+    assertNull(result)
+  }
+
+  test("null key replaces") {
+    value = "a value"
+    result = map.put(null, value)
+    assertTrue(map.containsKey(null))
+    assertTrue(map.containsValue(value))
+    assertTrue(map.get(null) eq value)
+    assertNull(result)
+  }
+
+  test("null value") {
+    val key = "a key"
+    result = map.put(key, null)
+    assertTrue(map.containsKey(key))
+    assertTrue(map.containsValue(null))
+    assertNull(map.get(key))
+    assertNull(result)
+  }
+
+  test("another null key replaces old val") {
+    anothervalue = "another value"
+    result = map.put(null, anothervalue)
+    assertTrue(map.containsKey(null))
+    assertTrue(map.containsValue(anothervalue))
+    assertTrue(map.get(null) eq anothervalue)
+    assertTrue(result eq value)
+  }
+
+  test("remove a null key") {
+    result = map.remove(null)
+    assertTrue(result eq anothervalue)
+    assertTrue(!map.containsKey(null))
+    assertTrue(!map.containsValue(anothervalue))
+    assertNull(map.get(null))
+  }
+}

--- a/unit-tests/src/test/scala/java/util/IdentityHashMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/IdentityHashMapSuite.scala
@@ -80,18 +80,18 @@ object IdentityHashMapSuite extends MapSuite {
   }
 
   test("Regression for HARMONY-37") {
-    // problem with size
     // cannot link: @java.util.IdentityHashMap::field.size
+    // requires size()
     val map = factory.empty[String, String]
     map.remove("absent")
-    //assertEquals(0, map.size) // Size is incorrect
+    assertEquals(0, map.size()) // Size is incorrect
     map.put("key", "value")
     map.remove("key")
-    //assertEquals(0, map.size) // After removing non-null element size is incorrect
+    assertEquals(0, map.size()) // After removing non-null element size is incorrect
     map.put(null, null)
-    //assertEquals(1, map.size) // adding literal null failed
+    assertEquals(1, map.size()) // adding literal null failed
     map.remove(null)
-    //assertEquals(0, map.size) // After removing null element size is incorrect
+    assertEquals(0, map.size()) // After removing null element size is incorrect
   }
   // other Harmony tests available
 }

--- a/unit-tests/src/test/scala/java/util/LinkedHashMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/LinkedHashMapSuite.scala
@@ -7,7 +7,7 @@ import scala.collection.JavaConversions._
 import scala.collection.{immutable => im}
 import scala.reflect.ClassTag
 
-class LinkedHashMapInsertionOrderSuite extends LinkedHashMapSuite
+object LinkedHashMapInsertionOrderSuite extends LinkedHashMapSuite
 
 object LinkedHashMapInsertionOrderLimitedSuite extends LinkedHashMapSuite {
   override def factory: LinkedHashMapSuiteFactory =

--- a/unit-tests/src/test/scala/java/util/MapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/MapSuite.scala
@@ -58,7 +58,7 @@ trait MapSuite extends tests.Suite {
 
   test("should store custom objects") {
     case class TestObj(num: Int)
-    val mp      = factory.empty[TestObj, TestObj]
+    val mp = factory.empty[TestObj, TestObj]
 
     val testKey = TestObj(100)
     mp.put(testKey, TestObj(12345))

--- a/unit-tests/src/test/scala/java/util/MapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/MapSuite.scala
@@ -58,13 +58,18 @@ trait MapSuite extends tests.Suite {
 
   test("should store custom objects") {
     case class TestObj(num: Int)
+    val mp      = factory.empty[TestObj, TestObj]
 
-    val mp = factory.empty[TestObj, TestObj]
-
-    mp.put(TestObj(100), TestObj(12345))
+    val testKey = TestObj(100)
+    mp.put(testKey, TestObj(12345))
     assertEquals(1, mp.size())
-    val one = mp.get(TestObj(100))
-    assertEquals(12345, one.num)
+    if (factory.allowsIdentityBasedKeys) {
+      val one = mp.get(testKey)
+      assertEquals(12345, one.num)
+    } else {
+      val one = mp.get(TestObj(100))
+      assertEquals(12345, one.num)
+    }
   }
 
   test("should remove stored elements") {
@@ -553,4 +558,6 @@ trait MapFactory {
   def allowsNullKeysQueries: Boolean = true
 
   def allowsNullValuesQueries: Boolean = true
+
+  def allowsIdentityBasedKeys: Boolean = false
 }


### PR DESCRIPTION
This is now targeting `0.3.x` first and can be reworked as needed to support `0.4.0`.