### PR TITLE
Assort batch of linker optimizations

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = "2.0.0-RC4"
 style = defaultWithAlign
 docstrings = JavaDoc
 assumeStandardLibraryStripMargin = true

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -66,7 +66,6 @@ object Attrs {
     var isDyn      = false
     var isStub     = false
     var isAbstract = false
-    val overrides  = mutable.UnrolledBuffer.empty[Global]
     val links      = mutable.UnrolledBuffer.empty[Attr.Link]
 
     attrs.foreach {

--- a/nir/src/main/scala/scala/scalanative/nir/Global.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Global.scala
@@ -13,6 +13,7 @@ sealed abstract class Global {
   final def mangle: String =
     Mangle(this)
 }
+
 object Global {
   final case object None extends Global {
     override def top: Global.Top =

--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -4,7 +4,7 @@ package nir
 import scala.language.implicitConversions
 
 final class Sig(val mangle: String) {
-  final def toProxy: Sig =
+  final lazy val toProxy: Sig =
     if (isMethod) {
       val Sig.Method(id, types) = this.unmangled
       Sig.Proxy(id, types.init).mangled

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -6,7 +6,9 @@ import java.nio.ByteBuffer
 import scala.collection.mutable
 import scalanative.nir.serialization.{Tags => T}
 
-final class BinaryDeserializer(buffer: ByteBuffer) {
+import scala.scalanative.util.Scope
+
+final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
   import buffer._
 
   private val header: Map[Global, Int] = {
@@ -34,6 +36,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
         buffer.position(offset)
         allDefns += getDefn
     }
+    scope.close()
     allDefns
   }
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -267,7 +267,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
       case g =>
         val top = Global.Top(getString)
         g match {
-          case T.TopGlobal => top
+          case T.TopGlobal    => top
           case T.MemberGlobal => Global.Member(top, getSig)
         }
     }
@@ -324,53 +324,65 @@ final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
   private def getParam(): Val.Local       = Val.Local(getLocal, getType)
 
   private def getTypes(): Seq[Type] = getSeq(getType)
-  private def getType(): Type = getInt match {
-    case T.VarargType      => Type.Vararg
-    case T.PtrType         => Type.Ptr
-    case T.BoolType        => Type.Bool
-    case T.CharType        => Type.Char
-    case T.ByteType        => Type.Byte
-    case T.ShortType       => Type.Short
-    case T.IntType         => Type.Int
-    case T.LongType        => Type.Long
-    case T.FloatType       => Type.Float
-    case T.DoubleType      => Type.Double
-    case T.ArrayValueType  => Type.ArrayValue(getType, getInt)
-    case T.StructValueType => Type.StructValue(getTypes)
-    case T.FunctionType    => Type.Function(getTypes, getType)
+  private def getType(): Type = {
+    val kind = getInt
+    kind match {
+      case T.RefType => Type.Ref(getGlobal, getBool, getBool)
+      case otherKind =>
+        otherKind match {
+          case T.VarargType      => Type.Vararg
+          case T.PtrType         => Type.Ptr
+          case T.BoolType        => Type.Bool
+          case T.CharType        => Type.Char
+          case T.ByteType        => Type.Byte
+          case T.ShortType       => Type.Short
+          case T.IntType         => Type.Int
+          case T.LongType        => Type.Long
+          case T.FloatType       => Type.Float
+          case T.DoubleType      => Type.Double
+          case T.ArrayValueType  => Type.ArrayValue(getType, getInt)
+          case T.StructValueType => Type.StructValue(getTypes)
+          case T.FunctionType    => Type.Function(getTypes, getType)
 
-    case T.NullType    => Type.Null
-    case T.NothingType => Type.Nothing
-    case T.VirtualType => Type.Virtual
-    case T.VarType     => Type.Var(getType)
-    case T.UnitType    => Type.Unit
-    case T.ArrayType   => Type.Array(getType, getBool)
-    case T.RefType     => Type.Ref(getGlobal, getBool, getBool)
+          case T.NullType    => Type.Null
+          case T.NothingType => Type.Nothing
+          case T.VirtualType => Type.Virtual
+          case T.VarType     => Type.Var(getType)
+          case T.UnitType    => Type.Unit
+          case T.ArrayType   => Type.Array(getType, getBool)
+        }
+    }
   }
 
   private def getVals(): Seq[Val] = getSeq(getVal)
-  private def getVal(): Val = getInt match {
-    case T.TrueVal        => Val.True
-    case T.FalseVal       => Val.False
-    case T.NullVal        => Val.Null
-    case T.ZeroVal        => Val.Zero(getType)
-    case T.CharVal        => Val.Char(getShort.toChar)
-    case T.ByteVal        => Val.Byte(get)
-    case T.ShortVal       => Val.Short(getShort)
-    case T.IntVal         => Val.Int(getInt)
-    case T.LongVal        => Val.Long(getLong)
-    case T.FloatVal       => Val.Float(getFloat)
-    case T.DoubleVal      => Val.Double(getDouble)
-    case T.StructValueVal => Val.StructValue(getVals)
-    case T.ArrayValueVal  => Val.ArrayValue(getType, getVals)
-    case T.CharsVal       => Val.Chars(getString)
-    case T.LocalVal       => Val.Local(getLocal, getType)
-    case T.GlobalVal      => Val.Global(getGlobal, getType)
+  private def getVal(): Val = {
+    val kind = getInt
+    kind match {
+      case T.LocalVal => Val.Local(getLocal, getType)
+      case otherKind =>
+        otherKind match {
+          case T.TrueVal        => Val.True
+          case T.FalseVal       => Val.False
+          case T.NullVal        => Val.Null
+          case T.ZeroVal        => Val.Zero(getType)
+          case T.CharVal        => Val.Char(getShort.toChar)
+          case T.ByteVal        => Val.Byte(get)
+          case T.ShortVal       => Val.Short(getShort)
+          case T.IntVal         => Val.Int(getInt)
+          case T.LongVal        => Val.Long(getLong)
+          case T.FloatVal       => Val.Float(getFloat)
+          case T.DoubleVal      => Val.Double(getDouble)
+          case T.StructValueVal => Val.StructValue(getVals)
+          case T.ArrayValueVal  => Val.ArrayValue(getType, getVals)
+          case T.CharsVal       => Val.Chars(getString)
+          case T.GlobalVal      => Val.Global(getGlobal, getType)
 
-    case T.UnitVal    => Val.Unit
-    case T.ConstVal   => Val.Const(getVal)
-    case T.StringVal  => Val.String(getString)
-    case T.VirtualVal => Val.Virtual(getLong)
+          case T.UnitVal    => Val.Unit
+          case T.ConstVal   => Val.Const(getVal)
+          case T.StringVal  => Val.String(getString)
+          case T.VirtualVal => Val.Virtual(getLong)
+        }
+    }
   }
 }
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -77,12 +77,13 @@ final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
   }
 
   private def getString(): String = {
+    import scala.scalanative.io.internedStrings
     val arr = new Array[Byte](getInt)
     get(arr)
     val s = new String(arr, "UTF-8")
-    val ref = BinaryDeserializer.internedStrings.get(s)
+    val ref = internedStrings.get(s)
     if (ref == null) {
-      BinaryDeserializer.internedStrings.put(s, new java.lang.ref.WeakReference(s))
+      internedStrings.put(s, new java.lang.ref.WeakReference(s))
       s
     } else {
       ref.get()
@@ -316,11 +317,4 @@ final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
     case T.StringVal  => Val.String(getString)
     case T.VirtualVal => Val.Virtual(getLong)
   }
-}
-
-object BinaryDeserializer {
-    import java.util.WeakHashMap
-    import java.lang.ref.WeakReference
-    private[scalanative] val internedStrings: WeakHashMap[String, WeakReference[String]] =
-      new WeakHashMap[String, WeakReference[String]]()
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -29,7 +29,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
 
   final def deserialize(): Seq[Defn] = {
     val allDefns = mutable.UnrolledBuffer.empty[Defn]
-    header.map {
+    header.foreach {
       case (g, offset) =>
         buffer.position(offset)
         allDefns += getDefn
@@ -37,15 +37,42 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
     allDefns
   }
 
-  private def getSeq[T](getT: => T): Seq[T] =
-    (1 to getInt).map(_ => getT).toSeq
+  private def getSeq[T](getT: => T): Seq[T] = {
+    var i: Int = 1
+    val end = getInt
+    var seq: List[T] = Nil
+    while (i <= end) {
+        seq = getT :: seq
+        i += 1
+    }
+    seq.reverse
+  }
 
   private def getOpt[T](getT: => T): Option[T] =
     if (get == 0) None else Some(getT)
 
-  private def getInts(): Seq[Int] = getSeq(getInt)
+  private def getInts(): Seq[Int] = {
+    var i: Int = 1
+    val end = getInt
+    var seq: List[Int] = Nil
+    while (i <= end) {
+        seq = getInt :: seq
+        i += 1
+    }
+    seq.reverse
+  }
 
-  private def getStrings(): Seq[String] = getSeq(getString)
+  private def getStrings(): Seq[String] = {
+    var i: Int = 1
+    val end = getInt
+    var seq: List[String] = Nil
+    while (i <= end) {
+        seq = getString :: seq
+        i += 1
+    }
+    seq.reverse
+  }
+
   private def getString(): String = {
     val arr = new Array[Byte](getInt)
     get(arr)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -8,8 +8,9 @@ import scalanative.nir.serialization.{Tags => T}
 
 import scala.scalanative.util.Scope
 
-final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
+final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope, caches: SerializationCaches) {
   import buffer._
+  import caches._
 
   private val header: List[(Global, Int)] = {
     buffer.position(0)
@@ -33,8 +34,6 @@ final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
     }
     seq
   }
-
-  //final def globals: Set[Global] = header.keySet
 
   final def deserialize(): Seq[Defn] = {
     var allDefns = List.empty[Defn]
@@ -84,22 +83,20 @@ final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
   }
 
   private def getString(): String = {
-    import scala.scalanative.io.internedStrings
-
     val length = getInt
     val arr = {
       if (length <= 128) {
-        buffer.get(BinaryDeserializer.sharedArr128, 0, length)
-        BinaryDeserializer.sharedArr128
+        buffer.get(sharedArr128, 0, length)
+        sharedArr128
       } else if (length <= 256) {
-        buffer.get(BinaryDeserializer.sharedArr256, 0, length)
-        BinaryDeserializer.sharedArr256
+        buffer.get(sharedArr256, 0, length)
+        sharedArr256
       } else if (length <= 512) {
-        buffer.get(BinaryDeserializer.sharedArr512, 0, length)
-        BinaryDeserializer.sharedArr512
+        buffer.get(sharedArr512, 0, length)
+        sharedArr512
       } else {
-        buffer.get(BinaryDeserializer.sharedArr4096, 0, length)
-        BinaryDeserializer.sharedArr4096
+        buffer.get(sharedArr4096, 0, length)
+        sharedArr4096
       }
     }
 
@@ -388,11 +385,4 @@ final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
         }
     }
   }
-}
-
-object BinaryDeserializer {
-  private[serialization] val sharedArr128  = new Array[Byte](128)
-  private[serialization] val sharedArr256  = new Array[Byte](256)
-  private[serialization] val sharedArr512  = new Array[Byte](512)
-  private[serialization] val sharedArr4096 = new Array[Byte](4096)
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -261,13 +261,16 @@ final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
 
   private def getGlobals(): Seq[Global]      = getSeq(getGlobal)
   private def getGlobalOpt(): Option[Global] = getOpt(getGlobal)
-  private def getGlobal(): Global = getInt match {
-    case T.NoneGlobal =>
-      Global.None
-    case T.TopGlobal =>
-      Global.Top(getString)
-    case T.MemberGlobal =>
-      Global.Member(Global.Top(getString), getSig)
+  private def getGlobal(): Global = {
+    getInt match {
+      case T.NoneGlobal => Global.None
+      case g =>
+        val top = Global.Top(getString)
+        g match {
+          case T.TopGlobal => top
+          case T.MemberGlobal => Global.Member(top, getSig)
+        }
+    }
   }
 
   private def getSig(): Sig =

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -121,6 +121,8 @@ final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
     // Inlined because overhead of creating sequence + using `Attrs.fromSeq` is high
     import scala.scalanative.nir.Attr._
     var inline     = Attrs.None.inline
+    var specialize = Attrs.None.specialize
+    var opt        = Attrs.None.opt
     var isExtern   = false
     var isDyn      = false
     var isStub     = false
@@ -132,17 +134,19 @@ final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope) {
     var seq: List[Attr] = Nil
     while (i <= end) {
       getAttr match {
-        case attr: Inline    => inline = attr
-        case Extern          => isExtern = true
-        case Dyn             => isDyn = true
-        case Stub            => isStub = true
-        case link: Attr.Link => links ::= link
-        case Abstract        => isAbstract = true
+        case attr: Inline     => inline = attr
+        case attr: Specialize => specialize = attr
+        case attr: Opt        => opt = attr
+        case Extern           => isExtern = true
+        case Dyn              => isDyn = true
+        case Stub             => isStub = true
+        case link: Attr.Link  => links ::= link
+        case Abstract         => isAbstract = true
       }
       i += 1
     }
 
-    new Attrs(inline, isExtern, isDyn, isStub, isAbstract, links)
+    new Attrs(inline, specialize, opt, isExtern, isDyn, isStub, isAbstract, links)
   }
 
   private def getAttr(): Attr = getInt match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -8,7 +8,9 @@ import scalanative.nir.serialization.{Tags => T}
 
 import scala.scalanative.util.Scope
 
-final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope, caches: SerializationCaches) {
+final class BinaryDeserializer(buffer: ByteBuffer,
+                               scope: Scope,
+                               caches: SerializationCaches) {
   import buffer._
   import caches._
 
@@ -143,7 +145,14 @@ final class BinaryDeserializer(buffer: ByteBuffer, scope: Scope, caches: Seriali
       i += 1
     }
 
-    new Attrs(inline, specialize, opt, isExtern, isDyn, isStub, isAbstract, links)
+    new Attrs(inline,
+              specialize,
+              opt,
+              isExtern,
+              isDyn,
+              isStub,
+              isAbstract,
+              links)
   }
 
   private def getAttr(): Attr = getInt match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/SerializationCaches.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/SerializationCaches.scala
@@ -1,0 +1,26 @@
+package scala.scalanative
+package nir
+package serialization
+
+import java.{util => ju}
+import java.lang.ref.WeakReference
+
+private[scalanative] class SerializationCaches(
+    val sharedArr128: Array[Byte],
+    val sharedArr256: Array[Byte],
+    val sharedArr512: Array[Byte],
+    val sharedArr4096: Array[Byte],
+    val internedStrings: ju.WeakHashMap[String, WeakReference[String]]
+)
+
+private[scalanative] object SerializationCaches {
+  def empty(
+      internedStrings: ju.WeakHashMap[String, WeakReference[String]]
+  ): SerializationCaches = new SerializationCaches(
+    new Array[Byte](128),
+    new Array[Byte](256),
+    new Array[Byte](512),
+    new Array[Byte](4096),
+    internedStrings
+  )
+}

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
@@ -5,6 +5,8 @@ import java.nio._
 import java.nio.file.{StandardOpenOption => OpenOpt, _}
 import java.nio.channels._
 
+import scala.scalanative.util.Scope
+
 package object serialization {
   def serializeText(defns: Seq[Defn], buffer: ByteBuffer): Unit = {
     val builder = Show.newBuilder
@@ -15,6 +17,6 @@ package object serialization {
   def serializeBinary(defns: Seq[Defn], buffer: ByteBuffer): Unit =
     (new BinarySerializer(buffer)).serialize(defns)
 
-  def deserializeBinary(buffer: ByteBuffer): Seq[Defn] =
-    (new BinaryDeserializer(buffer)).deserialize()
+  def deserializeBinary(buffer: ByteBuffer)(implicit scope: Scope): Seq[Defn] =
+    (new BinaryDeserializer(buffer, scope)).deserialize()
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
@@ -18,8 +18,8 @@ package object serialization {
     (new BinarySerializer(buffer)).serialize(defns)
 
   def deserializeBinary(
-    buffer: ByteBuffer,
-    caches: SerializationCaches
+      buffer: ByteBuffer,
+      caches: SerializationCaches
   )(implicit scope: Scope): Seq[Defn] =
     (new BinaryDeserializer(buffer, scope, caches)).deserialize()
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/package.scala
@@ -17,6 +17,9 @@ package object serialization {
   def serializeBinary(defns: Seq[Defn], buffer: ByteBuffer): Unit =
     (new BinarySerializer(buffer)).serialize(defns)
 
-  def deserializeBinary(buffer: ByteBuffer)(implicit scope: Scope): Seq[Defn] =
-    (new BinaryDeserializer(buffer, scope)).deserialize()
+  def deserializeBinary(
+    buffer: ByteBuffer,
+    caches: SerializationCaches
+  )(implicit scope: Scope): Seq[Defn] =
+    (new BinaryDeserializer(buffer, scope, caches)).deserialize()
 }

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -22,6 +22,9 @@ addSbtPlugin("com.eed3si9n"       % "sbt-dirty-money"   % "0.2.0")
 addSbtPlugin("org.foundweekends"  % "sbt-bintray"       % "0.5.4")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"           % "1.0.0")
 addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"   % "0.3.0")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"           % "0.3.5")
+addSbtPlugin("io.get-coursier"    % "sbt-coursier"      % "1.1.0-M7")
+addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"     % "0.7.0")
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M7")

--- a/tools-benchmarks/src/main/scala/scala/scalanative/linker/benchmarks/TestSuiteLinkerBench.scala
+++ b/tools-benchmarks/src/main/scala/scala/scalanative/linker/benchmarks/TestSuiteLinkerBench.scala
@@ -24,6 +24,7 @@ abstract class TestSuiteLinkerBench
     val classpath = TestSuiteBuildInfo.fullTestSuiteClasspath.map(_.toPath)
     val config = build.Config.empty
       .withWorkdir(workdir)
+      .withLinkStubs(true)
       .withClassPath(classpath)
       .withMainClass("scala.scalanative.testinterface.TestMain$")
       .withNativelib(classpath.find(_.toString.contains("nativelib")).head)

--- a/tools-benchmarks/src/main/scala/scala/scalanative/linker/benchmarks/TestSuiteLinkerBench.scala
+++ b/tools-benchmarks/src/main/scala/scala/scalanative/linker/benchmarks/TestSuiteLinkerBench.scala
@@ -1,0 +1,42 @@
+package scala.scalanative.linker.benchmarks
+
+import java.nio.file.{Path, Paths, Files}
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+import scala.scalanative.build
+import scala.scalanative.internal.build.TestSuiteBuildInfo
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.Mode.SampleTime
+
+@State(Scope.Benchmark)
+abstract class TestSuiteLinkerBench
+    extends scala.scalanative.linker.ReachabilitySuite {
+  var workdir: Path = _
+
+  @Setup(Level.Trial) def spawn(): Unit = {
+    workdir = Files.createTempDirectory("linker-benchmarks")
+  }
+
+  @Benchmark
+  def linkTestSuite(): Unit = {
+    val classpath = TestSuiteBuildInfo.fullTestSuiteClasspath.map(_.toPath)
+    val config = build.Config.empty
+      .withWorkdir(workdir)
+      .withClassPath(classpath)
+      .withMainClass("scala.scalanative.testinterface.TestMain$")
+      .withNativelib(classpath.find(_.toString.contains("nativelib")).head)
+    val entries = build.ScalaNative.entries(config)
+    val linked  = build.ScalaNative.link(config, entries)
+    assert(linked.unavailable.size == 0)
+  }
+}
+
+@Fork(1)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(SampleTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 30, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+class HotTestSuiteLinkerBench extends TestSuiteLinkerBench

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -50,6 +50,9 @@ sealed trait Config {
   /** The LTO mode to use used during a release build. */
   def LTO: String
 
+  /** A private caches instance to use during a linker run. */
+  private[scalanative] def runCaches: RunCaches
+
   /** Create a new config with given garbage collector. */
   def withGC(value: GC): Config
 
@@ -111,7 +114,8 @@ object Config {
       mode = Mode.default,
       linkStubs = false,
       logger = Logger.default,
-      LTO = "none"
+      LTO = "none",
+      runCaches = RunCaches.empty
     )
 
   private final case class Impl(nativelib: Path,
@@ -127,7 +131,8 @@ object Config {
                                 mode: Mode,
                                 linkStubs: Boolean,
                                 logger: Logger,
-                                LTO: String)
+                                LTO: String,
+                                runCaches: RunCaches)
       extends Config {
     def withNativelib(value: Path): Config =
       copy(nativelib = value)

--- a/tools/src/main/scala/scala/scalanative/build/RunCaches.scala
+++ b/tools/src/main/scala/scala/scalanative/build/RunCaches.scala
@@ -1,0 +1,22 @@
+package scala.scalanative.build
+
+import scala.scalanative.nir.serialization.SerializationCaches
+
+import java.{util => ju}
+import java.lang.ref.WeakReference
+
+private[scalanative] class RunCaches(
+    val internedStrings: ju.WeakHashMap[String, WeakReference[String]],
+    val serializationCaches: SerializationCaches
+)
+
+private[scalanative] object RunCaches {
+  val empty: RunCaches = {
+    val sharedInternedStrings =
+      new ju.WeakHashMap[String, WeakReference[String]]()
+    new RunCaches(
+      sharedInternedStrings,
+      SerializationCaches.empty(sharedInternedStrings)
+    )
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
@@ -14,7 +14,7 @@ object ClassLoader {
 
   def fromDisk(config: build.Config)(implicit in: Scope): ClassLoader = {
     val classpath = config.classPath.map { path =>
-      ClassPath(VirtualDirectory.real(path))
+      ClassPath(VirtualDirectory.real(path), config)
     }
     new FromDisk(classpath)
   }

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -28,14 +28,13 @@ object ClassPath {
     new Impl(directory)
 
   private final class Impl(directory: VirtualDirectory) extends ClassPath {
-    private val files =
-      directory.files
-        .filter(_.toString.endsWith(".nir"))
-        .map { file =>
+    private val files = {
+      directory.files.foldLeft(Map.empty[Global.Top, Path]) {
+        case (acc, file) =>
           val name = Global.Top(io.packageNameFromPath(file))
-          name -> file
-        }
-        .toMap
+          acc + (name -> file)
+      }
+    }
 
     private val cache =
       mutable.Map.empty[Global, Option[Seq[Defn]]]

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -46,7 +46,9 @@ object ClassPath {
     def load(name: Global): Option[Seq[Defn]] =
       cache.getOrElseUpdate(name, {
         files.get(name.top).map { file =>
-          deserializeBinary(directory.read(file))
+          Scope { implicit scope =>
+            deserializeBinary(directory.read(file))
+          }
         }
       })
   }

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -33,7 +33,6 @@ object ClassPath {
         .filter(_.toString.endsWith(".nir"))
         .map { file =>
           val name = Global.Top(io.packageNameFromPath(file))
-
           name -> file
         }
         .toMap

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -24,14 +24,17 @@ object ClassPath {
     new Impl(VirtualDirectory.local(directory), config)
 
   /** Create classpath based on the virtual directory. */
-  private[scalanative] def apply(directory: VirtualDirectory, config: build.Config): ClassPath =
+  private[scalanative] def apply(directory: VirtualDirectory,
+                                 config: build.Config): ClassPath =
     new Impl(directory, config)
 
-  private final class Impl(directory: VirtualDirectory, config: build.Config) extends ClassPath {
+  private final class Impl(directory: VirtualDirectory, config: build.Config)
+      extends ClassPath {
     private val files = {
       directory.files.foldLeft(Map.empty[Global.Top, Path]) {
         case (acc, file) =>
-          val name = Global.Top(io.packageNameFromPath(file, config.runCaches.internedStrings))
+          val name = Global.Top(
+            io.packageNameFromPath(file, config.runCaches.internedStrings))
           acc + (name -> file)
       }
     }
@@ -46,7 +49,8 @@ object ClassPath {
       cache.getOrElseUpdate(name, {
         files.get(name.top).map { file =>
           Scope { implicit scope =>
-            deserializeBinary(directory.read(file), config.runCaches.serializationCaches)
+            deserializeBinary(directory.read(file),
+                              config.runCaches.serializationCaches)
           }
         }
       })

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -20,18 +20,18 @@ sealed trait ClassPath {
 object ClassPath {
 
   /** Create classpath based on the directory. */
-  def apply(directory: Path): ClassPath =
-    new Impl(VirtualDirectory.local(directory))
+  def apply(directory: Path, config: build.Config): ClassPath =
+    new Impl(VirtualDirectory.local(directory), config)
 
   /** Create classpath based on the virtual directory. */
-  private[scalanative] def apply(directory: VirtualDirectory): ClassPath =
-    new Impl(directory)
+  private[scalanative] def apply(directory: VirtualDirectory, config: build.Config): ClassPath =
+    new Impl(directory, config)
 
-  private final class Impl(directory: VirtualDirectory) extends ClassPath {
+  private final class Impl(directory: VirtualDirectory, config: build.Config) extends ClassPath {
     private val files = {
       directory.files.foldLeft(Map.empty[Global.Top, Path]) {
         case (acc, file) =>
-          val name = Global.Top(io.packageNameFromPath(file))
+          val name = Global.Top(io.packageNameFromPath(file, config.runCaches.internedStrings))
           acc + (name -> file)
       }
     }
@@ -46,7 +46,7 @@ object ClassPath {
       cache.getOrElseUpdate(name, {
         files.get(name.top).map { file =>
           Scope { implicit scope =>
-            deserializeBinary(directory.read(file))
+            deserializeBinary(directory.read(file), config.runCaches.serializationCaches)
           }
         }
       })

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 import scalanative.nir._
 import scalanative.codegen.Metadata
 
-class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
+final class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
   val unavailable = mutable.Set.empty[Global]
   val loaded      = mutable.Map.empty[Global, mutable.Map[Global, Defn]]
   val enqueued    = mutable.Set.empty[Global]

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -127,7 +127,7 @@ final class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoade
     if (!name.isTop) {
       reachEntry(name.top)
     }
-    from(name) = Global.None
+    from.put(name, Global.None)
     reachGlobalNow(name)
     val info = infos.get(name)
     if (info != null) {
@@ -632,8 +632,7 @@ final class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoade
   }
 
   def resolve(cls: Class, sig: Sig): Option[Global] = {
-    //TODO(jvican): Re-enable this assert method
-    //assert(loaded.containsKey(cls.name))
+    assert(loaded.containsKey(cls.name))
 
     def lookupSig(cls: Class, sig: Sig): Option[Global] = {
       val tryMember = cls.name.member(sig)

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -5,7 +5,9 @@ import scala.collection.mutable
 import scalanative.nir._
 import scalanative.codegen.Metadata
 
-final class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
+final class Reach(config: build.Config,
+                  entries: Seq[Global],
+                  loader: ClassLoader) {
   import java.{util => ju}
   val unavailable = new ju.HashSet[Global]
   val loaded      = new ju.HashMap[Global, mutable.Map[Global, Defn]]
@@ -136,7 +138,7 @@ final class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoade
           if (!cls.attrs.isAbstract) {
             reachAllocation(cls)
             if (cls.isModule) {
-              val init = cls.name.member(Sig.Ctor(Seq()))
+              val init  = cls.name.member(Sig.Ctor(Seq()))
               val defns = loaded.get(cls.name)
               if (defns != null && defns.contains(init)) {
                 reachGlobal(init)
@@ -297,7 +299,7 @@ final class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoade
     reachGlobalNow(name)
     infos.get(name) match {
       case info: ScopeInfo => Some(info)
-      case _ => None
+      case _               => None
     }
   }
 
@@ -551,7 +553,7 @@ final class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoade
       reachDynamicMethodTargets(dynsig)
     case Op.Module(n) =>
       classInfo(n).foreach(reachAllocation)
-      val init = n.member(Sig.Ctor(Seq()))
+      val init  = n.member(Sig.Ctor(Seq()))
       val defns = loaded.get(n)
       if (defns != null) {
         if (defns.contains(init)) {

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -70,7 +70,8 @@ object VirtualDirectory {
 
     override def read(path: Path)(implicit scope: Scope): ByteBuffer = {
       import java.nio.channels.FileChannel
-      val channel = acquire(FileChannel.open(resolve(path), StandardOpenOption.READ))
+      val channel = acquire(
+        FileChannel.open(resolve(path), StandardOpenOption.READ))
       channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size())
     }
 
@@ -105,7 +106,9 @@ object VirtualDirectory {
       acquire {
         val uri = URI.create(s"jar:${path.toUri}")
         try {
-          FileSystems.newFileSystem(uri, Map("create" -> "false", "useTempFile" -> "true").asJava)
+          FileSystems.newFileSystem(
+            uri,
+            Map("create" -> "false", "useTempFile" -> "true").asJava)
         } catch {
           case e: FileSystemAlreadyExistsException =>
             FileSystems.getFileSystem(uri)

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -90,8 +90,9 @@ object VirtualDirectory {
         .walk(path, Integer.MAX_VALUE, FileVisitOption.FOLLOW_LINKS)
         .iterator()
         .asScala
+        .filter(_.toString.endsWith(".nir"))
         .map(fp => path.relativize(fp))
-        .toSeq
+        .toList
   }
 
   private final class JarDirectory(path: Path)(implicit scope: Scope)
@@ -120,6 +121,8 @@ object VirtualDirectory {
             .walk(path, Integer.MAX_VALUE, FileVisitOption.FOLLOW_LINKS)
             .iterator()
             .asScala
+            .filter(_.toString.endsWith(".nir"))
+            .toList
         }
     }
   }

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -16,7 +16,7 @@ sealed trait VirtualDirectory {
     files.contains(path)
 
   /** Reads a contents of file with given path. */
-  def read(path: Path): ByteBuffer
+  def read(path: Path)(implicit scope: Scope): ByteBuffer
 
   /** Replaces contents of file with given value. */
   def write(path: Path, buffer: ByteBuffer): Unit
@@ -37,7 +37,7 @@ object VirtualDirectory {
   }
 
   /** Virtual directory that represents contents of the jar file. */
-  def jar(file: Path)(implicit in: Scope): VirtualDirectory = {
+  def jar(file: Path)(implicit scope: Scope): VirtualDirectory = {
     val absolute = file.toAbsolutePath
     assert(Files.exists(file), s"Jar doesn't exist: $absolute")
     assert(absolute.toString.endsWith(".jar"), s"Not a jar: $absolute")
@@ -68,10 +68,10 @@ object VirtualDirectory {
                        StandardOpenOption.WRITE,
                        StandardOpenOption.TRUNCATE_EXISTING)
 
-    override def read(path: Path): ByteBuffer = {
-      val bytes  = Files.readAllBytes(resolve(path))
-      val buffer = ByteBuffer.wrap(bytes)
-      buffer
+    override def read(path: Path)(implicit scope: Scope): ByteBuffer = {
+      import java.nio.channels.FileChannel
+      val channel = acquire(FileChannel.open(resolve(path), StandardOpenOption.READ))
+      channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size())
     }
 
     override def write(path: Path, buffer: ByteBuffer): Unit = {
@@ -94,13 +94,17 @@ object VirtualDirectory {
         .toSeq
   }
 
-  private final class JarDirectory(path: Path)(implicit in: Scope)
+  private final class JarDirectory(path: Path)(implicit scope: Scope)
       extends NioDirectory {
+    override def read(path: Path)(implicit scope: Scope): ByteBuffer = {
+      ByteBuffer.wrap(Files.readAllBytes(resolve(path)))
+    }
+
     private val fileSystem: FileSystem =
       acquire {
         val uri = URI.create(s"jar:${path.toUri}")
         try {
-          FileSystems.newFileSystem(uri, Map("create" -> "false").asJava)
+          FileSystems.newFileSystem(uri, Map("create" -> "false", "useTempFile" -> "true").asJava)
         } catch {
           case e: FileSystemAlreadyExistsException =>
             FileSystems.getFileSystem(uri)
@@ -123,7 +127,7 @@ object VirtualDirectory {
   private final object EmptyDirectory extends VirtualDirectory {
     override def files = Seq.empty
 
-    override def read(path: Path): ByteBuffer =
+    override def read(path: Path)(implicit scope: Scope): ByteBuffer =
       throw new UnsupportedOperationException(
         "Can't read from empty directory.")
 

--- a/util/src/main/scala/scala/scalanative/io/package.scala
+++ b/util/src/main/scala/scala/scalanative/io/package.scala
@@ -20,8 +20,8 @@ package object io {
   import java.{util => ju}
   import java.lang.ref.WeakReference
   def packageNameFromPath(
-    path: Path,
-    internedStrings: ju.WeakHashMap[String, WeakReference[String]]
+      path: Path,
+      internedStrings: ju.WeakHashMap[String, WeakReference[String]]
   ): String = {
     @scala.annotation.tailrec
     def replace(

--- a/util/src/main/scala/scala/scalanative/io/package.scala
+++ b/util/src/main/scala/scala/scalanative/io/package.scala
@@ -17,7 +17,12 @@ package object io {
     finally pool.reclaim(buffer)
   }
 
-  def packageNameFromPath(path: Path): String = {
+  import java.{util => ju}
+  import java.lang.ref.WeakReference
+  def packageNameFromPath(
+    path: Path,
+    internedStrings: ju.WeakHashMap[String, WeakReference[String]]
+  ): String = {
     @scala.annotation.tailrec
     def replace(
         b: StringBuilder,
@@ -56,10 +61,4 @@ package object io {
       ref.get()
     }
   }
-
-  import java.util.WeakHashMap
-  import java.lang.ref.WeakReference
-  private[scalanative] val internedStrings
-      : WeakHashMap[String, WeakReference[String]] =
-    new WeakHashMap[String, WeakReference[String]]()
 }


### PR DESCRIPTION
The following PR builds upon #1548 to optimize the linking time in Scala Native's test suite. Most of the optimization has to do the binary deserializer and easing memory use, though there are some optimizations that inline code to be more friendly with the branch predictor.

Most of the optimizations are quite naive. However, based on my profiling and benchmarking they cut almost 35% of the running time of linker when it gets hot. I'll publish these numbers in their entirety when benchmarks finish to run for this branch, as I had to rebase all the optimizations upon latest master.

There might be some unnecessary code changes that I didn't spot while re-reviewing these changes. If there are, let me know @densh and I'll fix them up.