### PR TITLE
Fix #1551: Provide minimal, US-only DateFormatSymbols to aid linking

### DIFF
--- a/javalib/src/main/scala/java/text/DateFormatSymbols.scala
+++ b/javalib/src/main/scala/java/text/DateFormatSymbols.scala
@@ -1,41 +1,149 @@
 package java.text
 
-import scalanative.native.stub
-
 import java.util.Locale
+import java.util.MissingResourceException
+
+// A mimimal implementation which supports only Locale.US.
 
 class DateFormatSymbols(locale: Locale)
     extends java.io.Serializable
     with Cloneable {
+
   def this() = this {
-    // should be Locale.getDefault(Locale.Category.FORMAT), but scala-native doesn't support it yet
+    // should be Locale.getDefault(Locale.Category.FORMAT),
+    // but scala-native doesn't support it yet
     Locale.getDefault()
   }
 
-  @stub
-  def getAmPmStrings(): Array[String] = ???
+  if (!locale.equals(Locale.US)) {
+    throw new MissingResourceException(s"Locale not found: ${locale.toString}",
+                                       "",
+                                       "")
+  }
 
-  @stub
-  def getEras(): Array[String] = ???
+  private var amPmStrings = Array("AM", "PM")
 
-  @stub
-  def getMonths(): Array[String] = ???
+  private var eras = Array("BC", "AD")
 
-  @stub
-  def getShortMonths(): Array[String] = ???
+  private var localPatternChars = "GyMdkHmsSEDFwWahKzZ"
 
-  @stub
-  def getShortWeekdays(): Array[String] = ???
+  private var longMonths = Array("January",
+                                 "February",
+                                 "March",
+                                 "April",
+                                 "May",
+                                 "June",
+                                 "July",
+                                 "August",
+                                 "September",
+                                 "October",
+                                 "November",
+                                 "December",
+                                 "")
 
-  @stub
-  def getWeekdays(): Array[String] = ???
-}
+  private var shortMonths: Option[Array[String]] = None
 
