### PR TITLE
Fix #1560, part 2: Implement AtomicReference getAndUpdate & updateAndGet

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
@@ -1,8 +1,8 @@
 package java.util.concurrent.atomic
 
-// 2019-04-25 Note Well!
+// Note Well!
 //    Almost all of the methods in this and other Atomic*.scala files
-//    are manifestly not atomic.  The two methods added to day
+//    are manifestly not atomic.  The two methods added today
 //    and the prior art all rely upon the fact that Scala Native is
 //    currently single threaded.  They will break, bring great gnashing
 //    of teeth & horrid pain if/when SN becomes multi-threaded.

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
@@ -1,11 +1,7 @@
 package java.util.concurrent.atomic
 
-// Note Well!
-//    Almost all of the methods in this and other Atomic*.scala files
-//    are manifestly not atomic.  The two methods added today
-//    and the prior art all rely upon the fact that Scala Native is
-//    currently single threaded.  They will break, bring great gnashing
-//    of teeth & horrid pain if/when SN becomes multi-threaded.
+// Warning: The current implementation of this entire package relies on
+//          Scala Native being single threaded.
 
 import java.util.function.UnaryOperator
 

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
@@ -1,5 +1,14 @@
 package java.util.concurrent.atomic
 
+// 2019-04-25 Note Well!
+//    Almost all of the methods in this and other Atomic*.scala files
+//    are manifestly not atomic.  The two methods added to day
+//    and the prior art all rely upon the fact that Scala Native is
+//    currently single threaded.  They will break, bring great gnashing
+//    of teeth & horrid pain if/when SN becomes multi-threaded.
+
+import java.util.function.UnaryOperator
+
 class AtomicReference[T <: AnyRef](private[this] var value: T)
     extends Serializable {
 
@@ -28,6 +37,17 @@ class AtomicReference[T <: AnyRef](private[this] var value: T)
     val old = value
     value = newValue
     old
+  }
+
+  final def getAndUpdate(updateFunction: UnaryOperator[T]): T = {
+    val old = value
+    value = updateFunction(old)
+    old
+  }
+
+  final def updateAndGet(updateFunction: UnaryOperator[T]): T = {
+    value = updateFunction(value)
+    value
   }
 
   override def toString(): String =

--- a/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicReferenceSuite.scala.disabled
+++ b/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicReferenceSuite.scala.disabled
@@ -1,0 +1,72 @@
+package java.util
+package concurrent
+package atomic
+
+import java.util.function.UnaryOperator
+
+object AtomicReferenceSuite extends tests.Suite {
+
+  // This test suite is INCOMPLETE (obviously!).
+  // It tests the get() method used by the two methods added
+  // today 2019-04-25: getAndUpdate() and updateAndGet()
+
+  // getAndUpdate() and updateAndGet() test that the expected
+  // values are returned in the success case. It was not evident
+  // how to test concurrent and contended access patterns.
+  //
+  // The implementation of getAndUpdate() and updateAndGet() many
+  // other methods in j.u.concurrent.atomic currently (2019-04-25)
+  // relies upon Scala Native itself being single threaded. That is,
+  // the routines belie their names.
+
+  test("get") {
+
+    val expected = -1
+    val ar       = new AtomicReference(expected)
+
+    val result = ar.get()
+
+    assert(result == expected, s"result: ${result} != expected: ${expected}")
+  }
+
+  test("getAndUpdate(updateFunction)") {
+
+    val expectedValue    = 100
+    val expectedNewValue = expectedValue / 2
+
+    val tax = new UnaryOperator[Int] {
+      override def apply(t: Int): Int = t / 2
+    }
+
+    val ar = new AtomicReference[Int](expectedValue)
+
+    val value = ar.getAndUpdate(tax)
+
+    assert(value == expectedValue,
+           s"result before function: ${value} != expected: ${expectedValue}")
+
+    val newValue = ar.get()
+
+    assert(newValue == expectedNewValue,
+           s"newValue after function: ${newValue} != " +
+             s"expected: ${expectedNewValue}")
+  }
+
+  test("updateAndGet(updateFunction)") {
+
+    val initialValue = 100
+    val expected     = initialValue * 3
+
+    val reward = new UnaryOperator[Int] {
+      override def apply(t: Int): Int = t * 3
+    }
+
+    val ar = new AtomicReference[Int](initialValue)
+
+    val result = ar.updateAndGet(reward)
+
+    assert(result == expected,
+           s"result after function: ${result} != expected: ${expected}")
+  }
+
+}

