### PR TITLE
Add benchmarks project for `tools`

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = "2.0.0-RC4"
 style = defaultWithAlign
 docstrings = JavaDoc
 assumeStandardLibraryStripMargin = true

--- a/nir/src/main/scala/scala/scalanative/nir/Global.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Global.scala
@@ -13,6 +13,7 @@ sealed abstract class Global {
   final def mangle: String =
     Mangle(this)
 }
+
 object Global {
   final case object None extends Global {
     override def top: Global.Top =

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -22,6 +22,9 @@ addSbtPlugin("com.eed3si9n"       % "sbt-dirty-money"   % "0.2.0")
 addSbtPlugin("org.foundweekends"  % "sbt-bintray"       % "0.5.4")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"           % "1.0.0")
 addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"   % "0.3.0")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"           % "0.3.5")
+addSbtPlugin("io.get-coursier"    % "sbt-coursier"      % "1.1.0-M7")
+addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"     % "0.7.0")
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M7")

--- a/tools-benchmarks/src/main/scala/scala/scalanative/linker/benchmarks/TestSuiteLinkerBench.scala
+++ b/tools-benchmarks/src/main/scala/scala/scalanative/linker/benchmarks/TestSuiteLinkerBench.scala
@@ -24,6 +24,7 @@ abstract class TestSuiteLinkerBench
     val classpath = TestSuiteBuildInfo.fullTestSuiteClasspath.map(_.toPath)
     val config = build.Config.empty
       .withWorkdir(workdir)
+      .withLinkStubs(true)
       .withClassPath(classpath)
       .withMainClass("scala.scalanative.testinterface.TestMain$")
       .withNativelib(classpath.find(_.toString.contains("nativelib")).head)

--- a/tools-benchmarks/src/main/scala/scala/scalanative/linker/benchmarks/TestSuiteLinkerBench.scala
+++ b/tools-benchmarks/src/main/scala/scala/scalanative/linker/benchmarks/TestSuiteLinkerBench.scala
@@ -1,0 +1,42 @@
+package scala.scalanative.linker.benchmarks
+
+import java.nio.file.{Path, Paths, Files}
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+import scala.scalanative.build
+import scala.scalanative.internal.build.TestSuiteBuildInfo
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.Mode.SampleTime
+
+@State(Scope.Benchmark)
+abstract class TestSuiteLinkerBench
+    extends scala.scalanative.linker.ReachabilitySuite {
+  var workdir: Path = _
+
+  @Setup(Level.Trial) def spawn(): Unit = {
+    workdir = Files.createTempDirectory("linker-benchmarks")
+  }
+
+  @Benchmark
+  def linkTestSuite(): Unit = {
+    val classpath = TestSuiteBuildInfo.fullTestSuiteClasspath.map(_.toPath)
+    val config = build.Config.empty
+      .withWorkdir(workdir)
+      .withClassPath(classpath)
+      .withMainClass("scala.scalanative.testinterface.TestMain$")
+      .withNativelib(classpath.find(_.toString.contains("nativelib")).head)
+    val entries = build.ScalaNative.entries(config)
+    val linked  = build.ScalaNative.link(config, entries)
+    assert(linked.unavailable.size == 0)
+  }
+}
+
+@Fork(1)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(SampleTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 30, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+class HotTestSuiteLinkerBench extends TestSuiteLinkerBench

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -33,7 +33,6 @@ object ClassPath {
         .filter(_.toString.endsWith(".nir"))
         .map { file =>
           val name = Global.Top(io.packageNameFromPath(file))
-
           name -> file
         }
         .toMap


### PR DESCRIPTION
Adds a new benchmarking project for `tools` (the linker and optimizer)
which measures the linking time of the test suite.

This commit also changes a few more things in the build:

1. Adds sbt-coursier to speed up resolution of the meta-project and the
   sbt project.
2. Specifies the scalafmt version in `.scalafmt.conf`
3. Upgrades from 2.12.7 to 2.12.8