### PR TITLE
Fix #1693: j.u.AbstractCollection#toString output now matches Scala JVM

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractCollection.scala
+++ b/javalib/src/main/scala/java/util/AbstractCollection.scala
@@ -78,5 +78,5 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   }
 
   override def toString(): String =
-    iterator.asScala.mkString("[", ",", "]")
+    iterator.asScala.mkString("[", ", ", "]")
 }

--- a/unit-tests/src/test/scala/java/util/ArrayListSuite.scala
+++ b/unit-tests/src/test/scala/java/util/ArrayListSuite.scala
@@ -394,4 +394,14 @@ object ArrayListSuite extends tests.Suite {
     assert(!al.contains(5))
   }
 
+  test("toString()") {
+    val al = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+
+    // Note well the space/blank after the commas. This matches Scala JVM.
+    val expected = "[1, 2, 3, 2]"
+
+    val result = al.toString
+    assert(result == expected, s"result: ${result} != expected: ${expected}")
+  }
+
 }


### PR DESCRIPTION
  * This PR fixes Scala Native Issue #1693 "j.u.AbstractCollection#toString
    output does not match Scala JVM "

    The prior behavior, ported from Scala.js, formats
    an ArrayList with elements (1, 2, 3, 2) as `[1,2,3,2]`.
    Now that ArrayList is formatted to follow Scala JVM
    practice: `[1, 2, 3, 2]`. Note the whitespace after the commas.

    After checking on SN gitter, there seems to be no good reason for
    Scala Native to differ from Scala JVM here. The Scala.js
    format may have come from a desire to match CSV (Comma Separated
    Values) formats but Scala Native does not have that need.

    The hazards of depending upon a given format are well known,
    particularly when it comes to white space. Sometimes checking
    for a string match is the best that can be done, so SN
    should not make that difficult if it can easily be avoided.

  * After the dust settles on this PR, I hope to check with the
    Scala.js team to see if they would welcome a similar PR.

  * A unit test was added to ArrayListSuite.scala to test this fix.
    ArrayList is a concrete class which inherits toString() from
    AbstractCollection and does not override it.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in release-fast mode using sbt 1.2.8 on
    X86_64 only . All tests pass.