### PR TITLE
Fix #1644: Java I/O now checks fcntl.open result & reports errno; requires PR #1635

### DIFF
--- a/javalib/src/main/scala/java/io/FileDescriptor.scala
+++ b/javalib/src/main/scala/java/io/FileDescriptor.scala
@@ -1,9 +1,10 @@
 package java.io
 
-import scala.scalanative.unsigned._
-import scala.scalanative.unsafe._
+import scalanative.unsigned._
+import scalanative.unsafe._
+import scalanative.io.FcntlHelpers.checkedOpen
 import scalanative.libc.{errno, string}
-import scala.scalanative.posix.{fcntl, unistd}
+import scalanative.posix.{fcntl, unistd}
 
 /** Wraps a UNIX file descriptor */
 final class FileDescriptor private[java] (private[java] val fd: Int,
@@ -33,13 +34,8 @@ object FileDescriptor {
   val out: FileDescriptor = new FileDescriptor(unistd.STDOUT_FILENO)
   val err: FileDescriptor = new FileDescriptor(unistd.STDERR_FILENO)
 
-  private[io] def openReadOnly(file: File): FileDescriptor =
-    Zone { implicit z =>
-      val fd = fcntl.open(toCString(file.getPath), fcntl.O_RDONLY, 0.toUInt)
-      if (fd == -1) {
-        throw new FileNotFoundException(
-          s"${file} (${fromCString(string.strerror(errno.errno))})")
-      }
-      new FileDescriptor(fd, true)
-    }
+  private[io] def openReadOnly(file: File): FileDescriptor = {
+    val fd = checkedOpen(file.getPath, fcntl.O_RDONLY, 0.toUInt)
+    new FileDescriptor(fd, true)
+  }
 }

--- a/javalib/src/main/scala/java/io/FileDescriptor.scala
+++ b/javalib/src/main/scala/java/io/FileDescriptor.scala
@@ -2,6 +2,7 @@ package java.io
 
 import scala.scalanative.unsigned._
 import scala.scalanative.unsafe._
+import scalanative.libc.{errno, string}
 import scala.scalanative.posix.{fcntl, unistd}
 
 /** Wraps a UNIX file descriptor */
@@ -36,7 +37,8 @@ object FileDescriptor {
     Zone { implicit z =>
       val fd = fcntl.open(toCString(file.getPath), fcntl.O_RDONLY, 0.toUInt)
       if (fd == -1) {
-        throw new FileNotFoundException("No such file " + file.getPath)
+        throw new FileNotFoundException(
+          s"${file} (${fromCString(string.strerror(errno.errno))})")
       }
       new FileDescriptor(fd, true)
     }

--- a/javalib/src/main/scala/java/io/FileDescriptor.scala
+++ b/javalib/src/main/scala/java/io/FileDescriptor.scala
@@ -2,7 +2,7 @@ package java.io
 
 import scalanative.unsigned._
 import scalanative.unsafe._
-import scalanative.io.FcntlHelpers.checkedOpen
+import scalanative.io.FcntlHelpers.fcntlOpenOrThrow
 import scalanative.libc.{errno, string}
 import scalanative.posix.{fcntl, unistd}
 
@@ -35,7 +35,7 @@ object FileDescriptor {
   val err: FileDescriptor = new FileDescriptor(unistd.STDERR_FILENO)
 
   private[io] def openReadOnly(file: File): FileDescriptor = {
-    val fd = checkedOpen(file.getPath, fcntl.O_RDONLY, 0.toUInt)
+    val fd = fcntlOpenOrThrow(file.getPath, fcntl.O_RDONLY, 0.toUInt)
     new FileDescriptor(fd, true)
   }
 }

--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -1,6 +1,7 @@
 package java.io
 
 import scalanative.unsafe.{fromCString, toCString, Zone}
+import scalanative.io.FcntlHelpers.checkedOpen
 import scalanative.libc.{errno, stdio, string}
 import scalanative.posix.{fcntl, unistd}
 import scalanative.posix.sys.stat
@@ -223,11 +224,7 @@ private object RandomAccessFile {
             s"""Illegal mode "${_flags}" must be one of "r", "rw", "rws" or "rwd"""")
       }
       val mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
-      val fd   = open(toCString(file.getPath), flags, mode)
-      if (fd == -1) {
-        throw new FileNotFoundException(
-          s"${file} (${fromCString(string.strerror(errno.errno))})")
-      }
+      val fd   = checkedOpen(file.getPath, flags, mode)
       new FileDescriptor(fd)
     }
 

--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -1,7 +1,7 @@
 package java.io
 
-import scalanative.unsafe.{toCString, Zone}
-import scalanative.libc.stdio
+import scalanative.unsafe.{fromCString, toCString, Zone}
+import scalanative.libc.{errno, stdio, string}
 import scalanative.posix.{fcntl, unistd}
 import scalanative.posix.sys.stat
 
@@ -224,6 +224,10 @@ private object RandomAccessFile {
       }
       val mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
       val fd   = open(toCString(file.getPath), flags, mode)
+      if (fd == -1) {
+        throw new FileNotFoundException(
+          s"${file} (${fromCString(string.strerror(errno.errno))})")
+      }
       new FileDescriptor(fd)
     }
 

