### PR TITLE
[0.3.x] Add stubs to URL and URLConnection

### DIFF
--- a/javalib/src/main/scala/java/net/URL.scala
+++ b/javalib/src/main/scala/java/net/URL.scala
@@ -13,4 +13,8 @@ class URL(from: String) {
   def openStream(): java.io.InputStream = ???
   @stub
   override def hashCode: Int = ???
+  @stub
+  def toURI(): java.net.URI = ???
+  @stub
+  def toExternalForm(): java.lang.String = ???
 }

--- a/javalib/src/main/scala/java/net/URLConnection.scala
+++ b/javalib/src/main/scala/java/net/URLConnection.scala
@@ -1,6 +1,16 @@
 package java.net
 
+import scalanative.native.stub
+
 class URLConnection {
-  @scalanative.native.stub
+  @stub
   def getLastModified(): scala.Long = ???
+  @stub
+  def connect(): Unit = ???
+  @stub
+  def getContentType(): String = ???
+  @stub
+  def getInputStream(): java.io.InputStream = ???
+  @stub
+  def setRequestProperty(key: String, value: String): Unit = ???
 }


### PR DESCRIPTION
This is the last known change to support `sconfig` for `scalafmt`.
Issue https://github.com/scala-native/scala-native/issues/1412