### PR TITLE
Fix sn.regex parsing of OR expressions with a common prefix.

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
@@ -10,7 +10,9 @@ package regex
 
 import java.util.ArrayList
 import java.util.Arrays
+import java.util.HashMap;
 import java.util.List
+import java.util.Map;
 
 import java.util.regex.PatternSyntaxException
 
@@ -30,6 +32,8 @@ class Parser(wholeRegexp: String, _flags: Int) {
   private val stack        = new Stack()
   private var free: Regexp = _
   private var numCap       = 0 // number of capturing groups seen
+
+  private val namedGroups = new HashMap[String, Int]()
 
   // Allocate a Regexp, from the free list if possible.
   private def newRegexp(op: ROP): Regexp = {
@@ -460,9 +464,14 @@ class Parser(wholeRegexp: String, _flags: Int) {
       lensub = lenout
       s = 0
 
-      // Round 2: Factor out common complex prefixes,
-      // just the first piece of each concatenation,
-      // whatever it is.	This is good enough a lot of the time.
+      // Round 2: Factor out common simple prefixes,
+      // just the first piece of each concatenation.
+      // This will be good enough a lot of the time.
+      //
+      // Complex subexpressions (e.g. involving quantifiers)
+      // are not safe to factor because that collapses their
+      // distinct paths through the automaton, which affects
+      // correctness in some cases.
       start = 0
       lenout = 0
       var first: Regexp = null
@@ -478,7 +487,21 @@ class Parser(wholeRegexp: String, _flags: Int) {
         var continue       = false
         if (i < lensub) {
           ifirst = leadingRegexp(array(s + i))
-          if (first != null && first.equals(ifirst)) {
+          // first must be a character class OR a fixed repeat of a
+          // character class.
+
+          /// SN: This hairy next block is adapted for SN directly from
+          /// Go code, dated 2016-01-07. It is not in re2j V1.3, dated
+          /// 2019-07-23:
+          ///     https://github.com/golang/go/commit/
+          ///     5ccaf0255b75063a9c685009e77cee24e26a509e
+          /// Ugly as sin! but it fixes the test cases in its PR (and now in
+          /// sn.regex ParserSuite.scala).
+
+          if (first != null && first.equals(ifirst) &&
+              (isCharClass(first) ||
+              (first.op == ROP.REPEAT &&
+              first.min == first.max && isCharClass(first.subs(0))))) {
             continue = true
           }
         }
@@ -856,6 +879,7 @@ class Parser(wholeRegexp: String, _flags: Int) {
                                          wholeRegexp,
                                          t.pos())
       }
+      stack.get(0).namedGroups = namedGroups
       stack.get(0)
     }
   }
@@ -867,25 +891,60 @@ class Parser(wholeRegexp: String, _flags: Int) {
   private def parsePerlFlags(t: StringIterator): Unit = {
     val startPos = t.pos()
 
+    /// SN Porting Note:
+    ///	    This code has been edited to support both the (?P<name>expr)
+    ///	    idiom in the re2j description below and the (?<name>expr)
+    ///	    idiom it describes as Perl but which is used by Java.
+    ///
+    // Check for named captures, first introduced in Python's regexp library.
+    // As usual, there are three slightly different syntaxes:
+    //
+    //	 (?P<name>expr)	  the original, introduced by Python
+    //	 (?<name>expr)	  the .NET alteration, adopted by Perl 5.10
+    //	 (?'name'expr)	  another .NET alteration, adopted by Perl 5.10
+    //
+    // Perl 5.10 gave in and implemented the Python version too,
+    // but they claim that the last two are the preferred forms.
+    // PCRE and languages based on it (specifically, PHP and Ruby)
+    // support all three as well.  EcmaScript 4 uses only the Python form.
+    //
+    // In both the open source world (via Code Search) and the
+    // Google source tree, (?P<expr>name) is the dominant form,
+    // so that's the one we implement.	One is enough.
+
     val s = t.rest()
-    if (s.startsWith("(?<")) {
+
+    val Tuple3(isNamedCapture, namedCaptureStart, namedCaptureSkip) =
+      if (s.startsWith("(?<")) { // Java style is most likely
+        (true, 3, 4)
+      } else if (s.startsWith("(?P<")) { // Perl/Python style
+        (true, 4, 5)
+      } else {
+        (false, -1, 1)
+      }
+
+    if (isNamedCapture) {
       // Pull out name.
       val end = s.indexOf('>')
       if (end < 0) {
         throw new PatternSyntaxException(ERR_INVALID_NAMED_CAPTURE, s, 0)
       }
-      val name = s.substring(3, end) // "name"
+      val name = s.substring(namedCaptureStart, end) // "name"
       t.skipString(name)
-      t.skip(4) // "(?<>"
+      t.skip(namedCaptureSkip) // "(?<>" or "(?P<>"
       if (!isValidCaptureName(name)) {
-        throw new PatternSyntaxException(ERR_INVALID_NAMED_CAPTURE,
-                                         s.substring(0, end),
-                                         0) // "(?P<name>"
+        throw new PatternSyntaxException(ERR_INVALID_NAMED_CAPTURE, s, end) // "(?<name>" or "(?P<name>"
       }
       // Like ordinary capture, but named.
       val re = op(ROP.LEFT_PAREN)
       numCap += 1
       re.cap = numCap
+      if (namedGroups.put(name, numCap) != 0) {
+        throw new PatternSyntaxException(
+          ERR_DUPLICATE_NAMED_CAPTURE + s" Y<${name}> " + "is already defined",
+          s,
+          end)
+      }
       re.name = name
     } else {
 
@@ -1287,7 +1346,7 @@ object Parser {
     "Illegal/unsupported escape sequence"
 
   private final val ERR_INVALID_NAMED_CAPTURE =
-    "Bad named capture group"
+    "capturing group name does not start with a Latin letter"
 
   private final val ERR_INVALID_PERL_OP =
     "Bad perl operator"
@@ -1309,6 +1368,9 @@ object Parser {
 
   private final val ERR_TRAILING_BACKSLASH =
     "Trailing Backslash"
+
+  private final val ERR_DUPLICATE_NAMED_CAPTURE =
+    "Named capturing group"
 
   // Hack to expose ArrayList.removeRange().
   private class Stack extends ArrayList[Regexp] {

--- a/unit-tests/src/test/scala/scala/scalanative/regex/ParserSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/ParserSuite.scala
@@ -235,7 +235,8 @@ object ParserSuite extends tests.Suite {
     Array("(?-m)\\A", "bot{}"),
     Array("(?-m)\\z", "eot{\\z}"),
     // Test named captures
-    Array("(?<name>a)", "cap{name:lit{a}}"),
+    Array("(?P<name>a)", "cap{name:lit{a}}"), // Perl style
+    Array("(?<name>a)", "cap{name:lit{a}}"),  // Java style
     // Case-folded literals
     Array("[Aa]", "litfold{A}"),
     Array("[\\x{100}\\x{101}]", "litfold{Ā}"),
@@ -243,11 +244,13 @@ object ParserSuite extends tests.Suite {
     // Strings
     Array("abcde", "str{abcde}"),
     Array("[Aa][Bb]cd", "cat{strfold{AB}str{cd}}"),
+
     // Factoring.
     Array(
       "abc|abd|aef|bcx|bcy",
       "alt{cat{lit{a}alt{cat{lit{b}cc{0x63-0x64}}str{ef}}}cat{str{bc}cc{0x78-0x79}}}"),
-//    Array("ax+y|ax+z|ay+w", "cat{lit{a}alt{cat{plus{lit{x}}cc{0x79-0x7a}}cat{plus{lit{y}}lit{w}}}}"), // TODO: fails because of equals  if (first != null && first.equals(ifirst)) {
+    Array("ax+y|ax+z|ay+w", "cat{lit{a}alt{cat{plus{lit{x}}lit{y}}cat{plus{lit{x}}lit{z}}cat{plus{lit{y}}lit{w}}}}"),
+
     // Bug fixes.
     Array("(?:.)", "dot{}"),
     Array("(?:x|(?:xa))", "cat{lit{x}alt{emp{}lit{a}}}"),
@@ -262,6 +265,7 @@ object ParserSuite extends tests.Suite {
     Array("[\\x00-\\x{10FFFF}]", "dot{}"),
     Array("[^\\x00-\\x{10FFFF}]", "cc{}"),
     Array("(?:[a][a-])", "cat{lit{a}cc{0x2d 0x61}}"),
+
     // RE2 prefix_tests
     Array("abc|abd", "cat{str{ab}cc{0x63-0x64}}"),
     Array("a(?:b)c|abd", "cat{str{ab}cc{0x63-0x64}}"),
@@ -269,11 +273,16 @@ object ParserSuite extends tests.Suite {
       "abc|abd|aef|bcx|bcy",
       "alt{cat{lit{a}alt{cat{lit{b}cc{0x63-0x64}}str{ef}}}" + "cat{str{bc}cc{0x78-0x79}}}"),
     Array("abc|x|abd", "alt{str{abc}lit{x}str{abd}}"),
-    Array("(?i)abc|ABD", "cat{strfold{AB}cc{0x43-0x44 0x63-0x64}}")
-//    Array("[ab]c|[ab]d", "cat{cc{0x61-0x62}cc{0x63-0x64}}")
-//    Array("(?:xx|yy)c|(?:xx|yy)d", "cat{alt{str{xx}str{yy}}cc{0x63-0x64}}"),
-//    Array("x{2}|x{2}[0-9]", "cat{rep{2,2 lit{x}}alt{emp{}cc{0x30-0x39}}}"),
-//    Array("x{2}y|x{2}[0-9]y", "cat{rep{2,2 lit{x}}alt{lit{y}cat{cc{0x30-0x39}lit{y}}}}")
+    Array("(?i)abc|ABD", "cat{strfold{AB}cc{0x43-0x44 0x63-0x64}}"),
+    Array("[ab]c|[ab]d", "cat{cc{0x61-0x62}cc{0x63-0x64}}"),
+    Array(".c|.d", "cat{dot{}cc{0x63-0x64}}"),
+    Array("x{2}|x{2}[0-9]", "cat{rep{2,2 lit{x}}alt{emp{}cc{0x30-0x39}}}"),
+
+// Still failing 2019-09-02: "scala.MatchError: 2"
+//    Array("x{2}y|x{2}[0-9]y", "cat{rep{2,2 lit{x}}alt{lit{y}cat{cc{0x30-0x39}lit{y}}}}"),
+
+    Array("a.*?c|a.*?b",
+	"cat{lit{a}alt{cat{nstar{dot{}}lit{c}}cat{nstar{dot{}}lit{b}}}}")
   )
 
   // TODO(adonovan): add some tests for:
@@ -492,7 +501,10 @@ object ParserSuite extends tests.Suite {
     "[a-Z]",
     "(?i)[a-Z]",
     "a{100000}",
-    "a{100000,}"
+    "a{100000,}",
+    // Group names may not be repeated
+    "(?P<foo>bar)(?P<foo>baz)",
+    "(?<foo>bar)(?<foo>baz)"
   )
 
   private val ONLY_PERL = Array("[a-b-c]",


### PR DESCRIPTION
##### This PR requires earlier PR #1700. That PR has its own set of prerequisites. Travis CI will fail until those are merged.

  * This PR addresses open issue 93, "Incorrect match found when capturing
    groups are not used ", dated 2019-08-13, in the
    [re2j](https://github.com/google/re2j/) GitHub repository.

    "a.*?c|a.*?b" is an example which evokes the reported failure.
    See the re2j issue for before/after details. MatcherSuite.scala
    has a test point using that string giving the exact after details.

    My thanks and appreciation to the @EricEdens for reporting the
    re2j Issue and supplying a URL to the fix in the upstream Go
    code.

    Thanks also to golang/go developers @junyer and @rsc for the
    [Go](https://github.com/golang/go/) PR "regexp/syntax: fix factoring
    of common prefixes in alternations", dated 2016-01-07,
    commit 5ccaf0255b75063a9c685009e77cee24e26a509e.

    This PR ports the Go code and fixes the reported issue reported
    in re2j.

 * I believe there are no additional intellectual properties or license issues
   introduced by porting directly from Go. sn.regex code already carries
   the license of the upstream Go code.

 * unit-test sn.regex MatcherSuite.scala notes:

      + The code for this PR allowed several tests previously commented out in
        re2j and carried over to sn to execute and pass.  One test
        remains commented out because it continues to fail for reasons
        needing to be investigated.

      + I synchronized the section marked "RE2 prefix_tests" with
        the latest [Go tests](https://github.com/golang/go/blob/master/src/regexp/syntax/parse_test.go)

      + I deleted a commented out test that was commented out in re2j and
        does not exist in current Go.

      + It looks like sn.regex and re2j are both missing a fix  tested in the
       "Valid repetitions" section of the latest Go tests. That defect is unrelated
       to this PR beyond the fact that it was discovered whilst preparing this PR.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in release-fast mode using sbt 1.2.8 on
    X86_64 only . All tests pass.