### PR TITLE
#1578: SocketInputStream#read() wrongly reports character 255 as EOF.

### DIFF
--- a/javalib/src/main/scala/java/net/SocketInputStream.scala
+++ b/javalib/src/main/scala/java/net/SocketInputStream.scala
@@ -14,7 +14,7 @@ private[net] class SocketInputStream(socket: PlainSocketImpl)
     val buffer = new Array[Byte](1)
     socket.read(buffer, 0, 1) match {
       case -1 => -1
-      case _  => buffer(0)
+      case _  => buffer(0) & 0xFF // Convert to Int with _no_ sign extension.
     }
   }
 


### PR DESCRIPTION

  * Issue #1578 reported that the SocketInputStream read() method
    wrongly returned end-of-file (EOF, OxFFFFFFFF) after reading a
    character 255.

    This PR fixes the reported issue.

Documentation:

  * None needed beyond an entry in the changelog.

Testing:

  * Because this is socket code no simple unit-test is evident.

  * In my private development environment I built and tested ("test-all")
    in debug mode with sbt 0.13.18 using the existing 254
    unit-test Suites, ten additional Suites, and a private version
    of DataInputStream.scala (DIS).

    That private version of DIS is a preliminary version of a fix
    to #1579.  After a series of calls its readFully() calls the SIS#read()
    of this PR.

    The 265 unit-tests executed as expected and without regression.
    That would only happen if those edits were effective.

    PR #1582 was submitted because it contains a more performant
    version of DIS#readFully. That version of readFully does not
    directly exercise the edits of this PR.


