### PR TITLE
Fix #1612: Remove code that is hiding the true exception

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/regex/RE2.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/RE2.scala
@@ -19,7 +19,6 @@
 package scala.scalanative
 package regex
 
-import java.io.UnsupportedEncodingException
 import java.util.ArrayList
 import java.util.Arrays
 import java.util.List
@@ -775,12 +774,8 @@ object RE2 {
     val prefixBuilder = new java.lang.StringBuilder()
     re2.prefixComplete = prog.prefix(prefixBuilder)
     re2.prefix = prefixBuilder.toString()
-    try {
-      re2.prefixUTF8 = re2.prefix.getBytes("UTF-8")
-    } catch {
-      case e: UnsupportedEncodingException =>
-        throw new IllegalStateException("can't happen")
-    }
+    re2.prefixUTF8 = re2.prefix.getBytes("UTF-8")
+
     if (!re2.prefix.isEmpty()) {
       re2.prefixRune = re2.prefix.codePointAt(0)
     }

--- a/unit-tests/src/test/scala/scala/scalanative/regex/GoTestUtils.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/GoTestUtils.scala
@@ -1,8 +1,6 @@
 package scala.scalanative
 package regex
 
-import java.io.UnsupportedEncodingException
-
 // Utilities to make JUnit act a little more like Go's "testing" package.
 object GoTestUtils {
   def len[A](array: Array[A]): Int =
@@ -17,41 +15,25 @@ object GoTestUtils {
     if (array == null) 0
     else array.length
 
-  def utf8(s: String): Array[Byte] =
-    try {
-      s.getBytes("UTF-8")
-    } catch {
-      case e: UnsupportedEncodingException =>
-        throw new IllegalStateException("can't happen")
-    }
+  def utf8(s: String): Array[Byte] = s.getBytes("UTF-8")
 
   // Beware: logically this operation can fail, but Java doesn't detect it.
-  def fromUTF8(b: Array[Byte]): String =
-    try new String(b, "UTF-8")
-    catch {
-      case e: UnsupportedEncodingException =>
-        throw new IllegalStateException("can't happen")
-    }
+  def fromUTF8(b: Array[Byte]): String = new String(b, "UTF-8")
 
   // Convert |idx16|, which are Java (UTF-16) string indices, into the
   // corresponding indices in the UTF-8 encoding of |text|.
-  //
-  def utf16IndicesToUtf8(idx16: Array[Int], text: String): Array[Int] =
-    try {
-      val idx8 = new Array[Int](idx16.length)
-      var i    = 0
-      while (i < idx16.length) {
-        idx8(i) =
-          if (idx16(i) == -1) -1
-          else text.substring(0, idx16(i)).getBytes("UTF-8").length // yikes
+  def utf16IndicesToUtf8(idx16: Array[Int], text: String): Array[Int] = {
+    val idx8 = new Array[Int](idx16.length)
+    var i    = 0
+    while (i < idx16.length) {
+      idx8(i) =
+        if (idx16(i) == -1) -1
+        else text.substring(0, idx16(i)).getBytes("UTF-8").length // yikes
 
-        {
-          i += 1; i
-        }
+      {
+        i += 1; i
       }
-      idx8
-    } catch {
-      case e: UnsupportedEncodingException =>
-        throw new IllegalStateException(e)
     }
+    idx8
+  }
 }


### PR DESCRIPTION
During normal circumstances these exceptions should never occur. 

Catching the exceptions only diverts attention to the code that caught the code and away from the source of the error.

This also makes the code cleaner and more readable.