### PR TITLE
Fix Issue #1480: "Character.scala should return StringIndexOutOfBounds"

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -304,7 +304,7 @@ object Character {
     val len      = seq.length
     val endIndex = offset + count
     if (offset < 0 || count < 0 || endIndex > len) {
-      throw new IndexOutOfBoundsException()
+      throw new StringIndexOutOfBoundsException()
     }
 
     var result = 0
@@ -334,8 +334,9 @@ object Character {
                          index: scala.Int,
                          codePointOffset: scala.Int): scala.Int = {
     val end = start + count
-    if (start < 0 || count < 0 || end > seq.length || index < start || index > end) {
-      throw new IndexOutOfBoundsException()
+    if (start < 0 || count < 0 || end > seq.length || index < start
+        || index > end) {
+      throw new StringIndexOutOfBoundsException()
     }
 
     if (codePointOffset == 0) {
@@ -346,7 +347,7 @@ object Character {
       while (codePoints > 0) {
         codePoints -= 1
         if (i >= end) {
-          throw new IndexOutOfBoundsException()
+          throw new StringIndexOutOfBoundsException()
         }
         if (isHighSurrogate(seq(i))) {
           val next = i + 1
@@ -364,7 +365,7 @@ object Character {
         codePoints -= 1
         i -= 1
         if (i < start) {
-          throw new IndexOutOfBoundsException()
+          throw new StringIndexOutOfBoundsException()
         }
         if (isLowSurrogate(seq(i))) {
           val prev = i - 1

--- a/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
@@ -283,6 +283,40 @@ object CharacterSuite extends tests.Suite {
     }
   }
 
+  test("offsetByCodePoints - invalid values") {
+    val str1 = "<bad args>"
+    val arr1 = str1.toArray
+
+    assertThrows[java.lang.NullPointerException] {
+      Character.offsetByCodePoints(null.asInstanceOf[Array[Char]],
+                                   1,
+                                   arr1.length,
+                                   0,
+                                   0)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.offsetByCodePoints(arr1, -1, arr1.length, 0, 0)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.offsetByCodePoints(arr1, 0, -1, 0, 0)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.offsetByCodePoints(arr1, 1, arr1.length, 2, 0)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.offsetByCodePoints(arr1, 2, arr1.length, 1, 0)
+    }
+
+    assertThrows[java.lang.StringIndexOutOfBoundsException] {
+      Character.offsetByCodePoints(arr1, 2, arr1.length, arr1.length + 1, 0)
+    }
+
+  }
+
   def toInt(hex: String): Int = Integer.parseInt(hex, 16)
 
   /** toUpperCase/toLowerCase based on Unicode 7 case folding.


### PR DESCRIPTION
  * The presenting issue was described in issue #1480, "Character.scala
    return StringIndexOutOfBounds in many places". The issue was discovered
    whilst porting re2s to ScalaNative.

  * The type of the exception thrown was changed from the prior
    IndexOutOfBoundsException to its subclass StringIndexOutOfBoundsException.
    Oracle JVM documentation specifies the former, but the JVM itself
    implements the latter.  Character.scala should now consistently
    throw the JVM de facto standard.

  * The change remaining after PR #1484 were in method offsetByCodePoints().
    I added a test in CharacterSuite.scala to test that the most
    common cases of invalid argument were tested and returned
    the expected StringIndexOutOfBounds.

    After the argument check, there are two places in the body of
    the method where an exception is thrown. Visual inspection of
    the code shows that the now expected StringIndexOutOfBounds
    is returned.

    There was no easy way to write a unit-test to trigger those
    lines of code. I also checked to see if I could borrow use
    code from scala.js or Harmony to trigger those lines.  Nothing
    relevant.  Visual inspection will have to do for now.

Documentation:

    This needs a release note. There is a user visible change to
    the exception thrown in 5 places.  The new exceptions conform
    to JVM practice, but may break existing SN code.

Testing:

  * Built and tested ("test-all") on X86_64 using sbt 1.2.6 in
    debug mode. Release mode failed with OutOfMemory exception.
    All tests expected to pass do so.