### PR TITLE
named captures in sn.regex appendReplacement; parity with re2j release V1.3

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/regex/Matcher.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Matcher.scala
@@ -3,6 +3,8 @@
 package scala.scalanative
 package regex
 
+import java.util.Map
+
 // A stateful iterator that interprets a regex {@code Pattern} on a
 // specific input.  Its interface mimics the JDK 1.4.2
 // {@code java.util.regex.Matcher}.
@@ -56,6 +58,8 @@ final class Matcher private (private var _pattern: Pattern) {
   // The group indexes, in [start, end) pairs.	Zeroth pair is overall match.
   // By convention a pair (-1, -1) indicates no or null match.
   private var _groups: Array[Int] = createGroups(_groupCount)
+
+  private val namedGroups: Map[String, Int] = _pattern.re2.namedGroups
 
   private var _inputSequence: CharSequence = ""
 
@@ -154,16 +158,53 @@ final class Matcher private (private var _pattern: Pattern) {
     _groups(2 * group + 1)
   }
 
-  def start(name: String): Int    = start(groupIndex(name))
-  def end(name: String): Int      = end(groupIndex(name))
-  def group(name: String): String = group(groupIndex(name))
-
-  private def groupIndex(name: String): Int = {
-    val pos = _pattern.re2.findNamedCapturingGroups(name)
-    if (pos == -1) {
-      throw new IllegalArgumentException(s"No group with name <$name>")
+  private def getOrThrow(_map: Map[String, Int],
+                         key: String,
+                         msg: String): Int = {
+    val v = _map.get(key)
+    // Use knowledge about how the map is used to save execution cycles
+    // on error path. There will never be a _named_ group with index 0,
+    // so any 0 here truely means the name was not found.
+    if (v == 0) {
+      throw new IllegalStateException(msg)
     }
-    pos
+    v
+  }
+
+  /**
+   * Returns the start of the named group of the most recent match, or -1
+   * if the group was not matched.
+   *
+   * @param group the group name
+   * @throws IllegalStateException if no group with that name exists
+   */
+  def start(_group: String): Int = {
+    val g = getOrThrow(namedGroups, _group, "No match found")
+    start(g)
+  }
+
+  /**
+   * Returns the end of the named group of the most recent match, or -1
+   * if the group was not matched.
+   *
+   * @param group the group name
+   * @throws IllegalStateException if no group with that name exists
+   */
+  def end(_group: String): Int = {
+    val g = getOrThrow(namedGroups, _group, "No match found")
+    end(g)
+  }
+
+  /**
+   * Returns the named group of the most recent match, or {@code null} if the
+   * group was not matched.
+   *
+   * @param group the group name
+   * @throws IllegalStateException if no group with that name exists
+   */
+  def group(_group: String): String = {
+    val g = getOrThrow(namedGroups, _group, "No match found")
+    group(g)
   }
 
   def region(start: Int, end: Int): Matcher = {
@@ -414,11 +455,13 @@ final class Matcher private (private var _pattern: Pattern) {
             j += 1
           }
           if (j == replacement.length || replacement.charAt(j) == ' ') {
-            throw new IllegalArgumentException(
-              "named capturing group is missing trailing '}'")
+            throw new IllegalStateException("No match available")
           }
           val groupName = replacement.substring(i + 1, j)
-          sb.append(this.group(groupName))
+          // JVM uses slightly different Exception message for non-extant
+          // named group in replacement string.
+          val gid = getOrThrow(namedGroups, groupName, "No match available")
+          sb.append(this.group(gid))
           i += 1 // '}'
           last = j + 1
         }

--- a/unit-tests/src/test/scala/scala/scalanative/regex/MatcherSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/MatcherSuite.scala
@@ -187,6 +187,104 @@ object MatcherSuite extends tests.Suite {
     )
   }
 
+  // This helper is named appendReplacement() in re2j. That name causes
+  // conflicts with the 'import m._' idiom used in this Suite.
+  private def re2jAppendReplacement(m: Matcher, replacement: String): String = {
+    val b = new StringBuffer()
+    m.appendReplacement(b, replacement)
+    b.toString()
+  }
+
+  test("Named Groups - Perl") {
+
+    val p = Pattern.compile(
+      "(?P<baz>f(?P<foo>b*a(?P<another>r+)){0,10})" +
+        "(?P<bag>bag)?(?P<nomatch>zzz)?")
+
+    val m = p.matcher("fbbarrrrrbag")
+
+    assert(m.matches(), "match failed")
+    assertEquals("fbbarrrrr", m.group("baz"))
+    assertEquals("bbarrrrr", m.group("foo"))
+    assertEquals("rrrrr", m.group("another"))
+    assertEquals(0, m.start("baz"))
+    assertEquals(1, m.start("foo"))
+    assertEquals(4, m.start("another"))
+    assertEquals(9, m.end("baz"))
+    assertEquals(9, m.end("foo"))
+    assertEquals("bag", m.group("bag"))
+    assertEquals(9, m.start("bag"))
+    assertEquals(12, m.end("bag"))
+    assertEquals(null, m.group("nomatch"))
+    assertEquals(-1, m.start("nomatch"))
+    assertEquals(-1, m.end("nomatch"))
+
+    assertThrowsAnd[IllegalStateException](m.group("nonexistent"))(
+      _.getMessage == "No match found"
+    )
+
+    // appendReplacement
+
+    assertEquals("whatbbarrrrreverbag",
+                 re2jAppendReplacement(m, "what$2ever${bag}"))
+
+    assertThrowsAnd[IllegalStateException](
+      re2jAppendReplacement(m, "what$2ever${no-final-brace "))(
+      _.getMessage == "No match available"
+    )
+
+    assertThrowsAnd[IllegalStateException](
+      re2jAppendReplacement(m, "what$2ever${NOTbag}"))(
+      _.getMessage == "No match available"
+    )
+
+  }
+
+  test(s"Named Groups - Java") {
+
+    val p = Pattern.compile(
+      "(?<baz>f(?<foo>b*a(?<another>r+)){0,10})" +
+        "(?<bag>bag)?(?<nomatch>zzz)?")
+
+    val m = p.matcher("fbbarrrrrbag")
+
+    assert(m.matches(), "match failed")
+    assertEquals("fbbarrrrr", m.group("baz"))
+    assertEquals("bbarrrrr", m.group("foo"))
+    assertEquals("rrrrr", m.group("another"))
+    assertEquals(0, m.start("baz"))
+    assertEquals(1, m.start("foo"))
+    assertEquals(4, m.start("another"))
+    assertEquals(9, m.end("baz"))
+    assertEquals(9, m.end("foo"))
+    assertEquals("bag", m.group("bag"))
+    assertEquals(9, m.start("bag"))
+    assertEquals(12, m.end("bag"))
+    assertEquals(null, m.group("nomatch"))
+    assertEquals(-1, m.start("nomatch"))
+    assertEquals(-1, m.end("nomatch"))
+
+    assertThrowsAnd[IllegalStateException](m.group("nonexistent"))(
+      _.getMessage == "No match found"
+    )
+
+    // appendReplacement
+
+    assertEquals("whatbbarrrrreverbag",
+                 re2jAppendReplacement(m, "what$2ever${bag}"))
+
+    assertThrowsAnd[IllegalStateException](
+      re2jAppendReplacement(m, "what$2ever${no-final-brace "))(
+      _.getMessage == "No match available"
+    )
+
+    assertThrowsAnd[IllegalStateException](
+      re2jAppendReplacement(m, "what$2ever${NOTbag}"))(
+      _.getMessage == "No match available"
+    )
+
+  }
+
   test("issue #852, StringIndexOutOfBoundsException") {
     val JsonNumberRegex =
       """(-)?((?:[1-9][0-9]*|0))(?:\.([0-9]+))?(?:[eE]([-+]?[0-9]+))?""".r


### PR DESCRIPTION

#### This PR requires earlier PR #1699 & earlier. Travis CI will fail until those are merged.

  * This PR addresses a number of PRs in the parent code [re2j]
    (https://github.com/google/re2j/). It brings sn.regex up to date
    with all relevant PRs in the re2j repository dated 2019-08-21,
    commit 86028a5d722956800c6d6257e713d539e1bdd24d.

    In particular, it incorporates all relevant PRs included in
    re2j Release V1.3, dated 2019-07-22, commit
    222899bc5e058380935311eba419a722f00b3d69

      + This PR is most closely related to re2j PR "Add named capture group
      support to appendReplacement " dated 2018-03-05,
      commit 0e87e2a2bb403edb4196698b6707eaa2c524cf96

       + It looks like some of that work had been done as part of the
       original port to sn.regex.  This PR more closely aligns
       the work, adding test cases and such.

       + re2j PR "simplify Matcher.appendReplacement(StringBuffer, String)"
     dated 2019-03-05 is not relevant because the subject code
     was eliminated during the port to sn.regex because it was never
     used.

      + Other re2j PRs up to and including the top of the stack dated
       2019-08-21 were considered and found to be not relevant.

  * My thanks and appreciation to the re2j developers for the
    re2j PRs.

 * Deviations of note from re2j code:

      + Some Exceptions were changed from IllegalArgumentException
        to the IllegalStateException used by Java 8.  The corresponding
	messages were changed to match Java 8 as closely as feasible.
	In many case the re2j message was better because it gave the
	name of the duplicated group or such. For sn.regex, Java 8
	alignment is more important.

        Some of the indices given by "near index X" are only true
	but the value of X may not be as good an approximation
	as on JVM. Similarly, sn.regex may echo a failing group
	in printStack() as only the near context which failed.
	Java 8 tends to give the entire string, making it easier to
	see a duplicate or such. Improvements for the next generation.

  * unit-test points were ported from re2j PR and additional test points
    created, particularly for Exception type and messages.

  * The code used by the "stack safe" test in NamedGroupSuite.scala
    was made more robust & more correct.  A probabilistic fix had been added
    to PR #1699 to deal with one of two Heisenbugs. This PR makes
    a deterministic fixes to both. See file for details. Heisenbugs,
    especially in automated test code, are a massive pain.

    Normally in a test Suite, Random would be initialized with a seed
    so that the results would be reproducible, run over run.  This
    was not done in NamedGroupSuite so that more group names would
    be tested over the long run.  Yes, this can lead to Heisenbugs.
    A trade-off.

    I chose this approach because I want to know if there is a bad
    case lurking.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in release-fast mode using sbt 1.2.8 on
    X86_64 only . All tests pass.