### PR TITLE
[0.3.x] Fix #1560: implement AtomicReference getAndUpdate & updateAndGet

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
@@ -1,5 +1,10 @@
 package java.util.concurrent.atomic
 
+// Warning: The current implementation of this entire package relies on
+//          Scala Native being single threaded.
+
+import java.util.function.UnaryOperator
+
 class AtomicReference[T <: AnyRef](private[this] var value: T)
     extends Serializable {
 
@@ -28,6 +33,17 @@ class AtomicReference[T <: AnyRef](private[this] var value: T)
     val old = value
     value = newValue
     old
+  }
+
+  final def getAndUpdate(updateFunction: UnaryOperator[T]): T = {
+    val old = value
+    value = updateFunction(old)
+    old
+  }
+
+  final def updateAndGet(updateFunction: UnaryOperator[T]): T = {
+    value = updateFunction(value)
+    value
   }
 
   override def toString(): String =

--- a/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicReferenceSuite.scala.disabled
+++ b/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicReferenceSuite.scala.disabled
@@ -1,0 +1,69 @@
+package java.util
+package concurrent
+package atomic
+
+import java.util.function.UnaryOperator
+
+object AtomicReferenceSuite extends tests.Suite {
+
+  // This test suite is INCOMPLETE (obviously!).
+  //
+  // The get() method is used by getAndUpdate() and updateAndGet().
+  // The test is only a shallow probe before use.
+  //
+  // getAndUpdate() and updateAndGet() test only that the expected
+  // values are returned in the success case. It was not evident
+  // how to test concurrent and contended access patterns within
+  // the scope of unit-tests.
+
+  test("get") {
+
+    val expected = -1
+    val ar       = new AtomicReference(expected)
+
+    val result = ar.get()
+
+    assert(result == expected, s"result: ${result} != expected: ${expected}")
+  }
+
+  test("getAndUpdate(updateFunction)") {
+
+    val expectedValue    = 100
+    val expectedNewValue = expectedValue / 2
+
+    val tax = new UnaryOperator[Int] {
+      override def apply(t: Int): Int = t / 2
+    }
+
+    val ar = new AtomicReference[Int](expectedValue)
+
+    val value = ar.getAndUpdate(tax)
+
+    assert(value == expectedValue,
+           s"result before function: ${value} != expected: ${expectedValue}")
+
+    val newValue = ar.get()
+
+    assert(newValue == expectedNewValue,
+           s"newValue after function: ${newValue} != " +
+             s"expected: ${expectedNewValue}")
+  }
+
+  test("updateAndGet(updateFunction)") {
+
+    val initialValue = 100
+    val expected     = initialValue * 3
+
+    val reward = new UnaryOperator[Int] {
+      override def apply(t: Int): Int = t * 3
+    }
+
+    val ar = new AtomicReference[Int](initialValue)
+
+    val result = ar.updateAndGet(reward)
+
+    assert(result == expected,
+           s"result after function: ${result} != expected: ${expected}")
+  }
+
+}


### PR DESCRIPTION
Cherry-pick of master SHA d963c87f3d3ae7eabab958ce4229e1d29c92c179

* Fix #1560, part 2: Implement AtomicReference getAndUpdate & updateAndGet

  * This pull request is the second of two which address Issue #1560.
    The first in the series was PR #1566 by @ekrich and the 0.3.9
    variant, PR #1567.

    The intent was to enable a SN build of scalafmt.

    That issue is now fixed.

  * Almost all complex code in SN java.util.concurrent.atomic
    relies upon the fact that SN is now single threaded.
    This code makes the same assumption.

    All of this code will be a hard to find hazard and hindrance
    once SN supports multithreading.

  * A small test Suite to exercise the methods implemented was created.
    The tests in the suite excercise (only) the newly implemented methods and
    check that the expected values are returned. There was no obvious way
    to test concurrency.

    When it is run test-only all tests run and pass.

    The new Suite seems to drive the testing framwork over its
    (memory?) limit.  In my private build the new Suite runs
    just fine if I delete some existing Suites.  Another manifestation
    of the same issue I encountered whilst implementing regex.

    I am submitting the unit-tests but naming the file
    AtomicReferenceSuite.scala.disabled to pass Travis CI
    until the test-runner is fixed. It took me a while to figure
    them out and they may prove useful to a future developer.

Documentation:

    A one line entry in the change log is suggested.

Testing:

  * Built and tested ("test-all") in debug mode using sbt 1.2.6 on
    X86_64 only . All test expected to pass do so.