### PR TITLE
Fix #1530: NIO Files.find should respect FOLLOW_LINKS option

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -248,9 +248,18 @@ object Files {
            matcher: BiPredicate[Path, BasicFileAttributes],
            options: Array[FileVisitOption]): Stream[Path] = {
     val stream = walk(start, maxDepth, 0, options, SSet.empty).filter { p =>
-      val attributes = getFileAttributeView(p,
-                                            classOf[BasicFileAttributeView],
-                                            Array.empty).readAttributes()
+      //
+      // See comments for FileVisitOption & linkOpts in _walkFileTree
+      val linkOpts =
+        if (options.contains(FileVisitOption.FOLLOW_LINKS))
+          Array.empty[LinkOption]
+        else
+          Array(LinkOption.NOFOLLOW_LINKS)
+
+      val attributes =
+        getFileAttributeView(p, classOf[BasicFileAttributeView], linkOpts)
+          .readAttributes()
+
       matcher.test(p, attributes)
     }
     new WrappedScalaStream(stream.toStream, None)

--- a/unit-tests/src/test/scala/java/nio/file/FilesSuite.scala
+++ b/unit-tests/src/test/scala/java/nio/file/FilesSuite.scala
@@ -975,8 +975,8 @@ object FilesSuite extends tests.Suite {
       assert(itFollowGood.hasNext,
              s"Should have found a Path when following symlinks")
 
-      val foundPath      = itFollowGood.next
-      val foundName      = foundPath.getFileName.toString
+      val foundPath = itFollowGood.next
+      val foundName = foundPath.getFileName.toString
 
       assert(foundName == soughtName,
              s"found: |$foundName| != expected: |$soughtName|")

--- a/unit-tests/src/test/scala/java/nio/file/FilesSuite.scala
+++ b/unit-tests/src/test/scala/java/nio/file/FilesSuite.scala
@@ -975,11 +975,8 @@ object FilesSuite extends tests.Suite {
       assert(itFollowGood.hasNext,
              s"Should have found a Path when following symlinks")
 
-      // We want soughtName _exactly_ so do not use endsWith(),
-      // which would report true for, say, Foo${soughtName}.
       val foundPath      = itFollowGood.next
-      val foundNameCount = foundPath.getNameCount
-      val foundName      = foundPath.getName(foundNameCount - 1).toString
+      val foundName      = foundPath.getFileName.toString
 
       assert(foundName == soughtName,
              s"found: |$foundName| != expected: |$soughtName|")


### PR DESCRIPTION
  * I am marking this one as draft until after #1531 is merged. Both PRs touch the 
    same two files. They should merge cleanly, in either order but I want to prevent
    causing extra work for others and save myself the embarrassment of merge
    failures.  Other than that and removing this note, it is ready to go. 

   * Issue #1530 reported a problem with NIO Files.find which was
    identical to the problem originally reported in Issue $1354 for
    Files.walkFileTree().  #1530 was discovered whilst fixing #1354.

    #1530 is not fixed. Code examination shows that there should
    be no other places in Files.scala with the identical defect.

    I _will_ be creating an Issue for a possible related problem,
    Files.find() with broken symlinks to files, not directories.
    I do not have enough evidence to indict there.

  * Two unit tests was added to FilesSuite.scala to exercise the
    2x2 case square of FileVisitOption.FOLLOW_LINKS present & absent each with
    valid and broken directory symlinks.

  * Almost all of this PR parallels PR #1351. That parallelism
    might draw a reviewer to expect a try/catch in Files.find() to call
    visitor.visitFileFailed(). Files.find() does not use a visitor
    so no try/catch is needed.

Documentation:

    None needed other than the title in the change log.

Testing:

  * Built and tested ("test-all") on X86_64 using sbt 1.2.6 in
    debug mode. All tests expected to pass do so.