### PR TITLE
Fix #1659: Posixlib & libc documentation pages now define N/A

### DIFF
--- a/docs/lib/libc.rst
+++ b/docs/lib/libc.rst
@@ -3,13 +3,13 @@
 C Standard Library
 ==================
 
-Scala Native provides bindings for the core subset of the
+Scala Native provides bindings for a core subset of the
 `C standard library <https://en.cppreference.com/w/c/header>`_:
 
 ============== ==================================
 C Header       Scala Native Module
 ============== ==================================
-assert.h_      N/A
+assert.h_      N/A - *indicates binding not available*
 complex.h_     scala.scalanative.libc.complex_
 ctype.h_       scala.scalanative.libc.ctype_
 errno.h_       scala.scalanative.libc.errno_

--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -3,13 +3,13 @@
 C POSIX Library
 ===============
 
-Scala Native provides bindings for the core subset of the
+Scala Native provides bindings for a core subset of the
 `POSIX library <https://pubs.opengroup.org/onlinepubs/9699919799/idx/head.html>`_:
 
 ================= ==================================
 C Header          Scala Native Module
 ================= ==================================
-`aio.h`_          N/A
+`aio.h`_          N/A - *indicates binding not available*
 `arpa/inet.h`_    scala.scalanative.posix.arpa.inet_
 `assert.h`_       N/A
 `complex.h`_      scala.scalanative.libc.complex_


### PR DESCRIPTION
  * This pull request was motivated by Issue #1659  "Posixlib & libc
    documentation pages should define N/A"

    That issue is now fixed.

Documentation:

  * No documentation change needed: The change announces itself.

Testing:

  * Successfully  built (sphinx-build) locally and result visually inspected
    in Firefox browser (file: URL).