### PR TITLE
Add unimplemented method to java.util.Properties

### DIFF
--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -3,6 +3,7 @@ package java.util
 import java.{util => ju}
 
 import scala.collection.JavaConverters._
+import scala.scalanative.native.stub
 
 class Properties(protected val defaults: Properties)
     extends ju.Hashtable[AnyRef, AnyRef] {
@@ -12,8 +13,10 @@ class Properties(protected val defaults: Properties)
   def setProperty(key: String, value: String): AnyRef =
     put(key, value)
 
+  @stub
   def load(inStream: java.io.InputStream): Unit = ???
 
+  @stub
   def load(reader: java.io.Reader): Unit = ???
 
   def getProperty(key: String): String =

--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -14,6 +14,8 @@ class Properties(protected val defaults: Properties)
 
   def load(inStream: java.io.InputStream): Unit = ???
 
+  def load(reader: java.io.Reader): Unit = ???
+
   def getProperty(key: String): String =
     getProperty(key, defaultValue = null)
 
@@ -52,7 +54,6 @@ class Properties(protected val defaults: Properties)
   }
 
   // TODO:
-  // def load(reader: Reader): Unit
   // @deprecated("", "") def save(out: OutputStream, comments: String): Unit
   // def store(writer: Writer, comments: String): Unit
   // def store(out: OutputStream, comments: String): Unit


### PR DESCRIPTION
This is an extra method needed to link `ekrich/sconfig` that was found when working on the `java.net.URL` code change but it seems better as a separate PR. We have had some PRs working on `Properties` but nothing solid yet and this should be easy to rebase for WIP.

EDIT: This is targeted for both `0.3.x` and `master`.