### PR TITLE
WIP: Implement j.u & j.u.c classes required by scala-java-time, rework after SN scala 2.12

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -572,6 +572,8 @@ Here is the list of currently available classes:
 * ``java.util.WeakHashMap$ValuesView``
 * ``java.util.concurrent.Callable``
 * ``java.util.concurrent.CancellationException``
+* ``java.util.concurrent.ConcurrentHashMap``
+* ``java.util.concurrent.ConcurrentMap``
 * ``java.util.concurrent.ExecutionException``
 * ``java.util.concurrent.Executor``
 * ``java.util.concurrent.RejectedExecutionException``

--- a/javalib/src/main/scala/java/util/HashMap.scala
+++ b/javalib/src/main/scala/java/util/HashMap.scala
@@ -1,164 +1,539 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+/// SN porting notes:
+///   Ported, with thanks & gratitude, from Scala-js original dated 2019-08-14
+///    commit: https://github.com/scala-js/scala-js/commit/
+///               a5c1d2095df42166e75974a39232898e982e5836
+
 package java.util
 
-import scala.collection.mutable
+import scala.annotation.tailrec
 
-class HashMap[K, V] protected (inner: mutable.Map[AnyRef, V])
+import java.{util => ju}
+
+import ScalaOps._
+
+// SN Port: Java 8 specifies loadFactor as Float. Scala.js used Double.
+
+class HashMap[K, V](initialCapacity: Int, loadFactor: Float)
     extends AbstractMap[K, V]
     with Serializable
