### PR TITLE
Fix #1616: Provide posix.time strptime declaration & tests

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -30,11 +30,12 @@ object time {
   def localtime_r(time: Ptr[time_t], tm: Ptr[tm]): Ptr[tm] = extern
   @name("scalanative_mktime")
   def mktime(time: Ptr[tm]): time_t = extern
-  @name("scalanative_strftime")
   def strftime(str: Ptr[CChar],
                count: CSize,
                format: CString,
                time: Ptr[tm]): CSize = extern
+  def strptime(str: Ptr[CChar], format: CString, time: Ptr[tm]): CString =
+    extern
   def time(arg: Ptr[time_t]): time_t = extern
   def tzset(): Unit                  = extern
   @name("scalanative_daylight")

--- a/unit-tests/src/test/scala/scala/scalanative/posix/TimeSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/TimeSuite.scala
@@ -93,4 +93,95 @@ object TimeSuite extends tests.Suite {
       assert("Monday Mon Jan  1 00:00:00 1900".equals(dateString))
     }
   }
+
+  test(s"strptime() - detect invalid format") {
+    Zone { implicit z =>
+      val tmPtr = alloc[tm]
+
+      // %Q in format is invalid
+      val result =
+        strptime(c"December 31, 2016 23:59:60", c"%B %d, %Y %Q", tmPtr)
+
+      assert(result == null, s"expected null result, got pointer")
+    }
+  }
+
+  test(s"strptime() - detect invalid string") {
+    Zone { implicit z =>
+      val tmPtr = alloc[tm]
+
+      // 32 in string is invalid
+      val result =
+        strptime(c"December 32, 2016 23:59:60", c"%B %d, %Y %T", tmPtr)
+
+      assert(result == null, s"expected null result, got pointer")
+    }
+  }
+
+  test(s"strptime() - detect string shorter than format") {
+    Zone { implicit z =>
+      val tmPtr = alloc[tm]
+
+      val result =
+        strptime(c"December 32, 2016 23:59", c"%B %d, %Y %T", tmPtr)
+
+      assert(result == null, s"expected null result, got pointer")
+    }
+  }
+
+  test("strptime() for December 31, 2016 23:59:60") {
+    Zone { implicit z =>
+      val tmPtr = alloc[tm]
+
+      // A leap second was added at this time
+      val result =
+        strptime(c"December 31, 2016 23:59:60", c"%B %d, %Y %T", tmPtr)
+
+      assert(result != null, s"error: unexpected null returned")
+
+      val expectedYear = 116
+      assert(tmPtr.tm_year == expectedYear,
+             s"tm_year: ${tmPtr.tm_year} != expected: ${expectedYear}")
+
+      val expectedMonth = 11
+      assert(tmPtr.tm_mon == expectedMonth,
+             s"tm_mon: ${tmPtr.tm_mon} != expected: ${expectedMonth}")
+
+      val expectedMday = 31
+      assert(tmPtr.tm_mday == expectedMday,
+             s"tm_mon: ${tmPtr.tm_mday} != expected: ${expectedMday}")
+
+      val expectedHour = 23
+      assert(tmPtr.tm_hour == expectedHour,
+             s"tm_mon: ${tmPtr.tm_hour} != expected: ${expectedHour}")
+
+      val expectedMin = 59
+      assert(tmPtr.tm_min == expectedMin,
+             s"tm_min: ${tmPtr.tm_min} != expected: ${expectedMin}")
+
+      val expectedSec = 60
+      assert(tmPtr.tm_sec == expectedSec,
+             s"tm_sec: ${tmPtr.tm_sec} != expected: ${expectedSec}")
+
+      val expectedIsdst = 0
+      assert(tmPtr.tm_isdst == expectedIsdst,
+             s"tm_isdst: ${tmPtr.tm_isdst} != expected: ${expectedIsdst}")
+    }
+  }
+
+  test("strptime() -- extra text after date string is OK") {
+    Zone { implicit z =>
+      val tmPtr = alloc[tm]
+
+      val result =
+        strptime(c"December 31, 2016 23:59:60 UTC", c"%B %d, %Y %T ", tmPtr)
+
+      assert(result != null, s"error: null returned")
+
+      val expected = 'U'
+      assert(!result == expected,
+             s"character: ${!result} != expected: ${expected}")
+    }
+  }
+
 }


### PR DESCRIPTION
  * This pull request was motivated by Issue #1616
    "posix.time strptime method is missing".

    That issue is now fixed and four unit tests were added to the
    existing TimeSuite to exercise the declaration and method.

  * strptime is the converse of strftime. Scala Native has supported
    the latter for a year or so. Ubuntu "man strptime" describes
    strptime as compliant with several posix standard iterations
    but it may actually first appear in the posix follow on XOPEN
    standards.  Because of the usefulness of the method, I did
    not do too march archaeology. Most current developers would expect
    it to be supported, particularly if strftime was supported.

  * I believe the current standard for the posix sub-project is that
    clib functions which are basically straight pass-through do not
    require @name annotations.  For that reason, I did not add one
    for strptime.  Since strftime and strptime are so closely related
    I removed the existing @name annotation from the former.  This
    means that both use the same convention.

  * To focus attention on the current change, I did not do a sweep
    through and check if time.scala matches the current OpenGroup
    description for time.h.  Such a sweep should happen, as time
    allows.
 
 * scalafmt insists on doing something ugly/dumb with the formatting of
   strptime. I left it as scalafmt wrote it because a // format:off would
   probably be more disruptive to the reader.

Documentation:

  * The standard changelog entry is requested.

  * I checked the SN 0.4.0-M2 ReadTheDocs for posixlib and
      no change is necessary. This PR introduces a method inside
      an already listed file.

Testing:

  * Built and tested ("test-all") in debug mode using sbt 1.2.8 on
    X86_64 only . All tests pass.