### PR TITLE
Fix #1588: make nir dumping opt-in

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -258,7 +258,8 @@ lazy val projectSettings =
     scalaVersion := libScalaVersion,
     resolvers := Nil,
     scalacOptions ++= Seq("-target:jvm-1.8"),
-    nativeCheck := true
+    nativeCheck := true,
+    nativeDump := true
   )
 
 lazy val util =

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -34,12 +34,25 @@ object Show {
   def dump(defns: Seq[Defn], fileName: String): Unit = {
     val pw = new java.io.PrintWriter(fileName)
     try {
-      defns.foreach { defn =>
-        if (defn != null) {
-          pw.write(defn.show)
-          pw.write("\n")
+      util
+        .partitionBy(defns)(_.name)
+        .par
+        .map {
+          case (_, defns) =>
+            defns.collect {
+              case defn if defn != null =>
+                (defn.name, defn.show)
+            }
         }
-      }
+        .seq
+        .flatten
+        .toSeq
+        .sortBy(_._1)
+        .foreach {
+          case (_, shown) =>
+            pw.write(shown)
+            pw.write("\n")
+        }
     } finally {
       pw.close()
     }

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -46,6 +46,10 @@ object ScalaNativePlugin extends AutoPlugin {
 
     val nativeCheck =
       settingKey[Boolean]("Shall native toolchain check NIR during linking?")
+
+    val nativeDump =
+      settingKey[Boolean](
+        "Shall native toolchain dump intermediate NIR to disk during linking?")
   }
 
   @deprecated("use autoImport instead", "0.3.7")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -71,7 +71,9 @@ object ScalaNativePluginInternal {
     nativeLTO := Discover.LTO(),
     nativeLTO in NativeTest := (nativeLTO in Test).value,
     nativeCheck := false,
-    nativeCheck in NativeTest := (nativeCheck in Test).value
+    nativeCheck in NativeTest := (nativeCheck in Test).value,
+    nativeDump := false,
+    nativeDump in NativeTest := (nativeDump in Test).value
   )
 
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
@@ -133,6 +135,7 @@ object ScalaNativePluginInternal {
         .withLinkStubs(nativeLinkStubs.value)
         .withLTO(nativeLTO.value)
         .withCheck(nativeCheck.value)
+        .withDump(nativeDump.value)
     },
     nativeLink := {
       val logger  = streams.value.log.toLogger

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -51,8 +51,9 @@ object Build {
    *  @return `outpath`, the path to the resulting native binary.
    */
   def build(config: Config, outpath: Path): Path = config.logger.time("Total") {
-    val entries   = ScalaNative.entries(config)
-    val linked    = ScalaNative.link(config, entries)
+    val entries = ScalaNative.entries(config)
+    val linked  = ScalaNative.link(config, entries)
+    ScalaNative.logLinked(config, linked)
     val optimized = ScalaNative.optimize(config, linked)
 
     IO.getAll(config.workdir, "glob:**.ll").foreach(Files.delete)

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -51,14 +51,9 @@ object Build {
    *  @return `outpath`, the path to the resulting native binary.
    */
   def build(config: Config, outpath: Path): Path = config.logger.time("Total") {
-    val entries = ScalaNative.entries(config)
-    val linked  = ScalaNative.link(config, entries)
-
-    logLinked(config, linked)
-    nir.Show.dump(linked.defns, "linked.hnir")
-
+    val entries   = ScalaNative.entries(config)
+    val linked    = ScalaNative.link(config, entries)
     val optimized = ScalaNative.optimize(config, linked)
-    nir.Show.dump(optimized.defns, "optimized.hnir")
 
     IO.getAll(config.workdir, "glob:**.ll").foreach(Files.delete)
     ScalaNative.codegen(config, optimized)
@@ -73,37 +68,5 @@ object Build {
     }
 
     LLVM.link(config, linked, objectFiles, unpackedLib, outpath)
-  }
-
-  private def logLinked(config: Config, linked: linker.Result): Unit = {
-    def showLinkingErrors(): Nothing = {
-      config.logger.error("missing symbols:")
-      linked.unavailable.sortBy(_.show).foreach { name =>
-        config.logger.error("* " + name.mangle)
-        val from    = linked.referencedFrom
-        var current = from(name)
-        while (from.contains(current) && current != Global.None) {
-          config.logger.error("  - from " + current.mangle)
-          current = from(current)
-        }
-      }
-      throw new BuildException("unable to link")
-    }
-
-    def showStats(): Unit = {
-      val classCount = linked.defns.count {
-        case _: nir.Defn.Class | _: nir.Defn.Module => true
-        case _                                      => false
-      }
-      val methodCount = linked.defns.count(_.isInstanceOf[nir.Defn.Define])
-      config.logger.info(
-        s"Discovered ${classCount} classes and ${methodCount} methods")
-    }
-
-    if (linked.unavailable.nonEmpty) {
-      showLinkingErrors()
-    } else {
-      showStats()
-    }
   }
 }

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -53,6 +53,9 @@ sealed trait Config {
   /** Shall linker check that NIR is well-formed after every phase? */
   def check: Boolean
 
+  /** Shall linker dump intermediate NIR after every phase? */
+  def dump: Boolean
+
   /** Create a new config with given garbage collector. */
   def withGC(value: GC): Config
 
@@ -97,6 +100,9 @@ sealed trait Config {
 
   /** Create a new config with given check value. */
   def withCheck(value: Boolean): Config
+
+  /** Create a new config with given dump value. */
+  def withDump(value: Boolean): Config
 }
 
 object Config {
@@ -118,7 +124,8 @@ object Config {
       linkStubs = false,
       logger = Logger.default,
       LTO = "none",
-      check = false
+      check = false,
+      dump = false
     )
 
   private final case class Impl(nativelib: Path,
@@ -135,7 +142,8 @@ object Config {
                                 linkStubs: Boolean,
                                 logger: Logger,
                                 LTO: String,
-                                check: Boolean)
+                                check: Boolean,
+                                dump: Boolean)
       extends Config {
     def withNativelib(value: Path): Config =
       copy(nativelib = value)
@@ -181,5 +189,8 @@ object Config {
 
     def withCheck(value: Boolean): Config =
       copy(check = value)
+
+    def withDump(value: Boolean): Config =
+      copy(dump = value)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -31,15 +31,11 @@ private[scalanative] object ScalaNative {
   def link(config: Config, entries: Seq[Global]): linker.Result =
     dump(config, "linked") {
       check(config) {
-        val linked =
-          config.logger.time("Linking")(Link(config, entries))
-
-        logLinked(config, linked)
-
-        linked
+        config.logger.time("Linking")(Link(config, entries))
       }
     }
 
+  /** Show linked universe stats or fail with missing symbols. */
   def logLinked(config: Config, linked: linker.Result): Unit = {
     def showLinkingErrors(): Nothing = {
       config.logger.error("missing symbols:")

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -29,20 +29,59 @@ private[scalanative] object ScalaNative {
    *  assumption.
    */
   def link(config: Config, entries: Seq[Global]): linker.Result =
-    check(config) {
-      config.logger.time("Linking") {
-        Link(config, entries)
+    dump(config, "linked") {
+      check(config) {
+        val linked =
+          config.logger.time("Linking")(Link(config, entries))
+
+        logLinked(config, linked)
+
+        linked
       }
     }
 
+  def logLinked(config: Config, linked: linker.Result): Unit = {
+    def showLinkingErrors(): Nothing = {
+      config.logger.error("missing symbols:")
+      linked.unavailable.sortBy(_.show).foreach { name =>
+        config.logger.error("* " + name.mangle)
+        val from    = linked.referencedFrom
+        var current = from(name)
+        while (from.contains(current) && current != Global.None) {
+          config.logger.error("  - from " + current.mangle)
+          current = from(current)
+        }
+      }
+      throw new BuildException("unable to link")
+    }
+
+    def showStats(): Unit = {
+      val classCount = linked.defns.count {
+        case _: nir.Defn.Class | _: nir.Defn.Module => true
+        case _                                      => false
+      }
+      val methodCount = linked.defns.count(_.isInstanceOf[nir.Defn.Define])
+      config.logger.info(
+        s"Discovered ${classCount} classes and ${methodCount} methods")
+    }
+
+    if (linked.unavailable.nonEmpty) {
+      showLinkingErrors()
+    } else {
+      showStats()
+    }
+  }
+
   /** Optimizer high-level NIR under closed-world assumption. */
   def optimize(config: Config, linked: linker.Result): linker.Result =
-    check(config) {
-      config.logger.time(s"Optimizing (${config.mode} mode)") {
-        val optimized =
-          interflow.Interflow(config, linked)
+    dump(config, "optimized") {
+      check(config) {
+        config.logger.time(s"Optimizing (${config.mode} mode)") {
+          val optimized =
+            interflow.Interflow(config, linked)
 
-        linker.Link(config, linked.entries, optimized)
+          linker.Link(config, linked.entries, optimized)
+        }
       }
     }
 
@@ -99,6 +138,18 @@ private[scalanative] object ScalaNative {
           warn("")
           warn(s"${errors.size} errors found")
         }
+      }
+    }
+
+    linked
+  }
+
+  def dump(config: Config, phase: String)(
+      linked: scalanative.linker.Result): scalanative.linker.Result = {
+    if (config.dump) {
+      config.logger.time("Dumping intermediate code") {
+        val path = config.workdir.resolve(phase + ".hnir")
+        nir.Show.dump(linked.defns, path.toFile.getAbsolutePath)
       }
     }
 


### PR DESCRIPTION
Similarly to #1595, we put dumping of intermediate NIR after linking and optimization behind a flag.