### PR TITLE
Implement Zone methods to allow open-ended zones (#1428)

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/native/Zone.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Zone.scala
@@ -4,24 +4,32 @@ package native
 import scala.annotation.implicitNotFound
 import scalanative.runtime.{libc, RawPtr, fromRawPtr}
 
-/** Zone allocator that automatically frees allocations whenever
- *  syntactic boundary of the zone is over.
- */
+/** Zone allocator which manages memory allocations. */
 @implicitNotFound("Given method requires an implicit zone.")
 trait Zone {
 
   /** Allocates memory of given size. */
   def alloc(size: CSize): Ptr[Byte]
+
+  /** Frees allocations. This zone allocator is not reusable once closed. */
+  def close(): Unit
+
+  /** Return this zone allocator is closed or not. */
+  def isClosed: Boolean
+
 }
 
 object Zone {
 
   /** Run given function with a fresh zone and destroy it afterwards. */
   final def apply[T](f: Zone => T): T = {
-    val zone = new ZoneImpl
+    val zone = Zone.open()
     try f(zone)
     finally zone.close()
   }
+
+  /** Create a new zone allocator. Use Zone#close to free allocations. */
+  final def open(): Zone = new ZoneImpl
 
   /** Minimalistic zone allocator that uses underlying
    *  system allocator for allocations, and frees all of
@@ -30,7 +38,10 @@ object Zone {
   private class ZoneImpl extends Zone {
     final class Node(val head: RawPtr, val tail: Node)
 
-    private var node: Node = null
+    private var node: Node      = null
+    private var closed: Boolean = false
+
+    final override def isClosed: Boolean = closed
 
     final def alloc(size: CSize): Ptr[Byte] = {
       val rawptr = libc.malloc(size)
@@ -38,11 +49,12 @@ object Zone {
       fromRawPtr[Byte](rawptr)
     }
 
-    final def close(): Unit = {
+    final override def close(): Unit = {
       while (node != null) {
         libc.free(node.head)
         node = node.tail
       }
+      closed = true
     }
   }
 }

--- a/nativelib/src/main/scala/scala/scalanative/native/Zone.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Zone.scala
@@ -47,6 +47,9 @@ object Zone {
     final override def isClosed: Boolean = closed
 
     final def alloc(size: CSize): Ptr[Byte] = {
+      if (isClosed) {
+        throw new IllegalStateException("zone allocator is closed")
+      }
       val rawptr = libc.malloc(size)
       node = new Node(rawptr, node)
       fromRawPtr[Byte](rawptr)

--- a/nativelib/src/main/scala/scala/scalanative/native/Zone.scala
+++ b/nativelib/src/main/scala/scala/scalanative/native/Zone.scala
@@ -14,6 +14,9 @@ trait Zone {
   /** Frees allocations. This zone allocator is not reusable once closed. */
   def close(): Unit
 
+  /** Return this zone allocator is open or not. */
+  def isOpen: Boolean = !isClosed
+
   /** Return this zone allocator is closed or not. */
   def isClosed: Boolean
 

--- a/unit-tests/src/test/scala/scala/scalanative/native/ZoneSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/native/ZoneSuite.scala
@@ -19,7 +19,7 @@ object ZoneSuite extends tests.Suite {
     assert(sum == (0 until n).sum)
   }
 
-  test("zone allocator alloc") {
+  test("zone allocator alloc with apply") {
     Zone { implicit z =>
       val ptr = z.alloc(64 * sizeof[Int])
 
@@ -29,5 +29,21 @@ object ZoneSuite extends tests.Suite {
 
       assertAccessible(ptr2, 128)
     }
+  }
+
+  test("zone allocator alloc with open") {
+    implicit val zone: Zone = Zone.open()
+    assert(!zone.isClosed)
+
+    val ptr = zone.alloc(64 * sizeof[Int])
+
+    assertAccessible(ptr, 64)
+
+    val ptr2 = alloc[Int](128)
+
+    assertAccessible(ptr2, 128)
+
+    zone.close()
+    assert(zone.isClosed)
   }
 }

--- a/unit-tests/src/test/scala/scala/scalanative/native/ZoneSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/native/ZoneSuite.scala
@@ -48,4 +48,14 @@ object ZoneSuite extends tests.Suite {
     assert(!zone.isOpen)
     assert(zone.isClosed)
   }
+
+  test("alloc throws exception if zone allocator is closed") {
+    implicit val zone: Zone = Zone.open()
+
+    zone.alloc(64 * sizeof[Int])
+
+    zone.close()
+
+    assertThrows[IllegalStateException](zone.alloc(64 * sizeof[Int]))
+  }
 }

--- a/unit-tests/src/test/scala/scala/scalanative/native/ZoneSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/native/ZoneSuite.scala
@@ -33,6 +33,7 @@ object ZoneSuite extends tests.Suite {
 
   test("zone allocator alloc with open") {
     implicit val zone: Zone = Zone.open()
+    assert(zone.isOpen)
     assert(!zone.isClosed)
 
     val ptr = zone.alloc(64 * sizeof[Int])
@@ -44,6 +45,7 @@ object ZoneSuite extends tests.Suite {
     assertAccessible(ptr2, 128)
 
     zone.close()
+    assert(!zone.isOpen)
     assert(zone.isClosed)
   }
 }


### PR DESCRIPTION
Implementation for https://github.com/scala-native/scala-native/issues/1428.

### Changes

- Added `open` to Zone companion object
- Added `close` and `isClosed` to Zone trait