### PR TITLE
Fix #1673: regex ANY_CHARACTER "\\n|." ANY_CHARACTER idiom now works

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
@@ -14,6 +14,8 @@ import java.util.List
 
 import java.util.regex.PatternSyntaxException
 
+import scala.annotation.switch
+
 import Regexp.{Op => ROP}
 
 // A parser of regular expression patterns.
@@ -1567,25 +1569,31 @@ object Parser {
   // does re match r?
   private def matchRune(re: Regexp, r: Int): Boolean = {
 
-    var matched = false
+    val matched = (re.op: @switch) match {
 
-    (re.op: @scala.annotation.switch) match {
-      case ROP.LITERAL => re.runes.length == 1 && re.runes(0) == r
+      case ROP.LITERAL => (re.runes.length == 1) && (re.runes(0) == r)
 
       case ROP.CHAR_CLASS =>
-        var i = 0
-        while (i < re.runes.length) {
-          if (re.runes(i) <= r && r <= re.runes(i + 1)) {
-            matched = true
+        val len = re.runes.length
+        assert((len % 2) == 0, s"matchRune: runs.length ${len} must be even")
+
+        var found = false
+        var i     = 0
+
+        while ((i < len) && (!found)) {
+          if ((re.runes(i) <= r) && (r <= re.runes(i + 1))) {
+            found = true
           }
           i += 2
         }
 
-      case ROP.ANY_CHAR_NOT_NL => r != '\n'
+        found
 
-      case ROP.ANY_CHAR => matched = true
+      case ROP.ANY_CHAR_NOT_NL => (r != '\n')
 
-      case _ =>
+      case ROP.ANY_CHAR => true
+
+      case _ => false
     }
 
     matched

--- a/unit-tests/src/test/scala/scala/scalanative/regex/ParserSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/ParserSuite.scala
@@ -165,7 +165,7 @@ object ParserSuite extends tests.Suite {
       "(?i)\\W",
       "cc{0x0-0x2f 0x3a-0x40 0x5b-0x5e 0x60 0x7b-0x17e 0x180-0x2129 0x212b-0x10ffff}"),
     Array("[^\\\\]", "cc{0x0-0x5b 0x5d-0x10ffff}"),
-    //  { "\\C", "byte{}" },  // probably never
+    //	{ "\\C", "byte{}" },  // probably never
     // Unicode, negatives, and a double negative.
     Array("\\p{Braille}", "cc{0x2800-0x28ff}"),
     Array("\\P{Braille}", "cc{0x0-0x27ff 0x2900-0x10ffff}"),
@@ -316,11 +316,23 @@ object ParserSuite extends tests.Suite {
   private val NOMATCHNL_TESTS = Array(
     Array(".", "dnl{}"),
     Array("\n", "lit{\n}"),
+    // These two tests exercise a pattern containing NL, using the NOMATCHNL
+    // flag (well, flags == 0). Dot will not match NL, so the alternation
+    // ".|\n" idiom is uses as a way to match any character, including NL.
+    //
+    // Yes, these tests belong here and not in MATCHNL_TESTS above.
+    // When MATCHNL, a.k.a DOTALL is the flag, there is no need for the idiom.
+    //
+    // Test both forms of alternation idiom for ROP.ANY_CHAR a.k.a. dot{}.
+    // The code paths differ slightly depending on the left term.
+    Array(".|\\n", "dot{}"),
+    Array("\\n|.", "dot{}"),
     Array("[^a]", "cc{0x0-0x9 0xb-0x60 0x62-0x10ffff}"),
-    Array("[a\\n]", "cc{0xa 0x61}"))
+    Array("[a\\n]", "cc{0xa 0x61}")
+  )
 
   test("ParseNoMatchNL") {
-    testParseDump(NOMATCHNL_TESTS, 0)
+    testParseDump(NOMATCHNL_TESTS, 0) // All flags are clear.
   }
 
   // Test Parse -> Dump.


### PR DESCRIPTION
  * This PR was motivated by Issue #1673 " regex RE2 wrongly ignores newline
    in OR groups".

    The defect was a botched rewrite of the Parser.scala method
    matchRune() in an attempt to remove multiple `return` statements.

    The issue is now fixed for the two patterns which would evoke
    the presenting problem.  The patterns "\\n|." and ".|\\n"
    are both used to indicate a match to ANY_CHARACTER, including
    newline. Because regex is defined to have a preference for the
    left term, they execute slightly different code paths.
  
  * The defect was in SN 0.4.0 code, so this PR is not a candidate for
     backport to the SN 0.3.n series.

  * Two unit-test cases were added to ParserSuite.scala. Each tests
    one of the two patterns which evoked Issue #1673.

  * Details for future maintainers.

    + The FLAGS argument to testParseDump() in NOMATCHNL_TESTS as 0.
      That is, all flags are clear. This mean MATCH_NL is clear, which
      matches Java 8 DOTALL being clear: dot does not match newline.

     +  Most of rest of Suite uses FLAGS which match PERL:
       TEST_FLAGS = MATCH_NL | PERL_X | UNICODE_GROUPS`
       This sets dot to match newline and does not evoke Issue #1673.

    + Before this PR, Parser.scala with MATCH_NL clear compiled uses of
      the patterns to "dnl{}"; that is, ROP.ANY_CHAR_NOT_NL.
      As of this PR, the patterns get compiled to the correct and
      expected "dnl{}", ROP.ANY_CHAR. See NONMATCHNL_TESTS .

Documentation:

   * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in release-fast mode using sbt 1.2.8 on
    X86_64 only . All tests pass.