-    with Cloneable { self =>
+    with Cloneable {
+  self =>
 
-  protected def boxKey(key: K): AnyRef =
-    key.asInstanceOf[AnyRef]
-  protected def unboxKey(box: AnyRef): K =
-    box.asInstanceOf[K]
+  import HashMap._
+
+  if (initialCapacity < 0)
+    throw new IllegalArgumentException("initialCapacity < 0")
+  if (loadFactor <= 0.0)
+    throw new IllegalArgumentException("loadFactor <= 0.0")
 
   def this() =
-    this(mutable.AnyRefMap.empty[AnyRef, V])
-
-  def this(initialCapacity: Int, loadFactor: Float) = {
-    this()
-    if (initialCapacity < 0)
-      throw new IllegalArgumentException("initialCapacity < 0")
-    else if (loadFactor < 0.0)
-      throw new IllegalArgumentException("loadFactor <= 0.0")
-  }
+    this(HashMap.DEFAULT_INITIAL_CAPACITY, HashMap.DEFAULT_LOAD_FACTOR)
 
   def this(initialCapacity: Int) =
     this(initialCapacity, HashMap.DEFAULT_LOAD_FACTOR)
 
   def this(m: Map[_ <: K, _ <: V]) = {
-    this()
+    this(m.size())
     putAll(m)
   }
 
-  override def clear(): Unit =
-    inner.clear()
+  /** The actual hash table.
+   *
+   *  In each bucket, nodes are sorted by increasing value of `hash`.
+   *
+   *  Deviation from the JavaDoc: we do not use `initialCapacity` as is for the
+   *  number of buckets. Instead we round it up to the next power of 2. This
+   *  allows some algorithms to be more efficient, notably `index()` and
+   *  `growTable()`. Since the number of buckets is not observable from the
+   *  outside, this deviation does not change any semantics.
+   */
+  private[this] var table = new Array[Node[K, V]](tableSizeFor(initialCapacity))
 
-  override def clone(): AnyRef = {
-    new HashMap(inner.clone())
+  /** The next size value at which to resize (capacity * load factor). */
+  private[this] var threshold: Int = newThreshold(table.length)
+
+  private[this] var contentSize: Int = 0
+
+  /* Internal API for LinkedHashMap: these methods are overridden in
+   * LinkedHashMap to implement its insertion- or access-order.
+   */
+
+  private[util] def newNode(key: K,
+                            hash: Int,
+                            value: V,
+                            previous: Node[K, V],
+                            next: Node[K, V]): Node[K, V] = {
+    new Node(key, hash, value, previous, next)
+  }
+
+  private[util] def nodeWasAccessed(node: Node[K, V]): Unit = ()
+
+  private[util] def nodeWasAdded(node: Node[K, V]): Unit = ()
+
+  private[util] def nodeWasRemoved(node: Node[K, V]): Unit = ()
+
+  // Public API
+
+  override def size(): Int =
+    contentSize
+
+  override def isEmpty(): Boolean =
+    contentSize == 0
+
+  override def get(key: Any): V = {
+    val node = findNode(key)
+    if (node eq null) {
+      null.asInstanceOf[V]
+    } else {
+      nodeWasAccessed(node)
+      node.value
+    }
   }
 
   override def containsKey(key: Any): Boolean =
-    inner.contains(boxKey(key.asInstanceOf[K]))
-
-  override def containsValue(value: Any): Boolean =
-    inner.valuesIterator.contains(value.asInstanceOf[V])
-
-  override def entrySet(): Set[Map.Entry[K, V]] =
-    new EntrySet
-
-  override def get(key: Any): V = inner match {
-    case _: mutable.AnyRefMap[_, _] =>
-      val inner = this.inner.asInstanceOf[mutable.AnyRefMap[AnyRef, V]]
-      inner.getOrNull(boxKey(key.asInstanceOf[K]))
-    case _ =>
-      inner.get(boxKey(key.asInstanceOf[K])).getOrElse(null.asInstanceOf[V])
-  }
-
-  override def isEmpty(): Boolean =
-    inner.isEmpty
-
-  override def keySet(): Set[K] =
-    new KeySet
+    findNode(key) ne null
 
   override def put(key: K, value: V): V =
-    inner.put(boxKey(key), value).getOrElse(null.asInstanceOf[V])
+    put0(key, value)
+
+  override def putAll(m: Map[_ <: K, _ <: V]): Unit = {
+    m match {
+      case m: ju.HashMap[_, _] =>
+        val iter = m.nodeIterator()
+        while (iter.hasNext()) {
+          val next = iter.next()
+          put0(next.key, next.value, next.hash)
+        }
+      case _ =>
+        super.putAll(m)
+    }
+  }
 
   override def remove(key: Any): V = {
-    val boxedKey = boxKey(key.asInstanceOf[K])
-    inner.get(boxedKey).fold(null.asInstanceOf[V]) { value =>
-      inner -= boxedKey
-      value
+    val node = remove0(key)
+    if (node eq null) null.asInstanceOf[V]
+    else node.value
+  }
+
+  override def clear(): Unit = {
+    ju.Arrays.fill(table.asInstanceOf[Array[AnyRef]], null)
+    contentSize = 0
+  }
+
+  override def containsValue(value: Any): Boolean =
+    valueIterator().scalaOps.exists(Objects.equals(value, _))
+
+  override def keySet(): ju.Set[K] =
+    new KeySet
+
+  override def values(): ju.Collection[V] =
+    new Values
+
+  def entrySet(): ju.Set[ju.Map.Entry[K, V]] =
+    new EntrySet
+
+  override def clone(): AnyRef =
+    new HashMap[K, V](this)
+
+  // Elementary operations
+
+  @inline private def index(hash: Int): Int =
+    hash & (table.length - 1)
+
+  @inline
+  private def findNode(key: Any): Node[K, V] = {
+    val hash = computeHash(key)
+    findNode0(key, hash, index(hash))
+  }
+
+  @inline
+  private def findNodeAndIndexForRemoval(key: Any): (Node[K, V], Int) = {
+    val hash = computeHash(key)
+    val idx  = index(hash)
+    val node = findNode0(key, hash, idx)
+    (node, idx)
+  }
+
+  private def findNode0(key: Any, hash: Int, idx: Int): Node[K, V] = {
+    @inline
+    @tailrec
+    def loop(node: Node[K, V]): Node[K, V] = {
+      if (node eq null) null
+      else if (hash == node.hash && Objects.equals(key, node.key)) node
+      else if (hash < node.hash) null
+      else loop(node.next)
+    }
+    loop(table(idx))
+  }
+
+  // Heavy lifting: modifications
+
+  /** Adds a key-value pair to this map
+   *
+   *  @param key the key to add
+   *  @param value the value to add
+   *  @return the old value associated with `key`, or `null` if there was none
+   */
+  @inline
+  private[this] def put0(key: K, value: V): V =
+    put0(key, value, computeHash(key))
+
+  /** Adds a key-value pair to this map
+   *
+   *  @param key the key to add
+   *  @param value the value to add
+   *  @param hash the **improved** hashcode of `key` (see computeHash)
+   *  @return the old value associated with `key`, or `null` if there was none
+   */
+  private[this] def put0(key: K, value: V, hash: Int): V = {
+    if (contentSize + 1 >= threshold)
+      growTable()
+    val idx = index(hash)
+    put0(key, value, hash, idx)
+  }
+
+  /** Adds a key-value pair to this map
+   *
+   *  @param key the key to add
+   *  @param value the value to add
+   *  @param hash the **improved** hashcode of `key` (see computeHash)
+   *  @param idx the index in the `table` corresponding to the `hash`
+   *  @return the old value associated with `key`, or `null` if there was none
+   */
+  private[this] def put0(key: K, value: V, hash: Int, idx: Int): V = {
+    // scalastyle:off return
+    val newNode = table(idx) match {
+      case null =>
+        val newNode = this.newNode(key, hash, value, null, null)
+        table(idx) = newNode
+        newNode
+      case first =>
+        var prev: Node[K, V] = null
+        var n                = first
+        while ((n ne null) && n.hash <= hash) {
+          if (n.hash == hash && Objects.equals(key, n.key)) {
+            nodeWasAccessed(n)
+            val old = n.value
+            n.value = value
+            return old
+          }
+          prev = n
+          n = n.next
+        }
+        val newNode = this.newNode(key, hash, value, prev, n)
+        if (prev eq null)
+          table(idx) = newNode
+        else
+          prev.next = newNode
+        if (n ne null)
+          n.previous = newNode
+        newNode
+    }
+    contentSize += 1
+    nodeWasAdded(newNode)
+    null.asInstanceOf[V]
+    // scalastyle:on return
+  }
+
+  /** Removes a key from this map if it exists.
+   *
+   *  @param key the key to remove
+   *  @return the node that contained `key` if it was present, otherwise null
+   */
+  private def remove0(key: Any): Node[K, V] = {
+    val (node, idx) = findNodeAndIndexForRemoval(key)
+    if (node ne null)
+      remove0(node, idx)
+    node
+  }
+
+  private[util] final def removeNode(node: Node[K, V]): Unit =
+    remove0(node, index(node.hash))
+
+  private def remove0(node: Node[K, V], idx: Int): Unit = {
+    val previous = node.previous
+    val next     = node.next
+    if (previous eq null)
+      table(idx) = next
+    else
+      previous.next = next
+    if (next ne null)
+      next.previous = previous
+    contentSize -= 1
+    nodeWasRemoved(node)
+  }
+
+  /** Grow the size of the table (always times 2). */
+  private[this] def growTable(): Unit = {
+    val oldTable = table
+    val oldlen   = oldTable.length
+    val newlen   = oldlen * 2
+    val newTable = new Array[Node[K, V]](newlen)
+    table = newTable
+    threshold = newThreshold(newlen)
+
+    /* Split the nodes of each bucket from the old table into the "low" and
+     * "high" indices of the new table. Since the new table contains exactly
+     * twice as many buckets as the old table, every index `i` from the old
+     * table is split into indices `i` and `oldlen + i` in the new table.
+     */
+    var i = 0
+    while (i < oldlen) {
+      var lastLow: Node[K, V]  = null
+      var lastHigh: Node[K, V] = null
+      var node                 = oldTable(i)
+      while (node ne null) {
+        if ((node.hash & oldlen) == 0) {
+          // go to low
+          node.previous = lastLow
+          if (lastLow eq null)
+            newTable(i) = node
+          else
+            lastLow.next = node
+          lastLow = node
+        } else {
+          // go to high
+          node.previous = lastHigh
+          if (lastHigh eq null)
+            newTable(oldlen + i) = node
+          else
+            lastHigh.next = node
+          lastHigh = node
+        }
+        node = node.next
+      }
+      if (lastLow ne null)
+        lastLow.next = null
+      if (lastHigh ne null)
+        lastHigh.next = null
+      i += 1
     }
   }
 
-  override def size(): Int =
-    inner.size
+  /** Rounds up `capacity` to a power of 2, with a maximum of 2^30. */
+  @inline private[this] def tableSizeFor(capacity: Int): Int =
+    Math.min(Integer.highestOneBit(Math.max(capacity - 1, 4)) * 2, 1 << 30)
 
-  override def values(): Collection[V] =
-    new ValuesView
+  @inline private[this] def newThreshold(size: Int): Int =
+    (size.toDouble * loadFactor).toInt
 
-  private class EntrySet
-      extends AbstractSet[Map.Entry[K, V]]
-      with AbstractMapView[Map.Entry[K, V]] {
-    override def iterator(): Iterator[Map.Entry[K, V]] = {
-      new AbstractMapViewIterator[Map.Entry[K, V]] {
-        override protected def getNextForm(key: AnyRef): Map.Entry[K, V] = {
-          new AbstractMap.SimpleEntry(unboxKey(key), inner(key)) {
-            override def setValue(value: V): V = {
-              inner.update(key, value)
-              super.setValue(value)
-            }
+  // Iterators
+
+  private[util] def nodeIterator(): ju.Iterator[Node[K, V]] =
+    new NodeIterator
+
+  private[util] def keyIterator(): ju.Iterator[K] =
+    new KeyIterator
+
+  private[util] def valueIterator(): ju.Iterator[V] =
+    new ValueIterator
+
+  // The cast works around the lack of definition-site variance
+  private[util] final def entrySetIterator(): ju.Iterator[Map.Entry[K, V]] =
+    nodeIterator().asInstanceOf[ju.Iterator[Map.Entry[K, V]]]
+
+  private final class NodeIterator extends AbstractHashMapIterator[Node[K, V]] {
+    protected[this] def extract(node: Node[K, V]): Node[K, V] = node
+  }
+
+  private final class KeyIterator extends AbstractHashMapIterator[K] {
+    protected[this] def extract(node: Node[K, V]): K = node.key
+  }
+
+  private final class ValueIterator extends AbstractHashMapIterator[V] {
+    protected[this] def extract(node: Node[K, V]): V = node.value
+  }
+
+  private abstract class AbstractHashMapIterator[A] extends ju.Iterator[A] {
+    private[this] val len                  = table.length
+    private[this] var nextIdx: Int         = _ // 0
+    private[this] var nextNode: Node[K, V] = _ // null
+    private[this] var lastNode: Node[K, V] = _ // null
+
+    protected[this] def extract(node: Node[K, V]): A
+
+    /* Movements of `nextNode` and `nextIdx` are spread over `hasNext()` to
+     * simplify initial conditions, and preserving as much performance as
+     * possible while guaranteeing that constructing the iterator remains O(1)
+     * (the first linear behavior can happen when calling `hasNext()`, not
+     * before).
+     */
+
+    def hasNext(): Boolean = {
+      // scalastyle:off return
+      if (nextNode ne null) {
+        true
+      } else {
+        while (nextIdx < len) {
+          val node = table(nextIdx)
+          nextIdx += 1
+          if (node ne null) {
+            nextNode = node
+            return true
           }
         }
+        false
       }
+      // scalastyle:on return
+    }
+
+    def next(): A = {
+      if (!hasNext())
+        throw new NoSuchElementException("next on empty iterator")
+      val node = nextNode
+      lastNode = node
+      nextNode = node.next
+      extract(node)
+    }
+
+    def remove(): Unit = {
+      val last = lastNode
+      if (last eq null)
+        throw new IllegalStateException(
+          "next must be called at least once before remove")
+      removeNode(last)
+      lastNode = null
     }
   }
 
-  private class KeySet extends AbstractSet[K] with AbstractMapView[K] {
-    override def remove(o: Any): Boolean = {
-      val boxedKey = boxKey(o.asInstanceOf[K])
-      val contains = inner.contains(boxedKey)
-      if (contains)
-        inner -= boxedKey
-      contains
-    }
+  // Views
 
-    override def iterator(): Iterator[K] = {
-      new AbstractMapViewIterator[K] {
-        protected def getNextForm(key: AnyRef): K =
-          unboxKey(key)
-      }
-    }
-  }
+  private final class KeySet extends AbstractSet[K] {
+    def iterator(): Iterator[K] =
+      keyIterator()
 
-  private class ValuesView extends AbstractMapView[V] {
-    override def size(): Int =
-      inner.size
+    def size(): Int =
+      self.size()
 
-    override def iterator(): Iterator[V] = {
-      new AbstractMapViewIterator[V] {
-        protected def getNextForm(key: AnyRef): V = inner(key)
-      }
-    }
-  }
+    override def contains(o: Any): Boolean =
+      containsKey(o)
 
-  private trait AbstractMapView[E] extends AbstractCollection[E] {
-    override def size(): Int =
-      inner.size
+    override def remove(o: Any): Boolean =
+      self.remove0(o) ne null
 
     override def clear(): Unit =
-      inner.clear()
+      self.clear()
   }
 
-  private abstract class AbstractMapViewIterator[E] extends Iterator[E] {
-    protected val innerIterator = inner.keySet.iterator
+  private final class Values extends AbstractCollection[V] {
+    def iterator(): ju.Iterator[V] =
+      valueIterator()
 
-    protected var lastKey: Option[AnyRef] = None
+    def size(): Int =
+      self.size()
 
-    protected def getNextForm(key: AnyRef): E
+    override def contains(o: Any): Boolean =
+      containsValue(o)
 
-    final override def next: E = {
-      lastKey = Some(innerIterator.next())
-      getNextForm(lastKey.get)
+    override def clear(): Unit =
+      self.clear()
+  }
+
+  private final class EntrySet extends AbstractSet[Map.Entry[K, V]] {
+    def iterator(): Iterator[Map.Entry[K, V]] =
+      entrySetIterator()
+
+    def size(): Int =
+      self.size()
+
+    override def contains(o: Any): Boolean = o match {
+      case o: Map.Entry[_, _] =>
+        val node = findNode(o.getKey())
+        (node ne null) && Objects.equals(node.getValue(), o.getValue())
+      case _ =>
+        false
     }
 
-    final override def hasNext: Boolean =
-      innerIterator.hasNext
-
-    final override def remove(): Unit = {
-      lastKey match {
-        case Some(key) =>
-          inner.remove(key)
-          lastKey = None
-        case None =>
-          throw new IllegalStateException
-      }
+    override def remove(o: Any): Boolean = o match {
+      case o: Map.Entry[_, _] =>
+        val key         = o.getKey()
+        val (node, idx) = findNodeAndIndexForRemoval(key)
+        if ((node ne null) && Objects.equals(node.getValue(), o.getValue())) {
+          remove0(node, idx)
+          true
+        } else {
+          false
+        }
+      case _ =>
+        false
     }
+
+    override def clear(): Unit =
+      self.clear()
   }
 }
 
 object HashMap {
-  private[HashMap] final val DEFAULT_INITIAL_CAPACITY = 16
-  private[HashMap] final val DEFAULT_LOAD_FACTOR      = 0.75f
+  private[util] final val DEFAULT_INITIAL_CAPACITY = 16
+  private[util] final val DEFAULT_LOAD_FACTOR      = 0.75f
+
+  /** Computes the improved hash of an original (`any.hashCode()`) hash. */
+  @inline private def improveHash(originalHash: Int): Int = {
+    /* Improve the hash by xoring the high 16 bits into the low 16 bits just in
+     * case entropy is skewed towards the high-value bits. We only use the
+     * lowest bits to determine the hash bucket.
+     *
+     * This function is also its own inverse. That is, for all ints i,
+     * improveHash(improveHash(i)) = i
+     * this allows us to retrieve the original hash when we need it, and that
+     * is why unimproveHash simply forwards to this method.
+     */
+    originalHash ^ (originalHash >>> 16)
+  }
+
+  /** Performs the inverse operation of improveHash.
+   *
+   *  In this case, it happens to be identical to improveHash.
+   */
+  @inline private def unimproveHash(improvedHash: Int): Int =
+    improveHash(improvedHash)
+
+  /** Computes the improved hash of this key */
+  @inline private def computeHash(k: Any): Int =
+    if (k == null) 0
+    else improveHash(k.hashCode())
+
+  private[util] class Node[K, V](val key: K,
+                                 val hash: Int,
+                                 var value: V,
+                                 var previous: Node[K, V],
+                                 var next: Node[K, V])
+      extends Map.Entry[K, V] {
+
+    def getKey(): K = key
+
+    def getValue(): V = value
+
+    def setValue(v: V): V = {
+      val oldValue = value
+      value = v
+      oldValue
+    }
+
+    override def equals(that: Any): Boolean = that match {
+      case that: Map.Entry[_, _] =>
+        Objects.equals(getKey(), that.getKey()) &&
+          Objects.equals(getValue(), that.getValue())
+      case _ =>
+        false
+    }
+
+    override def hashCode(): Int =
+      unimproveHash(hash) ^ Objects.hashCode(value)
+
+    override def toString(): String =
+      "" + getKey + "=" + getValue
+  }
 }

--- a/javalib/src/main/scala/java/util/IdentityHashMap.scala
+++ b/javalib/src/main/scala/java/util/IdentityHashMap.scala
@@ -1,13 +1,311 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+/// SN porting notes:
+///   Ported, with thanks & gratitude, from Scala-js original dated 2019-09-25
+///    commit: https://github.com/scala-js/scala-js/commit/
+///               284d2872c1ac4e2588c325a032a56b12f8bf8240
+
 package java.util
 
-class IdentityHashMap[K, V] extends HashMap[K, V] {
+import java.{util => ju}
 
-  override def boxKey(key: K): AnyRef =
-    IdentityBox(key)
+import scala.annotation.tailrec
 
-  override def unboxKey(box: AnyRef): K =
-    box match {
-      case IdentityBox(value) => value.asInstanceOf[K]
-      case _                  => null.asInstanceOf[K]
+import ScalaOps._
+
+class IdentityHashMap[K, V](inner: HashMap[IdentityHashMap.IdentityBox[K], V])
+    extends AbstractMap[K, V]
+    with Map[K, V]
+    with Serializable
+    with Cloneable {
+  self =>
+
+  import IdentityHashMap._
+
+  def this(expectedMaxSize: Int) = {
+    this(
+      new HashMap[IdentityHashMap.IdentityBox[K], V](
+        expectedMaxSize,
+        HashMap.DEFAULT_LOAD_FACTOR))
+  }
+
+  def this() =
+    this(HashMap.DEFAULT_INITIAL_CAPACITY)
+
+  def this(initialMap: java.util.Map[_ <: K, _ <: V]) = {
+    this(initialMap.size())
+    putAll(initialMap)
+  }
+
+  override def clear(): Unit = inner.clear()
+
+  override def clone(): AnyRef = {
+    new IdentityHashMap(inner.clone().asInstanceOf[HashMap[IdentityBox[K], V]])
+  }
+
+  override def containsKey(key: Any): Boolean =
+    inner.containsKey(IdentityBox(key))
+
+  override def containsValue(value: Any): Boolean =
+    inner.valueIterator().scalaOps.exists(same(_, value))
+
+  override def get(key: Any): V =
+    inner.get(IdentityBox(key))
+
+  override def isEmpty(): Boolean = inner.isEmpty()
+
+  override def put(key: K, value: V): V =
+    inner.put(IdentityBox(key), value)
+
+  override def remove(key: Any): V =
+    inner.remove(IdentityBox(key))
+
+  override def size(): Int = inner.size()
+
+  override def values(): Collection[V] = new Values
+
+  override def keySet(): ju.Set[K] = new KeySet
+
+  override def entrySet(): Set[Map.Entry[K, V]] = new EntrySet
+
+  // Views
+
+  private final class Values extends AbstractCollection[V] {
+    def iterator(): ju.Iterator[V] =
+      inner.valueIterator()
+
+    def size(): Int =
+      self.size()
+
+    override def contains(o: Any): Boolean =
+      containsValue(o)
+
+    override def remove(o: Any): Boolean = {
+      @tailrec
+      def findAndRemove(iter: Iterator[V]): Boolean = {
+        if (iter.hasNext) {
+          if (same(iter.next(), o)) {
+            iter.remove()
+            true
+          } else {
+            findAndRemove(iter)
+          }
+        } else {
+          false
+        }
+      }
+      findAndRemove(iterator())
     }
+
+    override def removeAll(c: Collection[_]): Boolean =
+      c.scalaOps.foldLeft(false)((prev, elem) => this.remove(elem) || prev)
+
+    override def retainAll(c: Collection[_]): Boolean = {
+      val iter    = iterator()
+      var changed = false
+      while (iter.hasNext) {
+        val elem = iter.next()
+        if (!findSame(elem, c)) {
+          iter.remove()
+          changed = true
+        }
+      }
+      changed
+    }
+
+    override def clear(): Unit =
+      self.clear()
+  }
+
+  private final class KeySet extends AbstractSet[K] {
+    def iterator(): Iterator[K] = {
+      new ju.Iterator[K] {
+        private val iter = inner.keyIterator()
+
+        def hasNext(): Boolean =
+          iter.hasNext()
+
+        def next(): K =
+          iter.next().inner
+
+        def remove(): Unit =
+          iter.remove()
+      }
+    }
+
+    def size(): Int =
+      self.size()
+
+    override def contains(o: Any): Boolean =
+      containsKey(o)
+
+    override def remove(o: Any): Boolean = {
+      val hasKey = contains(o)
+      if (hasKey)
+        self.remove(o)
+      hasKey
+    }
+
+    override def removeAll(c: Collection[_]): Boolean = {
+      if (size > c.size) {
+        c.scalaOps.foldLeft(false)((prev, elem) => this.remove(elem) || prev)
+      } else {
+        @tailrec
+        def removeAll(iter: Iterator[K], modified: Boolean): Boolean = {
+          if (iter.hasNext) {
+            if (findSame(iter.next(), c)) {
+              iter.remove()
+              removeAll(iter, true)
+            } else {
+              removeAll(iter, modified)
+            }
+          } else {
+            modified
+          }
+        }
+        removeAll(this.iterator, false)
+      }
+    }
+
+    override def retainAll(c: Collection[_]): Boolean = {
+      val iter    = iterator()
+      var changed = false
+      while (iter.hasNext) {
+        val elem = iter.next()
+        if (!findSame(elem, c)) {
+          iter.remove()
+          changed = true
+        }
+      }
+      changed
+    }
+
+    override def clear(): Unit =
+      self.clear()
+  }
+
+  private final class EntrySet extends AbstractSet[Map.Entry[K, V]] {
+    def iterator(): Iterator[Map.Entry[K, V]] = {
+      new ju.Iterator[Map.Entry[K, V]] {
+        private val iter = inner.entrySetIterator()
+
+        def hasNext(): Boolean =
+          iter.hasNext()
+
+        def next(): Map.Entry[K, V] =
+          new MapEntry(iter.next())
+
+        def remove(): Unit =
+          iter.remove()
+      }
+    }
+
+    def size(): Int =
+      inner.size()
+
+    override def contains(value: Any): Boolean = {
+      value match {
+        case value: Map.Entry[_, _] =>
+          val thatKey = value.getKey()
+          self.containsKey(thatKey) && same(self.get(thatKey), value.getValue())
+        case _ =>
+          false
+      }
+    }
+
+    override def remove(value: Any): Boolean = {
+      value match {
+        case value: Map.Entry[_, _] =>
+          val thatKey   = value.getKey()
+          val thatValue = value.getValue()
+          if (self.containsKey(thatKey) && same(self.get(thatKey), thatValue)) {
+            self.remove(thatKey)
+            true
+          } else {
+            false
+          }
+        case _ =>
+          false
+      }
+    }
+
+    override def clear(): Unit =
+      inner.clear()
+  }
+}
+
+object IdentityHashMap {
+  private final case class IdentityBox[+K](inner: K) {
+    override def equals(o: Any): Boolean = {
+      o match {
+        case o: IdentityBox[_] =>
+          same(inner, o.inner)
+        case _ =>
+          false
+      }
+    }
+
+    override def hashCode(): Int =
+      // SN port: inner is known to be a HashMap, so can always cast of Object.
+      System.identityHashCode(inner.asInstanceOf[Object])
+  }
+
+  @inline private def same(v1: Any, v2: Any): Boolean =
+    v1.asInstanceOf[AnyRef] eq v2.asInstanceOf[AnyRef]
+
+  private def findSame[K](elem: K, c: Collection[_]): Boolean = {
+    // scalastyle:off return
+    val iter = c.iterator()
+    while (iter.hasNext) {
+      if (same(elem, iter.next()))
+        return true
+    }
+    false
+    // scalastyle:on return
+  }
+
+  private final class MapEntry[K, V](entry: Map.Entry[IdentityBox[K], V])
+      extends Map.Entry[K, V] {
+
+    override def equals(other: Any): Boolean =
+      other match {
+        case other: Map.Entry[_, _] =>
+          same(this.getKey(), other.getKey()) &&
+            same(this.getValue(), other.getValue())
+        case _ =>
+          false
+      }
+
+    def getKey(): K =
+      entry.getKey().inner
+
+    def getValue(): V =
+      entry.getValue()
+
+    override def hashCode(): Int = {
+      val ev = entry.getValue
+      val evHashCode = if (ev.getClass.isPrimitive) {
+        ev.##
+      } else {
+        System.identityHashCode(ev.asInstanceOf[Object])
+      }
+      entry.getKey().hashCode() ^ evHashCode
+    }
+
+    def setValue(value: V): V =
+      entry.setValue(value)
+
+    override def toString(): String =
+      "" + this.getKey() + "=" + this.getValue()
+  }
 }

--- a/javalib/src/main/scala/java/util/LinkedHashMap.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashMap.scala
@@ -1,75 +1,176 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+/// SN porting notes:
+///   Ported, with thanks & gratitude, from Scala-js original dated 2019-07-31
+///    commit: https://github.com/scala-js/scala-js/commit/
+///               2f519823eec1f8d23f6852ebb6e4e19be8573569
+
 package java.util
 
-import scala.collection.mutable
+import java.{util => ju}
 
-class LinkedHashMap[K, V] private (inner: mutable.LinkedHashMap[AnyRef, V],
-                                   accessOrder: Boolean)
-    extends HashMap[K, V](inner) { self =>
+class LinkedHashMap[K, V](initialCapacity: Int,
+                          loadFactor: Float,
+                          accessOrder: Boolean)
+    extends HashMap[K, V](initialCapacity, loadFactor) {
+  self =>
 
-  override protected def boxKey(key: K): AnyRef =
-    Box(key)
-  override protected def unboxKey(box: AnyRef): K =
-    box.asInstanceOf[Box[K]].inner
+  import LinkedHashMap._
 
-  def this() =
-    this(mutable.LinkedHashMap.empty[AnyRef, V], false)
+  /** Node that was least recently created (or accessed under access-order). */
+  private var eldest: Node[K, V] = _
 
-  def this(initialCapacity: Int, loadFactor: Float, accessOrder: Boolean) = {
-    this(mutable.LinkedHashMap.empty[AnyRef, V], accessOrder)
-    if (initialCapacity < 0)
-      throw new IllegalArgumentException("initialCapacity < 0")
-    else if (loadFactor < 0.0)
-      throw new IllegalArgumentException("loadFactor <= 0.0")
-  }
+  /** Node that was most recently created (or accessed under access-order). */
+  private var youngest: Node[K, V] = _
 
   def this(initialCapacity: Int, loadFactor: Float) =
     this(initialCapacity, loadFactor, false)
 
   def this(initialCapacity: Int) =
-    this(initialCapacity, LinkedHashMap.DEFAULT_LOAD_FACTOR)
+    this(initialCapacity, HashMap.DEFAULT_LOAD_FACTOR)
+
+  def this() =
+    this(HashMap.DEFAULT_INITIAL_CAPACITY)
 
   def this(m: Map[_ <: K, _ <: V]) = {
-    this()
+    this(m.size())
     putAll(m)
   }
 
-  override def get(key: scala.Any): V = {
-    val value = super.get(key)
-    if (accessOrder) {
-      val boxedKey = Box(key.asInstanceOf[K])
-      if (value != null || containsKey(boxedKey)) {
-        inner.remove(boxedKey)
-        inner(boxedKey) = value
-      }
-    }
-    value
+  private def asMyNode(node: HashMap.Node[K, V]): Node[K, V] =
+    node.asInstanceOf[Node[K, V]]
+
+  private[util] override def newNode(
+      key: K,
+      hash: Int,
+      value: V,
+      previous: HashMap.Node[K, V],
+      next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+    new Node(key, hash, value, previous, next, null, null)
   }
 
-  override def put(key: K, value: V): V = {
-    val oldValue = {
-      if (accessOrder) {
-        val old = remove(key)
-        super.put(key, value)
-        old
-      } else {
-        super.put(key, value)
+  private[util] override def nodeWasAccessed(node: HashMap.Node[K, V]): Unit = {
+    if (accessOrder) {
+      val myNode = asMyNode(node)
+      if (myNode.younger ne null) {
+        removeFromOrderedList(myNode)
+        appendToOrderedList(myNode)
       }
     }
-    val iter = entrySet().iterator()
-    if (iter.hasNext && removeEldestEntry(iter.next()))
-      iter.remove()
-    oldValue
+  }
+
+  private[util] override def nodeWasAdded(node: HashMap.Node[K, V]): Unit = {
+    appendToOrderedList(asMyNode(node))
+    if (removeEldestEntry(eldest))
+      removeNode(eldest)
+  }
+
+  private[util] override def nodeWasRemoved(node: HashMap.Node[K, V]): Unit =
+    removeFromOrderedList(asMyNode(node))
+
+  private def appendToOrderedList(node: Node[K, V]): Unit = {
+    val older = youngest
+    if (older ne null)
+      older.younger = node
+    else
+      eldest = node
+    node.older = older
+    node.younger = null
+    youngest = node
+  }
+
+  private def removeFromOrderedList(node: Node[K, V]): Unit = {
+    val older   = node.older
+    val younger = node.younger
+    if (older eq null)
+      eldest = younger
+    else
+      older.younger = younger
+    if (younger eq null)
+      youngest = older
+    else
+      younger.older = older
   }
 
   protected def removeEldestEntry(eldest: Map.Entry[K, V]): Boolean = false
 
+  private[util] override def nodeIterator(): ju.Iterator[HashMap.Node[K, V]] =
+    new NodeIterator
+
+  private[util] override def keyIterator(): ju.Iterator[K] =
+    new KeyIterator
+
+  private[util] override def valueIterator(): ju.Iterator[V] =
+    new ValueIterator
+
+  private final class NodeIterator
+      extends AbstractLinkedHashMapIterator[HashMap.Node[K, V]] {
+    protected[this] def extract(node: Node[K, V]): Node[K, V] = node
+  }
+
+  private final class KeyIterator extends AbstractLinkedHashMapIterator[K] {
+    protected[this] def extract(node: Node[K, V]): K = node.key
+  }
+
+  private final class ValueIterator extends AbstractLinkedHashMapIterator[V] {
+    protected[this] def extract(node: Node[K, V]): V = node.value
+  }
+
+  private abstract class AbstractLinkedHashMapIterator[A]
+      extends ju.Iterator[A] {
+    private[this] var nextNode: Node[K, V] = eldest
+    private[this] var lastNode: Node[K, V] = _
+
+    protected[this] def extract(node: Node[K, V]): A
+
+    def hasNext(): Boolean =
+      nextNode ne null
+
+    def next(): A = {
+      if (!hasNext())
+        throw new NoSuchElementException("next on empty iterator")
+      val node = nextNode
+      lastNode = node
+      nextNode = node.younger
+      extract(node)
+    }
+
+    def remove(): Unit = {
+      val last = lastNode
+      if (last eq null)
+        throw new IllegalStateException(
+          "next must be called at least once before remove")
+      removeNode(last)
+      lastNode = null
+    }
+  }
+
   override def clone(): AnyRef = {
-    new LinkedHashMap(inner.clone(), accessOrder)
+    val result = new LinkedHashMap[K, V](size(), loadFactor, accessOrder)
+    result.putAll(this)
+    result
   }
 }
 
 object LinkedHashMap {
 
-  private[LinkedHashMap] final val DEFAULT_INITIAL_CAPACITY = 16
-  private[LinkedHashMap] final val DEFAULT_LOAD_FACTOR      = 0.75f
+  private final class Node[K, V](key: K,
+                                 hash: Int,
+                                 value: V,
+                                 previous: HashMap.Node[K, V],
+                                 next: HashMap.Node[K, V],
+                                 var older: Node[K, V],
+                                 var younger: Node[K, V])
+      extends HashMap.Node[K, V](key, hash, value, previous, next)
+
 }

--- a/javalib/src/main/scala/java/util/NullRejectingHashMap.scala
+++ b/javalib/src/main/scala/java/util/NullRejectingHashMap.scala
@@ -1,0 +1,109 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+/// SN porting notes:
+///   Ported, with thanks & gratitude, from Scala-js original dated 2019-08-08 
+///    commit: https://github.com/scala-js/scala-js/commit/
+///               60c94e28c3b0d04b8c78399a4e8c1e67804a7095
+
+package java.util
+
+/** A subclass of `HashMap` that systematically rejects `null` keys and values.
+ *
+ *  This class is used as the implementation of some other hashtable-like data
+ *  structures that require non-`null` keys and values to correctly implement
+ *  their specifications.
+ */
+private[util] class NullRejectingHashMap[K, V](
+    initialCapacity: Int, loadFactor: Float) // SN Port: Float as in Java 8.
+    extends HashMap[K, V](initialCapacity, loadFactor) {
+
+  def this() =
+    this(HashMap.DEFAULT_INITIAL_CAPACITY, HashMap.DEFAULT_LOAD_FACTOR)
+
+  def this(initialCapacity: Int) =
+    this(initialCapacity, HashMap.DEFAULT_LOAD_FACTOR)
+
+  def this(m: Map[_ <: K, _ <: V]) = {
+    this(m.size())
+    putAll(m)
+  }
+
+  // Use Nodes that will reject `null`s in `setValue()`
+  override private[util] def newNode(key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+    new NullRejectingHashMap.Node(key, hash, value, previous, next)
+  }
+
+  override def get(key: Any): V = {
+    if (key == null)
+      throw new NullPointerException()
+    super.get(key)
+  }
+
+  override def containsKey(key: Any): Boolean = {
+    if (key == null)
+      throw new NullPointerException()
+    super.containsKey(key)
+  }
+
+  override def put(key: K, value: V): V = {
+    if (key == null || value == null)
+      throw new NullPointerException()
+    super.put(key, value)
+  }
+
+  @noinline
+  override def putAll(m: Map[_ <: K, _ <: V]): Unit = {
+    /* The only purpose of `impl` is to capture the wildcards as named types,
+     * so that we prevent type inference from inferring deprecated existential
+     * types.
+     */
+    @inline
+    def impl[K1 <: K, V1 <: V](m: Map[K1, V1]): Unit = {
+      val iter = m.entrySet().iterator()
+      while (iter.hasNext()) {
+        val entry = iter.next()
+        put(entry.getKey(), entry.getValue())
+      }
+    }
+    impl(m)
+  }
+
+  override def remove(key: Any): V = {
+    if (key == null)
+      throw new NullPointerException()
+    super.remove(key)
+  }
+
+  override def containsValue(value: Any): Boolean = {
+    if (value == null)
+      throw new NullPointerException()
+    super.containsValue(value)
+  }
+
+  override def clone(): AnyRef =
+    new NullRejectingHashMap[K, V](this)
+}
+
+private object NullRejectingHashMap {
+  private final class Node[K, V](key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V])
+      extends HashMap.Node[K, V](key, hash, value, previous, next) {
+
+    override def setValue(v: V): V = {
+      if (v == null)
+        throw new NullPointerException()
+      super.setValue(v)
+    }
+  }
+}

--- a/javalib/src/main/scala/java/util/Objects.scala
+++ b/javalib/src/main/scala/java/util/Objects.scala
@@ -1,3 +1,20 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+/// SN porting notes:
+///   Ported, with thanks & gratitude, from Scala-js original dated 2019-07-31
+///    commit: https://github.com/scala-js/scala-js/commit/
+///               e07d99d3e9b5de42beab6b0de79cf156d2e17dbe
+
 package java.util
 
 import scala.reflect.ClassTag
@@ -5,18 +22,17 @@ import scala.reflect.ClassTag
 object Objects {
 
   @inline
-  def equals(a: AnyRef, b: AnyRef): Boolean =
+  def equals(a: Any, b: Any): Boolean =
     if (a == null) b == null
     else a.equals(b)
 
   @inline
-  def deepEquals(a: AnyRef, b: AnyRef): Boolean = {
-    if (a eq b) true
+  def deepEquals(a: Any, b: Any): Boolean = {
+    if (a.asInstanceOf[AnyRef] eq b.asInstanceOf[AnyRef]) true
     else if (a == null || b == null) false
     else {
       (a, b) match {
-        case (a1: Array[AnyRef], a2: Array[AnyRef]) =>
-          Arrays.deepEquals(a1, a2)
+        case (a1: Array[AnyRef], a2: Array[AnyRef])   => Arrays.deepEquals(a1, a2)
         case (a1: Array[Long], a2: Array[Long])       => Arrays.equals(a1, a2)
         case (a1: Array[Int], a2: Array[Int])         => Arrays.equals(a1, a2)
         case (a1: Array[Short], a2: Array[Short])     => Arrays.equals(a1, a2)
@@ -25,13 +41,13 @@ object Objects {
         case (a1: Array[Boolean], a2: Array[Boolean]) => Arrays.equals(a1, a2)
         case (a1: Array[Float], a2: Array[Float])     => Arrays.equals(a1, a2)
         case (a1: Array[Double], a2: Array[Double])   => Arrays.equals(a1, a2)
-        case _                                        => a === b
+        case _                                        => Objects.equals(a, b)
       }
     }
   }
 
   @inline
-  def hashCode(o: AnyRef): Int =
+  def hashCode(o: Any): Int =
     if (o == null) 0
     else o.hashCode()
 
@@ -40,11 +56,11 @@ object Objects {
     Arrays.hashCode(values)
 
   @inline
-  def toString(o: AnyRef): String =
+  def toString(o: Any): String =
     String.valueOf(o)
 
   @inline
-  def toString(o: AnyRef, nullDefault: String): String =
+  def toString(o: Any, nullDefault: String): String =
     if (o == null) nullDefault
     else o.toString
 
@@ -64,11 +80,11 @@ object Objects {
     else obj
 
   @inline
-  def isNull(obj: AnyRef): Boolean =
+  def isNull(obj: Any): Boolean =
     obj == null
 
   @inline
-  def nonNull(obj: AnyRef): Boolean =
+  def nonNull(obj: Any): Boolean =
     obj != null
 
   // Requires the implementation of java.util.function

--- a/javalib/src/main/scala/java/util/ScalaOps.scala
+++ b/javalib/src/main/scala/java/util/ScalaOps.scala
@@ -1,0 +1,173 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+/// SN porting notes:
+///   Ported, with thanks & gratitude, from Scala-js original dated 2019-09-14 
+///    commit: https://github.com/scala-js/scala-js/commit/
+///               f700b9fad774b43e4f42c292dd54ca1fc7bdb044
+
+package java.util
+
+/** Make some Scala collection APIs available on Java collections. */
+private[java] object ScalaOps {
+
+  implicit class IntScalaOps private[ScalaOps] (val __self: Int) extends AnyVal {
+    @inline def until(end: Int): SimpleRange =
+      new SimpleRange(__self, end)
+  }
+
+  @inline
+  final class SimpleRange(start: Int, end: Int) {
+    @inline
+    def foreach[U](f: Int => U): Unit = {
+      var i = start
+      while (i < end) {
+        f(i)
+        i += 1
+      }
+    }
+  }
+
+  implicit class ToJavaIterableOps[A] private[ScalaOps] (
+      val __self: java.lang.Iterable[A])
+      extends AnyVal {
+    def scalaOps: JavaIterableOps[A] = new JavaIterableOps[A](__self)
+  }
+
+  class JavaIterableOps[A] private[ScalaOps] (
+      val __self: java.lang.Iterable[A])
+      extends AnyVal {
+
+    @inline def foreach[U](f: A => U): Unit =
+      __self.iterator().scalaOps.foreach(f)
+
+    @inline def count(f: A => Boolean): Int =
+      __self.iterator().scalaOps.count(f)
+
+    @inline def exists(f: A => Boolean): Boolean =
+      __self.iterator().scalaOps.exists(f)
+
+    @inline def forall(f: A => Boolean): Boolean =
+      __self.iterator().scalaOps.forall(f)
+
+    @inline def indexWhere(f: A => Boolean): Int =
+      __self.iterator().scalaOps.indexWhere(f)
+
+    @inline def find(f: A => Boolean): Option[A] =
+      __self.iterator().scalaOps.find(f)
+
+    @inline def foldLeft[B](z: B)(f: (B, A) => B): B =
+      __self.iterator().scalaOps.foldLeft(z)(f)
+
+    @inline def reduceLeft[B >: A](f: (B, A) => B): B =
+      __self.iterator().scalaOps.reduceLeft(f)
+
+    @inline def mkString(start: String, sep: String, end: String): String =
+      __self.iterator().scalaOps.mkString(start, sep, end)
+  }
+
+  implicit class ToJavaIteratorOps[A] private[ScalaOps] (
+      val __self: Iterator[A])
+      extends AnyVal {
+    def scalaOps: JavaIteratorOps[A] = new JavaIteratorOps[A](__self)
+  }
+
+  class JavaIteratorOps[A] private[ScalaOps] (val __self: Iterator[A])
+      extends AnyVal {
+
+    @inline def foreach[U](f: A => U): Unit = {
+      while (__self.hasNext())
+        f(__self.next())
+    }
+
+    @inline def count(f: A => Boolean): Int =
+      foldLeft(0)((prev, x) => if (f(x)) prev + 1 else prev)
+
+    @inline def exists(f: A => Boolean): Boolean = {
+      // scalastyle:off return
+      while (__self.hasNext()) {
+        if (f(__self.next()))
+          return true
+      }
+      false
+      // scalastyle:on return
+    }
+
+    @inline def forall(f: A => Boolean): Boolean =
+      !exists(x => !f(x))
+
+    @inline def indexWhere(f: A => Boolean): Int = {
+      // scalastyle:off return
+      var i = 0
+      while (__self.hasNext()) {
+        if (f(__self.next()))
+          return i
+        i += 1
+      }
+      -1
+      // scalastyle:on return
+    }
+
+    @inline def find(f: A => Boolean): Option[A] = {
+      // scalastyle:off return
+      while (__self.hasNext()) {
+        val x = __self.next()
+        if (f(x))
+          return Some(x)
+      }
+      None
+      // scalastyle:on return
+    }
+
+    @inline def foldLeft[B](z: B)(f: (B, A) => B): B = {
+      var result: B = z
+      while (__self.hasNext())
+        result = f(result, __self.next())
+      result
+    }
+
+    @inline def reduceLeft[B >: A](f: (B, A) => B): B = {
+      if (!__self.hasNext())
+        throw new NoSuchElementException("collection is empty")
+      foldLeft[B](__self.next())(f)
+    }
+
+    @inline def mkString(start: String, sep: String, end: String): String = {
+      var result: String = start
+      var first = true
+      while (__self.hasNext()) {
+        if (first)
+          first = false
+        else
+          result += sep
+        result += __self.next()
+      }
+      result + end
+    }
+  }
+
+  implicit class ToJavaEnumerationOps[A] private[ScalaOps] (
+      val __self: Enumeration[A])
+      extends AnyVal {
+    def scalaOps: JavaEnumerationOps[A] = new JavaEnumerationOps[A](__self)
+  }
+
+  class JavaEnumerationOps[A] private[ScalaOps] (val __self: Enumeration[A])
+      extends AnyVal {
+
+    @inline def foreach[U](f: A => U): Unit = {
+      while (__self.hasMoreElements())
+        f(__self.nextElement())
+    }
+  }
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
@@ -1,0 +1,249 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+/// SN porting notes:
+///   Ported, with thanks & gratitude, from Scala-js original dated 2019-08-08 
+///    commit: https://github.com/scala-js/scala-js/commit/
+///               60c94e28c3b0d04b8c78399a4e8c1e67804a7095
+///
+/// NOTE WELL & BEWARE:
+///   This file DOES NOT IMPLEMENT TRUE MULTI-THREADED CONCURRENCY!!!
+///   Antithetical to its name, this file assumes either the Scala Native
+///   mono-threaded model or else a Node.js/Scala.js event loop model of
+///   threading.
+
+package java.util.concurrent
+
+import java.io.Serializable
+import java.util._
+
+class ConcurrentHashMap[K, V] private (initialCapacity: Int, loadFactor: Float)
+    extends AbstractMap[K, V] with ConcurrentMap[K, V] with Serializable {
+
+  import ConcurrentHashMap._
+
+  def this() =
+    this(HashMap.DEFAULT_INITIAL_CAPACITY, HashMap.DEFAULT_LOAD_FACTOR)
+
+  def this(initialCapacity: Int) =
+    this(initialCapacity, HashMap.DEFAULT_LOAD_FACTOR)
+
+  def this(initialMap: java.util.Map[_ <: K, _ <: V]) = {
+    this(initialMap.size())
+    putAll(initialMap)
+  }
+
+  def this(initialCapacity: Int, loadFactor: Float, concurrencyLevel: Int) =
+    this(initialCapacity, loadFactor) // ignore concurrencyLevel
+
+  private[this] val inner: InnerHashMap[K, V] =
+    new InnerHashMap[K, V](initialCapacity, loadFactor)
+
+  override def size(): Int =
+    inner.size()
+
+  override def isEmpty(): Boolean =
+    inner.isEmpty()
+
+  override def get(key: Any): V =
+    inner.get(key)
+
+  override def containsKey(key: Any): Boolean =
+    inner.containsKey(key)
+
+  override def containsValue(value: Any): Boolean =
+    inner.containsValue(value)
+
+  override def put(key: K, value: V): V =
+    inner.put(key, value)
+
+  override def remove(key: Any): V =
+    inner.remove(key)
+
+  override def clear(): Unit =
+    inner.clear()
+
+  override def keySet(): ConcurrentHashMap.KeySetView[K, V] =
+    new ConcurrentHashMap.KeySetView[K, V](inner.keySet())
+
+  override def values(): Collection[V] =
+    inner.values()
+
+  override def entrySet(): Set[Map.Entry[K, V]] =
+    inner.entrySet()
+
+  override def hashCode(): Int =
+    inner.hashCode()
+
+  override def toString(): String =
+    inner.toString()
+
+  override def equals(o: Any): Boolean =
+    inner.equals(o)
+
+  def putIfAbsent(key: K, value: V): V = {
+    if (value == null)
+      throw new NullPointerException()
+    val old = inner.get(key) // throws if `key` is null
+    if (old == null)
+      inner.put(key, value)
+    old
+  }
+
+  def remove(key: Any, value: Any): Boolean = {
+    if (value == null)
+      throw new NullPointerException()
+    val old = inner.get(key) // throws if `key` is null
+    if (value.equals(old)) { // false if `old` is null
+      inner.remove(key)
+      true
+    } else {
+      false
+    }
+  }
+
+  override def replace(key: K, oldValue: V, newValue: V): Boolean = {
+    if (oldValue == null || newValue == null)
+      throw new NullPointerException()
+    val old = inner.get(key) // throws if `key` is null
+    if (oldValue.equals(old)) { // false if `old` is null
+      inner.put(key, newValue)
+      true
+    } else {
+      false
+    }
+  }
+
+  override def replace(key: K, value: V): V = {
+    if (value == null)
+      throw new NullPointerException()
+    val old = inner.get(key) // throws if `key` is null
+    if (old != null)
+      inner.put(key, value)
+    old
+  }
+
+  def contains(value: Any): Boolean =
+    containsValue(value)
+
+  def keys(): Enumeration[K] =
+    Collections.enumeration(inner.keySet())
+
+  def elements(): Enumeration[V] =
+    Collections.enumeration(values())
+}
+
+object ConcurrentHashMap {
+  import HashMap.Node
+
+  /** Inner HashMap that contains the real implementation of a
+   *  ConcurrentHashMap.
+   *
+   *  It is a null-rejecting hash map because some algorithms rely on the fact
+   *  that `get(key) == null` means the key was not in the map.
+   *
+   *  It also has snapshotting iterators to make sure they are *weakly
+   *  consistent*.
+   */
+  private final class InnerHashMap[K, V](initialCapacity: Int, loadFactor: Float)
+      extends NullRejectingHashMap[K, V](initialCapacity, loadFactor) {
+
+    override private[util] def nodeIterator(): Iterator[HashMap.Node[K, V]] =
+      new NodeIterator
+
+    override private[util] def keyIterator(): Iterator[K] =
+      new KeyIterator
+
+    override private[util] def valueIterator(): Iterator[V] =
+      new ValueIterator
+
+    private def makeSnapshot(): ArrayList[Node[K, V]] = {
+      val snapshot = new ArrayList[Node[K, V]](size())
+      val iter = super.nodeIterator()
+      while (iter.hasNext())
+        snapshot.add(iter.next())
+      snapshot
+    }
+
+    private final class NodeIterator extends AbstractCHMIterator[Node[K, V]] {
+      protected[this] def extract(node: Node[K, V]): Node[K, V] = node
+    }
+
+    private final class KeyIterator extends AbstractCHMIterator[K] {
+      protected[this] def extract(node: Node[K, V]): K = node.key
+    }
+
+    private final class ValueIterator extends AbstractCHMIterator[V] {
+      protected[this] def extract(node: Node[K, V]): V = node.value
+    }
+
+    private abstract class AbstractCHMIterator[A] extends Iterator[A] {
+      private[this] val innerIter = makeSnapshot().iterator()
+      private[this] var lastNode: Node[K, V] = _ // null
+
+      protected[this] def extract(node: Node[K, V]): A
+
+      def hasNext(): Boolean =
+        innerIter.hasNext()
+
+      def next(): A = {
+        val node = innerIter.next()
+        lastNode = node
+        extract(node)
+      }
+
+      def remove(): Unit = {
+        val last = lastNode
+        if (last eq null)
+          throw new IllegalStateException("next must be called at least once before remove")
+        removeNode(last)
+        lastNode = null
+      }
+    }
+  }
+
+  /* `KeySetView` is a public class in the JDK API. The result of
+   * `ConcurrentHashMap.keySet()` must be statically typed as a `KeySetView`,
+   * hence the existence of this class, although it forwards all its operations
+   * to the inner key set.
+   */
+  class KeySetView[K, V] private[ConcurrentHashMap] (inner: Set[K])
+      extends Set[K] with Serializable {
+
+    def contains(o: Any): Boolean = inner.contains(o)
+
+    def remove(o: Any): Boolean = inner.remove(o)
+
+    def iterator(): Iterator[K] = inner.iterator()
+
+    def size(): Int = inner.size()
+
+    def isEmpty(): Boolean = inner.isEmpty()
+
+    def toArray(): Array[AnyRef] = inner.toArray()
+
+    def toArray[T <: AnyRef](a: Array[T]): Array[T] = inner.toArray[T](a)
+
+    def add(e: K): Boolean = inner.add(e)
+
+    def containsAll(c: Collection[_]): Boolean = inner.containsAll(c)
+
+    def addAll(c: Collection[_ <: K]): Boolean = inner.addAll(c)
+
+    def removeAll(c: Collection[_]): Boolean = inner.removeAll(c)
+
+    def retainAll(c: Collection[_]): Boolean = inner.retainAll(c)
+
+    def clear(): Unit = inner.clear()
+  }
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentMap.scala
@@ -1,0 +1,27 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+/// SN porting notes:
+///   Ported, with thanks & gratitude, from Scala-js original dated 2018-10-12 
+///    commit: https://github.com/scala-js/scala-js/commit/
+///              9dc4d5b36ff2b2a3dfe2e91d5c6b1ef6d10d3e51
+
+package java.util.concurrent
+
+import java.util.Map
+
+trait ConcurrentMap[K, V] extends Map[K, V] {
+  def putIfAbsent(key: K, value: V): V
+  def remove(key: Any, value: Any): Boolean
+  def replace(key: K, oldValue: V, newValue: V): Boolean
+  def replace(key: K, value: V): V
+}

--- a/unit-tests/src/test/scala/java/util/concurrent/ConcurrentHashMapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/concurrent/ConcurrentHashMapSuite.scala
@@ -1,0 +1,274 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+// SN porting notes:
+///   Ported, with thanks & gratitude, from Scala-js original dated 2019-09-19
+///    commit: https://github.com/scala-js/scala-js/commit/
+///		 434b8ce12ce111831095a0abf8f347d0523a3d6f
+///
+///  The port of the Scala.js *MapFactory test idiom is minimal.
+
+package java.util.concurrent
+
+import scala.language.implicitConversions
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+import java.{util => ju}
+import java.util.concurrent.{ConcurrentHashMap => CHM}
+
+object ConcurrentHashMapTest extends tests.Suite {
+
+  // SN Port of two argument form.
+  private def assertTrue(msg: String, cond: Boolean): Unit = {
+    assert(cond, msg)
+  }
+
+  def factory: ConcurrentHashMapFactory = new ConcurrentHashMapFactory
+
+  test("should give proper Enumerator over elements") {
+    val chm = factory.empty[String, String]
+
+    chm.put("ONE", "one")
+    val elements = chm.elements
+    assertTrue(elements.hasMoreElements)
+    assertEquals("one", elements.nextElement)
+    assertFalse(elements.hasMoreElements)
+  }
+
+  test("should replace contained items") {
+    val chm = factory.empty[String, String]
+
+    chm.put("ONE", "one")
+    assertEquals("one", chm.replace("ONE", "two"))
+    expectThrows(classOf[NullPointerException], chm.replace("ONE", null))
+    expectThrows(classOf[NullPointerException], chm.replace(null, "one"))
+    assertEquals("two", chm.get("ONE"))
+
+    assertFalse(chm.replace("ONE", "one", "two"))
+    expectThrows(classOf[NullPointerException], chm.replace(null, "two", "one"))
+    expectThrows(classOf[NullPointerException], chm.replace("ONE", null, "one"))
+    expectThrows(classOf[NullPointerException], chm.replace("ONE", "two", null))
+
+    assertTrue(chm.replace("ONE", "two", "one"))
+    assertEquals("one", chm.get("ONE"))
+  }
+
+  test("putIfAbsent Scala.js Issue #2539") {
+    val chm = factory.empty[String, String]
+
+    assertNull(chm.putIfAbsent("abc", "def"))
+    assertEquals("def", chm.get("abc"))
+    assertNull(chm.putIfAbsent("123", "456"))
+    assertEquals("456", chm.get("123"))
+    assertEquals("def", chm.putIfAbsent("abc", "def"))
+    assertEquals("def", chm.putIfAbsent("abc", "ghi"))
+    assertEquals("456", chm.putIfAbsent("123", "789"))
+    assertEquals("def", chm.putIfAbsent("abc", "jkl"))
+  }
+
+  test("Iterators are weakly consistent") {
+    /* The Javadoc says the following about weakly consistent iterators:
+     * > they are guaranteed to traverse elements as they existed upon
+     * > construction exactly once, and may (but are not guaranteed to) reflect
+     * > any modifications subsequent to construction.
+     *
+     * The two subsentences seem to be contradictory, notably in terms of
+     * removal. Experimentation shows that iterators *can* reflect removals
+     * subsequent to construction.
+     *
+     * Therefore, we interpreted that the only actual guarantees are the
+     * following:
+     *
+     * - If a key existed when the iterator was created, and it is not removed,
+     *	 then eventually the iterator will yield it.
+     * - An iterator never yields the same key twice.
+     * - If an iterator yields a given key, then the associated value can be
+     *	 any value associated with the key at some point since the iterator was
+     *	 created (but not another, arbitrary value).
+     *
+     * This test aims at testing those guarantees, and only those guarantees,
+     * using random schedulings of concurrent `put` and `remove` operations
+     * while the iterator is used.
+     */
+
+    // Creates a new map with the state before creating the iterator
+    def createInitialMap(): CHM[String, String] = {
+      val m = factory.empty[String, String]
+      m.put("initial", "init")
+      m.put("there forever", "always")
+      m.put("mutated", "first value")
+      for (i <- 0 until 30)
+	m.put(i.toString(), s"value $i")
+      m
+    }
+
+    /* A list of operations that will randomly scheduled concurrently with the
+     * iteration.
+     */
+    val concurrentOperations = List[CHM[String, String] => Unit](
+	_.put("foo", "bar"),
+	_.put("babar", "baz"),
+	_.put("babar", "bazbaz"),
+	_.put("hello", "world"),
+	_.put("mutated", "second value"),
+	_.remove("initial"),
+	_.remove("hello")
+    )
+
+    // Per key, the set of values that we can possibly observe
+    val possibleValuesFor: Map[String, Set[String]] = {
+      Map(
+	  "initial" -> Set("init"),
+	  "there forever" -> Set("always"),
+	  "mutated" -> Set("first value", "second value"),
+	  "foo" -> Set("bar"),
+	  "babar" -> Set("baz", "bazbaz"),
+	  "hello" -> Set("world")
+      ) ++ (0 until 30).map(i => i.toString() -> Set(s"value $i"))
+    }
+
+    // The set of all the values that we can possibly observe (for values())
+    val allPossibleValues: Set[String] = possibleValuesFor.flatMap(_._2).toSet
+
+    /* The list of keys that we *must* observe at some point, because they
+     * exist before the iterator is created, and they are never removed.
+     */
+    val mandatoryKeys: List[String] =
+      List("there forever", "mutated") ++ (0 until 30).map(_.toString())
+
+    /* The list of values that we *must* observe at some point, because they
+     * are uniquely associated with a key that we must observe at some point.
+     */
+    val mandatoryValues: List[String] =
+      mandatoryKeys.map(possibleValuesFor(_)).filter(_.size == 1).map(_.head)
+
+    // The initial seed was generated at random
+    val topLevelRandom = new java.util.Random(2972838770879131323L)
+
+    // Test 30 different interleavings for entrySet()
+    for (_ <- 0 until 30) {
+      val random = new scala.util.Random(topLevelRandom.nextLong())
+      var shuffledOps = random.shuffle(concurrentOperations)
+      val m = createInitialMap()
+      val encounteredKeys = mutable.Set.empty[String]
+      val entryIter = m.entrySet().iterator()
+
+      while (entryIter.hasNext()) {
+	// Schedule 0-to-many concurrent operations before the next call to next()
+	while (shuffledOps.nonEmpty && random.nextBoolean()) {
+	  shuffledOps.head(m)
+	  shuffledOps = shuffledOps.tail
+	}
+
+	val entry = entryIter.next()
+	val key = entry.getKey()
+	val value = entry.getValue()
+	assertTrue(s"duplicate iteration of key '$key'", encounteredKeys.add(key))
+	assertTrue(s"unexpected key '$key'", possibleValuesFor.contains(key))
+	assertTrue(s"unexpected value '$value' for key '$key'",
+	    possibleValuesFor(key).contains(value))
+      }
+
+      for (key <- mandatoryKeys)
+	assertTrue(s"missing key '$key'", encounteredKeys.contains(key))
+    }
+
+    // Test 30 different interleavings for keySet()
+    for (_ <- 0 until 30) {
+      val random = new scala.util.Random(topLevelRandom.nextLong())
+      var shuffledOps = random.shuffle(concurrentOperations)
+      val m = createInitialMap()
+      val encounteredKeys = mutable.Set.empty[String]
+      val keyIter = m.keySet().iterator()
+
+      while (keyIter.hasNext()) {
+	// Schedule 0-to-many concurrent operations before the next call to next()
+	while (shuffledOps.nonEmpty && random.nextBoolean()) {
+	  shuffledOps.head(m)
+	  shuffledOps = shuffledOps.tail
+	}
+
+	val key = keyIter.next()
+	assertTrue(s"duplicate iteration of key '$key'", encounteredKeys.add(key))
+	assertTrue(s"unexpected key '$key'", possibleValuesFor.contains(key))
+      }
+
+      for (key <- mandatoryKeys)
+	assertTrue(s"missing key '$key'", encounteredKeys.contains(key))
+    }
+
+    // Test 30 different interleavings for values()
+    for (_ <- 0 until 30) {
+      val random = new scala.util.Random(topLevelRandom.nextLong())
+      var shuffledOps = random.shuffle(concurrentOperations)
+      val m = createInitialMap()
+      val encounteredValues = mutable.Set.empty[String]
+      val valueIter = m.values().iterator()
+
+      while (valueIter.hasNext()) {
+	// Schedule 0-to-many concurrent operations before the next call to next()
+	while (shuffledOps.nonEmpty && random.nextBoolean()) {
+	  shuffledOps.head(m)
+	  shuffledOps = shuffledOps.tail
+	}
+
+	val value = valueIter.next()
+	encounteredValues.add(value)
+	assertTrue(s"unexpected value '$value'",
+	    allPossibleValues.contains(value))
+      }
+
+      for (value <- mandatoryValues)
+	assertTrue(s"missing value '$value'", encounteredValues.contains(value))
+    }
+  }
+}
+
+trait MapFactory {
+  def implementationName: String
+
+  def empty[K: ClassTag, V: ClassTag]: ju.Map[K, V]
+
+  def allowsNullKeys: Boolean
+
+  def allowsNullValues: Boolean
+
+  def allowsNullKeysQueries: Boolean = true
+
+  def allowsNullValuesQueries: Boolean = true
+
+  def withSizeLimit: Option[Int] = None
+
+  def isIdentityBased: Boolean = false
+}
+
+trait ConcurrentMapFactory extends MapFactory {
+  def empty[K: ClassTag, V: ClassTag]: ju.concurrent.ConcurrentMap[K, V]
+
+  override def allowsNullValuesQueries: Boolean = false
+
+  override def allowsNullKeysQueries: Boolean = false
+}
+
+class ConcurrentHashMapFactory extends ConcurrentMapFactory {
+  def implementationName: String =
+    "java.util.concurrent.ConcurrentHashMap"
+
+  override def empty[K: ClassTag, V: ClassTag]: ju.concurrent.ConcurrentHashMap[K, V] =
+    new ju.concurrent.ConcurrentHashMap[K, V]
+
+  def allowsNullKeys: Boolean = false
+
+  def allowsNullValues: Boolean = false
+}


### PR DESCRIPTION
  * This PR was motivated by Issue #1023 "Missing methods to support
    scala-java-time". It implements a logical subset of the files
    required by that issue: java.util.concurrent.ConcurrentHashMap
    and j.u.c.ConcurrentMap.

    Implementing those two classes triggers a set of changes to
    the other files in this PR.

    There are at least two additional tranches of scala-java-time changes
    coming in additional PRs to implement CopyOnWriteArrayList and
    Map#putIfAbsent (and a whole whack of Java default methods).
    Smaller PRs should ease review & incorporation of review comments.

  * Most of the files were ported, with appreciation & thanks, from
    Scala.js. Some, but not all, of the Summer, 2019 Scala.js improvements
    were brought in transitively.

    @ekrich implemented IdentityHashMap.scala for Scala.js.

  * @ekrich, @densh -- when the time comes for review, could I draw
    your attention to the file j.u.IdentityHashMap.scala, private
    class MapEntry, method hashCode? I believe the handling of
    of Any and AnyVal values in the map is right but that small section
    would benefit from review.

  * The unit-test Suite ConcurrentHashMapSuite.scala was ported from
    Scala.js.  Scala.js has an elegant 'factory' approach to testing
    an inheritance tower.  I brought in only enough of that to minimally
    exercise the current PR.

Documentation:

  * The standard changelog entry is requested.

  * The two newly ported classes were added to docs/lib/javalib.rst.
    The documentation was rebuilt and the resultant .html file
    examined manually in a (Firefox) browser. The new information
    displayed and no new errors occurred in the documentation build.

Testing:

  * Built and tested ("test-all") in release-fast mode using sbt 1.2.8 on
    X86_64 only . All tests pass.