### PR TITLE
Fix #1008, #1528, partial #1579: unit-tests fails with more than 254 Suites 

### DIFF
--- a/javalib/src/main/scala/java/io/DataInputStream.scala
+++ b/javalib/src/main/scala/java/io/DataInputStream.scala
@@ -35,14 +35,21 @@ class DataInputStream(in: InputStream)
     readFully(b, 0, b.length)
 
   override final def readFully(b: Array[Byte], off: Int, len: Int): Unit = {
-    if (off < 0 || len < 0 || len > b.length - off)
+    if ((off < 0) || (len < 0) || (len > b.length - off)) {
       throw new IndexOutOfBoundsException()
-    var i = 0
-    while (i < len) {
-      val value = readByte()
-      if (value == -1) throw new EOFException()
-      b(i + off) = value
-      i += 1
+    }
+
+    var offset = off
+
+    while (offset < len) {
+      val nLeft = len - offset
+      val nRead = in.read(b, offset, nLeft)
+
+      if (nRead == -1) {
+        throw new EOFException()
+      } else {
+        offset += nRead
+      }
     }
   }
 


### PR DESCRIPTION

  * Issue #1008 reported problems with unit-tests when executing
    a large number of Suites.  Issue #1528 renewed concern with
    the problem.  Issue #1579 reported a number of problems
    in java.io.DataInputStream.scala.

    This PR fixes issues #1008 and #1528 by implementing a partial
    fix to #1579.

    The partial fix removes an erroneous end-of-file (EOF) test and
    the call to the other buggy code identified in #1579 and #1578.

    It was simpler to replace readFully with correct and more performant
    code than to create PRs for the entire fault chain.

    A full fix for Issue #1579 will follow on after this PR has been
    accepted. This sequencing of edits isolates & highlights the
    effective change in this PR and, I hope, allows for easier review.

  * Because of fundamental design issues the 'too many unit-tests' experience
    may re-appear in the future, but not for this reason.

    The current protocol sends a list of tasks from the local master
    process to the 'remote' (pseudo) process running the tests.
    The latter re-orders its internal list and replies with the newly
    ordered list.  Is is easy to conceive of a situation where
    these lists exceed the bounds of memory as the number of unit-test
    Suites grows into the thousands.

    Tasks (Suites) are executed on at a time, so I see no limit to the
    number of tasks there but each task itself must stay within the
    bounds of available memory.

Documentation:

  * None needed. Unit-tests are internal to SN.

Testing:

  * In my private development environment I built and tested ("test-all")
    in debug mode with both sbt 0.13.18 & 1.2.8 (1) and the existing 254
    unit-test Suites. All ran & passed (2).

  * I then enabled the previously disabled AtomicReferenceSuite.scala,
    giving 255 tests. I ran tests/test again and all 255 ran & passed.

  * I added 10 additional Suites, giving 265 Suites. and ran tests/test.
    All tests ran & passed, including Suites 255 through 265.

  * After this PR is accepted, I will submit another one which will
    enable AtomicReferenceSuite.scala.  This should provide the
    255th test and give final validation to this PR.  That seems
    to be conceptually simpler & easier all around than my submitting 10,
    or so, dummy Suites with this PR, only to delete them in another PR.

  Note 1: I believe it is a known issue, but for completeness
          I report that sbt 1.2.8 builds in release mode but
	  compiling unit-tests fails after after a half hour or so.

  Note 2: Due to a change in sbt between 0.13 and 1.0, link-order
          never passes for me with 1.2.n.  PR #1466 fixes this issue
	  and is awaiting acceptance.