### PR TITLE
[WIP] j.u.Date#toString output now matches JVM

### DIFF
--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -1,8 +1,14 @@
 package java.util
 
+import scalanative.libc.{errno, string}
+import scalanative.posix.time._
+import scalanative.unsafe._
+
+import java.io.IOException
+
 /** Ported from Scala JS and Apache Harmony
  * - omits deprecated methods
- * - toString not jdk compatible
+ * - toString code is new for Scala Native.
  */
 class Date(var milliseconds: Long)
     extends Object
@@ -33,6 +39,33 @@ class Date(var milliseconds: Long)
   def setTime(time: Long): Unit =
     milliseconds = time
 
-  override def toString(): String = s"Date($milliseconds)"
+  private var tzsetDone = false
+
+  private def secondsToString(seconds: Long): String = Zone { implicit z =>
+    val ttPtr = alloc[time_t]
+    !ttPtr = seconds
+    val tmPtr = alloc[tm]
+
+    if (!tzsetDone) {
+      tzset() // needed in order to portably use localtime_r
+      tzsetDone = true
+    }
+
+    if (localtime_r(ttPtr, tmPtr) == null) {
+      throw new IOException(fromCString(string.strerror(errno.errno)))
+    } else {
+      val bufSize = "Thu Jul 18 09:16:29 PDT 2019".length + 1
+      val buf     = alloc[Byte](bufSize)
+
+      val n = strftime(buf, bufSize, c"%a %b %d %T %Z %Y", tmPtr)
+
+      // strftime does not set errno on error
+      var result = if (n == 0) "" else fromCString(buf)
+
+      result
+    }
+  }
+
+  override def toString(): String = secondsToString(milliseconds / 1000L)
 
 }

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -60,7 +60,7 @@ class Date(var milliseconds: Long)
       val n = strftime(buf, bufSize, c"%a %b %d %T %Z %Y", tmPtr)
 
       // strftime does not set errno on error
-      var result = if (n == 0) "" else fromCString(buf)
+      val result = if (n == 0) "" else fromCString(buf)
 
       result
     }

--- a/unit-tests/src/test/scala/java/util/DateSuite.scala
+++ b/unit-tests/src/test/scala/java/util/DateSuite.scala
@@ -53,7 +53,7 @@ object DateSuite extends tests.Suite {
       "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{3} 20[1-3]\\d"
 
     assert(result.matches(expected),
-           s"result: ${result} does not match expected regex: '${expected}'")
+           s"result: '${result}' does not match expected regex: '${expected}'")
   }
 
 }

