### PR TITLE
Update scalafmt version

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = 1.5.1
 style = defaultWithAlign
 docstrings = JavaDoc
 assumeStandardLibraryStripMargin = true
@@ -5,4 +6,3 @@ project.excludeFilters = [
   scalalib/
 ]
 project.git = true
-runner.dialect = Scala211

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,3 +6,4 @@ project.excludeFilters = [
   scalalib/
 ]
 project.git = true
+runner.dialect = Scala211

--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,10 @@ def projectName(project: sbt.ResolvedProject): String = {
 }
 
 lazy val startupTransition: State => State = { s: State =>
-  if (System.getProperty("METALS_ENABLED") != null) "^^1.2.6" :: s
-  else s
+  Option(System.getenv("METALS_ENABLED")) match {
+    case Some(sb) => if (sb == "true") s"^^$sbt10Version" :: s else s
+    case None     => s
+  }
 }
 
 onLoad in Global := {

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@ import scala.util.Try
 import scalanative.sbtplugin.ScalaNativePluginInternal._
 import scalanative.io.packageNameFromPath
 
-val sbt13Version          = "0.13.17"
+val sbt13Version          = "0.13.18"
 val sbt13ScalaVersion     = "2.10.7"
-val sbt10Version          = "1.2.6"
-val sbt10ScalaVersion     = "2.12.7"
+val sbt10Version          = "1.2.8"
+val sbt10ScalaVersion     = "2.12.8"
 val libScalaVersion       = "2.11.12"
 val libCrossScalaVersions = Seq("2.11.8", "2.11.11", libScalaVersion)
 
@@ -29,7 +29,7 @@ lazy val startupTransition: State => State = { s: State =>
 
 onLoad in Global := {
   val sbtCrossVersion = (sbtVersion in pluginCrossBuild).value
-  val old = (onLoad in Global).value
+  val old             = (onLoad in Global).value
   if (sbtCrossVersion != sbt10Version) {
     startupTransition compose old
   } else {

--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,13 @@ lazy val startupTransition: State => State = { s: State =>
 }
 
 onLoad in Global := {
+  val sbtCrossVersion = (sbtVersion in pluginCrossBuild).value
   val old = (onLoad in Global).value
-  startupTransition compose old
+  if (sbtCrossVersion != sbt10Version) {
+    startupTransition compose old
+  } else {
+    old
+  }
 }
 
 // Provide consistent project name pattern.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.17
+sbt.version = 0.13.18

--- a/scripts/scalafmt
+++ b/scripts/scalafmt
@@ -3,7 +3,7 @@
 # set -x
 
 HERE="`dirname $0`"
-VERSION="1.2.0"
+VERSION="1.5.1"
 COURSIER="$HERE/.coursier"
 SCALAFMT="$HERE/.scalafmt-$VERSION"
 
@@ -13,7 +13,7 @@ if [ ! -f $COURSIER ]; then
 fi
 
 if [ ! -f $SCALAFMT ]; then
-  $COURSIER bootstrap com.geirsson:scalafmt-cli_2.11:$VERSION --main org.scalafmt.cli.Cli -o $SCALAFMT
+  $COURSIER bootstrap com.geirsson:scalafmt-cli_2.12:$VERSION --main org.scalafmt.cli.Cli -o $SCALAFMT
   chmod +x $SCALAFMT
 fi
 


### PR DESCRIPTION
The primary purpose of this PR is to update `scalafmt` to the latest production version `1.5.1`.

The secondary changes are are as follows:
- Change the `scalafmt` CLI runner to use the Scala 2.12 version
- Fix the `sbt` startup hook so Metals can index all the projects.
- Update minor versions of Scala and sbt.
- Add `version = 1.5.1` to the `.scalafmt.conf` file so you can format from inside VSCode.