### PR TITLE
Partial Fix #1412: Add minimal java.time.Duration

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1566,3 +1566,51 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ```
+
+# License notice for java.time API
+
+The origin of `java.time` is [JSR-310](https://jcp.org/en/jsr/detail?id=310)
+and was assigned a BSD license as described in strike-through text on the
+JSR page. The API was inspired by earlier work by Stephen Colebourne and
+others found at [Joda-Time](https://www.joda.org/joda-time/).
+The original project was hosted by ThreeTen and an information page can
+be found [here](https://www.threeten.org/) about the project.
+
+The code in Scala Native is based on derivative work at
+[cquiroz/scala-java-time](https://github.com/cquiroz/scala-java-time) and
+[scala-js/scala-js-java-time](https://github.com/scala-js/scala-js-java-time).
+The original license notice is included below:
+
+```
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+```

--- a/javalib/src/main/scala/java/time/Duration.scala
+++ b/javalib/src/main/scala/java/time/Duration.scala
@@ -1,0 +1,26 @@
+package java.time
+
+import java.time.temporal.TemporalAmount
+
+@SerialVersionUID(3078945930695997490L)
+final class Duration private (private val seconds: Long, private val nanos: Int)
+    extends TemporalAmount
+    with Ordered[Duration]
+    with Serializable {
+
+  def toMillis: Long = {
+    val result: Long = Math.multiplyExact(seconds, 1000)
+    Math.addExact(result, nanos / Duration.NANOS_PER_MILLI)
+  }
+
+  def compare(otherDuration: Duration): Int = {
+    val cmp: Int = java.lang.Long.compare(seconds, otherDuration.seconds)
+    if (cmp != 0) cmp
+    else nanos - otherDuration.nanos
+  }
+}
+
+@SerialVersionUID(3078945930695997490L)
+object Duration {
+  private val NANOS_PER_MILLI: Int = 1000000
+}

--- a/javalib/src/main/scala/java/time/Duration.scala
+++ b/javalib/src/main/scala/java/time/Duration.scala
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package java.time
 
 import java.time.temporal.TemporalAmount
@@ -9,7 +41,7 @@ final class Duration private (private val seconds: Long, private val nanos: Int)
     with Serializable {
 
   def toMillis: Long = {
-    val result: Long = Math.multiplyExact(seconds, 1000)
+    val result: Long = Math.multiplyExact(seconds, Duration.MILLIS_PER_SEC)
     Math.addExact(result, nanos / Duration.NANOS_PER_MILLI)
   }
 
@@ -18,9 +50,46 @@ final class Duration private (private val seconds: Long, private val nanos: Int)
     if (cmp != 0) cmp
     else nanos - otherDuration.nanos
   }
+
+  override def compareTo(other: Duration): Int = compare(other)
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case otherDuration: Duration =>
+        (this eq otherDuration) || (this.seconds == otherDuration.seconds && this.nanos == otherDuration.nanos)
+      case _ => false
+    }
+
+  override def hashCode: Int = (seconds ^ (seconds >>> 32)).toInt + (51 * nanos)
 }
 
 @SerialVersionUID(3078945930695997490L)
 object Duration {
   private val NANOS_PER_MILLI: Int = 1000000
+  private val MILLIS_PER_SEC: Int  = 1000
+  private val NANOS_PER_SEC: Int   = NANOS_PER_MILLI * MILLIS_PER_SEC
+
+  private def create(seconds: Long, nanoAdjustment: Int): Duration =
+    if ((seconds | nanoAdjustment) == 0) ZERO
+    else new Duration(seconds, nanoAdjustment)
+
+  val ZERO: Duration = new Duration(0, 0)
+
+  def ofMillis(millis: Long): Duration = {
+    var secs: Long = millis / MILLIS_PER_SEC
+    var mos: Int   = (millis % MILLIS_PER_SEC).toInt
+    if (mos < 0) {
+      mos += MILLIS_PER_SEC
+      secs -= 1
+    }
+    create(secs, mos * NANOS_PER_MILLI)
+  }
+
+  def ofSeconds(seconds: Long, nanoAdjustment: Long): Duration = {
+    val secs: Long =
+      Math.addExact(seconds, Math.floorDiv(nanoAdjustment, NANOS_PER_SEC))
+    val nos: Int = Math.floorMod(nanoAdjustment, NANOS_PER_SEC).toInt
+    create(secs, nos)
+  }
+
 }

--- a/javalib/src/main/scala/java/time/Duration.scala
+++ b/javalib/src/main/scala/java/time/Duration.scala
@@ -35,30 +35,31 @@ package java.time
 
 import java.time.temporal.TemporalAmount
 
-final class Duration private (private val seconds: Long, private val nanos: Int)
+final class Duration private (seconds: Long, nanos: Int)
     extends TemporalAmount
     with Comparable[Duration]
     with java.io.Serializable {
+
+  def getSeconds(): Long = seconds
+
+  def getNano(): Int = nanos
 
   def toMillis: Long = {
     val result: Long = Math.multiplyExact(seconds, Duration.MILLIS_PER_SEC)
     Math.addExact(result, nanos / Duration.NANOS_PER_MILLI)
   }
 
-  def compare(otherDuration: Duration): Int = {
-    val cmp: Int = java.lang.Long.compare(seconds, otherDuration.seconds)
-    if (cmp != 0) cmp
-    else nanos - otherDuration.nanos
+  def compareTo(that: Duration): Int = {
+    val secCmp = seconds.compareTo(that.getSeconds)
+    if (secCmp == 0) nanos.compareTo(that.getNano)
+    else secCmp
   }
 
-  override def compareTo(other: Duration): Int = compare(other)
-
-  override def equals(other: Any): Boolean =
-    other match {
-      case otherDuration: Duration =>
-        (this eq otherDuration) || (this.seconds == otherDuration.seconds && this.nanos == otherDuration.nanos)
-      case _ => false
-    }
+  override def equals(that: Any): Boolean = that match {
+    case that: Duration =>
+      seconds == that.getSeconds && nanos == that.getNano
+    case _ => false
+  }
 
   override def hashCode: Int = (seconds ^ (seconds >>> 32)).toInt + (51 * nanos)
 }

--- a/javalib/src/main/scala/java/time/Duration.scala
+++ b/javalib/src/main/scala/java/time/Duration.scala
@@ -30,15 +30,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// see the license file for more information about java.time
 package java.time
 
 import java.time.temporal.TemporalAmount
 
-@SerialVersionUID(3078945930695997490L)
 final class Duration private (private val seconds: Long, private val nanos: Int)
     extends TemporalAmount
-    with Ordered[Duration]
-    with Serializable {
+    with Comparable[Duration]
+    with java.io.Serializable {
 
   def toMillis: Long = {
     val result: Long = Math.multiplyExact(seconds, Duration.MILLIS_PER_SEC)
@@ -63,17 +63,16 @@ final class Duration private (private val seconds: Long, private val nanos: Int)
   override def hashCode: Int = (seconds ^ (seconds >>> 32)).toInt + (51 * nanos)
 }
 
-@SerialVersionUID(3078945930695997490L)
 object Duration {
-  private val NANOS_PER_MILLI: Int = 1000000
-  private val MILLIS_PER_SEC: Int  = 1000
-  private val NANOS_PER_SEC: Int   = NANOS_PER_MILLI * MILLIS_PER_SEC
+  private final val NANOS_PER_MILLI: Int = 1000000
+  private final val MILLIS_PER_SEC: Int  = 1000
+  private final val NANOS_PER_SEC: Int   = NANOS_PER_MILLI * MILLIS_PER_SEC
 
   private def create(seconds: Long, nanoAdjustment: Int): Duration =
     if ((seconds | nanoAdjustment) == 0) ZERO
     else new Duration(seconds, nanoAdjustment)
 
-  val ZERO: Duration = new Duration(0, 0)
+  final val ZERO: Duration = new Duration(0, 0)
 
   def ofMillis(millis: Long): Duration = {
     var secs: Long = millis / MILLIS_PER_SEC
@@ -91,5 +90,4 @@ object Duration {
     val nos: Int = Math.floorMod(nanoAdjustment, NANOS_PER_SEC).toInt
     create(secs, nos)
   }
-
 }

--- a/javalib/src/main/scala/java/time/Instant.scala
+++ b/javalib/src/main/scala/java/time/Instant.scala
@@ -1,6 +1,41 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// see the license file for more information about java.time
 package java.time
 
-final class Instant(private val epochMilli: Long) extends Comparable[Instant] {
+final class Instant(private val epochMilli: Long)
+    extends Comparable[Instant]
+    with java.io.Serializable {
 
   override def equals(other: Any): Boolean =
     other match {

--- a/javalib/src/main/scala/java/time/temporal/TemporalAmount.scala
+++ b/javalib/src/main/scala/java/time/temporal/TemporalAmount.scala
@@ -1,3 +1,42 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// see the license file for more information about java.time
 package java.time.temporal
 
-trait TemporalAmount {}
+trait TemporalAmount {
+  // TODO:
+  // def get(unit: TemporalUnit): Long
+  // def getUnits(): java.util.List[TemporalUnit]
+  // def addTo(temporal: Temporal): Temporal
+  // def subtractFrom(temporal: Temporal): Temporal
+}

--- a/javalib/src/main/scala/java/time/temporal/TemporalAmount.scala
+++ b/javalib/src/main/scala/java/time/temporal/TemporalAmount.scala
@@ -1,0 +1,3 @@
+package java.time.temporal
+
+trait TemporalAmount {}

--- a/unit-tests/src/test/scala/java/time/DurationSuite.scala
+++ b/unit-tests/src/test/scala/java/time/DurationSuite.scala
@@ -1,0 +1,24 @@
+package java.time
+
+object DurationSuite extends tests.Suite {
+
+  val one   = Duration.ofSeconds(350070L, 112233L)
+  val two   = Duration.ofSeconds(350070L, 112233L)
+  val three = Duration.ofSeconds(350070L, 0L)
+
+  test("equals") {
+    assert(one.equals(one))
+    assert(one.equals(two))
+    assert(two.equals(one))
+    assert(one != null)
+    assertNot(one.equals(new Object()))
+  }
+
+  test("compareTo") {
+    assert(one.compareTo(one) == 0)
+    assert(one.compareTo(two) == 0)
+    assert(two.compareTo(three) > 0)
+    assert(three.compareTo(one) < 0)
+  }
+
+}

--- a/unit-tests/src/test/scala/java/time/DurationSuite.scala
+++ b/unit-tests/src/test/scala/java/time/DurationSuite.scala
@@ -2,23 +2,24 @@ package java.time
 
 object DurationSuite extends tests.Suite {
 
-  val one   = Duration.ofSeconds(350070L, 112233L)
-  val two   = Duration.ofSeconds(350070L, 112233L)
-  val three = Duration.ofSeconds(350070L, 0L)
+  val v1 = Duration.ofSeconds(350070L, 112233L)
+  val v2 = Duration.ofSeconds(350070L, 112233L)
+  val v3 = Duration.ofSeconds(350070L, 0L)
 
   test("equals") {
-    assert(one.equals(one))
-    assert(one.equals(two))
-    assert(two.equals(one))
-    assert(one != null)
-    assertNot(one.equals(new Object()))
+    assert(v1.equals(v1))
+    assert(v1.equals(v2))
+    assert(v2.equals(v1))
+    assert(v1 != null)
+    assertNot(v1.equals(new Object()))
   }
 
   test("compareTo") {
-    assert(one.compareTo(one) == 0)
-    assert(one.compareTo(two) == 0)
-    assert(two.compareTo(three) > 0)
-    assert(three.compareTo(one) < 0)
+    assert(v1.compareTo(v1) == 0)
+    assert(v1.compareTo(v2) == 0)
+    assert(v2.compareTo(v1) == 0)
+    assert(v2.compareTo(v3) > 0)
+    assert(v3.compareTo(v1) < 0)
   }
 
 }


### PR DESCRIPTION
This is the 4th PR of 5 to support sconfig and then native scalafmt.
See #1412

This PR is targeted for 0.4.0 and 0.3.9.