### PR TITLE
Drop license notice for smarr/are-we-fast-yet

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 # License
 
 The original source code of the Scala Native toolchain and accompanying
-libraries is provided under the Apache License: 
+libraries is provided under the Apache License:
 
 ```
 
@@ -1672,56 +1672,9 @@ implementation. The original project copyright notice is available below:
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-# License notice for smarr/are-we-fast-yet
-
-Scala Native benchmarks are based on the code from [smarr/are-we-fast-yet
-](https://github.com/smarr/are-we-fast-yet). Original license notice is
-included below:
-
-```
-    # Overview
-
-    The benchmarks in this repository are from different sources and have different
-    licenses.
-
-    ## Richards and DeltaBlue
-
-    These benchmark are derived from the Smalltalk sources provided by Mario Wolczko.
-
-    License details are available at:
-      http://web.archive.org/web/20050825101121/http://www.sunlabs.com/people/mario/java_benchmarking/index.html
-
-    Further information:
-      http://www.wolczko.com/java_benchmarking.html
-
-    ## Computer Language Benchmarks Game
-
-    $Id: LICENSE,v 1.1 2012-12-29 19:28:50 igouy-guest Exp $
-
-    Revised BSD license
-
-    This is a specific instance of the Open Source Initiative (OSI) BSD license template
-    http://www.opensource.org/licenses/bsd-license.php
-
-
-    Copyright 2008-2012 Isaac Gouy
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-       Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-       Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-       Neither the name of "The Computer Language Benchmarks Game" nor the name of "The Computer Language Shootout Benchmarks" nor the name "bencher" nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-```
-
-
 # License notice for ryu IEEE754 Double & Float toString conversion
 
-Scala Native code to convert IEEE754 Double & Float values to strings 
+Scala Native code to convert IEEE754 Double & Float values to strings
 is based on code from [ulfjack/ryu](https://github.com/ulfjack/ryu) and
 heavily modified. Original license notice is included below:
 


### PR DESCRIPTION
The code and the corresponding notice has moved to:
https://github.com/scala-native/scala-native-benchmarks