### PR TITLE
Interflow: bring back inlining to debug mode

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/native/alwaysinline.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/alwaysinline.scala
@@ -1,0 +1,5 @@
+package scala.scalanative
+package native
+
+/** Always inline a method, even in debug mode. */
+final class alwaysinline extends scala.annotation.StaticAnnotation

--- a/nativelib/src/main/scala/scala/scalanative/native/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/package.scala
@@ -82,13 +82,13 @@ package object native {
   type CString = Ptr[CChar]
 
   /** Materialize tag for given type. */
-  def tagof[T](implicit tag: Tag[T]): Tag[T] = tag
+  @alwaysinline def tagof[T](implicit tag: Tag[T]): Tag[T] = tag
 
   /** The C 'sizeof' operator. */
-  def sizeof[T](implicit tag: Tag[T]): CSize = tag.size
+  @alwaysinline def sizeof[T](implicit tag: Tag[T]): CSize = tag.size
 
   /** C-style alignment operator. */
-  def alignmentof[T](implicit tag: Tag[T]): CSize = tag.alignment
+  @alwaysinline def alignmentof[T](implicit tag: Tag[T]): CSize = tag.alignment
 
   /** Heap allocate and zero-initialize a value
    *  using current implicit allocator.

--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -4,10 +4,11 @@ package nir
 import Type._
 
 object Rt {
-  val Object = Ref(Global.Top("java.lang.Object"))
-  val Class  = Ref(Global.Top("java.lang.Class"))
-  val String = Ref(Global.Top("java.lang.String"))
-  val Type   = StructValue(Seq(Int, Int, Ptr))
+  val Object  = Ref(Global.Top("java.lang.Object"))
+  val Class   = Ref(Global.Top("java.lang.Class"))
+  val String  = Ref(Global.Top("java.lang.String"))
+  val Type    = StructValue(Seq(Int, Int, Ptr))
+  val Runtime = Ref(Global.Top("scala.scalanative.runtime.package$"))
 
   val BoxedNull       = Ref(Global.Top("scala.runtime.Null$"))
   val BoxedUnit       = Ref(Global.Top("scala.runtime.BoxedUnit"))

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -38,6 +38,8 @@ trait NirDefinitions { self: NirGlobalAddons =>
 
     lazy val InlineHintClass = getRequiredClass(
       "scala.scalanative.native.inlinehint")
+    lazy val AlwaysInlineClass = getRequiredClass(
+      "scala.scalanative.native.alwaysinline")
 
     lazy val NativeModule = getRequiredModule(
       "scala.scalanative.native.package")

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -236,18 +236,22 @@ trait NirGenStat { self: NirGenPhase =>
 
     def genMethodAttrs(sym: Symbol): Attrs = {
       val inlineAttrs =
-        if (sym.hasFlag(ACCESSOR)) {
+        if (sym.isBridge || sym.hasFlag(ACCESSOR)) {
           Seq(Attr.AlwaysInline)
         } else {
           sym.annotations.collect {
-            case ann if ann.symbol == NoInlineClass   => Attr.NoInline
-            case ann if ann.symbol == InlineHintClass => Attr.InlineHint
-            case ann if ann.symbol == InlineClass     => Attr.AlwaysInline
-            case ann if ann.symbol == StubClass       => Attr.Stub
+            case ann if ann.symbol == NoInlineClass     => Attr.NoInline
+            case ann if ann.symbol == AlwaysInlineClass => Attr.AlwaysInline
+            case ann if ann.symbol == InlineHintClass   => Attr.InlineHint
+            case ann if ann.symbol == InlineClass       => Attr.InlineHint
           }
         }
+      val stubAttrs =
+        sym.annotations.collect {
+          case ann if ann.symbol == StubClass => Attr.Stub
+        }
 
-      Attrs.fromSeq(inlineAttrs)
+      Attrs.fromSeq(inlineAttrs ++ stubAttrs)
     }
 
     def genParams(dd: DefDef, isStatic: Boolean): Seq[Val.Local] =

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -1116,34 +1116,26 @@ object Lower {
                   Type.Int)
 
   val throwDivisionByZeroTy =
-    Type.Function(
-      Seq(Type.Ref(Global.Top("scala.scalanative.runtime.package$"))),
-      Type.Nothing)
+    Type.Function(Seq(Rt.Runtime), Type.Nothing)
   val throwDivisionByZero =
-    Global.Member(Global.Top("scala.scalanative.runtime.package$"),
+    Global.Member(Rt.Runtime.name,
                   Sig.Method("throwDivisionByZero", Seq(Type.Nothing)))
   val throwDivisionByZeroVal =
     Val.Global(throwDivisionByZero, Type.Ptr)
 
   val throwClassCastTy =
-    Type.Function(
-      Seq(Type.Ref(Global.Top("scala.scalanative.runtime.package$")),
-          Type.Ptr,
-          Type.Ptr),
-      Type.Nothing)
+    Type.Function(Seq(Rt.Runtime, Type.Ptr, Type.Ptr), Type.Nothing)
   val throwClassCast =
     Global.Member(
-      Global.Top("scala.scalanative.runtime.package$"),
+      Rt.Runtime.name,
       Sig.Method("throwClassCast", Seq(Type.Ptr, Type.Ptr, Type.Nothing)))
   val throwClassCastVal =
     Val.Global(throwClassCast, Type.Ptr)
 
   val throwNullPointerTy =
-    Type.Function(
-      Seq(Type.Ref(Global.Top("scala.scalanative.runtime.package$"))),
-      Type.Nothing)
+    Type.Function(Seq(Rt.Runtime), Type.Nothing)
   val throwNullPointer =
-    Global.Member(Global.Top("scala.scalanative.runtime.package$"),
+    Global.Member(Rt.Runtime.name,
                   Sig.Method("throwNullPointer", Seq(Type.Nothing)))
   val throwNullPointerVal =
     Val.Global(throwNullPointer, Type.Ptr)
@@ -1151,7 +1143,7 @@ object Lower {
   val throwUndefinedTy =
     Type.Function(Seq(Type.Ptr), Type.Nothing)
   val throwUndefined =
-    Global.Member(Global.Top("scala.scalanative.runtime.package$"),
+    Global.Member(Rt.Runtime.name,
                   Sig.Method("throwUndefined", Seq(Type.Nothing)))
   val throwUndefinedVal =
     Val.Global(throwUndefined, Type.Ptr)
@@ -1159,7 +1151,7 @@ object Lower {
   val throwOutOfBoundsTy =
     Type.Function(Seq(Type.Ptr, Type.Int), Type.Nothing)
   val throwOutOfBounds =
-    Global.Member(Global.Top("scala.scalanative.runtime.package$"),
+    Global.Member(Rt.Runtime.name,
                   Sig.Method("throwOutOfBounds", Seq(Type.Int, Type.Nothing)))
   val throwOutOfBoundsVal =
     Val.Global(throwOutOfBounds, Type.Ptr)
@@ -1167,7 +1159,7 @@ object Lower {
   val throwNoSuchMethodTy =
     Type.Function(Seq(Type.Ptr, Type.Ptr), Type.Nothing)
   val throwNoSuchMethod =
-    Global.Member(Global.Top("scala.scalanative.runtime.package$"),
+    Global.Member(Rt.Runtime.name,
                   Sig.Method("throwNoSuchMethod", Seq(Rt.String, Type.Nothing)))
   val throwNoSuchMethodVal =
     Val.Global(throwNoSuchMethod, Type.Ptr)

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -44,6 +44,8 @@ class Interflow(val mode: build.Mode)(implicit val linked: linker.Result)
     originals.contains(name) && originals(name).isInstanceOf[Defn.Define]
   def getOriginal(name: Global): Defn.Define =
     originals(name).asInstanceOf[Defn.Define]
+  def maybeOriginal(name: Global): Option[Defn.Define] =
+    originals.get(name).collect { case defn: Defn.Define => defn }
 
   def popTodo(): Global =
     todo.synchronized {


### PR DESCRIPTION
This PR brings back support for some limited inlining in debug mode. It includes:

1. Field accessors.
2. Compiler-generated bridges.
3. Constructors.
4. Methods annotated with `@alwaysinline`.

This is necessary to keep runtime performance of #1426 within realms of reason in debug mode. Otherwise we have to pay the cost of boxing on every single pointer operation. 

Due to parallelism in debug mode we have to inline unoptimized version of the method, rather than optimized one like in release mode. Given that all of the methods which we want to inline here are usually small this shouldn't be an issue.