### PR TITLE
Fix #1460: split release mode into release-fast and release-full

### DIFF
--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -67,10 +67,10 @@ Since Name                     Type            Description
 0.1   ``nativeClangPP``        ``File``        Path to ``clang++`` command
 0.1   ``nativeCompileOptions`` ``Seq[String]`` Extra options passed to clang verbatim during compilation
 0.1   ``nativeLinkingOptions`` ``Seq[String]`` Extra options passed to clang verbatim during linking
-0.1   ``nativeMode``           ``String``      Either ``"debug"`` or ``"release"`` (2)
-0.2   ``nativeGC``             ``String``      Either ``"none"``, ``"boehm"`` or ``"immix"`` (3)
+0.1   ``nativeMode``           ``String``      One of ``"debug"``, ``"release-fast"`` or ``"release-full"`` (2)
+0.2   ``nativeGC``             ``String``      One of ``"none"``, ``"boehm"`` or ``"immix"`` (3)
 0.3.3 ``nativeLinkStubs``      ``Boolean``     Whether to link ``@stub`` definitions, or to ignore them
-0.3.9 ``nativeLTO``            ``String``      Either ``"none"``, ``"full"`` or ``"thin"`` (4)
+0.3.9 ``nativeLTO``            ``String``      One of ``"none"``, ``"full"`` or ``"thin"`` (4)
 ===== ======================== =============== =========================================================
 
 1. See `Publishing`_ and `Cross compilation`_ for details.
@@ -81,7 +81,7 @@ Since Name                     Type            Description
 Compilation modes
 -----------------
 
-Scala Native supports two distinct linking modes:
+Scala Native supports three distinct linking modes:
 
 1. **debug.** (default)
 
@@ -89,10 +89,23 @@ Scala Native supports two distinct linking modes:
    optimizations and is much more suited for iterative development workflow.
    Similar to clang's ``-O0``.
 
-2. **release.**
+2. **release.** (deprecated since 0.4.0)
 
-   Optimized for best runtime performance at expense of longer compilation time.
+   Aliases to **release-full**.
+
+2. **release-fast.** (introduced in 0.4.0)
+
+   Optimize for runtime performance while still trying to keep
+   quick compilation time and small emitted code size.
    Similar to clang's ``-O2`` with addition of link-time optimization over
+   the whole application code.
+
+3. **release-full.** (introduced in 0.4.0)
+
+   Optimized for best runtime performance, even if hurts compilation
+   time and code size. This modes includes a number of more aggresive optimizations
+   such type-driven method duplication and more aggresive inliner.
+   Similar to clang's ``-O3`` with addition of link-time optimization over
    the whole application code.
 
 Garbage collectors
@@ -124,24 +137,19 @@ of release builds. There are three possible modes that are currently supported:
 1. **none.** (default)
 
    Does not inline across Scala/C boundary. Scala to Scala calls
-   are still optimized by emitting one fat LLVM IR module for
-   the whole application.
+   are still optimized.
 
-2. **full.** (Clang 3.8 or older)
+2. **full.** (available on Clang 3.8 or older)
 
-   Inlines across Scala/C boundary by merging all of the LLVM IR
-   modules into a single module for the whole application. Unlike
-   **none** this module also includes the runtime code thus allows
-   for additional optimization opportunities.
+   Inlines across Scala/C boundary using legacy FullLTO mode.
 
 3. **thin.** (recommended on Clang 3.9 or newer)
 
