### PR TITLE
Fix #1613: Restore the two argument fcntl.open() method.

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
@@ -3,10 +3,11 @@ package posix
 
 import scalanative.unsafe._
 import scalanative.posix.sys.stat.mode_t
-import scalanative.posix.sys.stat.mode_t
 
 @extern
 object fcntl {
+
+  def open(pathname: CString, flags: CInt): CInt = extern
 
   def open(pathname: CString, flags: CInt, mode: mode_t): CInt = extern
 

--- a/unit-tests/src/test/scala/scala/scalanative/posix/FcntlSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/FcntlSuite.scala
@@ -1,0 +1,33 @@
+package scala.scalanative.posix
+
+import scala.scalanative.unsafe._
+
+import scalanative.libc.{errno => Cerrno}
+
+import scalanative.posix.sys.stat
+
+object FcntlSuite extends tests.Suite {
+
+  test(s"open(pathname, flags) - existing file") {
+
+    Cerrno.errno = 0
+    val fileName = c"/dev/null"
+
+    val fd = fcntl.open(fileName, fcntl.O_RDWR)
+
+    unistd.close(fd)
+    assert(fd != -1, s"fd == -1 errno: ${Cerrno.errno}")
+  }
+
+  test(s"open(pathname, flags, mode) - existing file") {
+
+    Cerrno.errno = 0
+    val fileName = c"/dev/null"
+
+    val fd = fcntl.open(fileName, fcntl.O_RDWR, stat.S_IRUSR)
+
+    unistd.close(fd)
+    assert(fd != -1, s"fd == -1 errno: ${Cerrno.errno}")
+  }
+
+}


### PR DESCRIPTION
  * This pull request was motivated by Issue #1613
    "fcntl.open with two arguments may be broken in 0.4.0-M2".
    It appeared the method stopped working in commit
    2121d12f6bccc4dbd23.

    Code calling the two argument method in SN 0.4.0-M2 fails to
    compile:
```
[error] Unspecified value parameter mode.
[error]     val fd = fcntl.open(fileName, fcntl.O_RDWR)
[error]                        ^
[error] one error found
[error] (tests/test:compileIncremental) Compilation failed
[error] Total time: 1 s, completed Jun 2, 2019, 12:45:58 PM
```

    That issue is now fixed and a unit-test Suite created to
    detect its recurrence.

  * The current Pull Request makes minimal changes. The two
    argument form of the method restored and a redundant import
    is deleted. This is to isolate and highlight the operative
    change to aid review & acceptance.

    fcntl.scala will need future work to bring it into compliance with
    Posix/SingleUnix.

  * Only minimal tests were added in the new FcntlSuite.scala.
    These verify the current change and detect possible
    interference with the three argument version of open().

    Further improvement is invited and  left as an exercise for the
    Gentle Reader.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in release-fast mode using sbt 1.2.8 on
    X86_64 only . All tests pass.