### PR TITLE
Implement java.util.Properties.list

### DIFF
--- a/javalib/src/main/scala/java/util/Hashtable.scala
+++ b/javalib/src/main/scala/java/util/Hashtable.scala
@@ -44,6 +44,7 @@ class Hashtable[K, V] private (inner: mutable.HashMap[Box[Any], V])
   def containsKey(key: Any): Boolean =
     inner.contains(Box(key))
 
+  @throws[NullPointerException]
   def get(key: Any): V = {
     if (key == null)
       throw new NullPointerException
@@ -53,11 +54,16 @@ class Hashtable[K, V] private (inner: mutable.HashMap[Box[Any], V])
   // Not implemented
   // protected def rehash(): Unit
 
-  def put(key: K, value: V): V =
+  @throws[NullPointerException]
+  def put(key: K, value: V): V = {
+    if (key == null || value == null)
+      throw new NullPointerException
     inner
       .put(Box(key.asInstanceOf[AnyRef]), value)
       .getOrElse(null.asInstanceOf[V])
+  }
 
+  @throws[NullPointerException]
   def remove(key: Any): V = {
     if (key == null)
       throw new NullPointerException

--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -83,6 +83,4 @@ class Properties(protected val defaults: Properties)
   // def loadFromXML(in: InputStream): Unit
   // def storeToXML(os: OutputStream, comment: String): Unit
   // def storeToXML(os: OutputStream, comment: String, encoding: String): Unit
-  // def list(out: PrintStream): Unit
-  // def list(out: PrintWriter): Unit
 }

--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -1,5 +1,6 @@
 package java.util
 
+import java.io.{PrintStream, PrintWriter}
 import java.{util => ju}
 
 import scala.collection.JavaConverters._
@@ -49,6 +50,29 @@ class Properties(protected val defaults: Properties)
     if (defaults != null)
       set.addAll(defaults.stringPropertyNames())
     set
+  }
+
+  private def format(entry: ju.Map.Entry[AnyRef, AnyRef]): String = {
+    val key: String   = entry.getKey.asInstanceOf[String]
+    val value: String = entry.getValue.asInstanceOf[String]
+    if (key.length > 40)
+      s"${key.substring(0, 37)}...=$value"
+    else
+      s"$key=$value"
+  }
+
+  def list(out: PrintStream): Unit = {
+    out.println("-- listing properties --")
+    entrySet().asScala.foreach { entry =>
+      out.println(format(entry))
+    }
+  }
+
+  def list(out: PrintWriter): Unit = {
+    out.println("-- listing properties --")
+    entrySet().asScala.foreach { entry =>
+      out.println(format(entry))
+    }
   }
 
   // TODO:

--- a/unit-tests/src/test/scala/java/util/HashtableSuite.scala
+++ b/unit-tests/src/test/scala/java/util/HashtableSuite.scala
@@ -1,0 +1,10 @@
+package java.util
+
+object HashtableSuite extends tests.Suite {
+
+  test("put on null key or value") {
+    val t = new Hashtable[AnyRef, AnyRef]()
+    assertThrows[NullPointerException](t.put(null, "value"))
+    assertThrows[NullPointerException](t.put("key", null))
+  }
+}

--- a/unit-tests/src/test/scala/java/util/PropertiesSuite.scala
+++ b/unit-tests/src/test/scala/java/util/PropertiesSuite.scala
@@ -24,7 +24,7 @@ object PropertiesSuite extends tests.Suite {
 
     def assertResult(result: String): Unit = {
       val buffer4stream = new ByteArrayOutputStream
-      val stream = new PrintStream(buffer4stream)
+      val stream        = new PrintStream(buffer4stream)
       properties.list(stream)
       assertEquals(buffer4stream.toString.trim, result.trim)
       stream.flush()

--- a/unit-tests/src/test/scala/java/util/PropertiesSuite.scala
+++ b/unit-tests/src/test/scala/java/util/PropertiesSuite.scala
@@ -1,0 +1,52 @@
+package java.util
+
+import java.io._
+
+object PropertiesSuite extends tests.Suite {
+  test("put on null key or null value") {
+    val properties = new Properties
+    assertThrows[NullPointerException](properties.put(null, "any"))
+    assertThrows[NullPointerException](properties.put("any", null))
+  }
+
+  test("non-string values") {
+    val properties = new Properties
+
+    properties.put("age", Int.box(18))
+    assertNull(properties.getProperty("age"))
+    assertThrows[ClassCastException] {
+      properties.list(new PrintWriter(new ByteArrayOutputStream))
+    }
+  }
+
+  test("list") {
+    val properties = new Properties
+
+    def assertResult(result: String): Unit = {
+      val buffer4stream = new ByteArrayOutputStream
+      val stream = new PrintStream(buffer4stream)
+      properties.list(stream)
+      assertEquals(buffer4stream.toString.trim, result.trim)
+      stream.flush()
+    }
+
+    val result0 = "-- listing properties --\n"
+    assertResult(result0)
+
+    properties.put("name", "alice")
+    val result1 =
+      """
+        |-- listing properties --
+        |name=alice
+      """.stripMargin
+    assertResult(result1)
+
+    properties.put("p0000000000111111111122222222223333333333", "40")
+    val result2 =
+      """-- listing properties --
+        |name=alice
+        |p000000000011111111112222222222333333...=40
+      """.stripMargin
+    assertResult(result2)
+  }
+}


### PR DESCRIPTION
## Changes
1. Impl `ju.Properties.list`
2. Add null check on `ju.Hashtable.put`


for the put method of Hashtable: 

> This class implements a hash table, which maps keys to values. Any non-null object can be used as a key or as a value. 

## Ref
+ #1064 
+ https://docs.oracle.com/javase/8/docs/api/java/util/Hashtable.html