### PR TITLE
Fix #1592: j.t.DateFormatSymbols does not memoize correctly

### DIFF
--- a/javalib/src/main/scala/java/text/DateFormatSymbols.scala
+++ b/javalib/src/main/scala/java/text/DateFormatSymbols.scala
@@ -70,15 +70,21 @@ class DateFormatSymbols(locale: Locale)
 
   def getShortMonths(): Array[String] = {
     shortMonths match {
-      case None         => for (m <- longMonths) yield (m.slice(0, 3))
       case Some(months) => months
+      case None =>
+        val months = for (m <- longMonths) yield (m.slice(0, 3))
+        shortMonths = Some(months)
+        months
     }
   }
 
   def getShortWeekdays(): Array[String] = {
     shortWeekdays match {
-      case None       => for (d <- longWeekdays) yield (d.slice(0, 3))
       case Some(days) => days
+      case None =>
+        val days = for (d <- longWeekdays) yield d.slice(0, 3)
+        shortWeekdays = Some(days)
+        days
     }
   }
 

--- a/unit-tests/src/test/scala/java/text/DateFormatSymbolsSuite.scala
+++ b/unit-tests/src/test/scala/java/text/DateFormatSymbolsSuite.scala
@@ -171,7 +171,18 @@ object DateFormatSymbolsSuite extends tests.Suite {
            s"result: '${resultString}' != expected: '${expectedString}'")
   }
 
-// format: off
+  test("getShortMonths() - memorization") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val result   = dfs.getShortMonths()
+    val expected = dfs.getShortMonths()
+
+    // Test object quality. If memoization worked. should be same object.
+    assert(result == expected,
+           s"result: '${result}' != expected: '${expected}'")
+  }
+
+  // format: off
   private var shortWeekdays = Array("",
 				   "Sun",
 				   "Mon",
@@ -193,6 +204,17 @@ object DateFormatSymbolsSuite extends tests.Suite {
 
     assert(result.sameElements(expected),
            s"result: '${resultString}' != expected: '${expectedString}'")
+  }
+
+  test("getShortWeekdays() - memorization") {
+    val dfs = DateFormatSymbols.getInstance()
+
+    val result   = dfs.getShortWeekdays()
+    val expected = dfs.getShortWeekdays()
+
+    // Test object quality. If memoization worked. should be same object.
+    assert(result == expected,
+           s"result: '${result}' != expected: '${expected}'")
   }
 
 // format: off

--- a/unit-tests/src/test/scala/java/text/DateFormatSymbolsSuite.scala
+++ b/unit-tests/src/test/scala/java/text/DateFormatSymbolsSuite.scala
@@ -178,7 +178,7 @@ object DateFormatSymbolsSuite extends tests.Suite {
     val expected = dfs.getShortMonths()
 
     // Test object quality. If memoization worked. should be same object.
-    assert(result == expected,
+    assert(result.eq(expected),
            s"result: '${result}' != expected: '${expected}'")
   }
 
@@ -213,7 +213,7 @@ object DateFormatSymbolsSuite extends tests.Suite {
     val expected = dfs.getShortWeekdays()
 
     // Test object quality. If memoization worked. should be same object.
-    assert(result == expected,
+    assert(result.eq(expected),
            s"result: '${result}' != expected: '${expected}'")
   }
 


### PR DESCRIPTION
  * Issue #1592 reported that two methods, getShortWeekdays &
    getShortMonths, in java.text.DateFormatSymbols.scala
    did not properly store the first calculation of a local
    variable for subsequent use (memoize).

    The results of the two methods were correct in the flawed
    implementation and remain so in this PR.

    The issue is now fixed.

  * My thanks to @ekrich for originally detecting the flaw and
    for several rounds of making a solution readable.

  * A test for each of the affected methods  was added to
    DateFormatSymbolsSuite to check that the object returned on a second
    call is the same (strictly object equal) as that from the first call.

    All DateFormatSymbols tests, new & old, run and pass.

Documentation:

    None needed other than the title in the change log. No
    change in user facing behavior.

Testing:

  * Built and tested ("test-all") on X86_64 using sbt 1.2.8 in
    release-fast mode. All tests expected to pass do so.