### PR TITLE
Fix #1484 "j.l.Character.scala is missing 2 methods with CharSeq argment

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -236,20 +236,25 @@ object Character {
   @inline def charCount(codePoint: Int): Int =
     if (codePoint >= MIN_SUPPLEMENTARY_CODE_POINT) 2 else 1
 
+  def codePointAt(seq: Array[scala.Char], _index: scala.Int): scala.Int = {
+    codePointAt(seq, _index, seq.length)
+  }
+
   def codePointAt(seq: Array[scala.Char],
-                  _index: scala.Int,
+                  index: scala.Int,
                   limit: scala.Int): scala.Int = {
-    var index = _index
+
     if (index < 0 || index >= limit || limit < 0 || limit > seq.length) {
-      throw new ArrayIndexOutOfBoundsException()
+      throw new StringIndexOutOfBoundsException()
     }
 
-    val high = seq(index)
-    index += 1
-    if (index >= limit) {
+    val high      = seq(index)
+    val nextIndex = index + 1
+
+    if (nextIndex >= limit) {
       high
     } else {
-      val low = seq(index)
+      val low = seq(nextIndex)
       if (isSurrogatePair(high, low))
         toCodePoint(high, low)
       else
@@ -257,25 +262,40 @@ object Character {
     }
   }
 
-  def codePointBefore(seq: Array[scala.Char], _index: scala.Int): scala.Int = {
-    var index = _index
-    val len   = seq.length
+  def codePointAt(seq: CharSequence, _index: scala.Int): scala.Int = {
+    codePointAt(seq.toString.toArray[scala.Char], _index)
+  }
+
+  def codePointBefore(seq: Array[scala.Char], index: scala.Int): scala.Int = {
+    codePointBefore(seq, index, seq.length)
+  }
+
+  def codePointBefore(seq: Array[scala.Char],
+                      index: scala.Int,
+                      limit: scala.Int): scala.Int = {
+    val len = limit
     if (index < 1 || index > len) {
-      throw new ArrayIndexOutOfBoundsException(index)
+      throw new StringIndexOutOfBoundsException(index)
     }
 
-    index -= 1
-    val low = seq.charAt(index)
-    index -= 1
-    if (index < 0) {
+    val indexMinus1 = index - 1
+    val indexMinus2 = index - 2
+
+    val low = seq.charAt(indexMinus1)
+
+    if (indexMinus2 < 0) {
       low
     } else {
-      val high = seq(index)
+      val high = seq(indexMinus2)
       if (isSurrogatePair(high, low))
         toCodePoint(high, low)
       else
         low
     }
+  }
+
+  def codePointBefore(seq: CharSequence, index: scala.Int): scala.Int = {
+    codePointBefore(seq.toString.toArray[scala.Char], index)
   }
 
   def codePointCount(seq: Array[scala.Char],

--- a/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
@@ -13,6 +13,182 @@ package java.lang
 object CharacterSuite extends tests.Suite {
   import java.lang.Character._
 
+  // codePointAt tests
+  test("codePointAt - invalid values") {
+    val str1 = "<invalid values>"
+    val arr1 = str1.toArray
+
+    assertThrows[java.lang.NullPointerException] {
+      Character.codePointAt(null.asInstanceOf[Array[Char]], 1, arr1.length)
+    }
+
+    assertThrows[java.lang.NullPointerException] {
+      Character.codePointAt(null.asInstanceOf[Array[Char]], 1, arr1.length)
+    }
+
+    assertThrows[java.lang.NullPointerException] {
+      Character.codePointAt(null.asInstanceOf[Array[Char]], 2)
+    }
+
+    assertThrows[java.lang.NullPointerException] {
+      Character.codePointAt(null.asInstanceOf[CharSequence], 2)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.codePointAt(arr1, -1)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.codePointAt(str1, -1)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.codePointAt(arr1, 2, arr1.length + 1)
+    }
+  }
+
+  test("codePointAt - Array[Char]") {
+    val arr1 = "abcdEfghIjklMnoPqrsTuvwXyz".toArray
+
+    val result   = Character.codePointAt(arr1, 3, arr1.length)
+    val expected = 100 // 'd'
+    assert(result == expected, s"result: $result != expected: $expected")
+  }
+
+  test("codePointAt - CharSeq") {
+    val charSeq1: CharSequence = "abcdEfghIjklMnoPqrsTuvwXyz"
+
+    val result   = Character.codePointAt(charSeq1, 8)
+    val expected = 73 // 'I'
+    assert(result == expected, s"result: $result != expected: $expected")
+  }
+
+  test("codePointAt - Array[Char],CharSeq return same non-ASCII value") {
+    val str1  = "30\u20ac" // 'euro-character'
+    val index = str1.length - 1
+
+    val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
+    val resultCS = Character.codePointAt(str1, index)
+    val expected = 0x20AC // 'euro-character'
+
+    assert(resultCA == resultCS, s"resultCA: $resultCA != resultCS: $resultCS")
+    assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
+  }
+
+  testFails("codePointAt - high surrogate at end of line", issue = 1496) {
+    val str1  = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
+    val index = str1.length - 1
+
+    val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
+    val resultCS = Character.codePointAt(str1, index)
+    val expected = 0xDBFF // Character.MAX_HIGH_SURROGATE, 56319 decimal
+
+    assert(resultCA == resultCS, s"resultCA: $resultCA != resultCS: $resultCS")
+    assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
+  }
+
+  test("codePointAt - surrogate pair") {
+    // Character.MIN_HIGH_SURROGATE followed by Character.MAX_LOW_SURROGATE
+    val str1  = "before \uD800\uDFFF after"
+    val index = 7
+
+    val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
+    val resultCS = Character.codePointAt(str1, index)
+    val expected = 0x103FF // surrogate pair, decimal 66559
+
+    assert(resultCA == resultCS, s"resultCA: $resultCA != resultCS: $resultCS")
+    assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
+  }
+
+  // codePointBefore tests
+
+  test("codePointBefore - invalid values") {
+    val str1 = "<invalid values>"
+    val arr1 = str1.toArray
+
+    assertThrows[java.lang.NullPointerException] {
+      Character.codePointBefore(null.asInstanceOf[Array[Char]], 1)
+    }
+
+    assertThrows[java.lang.NullPointerException] {
+      Character.codePointBefore(null.asInstanceOf[CharSequence], 1)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.codePointBefore(arr1, -1)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.codePointBefore(str1, -1)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.codePointBefore(arr1, 0)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.codePointBefore(str1, 0)
+    }
+
+  }
+
+  test("codePointBefore - Array[Char]") {
+    val arr1  = "abcdEfghIjklMnopQrstUvwxYz".toArray
+    val index = 10
+
+    val result   = Character.codePointBefore(arr1, index)
+    val expected = 106 // 'j'
+
+    assert(result == expected, s"result: $result != expected: $expected")
+  }
+
+  test("codePointBefore - CharSeq") {
+    val str1  = "abcdEfghIjklMnoPqrsTuvwXyz"
+    val index = str1.length - 1
+
+    val result   = Character.codePointBefore(str1, index)
+    val expected = 121 // 'y'
+
+    assert(result == expected, s"result: $result != expected: $expected")
+  }
+
+  test("codePointBefore - Array[Char], CharSeq return same non-ASCII value") {
+    val str1  = "bugsabound\u03bb" // Greek small letter lambda
+    val index = str1.length
+
+    val resultCA = Character.codePointBefore(str1.toArray, index)
+    val resultCS = Character.codePointBefore(str1, index)
+    val expected = 955 // Greek snall letter lambda
+
+    assert(resultCA == resultCS, s"resultCA: $resultCA != resultCS: $resultCS")
+    assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
+  }
+
+  testFails("codePointBefore - high surrogate at end of line", issue = 1496) {
+    val str1  = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
+    val index = str1.length
+
+    val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
+    val resultCS = Character.codePointAt(str1, index)
+    val expected = 0xDBFF // Character.MAX_HIGH_SURROGATE, 56319 decimal
+
+    assert(resultCA == resultCS, s"resultCA: $resultCA != resultCS: $resultCS")
+    assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
+  }
+
+  test("codePointBefore - surrogate pair") {
+    // Character.MIN_HIGH_SURROGATE followed by Character.MAX_LOW_SURROGATE
+    val str1  = "Denali\uD800\uDFFF"
+    val index = str1.length
+
+    val resultCA = Character.codePointBefore(str1.toArray, index, str1.length)
+    val resultCS = Character.codePointBefore(str1, index)
+    val expected = 0x103FF // surrogate pair, decimal 66559
+
+    assert(resultCA == resultCS, s"resultCA: $resultCA != resultCS: $resultCS")
+    assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
+  }
+
   // Ported, with gratitude & possibly modifications
   // from ScalaJs CharacterTest.scala
   // https://github.com/scala-js/scala-js/blob/master/


### PR DESCRIPTION

  * The presenting issue was reported as Issue #1484 "j.l.Character.scala
    is missing 2 methods with CharSeq argument"

    That issue is now fixed and relevant unit-tests provided.

  * This is the second of two PRs which unblock re2s porting efforts.

  * Because the new methods were implemented on top of the existing
    methods instead of as cut & paste duplication, the original
    array based codePointAt() and codePointBefore() methods now
    throw StringIndexOutOfBoundsException instead of the previous
    ArrayIndexOutOfBoundsException.  This keeps the two sets of
    routines consistent and simpler.

    See issue #1480 for the a full discussion of issue in the rest of
    Character.scala.  To keep changes focused on the newly provided
    methods, I did not correct the exception in other methods.

    See also issues #1479 for  a full discussion of the closely related
    Excption issue in String.scala, now fixed.

Documentation:

  * Could have a minor mention in release notes but probably falls
    under the general category of "Interop improvement".  The
    change of exception message will be covered by an upcoming
    PR to Character.scala which changes all the Exception messages to
    the JVM de-facto standard.

Testing:

  * Built and tested ("test-all") with sbt 1.2.6 in release mode on
    X86_64 only . All tests pass. Travis CI should cover the sbt 0.13.7
    in debug mode cell of the 2x2 matrix.

  * Unit tests for re2s will heavily exercise these routines.