-object DateFormatSymbols {
-  def getInstance(locale: Locale): DateFormatSymbols = {
-    // should check availability of the locale
-    new DateFormatSymbols(locale)
+  private var longWeekdays = Array("",
+                                   "Sunday",
+                                   "Monday",
+                                   "Tuesday",
+                                   "Wednesday",
+                                   "Thursday",
+                                   "Friday",
+                                   "Saturday")
+
+  private var shortWeekdays: Option[Array[String]] = None
+
+  // Rump implementation. Save binary size of discouraged method.
+  // See comments just above getZoneStrings() for details.
+
+  private var zoneStrings: Array[Array[String]] =
+    Array(Array("", "", "", "", ""))
+
+  def getAmPmStrings(): Array[String] = amPmStrings
+
+  def getEras(): Array[String] = eras
+
+  def getLocalPatternChars() = localPatternChars
+
+  def getMonths(): Array[String] = longMonths
+
+  def getShortMonths(): Array[String] = {
+    shortMonths match {
+      case None         => for (m <- longMonths) yield (m.slice(0, 3))
+      case Some(months) => months
+    }
+  }
+
+  def getShortWeekdays(): Array[String] = {
+    shortWeekdays match {
+      case None       => for (d <- longWeekdays) yield (d.slice(0, 3))
+      case Some(days) => days
+    }
+  }
+
+  def getWeekdays(): Array[String] = longWeekdays
+
+  def setAmPmStrings(newAmpms: Array[String]): Unit = {
+    amPmStrings = newAmpms
+  }
+
+  def setEras(newEras: Array[String]): Unit = { eras = newEras }
+
+  def setLocalPatternChars(newLocalPatternChars: String): Unit = {
+    localPatternChars = newLocalPatternChars
+  }
+
+  def setMonths(newMonths: Array[String]): Unit = { longMonths = newMonths }
+
+  def setShortMonths(newShortMonths: Array[String]): Unit = {
+    shortMonths = Some(newShortMonths)
+  }
+
+  def setShortWeekdays(newShortWeekdays: Array[String]): Unit = {
+    shortWeekdays = Some(newShortWeekdays)
+  }
+
+  def setWeekdays(newWeekdays: Array[String]): Unit = {
+    longWeekdays = newWeekdays
+  }
+
+  // The Java 8 documentation says that use of this method is discourated.
+  // It recomments TimeZone.getDisplayName().
+
+  def getZoneStrings(): Array[Array[String]] = {
+    zoneStrings
+  }
+
+  def setZoneStrings(newZoneStrings: Array[Array[String]]): Unit = {
+
+    if (newZoneStrings == null) {
+      throw new NullPointerException()
+    }
+
+    for (i <- 0 until newZoneStrings.length) {
+      val elem       = newZoneStrings(i)
+      val elemLength = elem.length
+      if (elemLength < 5)
+        throw new IllegalArgumentException
+    }
+
+    zoneStrings = newZoneStrings
   }
 }
 
-// vim: set tw=100:
+object DateFormatSymbols {
+
+  def getAvailableLocales(): Array[Locale] = Array(Locale.US)
+
+  def getInstance(): DateFormatSymbols = new DateFormatSymbols()
+
+  def getInstance(locale: Locale): DateFormatSymbols = {
+
+    if (locale == null) {
+      throw new NullPointerException() // match JVM, which has no message.
+    }
+
+    new DateFormatSymbols(locale)
+  }
+}

--- a/unit-tests/src/test/scala/java/text/DateFormatSymbolsSuite.scala
+++ b/unit-tests/src/test/scala/java/text/DateFormatSymbolsSuite.scala
@@ -1,0 +1,429 @@
+package java.text
+
+import java.lang.NullPointerException
+import java.util.Locale
+import java.util.MissingResourceException
+
+object DateFormatSymbolsSuite extends tests.Suite {
+
+  // NOTE WELL:
+  //
+  //	Use a new DateFormatSymbols instance in each test.
+  //	This keeps the environment being tested fresh and clean
+  //	with each test.
+  //
+  //	It is obvious after the pain of the fact that doing a set() test
+  //	a get() test which expects the default environment will fail.
+
+  // By design & specification the arrays in in this file have
+  // some empty strings (""). This means the display of first & last commas
+  // may be a bit unusual. mkString() is not broken, a better
+  // formatArrayAsString() is needed.
+
+  private def formatArrayAsString(a: Array[String]): String = {
+    a.mkString("Array(", ", ", ")")
+  }
+
+  // Test constructors
+
+  test("DateFormatSymbols()") {
+    val result = new DateFormatSymbols()
+    assert(result != null, s"DateFormatSymbols() returned null")
+  }
+
+  test("DateFormatSymbols(locale) - Locale.US") {
+
+    // One would expect to see Locale.US here but this differs for a reason.
+    // Create a directly equivalent locale instance to test that
+    // the checks for content, not object, equality.
+
+    val localeUS = new Locale("en", "US")
+
+    // .eq tests for strict object equality.
+    assert(!localeUS.eq(Locale.US),
+           s"new Locale should not be object equal to Locale.US.")
+
+    val result = new DateFormatSymbols(localeUS)
+
+    assert(result != null, s"DateFormatSymbols(Locale.US) returned null.")
+  }
+
+  test("DateFormatSymbols(locale) - not Locale.US, unsupported") {
+    val unsupportedLocale = Locale.FRANCE
+
+    assertThrows[MissingResourceException] {
+      new DateFormatSymbols(unsupportedLocale)
+    }
+  }
+
+  // Test object DateFormatSymbols methods before subsequently using them.
+
+  test("getAvailableLocales()") {
+    val result   = DateFormatSymbols.getAvailableLocales()
+    val expected = Array(Locale.US)
+
+    assert(result.sameElements(expected),
+           s"available locales: ${result} != expected: ${expected}")
+  }
+
+  test("getInstance()") {
+    val result = DateFormatSymbols.getInstance()
+    assert(result != null, s"getInstance() returned null")
+  }
+
+  test("getInstance(locale) - Null locale") {
+    assertThrowsAnd[NullPointerException] {
+      DateFormatSymbols.getInstance(null)
+    } {
+      _.getMessage == null
+    } // match JVM, no message
+  }
+
+  test("getInstance(locale) - Unsupported locale") {
+
+    assertThrowsAnd[MissingResourceException] {
+      DateFormatSymbols.getInstance(new Locale("es", "US"))
+    } { _.getMessage == "Locale not found: es_US" }
+  }
+
+  // Get methods
+
+  test("getAmPmStrings()") {
+    val dfs      = DateFormatSymbols.getInstance()
+    val result   = dfs.getAmPmStrings()
+    val expected = Array("AM", "PM")
+
+    assert(result.sameElements(expected),
+           s"result: ${result} != expected: ${expected}")
+  }
+
+  test("getEras()") {
+    val dfs      = DateFormatSymbols.getInstance()
+    val result   = dfs.getEras()
+    val expected = Array("BC", "AD")
+
+    assert(result.sameElements(expected),
+           s"result: ${result} != expected: ${expected}")
+  }
+
+  test("getLocalPatternChars()") {
+    val dfs      = DateFormatSymbols.getInstance()
+    val result   = dfs.getLocalPatternChars()
+    val expected = "GyMdkHmsSEDFwWahKzZ"
+
+    assert(result.sameElements(expected),
+           s"result: ${result} != expected: ${expected}")
+  }
+
+// format: off
+  private var longMonths = Array("January",
+				 "February",
+				 "March",
+				 "April",
+				 "May",
+				 "June",
+				 "July",
+				 "August",
+				 "September",
+				 "October",
+				 "November",
+				 "December",
+				 "")
+// format: on
+
+  test("getMonths()") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val result = dfs.getMonths()
+
+    val expected = longMonths
+
+    assert(result.sameElements(expected),
+           s"result: ${result} != expected: ${expected}")
+  }
+
+// format: off
+  private var shortMonths = Array("Jan",
+				 "Feb",
+				 "Mar",
+				 "Apr",
+				 "May",
+				 "Jun",
+				 "Jul",
+				 "Aug",
+				 "Sep",
+				 "Oct",
+				 "Nov",
+				 "Dec",
+				 "")
+// format: on
+
+  test("getShortMonths()") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val result       = dfs.getShortMonths()
+    val resultString = formatArrayAsString(result)
+
+    val expected       = shortMonths
+    val expectedString = formatArrayAsString(expected)
+
+    assert(result.sameElements(expected),
+           s"result: '${resultString}' != expected: '${expectedString}'")
+  }
+
+// format: off
+  private var shortWeekdays = Array("",
+				   "Sun",
+				   "Mon",
+				   "Tue",
+				   "Wed",
+				   "Thu",
+				   "Fri",
+				   "Sat")
+// format: on
+
+  test("getShortWeekdays()") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val result       = dfs.getShortWeekdays()
+    val resultString = formatArrayAsString(result)
+
+    val expected       = shortWeekdays
+    val expectedString = formatArrayAsString(expected)
+
+    assert(result.sameElements(expected),
+           s"result: '${resultString}' != expected: '${expectedString}'")
+  }
+
+// format: off
+  private var longWeekdays = Array("",
+				   "Sunday",
+				   "Monday",
+				   "Tuesday",
+				   "Wednesday",
+				   "Thursday",
+				   "Friday",
+				   "Saturday")
+// format: on
+
+  test("getWeekdays()") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val result       = dfs.getWeekdays()
+    val resultString = formatArrayAsString(result)
+
+    val expected       = longWeekdays
+    val expectedString = formatArrayAsString(expected)
+
+    assert(result.sameElements(expected),
+           s"result: '${resultString}' != expected: '${expectedString}'")
+  }
+
+  // getZoneStrings() is documented by Java as discouraged.
+  // This tests for the minimal set implemented in SN to keep binary
+  // size down.
+  // If that set is ever expanded, this test will need to change.
+
+  test("getZoneStrings()") {
+
+    val dfs = DateFormatSymbols.getInstance()
+
+    val result = dfs.getZoneStrings()
+    assert(result.length == 1,
+           s"result length: '${result.length}' != expected: 1")
+    val resultString = formatArrayAsString(result(0))
+
+    val expected       = Array(Array("", "", "", "", ""))
+    val expectedString = formatArrayAsString(expected(0))
+
+    assert(result(0).sameElements(expected(0)),
+           s"result: '${resultString}' != expected: '${expectedString}'")
+  }
+
+  // Set methods
+
+  test("setAmPmStrings(newAmpms)") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val expected       = Array("a.m.", "p.m.") // Locale.CANADA*
+    val expectedString = formatArrayAsString(expected)
+
+    dfs.setEras(expected)
+
+    val result       = dfs.getEras()
+    val resultString = formatArrayAsString(result)
+
+    assert(result.sameElements(expected),
+           s"result: '${resultString}' != expected: '${expectedString}'")
+  }
+
+  test("setEras(newEras)") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val expected       = Array("BCE", "CE")
+    val expectedString = formatArrayAsString(expected)
+
+    dfs.setEras(expected)
+
+    val result       = dfs.getEras()
+    val resultString = formatArrayAsString(result)
+
+    assert(result.sameElements(expected),
+           s"result: '${resultString}' != expected: '${expectedString}'")
+  }
+
+  test("setLocalPatternChars(newLocalPatternChars)") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val expected = "QuothTheRaven"
+
+    dfs.setLocalPatternChars(expected)
+
+    val result = dfs.getLocalPatternChars()
+
+    assert(result.sameElements(expected),
+           s"result: '${result}' != expected: '${expected}'")
+  }
+
+// -----
+
+// format: off
+
+  private var longMonthsFR = Array("January",
+				 "February",
+				 "March",
+				 "April",
+				 "May",
+				 "June",
+				 "July",
+				 "August",
+				 "September",
+				 "October",
+				 "November",
+				 "December",
+				 "")
+// format: on
+
+  test("setMonths(newMonths)") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val expected       = longMonthsFR
+    val expectedString = formatArrayAsString(expected)
+
+    dfs.setMonths(expected)
+
+    val result       = dfs.getMonths()
+    val resultString = formatArrayAsString(result)
+
+    assert(result.sameElements(expected),
+           s"result: '${resultString}' != expected: '${expectedString}'")
+
+  }
+
+  private var shortMonthsFR = Array("January",
+                                    "February",
+                                    "March",
+                                    "April",
+                                    "May",
+                                    "June",
+                                    "July",
+                                    "August",
+                                    "September",
+                                    "October",
+                                    "November",
+                                    "December",
+                                    "")
+
+  test("setShortMonths(newShortMonths)") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val expected       = shortMonthsFR
+    val expectedString = formatArrayAsString(expected)
+
+    dfs.setShortMonths(expected)
+
+    val result       = dfs.getShortMonths()
+    val resultString = formatArrayAsString(result)
+
+    assert(result.sameElements(expected),
+           s"result: '${resultString}' != expected: '${expectedString}'")
+  }
+
+// format: off
+
+  private var shortWeekdaysFR = Array(".",
+				   "dim.",
+				   "lun.",
+				   "mar.",
+				   "mer.",
+				   "jeu.",
+				   "ven.",
+				   "sam.")
+// format: on
+
+  test("setShortWeekdays(newShortWeekdays)") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val expected       = shortWeekdaysFR
+    val expectedString = formatArrayAsString(expected)
+
+    dfs.setShortWeekdays(expected)
+
+    val result       = dfs.getShortWeekdays()
+    val resultString = formatArrayAsString(result)
+
+    assert(result.sameElements(expected),
+           s"result: '${resultString}' != expected: '${expectedString}'")
+  }
+
+  // Locale.FRANCE
+  private var longWeekdaysFR = Array("",
+                                     "dimanche",
+                                     "lundi",
+                                     "mardi",
+                                     "mercredi",
+                                     "jeudi",
+                                     "vendredi",
+                                     "samedi")
+// format: on
+
+  test("setWeekdays(newWeekdays)") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val expected       = longWeekdaysFR
+    val expectedString = formatArrayAsString(expected)
+
+    dfs.setWeekdays(expected)
+
+    val result       = dfs.getWeekdays()
+    val resultString = formatArrayAsString(result)
+
+    assert(result.sameElements(expected),
+           s"result: '${resultString}' != expected: '${expectedString}'")
+  }
+
+  // setZoneStrings() corresponds to getZoneStrings(). The latter is
+  // documented by Java as discouraged. So the former method is likely
+  // to be seldom used.
+  // Skip the usual NullPointerException and IllegalArgument tests
+  // to conserve implementation effort but do test the expected success case.
+
+  test("setZoneStrings(newZoneStrings)") {
+
+    val dfs = DateFormatSymbols.getInstance()
+
+    val expected       = Array(Array("UTC", "A", "B", "C", "D"))
+    val expectedString = formatArrayAsString(expected(0))
+
+    dfs.setZoneStrings(expected)
+
+    val result = dfs.getZoneStrings()
+    assert(result.length == 1,
+           s"result length: '${result.length}' != expected: 1")
+    val resultString = formatArrayAsString(result(0))
+
+    assert(result.sameElements(expected),
+           s"result: '${resultString}' != expected: '${expectedString}'")
+  }
+
+}


