### PR TITLE
Fix 1663: Dockerfile no longer needs cre2

### DIFF
--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -35,7 +35,7 @@ RUN \
   apt-get update && \
   apt-get install -y sbt
 
-RUN apt-get update && apt-get install -y clang-5.0 zlib1g-dev libgc-dev libre2-dev
+RUN apt-get update && apt-get install -y clang-5.0 zlib1g-dev libgc-dev
 
 ENV LC_ALL "C.UTF-8"
 


### PR DESCRIPTION
* This PR fixes Issue "Dockerfile no longer needs cre2".

  The library libre2-dev is no longer installed. As of SN 0.4.0,
  SN uses re2s instead of cre2.

Documentation:

* None needed: not a user facing change & relevant devos notified.

Testing:

* I know of know way to test this on my local system.  A  Travis CI build of this PR
  showed that libre2-dev was missing, as desired, and that the rest of the build worked, 
  modulo unrelated Travis timeouts.