### PR TITLE
Do not throw IOException on success

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -365,6 +365,7 @@ Here is the list of currently available classes:
 * ``java.nio.file.attribute.UserDefinedFileAttributeView``
 * ``java.nio.file.attribute.UserPrincipal``
 * ``java.nio.file.attribute.UserPrincipalLookupService``
+* ``java.nio.file.attribute.UserPrincipalNotFoundException``
 * ``java.nio.file.spi.FileSystemProvider``
 * ``java.rmi.Remote``
 * ``java.rmi.RemoteException``

--- a/javalib/src/main/scala/java/nio/file/FileSystem.scala
+++ b/javalib/src/main/scala/java/nio/file/FileSystem.scala
@@ -7,8 +7,7 @@ import java.nio.file.spi.FileSystemProvider
 import java.util.Set
 
 abstract class FileSystem extends Closeable {
-  // def getUserPrincipalLookupService(): UserPrincipalLookupService
-
+  def getUserPrincipalLookupService(): UserPrincipalLookupService
   def close(): Unit
   def getFileStores(): Iterable[FileStore]
   def getPath(first: String, more: Array[String]): Path

--- a/javalib/src/main/scala/java/nio/file/attribute/UserPrincipalNotFoundException.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/UserPrincipalNotFoundException.scala
@@ -1,0 +1,7 @@
+package java.nio.file.attribute
+
+import java.io.IOException
+
+class UserPrincipalNotFoundException(name: String) extends IOException {
+  def getName(): String = name
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/NativePosixFileAttributeView.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/NativePosixFileAttributeView.scala
@@ -38,9 +38,15 @@ final class NativePosixFileAttributeView(path: Path, options: Array[LinkOption])
 
   override def setOwner(owner: UserPrincipal): Unit =
     Zone { implicit z =>
-      val passwd = getPasswd(toCString(owner.getName))
-      if (unistd.chown(toCString(path.toString), passwd._2, -1.toUInt) != 0)
-        throwIOException()
+      val ownerName = owner.getName
+
+      getPasswd(toCString(ownerName)).fold {
+        throw new UserPrincipalNotFoundException(ownerName)
+      } { passwd =>
+        if (unistd.chown(toCString(path.toString), passwd._2, -1.toUInt) != 0) {
+          throwIOException()
+        }
+      }
     }
 
   override def setPermissions(perms: Set[PosixFilePermission]): Unit =
@@ -58,11 +64,14 @@ final class NativePosixFileAttributeView(path: Path, options: Array[LinkOption])
 
   override def setGroup(group: GroupPrincipal): Unit =
     Zone { implicit z =>
-      val _group = getGroup(toCString(group.getName))
-      val err    = unistd.chown(toCString(path.toString), -1.toUInt, _group._2)
+      val grpName = group.getName
 
-      if (err != 0) {
-        throwIOException()
+      getGroup(toCString(grpName)).fold {
+        throw new UserPrincipalNotFoundException(grpName)
+      } { group =>
+        if (unistd.chown(toCString(path.toString), -1.toUInt, group._2) != 0) {
+          throwIOException()
+        }
       }
     }
 
@@ -102,10 +111,10 @@ final class NativePosixFileAttributeView(path: Path, options: Array[LinkOption])
       }
 
       private def filePasswd()(implicit z: Zone) =
-        getPasswd(st_uid)
+        getPasswd(st_uid).fold(st_uid.toString)(_.toString)
 
       private def fileGroup()(implicit z: Zone) =
-        getGroup(st_gid)
+        getGroup(st_gid).fold(st_gid.toString)(_.toString)
 
       override def fileKey = st_ino.asInstanceOf[Object]
 
@@ -207,40 +216,69 @@ final class NativePosixFileAttributeView(path: Path, options: Array[LinkOption])
     else throwIOException()
   }
 
-  private def getGroup(name: CString)(implicit z: Zone): Ptr[grp.group] = {
+  private def getGroup(name: CString)(
+      implicit z: Zone): Option[Ptr[grp.group]] = {
     val buf = alloc[grp.group]
+
+    errno.errno = 0
     val err = grp.getgrnam(name, buf)
 
-    if (err == 0) buf
-    else throwIOException()
+    if (err == 0) {
+      Some(buf)
+    } else if (errno.errno == 0) {
+      None
+    } else {
+      throwIOException()
+    }
   }
 
-  private def getGroup(gid: stat.gid_t)(implicit z: Zone): String = {
+  private def getGroup(gid: stat.gid_t)(
+      implicit z: Zone): Option[Ptr[grp.group]] = {
     val buf = alloc[grp.group]
+
+    errno.errno = 0
     val err = grp.getgrgid(gid, buf)
 
-    if (err == 0) fromCString(buf._1)
-    else if (err == -1) throwIOException()
-    else gid.toString
+    if (err == 0) {
+      Some(buf)
+    } else if (errno.errno == 0) {
+      None
+    } else {
+      throwIOException()
+    }
   }
 
-  private def getPasswd(name: CString)(implicit z: Zone): Ptr[pwd.passwd] = {
+  private def getPasswd(name: CString)(
+      implicit z: Zone): Option[Ptr[pwd.passwd]] = {
     val buf = alloc[pwd.passwd]
+
+    errno.errno = 0
     val err = pwd.getpwnam(name, buf)
 
-    if (err == 0) buf
-    else throwIOException()
+    if (err == 0) {
+      Some(buf)
+    } else if (errno.errno == 0) {
+      None
+    } else {
+      throwIOException()
+    }
   }
 
-  private def getPasswd(uid: stat.uid_t)(implicit z: Zone): String = {
+  private def getPasswd(uid: stat.uid_t)(
+      implicit z: Zone): Option[Ptr[pwd.passwd]] = {
     val buf = alloc[pwd.passwd]
+
+    errno.errno = 0
     val err = pwd.getpwuid(uid, buf)
 
-    if (err == 0) fromCString(buf._1)
-    else if (err == -1) throwIOException()
-    else uid.toString
+    if (err == 0) {
+      Some(buf)
+    } else if (errno.errno == 0) {
+      None
+    } else {
+      throwIOException()
+    }
   }
-
 }
 private object NativePosixFileAttributeView {
   val permMap =

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystem.scala
@@ -39,6 +39,9 @@ class UnixFileSystem(override val provider: FileSystemProvider,
   @stub
   override def getFileStores(): Iterable[FileStore] = ???
 
+  override def getUserPrincipalLookupService(): UserPrincipalLookupService =
+    attribute.NativeUserPrincipalLookupService
+
   override def getPath(first: String, more: Array[String]): Path =
     new UnixPath(this, (first +: more).mkString("/"))
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/attribute/NativeUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/attribute/NativeUserPrincipalLookupService.scala
@@ -1,0 +1,76 @@
+package scala.scalanative.nio.fs.attribute
+
+import java.nio.file.attribute._
+
+import scalanative.unsigned._
+import scalanative.unsafe._
+import scalanative.libc._
+import scalanative.posix.{errno => e, grp, pwd, unistd, time, utime}, e._
+import scalanative.posix.sys.stat
+import scala.scalanative.nio.fs.UnixException
+
+final case class NativeUserPrincipal(uid: stat.uid_t)(name: Option[String])
+    extends UserPrincipal {
+  override def getName = {
+    name.getOrElse(uid.toString)
+  }
+}
+
+final case class NativeGroupPrincipal(gid: stat.gid_t)(name: Option[String])
+    extends GroupPrincipal {
+  override def getName: String = {
+    name.getOrElse(gid.toString)
+  }
+}
+
+object NativeUserPrincipalLookupService extends UserPrincipalLookupService {
+  override def lookupPrincipalByGroupName(group: String): NativeGroupPrincipal =
+    Zone { implicit z =>
+      val gid = getGroup(toCString(group)).fold {
+        throw new UserPrincipalNotFoundException(group)
+      }(_._2)
+
+      NativeGroupPrincipal(gid)(Some(group))
+    }
+
+  private def getGroup(name: CString)(
+      implicit z: Zone): Option[Ptr[grp.group]] = {
+    val buf = alloc[grp.group]
+
+    errno.errno = 0
+    val err = grp.getgrnam(name, buf)
+
+    if (err == 0) {
+      Some(buf)
+    } else if (errno.errno == 0) {
+      None
+    } else {
+      throw UnixException("getgrnam", errno.errno)
+    }
+  }
+
+  override def lookupPrincipalByName(name: String): NativeUserPrincipal = Zone {
+    implicit z =>
+      val uid = getPasswd(toCString(name)).fold {
+        throw new UserPrincipalNotFoundException(name)
+      }(_._2)
+
+      NativeUserPrincipal(uid)(Some(name))
+  }
+
+  private def getPasswd(name: CString)(
+      implicit z: Zone): Option[Ptr[pwd.passwd]] = {
+    val buf = alloc[pwd.passwd]
+
+    errno.errno = 0
+    val err = pwd.getpwnam(name, buf)
+
+    if (err == 0) {
+      Some(buf)
+    } else if (errno.errno == 0) {
+      None
+    } else {
+      throw UnixException("getpwnam", errno.errno)
+    }
+  }
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/attribute/NativeUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/attribute/NativeUserPrincipalLookupService.scala
@@ -27,7 +27,12 @@ object NativeUserPrincipalLookupService extends UserPrincipalLookupService {
   override def lookupPrincipalByGroupName(group: String): NativeGroupPrincipal =
     Zone { implicit z =>
       val gid = getGroup(toCString(group)).fold {
-        throw new UserPrincipalNotFoundException(group)
+        try {
+          group.toInt.toUInt
+        } catch {
+          case _: NumberFormatException =>
+            throw new UserPrincipalNotFoundException(group)
+        }
       }(_._2)
 
       NativeGroupPrincipal(gid)(Some(group))
@@ -84,7 +89,12 @@ object NativeUserPrincipalLookupService extends UserPrincipalLookupService {
   override def lookupPrincipalByName(name: String): NativeUserPrincipal = Zone {
     implicit z =>
       val uid = getPasswd(toCString(name)).fold {
-        throw new UserPrincipalNotFoundException(name)
+        try {
+          name.toInt.toUInt
+        } catch {
+          case _: NumberFormatException =>
+            throw new UserPrincipalNotFoundException(name)
+        }
       }(_._2)
 
       NativeUserPrincipal(uid)(Some(name))

--- a/unit-tests/src/test/scala/java/nio/file/attribute/UserPrincipalLookupServiceSuite.scala
+++ b/unit-tests/src/test/scala/java/nio/file/attribute/UserPrincipalLookupServiceSuite.scala
@@ -1,6 +1,7 @@
 package java.nio.file.attribute
 
 import java.nio.file.FileSystems
+import scala.util.Random
 
 object UserPrincipalLookupServiceSuite extends tests.Suite {
   val isTravis = System.getenv("TRAVIS") == "true"
@@ -27,5 +28,18 @@ object UserPrincipalLookupServiceSuite extends tests.Suite {
       assertThrows[UserPrincipalNotFoundException](
         lookupService.lookupPrincipalByGroupName("gobbledygook"))
     }
+  }
+
+  test("lookupPrincipalByName succeeds for numeric name") {
+    val expected = Random.nextInt.toString
+
+    assert(lookupService.lookupPrincipalByName(expected).getName == expected)
+  }
+
+  test("lookupPrincipalByGroupName succeeds for numeric name") {
+    val expected = Random.nextInt.toString
+
+    assert(
+      lookupService.lookupPrincipalByGroupName(expected).getName == expected)
   }
 }

--- a/unit-tests/src/test/scala/java/nio/file/attribute/UserPrincipalLookupServiceSuite.scala
+++ b/unit-tests/src/test/scala/java/nio/file/attribute/UserPrincipalLookupServiceSuite.scala
@@ -1,0 +1,31 @@
+package java.nio.file.attribute
+
+import java.nio.file.FileSystems
+
+object UserPrincipalLookupServiceSuite extends tests.Suite {
+  val isTravis = System.getenv("TRAVIS") == "true"
+
+  val lookupService = FileSystems.getDefault.getUserPrincipalLookupService
+
+  test("lookupPrincipalByName succeeds for `root` user") {
+    assert(lookupService.lookupPrincipalByName("root").getName == "root")
+  }
+
+  test("lookupPrincipalByName throws exception for `gobbledygook` user") {
+    if (isTravis) {
+      assertThrows[UserPrincipalNotFoundException](
+        lookupService.lookupPrincipalByName("gobbledygook"))
+    }
+  }
+
+  test("lookupPrincipalByGroupName succeeds for `root` group") {
+    assert(lookupService.lookupPrincipalByGroupName("root").getName == "root")
+  }
+
+  test("lookupPrincipalByGroupName throws exception for `gobbledygook` group") {
+    if (isTravis) {
+      assertThrows[UserPrincipalNotFoundException](
+        lookupService.lookupPrincipalByGroupName("gobbledygook"))
+    }
+  }
+}


### PR DESCRIPTION
Hi.

1. preparation
```console
$ touch /tmp/foo
$ sudo chown :1234 !$
```
2. run
```scala
import java.nio.file._
import java.nio.file.attribute

val p = Paths.get("/tmp/foo")

println(Files.readAttributes(p, classOf[attribute.PosixFileAttributes], LinkOption.NOFOLLOW_LINKS).group.getName)
```
throws an IOException (whereas there is no error actually):
```
java.io.IOException: Success
	at java.lang.Throwable.fillInStackTrace(Unknown Source)
	at java.lang.Throwable.init(Unknown Source)
	at java.lang.Exception.init(Unknown Source)
	at java.io.IOException.init(Unknown Source)
	at java.io.IOException.init(Unknown Source)
	at scala.scalanative.nio.fs.UnixException$.apply(Unknown Source)
	at scala.scalanative.nio.fs.NativePosixFileAttributeView.scala$scalanative$nio$fs$NativePosixFileAttributeView$$throwIOException(Unknown Source)
	at scala.scalanative.nio.fs.NativePosixFileAttributeView.scala$scalanative$nio$fs$NativePosixFileAttributeView$$getGroup(Unknown Source)
	at scala.scalanative.nio.fs.NativePosixFileAttributeView$$anon$2.scala$scalanative$nio$fs$NativePosixFileAttributeView$$anon$$fileGroup(Unknown Source)
	at scala.scalanative.nio.fs.NativePosixFileAttributeView$$anon$2$$anon$1$$anonfun$2.apply(Unknown Source)
	at scala.scalanative.nio.fs.NativePosixFileAttributeView$$anon$2$$anon$1$$anonfun$2.apply(Unknown Source)
	at scala.scalanative.native.Zone$.apply(Unknown Source)
	at scala.scalanative.nio.fs.NativePosixFileAttributeView$$anon$2$$anon$1.init(Unknown Source)
	at scala.scalanative.nio.fs.NativePosixFileAttributeView$$anon$2.group(Unknown Source)
	at Main$.main(Unknown Source)
```
Running the program on the JVM, simply prints out "1234" for the group name.