### PR TITLE
Update travis_setup.sh to llvm9

### DIFF
--- a/scripts/travis_setup.sh
+++ b/scripts/travis_setup.sh
@@ -13,8 +13,8 @@ if [ "$(uname)" == "Darwin" ]; then
     brew link bdw-gc
     brew install jq
     brew install re2
-    brew install llvm@4
-    export PATH="/usr/local/opt/llvm@4/bin:$PATH"
+    brew install llvm@9
+    export PATH="/usr/local/opt/llvm@9/bin:$PATH"
 
 else
 


### PR DESCRIPTION
llvm4 has been removed from homebrew in https://github.com/Homebrew/homebrew-core/commit/5b9c4d074255b279151636b20dc5e14fa1b0317c