### PR TITLE
Fix 2059:  Remove non-standard fcntl.close() & use proper unistd.close().

### DIFF
--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -5,7 +5,7 @@ import scalanative.unsigned._
 import scalanative.unsafe._
 import scalanative.libc._, stdlib._, stdio._, string._
 import scalanative.nio.fs.UnixException
-import scalanative.posix.unistd, unistd._
+import scalanative.posix.unistd
 import scalanative.runtime
 
 class FileInputStream(fd: FileDescriptor, file: Option[File])

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -5,7 +5,7 @@ import scalanative.unsigned._
 import scalanative.unsafe._
 import scalanative.libc._, stdlib._, stdio._, string._
 import scalanative.nio.fs.UnixException
-import scalanative.posix.unistd
+import scalanative.posix.unistd, unistd.lseek
 import scalanative.runtime
 
 class FileInputStream(fd: FileDescriptor, file: Option[File])

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -5,7 +5,7 @@ import scalanative.unsigned._
 import scalanative.unsafe._
 import scalanative.libc._, stdlib._, stdio._, string._
 import scalanative.nio.fs.UnixException
-import scalanative.posix.{fcntl, unistd}, unistd._
+import scalanative.posix.unistd, unistd._
 import scalanative.runtime
 
 class FileInputStream(fd: FileDescriptor, file: Option[File])
@@ -23,7 +23,7 @@ class FileInputStream(fd: FileDescriptor, file: Option[File])
   }
 
   override def close(): Unit =
-    fcntl.close(fd.fd)
+    unistd.close(fd.fd)
 
   override protected def finalize(): Unit =
     close()

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -17,7 +17,7 @@ class FileOutputStream(fd: FileDescriptor, file: Option[File] = None)
   def this(name: String) = this(new File(name))
 
   override def close(): Unit =
-    fcntl.close(fd.fd)
+    unistd.close(fd.fd)
 
   override protected def finalize(): Unit =
     close()

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -456,7 +456,7 @@ object Files {
       if (read == -1) throw UnixException(path.toString, errno.errno)
       bytes.asInstanceOf[Array[Byte]]
     } finally {
-      fcntl.close(fd)
+      unistd.close(fd)
     }
   }
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
@@ -11,8 +11,6 @@ object fcntl {
 
   def open(pathname: CString, flags: CInt, mode: mode_t): CInt = extern
 
-  def close(fd: CInt): CInt = extern
-
   def fcntl(fd: CInt, cmd: CInt, flags: CInt): CInt = extern
 
   @name("scalanative_f_dupfd")

--- a/unit-tests/src/test/scala/java/lang/ProcessTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ProcessTest.scala
@@ -59,13 +59,13 @@ class ProcessTest {
     val out =
       try {
         unistd.dup2(fd, unistd.STDOUT_FILENO)
-        fcntl.close(fd)
+        unistd.close(fd)
         val proc = new ProcessBuilder("ls", resourceDir).inheritIO().start()
         proc.waitFor(5, TimeUnit.SECONDS)
         readInputStream(new FileInputStream(f.toFile))
       } finally {
         unistd.dup2(savedFD, unistd.STDOUT_FILENO)
-        fcntl.close(savedFD)
+        unistd.close(savedFD)
       }
 
     assertEquals(scripts, out.split("\n").toSet)


### PR DESCRIPTION
We remove the declaration of fcntl.close(), which is not in any POSIX standard, and correct
all references.