### PR TITLE
Fix #1574: emit all class definitions in one module

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -54,7 +54,7 @@ object CodeGen {
       // of available processesors. This prevents LLVM from optimizing
       // across IR module boundary unless LTO is turned on.
       def separate(): Unit =
-        partitionBy(assembly, procs)(_.name).par.foreach {
+        partitionBy(assembly, procs)(_.name.top.mangle).par.foreach {
           case (id, defns) =>
             val sorted = defns.sortBy(_.name.show)
             val impl   = new Impl(config.targetTriple, env, sorted)


### PR DESCRIPTION
This a potential fix for #1574. Previously unit tests failed
in debug mode on macOS on machines with 8 virtual cores.
This PR changes the partition scheme to bundle all definitions 
for a given class together in LLVM output. 

I suspect that that the underlying issue could be a bug in LLVM.
It works as expected if we emit a single LLVM module, or use
any of the optimization modes other than -O0 or use lto.