### PR TITLE
WIP: Fix #1646: posix lib sys/resource.scala needs implementation

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -65,7 +65,7 @@ C Header          Scala Native Module
 `sys/ipc.h`_      N/A
 `sys/mman.h`_     N/A
 `sys/msg.h`_      N/A
-`sys/resource.h`_ N/A
+`sys/resource.h`_ scala.scalanative.posix.sys.resource_
 `sys/select.h`_   scala.scalanative.posix.sys.select_
 `sys/sem.h`_      N/A
 `sys/shm.h`_      N/A
@@ -196,6 +196,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.regex: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/regex.scala
 .. _scala.scalanative.posix.sched: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/sched.scala
 .. _scala.scalanative.posix.stdlib: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
+.. _scala.scalanative.posix.sys.resource: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
 .. _scala.scalanative.posix.sys.select: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
 .. _scala.scalanative.posix.sys.socket: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
 .. _scala.scalanative.posix.sys.stat: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala

--- a/nativelib/src/main/resources/posix/sys/resource.c
+++ b/nativelib/src/main/resources/posix/sys/resource.c
@@ -63,32 +63,32 @@ int scalanative_setrlimit(int resource, struct scalanative_rlimit *snRlim) {
     return status;
 }
 
-int scalanative_PRIO_PROCESS() { return PRIO_PROCESS; };
+int scalanative_prio_process() { return PRIO_PROCESS; };
 
-int scalanative_PRIO_PGRP() { return PRIO_PGRP; };
+int scalanative_prio_pgrp() { return PRIO_PGRP; };
 
-int scalanative_PRIO_USER() { return PRIO_USER; };
+int scalanative_prio_user() { return PRIO_USER; };
 
-rlim_t scalanative_RLIM_INFINITY() { return RLIM_INFINITY; };
+rlim_t scalanative_rlim_infinity() { return RLIM_INFINITY; };
 
-rlim_t scalanative_RLIM_SAVED_CUR() { return RLIM_SAVED_CUR; };
+rlim_t scalanative_rlim_saved_cur() { return RLIM_SAVED_CUR; };
 
-rlim_t scalanative_RLIM_SAVED_MAX() { return RLIM_SAVED_MAX; };
+rlim_t scalanative_rlim_saved_max() { return RLIM_SAVED_MAX; };
 
-int scalanative_RLIMIT_AS() { return RLIMIT_AS; };
+int scalanative_rlimit_as() { return RLIMIT_AS; };
 
-int scalanative_RLIMIT_CORE() { return RLIMIT_CORE; };
+int scalanative_rlimit_core() { return RLIMIT_CORE; };
 
-int scalanative_RLIMIT_CPU() { return RLIMIT_CPU; };
+int scalanative_rlimit_cpu() { return RLIMIT_CPU; };
 
-int scalanative_RLIMIT_DATA() { return RLIMIT_DATA; };
+int scalanative_rlimit_data() { return RLIMIT_DATA; };
 
-int scalanative_RLIMIT_FSIZE() { return RLIMIT_FSIZE; };
+int scalanative_rlimit_fsize() { return RLIMIT_FSIZE; };
 
-int scalanative_RLIMIT_NOFILE() { return RLIMIT_NOFILE; };
+int scalanative_rlimit_nofile() { return RLIMIT_NOFILE; };
 
-int scalanative_RLIMIT_STACK() { return RLIMIT_STACK; };
+int scalanative_rlimit_stack() { return RLIMIT_STACK; };
 
-int scalanative_RUSAGE_CHILDREN() { return RUSAGE_CHILDREN; };
+int scalanative_rusage_children() { return RUSAGE_CHILDREN; };
 
-int scalanative_RUSAGE_SELF() { return RUSAGE_SELF; };
+int scalanative_rusage_self() { return RUSAGE_SELF; };

