### PR TITLE
Partial Fix #1412: Enhance java.io.File to support URI

### DIFF
--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -330,30 +330,21 @@ class File(_path: String) extends Serializable with Comparable[File] {
 
   // Ported from Apache Harmony
   def toURI(): URI = {
-    import java.net.URISyntaxException
     val path = getAbsolutePath()
-    try {
-      if (!path.startsWith("/")) {
-        // start with sep.
-        new URI(
-          "file",
-          null,
-          new StringBuilder(path.length + 1).append('/').append(path).toString,
-          null,
-          null)
-      } else if (path.startsWith("//")) {
-        // UNC path
-        new URI("file", "", path, null)
-      } else {
-        new URI("file", null, path, null, null)
-      }
-
-    } catch {
-      case e: URISyntaxException =>
-        // this should never happen
-        return null
+    if (!path.startsWith("/")) {
+      // start with sep.
+      new URI(
+        "file",
+        null,
+        new StringBuilder(path.length + 1).append('/').append(path).toString,
+        null,
+        null)
+    } else if (path.startsWith("//")) {
+      // UNC path
+      new URI("file", "", path, null)
+    } else {
+      new URI("file", null, path, null, null)
     }
-
   }
 }
 
@@ -575,18 +566,24 @@ object File {
   private def checkURI(uri: URI): Unit = {
     def throwExc(msg: String): Unit =
       throw new IllegalArgumentException(s"$msg: $uri")
-    def compMsg(comp: String): String = s"Found $comp component in URI"
+    def compMsg(comp: String): String =
+      s"Found $comp component in URI"
 
-    if (!uri.isAbsolute) throwExc("URI is not absolute")
-    else if (!uri.getRawSchemeSpecificPart.startsWith("/"))
+    if (!uri.isAbsolute) {
+      throwExc("URI is not absolute")
+    } else if (!uri.getRawSchemeSpecificPart.startsWith("/")) {
       throwExc("URI is not hierarchical")
-    else if (uri.getScheme == null || !(uri.getScheme == "file"))
+    } else if (uri.getScheme == null || !(uri.getScheme == "file")) {
       throwExc("Expected file scheme in URI")
-    else if (uri.getRawPath == null || uri.getRawPath.length == 0)
+    } else if (uri.getRawPath == null || uri.getRawPath.length == 0) {
       throwExc("Expected non-empty path in URI")
-    else if (uri.getRawAuthority != null) throwExc(compMsg("authority"))
-    else if (uri.getRawQuery != null) throwExc(compMsg("query"))
-    else if (uri.getRawFragment != null) throwExc(compMsg("fragment"))
+    } else if (uri.getRawAuthority != null) {
+      throwExc(compMsg("authority"))
+    } else if (uri.getRawQuery != null) {
+      throwExc(compMsg("query"))
+    } else if (uri.getRawFragment != null) {
+      throwExc(compMsg("fragment"))
+    }
     // else URI is ok
   }
 }

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -1,6 +1,7 @@
 package java.io
 
 import java.nio.file.{FileSystems, Path}
+import java.net.URI
 
 import scala.annotation.tailrec
 import scalanative.posix.{fcntl, limits, unistd, utime}
@@ -27,7 +28,10 @@ class File(_path: String) extends Serializable with Comparable[File] {
   def this(parent: File, child: String) =
     this(Option(parent).map(_.path).orNull, child)
 
-  // def this(uri: URI)
+  def this(uri: URI) = {
+    this(uri.getPath)
+    checkURI(uri)
+  }
 
   def compareTo(file: File): Int = {
     if (caseSensitive) getPath().compareTo(file.getPath())
@@ -323,8 +327,33 @@ class File(_path: String) extends Serializable with Comparable[File] {
 
   @stub
   def toURL(): java.net.URL = ???
-  @stub
-  def toURI(): java.net.URI = ???
+
+  def toURI(): URI = {
+    import java.net.URISyntaxException
+    val path = getAbsolutePath()
+    try {
+      if (!path.startsWith("/")) {
+        // start with sep.
+        new URI(
+          "file",
+          null,
+          new StringBuilder(path.length + 1).append('/').append(path).toString,
+          null,
+          null)
+      } else if (path.startsWith("//")) {
+        // UNC path
+        new URI("file", "", path, null)
+      } else {
+        new URI("file", null, path, null, null)
+      }
+
+    } catch {
+      case e: URISyntaxException =>
+        // this should never happen
+        return null
+    }
+
+  }
 }
 
 object File {
@@ -541,4 +570,21 @@ object File {
                                minLength = true,
                                throwOnError = true)
 
+  // Ported from Apache Harmony
+  private def checkURI(uri: URI): Unit = {
+    def throwExc(msg: String): Unit =
+      throw new IllegalArgumentException(s"$msg: $uri")
+    def compMsg(comp: String): String = s"Found $comp component in URI"
+
+    if (!uri.isAbsolute) throwExc("URI is not absolute")
+    else if (!uri.getRawSchemeSpecificPart.startsWith("/"))
+      throwExc("URI is not hierarchical")
+    else if (uri.getScheme == null || !(uri.getScheme == "file"))
+      throwExc("Expected file scheme in URI")
+    else if (uri.getRawPath == null || uri.getRawPath.length == 0)
+      throwExc("Expected non-empty path in URI")
+    else if (uri.getRawAuthority != null) throwExc(compMsg("authority"))
+    else if (uri.getRawQuery != null) throwExc(compMsg("query"))
+    else if (uri.getRawFragment != null) throwExc(compMsg("fragment"))
+  }
 }

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -328,6 +328,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
   @stub
   def toURL(): java.net.URL = ???
 
+  // Ported from Apache Harmony
   def toURI(): URI = {
     import java.net.URISyntaxException
     val path = getAbsolutePath()
@@ -586,5 +587,6 @@ object File {
     else if (uri.getRawAuthority != null) throwExc(compMsg("authority"))
     else if (uri.getRawQuery != null) throwExc(compMsg("query"))
     else if (uri.getRawFragment != null) throwExc(compMsg("fragment"))
+    // else URI is ok
   }
 }

--- a/unit-tests/src/test/scala/java/io/FileSuite.scala
+++ b/unit-tests/src/test/scala/java/io/FileSuite.scala
@@ -1,0 +1,34 @@
+package java.io
+
+import java.net.URI
+
+object FileSuite extends tests.Suite {
+
+  test("Try to create a `File` with a bad `URI`") {
+    val badURIs = Array(
+      new URI("http://foo.com/"),
+      new URI("relpath/foo.txt"),
+      new URI("file://path?foo=bar"),
+      new URI("file://path#frag"),
+      new URI("file://user@host/path"),
+      new URI("file://host:8080/path")
+    )
+
+    for (uri <- badURIs) {
+      assertThrows[IllegalArgumentException] { new File(uri) }
+    }
+  }
+
+  test("Get a `URI` from a `File`") {
+    val u1 = new File("path").toURI
+    assertNotNull(u1)
+    assert(u1.getScheme == "file")
+    assert(u1.getPath.endsWith("path"))
+
+    val u2 = new File("/path/to/file.txt").toURI
+    assertNotNull(u2)
+    assert(u2.getScheme == "file")
+    assert(u2.getPath.endsWith("file.txt"))
+    assert(u2.toString == "file:/path/to/file.txt")
+  }
+}


### PR DESCRIPTION
This is the 3rd PR of 5 to support [sconfig](https://github.com/ekrich/sconfig) and then native `scalafmt`.
See https://github.com/scala-native/scala-native/issues/1412

This PR is targeted for 0.4.0 and 0.3.9.