### PR TITLE
j.u.Date#toString output now matches JVM

### DIFF
--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -1,8 +1,12 @@
 package java.util
 
+import scalanative.posix.time, time.time_t
+import scalanative.posix.sys.types.size_t
+import scalanative.unsafe._
+
 /** Ported from Scala JS and Apache Harmony
  * - omits deprecated methods
- * - toString not jdk compatible
+ * - toString code created ab ovo for Scala Native.
  */
 class Date(var milliseconds: Long)
     extends Object
@@ -33,6 +37,45 @@ class Date(var milliseconds: Long)
   def setTime(time: Long): Unit =
     milliseconds = time
 
-  override def toString(): String = s"Date($milliseconds)"
+  override def toString(): String = {
+    val seconds = milliseconds / 1000L
+    val default = s"Date($milliseconds)"
+    Date.secondsToString(seconds, default)
+  }
 
+}
+
+@extern
+private object DateC {
+
+  def scalanative_ju_secondsToLocaltime(seconds: Ptr[time_t],
+                                        format: CString,
+                                        fallback: CString,
+                                        buf: Ptr[Byte],
+                                        maxsize: size_t): CString = extern
+}
+
+private object Date {
+
+  def secondsToString(seconds: Long, default: String): String = Zone {
+    implicit z =>
+      val ttPtr = alloc[time_t]
+      !ttPtr = seconds
+
+      // 72 is gross over-provisioning based on fear.
+      // Most result strings should be about 28 + 1 for terminal NULL
+      // + 2 because some IANA timezone abbreviation can have 5 characters.
+      val bufSize = 72
+      val buf     = alloc[Byte](bufSize)
+
+      val cstr = DateC.scalanative_ju_secondsToLocaltime(
+        ttPtr,
+        c"%a %b %d %T %Z %Y",
+        toCString(default),
+        buf,
+        bufSize
+      )
+
+      fromCString(cstr)
+  }
 }

--- a/nativelib/src/main/resources/java/util/date.c
+++ b/nativelib/src/main/resources/java/util/date.c
@@ -1,0 +1,27 @@
+// date.c - helper functions for javalib java.util.Date class
+
+#include <stddef.h>
+#include <time.h>
+
+char *scalanative_ju_secondsToLocaltime(const time_t *seconds,
+                                        const char *format,
+                                        const char *fallback, char *buf,
+                                        size_t maxsize) {
+    char *result = (char *)fallback;
+
+    if (maxsize > 0) {
+        struct tm tm;
+
+        tzset();
+        struct tm *tmPtr = localtime_r(seconds, &tm);
+
+        if (tmPtr != NULL) {
+            int n = strftime(buf, maxsize, format, tmPtr);
+            if (n > 0) {
+                result = buf; // only on known success.
+            }
+        }
+    }
+
+    return result;
+}

--- a/unit-tests/src/test/scala/java/util/DateSuite.scala
+++ b/unit-tests/src/test/scala/java/util/DateSuite.scala
@@ -47,6 +47,13 @@ object DateSuite extends tests.Suite {
   }
 
   test("toString") {
-    assert(now.toString equals "Date(1490986064740)")
+    // val now : java.util.Date = Fri Mar 31 14:47:44 EDT 2017
+    val result = now.toString
+    val expected = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
+      "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{2,5} 20[1-3]\\d"
+
+    assert(result.matches(expected),
+           s"result: '${result}' does not match expected regex: '${expected}'")
   }
+
 }


### PR DESCRIPTION
* This PR fixes a problem reported by @ekrich on gitter. Previously
  Scala Native java.util.Date method toString would return a result
  of the form "Date(1234567)". This differed from the form returned
  by Java "Thu Jul 18 09:16:29 PDT 2019".

  The difference meant that the output of SN Properties#store differed
  from the JVM, complicating Properties.scala development.

  Scala Native now returns the same result as if it had executed on
  the JVM.

* Note Well:  In order for the translation from Date object to string
  to succeed, the C timezone and locale environments need to be
  set up appropriately as to the expected result.  This is not
  an issue on most systems.

  Concretely, a system set up to use GMT would show GMT as the timezone name.
  A system set up to use, say, French weekday names would show them.

  This is NOT general (Java) Locale support.

* The test case for Date.toString was updated in `java/util/Suite.scala`

  The test case gives a sanity check for the resultant format rather
  than testing for an exact output.  The latter can change depending
  upon the environment in which the test is executed. A good example
  is the three character timezone name.

  The regex pattern used for the sanity check will need to be revisited
  in twenty years and then again in 100 and 1000 years.  That only
  my code should last so long.

* This PR gives user visible parity with Java VM practice.  The
  implementation may need to change as methods in java.time mature
  or become available.

Documentation:

* The standard changelog entry is requested.

Testing:

* Built and tested ("test-all") in debug mode using sbt 1.2.8 on
    X86_64 only . All tests pass.