### PR TITLE
Commix: Linux/MacOs friendly CPU count

### DIFF
--- a/nativelib/src/main/resources/gc/commix/Settings.c
+++ b/nativelib/src/main/resources/gc/commix/Settings.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/sysinfo.h>
+#include <unistd.h>
 
 /*
  Accepts number of bytes or number with a suffix letter for indicating the
@@ -92,7 +92,8 @@ int Settings_GCThreadCount() {
     char *str = getenv("SCALANATIVE_GC_THREADS");
     if (str == NULL) {
         // default is number of cores - 1, but no less than 1 and no more than 8
-        int defaultGThreadCount = get_nprocs() - 1;
+        int processorCount = (int) sysconf(_SC_NPROCESSORS_ONLN);
+        int defaultGThreadCount = processorCount - 1;
         if (defaultGThreadCount < 1) {
             defaultGThreadCount = 1;
         } else if (defaultGThreadCount > 8) {


### PR DESCRIPTION
Instead of Linux-specific `get_nprocs()` from `sys/sysinfo.h` using more generic POSIX `sysconf(_SC_NPROCESSORS_ONLN)` from `unistd.h`.

- [x] tested on Linux
- [ ] tested on MacOs