### PR TITLE
Interflow: intrinsify getRawType rather than getClass

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -14,11 +14,11 @@ object Rt {
   val BoxedUnit       = Ref(Global.Top("scala.runtime.BoxedUnit"))
   val BoxedUnitModule = Ref(Global.Top("scala.scalanative.runtime.BoxedUnit$"))
 
+  val GetRawTypeSig       = Sig.Method("getRawType", Seq(Rt.Object, Ptr))
   val JavaEqualsSig       = Sig.Method("equals", Seq(Object, Bool))
   val JavaHashCodeSig     = Sig.Method("hashCode", Seq(Int))
   val ScalaEqualsSig      = Sig.Method("scala_==", Seq(Object, Bool))
   val ScalaHashCodeSig    = Sig.Method("scala_##", Seq(Int))
-  val GetClassSig         = Sig.Method("getClass", Seq(Class))
   val IsArraySig          = Sig.Method("isArray", Seq(Bool))
   val IsAssignableFromSig = Sig.Method("isAssignableFrom", Seq(Class, Bool))
   val GetNameSig          = Sig.Method("getName", Seq(String))
@@ -31,6 +31,10 @@ object Rt {
   val PowSig  = Sig.Method("pow", Seq(Double, Double, Double))
   val MaxSig  = Sig.Method("max", Seq(Double, Double, Double))
   val SqrtSig = Sig.Method("sqrt", Seq(Double, Double))
+
+  val GetRawTypeTy   = Function(Seq(Runtime, Object), Ptr)
+  val GetRawTypeName = Global.Member(Runtime.name, GetRawTypeSig)
+  val GetRawType     = Val.Global(GetRawTypeName, Ptr)
 
   val StringName               = String.name
   val StringValueName          = StringName member Sig.Field("value")

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -67,8 +67,8 @@ trait PolyInline { self: Interflow =>
       (0 until targets.size).map(i => impls.indexOf(targets(i)._2))
     val mergeLabel = fresh()
 
-    val objptr = emit.conv(Conv.Bitcast, Type.Ptr, obj, Next.None)
-    val objty  = emit.load(Type.Ptr, objptr, Next.None)
+    val objty =
+      emit.call(Rt.GetRawTypeTy, Rt.GetRawType, Seq(Val.Null, obj), Next.None)
 
     checkLabels.zipWithIndex.foreach {
       case (checkLabel, idx) =>


### PR DESCRIPTION
This is a minor refactoring of Interflow's implementation of getClass.

Now, we can avoid doing unsafe `load(bitcast[ptr] obj)` to get raw type in the polymorphic inlining implementation and just use `getRawType` instead. Subsequent revisits of the same code can be folded away if the type of the object becomes more specific, unlike unsafe load of the type pointer.

Additionally, implementation of `getClass` doesn't have to be intrinsified any more because it's just an allocation of a wrapper over raw type. 