### PR TITLE
Fix #1623: infinite loop in j.i.RandomAccessFile#readLine

### DIFF
--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -106,7 +106,7 @@ class RandomAccessFile private (file: File,
           case '\r' =>
             // If there's a newline after carriage-return, we must eat it too.
             if (pos < end) {
-              if (readChar() == '\n') {
+              if (readByte().toChar == '\n') {
                 pos += 1
               } else {
                 seek(getFilePointer - 1)

--- a/unit-tests/src/test/scala/java/io/RandomAccessFileSuite.scala
+++ b/unit-tests/src/test/scala/java/io/RandomAccessFileSuite.scala
@@ -79,7 +79,7 @@ object RandomAccessFileSuite extends tests.Suite {
   testWithRAF("Can write and read a whole line with terminator = '\\n'") {
     raf =>
       val line = "Hello, world!"
-      raf.writeChars(line + '\n')
+      raf.writeBytes(line + '\n')
       raf.seek(0)
       assert(raf.readLine() == line)
   }
@@ -87,7 +87,7 @@ object RandomAccessFileSuite extends tests.Suite {
   testWithRAF("Can write and read a whole line with terminator = '\\r'") {
     raf =>
       val line = "Hello, world!"
-      raf.writeChars(line + '\r')
+      raf.writeBytes(line + '\r')
       raf.seek(0)
       assert(raf.readLine() == line)
   }
@@ -95,7 +95,7 @@ object RandomAccessFileSuite extends tests.Suite {
   testWithRAF("Can write and read a whole line with terminator = '\\r\\n'") {
     raf =>
       val line = "Hello, world!"
-      raf.writeChars(line + "\r\n")
+      raf.writeBytes(line + "\r\n")
       raf.seek(0)
       assert(raf.readLine() == line)
   }

--- a/unit-tests/src/test/scala/java/io/RandomAccessFileSuite.scala
+++ b/unit-tests/src/test/scala/java/io/RandomAccessFileSuite.scala
@@ -81,23 +81,41 @@ object RandomAccessFileSuite extends tests.Suite {
       val line = "Hello, world!"
       raf.writeBytes(line + '\n')
       raf.seek(0)
-      assert(raf.readLine() == line)
+
+      val result = raf.readLine()
+
+      assert(result.length == line.length,
+             s"result length: ${result.length} != expected: ${line.length}")
+
+      assert(result == line, s"result: '${result}' != expected: '${line}'")
   }
 
   testWithRAF("Can write and read a whole line with terminator = '\\r'") {
     raf =>
       val line = "Hello, world!"
-      raf.writeBytes(line + '\r')
+      raf.writeBytes(line + '\n')
       raf.seek(0)
-      assert(raf.readLine() == line)
+
+      val result = raf.readLine()
+
+      assert(result.length == line.length,
+             s"result length: ${result.length} != expected: ${line.length}")
+
+      assert(result == line, s"result: '${result}' != expected: '${line}'")
   }
 
   testWithRAF("Can write and read a whole line with terminator = '\\r\\n'") {
     raf =>
       val line = "Hello, world!"
-      raf.writeBytes(line + "\r\n")
+      raf.writeBytes(line + '\n')
       raf.seek(0)
-      assert(raf.readLine() == line)
+
+      val result = raf.readLine()
+
+      assert(result.length == line.length,
+             s"result length: ${result.length} != expected: ${line.length}")
+
+      assert(result == line, s"result: '${result}' != expected: '${line}'")
   }
 
   testWithRAF("Can write and read a Long") { raf =>


### PR DESCRIPTION
  * This pull request was motivated by Issue #1623
    "j.i.RandomAccessFile loops forever".

    That issue is now fixed and the corresponding tests in
    RandomAccessFileSuite.scala corrected.

    Issue #1623 contained code which allows reproducing the issue.

  * The defect was readLine confusing two byte Java characters
    with one byte file characters. That is, it was not following the
    Java 8 description for readLine. That section describes reading
    one file byte and converting it to a two-byte Java character.

    The previous code was reading two bytes at a time. This would
    result in reaching end of file (EOF) prematurely. read() Code in
    the underlying DataInputStream.scala (DIS) is not properly throwing
    an EOFException.

    The RAF readByte() code appeared to not test the EOF actually
    returned by the DIS code. A double fault.  Correcting DIS
    will be handled in another PR.

    This mistaken EOF handling lead to the infinite loop.

  * RandomAccessFileSuite.scala existed and had three tests for the
    readLine method. Previously these tests passed because the
    write portion of the test had the same mistaken understanding
    of the required translation of Java characters to file bytes.

    The test would incorrectly write two bytes for each Java character
    instead of the now correct one byte. Then the test would
    read the file back in using readLine code which read two characters
    instead of one.  Test passed but inspecting the file shows
    that it contains garbage: a mangled "Hello World!".

  * If one follows the Java 8 documentation closely, the straight forward
    implementation is to catch any EOFException returned by underlying
    layers. Exceptions as flow control for expected and common events
    is expensive in Scala Native.

    Sufficient information was availble in readLine to allow the method
    to handle EOF by math rather than by Exception.

  * The underlying DataInputStream class has a readLine method. The
    Java 8 documentation describes that method as deprecated since
    Java 1.1, so RAF readLine was not implemented by delegation.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in debug mode using sbt 1.2.8 on
    X86_64 only . All tests pass.