### PR TITLE
Fix #1500 "Class ArrayList toArray method can return elements beyond …

### DIFF
--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -76,7 +76,7 @@ class ArrayList[E] private (private[this] var inner: Array[Any],
   override def clone(): AnyRef = new ArrayList(inner, _size)
 
   override def toArray(): Array[AnyRef] =
-    inner.map(_.asInstanceOf[AnyRef])
+    inner.slice(0, _size).map(_.asInstanceOf[AnyRef])
 
   override def toArray[T](a: Array[T]): Array[T] =
     if (a == null)

--- a/unit-tests/src/test/scala/java/util/ArrayListSuite.scala
+++ b/unit-tests/src/test/scala/java/util/ArrayListSuite.scala
@@ -159,6 +159,27 @@ object ArrayListSuite extends tests.Suite {
         (al1.toArray()))
   }
 
+  test("toArray() - default initial capacity, then add elements") {
+    // Issue #1500 discovered by re2s ExecTestSuite.
+
+    val al1          = new ArrayList[String]()
+    val data         = Array("alpha", "omega")
+    val expectedSize = data.size
+
+    for (d <- data) al1.add(d)
+
+    val arr1     = al1.toArray
+    val arr1Size = arr1.size
+
+    assert(arr1Size == expectedSize,
+           s"toArray.size: $arr1Size != expected: $expectedSize")
+
+    // Discovering code in re2s ExecTestSuite used .deep not sameElements.
+    // Should have same result as sameElements, but via different path.
+
+    assert(arr1.deep == data.deep, "a1.toArray.deep != data.deep")
+  }
+
   test("toArray[T](arr: Array[T]) when arr is shorter") {
     val al1  = new ArrayList[String](Seq("apple", "banana", "cherry").asJava)
     val ain  = Array.empty[String]


### PR DESCRIPTION
…end"

  * The presenting issue was reported as Issue #1500 "Class ArrayList
    toArray method can return elements beyond end"

    That issue is now fixed and a new unit-test provided.

  * There was an existing unit-test for toArray. It appears to
    have been passing for a long time.

    That test created the ArrayList from a Sequence.  I believe that
    gives the new ArrayList a known original capacity & size. That is,
    no 'phantom' elements between size & capacity.

    The test added by this PR follows the code in re2s.ExecTestSuite
    which detected the flaw. The code in the unit-test of this PR
    creates an empty ArrayList, with default capacity (10). It then
    adds two elements.  size is now less than capacity. Previously,
    toArray would create the output array with 'capacity' number
    of elements, not size.  That is, it would copy over garbage
    elements beyond the 'end' of the source list. The new unit
    test verifies that only size number of elements are copied and
    that the elements copied are the expected ones.

  * unit-tests for toArray methods with different signatures exist
    and have been passing for a long time.  Visual inspection of
    the underlying code in ArrayList did not reveal susceptibility
    to the flaw fixed by this PR.  It there are any reports of
    weirdness in these other methods, additional tests could be provided.

Documentation:

  * Could have a minor mention in release notes but probably falls
    under the general category of "Interop improvement".

Testing:

  * Built  ("test-all") with sbt 1.2.6. Tested with sbt 1.2.6 in Debug mode (see footnote 1)
    on  X86_64 only . All tests other than link-order passed (see footnote 2) Travis CI should cover
    the sbt 0.13.7 in debug mode cell of the 2x2 matrix.

    footnote 1:  testing in Release mode failed on me in unrelated code (ProcessSuite).
                       I will create an issue for this if I can isolate it. Release mode is in
                       active development now, so some breakage is going to happen.

    footnote 2:  The failing link-order with sbt 1.2.6 on at least some systems is a well 
                       discussed issue but needs to be mentioned for historical completeness.
                       Sorry for the tedium of repetition.

                       There is a PR in the queue which fixes it  


  * Since the newly added test is derived from re2s ExecTestSuite,
    the fix will also be exercised whenever that suite is run.
    It is an expensive Suite, so it may not be run often.