### PR TITLE
Fix #1470: Correct/Fix sys/select.scala fd_set declaration, remove selectOps. Breaking changes.

### DIFF
--- a/javalib/src/main/scala/java/net/PlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/PlainSocketImpl.scala
@@ -18,8 +18,8 @@ import scala.scalanative.posix.pollOps._
 import scala.scalanative.posix.sys.ioctl._
 import scala.scalanative.posix.fcntl._
 import scala.scalanative.posix.sys.select._
-import scala.scalanative.posix.sys.selectOps._
 import scala.scalanative.posix.sys.time._
+import scala.scalanative.posix.sys.timeOps._
 import scala.scalanative.posix.unistd.{close => cClose}
 import java.io.{FileDescriptor, IOException, OutputStream, InputStream}
 

--- a/nativelib/src/main/resources/posix/sys/select.c
+++ b/nativelib/src/main/resources/posix/sys/select.c
@@ -4,6 +4,25 @@
 #include <stddef.h>
 #include <string.h>
 
+#if (FD_SETSIZE > 1024)
+// Cross checking code is a mixed blessing. It can generate both
+// false positives and get out of sync. Such code should, in general,
+// be avoided.
+//
+// Here there is a magic compile time constant that _is_ going to grow,
+// sometime after tomorrow. That change will cause a mismatch
+// between this C code and the scala static type declaration and
+// undesired things will happen.
+//
+// For one example, FD_ZERO below will try to clear memory beyond the end
+// of the smaller fd_set allocated by the scala code.
+//
+// Being robust to such a change is well worth the code smell of this
+// large block comment. Miserere mei peccatoris.
+//
+#error("Probable size mismatch with static fd_set type in select.scala ")
+#endif
+
 #define FDBITS (8 * sizeof(long))
 
 struct scalanative_timeval {

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
@@ -1,14 +1,29 @@
 package scala.scalanative.posix.sys
 
-import scalanative.native._, Nat._
+import scalanative.native._
+import scalanative.native.Nat.{Digit, _1, _6}
 import scalanative.posix.inttypes._
 import scalanative.posix.time._
 
 @extern
 object select {
-  type suseconds_t = CLongInt
 
-  type fd_set = CStruct1[Ptr[CLongInt]]
+  // posix requires this file declares suseconds_t. Use single point of truth.
+
+  type suseconds_t = types.suseconds_t
+
+  // The declaration of type fd_set closely follows the Linux C declaration.
+
+  // 16 * 64 == 1024 == FD_SETSIZE.
+  // Assured by assertion() in nativelib select.c. See comments there.
+
+  private[this] type _16 = Digit[_1, _6]
+
+  type fd_set = CStruct1[CArray[CLongInt, _16]]
+
+  // Allocation & usage example:
+  //     val fdsetPtr = stackalloc[fd_set].asInstanceOf[Ptr[fd_set]]
+  //     FD_ZERO(fdsetPtr)
 
   @name("scalanative_select")
   def select(nfds: CInt,
@@ -31,18 +46,5 @@ object select {
 
   @name("scalanative_FD_ZERO")
   def FD_ZERO(set: Ptr[fd_set]): Unit = extern
-
-}
-
-object selectOps {
-  import select._
-
-  implicit class timevalOps(val ptr: Ptr[time.timeval]) extends AnyVal {
-    def tv_sec: time_t       = !(ptr._1)
-    def tv_usec: suseconds_t = !(ptr._2)
-
-    def tv_sec_=(v: time_t): Unit       = !ptr._1 = v
-    def tv_usec_=(v: suseconds_t): Unit = !ptr._2 = v
-  }
 
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
@@ -33,19 +33,22 @@ object select {
   // Allocation & usage example:
   //
   // An fd_set is arguably too large to allocate on the stack, so use a Zone.
-  // Zone.alloc is documented as returning zeroed memory. No need to FD_ZERO.
   //
   //    import scalanative.native.{Zone, alloc}
   //
   //    Zone {
-  //        val fdsetPtr = alloc[fd_set].cast[Ptr[fd_set]]
+  //
+  //        // Zone.alloc is documented as returning zeroed memory.
+  //        val fdsetPtr = alloc[fd_set] //  No need to FD_ZERO.
   //        FD_SET(sock, fdsetPtr)
+  //
+  //        // If used, allocate writefds and/or exceptfds the same way.
   //
   //        val result = select(nfds, fdsetPtr, writefds, exceptfds)
   //        // check result.
   //        // do work implied by result.
   //
-  //    } // fdsetPtr and memory it points to are not valid outsize Zone.
+  //    } // fdsetPtr and memory it points to are not valid outsize of Zone.
 
   @name("scalanative_select")
   def select(nfds: CInt,

--- a/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
+++ b/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
@@ -46,7 +46,7 @@ object SocketHelpers {
         fcntl(sock, F_SETFL, O_NONBLOCK)
 
         // Zone.alloc is documented as returning zeroed memory.
-        val fdsetPtr = alloc[fd_set].cast[Ptr[fd_set]]
+        val fdsetPtr = alloc[fd_set] //  No need to FD_ZERO
         FD_SET(sock, fdsetPtr)
 
         val time = alloc[timeval]

--- a/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
+++ b/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
@@ -8,7 +8,6 @@ import scala.scalanative.posix.arpa.inet._
 import scala.scalanative.posix.sys.socketOps._
 import scala.scalanative.posix.sys.socket._
 import scala.scalanative.posix.sys.select._
-import scala.scalanative.posix.sys.selectFdSet
 import scala.scalanative.posix.unistd.close
 import scala.scalanative.posix.fcntl._
 import scala.scalanative.posix.sys.time.timeval
@@ -46,7 +45,8 @@ object SocketHelpers {
 
         fcntl(sock, F_SETFL, O_NONBLOCK)
 
-        val fdsetPtr = selectFdSet.createZeroed
+        // Zone.alloc is documented as returning zeroed memory.
+        val fdsetPtr = alloc[fd_set].cast[Ptr[fd_set]]
         FD_SET(sock, fdsetPtr)
 
         val time = alloc[timeval]


### PR DESCRIPTION
This PR simplifies and supersedes PR #1253 "Correct/Fix posix
sys/select.scala fd_set declaration".

The presenting problem and its current state is described in Issue #1470.
The problem has a complicated history and has resulted in a number of now merged PRs.

I believe this PR is ready for merge and the issues below addressed.

I include these  sssues for discussion as an aid to informed review:

- Macro

  * This is a breaking change.  Then again, any code using the
    existing definitions is broken now.

    I think uses of the 0.3.8 idiom get by because two
    stackallocs are done one after the other.  When the first
    gets overwritten, it spills into the second, instead of
    random memory.  This is pretty fragile.  If something
    else gets allocated on the stack between the stackallocs,
    the an FD_ZERO will clobber the intervening variable.

  * The major issue for review is the declaration of fd_set type
    to use a fixed size static buffer.  The declaration in this
    PR closely follows the C declaration and brings with it the
    entire dependency on the buffer of fd_set being a fixed size
    buffer, almost always 1024 bits.

    I can dive down the rabbit hole of a long & tedious discussion
    about the sacredness of 1024 bits but I think that discussion
    now will only annoy non-network guru reviewers.

  * An example of a simple allocation of a fixed size buffer fd_set
    is provided.  An experienced programmer will notice immediately
    that there are ways to save memory by allocating so-called short
    buffers and avoiding calling FD_SET. There is an escape hatch.
    Then again, an experienced network programmer would probably not
    be willingly dealing with select() in the first place. poll()
    is the more efficient and contemporary idiom.

- Meso

  * This PR removes selectOps in favor of timeOps.  That change could
    be factored out into a separate PR if that would aid review or
    audit trail.

    I had to go one way or the other. Seemed to me like the
    FD_SET change would cause someone to edit a file, they probably
    want to make both sets of edits at the same time: sort by file, not
    commit.

  * I believe that it is early enough in SN development that removing
    selectOps is better than letting duplicate & stale code remain
    in place forever.

- Micro

  * There is a 32/64 bit issue on which I will have to check with
    @shadaj.  I have been advised to program to 64 bit machines and
    let the 32 bit port follow along.  select.scala follows the
    C implementation of the first element of an fd_set struct being
    an array of CLongint.

         type fd_set = CStruct1[CArray[CLongInt, _16]]

    On 32 bit machines this needs to be the mildly unexpected CLongLong.
    CLongLong works for both 32 & 64 bit machines but gives a slightly
    jarring implication on 64 bit (which is why I wrote it the way I did.)

  * To keep this PR focused on select related changes, I created issues
    for two small defects in SocketHelpers.scala. I have the fixes
    in my sandbox code, but kept them out of this PR.

Documentation:

   * A release note is needed which says something like
   ```
    The declaration of the type fd_set in ScalaNative 0.3.8 declared the wrong number of 
    bytes.  This defect revealed itself when using SCALANATIVE_MODE="release".

    This defect has now been corrected and is a breaking change.
    The type fd_set declares the the 1024 bit ==  16 long Int fixed size buffer documented for
    glibc FD_ZERO.

    Another breaking change is that object socketOps has been removed. posix.sys.timeOps
    provides the same conversions from a more logical  location.
   ```

Testing:

  * Built and tested ("test-all") with sbt 1.2.6 release modes on
    X86_64 only . All tests, other than the perennial malefactor link-order, pass.
  
    The scripted-tests java-net-socket IsReachableTest calls  SocketHelpers.isReachableByEcho
    which calls select() twice. So both SocketHelpers and select() are getting exercised at least once.

    To assure myself that the current edits would not make people in the
    wild unhappy after they had already been forced to make code changes
    to correct the allocation of fd_set, I created a private copy
    of PlainSocketImplementation.scala using a version of that file which
    still called select().  I then modified the file to use the new
    fd_set declaration & allocation.

    Using the private, modified copy of PlainSocketImpl.scala, I did
    a complete rebuild & test-all in the four square sbt version
    by release/debug mode matrix.  All tests, modulo know breakage
    elsewhere, passed as expected.