### PR TITLE
Suite.scala now shows Exception message only once per report

### DIFF
--- a/unit-tests/src/main/scala/tests/Suite.scala
+++ b/unit-tests/src/main/scala/tests/Suite.scala
@@ -113,7 +113,6 @@ abstract class Suite {
     else {
       val exc          = thrown.get
       val indentSpaces = " " * indent
-      val info         = exc.toString
       val writer       = new java.io.StringWriter
       val printer      = new java.io.PrintWriter(writer)
       exc.printStackTrace(printer)
@@ -123,7 +122,7 @@ abstract class Suite {
         .map { line => s"\n${color}${indentSpaces}${line}" }
         .mkString("")
 
-      s"\n${color}${indentSpaces}${info}" + stacktrace
+      stacktrace
     }
   }
 


### PR DESCRIPTION
  * PR #1385 "Add assert(condition, message) to unit-tests", dated
    2019-02-26, was successful in its main objective.  Unfortunately I
    introduced a practice that experience has  proven to be exceedingly
    annoying: the message, if any, from the exception gets shown twice per
    Exception report/printStackTrace.

    The double reporting wastes the time of the developer trying to decode
    the report and adds no value. I have been looking at a lot of
    stack traces over the last 6 months and can testify to that.

    It was originally added when I was chasing flaws in the test runner
    where the remote test process would die and leave no message. The
    double reporting proved to be no help there. I never was able
    to catch the remote process in the act of dying prematurely.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in debug mode using sbt 1.2.8 & Java 8 on
    X86_64 only . All tests pass.