--- a/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicReferenceSuite.scala.disabled
+++ b/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicReferenceSuite.scala.disabled
@@ -8,15 +8,15 @@ object AtomicReferenceSuite extends tests.Suite {
 
   // This test suite is INCOMPLETE (obviously!).
   // It tests the get() method used by the two methods added
-  // today 2019-04-25: getAndUpdate() and updateAndGet()
+  // today: getAndUpdate() and updateAndGet()
 
   // getAndUpdate() and updateAndGet() test that the expected
   // values are returned in the success case. It was not evident
   // how to test concurrent and contended access patterns.
   //
   // The implementation of getAndUpdate() and updateAndGet() many
-  // other methods in j.u.concurrent.atomic currently (2019-04-25)
-  // relies upon Scala Native itself being single threaded. That is,
+  // other methods in j.u.concurrent.atomic currently
+  // rely upon Scala Native itself being single threaded. That is,
   // the routines belie their names.
 
   test("get") {

--- a/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicReferenceSuite.scala.disabled
+++ b/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicReferenceSuite.scala.disabled
@@ -7,17 +7,14 @@ import java.util.function.UnaryOperator
 object AtomicReferenceSuite extends tests.Suite {
 
   // This test suite is INCOMPLETE (obviously!).
-  // It tests the get() method used by the two methods added
-  // today: getAndUpdate() and updateAndGet()
-
-  // getAndUpdate() and updateAndGet() test that the expected
-  // values are returned in the success case. It was not evident
-  // how to test concurrent and contended access patterns.
   //
-  // The implementation of getAndUpdate() and updateAndGet() many
-  // other methods in j.u.concurrent.atomic currently
-  // rely upon Scala Native itself being single threaded. That is,
-  // the routines belie their names.
+  // The get() method is used by getAndUpdate() and updateAndGet().
+  // The test is only a shallow probe before use.
+  //
+  // getAndUpdate() and updateAndGet() test only that the expected
+  // values are returned in the success case. It was not evident
+  // how to test concurrent and contended access patterns within
+  // the scope of unit-tests.
 
   test("get") {
 


### PR DESCRIPTION
  * This pull request is the second of two which address Issue #1560.
    The first in the series was PR #1566 by @ekrich and the 0.3.9
    variant, PR #1567.

    The intent was to enable a SN build of scalafmt.

    That issue is now fixed.

  * Almost all complex code in SN java.util.concurrent.atomic
    relies upon the fact that SN is now single threaded.
    This code makes the same assumption.

    All of this code will be a hard to find hazard and hindrance
    once SN supports multithreading.

  * A small test Suite to exercise the methods implemented was created.
    The tests in the suite excercise (only) the newly implemented methods and
    check that the expected values are returned. There was no obvious way
    to test concurrency.

    When it is run test-only all tests run and pass.

    The new Suite seems to drive the testing framwork over its
    (memory?) limit.  In my private build the new Suite runs
    just fine if I delete some existing Suites.  Another manifestation
    of the same issue I encountered whilst implementing regex.

    I am submitting the unit-tests but naming the file
    AtomicReferenceSuite.scala.disabled to pass Travis CI
    until the test-runner is fixed. It took me a while to figure
    them out and they may prove useful to a future developer.

Documentation:

    * A one line entry in the change log is suggested.

Testing:

  * Built and tested ("test-all") in debug mode using sbt 1.2.6 on
    X86_64 only . All test expected to pass do so.