### PR TITLE
Increase ByteBuffer size

### DIFF
--- a/util/src/main/scala/scala/scalanative/io/ByteBufferPool.scala
+++ b/util/src/main/scala/scala/scalanative/io/ByteBufferPool.scala
@@ -7,7 +7,7 @@ final class ByteBufferPool {
   private var buffers: List[ByteBuffer] = Nil
 
   private def alloc(): ByteBuffer = {
-    ByteBuffer.allocateDirect(8 * 1024 * 1024)
+    ByteBuffer.allocateDirect(32 * 1024 * 1024)
   }
 
   def reclaim(buffer: ByteBuffer): Unit = synchronized {


### PR DESCRIPTION
My project [ONNX-Scala](https://github.com/EmergentOrder/onnx-scala) fails with `java.nio.BufferOverflowException` when compiling with scala-native. 
No doubt others will encounter this as well.
Publishing scala-native locally with this change solved it.