--- a/nativelib/src/main/resources/posix/sys/resource.c
+++ b/nativelib/src/main/resources/posix/sys/resource.c
@@ -1,0 +1,94 @@
+#include <sys/resource.h>
+
+struct scalanative_rlimit {
+    rlim_t rlim_cur;
+    rlim_t rlim_max;
+};
+
+struct scalanative_rusage {
+    struct timeval ru_utime;
+    struct timeval ru_stime;
+};
+
+static void convert_from_scalanative_rlimit(struct scalanative_rlimit *in,
+                                            struct rlimit *out) {
+    out->rlim_cur = in->rlim_cur;
+    out->rlim_max = in->rlim_max;
+}
+
+static void convert_to_scalanative_rlimit(struct rlimit *in,
+                                          struct scalanative_rlimit *out) {
+    out->rlim_cur = in->rlim_cur;
+    out->rlim_max = in->rlim_max;
+}
+
+static void convert_to_scalanative_rusage(struct rusage *in,
+                                          struct scalanative_rusage *out) {
+    out->ru_utime = in->ru_utime;
+    out->ru_stime = in->ru_stime;
+}
+
+int scalanative_getrlimit(int resource, struct scalanative_rlimit *snRlim) {
+    struct rlimit rlim;
+
+    int status = getrlimit(resource, &rlim);
+
+    if (status >= 0) {
+        convert_to_scalanative_rlimit(&rlim, snRlim);
+    } // contents at snRlim undefined on error.
+
+    return status;
+}
+
+int scalanative_getrusage(int who, struct scalanative_rusage *snUsage) {
+    struct rusage usage;
+
+    int status = getrusage(who, &usage);
+
+    if (status >= 0) {
+        convert_to_scalanative_rusage(&usage, snUsage);
+    } // contents at snUsage undefined on error.
+
+    return status;
+}
+
+int scalanative_setrlimit(int resource, struct scalanative_rlimit *snRlim) {
+
+    struct rlimit rlim;
+
+    convert_from_scalanative_rlimit(snRlim, &rlim);
+
+    int status = setrlimit(resource, &rlim);
+
+    return status;
+}
+
+int scalanative_PRIO_PROCESS() { return PRIO_PROCESS; };
+
+int scalanative_PRIO_PGRP() { return PRIO_PGRP; };
+
+int scalanative_PRIO_USER() { return PRIO_USER; };
+
+rlim_t scalanative_RLIM_INFINITY() { return RLIM_INFINITY; };
+
+rlim_t scalanative_RLIM_SAVED_CUR() { return RLIM_SAVED_CUR; };
+
+rlim_t scalanative_RLIM_SAVED_MAX() { return RLIM_SAVED_MAX; };
+
+int scalanative_RLIMIT_AS() { return RLIMIT_AS; };
+
+int scalanative_RLIMIT_CORE() { return RLIMIT_CORE; };
+
+int scalanative_RLIMIT_CPU() { return RLIMIT_CPU; };
+
+int scalanative_RLIMIT_DATA() { return RLIMIT_DATA; };
+
+int scalanative_RLIMIT_FSIZE() { return RLIMIT_FSIZE; };
+
+int scalanative_RLIMIT_NOFILE() { return RLIMIT_NOFILE; };
+
+int scalanative_RLIMIT_STACK() { return RLIMIT_STACK; };
+
+int scalanative_RUSAGE_CHILDREN() { return RUSAGE_CHILDREN; };
+
+int scalanative_RUSAGE_SELF() { return RUSAGE_SELF; };

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
@@ -41,50 +41,49 @@ object resource {
   def setrlimit(resource: CInt, rlim: Ptr[rlimit]): CInt = extern
 
   // Constants
-
-  @name("scalanative_PRIO_PROCESS")
+  @name("scalanative_prio_process")
   def PRIO_PROCESS: CInt = extern
 
-  @name("scalanative_PRIO_PGRP")
+  @name("scalanative_prio_pgrp")
   def PRIO_PGRP: CInt = extern
 
-  @name("scalanative_PRIO_USER")
+  @name("scalanative_prio_user")
   def PRIO_USER: CInt = extern
 
-  @name("scalanative_RLIM_INFINITY")
+  @name("scalanative_rlim_infinity")
   def RLIM_INFINITY: rlim_t = extern
 
-  @name("scalanative_RLIM_SAVED_CUR")
+  @name("scalanative_rlim_saved_cur")
   def RLIM_SAVED_CUR: rlim_t = extern
 
-  @name("scalanative_RLIM_SAVED_MAX")
+  @name("scalanative_rlim_saved_max")
   def RLIM_SAVED_MAX: rlim_t = extern
 
-  @name("scalanative_RLIMIT_AS")
+  @name("scalanative_rlimit_as")
   def RLIMIT_AS: CInt = extern
 
-  @name("scalanative_RLIMIT_CORE")
+  @name("scalanative_rlimit_core")
   def RLIMIT_CORE: CInt = extern
 
-  @name("scalanative_RLIMIT_CPU")
+  @name("scalanative_rlimit_cpu")
   def RLIMIT_CPU: CInt = extern
 
-  @name("scalanative_RLIMIT_DATA")
+  @name("scalanative_rlimit_data")
   def RLIMIT_DATA: CInt = extern
 
-  @name("scalanative_RLIMIT_FSIZE")
+  @name("scalanative_rlimit_fsize")
   def RLIMIT_FSIZE: CInt = extern
 
-  @name("scalanative_RLIMIT_NOFILE")
+  @name("scalanative_rlimit_nofile")
   def RLIMIT_NOFILE: CInt = extern
 
-  @name("scalanative_RLIMIT_STACK")
+  @name("scalanative_rlimit_stack")
   def RLIMIT_STACK: CInt = extern
 
-  @name("scalanative_RUSAGE_CHILDREN")
+  @name("scalanative_rusage_children")
   def RUSAGE_CHILDREN: CInt = extern
 
-  @name("scalanative_RUSAGE_SELF")
+  @name("scalanative_rusage_self")
   def RUSAGE_SELF: CInt = extern
 
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
@@ -1,0 +1,110 @@
+package scala.scalanative
+package posix
+package sys
+
+// Reference:
+//   The Open Group Base Specifications Issue 7, 2018 edition
+//   https://pubs.opengroup.org/onlinepubs/9699919799/basedefs\
+//       /sys_resource.h.html
+//
+//   Method argument names come from Ubuntu 19.04 linux man pages.
+//   Open Group seems to no longer suggest them.
+
+import scalanative.unsafe.{CInt, CStruct2, CUnsignedLongInt, Ptr, name, extern}
+
+@extern
+object resource {
+
+  type id_t = sys.types.id_t
+
+  type rlim_t = CUnsignedLongInt
+
+  type timeval = sys.time.timeval
+
+  type rlimit = CStruct2[rlim_t, // rlim_cur
+                         rlim_t] // rlim_max
+
+  type rusage = CStruct2[timeval, // ru_utime
+                         timeval] // ru_stime
+
+  def getpriority(which: CInt, who: id_t): CInt = extern
+
+  @name("scalanative_getrlimit")
+  def getrlimit(resource: CInt, rlim: Ptr[rlimit]): CInt = extern
+
+  @name("scalanative_getrusage")
+  def getrusage(who: CInt, usage: Ptr[rusage]): CInt = extern
+
+  def setpriority(which: CInt, who: id_t, prio: CInt): CInt = extern
+
+  @name("scalanative_setrlimit")
+  def setrlimit(resource: CInt, rlim: Ptr[rlimit]): CInt = extern
+
+  // Constants
+
+  @name("scalanative_PRIO_PROCESS")
+  def PRIO_PROCESS: CInt = extern
+
+  @name("scalanative_PRIO_PGRP")
+  def PRIO_PGRP: CInt = extern
+
+  @name("scalanative_PRIO_USER")
+  def PRIO_USER: CInt = extern
+
+  @name("scalanative_RLIM_INFINITY")
+  def RLIM_INFINITY: rlim_t = extern
+
+  @name("scalanative_RLIM_SAVED_CUR")
+  def RLIM_SAVED_CUR: rlim_t = extern
+
+  @name("scalanative_RLIM_SAVED_MAX")
+  def RLIM_SAVED_MAX: rlim_t = extern
+
+  @name("scalanative_RLIMIT_AS")
+  def RLIMIT_AS: CInt = extern
+
+  @name("scalanative_RLIMIT_CORE")
+  def RLIMIT_CORE: CInt = extern
+
+  @name("scalanative_RLIMIT_CPU")
+  def RLIMIT_CPU: CInt = extern
+
+  @name("scalanative_RLIMIT_DATA")
+  def RLIMIT_DATA: CInt = extern
+
+  @name("scalanative_RLIMIT_FSIZE")
+  def RLIMIT_FSIZE: CInt = extern
+
+  @name("scalanative_RLIMIT_NOFILE")
+  def RLIMIT_NOFILE: CInt = extern
+
+  @name("scalanative_RLIMIT_STACK")
+  def RLIMIT_STACK: CInt = extern
+
+  @name("scalanative_RUSAGE_CHILDREN")
+  def RUSAGE_CHILDREN: CInt = extern
+
+  @name("scalanative_RUSAGE_SELF")
+  def RUSAGE_SELF: CInt = extern
+
+}
+
+object resourceOps {
+
+  import resource.{rlimit, rlim_t, rusage, timeval}
+
+  implicit class rlimitOps(val ptr: Ptr[rlimit]) extends AnyVal {
+    def rlim_cur: rlim_t            = ptr._1
+    def rlim_max: rlim_t            = ptr._2
+    def rlim_cur_=(v: rlim_t): Unit = ptr._1 = v
+    def rlim_max_=(v: rlim_t): Unit = ptr._2 = v
+  }
+
+  implicit class rusageOps(val ptr: Ptr[rusage]) extends AnyVal {
+    def ru_utime: timeval            = ptr._1
+    def ru_stime: timeval            = ptr._2
+    def ru_utime_=(v: timeval): Unit = ptr._1 = v
+    def ru_stime_=(v: timeval): Unit = ptr._2 = v
+  }
+
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/time.scala
@@ -22,4 +22,12 @@ object timeOps {
     def tv_sec_=(v: time_t): Unit       = ptr._1 = v
     def tv_usec_=(v: suseconds_t): Unit = ptr._2 = v
   }
+
+  implicit class timevalValOps(val tv: timeval) extends AnyVal {
+    def tv_sec: time_t                  = tv._1
+    def tv_usec: suseconds_t            = tv._2
+    def tv_sec_=(v: time_t): Unit       = tv._1 = v
+    def tv_usec_=(v: suseconds_t): Unit = tv._2 = v
+  }
+
 }

--- a/unit-tests/src/test/scala/scala/scalanative/posix/sys/ResourceSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/sys/ResourceSuite.scala
@@ -1,0 +1,193 @@
+package scala.scalanative
+package posix
+package sys
+
+import scalanative.libc.errno
+import scalanative.posix.errno._
+import scalanative.unsafe.{CInt, Ptr, Zone, alloc}
+import scalanative.unsigned._
+
+import resource._, resourceOps._
+import timeOps._
+
+// Design notes:
+//
+//   * The two methods setpriority() & setrlimit() make changes to the
+//     process execution environment. For that reason they are not tested
+//     here.
+//
+//     unit-tests run sequentially in the same process, so a change caused
+//     by either of those methods could affect later tests in ways that are
+//     hard to trace.
+//
+//     A save/restore approach is possible, but works only with _exqusite_
+//     care that the restore is _always_executed, even on error. Too fragile
+//     for now.
+//
+//   * The intent here is not to be exhaustive but rather to exercise
+//     expected common sucess & failure paths for each method.
+
+object ResourceSuite extends tests.Suite {
+
+  case class TestInfo(name: String, value: CInt)
+
+  test("getpriority(which, who) - invalid arg: which") {
+
+    errno.errno = 0
+
+    val result = getpriority(-1, 0.toUInt)
+
+    assert(((result == -1) && (errno.errno != 0)),
+           s"Unexpected success result: ${result}")
+
+    val expected = EINVAL
+    assert(errno.errno == expected,
+           s"errno: ${errno.errno} != expected: ${expected}")
+  }
+
+  test("getpriority(which, who) - invalid arg: who") {
+
+    errno.errno = 0
+
+    val result = getpriority(PRIO_PROCESS, -1.toUInt)
+
+    assert(((result == -1) && (errno.errno != 0)),
+           s"Unexpected success result: ${result}")
+
+    val expected = ESRCH
+    assert(errno.errno == expected,
+           s"errno: ${errno.errno} != expected: ${expected}")
+  }
+
+  test("getpriority(which, who)") {
+
+    // format: off
+    val cases = Array(TestInfo("PRIO_PROCESS", PRIO_PROCESS),
+                      TestInfo("PRIO_PGRP",    PRIO_PGRP),
+                      TestInfo("PRIO_USER",    PRIO_USER)
+                     )
+    // format: on
+
+    for (c <- cases) {
+      errno.errno = 0
+
+      val result = getpriority(c.value, 0.toUInt)
+
+      assert(errno.errno == 0, s"errno: ${errno.errno} != expected: 0")
+
+      // Beware: these are linux un-nice "nice" priorities,
+      // where -20 is least "nice", so highest priority.
+      assert(((result >= -20) && (result <= 19)),
+             s"${c.name} result: ${result} not in inclusive range [-20, 19]")
+    }
+  }
+
+  test("getrlimit(resource, rlim) - invalid arg: resource") {
+    Zone { implicit z =>
+      val rlimPtr = alloc[rlimit]
+
+      val result = getrlimit(Integer.MAX_VALUE, rlimPtr)
+
+      val expectedResult = -1
+      assert(result == expectedResult,
+             s"result: ${result} != expected: ${expectedResult}")
+
+      val expectedErrno = EINVAL
+      assert(errno.errno == expectedErrno,
+             s"errno: ${errno.errno} != expected: ${expectedErrno}")
+    }
+
+  }
+
+  test("getrlimit(resource, rlim)") {
+    Zone { implicit z =>
+      // format: off
+      val cases = Array(TestInfo("RLIMIT_AS",     RLIMIT_AS),
+                        TestInfo("RLIMIT_CORE",   RLIMIT_CORE),
+                        TestInfo("RLIMIT_CPU",    RLIMIT_CPU),
+                        TestInfo("RLIMIT_DATA",   RLIMIT_DATA),
+                        TestInfo("RLIMIT_FSIZE",  RLIMIT_FSIZE),
+                        TestInfo("RLIMIT_NOFILE", RLIMIT_NOFILE),
+                        TestInfo("RLIMIT_STACK",  RLIMIT_STACK)
+                        )
+      // format: on
+
+      for (c <- cases) {
+        val rlimPtr = alloc[rlimit] // start each pass with all bytes 0.
+
+        val result = getrlimit(c.value, rlimPtr)
+
+        assert(result == 0, s"${c.name} result: ${result} != expected: 0")
+
+        // Coarse grain sanity checks. Do better someday.
+        assert(rlimPtr.rlim_cur >= 0.toUInt,
+               s"${c.name} rlim_cur: ${rlimPtr.rlim_cur} < 0")
+
+        assert(rlimPtr.rlim_max >= 0.toUInt,
+               s"${c.name} rlim_max: ${rlimPtr.rlim_max} < 0")
+
+        assert(rlimPtr.rlim_cur <= rlimPtr.rlim_max,
+               s"${c.name} rlim_cur > rlim_max")
+      }
+    }
+  }
+
+  test("getrusage(who, usage) - invalid arg: who") {
+    Zone { implicit z =>
+      val rusagePtr = alloc[rusage]
+
+      val result = getrusage(Integer.MIN_VALUE, rusagePtr)
+
+      assert(result == -1, s"Unexpected success result: ${result}")
+
+      val expected = EINVAL
+
+      assert(errno.errno == expected,
+             s"errno: ${errno.errno} != expected: ${expected}")
+    }
+  }
+
+  test("getrusage(who, usage) - RUSAGE_SELF") {
+    Zone { implicit z =>
+      val rusagePtr = alloc[rusage]
+
+      val result = getrusage(RUSAGE_SELF, rusagePtr)
+
+      assert(result == 0, s"result: ${result} != expected: 0")
+
+      assert(rusagePtr.ru_utime.tv_sec >= 0,
+             s"unexpected ru_utime.tv_sec: ${rusagePtr.ru_utime.tv_sec} < 0")
+
+      val MICROS_PER_SECOND = 1000 * 1000
+
+      val utUsec = rusagePtr.ru_utime.tv_usec
+      assert((utUsec >= 0) && (utUsec < MICROS_PER_SECOND),
+             s"unexpected ru_utime: ${rusagePtr.ru_utime.tv_sec} " +
+               s"${rusagePtr.ru_utime.tv_usec}")
+
+      val stUsec = rusagePtr.ru_stime.tv_usec
+      assert((stUsec >= 0) && (stUsec < MICROS_PER_SECOND),
+             s"unexpected ru_stime: ${rusagePtr.ru_utime.tv_sec} " +
+               s"${rusagePtr.ru_utime.tv_usec}")
+    }
+  }
+
+  test("getrusage(who, usage) - RUSAGE_CHILDREN") {
+    Zone { implicit z =>
+      val rusagePtr = alloc[rusage]
+
+      val result = getrusage(RUSAGE_CHILDREN, rusagePtr)
+
+      assert(result == 0, s"result: ${result} != expected: 0")
+
+      // tv_sec could validly be 0 if either no descendents
+      // have been created or descendents were created but
+      // all completed quickly.
+
+      assert(rusagePtr.ru_utime.tv_sec >= 0, s"unexpected ru_utime.tv_sec < 0")
+
+      assert(rusagePtr.ru_stime.tv_sec >= 0, s"unexpected ru_stime.tv_sec < 0")
+    }
+  }
+
+}


### PR DESCRIPTION
* This PR fixes Issue #1646 "posix lib sys/resource.scala needs
  implementation".

* The test suite `scalanative/posix/sys/ResourceSuite.scala` was created
  to validate the new resource.scala.

* The implicit class `timevalValOps` was added to `posix/sys/time.scala`
  to allow working with timeval fields by name rather than _N.
  This is similar to the existing `timevalOps` but works with type
  `timeval` rather than `Ptr[timeval]`.

Documentation:

* The standard changelog entry is requested.

* `docs/lib/posixlib.rst` now describes sys/resource.h as supported.

Testing:

* Built and tested ("test-all") in debug mode using sbt 1.2.8 on
  X86_64 only . All tests pass.

* Method setrlimit() is not tested in ResourceSuite.scala because it
  would 'dirty' the execution environment for the unit-tests process.

  The next PR in this series should exercise setrlimit() by setting the
  maximum number of files low in order to test running out of
  available file descriptors. See Issue #1644
  "j.i.RandomAccessFile & j.i.FileInputStream mishandle fcntl.open errors".