### PR TITLE
Fix CI failures on source check

### DIFF
--- a/scripts/source-checks
+++ b/scripts/source-checks
@@ -4,7 +4,7 @@ set -e
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
   echo "Incoming pull request from https://github.com/$TRAVIS_REPO_SLUG/pull/$TRAVIS_PULL_REQUEST"
-  author=$(curl -u dummy4dummy:dummy2dummy -s "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST" | jq -r ".user.login")
+  author=$(curl -s "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST" | jq -r ".user.login")
   echo "Pull request submitted by $author"
   signed=$(curl -s https://www.lightbend.com/contribute/cla/scala/check/$author | jq -r ".signed")
   


### PR DESCRIPTION
The API call to GitHub fails due to a change. The author is always `null` so the Lightbend CLA call in turn fails.

Ready for review.