### PR TITLE
Interflow: don't duplicate or inline in debug mode

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -284,7 +284,7 @@ trait Eval { self: Interflow =>
         val isPure =
           isPureModule(clsName)
         val isWhitelisted =
-          UseDef.pureWhitelist.contains(clsName)
+          Whitelist.pure.contains(clsName)
         val canDelay =
           isPure || isWhitelisted
 

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -8,58 +8,62 @@ import scalanative.linker._
 trait Inline { self: Interflow =>
   def shallInline(name: Global, args: Seq[Val])(
       implicit state: State,
-      linked: linker.Result): Boolean =
-    done
-      .get(name)
-      .fold[Boolean] {
-        false
-      } { defn =>
-        val isCtor = originalName(name) match {
-          case Global.Member(_, _: Sig.Ctor) =>
-            true
-          case Global.Member(_, Sig.Method("$init$", _)) =>
-            true
-          case _ =>
-            false
-        }
-        val isSmall =
-          defn.insts.size <= 8
-        val hasVirtualArgs =
-          args.exists(_.isInstanceOf[Val.Virtual])
-        val noInline =
-          defn.attrs.inline == Attr.NoInline
-        val hintInline =
-          defn.attrs.inline == Attr.AlwaysInline || defn.attrs.inline == Attr.InlineHint
-        val isRecursive =
-          context.contains(s"inlining ${name.show}")
-        val isBlacklisted =
-          blacklist.contains(name)
-        val calleeTooBig =
-          defn.insts.size > 8192
-        val callerTooBig =
-          mergeProcessor.currentSize() > 8192
-
-        val shall =
-          isCtor || hintInline || isSmall || (mode == build.Mode.Release && hasVirtualArgs)
-        val shallNot =
-          noInline || isRecursive || isBlacklisted || calleeTooBig || callerTooBig
-
-        if (shall) {
-          if (shallNot) {
-            log(s"not inlining ${name.show}, because:")
-            if (noInline) { log("* has noinline attr") }
-            if (isRecursive) { log("* is recursive") }
-            if (isBlacklisted) { log("* is blacklisted") }
-            if (callerTooBig) { log("* caller is too big") }
-            if (calleeTooBig) { log("* callee is too big") }
+      linked: linker.Result): Boolean = mode match {
+    case build.Mode.Debug =>
+      false
+    case build.Mode.Release =>
+      done
+        .get(name)
+        .fold[Boolean] {
+          false
+        } { defn =>
+          val isCtor = originalName(name) match {
+            case Global.Member(_, _: Sig.Ctor) =>
+              true
+            case Global.Member(_, Sig.Method("$init$", _)) =>
+              true
+            case _ =>
+              false
           }
-        } else {
-          log(
-            s"no reason to inline ${name.show}(${args.map(_.show).mkString(",")})")
-        }
+          val isSmall =
+            defn.insts.size <= 8
+          val hasVirtualArgs =
+            args.exists(_.isInstanceOf[Val.Virtual])
+          val noInline =
+            defn.attrs.inline == Attr.NoInline
+          val hintInline =
+            defn.attrs.inline == Attr.AlwaysInline || defn.attrs.inline == Attr.InlineHint
+          val isRecursive =
+            context.contains(s"inlining ${name.show}")
+          val isBlacklisted =
+            blacklist.contains(name)
+          val calleeTooBig =
+            defn.insts.size > 8192
+          val callerTooBig =
+            mergeProcessor.currentSize() > 8192
 
-        shall && !shallNot
-      }
+          val shall =
+            isCtor || hintInline || isSmall || hasVirtualArgs
+          val shallNot =
+            noInline || isRecursive || isBlacklisted || calleeTooBig || callerTooBig
+
+          if (shall) {
+            if (shallNot) {
+              log(s"not inlining ${name.show}, because:")
+              if (noInline) { log("* has noinline attr") }
+              if (isRecursive) { log("* is recursive") }
+              if (isBlacklisted) { log("* is blacklisted") }
+              if (callerTooBig) { log("* caller is too big") }
+              if (calleeTooBig) { log("* callee is too big") }
+            }
+          } else {
+            log(
+              s"no reason to inline ${name.show}(${args.map(_.show).mkString(",")})")
+          }
+
+          shall && !shallNot
+        }
+  }
 
   def inline(name: Global, args: Seq[Val])(implicit state: State,
                                            linked: linker.Result): Val =

--- a/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
@@ -55,23 +55,11 @@ object UseDef {
     collector.deps.distinct
   }
 
-  val pureWhitelist = {
-    val out = mutable.Set.empty[Global]
-    out += Global.Top("scala.Predef$")
-    out += Global.Top("scala.runtime.BoxesRunTime$")
-    out += Global.Top("scala.scalanative.runtime.Boxes$")
-    out += Global.Top("scala.scalanative.runtime.package$")
-    out += Global.Top("scala.scalanative.native.package$")
-    out += Global.Top("scala.collection.immutable.Range$")
-    out ++= codegen.Lower.BoxTo.values
-    out
-  }
-
   private def isPure(inst: Inst) = inst match {
     case Inst.Let(_, Op.Call(_, Val.Global(name, _), _), _) =>
-      pureWhitelist.contains(name)
+      Whitelist.pure.contains(name)
     case Inst.Let(_, Op.Module(name), _) =>
-      pureWhitelist.contains(name)
+      Whitelist.pure.contains(name)
     case Inst.Let(_, op, _) if op.isPure =>
       true
     case _ =>

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -19,6 +19,14 @@ trait Visit { self: Interflow =>
         notExtern && hasInsts && hasSema
       }
 
+  def shallDuplicate(name: Global, argtys: Seq[Type]): Boolean =
+    mode match {
+      case build.Mode.Debug =>
+        false
+      case build.Mode.Release =>
+        argumentTypes(name) != argtys
+    }
+
   def visitEntry(name: Global): Unit = {
     if (!name.isTop) {
       visitEntry(name.top)
@@ -171,7 +179,7 @@ trait Visit { self: Interflow =>
 
   def duplicateName(name: Global, argtys: Seq[Type]): Global = {
     val orig = originalName(name)
-    if (argumentTypes(orig) == argtys) {
+    if (!shallDuplicate(orig, argtys)) {
       orig
     } else {
       val Global.Member(top, sig) = orig

--- a/tools/src/main/scala/scala/scalanative/interflow/Whitelist.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Whitelist.scala
@@ -1,0 +1,27 @@
+package scala.scalanative
+package interflow
+
+import scala.collection.mutable
+import scalanative.nir._
+import scalanative.codegen.Lower
+
+object Whitelist {
+  val constantModules = {
+    val out = collection.mutable.Set.empty[Global]
+    out += Global.Top("scala.scalanative.runtime.BoxedUnit$")
+    out
+  }
+
+  val pure = {
+    val out = mutable.Set.empty[Global]
+    out += Global.Top("scala.Predef$")
+    out += Global.Top("scala.runtime.BoxesRunTime$")
+    out += Global.Top("scala.scalanative.runtime.Boxes$")
+    out += Global.Top("scala.scalanative.runtime.package$")
+    out += Global.Top("scala.scalanative.native.package$")
+    out += Global.Top("scala.collection.immutable.Range$")
+    out ++= Lower.BoxTo.values
+    out ++= constantModules
+    out
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -137,8 +137,10 @@ final class Class(val attrs: Attrs,
             false
         }
     }
+    val isWhitelisted =
+      interflow.Whitelist.constantModules.contains(name)
 
-    isModule && (attrs.isExtern || (hasEmptyOrNoCtor && hasNoFields))
+    isModule && (isWhitelisted || attrs.isExtern || (hasEmptyOrNoCtor && hasNoFields))
   }
   def resolve(sig: Sig): Option[Global] = {
     responds.get(sig)


### PR DESCRIPTION
To reduce compilation time in debug, we disable method duplication and inlining. This brings optimization time in debug down to the similar time we've used to have on 0.3.x. 