### PR TITLE
Fix 1664: Correct 0.4.0 regression in Posix strftime & a flaw in strptime

### DIFF
--- a/nativelib/src/main/resources/time.c
+++ b/nativelib/src/main/resources/time.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include <sys/time.h>
 
 #define __USE_XOPEN // strptime()
@@ -33,6 +34,19 @@ static void scalanative_tm_init(struct scalanative_tm *scala_tm,
 }
 
 static void tm_init(struct tm *tm, struct scalanative_tm *scala_tm) {
+
+  if (sizeof(struct tm) > sizeof(struct scalanative_tm)) {
+        // The size of the operating system struct tm can be larger than
+        // the scalanative tm.  On Linux this is true.
+        // Clearing the entire tm and then setting known fields ensures
+        // that any fields not known to scalanative, such as tm_zone,
+	// are zero/NULL, not J-Random garbage.
+	// strftime() in release mode if particularly sensitive to
+	// garbage beyond the end of the scalanative tm.
+
+        memset(tm, 0, sizeof(*tm));
+    }
+
     tm->tm_sec = scala_tm->tm_sec;
     tm->tm_min = scala_tm->tm_min;
     tm->tm_hour = scala_tm->tm_hour;

--- a/nativelib/src/main/resources/time.c
+++ b/nativelib/src/main/resources/time.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 #include <sys/time.h>
+
+#define __USE_XOPEN // strptime()
 #include <time.h>
 
 struct scalanative_tm {
@@ -89,6 +91,14 @@ size_t scalanative_strftime(char *buf, size_t maxsize, const char *format,
     struct tm tm;
     tm_init(&tm, scala_tm);
     return strftime(buf, maxsize, format, &tm);
+}
+
+char *scalanative_strptime(const char *s, const char *format,
+                           struct scalanative_tm *scala_tm) {
+    struct tm tm = {0};
+    char *result = strptime(s, format, &tm);
+    scalanative_tm_init(scala_tm, &tm);
+    return result;
 }
 
 long long scalanative_current_time_millis() {

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -12,36 +12,56 @@ object time {
   type timespec = CStruct2[time_t, CLong]
   type tm       = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
 
+  // Some methods here have a @name annotation and some do not.
+  // Methods where a @name extern "glue" layer would simply pass through
+  // the arguments or return value do not need that layer & its
+  // annotation.
+
   @name("scalanative_asctime")
   def asctime(time_ptr: Ptr[tm]): CString = extern
+
   @name("scalanative_asctime_r")
   def asctime_r(time_ptr: Ptr[tm], buf: Ptr[CChar]): CString = extern
-  def clock(): clock_t                                       = extern
-  def ctime(time: Ptr[time_t]): CString                      = extern
-  def ctime_r(time: Ptr[time_t], buf: Ptr[CChar]): CString   = extern
-  def difftime(time_end: CLong, time_beg: CLong): CDouble    = extern
+
+  def clock(): clock_t                                     = extern
+  def ctime(time: Ptr[time_t]): CString                    = extern
+  def ctime_r(time: Ptr[time_t], buf: Ptr[CChar]): CString = extern
+  def difftime(time_end: CLong, time_beg: CLong): CDouble  = extern
+
   @name("scalanative_gmtime")
   def gmtime(time: Ptr[time_t]): Ptr[tm] = extern
+
   @name("scalanative_gmtime_r")
   def gmtime_r(time: Ptr[time_t], tm: Ptr[tm]): Ptr[tm] = extern
+
   @name("scalanative_localtime")
   def localtime(time: Ptr[time_t]): Ptr[tm] = extern
+
   @name("scalanative_localtime_r")
   def localtime_r(time: Ptr[time_t], tm: Ptr[tm]): Ptr[tm] = extern
+
   @name("scalanative_mktime")
   def mktime(time: Ptr[tm]): time_t = extern
+
+  @name("scalanative_strftime")
   def strftime(str: Ptr[CChar],
                count: CSize,
                format: CString,
                time: Ptr[tm]): CSize = extern
+
+  @name("scalanative_strptime")
   def strptime(str: Ptr[CChar], format: CString, time: Ptr[tm]): CString =
     extern
+
   def time(arg: Ptr[time_t]): time_t = extern
   def tzset(): Unit                  = extern
+
   @name("scalanative_daylight")
   def daylight(): CInt = extern
+
   @name("scalanative_timezone")
   def timezone(): CLong = extern
+
   @name("scalanative_tzname")
   def tzname(): Ptr[CStruct2[CString, CString]] = extern
 }

--- a/unit-tests/src/test/scala/scala/scalanative/posix/TimeSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/TimeSuite.scala
@@ -1,6 +1,8 @@
 package scala.scalanative.posix
 
+import scalanative.libc.{errno => libcErrno, string}
 import scala.scalanative.unsafe._
+import java.io.IOException
 
 import time._
 import timeOps.tmOps
@@ -62,6 +64,56 @@ object TimeSuite extends tests.Suite {
   test("time() should be bigger than the timestamp when I wrote this code") {
     // arbitrary date set at the time when I was writing this.
     assert(now_time_t > 1502752688)
+  }
+
+  test("strftime() should not read memory outside struct tm") {
+    Zone { implicit z =>
+      if (sizeof[tm] < 56) {
+
+        val ttPtr = alloc[time_t]
+        !ttPtr = 1490986064740L / 1000L // Fri Mar 31 14:47:44 EDT 2017
+
+        // This code is testing for reading past the end of a "short"
+        // Scala Native tm, so the linux 56 byte form is necessary here.
+        val tmBufSize = 7
+
+        // alloc will zero/clear all bytes
+        val tmBuf = alloc[Ptr[Byte]](tmBufSize)
+        val tmPtr = tmBuf.asInstanceOf[Ptr[tm]]
+
+        if (localtime_r(ttPtr, tmPtr) == null) {
+          throw new IOException(fromCString(string.strerror(libcErrno.errno)))
+        } else {
+          val unexpected = "BOGUS"
+
+          // With the "short" 36 byte SN struct tm tmBuf(6) is
+          // is linux tm_zone, and outside the posix minimal required range.
+          // strftime() should not read it.
+
+          tmBuf(6) = toCString(unexpected)
+
+          val bufSize = 70 // grossly over-provision rather than chase bugs
+          val buf     = alloc[Byte](bufSize) // will zero/clear all bytes
+          val n       = strftime(buf, bufSize, c"%a %b %d %T %Z %Y", tmPtr)
+
+          // strftime does not set errno on error
+          assert(n != 0, s"unexpected zero from strftime")
+
+          val result = fromCString(buf)
+
+          assert(
+            result.indexOf(unexpected, "Fri Mar 31 14:47:44 ".length) == -1,
+            s"result: '${result}' contains unexpected ${unexpected}")
+
+          val regex = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
+            "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{2,5} 20[1-3]\\d"
+
+          assert(
+            result.matches(regex),
+            s"result: '${result}' does not match expected regex: '${regex}'")
+        }
+      }
+    }
   }
 
   test("strftime() for 1900-01-01T00:00:00Z") {
@@ -126,6 +178,71 @@ object TimeSuite extends tests.Suite {
         strptime(c"December 32, 2016 23:59", c"%B %d, %Y %T", tmPtr)
 
       assert(result == null, s"expected null result, got pointer")
+    }
+  }
+
+  test("strptime() should not write memory outside struct tm") {
+    Zone { implicit z =>
+      // Linux 56 Bytes, Posix specifies 36 but allows more.
+      val tmBufSize = 7
+      val tmBuf     = alloc[Ptr[Byte]](tmBufSize) // will zero/clear all bytes
+      val tmPtr     = tmBuf.asInstanceOf[Ptr[tm]]
+
+      val cp =
+        strptime(c"Fri Mar 31 14:47:44 EDT 2017", c"%a %b %d %T %Z %Y", tmPtr)
+
+      assert(cp != null, s"strptime() returned unexpected null pointer")
+
+      val ch = cp(0)
+      assert(ch == '\0',
+             s"strptime() returned unexpected non-null character: ${ch}")
+
+      val tm_gmtoff = tmBuf(5) // tm_gmtoff is outside posix minimal range.
+      assert(tm_gmtoff == null, s"tm_gmtoff: ${tm_gmtoff} != expected: 0")
+
+      val tm_zone = tmBuf(6) // tm_zone is outside posix minimal range.
+      assert(tm_zone == null, s"tm_zone: ${tm_zone} != expected: null")
+
+      // Major concerning conditions passed. Sanity check the tm proper.
+
+      val expectedSec = 44
+      assert(tmPtr.tm_sec == expectedSec,
+             s"tm_sec: ${tmPtr.tm_sec} != expected: ${expectedSec}")
+
+      val expectedMin = 47
+      assert(tmPtr.tm_min == expectedMin,
+             s"tm_min: ${tmPtr.tm_min} != expected: ${expectedMin}")
+
+      val expectedHour = 14
+      assert(tmPtr.tm_hour == expectedHour,
+             s"tm_mon: ${tmPtr.tm_hour} != expected: ${expectedHour}")
+
+      val expectedMday = 31
+      assert(tmPtr.tm_mday == expectedMday,
+             s"tm_mon: ${tmPtr.tm_mday} != expected: ${expectedMday}")
+
+      val expectedMonth = 2
+      assert(tmPtr.tm_mon == expectedMonth,
+             s"tm_mon: ${tmPtr.tm_mon} != expected: ${expectedMonth}")
+
+      val expectedYear = 117
+      assert(tmPtr.tm_year == expectedYear,
+             s"tm_year: ${tmPtr.tm_year} != expected: ${expectedYear}")
+
+      val expectedWday = 5
+      assert(tmPtr.tm_wday == expectedWday,
+             s"tm_wday: ${tmPtr.tm_wday} != expected: ${expectedWday}")
+
+      val expectedYday = 89
+      assert(tmPtr.tm_yday == expectedYday,
+             s"tm_yday: ${tmPtr.tm_yday} != expected: ${expectedYday}")
+
+      // strptime() parses %Z but does not set corresponding field.
+      // Daylight saving time in most of the USA started March 12, 2017,
+      // so this would be a 1 if the field were being set.
+      val expectedIsdst = 0
+      assert(tmPtr.tm_isdst == expectedIsdst,
+             s"tm_isdst: ${tmPtr.tm_isdst} != expected: ${expectedIsdst}")
     }
   }
 


### PR DESCRIPTION
* This PR fixes Issue "Correct 0.4.0 regression in posix/strftime".

* In addition, it fixes a flaw in strptime() where structures were
  not being handled correctly. It needed a @name "glue" layer.

* I reviewed the other methods in time.scala for problems handling
  structures. To aid this review, I did some white space changes,
  making the @name/def pair more visible.

  I also added a brief comment describing when a @name glue layer is
  probably needed and when it is not.
  Bread crumbs, but not loaves, are good.

* Two test cases were added to TimeSuite.scala: one for each of strftime()
  and strptime(). The strftime() case fails before this PR and passes
  as of this PR.

  By chance, there was not a problem with strptime(), at least on
  Linux, before this PR.  Depending upon the implementation,
  strptime() may or may not write into the provided struct tm
  when it is parsing a "%Z" or "%z" format specifier.  Looks like
  it was parsing but not writing on Linux.  If it had been writing,
  the code before this PR would have written into space it do not own.
  Not Good!

Documentation:

* The standard changelog entry is requested.

Testing:

* Built and tested ("test-all") in debug mode using sbt 1.2.8 on
    X86_64 only . All tests pass.