### PR TITLE
Commix: named semaphores

### DIFF
--- a/nativelib/src/main/resources/gc/commix/GCThread.c
+++ b/nativelib/src/main/resources/gc/commix/GCThread.c
@@ -71,7 +71,7 @@ static inline void GCThread_sweepMaster(GCThread *thread, Heap *heap,
 void *GCThread_loop(void *arg) {
     GCThread *thread = (GCThread *)arg;
     Heap *heap = thread->heap;
-    sem_t *start = &heap->gcThreads.startWorkers;
+    sem_t *start = heap->gcThreads.startWorkers;
     Stats *stats = Stats_OrNull(thread->stats);
 
     while (true) {
@@ -102,7 +102,7 @@ void *GCThread_loop(void *arg) {
 void *GCThread_loopMaster(void *arg) {
     GCThread *thread = (GCThread *)arg;
     Heap *heap = thread->heap;
-    sem_t *start = &heap->gcThreads.startMaster;
+    sem_t *start = heap->gcThreads.startMaster;
     Stats *stats = Stats_OrNull(thread->stats);
     while (true) {
         thread->active = false;
@@ -169,11 +169,11 @@ int GCThread_ActiveCount(Heap *heap) {
 }
 
 INLINE void GCThread_WakeMaster(Heap *heap) {
-    sem_post(&heap->gcThreads.startMaster);
+    sem_post(heap->gcThreads.startMaster);
 }
 
 INLINE void GCThread_WakeWorkers(Heap *heap, int toWake) {
-    sem_t *startWorkers = &heap->gcThreads.startWorkers;
+    sem_t *startWorkers = heap->gcThreads.startWorkers;
     for (int i = 0; i < toWake; i++) {
         sem_post(startWorkers);
     }

--- a/nativelib/src/main/resources/gc/commix/Heap.h
+++ b/nativelib/src/main/resources/gc/commix/Heap.h
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include <pthread.h>
 #include <semaphore.h>
+#include <fcntl.h>
 
 typedef struct {
     word_t *blockMetaStart;
@@ -28,8 +29,8 @@ typedef struct {
     double maxMarkTimeRatio;
     double minFreeRatio;
     struct {
-        sem_t startWorkers;
-        sem_t startMaster;
+        sem_t *startWorkers;
+        sem_t *startMaster;
         atomic_uint_fast8_t phase;
         int count;
         void *all;

--- a/nativelib/src/main/resources/gc/commix/Phase.c
+++ b/nativelib/src/main/resources/gc/commix/Phase.c
@@ -23,8 +23,8 @@ void Phase_Init(Heap *heap, uint32_t initialBlockCount) {
         sem_open(startMasterName, O_CREAT | O_EXCL, 0644, 0);
     // clean up when process closes
     // also prevents any other process from `sem_open`ing it
-    sem_unlink("startWorkers");
-    sem_unlink("startMaster");
+    sem_unlink(startWorkersName);
+    sem_unlink(startMasterName);
 
     heap->sweep.cursor = initialBlockCount;
     heap->lazySweep.cursorDone = initialBlockCount;

--- a/nativelib/src/main/resources/gc/commix/Phase.c
+++ b/nativelib/src/main/resources/gc/commix/Phase.c
@@ -3,10 +3,28 @@
 #include "State.h"
 #include "Allocator.h"
 #include "BlockAllocator.h"
+#include <stdio.h>
+#include <unistd.h>
 
 void Phase_Init(Heap *heap, uint32_t initialBlockCount) {
-    sem_init(&heap->gcThreads.startWorkers, 0, 0);
-    sem_init(&heap->gcThreads.startMaster, 0, 0);
+    pid_t pid = getpid();
+    // size = static part + 32 bit int as string
+    char startWorkersName[32 + 10];
+    char startMasterName[31 + 10];
+    snprintf(startWorkersName, 32 + 10, "scalanative_commix_startWorkers_%d",
+             pid);
+    snprintf(startMasterName, 31 + 10, "scalanative_commix_startMaster_%d",
+             pid);
+    // only reason for using named semaphores here is for compatibility with
+    // MacOs we do not share them across processes
+    heap->gcThreads.startWorkers =
+        sem_open(startWorkersName, O_CREAT | O_EXCL, 0644, 0);
+    heap->gcThreads.startMaster =
+        sem_open(startMasterName, O_CREAT | O_EXCL, 0644, 0);
+    // clean up when process closes
+    // also prevents any other process from `sem_open`ing it
+    sem_unlink("startWorkers");
+    sem_unlink("startMaster");
 
     heap->sweep.cursor = initialBlockCount;
     heap->lazySweep.cursorDone = initialBlockCount;


### PR DESCRIPTION
Using named semaphores only for comparability with MacOs see #1654 .
Needs changes from #1657 to compile on Mac.

- [x] tested on Linux
- [ ] tested on MacOs