### PR TITLE
Fix #1559: Improved Java 8 compatibility when parsing IEEE754 strings.

### DIFF
--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -1,10 +1,12 @@
 package java.lang
 
 import scalanative.unsafe._
-import scalanative.libc._
+import scalanative.libc
 
 import scalanative.runtime.ieee754tostring.ryu.{RyuRoundingMode, RyuDouble}
 import scalanative.runtime.Intrinsics
+
+import java.lang.IEEE754Helpers.parseIEEE754
 
 final class Double(val _value: scala.Double)
     extends Number
@@ -241,16 +243,7 @@ object Double {
     Math.min(a, b)
 
   def parseDouble(s: String): scala.Double =
-    Zone { implicit z =>
-      val cstr = toCString(s)
-      val end  = stackalloc[CString]
-
-      errno.errno = 0
-      val res = stdlib.strtod(cstr, end)
-
-      if (errno.errno == 0 && cstr != !end && string.strlen(!end) == 0) res
-      else throw new NumberFormatException(s)
-    }
+    parseIEEE754[scala.Double](s, libc.stdlib.strtod)
 
   @inline def sum(a: scala.Double, b: scala.Double): scala.Double =
     a + b

--- a/javalib/src/main/scala/java/lang/Float.scala
+++ b/javalib/src/main/scala/java/lang/Float.scala
@@ -1,10 +1,12 @@
 package java.lang
 
 import scalanative.unsafe._
-import scalanative.libc._
+import scalanative.libc
 import scalanative.runtime.Intrinsics
 
 import scalanative.runtime.ieee754tostring.ryu.{RyuRoundingMode, RyuFloat}
+
+import java.lang.IEEE754Helpers.parseIEEE754
 
 final class Float(val _value: scala.Float)
     extends Number
@@ -235,16 +237,7 @@ object Float {
     Math.min(a, b)
 
   def parseFloat(s: String): scala.Float =
-    Zone { implicit z =>
-      val cstr = toCString(s)
-      val end  = stackalloc[CString]
-
-      errno.errno = 0
-      val res = stdlib.strtof(cstr, end)
-
-      if (errno.errno == 0 && cstr != !end && string.strlen(!end) == 0) res
-      else throw new NumberFormatException(s)
-    }
+    parseIEEE754[scala.Float](s, libc.stdlib.strtof)
 
   @inline def sum(a: scala.Float, b: scala.Float): scala.Float =
     a + b

--- a/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
+++ b/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
@@ -6,7 +6,7 @@ import scalanative.libc.errno
 import scala.annotation.{switch, tailrec}
 import scalanative.posix.errno.ERANGE
 
-private [java] object  IEEE754Helpers {
+private[java] object IEEE754Helpers {
 
   // Java parseDouble() and parseFloat() allow characters at & after
   // after where C strtod() or strtof() stops. Continuous trailing whitespace
@@ -34,7 +34,6 @@ private [java] object  IEEE754Helpers {
     }
   }
 
-
   def parseIEEE754[T](s: String, f: (CString, Ptr[CString]) => T): T = {
     Zone { implicit z =>
       val cstr = toCString(s)
@@ -47,19 +46,19 @@ private [java] object  IEEE754Helpers {
 
       if (errno.errno != 0) {
         if (errno.errno != ERANGE) {
-        // The need to use \042 for double quote seems to be a Scala 2.11 bug.
-        // Uglier workarounds exist.
+          // The need to use \042 for double quote seems to be a Scala 2.11 bug.
+          // Uglier workarounds exist.
           throw new NumberFormatException(exceptionMsg)
         }
         // Else strtod() or strtof() will have returned the proper type for
         // 0.0 (too close to zero) or +/- infinity. Slick C lib design!
       } else if (!end == cstr) {
-          throw new NumberFormatException(exceptionMsg)
+        throw new NumberFormatException(exceptionMsg)
       } else if ((!end(0) == 0) ||
-          vetIEEE754Tail(s.slice((!end - cstr).toInt, s.length))) {
-         res
+                 vetIEEE754Tail(s.slice((!end - cstr).toInt, s.length))) {
+        res
       } else {
-          throw new NumberFormatException(exceptionMsg)
+        throw new NumberFormatException(exceptionMsg)
       }
 
       res

--- a/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
+++ b/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
@@ -3,66 +3,88 @@ package java.lang
 import scalanative.unsafe._
 import scalanative.libc.errno
 
-import scala.annotation.{switch, tailrec}
 import scalanative.posix.errno.ERANGE
 
 private[java] object IEEE754Helpers {
-
-  // Java parseDouble() and parseFloat() allow characters at & after
-  // after where C strtod() or strtof() stops. Continuous trailing whitespace
-  // with or without an initial 'D', 'd', 'F', 'f' size indicator
-  // is allowed.
-  // The whitespace can include tabs ('\t') and even newlines! ('\n').
-  // Perhaps even Unicode....
+  // Java parseDouble() and parseFloat() allow characters at and after
+  // the address where C strtod() or strtof() stopped.
+  // Continuous trailing whitespace with or without an initial
+  // 'D', 'd', 'F', 'f' size indicator is allowed.
   //
-  // The Java trim method is used to ensure that Java rules are followed.
-  // It might not be the most memory & runtime efficient, but if execution
-  // is in this routine, it is already on a slow path.
+  // Whitespace is defined by Java as being any character with an unsigned code
+  // <= '\u0020'. URL:
+  //   https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#trim--
+  // It can include horizontal tabs ('\t') and even newlines!('\n').
 
-  @tailrec
-  def vetIEEE754Tail(tail: String): Boolean = {
+  // DO NOT USE STRING INTERPOLATION with an interior double quote ("),
+  // a.k.a Unicode "QUOTATION MARK" (\u0022).
+  // Double quote failing interpolated strings is a longstanding
+  // bug in many Scala versions, including 2.11.n, 2.12.n, & 2.13.2.
+  // See URLS:
+  //     https://github.com/scala/bug/issues/6476
+  //     https://github.com/scala/scala/pull/8830
+  // The second is yet unmerged for Scala 2.13.x.
 
-    if (tail.length <= 0) {
-      true
-    } else {
-      val rest = tail.tail.trim
-      (tail(0): @scala.annotation.switch) match {
-        case 'D' | 'd' => vetIEEE754Tail(rest)
-        case 'F' | 'f' => vetIEEE754Tail(rest)
-        case _         => (tail.trim.length == 0)
-      }
+  private def exceptionMsg(s: String) = "For input string \"" + s + "\""
+
+  private def bytesToCString(bytes: Array[scala.Byte], n: Int)(
+      implicit z: Zone): CString = {
+    val cStr = z.alloc(n + 1) // z.alloc() does not clear bytes.
+
+    var c = 0
+    while (c < n) {
+      !(cStr + c) = bytes(c)
+      c += 1
     }
+
+    !(cStr + n) = 0.toByte
+
+    cStr
   }
 
   def parseIEEE754[T](s: String, f: (CString, Ptr[CString]) => T): T = {
     Zone { implicit z =>
-      val cstr = toCString(s)
-      val end  = stackalloc[CString]
+      val bytes    = s.getBytes(java.nio.charset.Charset.defaultCharset())
+      val bytesLen = bytes.length
+
+      val cStr = bytesToCString(bytes, bytesLen)
+
+      val end = stackalloc[CString] // Address one past last parsed cStr byte.
 
       errno.errno = 0
-      var res = f(cstr, end)
-
-      def exceptionMsg = s"For input string \042${s}\042"
+      var res = f(cStr, end)
 
       if (errno.errno != 0) {
-        if (errno.errno != ERANGE) {
-          // The need to use \042 for double quote seems to be a Scala 2.11 bug.
-          // Uglier workarounds exist.
-          throw new NumberFormatException(exceptionMsg)
+        if (errno.errno == ERANGE) {
+          // Do nothing. res holds the proper value as returned by strtod()
+          // or strtof(): 0.0 for string translations too close to zero
+          // or +/- infinity for values too +/- large for an IEEE754.
+          // Slick C lib design!
+        } else {
+          throw new NumberFormatException(exceptionMsg(s))
         }
-        // Else strtod() or strtof() will have returned the proper type for
-        // 0.0 (too close to zero) or +/- infinity. Slick C lib design!
-      } else if (!end == cstr) {
-        throw new NumberFormatException(exceptionMsg)
-      } else if ((!end(0) == 0) ||
-                 vetIEEE754Tail(s.slice((!end - cstr).toInt, s.length))) {
-        res
+      } else if (!end == cStr) { // No leading digit found: only "D" not "0D"
+        throw new NumberFormatException(exceptionMsg(s))
       } else {
-        throw new NumberFormatException(exceptionMsg)
+        // Beware: cStr may have interior NUL/null bytes. Better to
+        //         consider it a counted byte array rather than a proper
+        //         C string.
+
+        val nSeen = !end - cStr
+
+        // magic: is first char one of D d F f
+        var idx = if ((cStr(nSeen) & 0xdd) == 0x44) (nSeen + 1) else nSeen
+
+        while (idx < bytesLen) { // Check for garbage in the unparsed remnant.
+          val b = cStr(idx)
+          if ((b < 0) || b > 0x20) {
+            throw new NumberFormatException(exceptionMsg(s))
+          }
+          idx += 1
+        }
       }
 
       res
     }
   }
-
 }

--- a/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
+++ b/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
@@ -1,0 +1,69 @@
+package java.lang
+
+import scalanative.unsafe._
+import scalanative.libc.errno
+
+import scala.annotation.{switch, tailrec}
+import scalanative.posix.errno.ERANGE
+
+private [java] object  IEEE754Helpers {
+
+  // Java parseDouble() and parseFloat() allow characters at & after
+  // after where C strtod() or strtof() stops. Continuous trailing whitespace
+  // with or without an initial 'D', 'd', 'F', 'f' size indicator
+  // is allowed.
+  // The whitespace can include tabs ('\t') and even newlines! ('\n').
+  // Perhaps even Unicode....
+  //
+  // The Java trim method is used to ensure that Java rules are followed.
+  // It might not be the most memory & runtime efficient, but if execution
+  // is in this routine, it is already on a slow path.
+
+  @tailrec
+  def vetIEEE754Tail(tail: String): Boolean = {
+
+    if (tail.length <= 0) {
+      true
+    } else {
+      val rest = tail.tail.trim
+      (tail(0): @scala.annotation.switch) match {
+        case 'D' | 'd' => vetIEEE754Tail(rest)
+        case 'F' | 'f' => vetIEEE754Tail(rest)
+        case _         => (tail.trim.length == 0)
+      }
+    }
+  }
+
+
+  def parseIEEE754[T](s: String, f: (CString, Ptr[CString]) => T): T = {
+    Zone { implicit z =>
+      val cstr = toCString(s)
+      val end  = stackalloc[CString]
+
+      errno.errno = 0
+      var res = f(cstr, end)
+
+      def exceptionMsg = s"For input string \042${s}\042"
+
+      if (errno.errno != 0) {
+        if (errno.errno != ERANGE) {
+        // The need to use \042 for double quote seems to be a Scala 2.11 bug.
+        // Uglier workarounds exist.
+          throw new NumberFormatException(exceptionMsg)
+        }
+        // Else strtod() or strtof() will have returned the proper type for
+        // 0.0 (too close to zero) or +/- infinity. Slick C lib design!
+      } else if (!end == cstr) {
+          throw new NumberFormatException(exceptionMsg)
+      } else if ((!end(0) == 0) ||
+          vetIEEE754Tail(s.slice((!end - cstr).toInt, s.length))) {
+         res
+      } else {
+          throw new NumberFormatException(exceptionMsg)
+      }
+
+      res
+    }
+  }
+
+}

--- a/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
@@ -238,6 +238,15 @@ object DoubleSuite extends tests.Suite {
     //   Too close to 0 - java.lang.Double.MIN_VALUE divided by 10
     assert(Double.parseDouble("4.9E-325") == 0.0, "a22")
 
+    // Scala Native Issue #1836, a string Too Big reported from the wild.
+    val a = "-274672389457236457826542634627345697228374687236476867674746" +
+      "2342342342342342342342323423423423423423426767456345745293762384756" +
+      "2384756345634568456345689345683475863465786485764785684564576348756" +
+      "7384567845678658734587364576745683475674576345786348576847567846578" +
+      "3456702897830296720476846578634576384567845678346573465786457863"
+
+    assert(Double.parseDouble(a) == Double.NEGATIVE_INFINITY, "a23")
+
     // Hexadecimal strings
     assert(Double.parseDouble("0x0p1") == 0.0f, "a30")
     assert(Double.parseDouble("0x1p0") == 1.0f, "a31")

--- a/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
@@ -196,30 +196,32 @@ object DoubleSuite extends tests.Suite {
     assert(Double.parseDouble("-Infinity") == Double.NEGATIVE_INFINITY)
     assert(Double.isNaN(Double.parseDouble("NaN")))
 
-    val epsilon = 0.0001
-    assert(Math.abs(Double.parseDouble("6.66D") - 6.66) < epsilon, "a8")
+    assert(Double.parseDouble("6.66D") == 6.66, "a8")
 
-    // Java allows trailing whitespace, including tabs.
-    assert(Math.abs(Double.parseDouble("6.66D\t ") - 6.66) < epsilon, "a9")
+    // Java allows trailing whitespace, including tabs & nulls.
+    assert(Double.parseDouble("6.66D\t ") == 6.66, "a9")
+    assert(Double.parseDouble("6.66D\u0000") == 6.66, "a9a")
 
-    assert(Math.abs(Double.parseDouble("6.66d") - 6.66) < epsilon, "a10")
+    assert(Double.parseDouble("6.66d") == 6.66, "a10")
 
-    assert(Math.abs(Double.parseDouble("7.77F") - 7.77) < epsilon, "a11")
-    assert(Math.abs(Double.parseDouble("7.77f") - 7.77) < epsilon, "a12")
+    assert(Double.parseDouble("7.77F") == 7.77, "a11")
+    assert(Double.parseDouble("7.77f") == 7.77, "a12")
 
     // Does not parse characters beyond IEEE754 spec.
-    assert(Math.abs(
-             Double.parseDouble("1.7976931348623157999999999")
-               - 1.7976931348623157) < epsilon,
+    assert(Double.parseDouble("1.7976931348623157999999999")
+             == 1.7976931348623157,
            "a13")
 
     assertThrows[NumberFormatException](Double.parseDouble(""))
+    assertThrows[NumberFormatException](Double.parseDouble("D"))
     assertThrows[NumberFormatException](Double.parseDouble("potato"))
     assertThrows[NumberFormatException](Double.parseDouble("0.0potato"))
     assertThrows[NumberFormatException](Double.parseDouble("0.potato"))
 
     assertThrows[NumberFormatException](Double.parseDouble("6.66 D"))
     assertThrows[NumberFormatException](Double.parseDouble("6.66D  Bad  "))
+    assertThrows[NumberFormatException](Double.parseDouble("6.66D\u0000a"))
+    assertThrows[NumberFormatException](Double.parseDouble("6.66D \u0100"))
 
     // Out of IEE754 range handling
 
@@ -237,16 +239,13 @@ object DoubleSuite extends tests.Suite {
     assert(Double.parseDouble("4.9E-325") == 0.0, "a22")
 
     // Hexadecimal strings
-    assert(Math.abs(Double.parseDouble("0x0p1") - 0.0f) < epsilon, "a30")
-    assert(Math.abs(Double.parseDouble("0x1p0") - 1.0f) < epsilon, "a31")
+    assert(Double.parseDouble("0x0p1") == 0.0f, "a30")
+    assert(Double.parseDouble("0x1p0") == 1.0f, "a31")
 
-    assert(Math.abs(Double.parseDouble("0x1p1F") - 2.0f) < epsilon, "a32")
+    assert(Double.parseDouble("0x1p1F") == 2.0f, "a32")
 
-    assert(Math.abs(Double.parseDouble("0x1.8eae14p6") - 99.67f) < epsilon,
-           "a33")
-    assert(Math.abs(Double.parseDouble("-0x1.8eae14p6") - -99.67f) < epsilon,
-           "a34")
-
+    assert(Double.parseDouble("0x1.8eae14p6") == 99.67f, "a33")
+    assert(Double.parseDouble("-0x1.8eae14p6") == -99.67f, "a34")
   }
 
   // scala.Double passes -0.0d without change. j.l.Double gets forced to +0.0.

--- a/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/DoubleSuite.scala
@@ -195,10 +195,58 @@ object DoubleSuite extends tests.Suite {
     assert(Double.parseDouble("Infinity") == Double.POSITIVE_INFINITY)
     assert(Double.parseDouble("-Infinity") == Double.NEGATIVE_INFINITY)
     assert(Double.isNaN(Double.parseDouble("NaN")))
+
+    val epsilon = 0.0001
+    assert(Math.abs(Double.parseDouble("6.66D") - 6.66) < epsilon, "a8")
+
+    // Java allows trailing whitespace, including tabs.
+    assert(Math.abs(Double.parseDouble("6.66D\t ") - 6.66) < epsilon, "a9")
+
+    assert(Math.abs(Double.parseDouble("6.66d") - 6.66) < epsilon, "a10")
+
+    assert(Math.abs(Double.parseDouble("7.77F") - 7.77) < epsilon, "a11")
+    assert(Math.abs(Double.parseDouble("7.77f") - 7.77) < epsilon, "a12")
+
+    // Does not parse characters beyond IEEE754 spec.
+    assert(Math.abs(
+             Double.parseDouble("1.7976931348623157999999999")
+               - 1.7976931348623157) < epsilon,
+           "a13")
+
     assertThrows[NumberFormatException](Double.parseDouble(""))
     assertThrows[NumberFormatException](Double.parseDouble("potato"))
     assertThrows[NumberFormatException](Double.parseDouble("0.0potato"))
     assertThrows[NumberFormatException](Double.parseDouble("0.potato"))
+
+    assertThrows[NumberFormatException](Double.parseDouble("6.66 D"))
+    assertThrows[NumberFormatException](Double.parseDouble("6.66D  Bad  "))
+
+    // Out of IEE754 range handling
+
+    //   Too big - java.lang.Double.MAX_VALUE times 10
+    assert(Double.parseDouble("1.7976931348623157E309") ==
+             Double.POSITIVE_INFINITY,
+           "a20")
+
+    //   Too big - Negative java.lang.Double.MAX_VALUE times 10
+    assert(Double.parseDouble("-1.7976931348623157E309") ==
+             Double.NEGATIVE_INFINITY,
+           "a21")
+
+    //   Too close to 0 - java.lang.Double.MIN_VALUE divided by 10
+    assert(Double.parseDouble("4.9E-325") == 0.0, "a22")
+
+    // Hexadecimal strings
+    assert(Math.abs(Double.parseDouble("0x0p1") - 0.0f) < epsilon, "a30")
+    assert(Math.abs(Double.parseDouble("0x1p0") - 1.0f) < epsilon, "a31")
+
+    assert(Math.abs(Double.parseDouble("0x1p1F") - 2.0f) < epsilon, "a32")
+
+    assert(Math.abs(Double.parseDouble("0x1.8eae14p6") - 99.67f) < epsilon,
+           "a33")
+    assert(Math.abs(Double.parseDouble("-0x1.8eae14p6") - -99.67f) < epsilon,
+           "a34")
+
   }
 
   // scala.Double passes -0.0d without change. j.l.Double gets forced to +0.0.

--- a/unit-tests/src/test/scala/java/lang/FloatSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/FloatSuite.scala
@@ -233,6 +233,15 @@ object FloatSuite extends tests.Suite {
     //   Too close to 0 - java.lang.Float.MIN_VALUE divided by 10
     assert(Float.parseFloat("1.4E-46") == 0.0f, "a22")
 
+    // Scala Native Issue #1836, a string Too Big reported from the wild.
+    val a = "274672389457236457826542634627345697228374687236476867674746" +
+      "2342342342342342342342323423423423423423426767456345745293762384756" +
+      "2384756345634568456345689345683475863465786485764785684564576348756" +
+      "7384567845678658734587364576745683475674576345786348576847567846578" +
+      "3456702897830296720476846578634576384567845678346573465786457863"
+
+    assert(Float.parseFloat(a) == Float.POSITIVE_INFINITY, "a23")
+
     // Hexadecimal strings
     assert(Float.parseFloat("0x0p1") == 0.0f, "a30")
     assert(Float.parseFloat("0x1p0") == 1.0f, "a31")

--- a/unit-tests/src/test/scala/java/lang/FloatSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/FloatSuite.scala
@@ -183,6 +183,8 @@ object FloatSuite extends tests.Suite {
   }
 
   test("parseFloat") {
+    val epsilon = 0.0001
+
     assert(Float.parseFloat("1.0") == 1.0f)
     assert(Float.parseFloat("-1.0") == -1.0f)
     assert(Float.parseFloat("0.0") == 0.0f)
@@ -190,10 +192,54 @@ object FloatSuite extends tests.Suite {
     assert(Float.parseFloat("Infinity") == Float.POSITIVE_INFINITY)
     assert(Float.parseFloat("-Infinity") == Float.NEGATIVE_INFINITY)
     assert(Float.isNaN(Float.parseFloat("NaN")))
+
+    assert(Math.abs(Float.parseFloat("6.66D") - 6.66f) < epsilon, "a8")
+
+    // Java allows trailing whitespace, including tabs.
+    assert(Math.abs(Float.parseFloat("6.66D\t ") - 6.66f) < epsilon, "a9")
+
+    assert(Math.abs(Float.parseFloat("6.66d") - 6.66f) < epsilon, "a10")
+
+    assert(Math.abs(Float.parseFloat("7.77F") - 7.77f) < epsilon, "a11")
+    assert(Math.abs(Float.parseFloat("7.77f") - 7.77f) < epsilon, "a12")
+
+    // Does not parse characters beyond IEEE754 spec.
+    assert(Math.abs(
+             Double.parseDouble("1.7976931348623157999999999")
+               - 1.7976931348623157f) < epsilon,
+           "a13")
+
     assertThrows[NumberFormatException](Float.parseFloat(""))
     assertThrows[NumberFormatException](Float.parseFloat("potato"))
     assertThrows[NumberFormatException](Float.parseFloat("0.0potato"))
     assertThrows[NumberFormatException](Float.parseFloat("0.potato"))
+
+    assertThrows[NumberFormatException](Float.parseFloat("6.66 D"))
+    assertThrows[NumberFormatException](Float.parseFloat("6.66D  Bad  "))
+
+    // Out of range errors
+    //   Too big - java.lang.Float.MAX_VALUE times 10
+
+    assert(Float.parseFloat("3.4028235E39") ==
+             Float.POSITIVE_INFINITY,
+           "a20")
+
+    //   Too big - Negative java.lang.Float.MAX_VALUE times 10
+    assert(Float.parseFloat("-3.4028235E39") ==
+             Float.NEGATIVE_INFINITY,
+           "a21")
+
+    //   Too close to 0 - java.lang.Float.MIN_VALUE divided by 10
+    assert(Float.parseFloat("1.4E-46") == 0.0f, "a22")
+
+    // Hexadecimal strings
+    assert(Math.abs(Float.parseFloat("0x0p1") - 0.0f) < epsilon, "a30")
+    assert(Math.abs(Float.parseFloat("0x1p0") - 1.0f) < epsilon, "a31")
+    assert(Math.abs(Float.parseFloat("0x1p1D") - 2.0f) < epsilon, "a32")
+
+    assert(Math.abs(Float.parseFloat("0x1.8eae14p6") - 99.67f) < epsilon, "a33")
+    assert(Math.abs(Float.parseFloat("-0x1.8eae14p6") - -99.67f) < epsilon,
+           "a34")
   }
 
   // scala.Float passes -0.0F without change. j.l.Double forced to +0.0.

--- a/unit-tests/src/test/scala/java/lang/FloatSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/FloatSuite.scala
@@ -183,8 +183,6 @@ object FloatSuite extends tests.Suite {
   }
 
   test("parseFloat") {
-    val epsilon = 0.0001
-
     assert(Float.parseFloat("1.0") == 1.0f)
     assert(Float.parseFloat("-1.0") == -1.0f)
     assert(Float.parseFloat("0.0") == 0.0f)
@@ -193,33 +191,36 @@ object FloatSuite extends tests.Suite {
     assert(Float.parseFloat("-Infinity") == Float.NEGATIVE_INFINITY)
     assert(Float.isNaN(Float.parseFloat("NaN")))
 
-    assert(Math.abs(Float.parseFloat("6.66D") - 6.66f) < epsilon, "a8")
+    assert(Float.parseFloat("6.66D") == 6.66f, "a8")
 
-    // Java allows trailing whitespace, including tabs.
-    assert(Math.abs(Float.parseFloat("6.66D\t ") - 6.66f) < epsilon, "a9")
+    // Java allows trailing whitespace, including tabs & nulls.
+    assert(Float.parseFloat("6.66D\t ") == 6.66f, "a9")
+    assert(Float.parseFloat("6.66D\u0000") == 6.66f, "a9a")
 
-    assert(Math.abs(Float.parseFloat("6.66d") - 6.66f) < epsilon, "a10")
+    assert(Float.parseFloat("6.66d") == 6.66f, "a10")
 
-    assert(Math.abs(Float.parseFloat("7.77F") - 7.77f) < epsilon, "a11")
-    assert(Math.abs(Float.parseFloat("7.77f") - 7.77f) < epsilon, "a12")
+    assert(Float.parseFloat("7.77F") == 7.77f, "a11")
+    assert(Float.parseFloat("7.77f") == 7.77f, "a12")
 
     // Does not parse characters beyond IEEE754 spec.
-    assert(Math.abs(
-             Double.parseDouble("1.7976931348623157999999999")
-               - 1.7976931348623157f) < epsilon,
-           "a13")
+    assert(
+      Float.parseFloat("1.7976931348623157999999999") == 1.7976931348623157f,
+      "a13")
 
     assertThrows[NumberFormatException](Float.parseFloat(""))
+    assertThrows[NumberFormatException](Float.parseFloat("F"))
     assertThrows[NumberFormatException](Float.parseFloat("potato"))
     assertThrows[NumberFormatException](Float.parseFloat("0.0potato"))
     assertThrows[NumberFormatException](Float.parseFloat("0.potato"))
 
-    assertThrows[NumberFormatException](Float.parseFloat("6.66 D"))
-    assertThrows[NumberFormatException](Float.parseFloat("6.66D  Bad  "))
+    assertThrows[NumberFormatException](Float.parseFloat("6.66 F"))
+    assertThrows[NumberFormatException](Float.parseFloat("6.66F  Bad  "))
+    assertThrows[NumberFormatException](Float.parseFloat("6.66F\u0000a"))
+    assertThrows[NumberFormatException](Float.parseFloat("6.66F \u0100"))
 
-    // Out of range errors
+    // Out of IEE754 range handling
+
     //   Too big - java.lang.Float.MAX_VALUE times 10
-
     assert(Float.parseFloat("3.4028235E39") ==
              Float.POSITIVE_INFINITY,
            "a20")
@@ -233,13 +234,12 @@ object FloatSuite extends tests.Suite {
     assert(Float.parseFloat("1.4E-46") == 0.0f, "a22")
 
     // Hexadecimal strings
-    assert(Math.abs(Float.parseFloat("0x0p1") - 0.0f) < epsilon, "a30")
-    assert(Math.abs(Float.parseFloat("0x1p0") - 1.0f) < epsilon, "a31")
-    assert(Math.abs(Float.parseFloat("0x1p1D") - 2.0f) < epsilon, "a32")
+    assert(Float.parseFloat("0x0p1") == 0.0f, "a30")
+    assert(Float.parseFloat("0x1p0") == 1.0f, "a31")
+    assert(Float.parseFloat("0x1p1D") == 2.0f, "a32")
 
-    assert(Math.abs(Float.parseFloat("0x1.8eae14p6") - 99.67f) < epsilon, "a33")
-    assert(Math.abs(Float.parseFloat("-0x1.8eae14p6") - -99.67f) < epsilon,
-           "a34")
+    assert(Float.parseFloat("0x1.8eae14p6") == 99.67f, "a33")
+    assert(Float.parseFloat("-0x1.8eae14p6") == -99.67f, "a34")
   }
 
   // scala.Float passes -0.0F without change. j.l.Double forced to +0.0.


### PR DESCRIPTION
  * This PR fixes Issue #1559 "toFloat/toDouble throw `NumberFormatException`
    when given trailing designation".

    My thanks to @teodimoff for detecting & reporting this issue.

    Strings such as "3.14f".toDouble and "3.14D".toFloat are now accepted in
    the same way they are in Java 8.

  * Also fixes, in passing, Scala Native PR #1836. Added test case from that Issue.

  * This PR supersedes PR #1638, which I will now close.  I had forgotten
    that I had already fixed the issue two months ago, duh!

    Upon comparing the code, I like the unified parseIEEE754 approach better
    because it is DRY.

    I rolled the more Java 8 compatible exception message from PR #1638
    forward into this one.

    The parseIEEE754 code handles close-to-zero and +/- Infinity
    better.

  * Java 8 allows contiguous whitespace in the after/to_the_left_of
    the IEEE754 value. This whitespace can be blanks, tabs, newlines
    or any character between 0 (NUL) and 0x20 (space).

  * I also fixed the way the parse handled values too close to zero
    or too far from zero in either positive or negative directions.
    These cases now return the expected values of 0.0, +Infinity, and
    -Infinity, respectively.

  * Any NumberFormatException thrown now uses the Java 8 idiom of
    echoing the input string within quotes: 'For input string: "+9z.93"'.
    This allows one to detect trailing whitespace.

 * Test cases were added to DoubleSuite.scala & FloatSuite.scala for
   the conditions covered by this PR. Test cases for parsing
   hexadecimal strings were also added to improve coverage.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in Debug mode using sbt 1.3.12 on
    X86_64 only . All tests pass.