-   Inlines across Scala/C boundary using LLVM's
-   `ThinLTO <https://clang.llvm.org/docs/ThinLTO.html>`_.
-   Unlike **none** and **full**
-   it's able to optimize the application in parallel.
-   It also offers the best runtime performance according
-   to our benchmarks.
+   Inlines across Scala/C boundary using LLVM's latest
+   `ThinLTO mode <https://clang.llvm.org/docs/ThinLTO.html>`_.
+   Offers both better compilation speed and
+   better runtime performance of the generated code
+   than the legacy FullLTO mode.
 
 Publishing
 ----------

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -117,8 +117,9 @@ private[scalanative] object LLVM {
   def compile(config: Config, llPaths: Seq[Path]): Seq[Path] = {
     val optimizationOpt =
       config.mode match {
-        case Mode.Debug   => "-O0"
-        case Mode.Release => "-O2"
+        case Mode.Debug       => "-O0"
+        case Mode.ReleaseFast => "-O2"
+        case Mode.ReleaseFull => "-O3"
       }
     val opts = optimizationOpt +: config.compileOptions
 
@@ -183,9 +184,9 @@ private[scalanative] object LLVM {
 
   private def lto(config: Config): Option[String] =
     (config.mode, config.LTO) match {
-      case (Mode.Debug, _)        => None
-      case (Mode.Release, "none") => None
-      case (Mode.Release, name)   => Some(name)
+      case (Mode.Debug, _)           => None
+      case (_: Mode.Release, "none") => None
+      case (_: Mode.Release, name)   => Some(name)
     }
 
   private def flto(config: Config): Seq[String] =

--- a/tools/src/main/scala/scala/scalanative/build/Mode.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Mode.scala
@@ -17,14 +17,26 @@ sealed abstract class Mode private (val name: String) {
   override def toString: String = name
 }
 object Mode {
-  private[scalanative] final case object Debug   extends Mode("debug")
-  private[scalanative] final case object Release extends Mode("release")
+  private[scalanative] final case object Debug extends Mode("debug")
+  private[scalanative] sealed trait Release
+  private[scalanative] final case object ReleaseFast
+      extends Mode("release-fast")
+      with Release
+  private[scalanative] final case object ReleaseFull
+      extends Mode("release-full")
+      with Release
 
   /** Debug compilation mode. */
   def debug: Mode = Debug
 
   /** Release compilation mode. */
-  def release: Mode = Release
+  def release: Mode = ReleaseFull
+
+  /** Release compilation mode that's still fast to compile. */
+  def releaseFast: Mode = ReleaseFast
+
+  /** Release compilation mode that's uses full set of optimizations. */
+  def releaseFull: Mode = ReleaseFull
 
   /** Default compilation mode. */
   def default: Mode = Debug
@@ -34,7 +46,11 @@ object Mode {
     case "debug" =>
       Debug
     case "release" =>
-      Release
+      ReleaseFull
+    case "release-fast" =>
+      ReleaseFast
+    case "release-full" =>
+      ReleaseFull
     case value =>
       throw new IllegalArgumentException(s"Unknown mode: '$value'")
   }

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -75,9 +75,9 @@ object CodeGen {
       }
 
       (config.mode, config.LTO) match {
-        case (build.Mode.Debug, _)        => separate()
-        case (build.Mode.Release, "none") => single()
-        case (build.Mode.Release, _)      => separate()
+        case (build.Mode.Debug, _)           => separate()
+        case (_: build.Mode.Release, "none") => single()
+        case (_: build.Mode.Release, _)      => separate()
       }
     }
 

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -12,7 +12,7 @@ trait Inline { self: Interflow =>
     val maybeDefn = mode match {
       case build.Mode.Debug =>
         maybeOriginal(name)
-      case build.Mode.Release =>
+      case _: build.Mode.Release =>
         maybeDone(name)
     }
 
@@ -58,7 +58,9 @@ trait Inline { self: Interflow =>
         val shall = mode match {
           case build.Mode.Debug =>
             isCtor || alwaysInline
-          case build.Mode.Release =>
+          case build.Mode.ReleaseFast =>
+            isCtor || alwaysInline || hintInline || isSmall
+          case build.Mode.ReleaseFull =>
             isCtor || alwaysInline || hintInline || isSmall || hasVirtualArgs
         }
         val shallNot =
@@ -124,7 +126,7 @@ trait Inline { self: Interflow =>
       val defn = mode match {
         case build.Mode.Debug =>
           getOriginal(name)
-        case build.Mode.Release =>
+        case _: build.Mode.Release =>
           getDone(name)
       }
 

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -43,12 +43,16 @@ trait PolyInline { self: Interflow =>
     case build.Mode.Debug =>
       false
 
-    case build.Mode.Release =>
+    case _: build.Mode.Release =>
       val targets    = polyTargets(op)
       val classCount = targets.map(_._1).size
       val implCount  = targets.map(_._2).distinct.size
 
-      classCount <= 16 && implCount >= 2 && implCount <= 4
+      if (mode == build.Mode.ReleaseFast) {
+        classCount <= 8 && implCount == 2
+      } else {
+        classCount <= 16 && implCount >= 2 && implCount <= 4
+      }
   }
 
   def polyInline(op: Op.Method, args: Seq[Val])(implicit state: State,

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -22,10 +22,10 @@ trait Visit { self: Interflow =>
 
   def shallDuplicate(name: Global, argtys: Seq[Type]): Boolean =
     mode match {
-      case build.Mode.Debug =>
+      case build.Mode.Debug | build.Mode.ReleaseFast =>
         false
 
-      case build.Mode.Release =>
+      case build.Mode.ReleaseFull =>
         if (!shallVisit(name)) {
           false
         } else {
@@ -48,7 +48,7 @@ trait Visit { self: Interflow =>
     mode match {
       case build.Mode.Debug =>
         linked.defns.foreach(defn => visitEntry(defn.name))
-      case build.Mode.Release =>
+      case _: build.Mode.Release =>
         linked.entries.foreach(visitEntry)
     }
 
@@ -78,7 +78,7 @@ trait Visit { self: Interflow =>
     mode match {
       case build.Mode.Debug =>
         None
-      case build.Mode.Release =>
+      case _: build.Mode.Release =>
         val dup = duplicateName(name, argtys)
         if (shallVisit(dup)) {
           if (!isDone(dup)) {
@@ -109,7 +109,7 @@ trait Visit { self: Interflow =>
     mode match {
       case build.Mode.Debug =>
         allTodo().par.foreach(visit)
-      case build.Mode.Release =>
+      case _: build.Mode.Release =>
         loop()
     }
   }


### PR DESCRIPTION
This PR adds a 3rd mode called `"release-size"`. Unlike regular release mode, optimizer is going to perform less of the optimizations that can increase code size (no method duplication, less inlining, less polymorphic inlining, `-Os`).