--- a/unit-tests/src/test/scala/java/util/DateSuite.scala
+++ b/unit-tests/src/test/scala/java/util/DateSuite.scala
@@ -49,8 +49,11 @@ object DateSuite extends tests.Suite {
   test("toString") {
     // val now : java.util.Date = Fri Mar 31 14:47:44 EDT 2017
     val result = now.toString
+
+    // See notes for test "strftime() for Fri Mar 31 14:47:44 EDT 2017"
+    // in posix.TimeSuite.
     val expected = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
-      "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{3} 20[1-3]\\d"
+      "\\d\\d \\d{2}:\\d{2}:\\d{2} (?: db|[A-Z]{2,5}) 20[1-3]\\d"
 
     assert(result.matches(expected),
            s"result: '${result}' does not match expected regex: '${expected}'")

--- a/unit-tests/src/test/scala/java/util/DateSuite.scala
+++ b/unit-tests/src/test/scala/java/util/DateSuite.scala
@@ -47,6 +47,13 @@ object DateSuite extends tests.Suite {
   }
 
   test("toString") {
-    assert(now.toString equals "Date(1490986064740)")
+    // val now : java.util.Date = Fri Mar 31 14:47:44 EDT 2017
+    val result = now.toString
+    val expected = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
+      "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{3} 20[1-3]\\d"
+
+    assert(result.matches(expected),
+           s"result: ${result} does not match expected regex: '${expected}'")
   }
+
 }

--- a/unit-tests/src/test/scala/scala/scalanative/posix/TimeSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/TimeSuite.scala
@@ -117,8 +117,19 @@ object TimeSuite extends tests.Suite {
 
         val result = fromCString(buf)
 
+        // Travis CI currently reports its timezone name as the
+        // apparently bogus "db", which is supposed to force UTC.
+        // Somebody apparently forgot to tell strftime %Z that.
+
+        // This test is using a known date which has two digits for
+        // day-of-month, so the second from left field should be
+        // two digits. This a stricter, hence. more informative,
+        // test that a one-or-two digit test. The latter is required
+        // in the general case where the number of days is in the
+        // range [1-31].
+
         val expected = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
-          "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{3} 20[1-3]\\d"
+          "\\d\\d \\d{2}:\\d{2}:\\d{2} (?: db|[A-Z]{2,5}) 20[1-3]\\d"
 
         assert(
           result.matches(expected),

--- a/unit-tests/src/test/scala/scala/scalanative/posix/TimeSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/TimeSuite.scala
@@ -108,25 +108,21 @@ object TimeSuite extends tests.Suite {
       if (localtime_r(ttPtr, tmPtr) == null) {
         throw new IOException(fromCString(string.strerror(libcErrno.errno)))
       } else {
-        val bufSize = "Fri Mar 31 14:47:44 EDT 2017".length + 1
+        val bufSize = 70 // easier to grossly overprovision than to chase bugs
         val buf     = alloc[Byte](bufSize)
 
         val n = strftime(buf, bufSize, c"%a %b %d %T %Z %Y", tmPtr)
 
-        // strftime does not set errno on error                                        assert(n != 0, s"unexpected zero from strftime")
+        // strftime does not set errno on error                                       assert(n != 0, s"unexpected zero from strftime")
 
         val result = fromCString(buf)
 
         // Travis CI currently reports its timezone name as the
         // apparently bogus "db", which is supposed to force UTC.
         // Somebody apparently forgot to tell strftime %Z that.
+        // It reports "db".
 
-        // This test is using a known date which has two digits for
-        // day-of-month, so the second from left field should be
-        // two digits. This a stricter, hence. more informative,
-        // test that a one-or-two digit test. The latter is required
-        // in the general case where the number of days is in the
-        // range [1-31].
+        // JVM Date.toString day-of-month always has two digits [01,31].
 
         val expected = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
           "\\d\\d \\d{2}:\\d{2}:\\d{2} (?: db|[A-Z]{2,5}) 20[1-3]\\d"

--- a/unit-tests/src/test/scala/scala/scalanative/posix/TimeSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/TimeSuite.scala
@@ -66,6 +66,55 @@ object TimeSuite extends tests.Suite {
     assert(now_time_t > 1502752688)
   }
 
+  test("strftime() should not read memory outside struct tm") {
+    Zone { implicit z =>
+      if (sizeof[tm] < 56) {
+
+        val ttPtr = alloc[time_t]
+        !ttPtr = 1490986064740L / 1000L // Fri Mar 31 14:47:44 EDT 2017
+
+        // This code is testing for reading past the end of a "short"
+        // Scala Native tm, so the linux 56 byte form is necessary here.
+        val tmBufSize = 7
+        val tmBuf     = alloc[Ptr[Byte]](tmBufSize) // will zero/clear all bytes
+        val tmPtr     = tmBuf.asInstanceOf[Ptr[tm]]
+
+        if (localtime_r(ttPtr, tmPtr) == null) {
+          throw new IOException(fromCString(string.strerror(libcErrno.errno)))
+        } else {
+          val unexpected = "BOGUS"
+
+          // With the "short" 36 byte SN struct tm tmBuf(6) is
+          // is linux tm_zone, and outside the posix minimal required range.
+          // strftime() should not read it.
+
+          tmBuf(6) = toCString(unexpected)
+
+          val bufSize = 70 // easier to grossly overprovision than to chase bugs
+          val buf     = alloc[Byte](bufSize) // will zero/clear all bytes
+          val n       = strftime(buf, bufSize, c"%a %b %d %T %Z %Y", tmPtr)
+
+          // strftime does not set errno on error
+          assert(n != 0, s"unexpected zero from strftime")
+
+          val result = fromCString(buf)
+
+          assert(
+            result.indexOf(unexpected, "Fri Mar 31 14:47:44 ".length) == -1,
+            s"result: '${result}' contains unexpected ${unexpected}")
+
+          val regex = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
+            "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{2,5} 20[1-3]\\d"
+
+          assert(
+            result.matches(regex),
+            s"result: '${result}' does not match expected regex: '${regex}'")
+          assert(false, s"result is : '${result}'")
+        }
+      }
+    }
+  }
+
   test("strftime() for 1900-01-01T00:00:00Z") {
     Zone { implicit z =>
       val isoDatePtr: Ptr[CChar] = alloc[CChar](70)
@@ -81,10 +130,7 @@ object TimeSuite extends tests.Suite {
     }
   }
 
-  // The "Monday Mon" is kind of wierd.  I think the idea is to test
-  // both the long and short form of the name and both %A and %c formats
-
-  test("strftime() for Monday Mon Jan  1 00:00:00 1900") {
+  test("strftime() for Monday Jan  1 00:00:00 1900") {
     Zone { implicit z =>
       val timePtr             = alloc[tm]
       val datePtr: Ptr[CChar] = alloc[CChar](70)
@@ -92,10 +138,12 @@ object TimeSuite extends tests.Suite {
       timePtr.tm_mday = 1
       timePtr.tm_wday = 1
 
-      strftime(datePtr, 70, c"%A %c", timePtr)
+      strftime(datePtr, 70, c"%A %b %e %T %Y", timePtr)
 
+      val expected           = "Monday Jan  1 00:00:00 1900"
       val dateString: String = fromCString(datePtr)
-      assert("Monday Mon Jan  1 00:00:00 1900".equals(dateString))
+      assert(expected.equals(dateString),
+             s"result: ${dateString} != expected: ${expected}")
     }
   }
 
@@ -113,7 +161,7 @@ object TimeSuite extends tests.Suite {
 
         val n = strftime(buf, bufSize, c"%a %b %d %T %Z %Y", tmPtr)
 
-        // strftime does not set errno on error                                       assert(n != 0, s"unexpected zero from strftime")
+        // strftime does not set errno on error					      assert(n != 0, s"unexpected zero from strftime")
 
         val result = fromCString(buf)
 
@@ -125,7 +173,7 @@ object TimeSuite extends tests.Suite {
         // JVM Date.toString day-of-month always has two digits [01,31].
 
         val expected = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
-          "\\d\\d \\d{2}:\\d{2}:\\d{2} (?: db|[A-Z]{2,5}) 20[1-3]\\d"
+          "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{2,5} 20[1-3]\\d"
 
         assert(
           result.matches(expected),
@@ -166,6 +214,71 @@ object TimeSuite extends tests.Suite {
         strptime(c"December 32, 2016 23:59", c"%B %d, %Y %T", tmPtr)
 
       assert(result == null, s"expected null result, got pointer")
+    }
+  }
+
+  test("strptime() should not write memory outside struct tm") {
+    Zone { implicit z =>
+      // Linux 56 Bytes, Posix specifies 36 but allows more.
+      val tmBufSize = 7
+      val tmBuf     = alloc[Ptr[Byte]](tmBufSize) // will zero/clear all bytes
+      val tmPtr     = tmBuf.asInstanceOf[Ptr[tm]]
+
+      val cp =
+        strptime(c"Fri Mar 31 14:47:44 EDT 2017", c"%a %b %d %T %Z %Y", tmPtr)
+
+      assert(cp != null, s"strptime() returned unexpected null pointer")
+
+      val ch = cp(0)
+      assert(ch == '\0',
+             s"strptime() returned unexpected non-null character: ${ch}")
+
+      val tm_gmtoff = tmBuf(5) // tm_gmtoff is outside posix minimal range.
+      assert(tm_gmtoff == null, s"tm_gmtoff: ${tm_gmtoff} != expected: 0")
+
+      val tm_zone = tmBuf(6) // tm_zone is outside posix minimal range.
+      assert(tm_zone == null, s"tm_zone: ${tm_zone} != expected: null")
+
+      // Major concerning conditions passed. Sanity check the tm proper.
+
+      val expectedSec = 44
+      assert(tmPtr.tm_sec == expectedSec,
+             s"tm_sec: ${tmPtr.tm_sec} != expected: ${expectedSec}")
+
+      val expectedMin = 47
+      assert(tmPtr.tm_min == expectedMin,
+             s"tm_min: ${tmPtr.tm_min} != expected: ${expectedMin}")
+
+      val expectedHour = 14
+      assert(tmPtr.tm_hour == expectedHour,
+             s"tm_mon: ${tmPtr.tm_hour} != expected: ${expectedHour}")
+
+      val expectedMday = 31
+      assert(tmPtr.tm_mday == expectedMday,
+             s"tm_mon: ${tmPtr.tm_mday} != expected: ${expectedMday}")
+
+      val expectedMonth = 2
+      assert(tmPtr.tm_mon == expectedMonth,
+             s"tm_mon: ${tmPtr.tm_mon} != expected: ${expectedMonth}")
+
+      val expectedYear = 117
+      assert(tmPtr.tm_year == expectedYear,
+             s"tm_year: ${tmPtr.tm_year} != expected: ${expectedYear}")
+
+      val expectedWday = 5
+      assert(tmPtr.tm_wday == expectedWday,
+             s"tm_wday: ${tmPtr.tm_wday} != expected: ${expectedWday}")
+
+      val expectedYday = 89
+      assert(tmPtr.tm_yday == expectedYday,
+             s"tm_yday: ${tmPtr.tm_yday} != expected: ${expectedYday}")
+
+      // strptime() parses %Z but does not set corresponding field.
+      // Daylight saving time in most of the USA started March 12, 2017,
+      // so this would be a 1 if the field were being set.
+      val expectedIsdst = 0
+      assert(tmPtr.tm_isdst == expectedIsdst,
+             s"tm_isdst: ${tmPtr.tm_isdst} != expected: ${expectedIsdst}")
     }
   }
 


### PR DESCRIPTION
I am sidelining this PR while I track down intermittent failures seen only on/in Travis CI.

The Date.toString() code works as advertised on my system (with timezone set up, 
default Ubuntu).  Unfortunately, anybody using it would probably see the same
Travis errors I am seeing. 

* This PR fixes a problem reported by @ekrich on gitter. Previously
  Scala Native java.util.Date method toString would return a result
  of the form "Date(1234567)". This differed from the form returned
  by Java "Thu Jul 18 09:16:29 PDT 2019".  

  To be fair, the code stated quite explicitly that the implemented format
  did not match the JVM: state what you do, and do it well.

  The differing formats  meant that the output of SN Properties#store differed
  from the JVM, complicating Properties.scala development.

  Scala Native now returns the same result as if it had executed on
  the JVM.

* Note Well:  In order for the translation from Date object to string
  to succeed, the C timezone and locale environments need to be
  set up appropriately as to the expected result.  This is not
  an issue on most systems.

  Concretely, a system set up to use GMT would show GMT as the timezone name.
  A system set up to use, say, French weekday names would show them.

  This is NOT general (Java) Locale support.

* The test case for Date.toString was updated in `java/util/Suite.scala`

  The test case gives a sanity check for the resultant format rather
  than testing for an exact output.  The latter can change depending
  upon the environment in which the test is executed. A good example
  is the three character timezone name.

  The regex pattern used for the sanity check will need to be revisited
  in twenty years and then again in 100 and 1000 years.  That only
  my code should last so long.

* This PR gives user visible parity with Java VM practice.  The
  implementation may need to change as methods in java.time mature
  or become available.

  The current secondsToString() implementation derives from unpublished
  design studies for Instant.scala & kin.

Documentation:

* The standard changelog entry is requested.

Testing:

* Built and tested ("test-all") in debug mode using sbt 1.2.8 on
    X86_64 only . All tests pass.