### PR DESCRIPTION
  * Issue #1551 reported an issue were the sandbox project in
    the SN build itself would not link due to missing DateFormatSymbols
    methods.

    This was an unintended consequence of PR #1522 which converted
    a number of routines from "???" to using the stub annotation.

    The Issue itself suggested adding nativeLinkStubs := true to
    the sandbox project in the SN project build.sbt.

    @densh suggested the better proposal of doing a minimal implementation.
    This PR takes that approach.

    The issue is now fixed.

  * A DateFormatSymbolsSuite was created and populated.
    All tests run and pass.

  * The implementation in this file almost complete for the only
    Locale it supports: Locale.US.

    The 'almost' comes from the method getZoneStrings(). That method
    is described in the Java 8 documentation as 'discouraged'.
    To save binary size, the method implemented returns results
    which are structurally proper according to the specification
    but semantically meaningless. To wit, five empty strings.

    The preferred TimeZone.getDisplayName(), which is, I think,
    currently unimplemented in SN, is the proper way to get this
    information.  Better that whatever effort is available be
    spent implementing that routine & kin.

  * This PR is one of a series needed in order to get unit-tests
    to link without nativeLinkStubs being true.

  * This PR does add some binary size. I will be creating a Issue
    to track what seems to be the underlying problem:  Something
    is eagerly loading code for methods which are never used.
    I say 'never used' because they never failed when they were
    '???'.

Documentation:

    None needed other than the title in the change log.

Testing:

  * Built and tested ("test-all") on X86_64 using sbt 1.2.6 in
    debug mode. All tests expected to pass do so.