### PR TITLE
Fix #1468: fix broken struct code generation

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -81,6 +81,7 @@ trait NirGenStat { self: NirGenPhase =>
       val fields = genStructFields(sym)
       val body   = cd.impl.body
 
+      buf += Defn.Class(attrs, name, None, Seq.empty)
       genMethods(cd)
     }
 


### PR DESCRIPTION
This commit fixes a regression that made LLVMIntrinsics
fail to link. The issue was caused by a missing parent global definition
for legacy `@struct` support that we still use internally.