### PR TITLE
Detect  invalid Unicode class specification "\\p".

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
@@ -1096,6 +1096,13 @@ class Parser(wholeRegexp: String, _flags: Int) {
       if (c == 'P') {
         sign = -1
       }
+      if (!t.more()) {
+        val pos = t.pos()
+        t.rewindTo(startPos);
+        throw new PatternSyntaxException(ERR_UNKNOWN_CHARACTER_PROPERTY_NAME,
+                                         t.rest(),
+                                         pos)
+      }
       c = t.pop()
       var name: String = ""
       if (c != '{') {
@@ -1106,10 +1113,11 @@ class Parser(wholeRegexp: String, _flags: Int) {
         val rest = t.rest()
         val end  = rest.indexOf('}')
         if (end < 0) {
+          val pos = t.pos()
           t.rewindTo(startPos)
-          throw new PatternSyntaxException(ERR_INVALID_CHAR_RANGE,
+          throw new PatternSyntaxException(ERR_UNKNOWN_CHARACTER_PROPERTY_NAME,
                                            t.str,
-                                           t.pos() - 1)
+                                           pos)
         }
         name = rest.substring(0, end) // e.g. "Han"
         t.skipString(name)
@@ -1298,7 +1306,7 @@ object Parser {
     "Unknown inline modifier"
 
   private final val ERR_INVALID_REPEAT_OP =
-    "invalid nested repetition operator"
+    "Invalid nested repetition operator"
 
   private final val ERR_INVALID_REPEAT_SIZE =
     "Dangling meta character '*'"
@@ -1314,6 +1322,9 @@ object Parser {
 
   private final val ERR_UNMATCHED_CLOSING_PAREN =
     "Unmatched closing ')'"
+
+  private final val ERR_UNKNOWN_CHARACTER_PROPERTY_NAME =
+    "Unknown character property name"
 
   // Hack to expose ArrayList.removeRange().
   private class Stack extends ArrayList[Regexp] {

--- a/unit-tests/src/test/scala/scala/scalanative/regex/RE2CompileSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/RE2CompileSuite.scala
@@ -41,9 +41,11 @@ object RE2CompileSuite extends tests.Suite {
 //          "Illegal/unsupported character class near index 3\n[a-z\n   ^"),
     Array("[z-a]", "Illegal character range near index 3\n[z-a]\n   ^"),
     Array("abc\\", "Trailing Backslash near index 4\nabc\\\n    ^"),
-    Array("a**", "invalid nested repetition operator near index 0\n**\n^"),
-    Array("a*+", "invalid nested repetition operator near index 0\n*+\n^"),
-    Array("\\x", "Illegal/unsupported escape sequence near index 1\n\\x\n ^")
+    Array("a**", "Invalid nested repetition operator near index 0\n**\n^"),
+    Array("a*+", "Invalid nested repetition operator near index 0\n*+\n^"),
+    Array("\\x", "Illegal/unsupported escape sequence near index 1\n\\x\n ^"),
+    Array("\\p", "Unknown character property name near index 2\n\\p\n  ^"),
+    Array("\\p{", "Unknown character property name near index 3\n\\p{\n   ^")
   )
 
   test("Compile") {
@@ -52,11 +54,13 @@ object RE2CompileSuite extends tests.Suite {
         RE2.compile(input)
         if (expectedError != null)
           fail(
-            "RE2.compile(" + input + ") was successful, expected " + expectedError)
+            "RE2.compile(" + input + ") was successful, expected "
+              + expectedError)
       } catch {
         case e: PatternSyntaxException =>
-          if (expectedError == null || !(e.getMessage == expectedError))
+          if (expectedError == null || !(e.getMessage == expectedError)) {
             fail("compiling " + input + "; unexpected error: " + e.getMessage)
+          }
       }
     }
   }


### PR DESCRIPTION
  * This PR ports [re2j](https://github.com/google/re2j/) PR
    #[74](https://github.com/google/re2j/)
    "Detect invalid Unicode class specification", dated 2018-10-23, to
    Scala Native.

    Prior to this PR, compiling the pattern "\\p" would lead to an
    unexpected java.lang.StringIndexOutOfBoundsException.
    As of this PR the PatternSyntaxException used by the JVM is thrown.

    The text of the exception is slightly different. JVM reports the unknown
    property name, or {?}. Doing that in SN regex is harder that time allowed.

  * A new ERR_UNKNOWN_CHARACTER_PROPERTY_NAME message was added and
    and the initial word of three messages converted to Titlecase as used by JVM.

    Message texts from SN regex (née re2s) still do not match JVM
    exactly but they are moving closer.

  * The message text for the invalid specification "\\p{" was
    also changed.

Documentation:

    * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in debug mode, Java 8, using sbt 1.2.8 on
    X86_64 only . All tests pass.