### PR TITLE
Fix #1487 "All unimplemented routines (???) in javalib need stub anno…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -530,7 +530,8 @@ lazy val tests =
         "SCALA_NATIVE_ENV_WITHOUT_VALUE" -> "",
         "SCALA_NATIVE_ENV_WITH_UNICODE"  -> 0x2192.toChar.toString,
         "SCALA_NATIVE_USER_DIR"          -> System.getProperty("user.dir")
-      )
+      ),
+      nativeLinkStubs := true
     )
     .enablePlugins(ScalaNativePlugin)
 

--- a/javalib/src/main/scala/java/lang/PipeIO.scala
+++ b/javalib/src/main/scala/java/lang/PipeIO.scala
@@ -93,6 +93,7 @@ private[lang] object PipeIO {
                (p, fd) => new BufferedOutputStream(new FileOutputStream(fd)))
 
   private final object NullInput extends Stream {
+    @stub
     override def process: UnixProcess                                = ???
     override def available(): Int                                    = 0
     override def close(): Unit                                       = {}

--- a/javalib/src/main/scala/java/lang/reflect/Constructor.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Constructor.scala
@@ -4,8 +4,10 @@ package reflect
 import scalanative.native.stub
 
 class Constructor[T] extends Executable {
+
   @stub
   def getParameterTypes(): scala.Array[Object] = ???
+
   @stub
   def newInstance(
       args: scala.scalanative.runtime.ObjectArray): java.lang.Object = ???

--- a/javalib/src/main/scala/java/lang/reflect/Field.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Field.scala
@@ -1,7 +1,12 @@
 package java.lang.reflect
 
+import scalanative.native.stub
+
 class Field {
+  @stub
   def get(obj: Object): Object = ???
-  def getName(): String        = ???
-  def getType(): Class[_]      = ???
+  @stub
+  def getName(): String = ???
+  @stub
+  def getType(): Class[_] = ???
 }

--- a/javalib/src/main/scala/java/lang/reflect/Method.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Method.scala
@@ -1,10 +1,22 @@
 package java.lang.reflect
 
+import scalanative.native.stub
+
 class Method {
-  def getDeclaringClass(): java.lang.Class[_]              = ???
-  def getName(): java.lang.String                          = ???
+
+  @stub
+  def getDeclaringClass(): java.lang.Class[_] = ???
+
+  @stub
+  def getName(): java.lang.String = ???
+
+  @stub
   def getParameterTypes(): scala.Array[java.lang.Class[_]] = ???
-  def getReturnType(): java.lang.Class[_]                  = ???
+
+  @stub
+  def getReturnType(): java.lang.Class[_] = ???
+
+  @stub
   def invoke(obj: java.lang.Object,
              args: scala.Array[Object]): java.lang.Object = ???
 }

--- a/javalib/src/main/scala/java/text/DateFormatSymbols.scala
+++ b/javalib/src/main/scala/java/text/DateFormatSymbols.scala
@@ -1,5 +1,7 @@
 package java.text
 
+import scalanative.native.stub
+
 import java.util.Locale
 
 class DateFormatSymbols(locale: Locale)
@@ -10,16 +12,22 @@ class DateFormatSymbols(locale: Locale)
     Locale.getDefault()
   }
 
+  @stub
   def getAmPmStrings(): Array[String] = ???
 
+  @stub
   def getEras(): Array[String] = ???
 
+  @stub
   def getMonths(): Array[String] = ???
 
+  @stub
   def getShortMonths(): Array[String] = ???
 
+  @stub
   def getShortWeekdays(): Array[String] = ???
 
+  @stub
   def getWeekdays(): Array[String] = ???
 }
 

--- a/javalib/src/main/scala/java/util/Calendar.scala
+++ b/javalib/src/main/scala/java/util/Calendar.scala
@@ -1,15 +1,21 @@
 package java.util
 
+import scalanative.native.stub
+
 import java.io.Serializable
 
 abstract class Calendar
     extends Serializable
     with Cloneable
     with Comparable[Calendar] {
+
+  @stub
   def get(field: Int): Int = ???
 
+  @stub
   def set(field: Int, value: Int): Unit = ???
 
+  @stub
   def set(year: Int,
           month: Int,
           date: Int,
@@ -17,20 +23,28 @@ abstract class Calendar
           minute: Int,
           second: Int): Unit = ???
 
+  @stub
   def compareTo(anotherCalendar: Calendar): Int = ???
 
+  @stub
   def getFirstDayOfWeek(): Int = ???
 
+  @stub
   def getMinimalDaysInFirstWeek(): Int = ???
 
+  @stub
   def getTime(): Date = ???
 
+  @stub
   def getTimeInMillis(): Long = ???
 
+  @stub
   def getTimeZone(): TimeZone = ???
 
+  @stub
   def setTime(date: Date): Unit = ???
 
+  @stub
   def setTimeZone(timezone: TimeZone): Unit = ???
 }
 

