### PR TITLE
Improved sn.regex named group support.

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -22,17 +22,6 @@ final class Matcher private[regex] (var _pattern: Pattern,
 
   private var anchoringBoundsInUse = true
 
-  private def groupIndex(name: String): Int = {
-
-    val pos = _pattern.compiled.re2.findNamedCapturingGroups(name)
-
-    if (pos == -1) {
-      throw new IllegalArgumentException(s"No group with name <$name>")
-    }
-
-    pos
-  }
-
   private def noLookAhead(methodName: String): Nothing =
     throw new UnsupportedOperationException(
       s"$methodName is not supported due to unsupported lookaheads.")
@@ -50,7 +39,7 @@ final class Matcher private[regex] (var _pattern: Pattern,
 
   def end(group: Int): Int = underlying.end(group)
 
-  def end(name: String): Int = end(groupIndex(name))
+  def end(name: String): Int = underlying.end(name)
 
   def find(): Boolean = underlying.find()
 
@@ -114,7 +103,7 @@ final class Matcher private[regex] (var _pattern: Pattern,
 
   def start(group: Int): Int = underlying.start(group)
 
-  def start(name: String): Int = start(groupIndex(name))
+  def start(name: String): Int = underlying.start(name)
 
   def toMatchResult(): MatchResult = this.clone.asInstanceOf[MatchResult]
 

--- a/nativelib/src/main/scala/scala/scalanative/regex/Matcher.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Matcher.scala
@@ -3,6 +3,8 @@
 package scala.scalanative
 package regex
 
+import java.util.Map
+
 // A stateful iterator that interprets a regex {@code Pattern} on a
 // specific input.  Its interface mimics the JDK 1.4.2
 // {@code java.util.regex.Matcher}.
@@ -56,6 +58,8 @@ final class Matcher private (private var _pattern: Pattern) {
   // The group indexes, in [start, end) pairs.	Zeroth pair is overall match.
   // By convention a pair (-1, -1) indicates no or null match.
   private var _groups: Array[Int] = createGroups(_groupCount)
+
+  private val namedGroups: Map[String, Int] = _pattern.re2.namedGroups
 
   private var _inputSequence: CharSequence = ""
 
@@ -154,16 +158,51 @@ final class Matcher private (private var _pattern: Pattern) {
     _groups(2 * group + 1)
   }
 
-  def start(name: String): Int    = start(groupIndex(name))
-  def end(name: String): Int      = end(groupIndex(name))
-  def group(name: String): String = group(groupIndex(name))
-
-  private def groupIndex(name: String): Int = {
-    val pos = _pattern.re2.findNamedCapturingGroups(name)
-    if (pos == -1) {
-      throw new IllegalArgumentException(s"No group with name <$name>")
+  private def getOrThrow(_map: Map[String, Int], key: String): Int = {
+    val v = _map.get(key)
+    // Use knowledge about how the map is used to save execution cycles
+    // on error path. There will never be a _named_ group with index 0,
+    // so any 0 here truely means the name was not found.
+    if (v == 0) {
+      throw new IllegalStateException("No match found")
     }
-    pos
+    v
+  }
+
+  /**
+   * Returns the start of the named group of the most recent match, or -1
+   * if the group was not matched.
+   *
+   * @param group the group name
+   * @throws IllegalStateException if no group with that name exists
+   */
+  def start(_group: String): Int = {
+    val g = getOrThrow(namedGroups, _group)
+    start(g)
+  }
+
+  /**
+   * Returns the end of the named group of the most recent match, or -1
+   * if the group was not matched.
+   *
+   * @param group the group name
+   * @throws IllegalStateException if no group with that name exists
+   */
+  def end(_group: String): Int = {
+    val g = getOrThrow(namedGroups, _group)
+    end(g)
+  }
+
+  /**
+   * Returns the named group of the most recent match, or {@code null} if the
+   * group was not matched.
+   *
+   * @param group the group name
+   * @throws IllegalStateException if no group with that name exists
+   */
+  def group(_group: String): String = {
+    val g = getOrThrow(namedGroups, _group)
+    group(g)
   }
 
   def region(start: Int, end: Int): Matcher = {

--- a/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
@@ -10,7 +10,9 @@ package regex
 
 import java.util.ArrayList
 import java.util.Arrays
+import java.util.HashMap;
 import java.util.List
+import java.util.Map;
 
 import java.util.regex.PatternSyntaxException
 
@@ -30,6 +32,8 @@ class Parser(wholeRegexp: String, _flags: Int) {
   private val stack        = new Stack()
   private var free: Regexp = _
   private var numCap       = 0 // number of capturing groups seen
+
+  private val namedGroups = new HashMap[String, Int]()
 
   // Allocate a Regexp, from the free list if possible.
   private def newRegexp(op: ROP): Regexp = {
@@ -856,6 +860,7 @@ class Parser(wholeRegexp: String, _flags: Int) {
                                          wholeRegexp,
                                          t.pos())
       }
+      stack.get(0).namedGroups = namedGroups
       stack.get(0)
     }
   }
@@ -867,25 +872,60 @@ class Parser(wholeRegexp: String, _flags: Int) {
   private def parsePerlFlags(t: StringIterator): Unit = {
     val startPos = t.pos()
 
+    /// SN Porting Note:
+    ///     This code has been edited to support both the (?P<name>expr)
+    ///     idiom in the re2j description below and the (?<name>expr)
+    ///     idiom it describes as Perl but which is used by Java.
+    ///
+    // Check for named captures, first introduced in Python's regexp library.
+    // As usual, there are three slightly different syntaxes:
+    //
+    //   (?P<name>expr)   the original, introduced by Python
+    //   (?<name>expr)    the .NET alteration, adopted by Perl 5.10
+    //   (?'name'expr)    another .NET alteration, adopted by Perl 5.10
+    //
+    // Perl 5.10 gave in and implemented the Python version too,
+    // but they claim that the last two are the preferred forms.
+    // PCRE and languages based on it (specifically, PHP and Ruby)
+    // support all three as well.  EcmaScript 4 uses only the Python form.
+    //
+    // In both the open source world (via Code Search) and the
+    // Google source tree, (?P<expr>name) is the dominant form,
+    // so that's the one we implement.  One is enough.
+
     val s = t.rest()
-    if (s.startsWith("(?<")) {
+
+    val Tuple3(isNamedCapture, namedCaptureStart, namedCaptureSkip) =
+      if (s.startsWith("(?<")) { // Java style is most likely
+        (true, 3, 4)
+      } else if (s.startsWith("(?P<")) { // Perl/Python style
+        (true, 4, 5)
+      } else {
+        (false, -1, 1)
+      }
+
+    if (isNamedCapture) {
       // Pull out name.
       val end = s.indexOf('>')
       if (end < 0) {
         throw new PatternSyntaxException(ERR_INVALID_NAMED_CAPTURE, s, 0)
       }
-      val name = s.substring(3, end) // "name"
+      val name = s.substring(namedCaptureStart, end) // "name"
       t.skipString(name)
-      t.skip(4) // "(?<>"
+      t.skip(namedCaptureSkip) // "(?<>" or "(?P<>"
       if (!isValidCaptureName(name)) {
-        throw new PatternSyntaxException(ERR_INVALID_NAMED_CAPTURE,
-                                         s.substring(0, end),
-                                         0) // "(?P<name>"
+        throw new PatternSyntaxException(ERR_INVALID_NAMED_CAPTURE, s, end) // "(?<name>" or "(?P<name>"
       }
       // Like ordinary capture, but named.
       val re = op(ROP.LEFT_PAREN)
       numCap += 1
       re.cap = numCap
+      if (namedGroups.put(name, numCap) != 0) {
+        throw new PatternSyntaxException(
+          ERR_DUPLICATE_NAMED_CAPTURE + s" <${name}> " + "is already defined",
+          s,
+          end)
+      }
       re.name = name
     } else {
 
@@ -1287,7 +1327,7 @@ object Parser {
     "Illegal/unsupported escape sequence"
 
   private final val ERR_INVALID_NAMED_CAPTURE =
-    "Bad named capture group"
+    "capturing group name does not start with a Latin letter"
 
   private final val ERR_INVALID_PERL_OP =
     "Bad perl operator"
@@ -1309,6 +1349,9 @@ object Parser {
 
   private final val ERR_TRAILING_BACKSLASH =
     "Trailing Backslash"
+
+  private final val ERR_DUPLICATE_NAMED_CAPTURE =
+    "Named capturing group"
 
   // Hack to expose ArrayList.removeRange().
   private class Stack extends ArrayList[Regexp] {

--- a/nativelib/src/main/scala/scala/scalanative/regex/Regexp.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Regexp.scala
@@ -9,6 +9,9 @@ package scala.scalanative
 package regex
 
 import java.util.Arrays
+import java.util.Map
+
+import scala.annotation.switch
 
 // Regular expression abstract syntax tree.
 // Produced by parser, used by compiler.
@@ -19,12 +22,17 @@ class Regexp {
 
   var op: Op              = _ // operator
   var flags: Int          = _ // bitmap of parse flags
-  var subs: Array[Regexp] = _ // subexpressions, if any.  Never null.
+  var subs: Array[Regexp] = EMPTY_SUBS // subexpressions, if any.  Never null.
   // subs[0] is used as the freelist.
   var runes: Array[Int] = _ // matched runes, for LITERAL, CHAR_CLASS
   var min, max: Int     = _ // min, max for REPEAT
   var cap: Int          = _ // capturing index, for CAPTURE
   var name: String      = _ // capturing name, for CAPTURE
+
+  // map of group name -> capturing index
+  var namedGroups: Map[String, Int] = _
+
+  // Do update copy ctor when adding new fields!
 
   def this(op: Regexp.Op) = {
     this()
@@ -42,6 +50,7 @@ class Regexp {
     this.max = that.max
     this.cap = that.cap
     this.name = that.name
+    this.namedGroups = that.namedGroups
   }
 
   def reinit(): Unit = {
@@ -62,7 +71,7 @@ class Regexp {
 
   // appendTo() appends the Perl syntax for |this| regular expression to |out|.
   private def appendTo(out: java.lang.StringBuilder): Unit = {
-    (op: @scala.annotation.switch) match {
+    (op: @switch) match {
       case Op.NO_MATCH =>
         out.append("[^\\x00-\\x{10FFFF}]")
       case Op.EMPTY_MATCH =>
@@ -77,7 +86,7 @@ class Regexp {
         } else {
           sub.appendTo(out)
         }
-        (op: @scala.annotation.switch) match {
+        (op: @switch) match {
           case Op.STAR =>
             out.append('*')
           case Op.PLUS =>
@@ -232,31 +241,80 @@ class Regexp {
     m
   }
 
-  def namedCaps(): Map[String, Int] = {
-    val groups = collection.mutable.Map[String, Int]()
-    def visit(re: Regexp): Unit = {
-      if (re.op == Op.CAPTURE && re.name != null) {
-        // Record first occurrence of each name.
-        // (The rule is that if you have the same name
-        // multiple times, only the leftmost one counts.)
-        if (!groups.contains(re.name)) {
-          groups += re.name -> re.cap
-        }
-      }
+  // SN Port: hashCode() ported from re2j aided by initial translation from
+  // http://http://javatoscala.com/.
 
-      if (re.subs != null) {
-        var i = 0
-        while (i < re.subs.length) {
-          visit(re.subs(i))
-          i += 1
-        }
-      }
+  override def hashCode(): Int = {
+    var hashcode: Int = op.hashCode
+    (op: @switch) match {
+      case Op.END_TEXT => hashcode += 31 * (flags & RE2.WAS_DOLLAR)
+      case Op.LITERAL | Op.CHAR_CLASS =>
+        hashcode += 31 * Arrays.hashCode(runes)
+      case Op.ALTERNATE | Op.CONCAT =>
+        hashcode += 31 * Arrays.deepHashCode(subs.asInstanceOf[Array[Object]])
+      case Op.STAR | Op.PLUS | Op.QUEST =>
+        hashcode += 31 * ((flags & RE2.NON_GREEDY) + subs(0).hashCode)
+      case Op.REPEAT =>
+        hashcode += 31 * (min + max + subs(0).hashCode)
+      case Op.CAPTURE =>
+        hashcode += 31 * (cap +
+          (if (name == null) 0 else name.hashCode) +
+          subs(0).hashCode)
+      case _ =>
+        // Fowler-Noll-Vo 32 bit hash constants. Public domain.
+        // http://isthe.com/chongo/tech/comp/fnv/
+        hashcode = (hashcode ^ 0x811C9DC5) * 0x01000193
     }
-    visit(this)
-    groups.toMap
+    hashcode
   }
 
-  // TODO: shallow copy shouldn't match, so removing equals
+  // SN Port: equals() ported from re2j aided by initial translation from
+  // http://http://javatoscala.com/.
+
+  override def equals(that: Any): Boolean = {
+    if (!(that.isInstanceOf[Regexp])) {
+      false
+    } else {
+      val x = this
+      val y = that.asInstanceOf[Regexp]
+
+      if (x.eq(y)) {
+        true
+      } else if (x.op != y.op) {
+        false
+      } else
+        (x.op: @switch) match {
+          case Op.END_TEXT =>
+            // The parse flags remember whether this is \z or \Z.
+            (x.flags & RE2.WAS_DOLLAR) == (y.flags & RE2.WAS_DOLLAR)
+
+          case Op.LITERAL | Op.CHAR_CLASS =>
+            x.runes.sameElements(y.runes)
+
+          case Op.ALTERNATE | Op.CONCAT =>
+            x.subs.sameElements(y.subs)
+
+          case Op.STAR | Op.PLUS | Op.QUEST =>
+            ((x.flags & RE2.NON_GREEDY) == (y.flags & RE2.NON_GREEDY)) &&
+              (x.subs(0).equals(y.subs(0)))
+
+          case Op.REPEAT =>
+            ((x.flags & RE2.NON_GREEDY) == (y.flags & RE2.NON_GREEDY)) &&
+              (x.min == y.min) &&
+              (x.max == y.max) &&
+              (x.subs(0).equals(y.subs(0)))
+
+          case Op.CAPTURE =>
+            (x.cap == y.cap) &&
+              (if (x.name == null) y.name == null else x.name == y.name) &&
+              (x.subs(0) == y.subs(0))
+
+          case _ =>
+            true // Handle ANY_CHAR, ANY_CHAR_NOT_NL, END_LINE, & others
+        }
+    }
+  }
+
 }
 
 object Regexp {

--- a/nativelib/src/main/scala/scala/scalanative/regex/Simplify.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Simplify.scala
@@ -25,21 +25,25 @@ object Simplify {
     if (re == null) {
       return null
     }
+
     (re.op: @scala.annotation.switch) match {
       case ROP.CAPTURE | ROP.CONCAT | ROP.ALTERNATE =>
         // Simplify children, building new Regexp if children change.
         var nre = re
         var i   = 0
+
         while (i < re.subs.length) {
           val sub  = re.subs(i)
           val nsub = simplify(sub)
-          if (nre == re && nsub != sub) {
+
+          if (nre.eq(re) && nsub != sub) { // object equality (.eq()) required
             // Start a copy.
             nre = new Regexp(re) // shallow copy
             nre.runes = null
             nre.subs = Parser.subarray(re.subs, 0, re.subs.length) // clone
           }
-          if (nre != re) {
+
+          if (!nre.eq(re)) { // object inequality (! .eq()) required.
             nre.subs(i) = nsub
           }
           i += 1

--- a/unit-tests/src/test/scala/java/util/regex/MatcherSuite.scala
+++ b/unit-tests/src/test/scala/java/util/regex/MatcherSuite.scala
@@ -559,14 +559,13 @@ object MatcherSuite extends tests.Suite {
     assert(find())
     assertEquals(group("S"), "Montreal, Canada")
     assertEquals(group("D"), "Lausanne, Switzerland")
+    assertThrowsAnd[IllegalStateException](group("foo"))(
+      _.getMessage == "No match found"
+    )
   }
 
-  // Do not expect support for re2 syntax in java.util.regex with
-  // scalanative.regex.
-  // No Issue number necessary.
-  testFails("named group (re2 syntax)", 0) {
-    // scalanative.regex behavior change, so no Issue #
-    // change pattern to java: "from (?<S>.*) to (?<D>.*)"
+  // re2 syntax is not defined in Java, but it works with scalanative.regex
+  test("named group (re2 syntax, not in Java 8)") {
     val m = matcher(
       "from (?P<S>.*) to (?P<D>.*)",
       "from Montreal, Canada to Lausanne, Switzerland"
@@ -576,8 +575,8 @@ object MatcherSuite extends tests.Suite {
     assert(find(), "A1")
     assert(group("S") == "Montreal, Canada", "A2")
     assert(group("D") == "Lausanne, Switzerland", "A3")
-    assertThrowsAnd[IllegalArgumentException](group("foo"))(
-      _.getMessage == "No group with name <foo>"
+    assertThrowsAnd[IllegalStateException](group("foo"))(
+      _.getMessage == "No match found"
     )
   }
 
@@ -784,9 +783,8 @@ object MatcherSuite extends tests.Suite {
     assertEquals(end("D"), 46)
   }
 
-  // Do not support re2 syntax in java.util.regex with scalanative.regex.
-  // No Issue number.
-  testFails("start(name)/end(name) re2 syntax", 0) {
+  // re2 syntax is not defined in Java, but it works with scalanative.regex
+  test("start(name)/end(name) re2 syntax (not in Java 8)") {
     val m = matcher(
       "from (?P<S>.*) to (?P<D>.*)",
       "from Montreal, Canada to Lausanne, Switzerland"
@@ -800,12 +798,12 @@ object MatcherSuite extends tests.Suite {
     assertEquals(start("D"), 25)
     assertEquals(end("D"), 46)
 
-    assertThrowsAnd[IllegalArgumentException](start("foo"))(
-      _.getMessage == "No group with name <foo>"
+    assertThrowsAnd[IllegalStateException](start("foo"))(
+      _.getMessage == "No match found"
     )
 
-    assertThrowsAnd[IllegalArgumentException](end("foo"))(
-      _.getMessage == "No group with name <foo>"
+    assertThrowsAnd[IllegalStateException](end("foo"))(
+      _.getMessage == "No match found"
     )
   }
 

--- a/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
+++ b/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
@@ -402,8 +402,8 @@ object PatternSuite extends tests.Suite {
     pass("(?<foo>a)", "a")
   }
 
-  // Do not support re2 syntax in java.util.regex.
-  testFails("(Not supported) re2 named groups", 0) { // Intended, No Issue
+  // re2 syntax is not defined in Java, but it works with scalanative.regex
+  test("re2 named groups (not in Java 8)") {
     pass("(?P<foo>a)", "a")
   }
 

--- a/unit-tests/src/test/scala/scala/scalanative/regex/MatcherSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/MatcherSuite.scala
@@ -187,6 +187,64 @@ object MatcherSuite extends tests.Suite {
     )
   }
 
+  test("Named Groups - Perl") {
+
+    val p = Pattern.compile(
+      "(?P<baz>f(?P<foo>b*a(?P<another>r+)){0,10})" +
+        "(?P<bag>bag)?(?P<nomatch>zzz)?")
+
+    val m = p.matcher("fbbarrrrrbag")
+
+    assert(m.matches(), "match failed");
+    assertEquals("fbbarrrrr", m.group("baz"));
+    assertEquals("bbarrrrr", m.group("foo"));
+    assertEquals("rrrrr", m.group("another"));
+    assertEquals(0, m.start("baz"));
+    assertEquals(1, m.start("foo"));
+    assertEquals(4, m.start("another"));
+    assertEquals(9, m.end("baz"));
+    assertEquals(9, m.end("foo"));
+    assertEquals("bag", m.group("bag"));
+    assertEquals(9, m.start("bag"));
+    assertEquals(12, m.end("bag"));
+    assertEquals(null, m.group("nomatch"));
+    assertEquals(-1, m.start("nomatch"));
+    assertEquals(-1, m.end("nomatch"));
+
+    assertThrowsAnd[IllegalStateException](m.group("nonexistent"))(
+      _.getMessage == "No match found"
+    )
+  }
+
+  test(s"Named Groups - Java") {
+
+    val p = Pattern.compile(
+      "(?<baz>f(?<foo>b*a(?<another>r+)){0,10})" +
+        "(?<bag>bag)?(?<nomatch>zzz)?")
+
+    val m = p.matcher("fbbarrrrrbag")
+
+    assert(m.matches(), "match failed");
+    assertEquals("fbbarrrrr", m.group("baz"));
+    assertEquals("bbarrrrr", m.group("foo"));
+    assertEquals("rrrrr", m.group("another"));
+    assertEquals(0, m.start("baz"));
+    assertEquals(1, m.start("foo"));
+    assertEquals(4, m.start("another"));
+    assertEquals(9, m.end("baz"));
+    assertEquals(9, m.end("foo"));
+    assertEquals("bag", m.group("bag"));
+    assertEquals(9, m.start("bag"));
+    assertEquals(12, m.end("bag"));
+    assertEquals(null, m.group("nomatch"));
+    assertEquals(-1, m.start("nomatch"));
+    assertEquals(-1, m.end("nomatch"));
+
+    assertThrowsAnd[IllegalStateException](m.group("nonexistent"))(
+      _.getMessage == "No match found"
+    )
+  }
+
   test("issue #852, StringIndexOutOfBoundsException") {
     val JsonNumberRegex =
       """(-)?((?:[1-9][0-9]*|0))(?:\.([0-9]+))?(?:[eE]([-+]?[0-9]+))?""".r

--- a/unit-tests/src/test/scala/scala/scalanative/regex/ParserSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/ParserSuite.scala
@@ -235,7 +235,8 @@ object ParserSuite extends tests.Suite {
     Array("(?-m)\\A", "bot{}"),
     Array("(?-m)\\z", "eot{\\z}"),
     // Test named captures
-    Array("(?<name>a)", "cap{name:lit{a}}"),
+    Array("(?P<name>a)", "cap{name:lit{a}}"), // Perl style
+    Array("(?<name>a)", "cap{name:lit{a}}"),  // Java style
     // Case-folded literals
     Array("[Aa]", "litfold{A}"),
     Array("[\\x{100}\\x{101}]", "litfold{Ā}"),
@@ -492,7 +493,10 @@ object ParserSuite extends tests.Suite {
     "[a-Z]",
     "(?i)[a-Z]",
     "a{100000}",
-    "a{100000,}"
+    "a{100000,}",
+    // Group names may not be repeated
+    "(?P<foo>bar)(?P<foo>baz)",
+    "(?<foo>bar)(?<foo>baz)"
   )
 
   private val ONLY_PERL = Array("[a-b-c]",


### PR DESCRIPTION
  * This PR requires earlier PRs: #1397, #1693, and #1698.
    Travis CI will fail until those are merged.

  * This PR ports [re2j](https://github.com/google/re2j/) PR #49,
    "Named group support", dated 2018-03-04,
    commit d0ec5a7cfec67a08735b720a956c92d1440b3789 to Scala Native.

    My thanks and appreciation to the re2j developer @sjamesr for the
    re2j PR.

 * Some named group support was activated/implemented when re2j was
   originally ported to Scala Native.  This PR removes that code
   in favor to the quote "new" re2j named group support.  I believe
   there is no major functional change. As more fully described below,
   a few Exceptions and their messages have been changed to conform to Java 8.

   My hope is that using some close relative of the re2j code will
   help future devos, myself included, identify and track relevant changes in
   the re2j repository.

   Requiescat in Pace, sn.regex named group support, we hardly knew ye!

 * Deviations of note from re2j code:

      + Adjusted Exception thrown and message to match Java 8.
      The re2j message was better in the sense that it gave the
      name not found, but SN is trying to hew close to Java 8.

      + Converted from namedGroups from Map[String, Integer] to
      Map[String, Int] to avoid boxing values which are known to be Ints.

      + Re-worked the named group methods start(name), end(name), and
        group(name) to use a common subroutine rather than open coding.
	This makes it easier to get the lookup & exception handling
	right and consistent.

  * unit-test points were ported/added:
      + sn.regex.MatcherSuite
      + sn.regex.ParserSuite
      + java.util.regex.MatcherSuite
      + java.util.regex.PatternSuite

    The majority of the testing of both Perl and Java syntax named group
    handling is done in sn.regex to stay close to the code which
    actually does the work.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in release-fast mode using sbt 1.2.8 on
    X86_64 only . All tests pass.