### PR TITLE
[0.3.x] Add override to allow sconfig to link

### DIFF
--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -68,6 +68,9 @@ class ArrayList[E] private (private[this] var inner: Array[Any],
   // cannot link: @java.util.ArrayList::isEmpty_bool
   override def isEmpty(): Boolean = _size == 0
 
+  // cannot link: @java.util.ArrayList::hashCode_i32
+  override def hashCode(): Int = inner.hashCode()
+
   override def indexOf(o: Any): Int = inner.indexOf(o)
 
   override def lastIndexOf(o: Any): Int = inner.lastIndexOf(o)


### PR DESCRIPTION
I am working on jdk11 support for `sconfig` and this is now causing problems.

```
[info] Compiling 1 Scala source to /Users/eric/workspace/sconfig/sconfig/native/target/scala-2.11/test-classes ...
[info] Done compiling.
[info] Linking (8622 ms)
[error] cannot link: @java.util.ArrayList::hashCode_i32
[error] unable to link
[error] (sconfigNative / Nativetest / nativeLink) unable to link
```

I thought maybe it was related to 2.13 collection compat code but not sure now. This does solve the issue.