### PR TITLE
Discover & use clang-9, if present.

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -136,16 +136,19 @@ object Discover {
 
   /** Versions of clang which are known to work with Scala Native. */
   private[scalanative] val clangVersions =
-    Seq(("8", ""),
-        ("8", "0"),
-        ("7", ""),
-        ("7", "0"), // LLVM changed version numbering scheme, try both.
-        ("6", "0"),
-        ("5", "0"),
-        ("4", "0"),
-        ("3", "9"),
-        ("3", "8"),
-        ("3", "7"))
+    Seq(
+      ("9", ""),
+      ("8", ""),
+      ("8", "0"),
+      ("7", ""),
+      ("7", "0"), // LLVM changed version numbering scheme, try both.
+      ("6", "0"),
+      ("5", "0"),
+      ("4", "0"),
+      ("3", "9"),
+      ("3", "8"),
+      ("3", "7")
+    )
 
   /** Discover concrete binary path using command name and
    *  a sequence of potential supported versions.


### PR DESCRIPTION
  * Six months have passed and clang-9 rc-2 is available. Discover and
    use it if installed on the build system.  This is the next
    in a long series of clang update PRs.
 
 * A year ago clang changed the format of its version suffix from containing a .0
   to not.  For two iterations, both the -7 and -7.0 forms were looked up.  This
   PR implements only a lookup on the 9 form. Enough transition time has passed.

  * Scala Native appears to build and run without notice using clang-9
    with and without lld-9. The only difference is the audible
    sizzle of Cool.

  * The Discovery code does not, and has not for years, discover
    llvm-config of the form llvm-config-N, where N is [3-9]. The current
    PR does no worse that prior art.  A PR for another day.

Documentation:

   * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in debug mode, Java 8, using sbt 1.2.8 on
    X86_64 only . All tests pass.

    Since clang-9 is not installed on Travis, this shows that this PR
    did not break the existing discovery process.

  * To show that the code change was effective on a system with
    clang-9 installed, I manually ran an sbt "sandbox/run" and examined
    the output of an immediately subsequent "last" command.
    The log file showed clang-9 in use and, where appropriate, lld-9.