--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -1,7 +1,7 @@
 package java.io
 
 import scalanative.unsafe.{fromCString, toCString, Zone}
-import scalanative.io.FcntlHelpers.checkedOpen
+import scalanative.io.FcntlHelpers.fcntlOpenOrThrow
 import scalanative.libc.{errno, stdio, string}
 import scalanative.posix.{fcntl, unistd}
 import scalanative.posix.sys.stat
@@ -224,7 +224,7 @@ private object RandomAccessFile {
             s"""Illegal mode "${_flags}" must be one of "r", "rw", "rws" or "rwd"""")
       }
       val mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
-      val fd   = checkedOpen(file.getPath, flags, mode)
+      val fd   = fcntlOpenOrThrow(file.getPath, flags, mode)
       new FileDescriptor(fd)
     }
 

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -39,6 +39,7 @@ import scalanative.unsafe._
 import scalanative.libc._
 import scalanative.posix.{dirent, fcntl, limits, unistd}, dirent._
 import scalanative.posix.sys.stat
+import scalanative.io.FcntlHelpers.checkedOpen
 import scalanative.nio.fs.{FileHelpers, UnixException}
 
 import scala.collection.immutable.{Map => SMap, Stream => SStream, Set => SSet}
@@ -115,7 +116,6 @@ object Files {
       out.write(value)
       written += 1
     }
-
     written
   }
 
