### PR TITLE
Fix Issue #1479 StringIndexOutOfBoundsException

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -88,7 +88,7 @@ final class _String()
       count = length
       System.arraycopy(data, start, value, 0, count)
     } else {
-      throw new IndexOutOfBoundsException()
+      throw new StringIndexOutOfBoundsException()
     }
   }
 
@@ -119,7 +119,7 @@ final class _String()
   def this(codePoints: Array[Int], offset: Int, count: Int) {
     this()
     if (offset < 0 || count < 0 || offset > codePoints.length - count) {
-      throw new IndexOutOfBoundsException()
+      throw new StringIndexOutOfBoundsException()
     } else {
       this.offset = 0
       this.value = new Array[Char](count * 2)
@@ -808,21 +808,21 @@ final class _String()
 
   def codePointAt(index: Int): Int =
     if (index < 0 || index >= count) {
-      throw new IndexOutOfBoundsException()
+      throw new StringIndexOutOfBoundsException()
     } else {
       Character.codePointAt(value, index + offset, offset + count)
     }
 
   def codePointBefore(index: Int): Int =
     if (index < 1 || index > count) {
-      throw new IndexOutOfBoundsException()
+      throw new StringIndexOutOfBoundsException()
     } else {
       Character.codePointBefore(value, index + offset)
     }
 
   def codePointCount(beginIndex: Int, endIndex: Int): Int =
     if (beginIndex < 0 || endIndex > count || beginIndex > endIndex) {
-      throw new IndexOutOfBoundsException()
+      throw new StringIndexOutOfBoundsException()
     } else {
       Character
         .codePointCount(value, beginIndex + offset, endIndex - beginIndex)

--- a/unit-tests/src/test/scala/java/lang/StringSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/StringSuite.scala
@@ -26,6 +26,30 @@ object StringSuite extends tests.Suite {
     }
   }
 
+  test("String(Array[Byte], start, length) with invalid start or length") {
+    val chars: Array[Char] = Array('a', 'b', 'c')
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      new String(chars, -1, chars.length) // invalid start
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      new String(chars, 0, chars.length + 1) // invalid length
+    }
+  }
+
+  test("String(Array[Int], offset, count) with invalid offset or count") {
+    val codePoints = Array[Int](235, 872, 700, 298)
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      new String(codePoints, -1, codePoints.length) // invalid offset
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      new String(codePoints, 0, codePoints.length + 1) // invalid length
+    }
+  }
+
   test("+") {
     assert("big 5" == "big " + 5.toByte)
     assert("big 5" == "big " + 5.toShort)
@@ -39,6 +63,43 @@ object StringSuite extends tests.Suite {
     assert("foo" == "" + "foo")
     assert("foobar" == "foo" + "bar")
     assert("foobarbaz" == "foo" + "bar" + "baz")
+  }
+
+  test("codePointAt(index) with invalid index") {
+    val data = "When in the Course"
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      data.codePointAt(-1)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      data.codePointAt(data.length + 1)
+    }
+  }
+
+  test("codePointBefore(index) with invalid index") {
+    val data = "of human events"
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      data.codePointBefore(-1)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      // Careful here, +1 is valid +2 is not
+      data.codePointBefore(data.length + 2)
+    }
+  }
+
+  test("codePointCount(beginIndex, endIndex) with invalid begin | end index") {
+    val data = "it becomes necessary"
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      data.codePointCount(-1, data.length)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      data.codePointCount(0, data.length + 1)
+    }
   }
 
   test("compareTo") {


### PR DESCRIPTION
  * The presenting issue was described in issue #1479, "String.scala should
    return StringIndexOutOfBounds in many places". The issue was discovered
    whilst porting re2s to ScalaNative.

  * In five places, the type of the exception thrown was changed from the prior
    IndexOutOfBoundsException to its subclass StringIndexOutOfBoundsException.
    Oracle JVM documentation specifies the former, but the JVM itself
    implements the latter.  String.scala should now consistently
    throw the JVM de facto standard.

  * Tests were added to StringSuite.scala to ensure that the scala JVM
    de facto standard is now met for these five cases.

Documentation:

  * This needs a release note. There is a user visible change to
    the exception thrown in 5 places.  The new exceptions conform
    to JVM practice, but may break existing SN code.

Testing:

  * Built and tested ("test-all") on X86_64 using sbt 0.13.7 in
    debug mode. All tests expected to pass do so.

    The test-all error that I see with sbt 1.2.6 and release mode
    appears to have nothing to do with these changes.  I am trying
    to isolate the defect there.