### PR TITLE
Split mangled and unmangled signatures

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Global.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Global.scala
@@ -4,6 +4,7 @@ package nir
 sealed abstract class Global {
   def top: Global.Top
   def member(sig: Sig): Global.Member
+  def member(sig: Sig.Unmangled): Global.Member = member(sig.mangled)
 
   final def isTop: Boolean =
     this.isInstanceOf[Global.Top]

--- a/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
@@ -14,9 +14,9 @@ object Mangle {
     impl.toString
   }
 
-  def apply(sig: Sig): String = {
+  def apply(sig: Sig.Unmangled): String = {
     val impl = new Impl
-    impl.mangleSig(sig)
+    impl.mangleUnmangledSig(sig)
     impl.toString
   }
 
@@ -40,7 +40,10 @@ object Mangle {
         util.unreachable
     }
 
-    def mangleSig(sig: Sig): Unit = sig match {
+    def mangleSig(sig: Sig): Unit =
+      str(sig.mangle)
+
+    def mangleUnmangledSig(sig: Sig.Unmangled): Unit = sig match {
       case Sig.Field(id) =>
         str("F")
         mangleIdent(id)

--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -14,23 +14,24 @@ object Rt {
   val BoxedUnit       = Ref(Global.Top("scala.runtime.BoxedUnit"))
   val BoxedUnitModule = Ref(Global.Top("scala.scalanative.runtime.BoxedUnit$"))
 
-  val GetRawTypeSig       = Sig.Method("getRawType", Seq(Rt.Object, Ptr))
-  val JavaEqualsSig       = Sig.Method("equals", Seq(Object, Bool))
-  val JavaHashCodeSig     = Sig.Method("hashCode", Seq(Int))
-  val ScalaEqualsSig      = Sig.Method("scala_==", Seq(Object, Bool))
-  val ScalaHashCodeSig    = Sig.Method("scala_##", Seq(Int))
-  val IsArraySig          = Sig.Method("isArray", Seq(Bool))
-  val IsAssignableFromSig = Sig.Method("isAssignableFrom", Seq(Class, Bool))
-  val GetNameSig          = Sig.Method("getName", Seq(String))
-  val BitCountSig         = Sig.Method("bitCount", Seq(Int, Int))
-  val ReverseBytesSig     = Sig.Method("reverseBytes", Seq(Int, Int))
+  val GetRawTypeSig    = Sig.Method("getRawType", Seq(Rt.Object, Ptr)).mangled
+  val JavaEqualsSig    = Sig.Method("equals", Seq(Object, Bool)).mangled
+  val JavaHashCodeSig  = Sig.Method("hashCode", Seq(Int)).mangled
+  val ScalaEqualsSig   = Sig.Method("scala_==", Seq(Object, Bool)).mangled
+  val ScalaHashCodeSig = Sig.Method("scala_##", Seq(Int)).mangled
+  val IsArraySig       = Sig.Method("isArray", Seq(Bool)).mangled
+  val IsAssignableFromSig =
+    Sig.Method("isAssignableFrom", Seq(Class, Bool)).mangled
+  val GetNameSig      = Sig.Method("getName", Seq(String)).mangled
+  val BitCountSig     = Sig.Method("bitCount", Seq(Int, Int)).mangled
+  val ReverseBytesSig = Sig.Method("reverseBytes", Seq(Int, Int)).mangled
   val NumberOfLeadingZerosSig =
-    Sig.Method("numberOfLeadingZeros", Seq(Int, Int))
-  val CosSig  = Sig.Method("cos", Seq(Double, Double))
-  val SinSig  = Sig.Method("sin", Seq(Double, Double))
-  val PowSig  = Sig.Method("pow", Seq(Double, Double, Double))
-  val MaxSig  = Sig.Method("max", Seq(Double, Double, Double))
-  val SqrtSig = Sig.Method("sqrt", Seq(Double, Double))
+    Sig.Method("numberOfLeadingZeros", Seq(Int, Int)).mangled
+  val CosSig  = Sig.Method("cos", Seq(Double, Double)).mangled
+  val SinSig  = Sig.Method("sin", Seq(Double, Double)).mangled
+  val PowSig  = Sig.Method("pow", Seq(Double, Double, Double)).mangled
+  val MaxSig  = Sig.Method("max", Seq(Double, Double, Double)).mangled
+  val SqrtSig = Sig.Method("sqrt", Seq(Double, Double)).mangled
 
   val GetRawTypeTy   = Function(Seq(Runtime, Object), Ptr)
   val GetRawTypeName = Global.Member(Runtime.name, GetRawTypeSig)
@@ -56,7 +57,7 @@ object Rt {
     "ObjectArray"
   ).map { arr =>
     val cls = Global.Top("scala.scalanative.runtime." + arr)
-    val sig = Sig.Method("alloc", Seq(Int, Ref(cls)))
+    val sig = Sig.Method("alloc", Seq(Int, Ref(cls))).mangled
     sig -> cls
   }.toMap
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -1,6 +1,8 @@
 package scala.scalanative
 package nir
 
+import scala.language.implicitConversions
+
 final class Sig(val mangle: String) {
   final def toProxy: Sig =
     if (isMethod) {
@@ -25,6 +27,7 @@ final class Sig(val mangle: String) {
 
   final def isField: Boolean     = mangle(0) == 'F'
   final def isCtor: Boolean      = mangle(0) == 'R'
+  final def isImplCtor: Boolean  = mangle.startsWith("M6$init$")
   final def isMethod: Boolean    = mangle(0) == 'D'
   final def isProxy: Boolean     = mangle(0) == 'P'
   final def isExtern: Boolean    = mangle(0) == 'C'

--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -1,18 +1,17 @@
 package scala.scalanative
 package nir
 
-sealed abstract class Sig {
-  final def toProxy: Sig.Proxy = this match {
-    case Sig.Method(id, types) =>
-      Sig.Proxy(id, types.init)
-    case _ =>
+final class Sig(val mangle: String) {
+  final def toProxy: Sig =
+    if (isMethod) {
+      val Sig.Method(id, types) = this.unmangled
+      Sig.Proxy(id, types.init).mangled
+    } else {
       util.unsupported(
         s"can't convert non-method sig ${this.mangle} to proxy sig")
-  }
+    }
   final def show: String =
     Show(this)
-  final lazy val mangle: String =
-    Mangle(this)
   final override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: Sig => other.mangle == mangle
@@ -22,13 +21,27 @@ sealed abstract class Sig {
     mangle.##
   final override def toString: String =
     mangle
+  final def unmangled: Sig.Unmangled = Unmangle.unmangleSig(mangle)
+
+  final def isField: Boolean     = mangle(0) == 'F'
+  final def isCtor: Boolean      = mangle(0) == 'R'
+  final def isMethod: Boolean    = mangle(0) == 'D'
+  final def isProxy: Boolean     = mangle(0) == 'P'
+  final def isExtern: Boolean    = mangle(0) == 'C'
+  final def isGenerated: Boolean = mangle(0) == 'G'
+  final def isDuplicate: Boolean = mangle(0) == 'K'
 }
 object Sig {
-  final case class Field(id: String)                    extends Sig
-  final case class Ctor(types: Seq[Type])               extends Sig
-  final case class Method(id: String, types: Seq[Type]) extends Sig
-  final case class Proxy(id: String, types: Seq[Type])  extends Sig
-  final case class Extern(id: String)                   extends Sig
-  final case class Generated(id: String)                extends Sig
-  final case class Duplicate(of: Sig, types: Seq[Type]) extends Sig
+  sealed abstract class Unmangled {
+    final def mangled: Sig = new Sig(Mangle(this))
+  }
+  final case class Field(id: String)                    extends Unmangled
+  final case class Ctor(types: Seq[Type])               extends Unmangled
+  final case class Method(id: String, types: Seq[Type]) extends Unmangled
+  final case class Proxy(id: String, types: Seq[Type])  extends Unmangled
+  final case class Extern(id: String)                   extends Unmangled
+  final case class Generated(id: String)                extends Unmangled
+  final case class Duplicate(of: Sig, types: Seq[Type]) extends Unmangled
+
+  implicit def unmangledToMangled(sig: Sig.Unmangled): Sig = sig.mangled
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
@@ -2,9 +2,9 @@ package scala.scalanative
 package nir
 
 object Unmangle {
-  def unmangleGlobal(s: String): Global = (new Impl(s)).readGlobal()
-  def unmangleType(s: String): Type     = (new Impl(s)).readType()
-  def unmangleSig(s: String): Sig       = (new Impl(s)).readSig()
+  def unmangleGlobal(s: String): Global     = (new Impl(s)).readGlobal()
+  def unmangleType(s: String): Type         = (new Impl(s)).readType()
+  def unmangleSig(s: String): Sig.Unmangled = (new Impl(s)).readUnmangledSig()
 
   private class Impl(s: String) {
     val chars = s.toArray
@@ -14,12 +14,12 @@ object Unmangle {
       case 'T' =>
         Global.Top(readIdent())
       case 'M' =>
-        Global.Member(Global.Top(readIdent()), readSig())
+        Global.Member(Global.Top(readIdent()), readUnmangledSig().mangled)
       case ch =>
         error(s"expected global, but got $ch")
     }
 
-    def readSig(): Sig = read() match {
+    def readUnmangledSig(): Sig.Unmangled = read() match {
       case 'F' =>
         Sig.Field(readIdent())
       case 'R' =>
@@ -33,7 +33,7 @@ object Unmangle {
       case 'G' =>
         Sig.Generated(readIdent())
       case 'K' =>
-        Sig.Duplicate(readSig(), readTypes())
+        Sig.Duplicate(readUnmangledSig(), readTypes())
       case ch =>
         error(s"expected sig, but got $ch")
     }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -180,15 +180,8 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
       Global.Member(Global.Top(getString), getSig)
   }
 
-  private def getSig(): Sig = getInt match {
-    case T.FieldSig     => Sig.Field(getString)
-    case T.CtorSig      => Sig.Ctor(getTypes)
-    case T.MethodSig    => Sig.Method(getString, getTypes)
-    case T.ProxySig     => Sig.Proxy(getString, getTypes)
-    case T.ExternSig    => Sig.Extern(getString)
-    case T.GeneratedSig => Sig.Generated(getString)
-    case T.DuplicateSig => Sig.Duplicate(getSig, getTypes)
-  }
+  private def getSig(): Sig =
+    new Sig(getString)
 
   private def getLocal(): Local =
     Local(getLong)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -251,32 +251,8 @@ final class BinarySerializer(buffer: ByteBuffer) {
       util.unreachable
   }
 
-  private def putSig(sig: Sig): Unit = sig match {
-    case Sig.Field(id) =>
-      putInt(T.FieldSig)
-      putString(id)
-    case Sig.Ctor(types) =>
-      putInt(T.CtorSig)
-      putTypes(types)
-    case Sig.Method(id, types) =>
-      putInt(T.MethodSig)
-      putString(id)
-      putTypes(types)
-    case Sig.Proxy(id, types) =>
-      putInt(T.ProxySig)
-      putString(id)
-      putTypes(types)
-    case Sig.Extern(id) =>
-      putInt(T.ExternSig)
-      putString(id)
-    case Sig.Generated(id) =>
-      putInt(T.GeneratedSig)
-      putString(id)
-    case Sig.Duplicate(sig, types) =>
-      putInt(T.DuplicateSig)
-      putSig(sig)
-      putTypes(types)
-  }
+  private def putSig(sig: Sig): Unit =
+    putString(sig.mangle)
 
   private def putLocal(local: Local): Unit =
     putLong(local.id)

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -195,7 +195,7 @@ final class Check(implicit linked: linker.Result) {
     case Op.Method(obj, sig) =>
       expect(Rt.Object, obj)
       sig match {
-        case _: Sig.Method | _: Sig.Ctor =>
+        case sig if sig.isMethod || sig.isCtor =>
           ok
         case _ =>
           error(s"method must take a method signature, not ${sig.show}")
@@ -217,7 +217,7 @@ final class Check(implicit linked: linker.Result) {
     case Op.Dynmethod(obj, sig) =>
       expect(Rt.Object, obj)
       sig match {
-        case _: Sig.Proxy =>
+        case sig if sig.isProxy =>
           ok
         case _ =>
           error(s"dynmethod must take a proxy signature, not ${sig.show}")

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -615,7 +615,8 @@ object CodeGen {
     def mangled(g: Global): String = g match {
       case Global.None =>
         unsupported(g)
-      case Global.Member(_, Sig.Extern(id)) =>
+      case Global.Member(_, sig) if sig.isExtern =>
+        val Sig.Extern(id) = sig.unmangled
         id
       case _ =>
         "_S" + g.mangle

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -21,9 +21,7 @@ trait Inline { self: Interflow =>
         false
       } { defn =>
         val isCtor = originalName(name) match {
-          case Global.Member(_, _: Sig.Ctor) =>
-            true
-          case Global.Member(_, Sig.Method("$init$", _)) =>
+          case Global.Member(_, sig) if sig.isCtor || sig.isImplCtor =>
             true
           case _ =>
             false

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -175,8 +175,9 @@ trait Visit { self: Interflow =>
   }
 
   def originalFunctionType(name: Global): Type = name match {
-    case Global.Member(owner, Sig.Duplicate(sig, _)) =>
-      originalFunctionType(Global.Member(owner, sig))
+    case Global.Member(owner, sig) if sig.isDuplicate =>
+      val Sig.Duplicate(base, _) = sig.unmangled
+      originalFunctionType(Global.Member(owner, base))
     case _ =>
       linked.infos(name).asInstanceOf[Method].ty
   }

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -141,7 +141,8 @@ trait Visit { self: Interflow =>
     }
 
   def originalName(name: Global): Global = name match {
-    case Global.Member(owner, Sig.Duplicate(origSig, argtys)) =>
+    case Global.Member(owner, sig) if sig.isDuplicate =>
+      val Sig.Duplicate(origSig, argtys) = sig.unmangled
       originalName(Global.Member(owner, origSig))
     case _ =>
       name
@@ -165,7 +166,8 @@ trait Visit { self: Interflow =>
   }
 
   def argumentTypes(name: Global): Seq[Type] = name match {
-    case Global.Member(_, Sig.Duplicate(_, argtys)) =>
+    case Global.Member(_, sig) if sig.isDuplicate =>
+      val Sig.Duplicate(_, argtys) = sig.unmangled
       argtys
     case _ =>
       val Type.Function(argtys, _) = linked.infos(name).asInstanceOf[Method].ty

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -216,7 +216,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
               case Rt.JavaHashCodeSig =>
                 update(Rt.ScalaHashCodeSig)
                 update(Rt.JavaHashCodeSig)
-              case sig @ (_: Sig.Method | _: Sig.Ctor) =>
+              case sig if sig.isMethod || sig.isCtor =>
                 update(sig)
               case _ =>
                 ()
@@ -259,7 +259,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
       // signature becomes reachable. The others are
       // stashed as dynamic candidates.
       info.responds.foreach {
-        case (sig: Sig.Method, impl) =>
+        case (sig, impl) if sig.isMethod =>
           val dynsig = sig.toProxy
           if (!dynsigs.contains(dynsig)) {
             val buf =


### PR DESCRIPTION
This change splits global signatures into two categories:

1. Mangled (default) just a string containing a mangled version of the signature.
2. Unmangled (recovered on-demand) an ADT that lets you pattern-match on signature structure.

This improves performance of signatures and globals when they are used as keys in hash maps.