### PR TITLE
Fix #1507 "j.l.Character#codePointCount throws IndexOutOfBoundsExcept…

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -289,7 +289,7 @@ object Character {
 
     var result = 0
     var i      = offset
-    while (i <= endIndex) {
+    while (i < endIndex) {
       var c = seq(i)
       if (isHighSurrogate(c)) {
         i += 1

--- a/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
@@ -13,6 +13,15 @@ package java.lang
 object CharacterSuite extends tests.Suite {
   import java.lang.Character._
 
+  test("codePointCount") {
+    val data     = "Mt. Whitney".toArray[scala.Char]
+    val offset   = 1
+    val expected = data.size - offset
+    val result   = Character.codePointCount(data, offset, expected)
+
+    assert(result == expected, s"result: $result != expected: $expected")
+  }
+
   // Ported, with gratitude & possibly modifications
   // from ScalaJs CharacterTest.scala
   // https://github.com/scala-js/scala-js/blob/master/


### PR DESCRIPTION
…ion"

  * The presenting issue was reported as Issue #1507
    "j.l.Character#codePointCount throws IndexOutOfBoundsException"

    That issue is now fixed and a unit-test test case has been provided.

Documentation:

  * Could have a minor mention in release notes but probably falls
    under the general category of "Interop improvement".

Testing:

  * Built and tested ("test-all") with sbt 1.2.6 in debug mode on
    X86_64 only . All tests pass[1]. Travis CI should cover the sbt 0.13.7
    in debug mode cell of the 2x2 matrix.

    [1] That is, all tests except link-order, which is known broken &
        has a PR in the queue to fix.

  * Unit tests for re2s will heavily exercise this fix.