### PR TITLE
Fix #1683: Implement suppression and non-writable trace for Throwable

### DIFF
--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -116,8 +116,23 @@ class Throwable protected (s: String,
   def getMessage(): String = s
 
   def getStackTrace(): Array[StackTraceElement] = {
-    if (stackTrace eq null) {
-      Array.empty[StackTraceElement]
+    // Be robust! Test this.stackTrace against null rather than relying upon
+    // the value of writableStackTrace.
+    //
+    // subclass scala.util.control.NoStackTrace overrides fillInStackTrace()
+    // so that it never touches this.stackTrace. This creates the situation
+    // where writeableStackTrace is true and this.stackTrace is null.
+    //
+    // If scala code creates this situation, then by the Gell-Mann principle
+    // user code in the wild is bound to do so.
+    //
+    // If stackTrace is null, no profit to calling fillInStackTrace().
+    // If writableStackTrace is true, then fillInStackTrace has already
+    // been called in the constructor. If the stack is not writable, then
+    // it can not be filled in.
+
+    if (stackTrace == null) {
+      Array.empty[StackTraceElement] // as specified by Java 8.
     } else
       this.synchronized {
         stackTrace.clone

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -67,12 +67,12 @@ class Throwable protected (s: String,
 
   private[this] var stackTrace: Array[StackTraceElement] = _
 
+  if (writableStackTrace)
+    fillInStackTrace()
+
   // We use an Array rather than, say, a List, so that Throwable does not
   // depend on the Scala collections.
   private[this] var suppressed: Array[Throwable] = _
-
-  if (writableStackTrace)
-    fillInStackTrace()
 
   final def addSuppressed(exception: Throwable): Unit = {
 

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -132,10 +132,10 @@ class Throwable protected (s: String,
 
     if (stackTrace eq null) {
       new Array[StackTraceElement](0) // as specified by Java 8.
-    } else
-      this.synchronized {
-        stackTrace.clone
-      }
+    } else {
+      // stackTrace is read-only at this point, no synchronized necessary.
+      stackTrace.clone
+    }
   }
 
   final def getSuppressed(): Array[Throwable] = {

--- a/unit-tests/src/test/scala/java/lang/ThrowablesSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/ThrowablesSuite.scala
@@ -1,0 +1,356 @@
+package java.lang
+
+// Portions of this Suite were ported, with thanks & gratitude,
+// from Scala.js testsuite/javalib/lang/ThrowablesTestOnJDK7.scala
+//
+// The rest is an original contribution to Scala Native.
+
+object ThrowablesSuite extends tests.Suite {
+
+  // Consolidate boilerplate; aids consistency.
+
+  private def getThrowableMessage(throwable: Throwable): String = {
+    if (throwable == null) "<null>" else throwable.getMessage
+  }
+
+  private def checkCause(throwable: Throwable,
+                         expectedCause: Throwable): Unit = {
+    val resultCause = throwable.getCause
+
+    val causeMessage = getThrowableMessage(throwable)
+
+    val expectedMessage = getThrowableMessage(expectedCause)
+
+    assert(resultCause == expectedCause,
+           s"cause: '${causeMessage}' != expected: '${expectedMessage}'")
+  }
+
+  private def checkMessage(throwable: Throwable,
+                           expectedMessage: String): Unit = {
+    val resultMessage = throwable.getMessage
+
+    assert(resultMessage == expectedMessage,
+           s"message: '${resultMessage}' != expected: '${expectedMessage}'")
+  }
+
+  private def checkStackTraceString(trace: String): Unit = {
+    val startText = "java.lang.Throwable"
+    assert(trace.startsWith(startText),
+           s"Expected trace to start with '${startText}' and it did not.")
+
+    val containsText = "\tat <none>.main(Unknown Source)"
+    assert(trace.contains(containsText),
+           s"Expected trace to contain '${containsText}' and it did not.")
+  }
+
+  private def checkStackTrace(throwable: Throwable): Unit = {
+    val sw = new java.io.StringWriter
+    val pw = new java.io.PrintWriter(sw)
+
+    throwable.printStackTrace(pw)
+
+    checkStackTraceString(sw.toString)
+  }
+
+  private def checkSuppressed(throwable: Throwable, expectedLength: Int) {
+    val getSuppressedLength = throwable.getSuppressed.length
+    assert(getSuppressedLength == expectedLength,
+           s"getSuppressed.length: ${getSuppressedLength} != " +
+             s"expected: ${expectedLength}")
+  }
+
+  private def checkConstructed(throwable: Throwable,
+                               expectedMessage: String,
+                               expectedCause: Throwable,
+                               expectedSuppressedLength: Int): Unit = {
+
+    checkMessage(throwable, expectedMessage)
+    checkCause(throwable, expectedCause)
+    checkSuppressed(throwable, 0)
+    checkStackTrace(throwable)
+  }
+
+  // Zero & two argument constructor tests will exercise cases where
+  // the rightmost two arguments are true.
+
+  test("Throwable(message, cause, false, false)") {
+    val expectedMessage = "Athchomar chomakea"
+    val expectedCause   = new Throwable("Khal Drogo")
+
+    val throwable = new Throwable(expectedMessage, expectedCause, false, false)
+
+    checkConstructed(throwable, expectedMessage, expectedCause, 0)
+
+  }
+
+  test("Throwable(message)") {
+    val expectedMessage = "Hello World"
+    val expectedCause   = null
+
+    val throwable = new Throwable(expectedMessage)
+
+    checkConstructed(throwable, expectedMessage, expectedCause, 0)
+
+  }
+
+  test("Throwable(cause)") {
+    val expectedMessageStem = "Primum Mobile"
+    val expectedMessage     = s"java.lang.Throwable: ${expectedMessageStem}"
+
+    val expectedCause = new Throwable(expectedMessageStem)
+
+    val throwable = new Throwable(expectedCause)
+
+    checkConstructed(throwable, expectedMessage, expectedCause, 0)
+
+  }
+
+  test("Throwable()") {
+    val expectedMessage = null
+    val expectedCause   = null
+
+    val throwable = new Throwable()
+
+    checkConstructed(throwable, expectedMessage, expectedCause, 0)
+
+  }
+
+  // Thirteen public methods are documented for class Throwable.
+  //
+  // Five (5) methods: fillinStackTrace(), getCause(), getMessage(),
+  // getSuppressed(), printStackTrace(PrintWriter), have been exercised by
+  // constructor tests above and do not need separate tests. This is the
+  // Thetis problem.
+  //
+  // Six methods are exercised below. getStackTrace() does not have a
+  // test of its own. It gets exercised by setStackTrace().
+  //
+  // The following two (2) do not have explicit tests:
+  //
+  // * Scala Native supports only the US Locale, so getLocalizedMessage()
+  //   is just a call to getMessage(), which is exercised.
+  //
+  // * printStackTrace() is a call to printStackTrace(System.err) where
+  //   the latter is exercised.
+  //
+  // This accounts for all thirteen methods.
+
+  test("addSuppressed(exception) - invalid arguments") {
+
+    assertThrows[java.lang.NullPointerException] {
+      val throwable = new Throwable()
+      throwable.addSuppressed(null)
+    }
+
+    assertThrows[java.lang.IllegalArgumentException] {
+      val throwable = new Throwable("Expect IllegalArgumentException")
+      throwable.addSuppressed(throwable)
+    }
+
+  }
+
+  test("addSuppressed(exception) - enabled == true") {
+    val throwable = new Throwable()
+
+    val sl = throwable.getSuppressed().length
+    assert(sl == 0, s"length: ${sl} != expected: 0")
+
+    val suppressed1 = new IllegalArgumentException("suppressed_1")
+    val suppressed2 = new UnsupportedOperationException("suppressed_2")
+
+    // There is no ordering guarantee in suppressed exceptions, so we compare
+    // sets.
+
+    throwable.addSuppressed(suppressed1)
+    assert(throwable.getSuppressed().toSet == Set(suppressed1),
+           s"first suppressed set did not match expected")
+
+    throwable.addSuppressed(suppressed2)
+    assert(throwable.getSuppressed().toSet == Set(suppressed1, suppressed2),
+           s"second suppressed set did not match expected")
+  }
+
+  test("addSuppressed(exception) - enabled == false") {
+    val throwable = new Throwable(null, null, false, true)
+
+    val sl0 = throwable.getSuppressed().length
+    assert(sl0 == 0, s"starting  suppressed length: ${sl0} != expected: 0")
+
+    val suppressed1 = new IllegalArgumentException("suppressed_1")
+    val suppressed2 = new UnsupportedOperationException("suppressed_2")
+
+    throwable.addSuppressed(suppressed1)
+    val sl1 = throwable.getSuppressed().length
+    assert(sl1 == 0, s"first suppressed length: ${sl1} != expected: 0")
+
+    throwable.addSuppressed(suppressed2)
+    val sl2 = throwable.getSuppressed().length
+    assert(sl2 == 0, s"second suppressed length: ${sl2} != expected: 0")
+
+  }
+
+  test("initCause(cause) - cases which throw an Exception") {
+
+    assertThrows[java.lang.IllegalArgumentException] {
+      val throwable = new Throwable()
+      throwable.initCause(throwable)
+    }
+
+    assertThrows[java.lang.IllegalStateException] {
+      val throwable = new Throwable(new Throwable("Lyta-Zod"))
+      throwable.initCause(new Throwable("Jayna-Zod"))
+    }
+
+    locally {
+      val throwable = new Throwable()
+      throwable.initCause(new Throwable("Kem"))
+
+      assertThrows[java.lang.IllegalStateException] {
+        throwable.initCause(new Throwable("Cor-Vex"))
+      }
+
+      assertThrows[java.lang.IllegalStateException] {
+        throwable.initCause(new Throwable("Jor-El"))
+      }
+    }
+
+  }
+
+  test("initCause(cause)") {
+
+    val throwable = new Throwable()
+    // Constructor test above has already verified that initial cause is null.
+
+    val causeMsg = "Nyssa-Vex"
+    val cause    = new Throwable(causeMsg)
+
+    throwable.initCause(cause)
+
+    val result = throwable.getCause
+
+    val resultMsg = if (result == null) "null" else result.getMessage
+
+    assert(result == cause,
+           s"unexpected cause: '${resultMsg}' != expected: '${causeMsg}'")
+  }
+
+  test("printStackTrace(PrintStream)") {
+    val throwable = new Throwable("Dev-Em")
+    val baos      = new java.io.ByteArrayOutputStream
+    val ps        = new java.io.PrintStream(baos)
+    val encoding  = "UTF-8"
+
+    throwable.printStackTrace(ps)
+
+    checkStackTraceString(baos.toString(encoding))
+
+  }
+
+  test("setStackTrace(stackTrace) - invalid arguments") {
+
+    assertThrows[java.lang.NullPointerException] {
+      val throwable = new Throwable()
+      throwable.setStackTrace(null)
+    }
+
+    assertThrows[java.lang.NullPointerException] {
+      val throwable = new Throwable()
+      val newStackTrace = Array(
+        new StackTraceElement("Zero", "noMethod", "noFile", 0),
+        new StackTraceElement("One", "noMethod", "noFile", 1),
+        null.asInstanceOf[StackTraceElement],
+        new StackTraceElement("Three", "noMethod", "noFile", 3)
+      )
+
+      throwable.setStackTrace(newStackTrace)
+    }
+
+  }
+
+  test("setStackTrace(stackTrace) - writable == true") {
+
+    val throwable = new Throwable(null, null, true, true)
+
+    val newStackTrace = Array(
+      new StackTraceElement("Zero", "noMethod", "noFile", 0),
+      new StackTraceElement("One", "noMethod", "noFile", 1),
+      new StackTraceElement("Two", "noMethod", "noFile", 2),
+      new StackTraceElement("Three", "noMethod", "noFile", 3)
+    )
+
+    val beforeStackTrace = throwable.getStackTrace()
+
+    throwable.setStackTrace(newStackTrace)
+
+    val afterStackTrace = throwable.getStackTrace()
+
+    assert(!afterStackTrace.sameElements(beforeStackTrace),
+           s"elements after setStackTrace() did not change")
+
+    assert(afterStackTrace.sameElements(newStackTrace),
+           s"elements after setsetStackTrace() are not as expected")
+  }
+
+  test("setStackTrace(stackTrace) - writable == false") {
+
+    val throwable = new Throwable(null, null, true, false)
+
+    val newStackTrace = Array(
+      new StackTraceElement("Zero", "noMethod", "noFile", 0),
+      new StackTraceElement("One", "noMethod", "noFile", 1),
+      new StackTraceElement("Two", "noMethod", "noFile", 2),
+      new StackTraceElement("Three", "noMethod", "noFile", 3)
+    )
+
+    val beforeStackTrace = throwable.getStackTrace()
+
+    throwable.setStackTrace(newStackTrace)
+
+    val afterStackTrace = throwable.getStackTrace()
+
+    assert(afterStackTrace.sameElements(beforeStackTrace),
+           s"stackTrace elements of non-writable stack differ")
+
+  }
+
+  test("setStackTrace(stackTrace) - write to returned stack") {
+    val throwable = new Throwable()
+    val trace1    = throwable.getStackTrace()
+
+    val savedElement0 = trace1(0)
+    trace1(0) = null
+
+    val trace2 = throwable.getStackTrace()
+
+    assert(trace2(0) == savedElement0,
+           s"writing into returned trace should not affect next getStackTrace")
+
+    assert(trace1(0) == null,
+           s"second getStackTrace() should not change first result")
+
+  }
+
+  test("toString()") {
+
+    val expectedClassName = "java.lang.Throwable"
+
+    locally {
+      val throwable = new Throwable()
+
+      val expected = expectedClassName
+      val result   = throwable.toString
+      assert(result == expected, s"result: ${result} != expected: ${expected}")
+    }
+
+    locally {
+      val message   = "Seg-El"
+      val throwable = new Throwable(message)
+
+      val expected = s"${expectedClassName}: ${message}"
+      val result   = throwable.toString
+      assert(result == expected, s"result: ${result} != expected: ${expected}")
+    }
+
+  }
+
+}

--- a/unit-tests/src/test/scala/java/lang/ThrowablesSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/ThrowablesSuite.scala
@@ -63,7 +63,6 @@ object ThrowablesSuite extends tests.Suite {
                                expectedMessage: String,
                                expectedCause: Throwable,
                                expectedSuppressedLength: Int): Unit = {
-
     checkMessage(throwable, expectedMessage)
     checkCause(throwable, expectedCause)
     checkSuppressed(throwable, 0)
@@ -80,7 +79,6 @@ object ThrowablesSuite extends tests.Suite {
     val throwable = new Throwable(expectedMessage, expectedCause, false, false)
 
     checkConstructed(throwable, expectedMessage, expectedCause, 0)
-
   }
 
   test("Throwable(message)") {
@@ -90,7 +88,6 @@ object ThrowablesSuite extends tests.Suite {
     val throwable = new Throwable(expectedMessage)
 
     checkConstructed(throwable, expectedMessage, expectedCause, 0)
-
   }
 
   test("Throwable(cause)") {
@@ -102,7 +99,6 @@ object ThrowablesSuite extends tests.Suite {
     val throwable = new Throwable(expectedCause)
 
     checkConstructed(throwable, expectedMessage, expectedCause, 0)
-
   }
 
   test("Throwable()") {
@@ -112,15 +108,13 @@ object ThrowablesSuite extends tests.Suite {
     val throwable = new Throwable()
 
     checkConstructed(throwable, expectedMessage, expectedCause, 0)
-
   }
 
   // Thirteen public methods are documented for class Throwable.
   //
   // Five (5) methods: fillinStackTrace(), getCause(), getMessage(),
   // getSuppressed(), printStackTrace(PrintWriter), have been exercised by
-  // constructor tests above and do not need separate tests. This is the
-  // Thetis problem.
+  // constructor tests above and do not need separate tests.
   //
   // Six methods are exercised below. getStackTrace() does not have a
   // test of its own. It gets exercised by setStackTrace().
@@ -136,7 +130,6 @@ object ThrowablesSuite extends tests.Suite {
   // This accounts for all thirteen methods.
 
   test("addSuppressed(exception) - invalid arguments") {
-
     assertThrows[java.lang.NullPointerException] {
       val throwable = new Throwable()
       throwable.addSuppressed(null)
@@ -146,7 +139,6 @@ object ThrowablesSuite extends tests.Suite {
       val throwable = new Throwable("Expect IllegalArgumentException")
       throwable.addSuppressed(throwable)
     }
-
   }
 
   test("addSuppressed(exception) - enabled == true") {
@@ -186,11 +178,9 @@ object ThrowablesSuite extends tests.Suite {
     throwable.addSuppressed(suppressed2)
     val sl2 = throwable.getSuppressed().length
     assert(sl2 == 0, s"second suppressed length: ${sl2} != expected: 0")
-
   }
 
   test("initCause(cause) - cases which throw an Exception") {
-
     assertThrows[java.lang.IllegalArgumentException] {
       val throwable = new Throwable()
       throwable.initCause(throwable)
@@ -213,11 +203,9 @@ object ThrowablesSuite extends tests.Suite {
         throwable.initCause(new Throwable("Jor-El"))
       }
     }
-
   }
 
   test("initCause(cause)") {
-
     val throwable = new Throwable()
     // Constructor test above has already verified that initial cause is null.
 
@@ -243,11 +231,9 @@ object ThrowablesSuite extends tests.Suite {
     throwable.printStackTrace(ps)
 
     checkStackTraceString(baos.toString(encoding))
-
   }
 
   test("setStackTrace(stackTrace) - invalid arguments") {
-
     assertThrows[java.lang.NullPointerException] {
       val throwable = new Throwable()
       throwable.setStackTrace(null)
@@ -264,11 +250,9 @@ object ThrowablesSuite extends tests.Suite {
 
       throwable.setStackTrace(newStackTrace)
     }
-
   }
 
   test("setStackTrace(stackTrace) - writable == true") {
-
     val throwable = new Throwable(null, null, true, true)
 
     val newStackTrace = Array(
@@ -292,7 +276,6 @@ object ThrowablesSuite extends tests.Suite {
   }
 
   test("setStackTrace(stackTrace) - writable == false") {
-
     val throwable = new Throwable(null, null, true, false)
 
     val newStackTrace = Array(
@@ -310,7 +293,6 @@ object ThrowablesSuite extends tests.Suite {
 
     assert(afterStackTrace.sameElements(beforeStackTrace),
            s"stackTrace elements of non-writable stack differ")
-
   }
 
   test("setStackTrace(stackTrace) - write to returned stack") {
@@ -327,11 +309,9 @@ object ThrowablesSuite extends tests.Suite {
 
     assert(trace1(0) == null,
            s"second getStackTrace() should not change first result")
-
   }
 
   test("toString()") {
-
     val expectedClassName = "java.lang.Throwable"
 
     locally {
@@ -350,7 +330,5 @@ object ThrowablesSuite extends tests.Suite {
       val result   = throwable.toString
       assert(result == expected, s"result: ${result} != expected: ${expected}")
     }
-
   }
-
 }


### PR DESCRIPTION
  * This PR was motivated by Issue #1683 "Implement suppression for
    Throwable".

    That issue and several related others are now fixed.

  * Some of the implementation and testing code was ported, with gratitude,
    from Scala JS. Thank you, @sjrd & team.

  * The requested four argument constructor and associated methods
    were implemented.  The SN Throwables class should now follow
    the Java 8 specification.

    Argument checking was tightened up to match specification.
    Exceptions messages match Scala JVM practice.

    initCause() was changed to follow the "at-most-once" semantics
    described by Java 8.

  * Several methods are described by Java 8 as being thread-safe.
    SN is currently mono-threaded but it makes no sense to
    introduce hard to find technical debt by writing new code
    which is supposed to be thread-safe and is not.

    These routines currently use `this.synchronized` which
    synchronizes on the entire class. If the way they were implemented
    seems to not be idiomatic, that is to prevent the bug described
    in SN Issue #1091. The synchronization protects each `var`
    accessed outside constructors. The latter are defined as mono-threaded
    by the Java specification.

    The locking can be done at a finer granularity if experience shows that
    the execution time lost due to lock contention is unacceptable,
    Throwables handling is pretty slow to begin with, so I suspect that
    lock contention will be hard to identify.

  * Extensive unit tests were implemented in the new ThrowablesSuite.scala.
    Each of the constructors and almost all methods are exercised.
    Reasons are given to be confident in the two untested methods.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in debug mode using sbt 1.2.8 & Java 8 on
    X86_64 only . All tests pass.

  * Built and tested ("test-all") in release-fast mode, LTO=thin using
    sbt 1.2.8 & Java 8 on X86_64 only . All tests pass.