### PR TITLE
Interflow: fix thread local context management

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -33,7 +33,7 @@ trait Inline { self: Interflow =>
           val hintInline =
             defn.attrs.inline == Attr.AlwaysInline || defn.attrs.inline == Attr.InlineHint
           val isRecursive =
-            context.contains(s"inlining ${name.show}")
+            hasContext(s"inlining ${name.show}")
           val isBlacklisted =
             this.isBlacklisted(name)
           val calleeTooBig =

--- a/tools/src/main/scala/scala/scalanative/interflow/Log.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Log.scala
@@ -7,7 +7,7 @@ trait Log { self: Interflow =>
 
   def in[T](msg: String)(f: => T): T = {
     if (show) { log(msg) }
-    context ::= msg
+    pushContext(msg)
     try {
       val start = System.nanoTime
       val res   = f
@@ -19,13 +19,13 @@ trait Log { self: Interflow =>
         log("unwinding " + msg + " due to: " + e.toString)
         throw e
     } finally {
-      context = context.tail
+      popContext()
     }
   }
 
   def log(msg: String): Unit =
     if (show) {
-      println(("  " * context.size) + msg)
+      println(("  " * contextDepth()) + msg)
     }
 
   def debug[T](msg: String)(f: => T): T = {


### PR DESCRIPTION
#1465 broke release mode as discovered by @LeeTibbert. This PR fixes the oversight in how context management is modeled using thread locals instead of scoped vars.  