--- a/javalib/src/main/scala/java/util/TimeZone.scala
+++ b/javalib/src/main/scala/java/util/TimeZone.scala
@@ -1,20 +1,29 @@
 package java.util
 
+import scalanative.native.stub
+
 class TimeZone extends Serializable with Cloneable {
+
+  @stub
   def getDisplayName(daylight: Boolean, style: Int, locale: Locale): String =
     ???
 
+  @stub
   def inDaylightTime(time: Date): Boolean = ???
 }
 
 object TimeZone {
-  val SHORT: Int = 0
+
+  final val SHORT = 0
 
   def getAvailableIDs(): Array[String] = Array.empty[String]
 
+  @stub
   def getTimeZone(ID: String): TimeZone = ???
 
+  @stub
   def getDefault(): TimeZone = ???
 
+  @stub
   def setDefault(zone: TimeZone): Unit = ???
 }

--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -265,6 +265,7 @@ final class Matcher private[regex] (var _pattern: Pattern,
     this
   }
 
+  @stub
   def region(start: Int, end: Int): Matcher = ???
 
   private[regex] def appendReplacement2(sb: StringBuffer,

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystem.scala
@@ -22,7 +22,10 @@ import scala.scalanative.native.{
   Zone,
   alloc
 }
+
 import scala.scalanative.posix.sys.statvfs
+
+import scalanative.native.stub
 
 class UnixFileSystem(override val provider: FileSystemProvider,
                      val root: String,
@@ -33,8 +36,8 @@ class UnixFileSystem(override val provider: FileSystemProvider,
   override def close(): Unit =
     closed = true
 
-  override def getFileStores(): Iterable[FileStore] =
-    ???
+  @stub
+  override def getFileStores(): Iterable[FileStore] = ???
 
   override def getPath(first: String, more: Array[String]): Path =
     new UnixPath(this, (first +: more).mkString("/"))

--- a/scripted-tests/run/java-io-file-2/build.sbt
+++ b/scripted-tests/run/java-io-file-2/build.sbt
@@ -5,6 +5,8 @@ enablePlugins(ScalaNativePlugin)
 
 scalaVersion := "2.11.12"
 
+nativeLinkStubs := true // DateFormatSymbols
+
 lazy val setupTests = taskKey[Unit]("")
 
 setupTests := {


### PR DESCRIPTION
…tation"

  * This pull request addresses Issue #1470. That issue is now fixed.

  * I examined 24 files. All but nine already had @stub annotations.
    I added that annotation to the remaining nine.

  * I added 'nativeLinkStubs := true' to unit-tests in the project root
    build.sbt. This allows the unit-tests to continue to link and execute.

  * I added 'nativeLinkStubs := true' to the build.sbt for the
    scripted-test java-io-file-2.  I tried several places in the
    project root build.sbt but could not get java-io-file-2 to link
    and execute.

    In my development sandbox, I have a US only implementation of
    DateFormatSymbols. The stubs in that file were causing the link of
    java-io-file-2 to fail.  DateFormatSymbols was also one of four
    files causing unit-tests to fail.  I hope to queue that work
    up as a Pull Request in the following weeks. That would allow
    the wart in java-io-file-2 build.sbt to be removed.

  * A number of files had commented out `???` lines; e.g.
    `// def foo(): Unit = ???`.  These probably originated before `@stub`
    was available.  I took a minimalist approach and did not touch
    those lines.  The edit I did not do would be to uncomment and
    add the `@stub` annotation.  I can do that in another PR if advised.

  * There is one slight unrelated drive-by edit to TimeZone.scala.
    While in that file adding '@stub' annotations, I edited the constant
    SHORT so that it will become a compile time constant (added `final`
    & removed type ascription).  The change was worthwhile and low
    risk but not worth the effort of another full PR.  I can revert that
    change if recommended.

Documentation:

   * None needed beyond title in change list.

Testing:

  * Built and tested ("test-all") in release mode using sbt 1.2.6 on
    X86_64 only . All tests pass.