### PR TITLE
nativelib regex RE2.Machine mutual exclusion improvements, re2j PR 85 & more

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/regex/RE2.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/RE2.scala
@@ -102,7 +102,7 @@ class RE2 private {
   // machine cache if possible, to avoid unnecessary allocation.
 
   def get(): Machine = {
-    /// SN: Having a return statement in the middle of the code is an
+    /// Scala Native: Having a return statement in the middle of the code is an
     /// eyesore that comes directly from the re2j base code.
     /// Its saving grace is that it _vastly_ simplifies the mutual
     /// exclusion logic.

--- a/nativelib/src/main/scala/scala/scalanative/regex/RE2.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/RE2.scala
@@ -102,8 +102,10 @@ class RE2 private {
   // machine cache if possible, to avoid unnecessary allocation.
 
   def get(): Machine = {
-    /// SN: Having two return statements is an eyesore that directly from
-    /// the re2j base code. It _vastly_ simplifies the mutual exclusion logic.
+    /// SN: Having a return statement in the middle of the code is an
+    /// eyesore that comes directly from the re2j base code.
+    /// Its saving grace is that it _vastly_ simplifies the mutual
+    /// exclusion logic.
 
     this.synchronized {
       if (!machine.isEmpty()) {
@@ -111,7 +113,7 @@ class RE2 private {
       }
     }
 
-    return new Machine(this);
+    new Machine(this)
   }
 
   // Clears the memory associated with this machine.


### PR DESCRIPTION
  * This PR ports [re2j](https://github.com/google/re2j/) PR #[85](https://github.com/google/re2j/pull/85) "Don't create Machine while holding this' monitor",
 dated 2019-02-22, to Scala Native.

    My thanks and appreciation to the re2j developer @sjamesr for the
    re2j PR. The porting is my original contribution.

  * Since ScalaNative is currently single threaded, this PR may seem
    to be not worth the overhead.  At the very least, it keeps the
    scalanative.regex/re2s implementation close to the re2j parent.

    In the longer run, I do believe that someday, Real Soon Now, a
    Big Switch will be thrown and not having synchronization issues
    that could & should have been avoided sprinkled all over the
    code base will be seen to be a Good Thing.

 * ScalaNative Issue #1091 describes a bug where monitor methods
   are not generated when `synchronized` is used with `def`.
   It reports that the code generated for interior synchronized blocks
   is correct.

   There are three uses of `synchronized` in the scalanative.regex package.

   + This PR naturally changed RE2.get().

   + RE2.reset() and RE2.put() were changed and the reason commented.

  * I do not understand why the upstream re2j changed the data structure from
    ArrayList to ArrayDeque, then uses it as a Queue. Seems like a slight 
    pessimization, if ArrayDeque is implemented in terms of ArrayList, as
    it now is in Scala Native. 

    It seemed kinder to future devos, including myself in three months, to follow
    the re2j change that to maintain lots of comments explaining why re2s/sn.regex
    and re2j differed.  This is especially important because of rounds of re2j PRs I hope
    to port in the near future.

  * No unit-tests were added. The re2j PR had no changes associated
    with testing. Focus testing the behavior on a single threaded
    ScalaNative would be hard.

    While it can not be shown that this PR introduced the positive
    change it describes, it can be shown, to a reasonable degree of
    certitude, that it did not introduce obvious negative changes,
    a.k.a. bugs: `test-all` in release-fast mode succeeds with no new
    performance issues.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in release-fast mode using sbt 1.3.10 on
    X86_64 only . All tests pass.