### PR TITLE
Fix #986: "java.util.regex.Matcher.region` is missing"

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -265,7 +265,18 @@ final class Matcher private[regex] (var _pattern: Pattern,
     this
   }
 
-  def region(start: Int, end: Int): Matcher = ???
+  // ATTENTION: This is a sub-minimal stub implementation in order
+  //            to get ScalaNative unit and scripted tests to link.
+  //            A full implementation would have required re-working
+  //            gen Match() to have an end parameter and its callers,
+  //            in particular find(start) to specify proper start and end.
+  //
+  //            This code may be replaced soon by re2s so it does not
+  //            make sense to make major changes now.
+
+  def region(start: Int, end: Int): Matcher = {
+    this 
+  }
 
   private[regex] def appendReplacement2(sb: StringBuffer,
                                         replacement: String,

--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -275,7 +275,7 @@ final class Matcher private[regex] (var _pattern: Pattern,
   //            make sense to make major changes now.
 
   def region(start: Int, end: Int): Matcher = {
-    this 
+    this
   }
 
   private[regex] def appendReplacement2(sb: StringBuffer,


### PR DESCRIPTION
  * This pull request addresses Issue #986. That issue is now fixed.

  * This PR names Issue #986 but it was motivated by and is a
    step towards fixing Issue #1487 "All unimplemented routines (???)
    in javalib need stub annotation". This PR removes the need
    for a stub in Matcher.region and is one step closer to
    letting unit & scripted tests link without nativeLinkStubs.

  * It is true that #986 is fixed, the fix was a minimal
    implementation. The Matcher.region links & executes but does
    nothing beyond return itself, unaltered.

    The Matcher code is soon to be extensively reworked to use
    re2s rather than re2. A proper Matcher.region fix would
    have required major changes. Better to make those changes
    when moving to re2s.  genMatch() and its callers need to be
    altered to respect start & end and tests for find(index) and
    region(startRegion, endRegion) added to MatcherSuite.

    I created issue #1518 so the issues in Matcher.region get
    remembered during and after the port to re2s.

Documentation:

    A one line release note is recommended.

Testing:

  * Built and tested ("test-all") in release mode using sbt 1.2.6 on
    X86_64 only . All tests pass.

    The tests link with but never actually call Matcher.region.