### PR TITLE
Fix #1511 "ProcessSuite should always use waitFor with a timeout"

### DIFF
--- a/unit-tests/src/test/scala/java/lang/ProcessSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/ProcessSuite.scala
@@ -10,7 +10,7 @@ import scala.io.Source
 
 object ProcessSuite extends tests.Suite {
 
-  private def blockTestOnConditions(process: Process): Unit = {
+  private def assertProcessExitOrTimeout(process: Process): Unit = {
     // Suspend execution of the test until either the specified
     // process has exited or a reasonable wait period has timed out.
     //
@@ -48,7 +48,7 @@ object ProcessSuite extends tests.Suite {
     val proc = new ProcessBuilder("ls", resourceDir).start()
     val out  = readInputStream(proc.getInputStream)
 
-    blockTestOnConditions(proc)
+    assertProcessExitOrTimeout(proc)
 
     assert(out.split("\n").toSet == scripts)
   }
@@ -77,7 +77,7 @@ object ProcessSuite extends tests.Suite {
     val proc = pb.start()
     val out  = readInputStream(proc.getInputStream)
 
-    blockTestOnConditions(proc)
+    assertProcessExitOrTimeout(proc)
 
     assert(out == "1")
   }
@@ -100,7 +100,7 @@ object ProcessSuite extends tests.Suite {
     pb.environment.put("PATH", s"$cwd/unit-tests/src/test/resources/process")
     val proc = pb.start()
 
-    blockTestOnConditions(proc)
+    assertProcessExitOrTimeout(proc)
 
     assert(readInputStream(proc.getErrorStream) == "foo")
     assert(readInputStream(proc.getInputStream) == "bar")
@@ -117,7 +117,7 @@ object ProcessSuite extends tests.Suite {
       proc.getOutputStream.write("quit\n".getBytes)
       proc.getOutputStream.flush()
 
-      blockTestOnConditions(proc)
+      assertProcessExitOrTimeout(proc)
 
       val out = Source.fromFile(file.toString).getLines mkString "\n"
       assert(out == "hello")
@@ -137,7 +137,7 @@ object ProcessSuite extends tests.Suite {
       os.write("hello\n".getBytes)
       os.write("quit\n".getBytes)
 
-      blockTestOnConditions(proc)
+      assertProcessExitOrTimeout(proc)
 
       val out = readInputStream(proc.getInputStream)
       assert(out == "hello")
@@ -153,7 +153,7 @@ object ProcessSuite extends tests.Suite {
     pb.redirectErrorStream(true)
     val proc = pb.start()
 
-    blockTestOnConditions(proc)
+    assertProcessExitOrTimeout(proc)
 
     val out = readInputStream(proc.getInputStream)
     val err = readInputStream(proc.getErrorStream)
@@ -209,7 +209,7 @@ object ProcessSuite extends tests.Suite {
     pb.environment.put("PATH", resourceDir)
     val proc = pb.start()
 
-    blockTestOnConditions(proc)
+    assertProcessExitOrTimeout(proc)
 
     val out = readInputStream(proc.getInputStream)
     assert(out == "hello\n")


### PR DESCRIPTION
  * The motivating issue was reported as Issue #1511
    "ProcessSuite should always use waitFor with a timeout"

    That issue is now fixed. Since the defects were in a unit-test
    Suite, there is no new test provided to test the test Suite.

  * My thanks to @eatkins for pointing out the defect and motivating
    this PR.

Documentation:

  * None needed. Unit-tests are internal to SN. There is a design
    note at the top of ProcessSuite.scala which describes the
    reasoning for future SN developers.

Testing:

  * Built and tested ("test-all") with sbt 1.2.6 in release mode on
    X86_64 only . All tests pass (footnote 1). Travis CI should cover
    the sbt 0.13.7 in debug mode cell of the 2x2 matrix.

  * The tests above show that the new timout test does not introduce
    problems when the underling process exits as expected.

    The existing test "waitFor with timeout times out" detects
    that the timeout should execute and terminate the test when
    the underlying process hangs, Q.E.D. I believe the logical space is
    covered so  there is no need to create an additional "hanging process"
    test.

    footnote 1: Of course, there is the standard disclaimer.
                By "All tests" I mean "all tests other than the known
                broken link-order".  There is a PR in the queue for
		that failure, caused by an change in sbt between 0.13.7
		and 1.2.6.