### PR TITLE
[0.3.x] Add unimplemented method to java.util.Properties (#1478)

### DIFF
--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -3,6 +3,7 @@ package java.util
 import java.{util => ju}
 
 import scala.collection.JavaConverters._
+import scala.scalanative.native.stub
 
 class Properties(protected val defaults: Properties)
     extends ju.Hashtable[AnyRef, AnyRef] {
@@ -12,7 +13,11 @@ class Properties(protected val defaults: Properties)
   def setProperty(key: String, value: String): AnyRef =
     put(key, value)
 
+  @stub
   def load(inStream: java.io.InputStream): Unit = ???
+
+  @stub
+  def load(reader: java.io.Reader): Unit = ???
 
   def getProperty(key: String): String =
     getProperty(key, defaultValue = null)
@@ -70,7 +75,6 @@ class Properties(protected val defaults: Properties)
     super.size()
 
   // TODO:
-  // def load(reader: Reader): Unit
   // @deprecated("", "") def save(out: OutputStream, comments: String): Unit
   // def store(writer: Writer, comments: String): Unit
   // def store(out: OutputStream, comments: String): Unit

--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -12,7 +12,7 @@ class Properties(protected val defaults: Properties)
 
   def setProperty(key: String, value: String): AnyRef =
     put(key, value)
-  
+
   def load(inStream: java.io.InputStream): Unit = ???
 
   @stub

--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -12,8 +12,7 @@ class Properties(protected val defaults: Properties)
 
   def setProperty(key: String, value: String): AnyRef =
     put(key, value)
-
-  @stub
+  
   def load(inStream: java.io.InputStream): Unit = ???
 
   @stub


### PR DESCRIPTION
This is a backport of #1478 with the `@stub` on the existing unimplemented method removed to avoid a breaking change.