### PR TITLE
Fix #1483 "j.u.ArrayList.scala is missing the removeRange method"

### DIFF
--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -144,6 +144,26 @@ class ArrayList[E] private (private[this] var inner: Array[Any],
         true
     }
 
+  override def removeRange(fromIndex: Int, toIndex: Int): Unit = {
+
+    // JVM documents fromIndex == toIndex as having 'no effect'
+    if (fromIndex != toIndex) {
+      if ((fromIndex < 0) || (fromIndex >= _size) || (toIndex > size)
+          || (toIndex < fromIndex)) {
+        // N.B.: JVM docs specify IndexOutOfBounds but use de facto.
+        throw new ArrayIndexOutOfBoundsException()
+      } else {
+        val srcIndex = toIndex
+        val dstIndex = fromIndex
+        val tailSize = _size - toIndex
+
+        System.arraycopy(inner, srcIndex, inner, dstIndex, tailSize)
+
+        _size -= (toIndex - fromIndex)
+      }
+    }
+  }
+
   override def clear(): Unit = {
     // fill the content of inner by null so that the elements can be garbage collected
     for (i <- (0 until _size)) {

--- a/unit-tests/src/test/scala/java/util/ArrayListSuite.scala
+++ b/unit-tests/src/test/scala/java/util/ArrayListSuite.scala
@@ -240,6 +240,18 @@ object ArrayListSuite extends tests.Suite {
     assert(al1.asScala == Seq(2, 1))
   }
 
+  test("addAll") {
+    val l = new java.util.ArrayList[String]()
+    l.add("First")
+    l.add("Second")
+    val l2 = new java.util.ArrayList[String]()
+    l2.addAll(0, l)
+    val iter = l2.iterator()
+    assert(iter.next() == "First")
+    assert(iter.next() == "Second")
+    assert(!iter.hasNext())
+  }
+
   test("remove(Int)") {
     val al1 = new ArrayList[Int](Seq(1, 2, 3, 2, 3).asJava)
     // remove last
@@ -260,16 +272,85 @@ object ArrayListSuite extends tests.Suite {
     assert(Seq(1, 3, 2) == al1.asScala)
   }
 
-  test("addAll") {
-    val l = new java.util.ArrayList[String]()
-    l.add("First")
-    l.add("Second")
-    val l2 = new java.util.ArrayList[String]()
-    l2.addAll(0, l)
-    val iter = l2.iterator()
-    assert(iter.next() == "First")
-    assert(iter.next() == "Second")
-    assert(!iter.hasNext())
+  test("removeRange(from, to) - indentical invalid indices") {
+    val aList    = new ArrayList[Int](Seq(-175, 24, 7, 44).asJava)
+    val expected = new ArrayList[Int](Seq(-175, 24, 7, 44).asJava) // ibid.
+
+    // Yes, the indices are invalid but no exception is expected because
+    // they are identical, which is tested first. That is called a 'quirk'
+    // or 'implementation dependent detail' of the documented specification.
+
+    aList.removeRange(-1, -1)
+
+    assert(aList == expected, s"result: $aList != expected: $expected")
+  }
+
+  test("removeRange(from, to) - Invalid indices") {
+    val aList = new ArrayList[Int](Seq(175, -24, -7, -44).asJava)
+
+    assertThrows[java.lang.ArrayIndexOutOfBoundsException] {
+      aList.removeRange(-1, 2) // fromIndex < 0
+    }
+
+    assertThrows[java.lang.ArrayIndexOutOfBoundsException] {
+      // Beware that from != too in this test.
+      // See 'from == to' quirk tested above.
+      aList.removeRange(aList.size, aList.size + 2) // fromIndex >= _size
+    }
+
+    assertThrows[java.lang.ArrayIndexOutOfBoundsException] {
+      aList.removeRange(0, aList.size + 1) // toIndex > size
+    }
+
+    assertThrows[java.lang.ArrayIndexOutOfBoundsException] {
+      aList.removeRange(2, -1) // toIndex < fromIndex
+    }
+
+  }
+
+  test("removeRange(from, to) - first two elements ") {
+    val aList    = new ArrayList[Int](Seq(284, -27, 995, 500, 267, 904).asJava)
+    val expected = new ArrayList[Int](Seq(995, 500, 267, 904).asJava)
+
+    aList.removeRange(0, 2)
+
+    assert(aList == expected, s"result: $aList != expected: $expected")
+  }
+
+  test("removeRange(from, to) - first two elements at head") {
+    val aList    = new ArrayList[Int](Seq(284, -27, 995, 500, 267, 904).asJava)
+    val expected = new ArrayList[Int](Seq(995, 500, 267, 904).asJava)
+
+    aList.removeRange(0, 2)
+
+    assert(aList == expected, s"result: $aList != expected: $expected")
+  }
+
+  test("removeRange(from, to) - two elements from middle") {
+    val aList    = new ArrayList[Int](Seq(7, 9, -1, 20).asJava)
+    val expected = new ArrayList[Int](Seq(7, 20).asJava)
+
+    aList.removeRange(1, 3)
+
+    assert(aList == expected, s"result: $aList != expected: $expected")
+  }
+
+  test("removeRange(from, to) - last two elements at tail") {
+    val aList    = new ArrayList[Int](Seq(50, 72, 650, 12, 7, 28, 3).asJava)
+    val expected = new ArrayList[Int](Seq(50, 72, 650, 12, 7).asJava)
+
+    aList.removeRange(aList.size - 2, aList.size)
+
+    assert(aList == expected, s"result: $aList != expected: $expected")
+  }
+
+  test("removeRange(from, to) - entire list, all elements") {
+    val aList    = new ArrayList[Int](Seq(50, 72, 650, 12, 7, 28, 3).asJava)
+    val expected = new ArrayList[Int](Seq().asJava)
+
+    aList.removeRange(0, aList.size)
+
+    assert(aList == expected, s"result: $aList != expected: $expected")
   }
 
   test("clear()") {


### PR DESCRIPTION
  * The presenting issue was reported in Issue #1483 "j.u.ArrayList.scala
    is missing the removeRange method".

    That issue is now fixed and relevant unit-tests provided.

  * This PR is 1 of 2 which will unblock re2s porting efforts.

  * The new method throws ArrayIndexOutOfBoundsException instead of the
    documented IndexOutOfBoundsException.  See issues #1479 and #1480 for the
    a full discussion of the closely related issues in String.scala &
    Character.scala.

  * Because the removeRange() method is declared "protected" it
    is relatively hard to determining what Scala JVM actually uses.
    I went with the educated guess of ArrayIndexOutOfBoundsException rather
    than its superior class IndexOutOfBoundsException to stay
    consistent with proven JVM practice in String.scala & Character.scala.
    Silly me, expecting consistency.

Documentation:

    A minor release note is requested.

Testing:

  * Built and tested ("test-all") with sbt 1.2.6 in release mode on
    X86_64 only . All tests pass. Travis CI should cover the sbt 0.13.7
    in debug mode cell of the 2x2 matrix.

    As this PR implements the method for the first time, there are no
    current users of ArrayList#removeRange beyond the unit tests. So
    "all tests passing" is weak confirmation.

    A soon to appear, for some values of soon, re2s WIP PR will
    heavily exercise removeRange.