### PR TITLE
Fix #1008, #1528, partial #1579: unit-tests fails with more than 254 Suites

### DIFF
--- a/javalib/src/main/scala/java/io/DataInputStream.scala
+++ b/javalib/src/main/scala/java/io/DataInputStream.scala
@@ -35,14 +35,21 @@ class DataInputStream(in: InputStream)
     readFully(b, 0, b.length)
 
   override final def readFully(b: Array[Byte], off: Int, len: Int): Unit = {
-    if (off < 0 || len < 0 || len > b.length - off)
+    if ((off < 0) || (len < 0) || (len > b.length - off)) {
       throw new IndexOutOfBoundsException()
-    var i = 0
-    while (i < len) {
-      val value = readByte()
-      if (value == -1) throw new EOFException()
-      b(i + off) = value
-      i += 1
+    }
+
+    var offset = off
+
+    while (offset < len) {
+      val nLeft = len - offset
+      val nRead = in.read(b, offset, nLeft)
+
+      if (nRead == -1) {
+        throw new EOFException()
+      } else {
+        offset += nRead
+      }
     }
   }
 

--- a/javalib/src/main/scala/java/io/DataInputStream.scala
+++ b/javalib/src/main/scala/java/io/DataInputStream.scala
@@ -35,20 +35,32 @@ class DataInputStream(in: InputStream)
     readFully(b, 0, b.length)
 
   override final def readFully(b: Array[Byte], off: Int, len: Int): Unit = {
-    if ((off < 0) || (len < 0) || (len > b.length - off)) {
+    if (b == null) {
+      throw new NullPointerException
+    }
+
+    // Use the same message texts as the JVM for all 3 cases. Yes, 3rd differs.
+    if ((off < 0) || ((off + len) > b.length)) {
+      val msg =
+        s"Range [${off}, ${off} + ${len}) out of bounds for length ${b.length}"
+      throw new IndexOutOfBoundsException(msg)
+    }
+
+    if (len < 0) {
       throw new IndexOutOfBoundsException()
     }
 
     var offset = off
+    var length = len
 
-    while (offset < len) {
-      val nLeft = len - offset
-      val nRead = in.read(b, offset, nLeft)
+    while (length > 0) {
+      val nread = in.read(b, offset, length)
 
-      if (nRead == -1) {
+      if (nread == -1) {
         throw new EOFException()
       } else {
-        offset += nRead
+        offset += nread
+        length -= nread
       }
     }
   }

--- a/unit-tests/src/test/scala/java/io/DataInputStreamSuite.scala
+++ b/unit-tests/src/test/scala/java/io/DataInputStreamSuite.scala
@@ -1,0 +1,198 @@
+package java.io
+
+object DataInputStreamSuite extends tests.Suite {
+
+  // readFully
+
+  test("readFully(b, off, len) - null buffer") {
+
+    val inputArray =
+      List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
+    val iaLength = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows[NullPointerException] {
+      dis.readFully(null.asInstanceOf[Array[Byte]], 0, 1)
+    }
+  }
+
+  test("readFully(b, off, len) - invalid offset argument") {
+
+    val inputArray =
+      List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
+    val iaLength = inputArray.length
+
+    val arrayIn     = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis         = new DataInputStream(arrayIn)
+    val outputArray = new Array[Byte](iaLength)
+
+    assertThrows[IndexOutOfBoundsException] {
+      dis.readFully(outputArray, -1, 1)
+    }
+  }
+
+  test("readFully(b, off, len) - invalid length argument") {
+
+    val inputArray =
+      List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
+    val iaLength = inputArray.length
+
+    val arrayIn     = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis         = new DataInputStream(arrayIn)
+    val outputArray = new Array[Byte](iaLength)
+
+    assertThrows[IndexOutOfBoundsException] {
+      dis.readFully(outputArray, 0, -1)
+    }
+  }
+
+  test("readFully(b, off, len) - invalid offset + length arguments") {
+
+    val inputArray =
+      List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
+    val iaLength = inputArray.length
+
+    val arrayIn     = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis         = new DataInputStream(arrayIn)
+    val outputArray = new Array[Byte](iaLength)
+
+    assertThrows[IndexOutOfBoundsException] {
+      dis.readFully(outputArray, 1, outputArray.length)
+    }
+  }
+
+  test("readFully(b, off, len) - len == 0") {
+
+    val inputArray = Array.tabulate[Byte](256)(i => i.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    val marker      = 255.toByte
+    val outputArray = Array.fill[Byte](iaLength)(marker.toByte)
+
+    dis.readFully(outputArray, 10, 0)
+
+    val index = outputArray.indexWhere(e => e != marker)
+
+    if (index >= 0) {
+      val result   = outputArray(index) & 0xFF // want to print 0-255
+      val expected = marker & 0xFF
+
+      assert(false,
+             s"byte at index ${index}: ${result} != expected: ${expected}")
+    }
+  }
+
+  test("readFully(b, off, len) - len == b.length") {
+
+    val inputArray = Array.tabulate[Byte](256)(i => i.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    val outputArray = Array.fill[Byte](iaLength)(0.toByte)
+    outputArray(0) = 255.toByte
+
+    dis.readFully(outputArray, 0, outputArray.length)
+
+    val zipped = outputArray.zip(inputArray)
+    val index  = zipped.indexWhere(x => x._1 != x._2)
+
+    if (index >= 0) {
+      val result   = outputArray(index) & 0xFF // want to print 0-255
+      val expected = inputArray(index) & 0xFF
+
+      assert(false,
+             s"byte at index ${index}: ${result} != expected: ${expected}")
+    }
+  }
+
+  test("readFully(b, off, len) - patch middle of buffer") {
+
+    val inputArray = Array.tabulate[Byte](10)(i => (i + 20).toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    val outputArray = Array.fill[Byte](20)(1.toByte)
+
+    val expectedArray = Array.fill[Byte](outputArray.length)(outputArray(0))
+
+    for (j <- 0 until iaLength) {
+      expectedArray(10 + j) = inputArray(j)
+    }
+
+    dis.readFully(outputArray, 10, inputArray.length)
+
+    val zipped = outputArray.zip(expectedArray)
+    val index  = zipped.indexWhere(x => x._1 != x._2)
+
+    if (index >= 0) {
+      val result   = outputArray(index) & 0xFF // want to print 0-255
+      val expected = inputArray(index) & 0xFF
+
+      assert(false,
+             s"byte at index ${index}: ${result} != expected: ${expected}")
+    }
+  }
+
+  test("readFully(b, off, len) - unexpected end of file") {
+
+    val inputArray = Array.tabulate[Byte](128)(i => i.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    val outputArray = Array.fill[Byte](iaLength + 1)(0.toByte)
+
+    assertThrows[EOFException] {
+      dis.readFully(outputArray, 0, outputArray.length)
+    }
+  }
+
+  test("readFully(b) - null buffer") {
+
+    val inputArray =
+      List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
+    val iaLength = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows[NullPointerException] {
+      dis.readFully(null.asInstanceOf[Array[Byte]])
+    }
+  }
+
+  test("readFully(b)") {
+
+    val inputArray = Array.tabulate[Byte](256)(i => i.toByte).reverse
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    val outputArray = Array.fill[Byte](iaLength)(0.toByte)
+
+    dis.readFully(outputArray)
+
+    val zipped = outputArray.zip(inputArray)
+    val index  = zipped.indexWhere(x => x._1 != x._2)
+
+    if (index >= 0) {
+      val result   = outputArray(index) & 0xFF // want to print 0-255
+      val expected = inputArray(index) & 0xFF
+
+      assert(false,
+             s"byte at index ${index}: ${result} != expected: ${expected}")
+    }
+  }
+
+}


### PR DESCRIPTION

  * Issue #1008 reported problems with unit-tests when executing
    a large number of Suites.  Issue #1528 renewed concern with
    the problem.  Issue #1579 reported a number of problems
    in java.io.DataInputStream.scala.

    This PR fixes issues #1008 and #1528 by implementing a partial
    fix to #1579.

    The partial fix removes an erroneous end-of-file (EOF) test and
    the call to the other buggy code identified in #1579 and #1578.

    It was simpler to replace readFully with correct and more performant
    code than to create PRs for the entire fault chain.

    A full fix for Issue #1579 will follow on after this PR has been
    accepted. This sequencing of edits isolates & highlights the
    effective change in this PR and, I hope, allows for easier review.

  * Because of fundamental design issues the 'too many unit-tests' experience
    may re-appear in the future, but not for this reason.

    The current protocol sends a list of tasks from the local master
    process to the 'remote' (pseudo) process running the tests.
    The latter re-orders its internal list and replies with the newly
    ordered list.  Is is easy to conceive of a situation where
    these lists exceed the bounds of memory as the number of unit-test
    Suites grows into the thousands.

    Tasks (Suites) are executed on at a time, so I see no limit to the
    number of tasks there but each task itself must stay within the
    bounds of available memory.

Documentation:

  * None needed. Unit-tests are internal to SN.

Testing:

  * In my private development environment I built and tested ("test-all")
    in debug mode with both sbt 0.13.18 & 1.2.8 (1) and the existing 254
    unit-test Suites. All ran & passed (2).

  * I then enabled the previously disabled AtomicReferenceSuite.scala,
    giving 255 tests. I ran tests/test again and all 255 ran & passed.

  * I added 10 additional Suites, giving 265 Suites. and ran tests/test.
    All tests ran & passed, including Suites 255 through 265.

  * After this PR is accepted, I will submit another one which will
    enable AtomicReferenceSuite.scala.  This should provide the
    255th test and give final validation to this PR.  That seems
    to be conceptually simpler & easier all around than my submitting 10,
    or so, dummy Suites with this PR, only to delete them in another PR.

  Note 1: I believe it is a known issue, but for completeness
          I report that sbt 1.2.8 builds in release mode but
	  compiling unit-tests fails after after a half hour or so.

  Note 2: Due to a change in sbt between 0.13 and 1.0, link-order
          never passes for me with 1.2.n.  PR #1466 fixes this issue
	  and is awaiting acceptance.