### PR TITLE
Fix #1559: Float & Double Strings with trailing type designation now parse

### DIFF
--- a/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
@@ -201,6 +201,37 @@ object DoubleSuite extends tests.Suite {
     assertThrows[NumberFormatException](Double.parseDouble("0.potato"))
   }
 
+  test("parseDouble - trailing characters, Issue #1559") {
+    // Normally floating point comparisons would be within a specified epsilon
+    // not exact equality.  In this test block the exact equality is
+    // intended & proper.
+
+    assert(Double.parseDouble("8   ") == 8.0, s"'8    ' failed")
+    assert(Double.parseDouble("+8") == 8.0, s"'+8' failed")
+    assert(Double.parseDouble("+8   ") == 8.0, s"'+8    ' failed")
+
+    assert(Double.parseDouble("+99.93    ") == 99.93, s"'+99.93    ' failed")
+
+    assert(Double.parseDouble("2.0E+2D") == 200.0, s"'2.0E+2D' failed")
+
+    assert(Double.parseDouble("2.0d") == 2.0, s"'2.0D' failed")
+
+    assert(Double.parseDouble("-3.14F") == -3.14, s"'-3.14F' failed")
+
+    assert(Double.parseDouble("-3.14f") == -3.14, s"'-3.14f' failed")
+
+    // Yes, JVM accepts trailing blanks for Double/Float (but not Integer)
+    assert(Double.parseDouble("2.9D    ") == 2.9, s"'2.9D    ' failed")
+
+    assertThrows[NumberFormatException](Double.parseDouble("2.9 D"))
+
+    assertThrows[NumberFormatException](Double.parseDouble("2.9D0"))
+
+    assertThrows[NumberFormatException](Double.parseDouble("2.8D 0  "))
+
+    assertThrows[NumberFormatException](Double.parseDouble("2.8D D"))
+  }
+
   // scala.Double passes -0.0d without change. j.l.Double gets forced to +0.0.
   private def assertD2sEquals(expected: String, f: scala.Double): Unit = {
     val result = f.toString

--- a/unit-tests/src/test/scala/java/lang/FloatSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/FloatSuite.scala
@@ -196,6 +196,37 @@ object FloatSuite extends tests.Suite {
     assertThrows[NumberFormatException](Float.parseFloat("0.potato"))
   }
 
+  test("parseFloat - trailing characters, Issue #1559") {
+    // Normally floating point comparisons would be within a specified epsilon
+    // not exact equality.  In this test block the exact equality is
+    // intended & proper.
+
+    assert(Float.parseFloat("8   ") == 8.0d, s"'8    ' failed")
+    assert(Float.parseFloat("+8") == 8.0f, s"'+8' failed")
+    assert(Float.parseFloat("+8   ") == 8.0f, s"'+8    ' failed")
+
+    assert(Float.parseFloat("+99.93    ") == 99.93f, s"'+99.93    ' failed")
+
+    assert(Float.parseFloat("2.0E+2D") == 200.0f, s"'2.0E+2D' failed")
+
+    assert(Float.parseFloat("2.0d") == 2.0f, s"'2.0D' failed")
+
+    assert(Float.parseFloat("-3.14F") == -3.14f, s"'-3.14F' failed")
+
+    assert(Float.parseFloat("-3.14f") == -3.14f, s"'-3.14f' failed")
+
+    // Yes, JVM accepts trailing blanks for Float/Float (but not Integer)
+    assert(Float.parseFloat("2.9F    ") == 2.9f, s"'2.9F    ' failed")
+
+    assertThrows[NumberFormatException](Float.parseFloat("2.9 F"))
+
+    assertThrows[NumberFormatException](Float.parseFloat("2.9F0"))
+
+    assertThrows[NumberFormatException](Float.parseFloat("2.8F 0  "))
+
+    assertThrows[NumberFormatException](Float.parseFloat("2.8F F"))
+  }
+
   // scala.Float passes -0.0F without change. j.l.Double forced to +0.0.
   private def assertF2sEquals(expected: String, f: scala.Float): Unit = {
     val result = f.toString


### PR DESCRIPTION

* This PR fixes Issue #1559 "toFloat/toDouble throw `NumberFormatException`
  when given trailing designation".

  My thanks to @teodimoff for detecting & reporting this issue.

  Strings such as "3.14f".toDouble and "3.14D".toFloat are now accepted in
  the same way they are in Java 8.

* Notes on trailing characters:

     + One line comments in each of Double.scala & Float.scala refer to this
        note.

     + Java 8 allows trailing upper & lower case "F" & "D", but not "L" or "I"

     + Java 8 also appears to allow arbitrary whitespace at the right
        of the string.  I could find no documentation describing or allowing
       it, but it certainly is the de facto rule..

       Not only are one or more spaces and horizontal tabs
       accepted but, in my experiments carriage return and form_feed/vertical_tab
       were also.  I did not test the entire menagerie of non-printing
       characters and went with allowing any character for which
       Java Character.isWhitespace return true.

* Any NumberFormatException thrown now uses the Java 8 idiom of
  echoing the input string within quotes: 'For input string: "+9z.93"'.
  This allows one to detect trailing whitespace.

* Unit tests were added to DoubleSuite.scala and FloatSuite.scala to
  exercise the parsing of Strings with trailing type designators and/or
  whitespace.

* The simplest rule is to say that toDouble/toFloat accept only Latin_1 characters
  in the C Locale.  That is, no Unicode, no commas for decimal seperators & etceteras.

  The trailing whitespace check may allow some Unicode whitespace characters
  to parse.  I did nothing to either facilitate or prevent that.

Documentation:

* The standard changelog entry is requested.

Testing:

* Built and tested ("test-all") in debug mode using sbt 1.2.8 on
    X86_64 only . All tests pass.