@@ -452,12 +452,7 @@ object Files {
     val len   = pathSize.toInt
     val bytes = scala.scalanative.runtime.ByteArray.alloc(len)
 
-    val fd = fcntl.open(toCString(path.toString), fcntl.O_RDONLY, 0.toUInt)
-
-    if (fd == -1) {
-      throw new FileNotFoundException(
-        s"${path} (${fromCString(string.strerror(errno.errno))})")
-    }
+    val fd = checkedOpen(path.toString, fcntl.O_RDONLY, 0.toUInt)
 
     try {
       var offset = 0

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -39,7 +39,7 @@ import scalanative.unsafe._
 import scalanative.libc._
 import scalanative.posix.{dirent, fcntl, limits, unistd}, dirent._
 import scalanative.posix.sys.stat
-import scalanative.io.FcntlHelpers.checkedOpen
+import scalanative.io.FcntlHelpers.fcntlOpenOrThrow
 import scalanative.nio.fs.{FileHelpers, UnixException}
 
 import scala.collection.immutable.{Map => SMap, Stream => SStream, Set => SSet}
@@ -452,7 +452,7 @@ object Files {
     val len   = pathSize.toInt
     val bytes = scala.scalanative.runtime.ByteArray.alloc(len)
 
-    val fd = checkedOpen(path.toString, fcntl.O_RDONLY, 0.toUInt)
+    val fd = fcntlOpenOrThrow(path.toString, fcntl.O_RDONLY, 0.toUInt)
 
     try {
       var offset = 0

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -7,6 +7,7 @@ import java.io.{
   BufferedReader,
   BufferedWriter,
   File,
+  FileNotFoundException,
   FileOutputStream,
   InputStream,
   InputStreamReader,
@@ -450,7 +451,14 @@ object Files {
     }
     val len   = pathSize.toInt
     val bytes = scala.scalanative.runtime.ByteArray.alloc(len)
-    val fd    = fcntl.open(toCString(path.toString), fcntl.O_RDONLY, 0.toUInt)
+
+    val fd = fcntl.open(toCString(path.toString), fcntl.O_RDONLY, 0.toUInt)
+
+    if (fd == -1) {
+      throw new FileNotFoundException(
+        s"${path} (${fromCString(string.strerror(errno.errno))})")
+    }
+
     try {
       var offset = 0
       var read   = 0

--- a/javalib/src/main/scala/scala/scalanative/io/FcntlHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/io/FcntlHelpers.scala
@@ -1,0 +1,23 @@
+package scala.scalanative.io
+
+import scalanative.libc.{errno, string}
+import scalanative.posix.fcntl
+import scalanative.posix.sys.stat.mode_t
+import scalanative.unsafe.{CInt, fromCString, toCString, Zone}
+
+import java.io.{FileNotFoundException}
+
+object FcntlHelpers {
+
+  def checkedOpen(pathname: String, flags: CInt, mode: mode_t): CInt =
+    Zone { implicit z =>
+      val fd = fcntl.open(toCString(pathname), flags, mode)
+
+      if (fd == -1) {
+        throw new FileNotFoundException(
+          s"${pathname} (${fromCString(string.strerror(errno.errno))})")
+      }
+
+      fd
+    }
+}

--- a/javalib/src/main/scala/scala/scalanative/io/FcntlHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/io/FcntlHelpers.scala
@@ -9,7 +9,7 @@ import java.io.{FileNotFoundException}
 
 object FcntlHelpers {
 
-  def checkedOpen(pathname: String, flags: CInt, mode: mode_t): CInt =
+  def fcntlOpenOrThrow(pathname: String, flags: CInt, mode: mode_t): CInt =
     Zone { implicit z =>
       val fd = fcntl.open(toCString(pathname), flags, mode)
 

--- a/unit-tests/src/test/scala/java/io/FileDescriptorSuite.scala
+++ b/unit-tests/src/test/scala/java/io/FileDescriptorSuite.scala
@@ -6,6 +6,25 @@ object FileDescriptorSuite extends tests.Suite {
   val err = FileDescriptor.err
   val fd  = new FileDescriptor()
 
+  test("FileDescriptor.openReadOnly should report errno on failure") {
+
+    // FileDescriptor.openReadOnly is private[io] and hard to invoke
+    // directly.
+    //
+    // The FileInputStream constructor below will call
+    // FileDescriptor.openReadOnly. Because it is public, it is both
+    // easier to work with and the way most users would get to
+    // FileDescriptor.openReadOnly in the first place.
+    //
+    // Test here, rather than in FileInputStreamSuite so that the Suite
+    // and code throwing the exception have corresponding names.
+
+    assertThrows[IOException] {
+      // /root is unlikely to be readable to users running this test.
+      val unused = new FileInputStream("/root")
+    }
+  }
+
   test("valid descriptors") {
     assert(in.valid())
     assert(out.valid())

--- a/unit-tests/src/test/scala/java/io/FileDescriptorSuite.scala
+++ b/unit-tests/src/test/scala/java/io/FileDescriptorSuite.scala
@@ -1,5 +1,7 @@
 package java.io
 
+import java.nio.file.{Files, Paths}
+
 object FileDescriptorSuite extends tests.Suite {
   val in  = FileDescriptor.in
   val out = FileDescriptor.out
@@ -19,10 +21,18 @@ object FileDescriptorSuite extends tests.Suite {
     // Test here, rather than in FileInputStreamSuite so that the Suite
     // and code throwing the exception have corresponding names.
 
+    val file = File.createTempFile("scala-native-test-FileDescriptor", "")
+
+    assert(file.setReadable(false, false), s"setReadable() failed")
+    assert(file.setWritable(false, false), s"setWritable(false) failed")
+
     assertThrows[IOException] {
-      // /root is unlikely to be readable to users running this test.
-      val unused = new FileInputStream("/root")
+      val unused = new FileInputStream(file)
     }
+
+    // Clean up only if expected throw happened, else leave audit trail.
+    assert(file.setWritable(true, true), s"setWritable(true) failed")
+    assert(file.delete(), s"delete() failed")
   }
 
   test("valid descriptors") {

--- a/unit-tests/src/test/scala/java/io/RandomAccessFileSuite.scala
+++ b/unit-tests/src/test/scala/java/io/RandomAccessFileSuite.scala
@@ -10,10 +10,18 @@ object RandomAccessFileSuite extends tests.Suite {
   }
 
   test("RandomAccessFile constructor should report errno on open failure") {
+    val file = File.createTempFile("scala-native-test-RandomAccessFile", "")
+
+    assert(file.setReadable(false, false), s"setReadable() failed")
+    assert(file.setWritable(false, false), s"setWritable(false) failed")
+
     assertThrows[IOException] {
-      // /root is unlikely to be read/writeable to users running this test.
-      val unused = new RandomAccessFile("/root", "rw")
+      val unused = new RandomAccessFile(file, "rw")
     }
+
+    // Clean up only if expected throw happened, else leave audit trail.
+    assert(file.setWritable(true, true), s"setWritable(true) failed")
+    assert(file.delete(), s"delete() failed")
   }
 
   test("valid file descriptor and sync success") {

--- a/unit-tests/src/test/scala/java/io/RandomAccessFileSuite.scala
+++ b/unit-tests/src/test/scala/java/io/RandomAccessFileSuite.scala
@@ -3,18 +3,16 @@ package java.io
 import scala.util.Try
 
 object RandomAccessFileSuite extends tests.Suite {
-  test("Creating a `RandomAccessFile` with an invalid mode throws an exception") {
+  test("Creating a RandomAccessFile with invalid mode throws an exception") {
     assertThrows[IllegalArgumentException] {
       new RandomAccessFile("file", "foo")
     }
   }
 
-  test(
-    "Creating a `RandomAccessFile` with mode = `r` and a non-existing file should throw an exception") {
-    val file = new File("i-dont-exist")
-    assert(!file.exists)
-    assertThrows[FileNotFoundException] {
-      new RandomAccessFile(file, "r")
+  test("RandomAccessFile constructor should report errno on open failure") {
+    assertThrows[IOException] {
+      // /root is unlikely to be read/writeable to users running this test.
+      val unused = new RandomAccessFile("/root", "rw")
     }
   }
 


### PR DESCRIPTION
* This PR fixes Issue #1644 "j.i.RandomAccessFile & j.i.FileInputStream
  mishandle fcntl.open errors" I changed the PR name for this PR
  since a java.nio file is also modified.

* I believe I found * fixed all uses of fcntl.open in java.io and java.nio.

  I checked in both packages that all usages of unistd.read and unistd.write
  checked the return status and reported errno on failure.

  It does not make sense to check the status of unistd.close as the is not
  much a program can do about failure.

  On a rapid read, there appeared to be some symlink cases which could
  benefit from throwing a more informative Exception containing errno.
  A task for the next Generation.

* Three unit-test cases were created in existing Suites to check that
  the return status of fcntl.open was checked and errno.errno reported
  correctly. as necessary.

  The Exception thrown is the same FileNotFoundException used by the
  JVM.  It also uses the same msg-within-parenthesis form as the JVM.
  The actual text of the message may vary slightly.

* Issue #1644 was concerned with errno being reported during an
  attempt to open more files that the operating system allowed.

  The two java.io tests trigger an fcntl.open failure by attempting
  to read the directory /root.  That directory is likely to exist on
  almost all systems and be read-protected.  Of course some day, someone
  is going to run the unit-tests as root and report false errors.

* Trying to trigger a "too many files" error would require using
  posix.setrlimit() to lower the number of available open files.
  Java VM raises the number of open files above the linux usual
  1024. unit-tests run in SBT, which uses the JVM, so tests run
  with a 50,000 or so OPEN_MAX. It is simply not reasonable to
  create that many files in a 'short test' to force a failure.

  Using setrlimit() to lower OPEN_MAX is the alternative but that
  'dirties' the execution environment for subsequent unit-tests.
  To the best of my understanding, all unit-tests run in the same
  process.

  I considered a creating a scripted test but doing so was too forbidding,
  especially after I found the SBT documentation for scripted.

* To convince myself that the original concern with handling "too many files"
  was solved by this PR, I created and executed a private program which
  lowered OPEN_MAX and then created to many files. Errno was properly
  reported and the Exception matched the JVM.

Documentation:

* The standard changelog entry is requested.

Testing:

* Built and tested ("test-all") in debug mode using sbt 1.2.8 on
  X86_64 only . All tests pass.