### PR TITLE
Upgrade build to sbt 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,9 +31,9 @@ lazy val startupTransition: State => State = { s: State =>
   }
 }
 
-onLoad in Global := {
-  val sbtCrossVersion = (sbtVersion in pluginCrossBuild).value
-  val old             = (onLoad in Global).value
+Global / onLoad := {
+  val sbtCrossVersion = (pluginCrossBuild / sbtVersion).value
+  val old             = (Global / onLoad).value
   if (sbtCrossVersion != sbt10Version) {
     startupTransition compose old
   } else {
@@ -115,16 +115,16 @@ lazy val publishSnapshot =
   taskKey[Unit]("Publish snapshot to sonatype on every commit to master.")
 
 lazy val setUpTestingCompiler = Def.task {
-  val nscpluginjar = (Keys.`package` in nscplugin in Compile).value
-  val nativelibjar = (Keys.`package` in nativelib in Compile).value
-  val auxlibjar    = (Keys.`package` in auxlib in Compile).value
-  val clibjar      = (Keys.`package` in clib in Compile).value
-  val posixlibjar  = (Keys.`package` in posixlib in Compile).value
-  val scalalibjar  = (Keys.`package` in scalalib in Compile).value
-  val javalibjar   = (Keys.`package` in javalib in Compile).value
+  val nscpluginjar = (nscplugin / Compile / Keys.`package`).value
+  val nativelibjar = (nativelib / Compile / Keys.`package`).value
+  val auxlibjar    = (auxlib / Compile / Keys.`package`).value
+  val clibjar      = (clib / Compile / Keys.`package`).value
+  val posixlibjar  = (posixlib / Compile / Keys.`package`).value
+  val scalalibjar  = (scalalib / Compile / Keys.`package`).value
+  val javalibjar   = (javalib / Compile / Keys.`package`).value
   val testingcompilercp =
-    (fullClasspath in testingCompiler in Compile).value.files
-  val testingcompilerjar = (Keys.`package` in testingCompiler in Compile).value
+    (testingCompiler / Compile / fullClasspath).value.files
+  val testingcompilerjar = (testingCompiler / Compile / Keys.`package`).value
 
   sys.props("scalanative.nscplugin.jar") = nscpluginjar.getAbsolutePath
   sys.props("scalanative.testingcompiler.cp") =
@@ -132,7 +132,7 @@ lazy val setUpTestingCompiler = Def.task {
   sys.props("scalanative.nativeruntime.cp") =
     Seq(nativelibjar, auxlibjar, clibjar, posixlibjar, scalalibjar, javalibjar) mkString pathSeparator
   sys.props("scalanative.nativelib.dir") =
-    ((crossTarget in Compile).value / "nativelib").getAbsolutePath
+    ((Compile / crossTarget).value / "nativelib").getAbsolutePath
 }
 
 // to publish plugin (we only need to do this once, it's already done!)
@@ -191,11 +191,11 @@ lazy val mavenPublishSettings = Seq(
 ) ++ publishSettings
 
 lazy val publishSettings = Seq(
-  publishArtifact in Compile := true,
-  publishArtifact in Test := false,
-  publishArtifact in (Compile, packageDoc) :=
+  Compile / publishArtifact := true,
+  Test / publishArtifact := false,
+  Compile / packageDoc / publishArtifact :=
     !version.value.contains("SNAPSHOT"),
-  publishArtifact in (Compile, packageSrc) :=
+  Compile / packageSrc / publishArtifact :=
     !version.value.contains("SNAPSHOT"),
   homepage := Some(url("http://www.scala-native.org")),
   startYear := Some(2015),
@@ -226,7 +226,7 @@ lazy val noPublishSettings = Seq(
   publish := {},
   publishLocal := {},
   publishSnapshot := { println("no publish") },
-  skip in publish := true
+  publish / skip := true
 ) ++ nameSettings
 
 lazy val toolSettings =
@@ -234,7 +234,7 @@ lazy val toolSettings =
     Seq(
       crossSbtVersions := List(sbt13Version, sbt10Version),
       scalaVersion := {
-        (sbtBinaryVersion in pluginCrossBuild).value match {
+        (pluginCrossBuild / sbtBinaryVersion).value match {
           case "0.13" => sbt13ScalaVersion
           case _      => sbt10ScalaVersion
         }
@@ -302,16 +302,16 @@ lazy val tools =
     .settings(mavenPublishSettings)
     .settings(
       libraryDependencies ++= Seq(
-        "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
-        "org.scalatest"  %% "scalatest"  % "3.0.0"  % "test"
+        "org.scalacheck" %% "scalacheck" % "1.14.3" % "test",
+        "org.scalatest"  %% "scalatest"  % "3.1.0"  % "test"
       ),
-      fullClasspath in Test := ((fullClasspath in Test) dependsOn setUpTestingCompiler).value,
+      Test / fullClasspath := ((Test / fullClasspath) dependsOn setUpTestingCompiler).value,
       publishLocal := publishLocal
-        .dependsOn(publishLocal in nir)
-        .dependsOn(publishLocal in util)
+        .dependsOn(nir / publishLocal)
+        .dependsOn(util / publishLocal)
         .value,
       // Running tests in parallel results in `FileSystemAlreadyExistsException`
-      parallelExecution in Test := false,
+      Test / parallelExecution := false,
       mimaSettings
     )
     .dependsOn(nir, util, testingCompilerInterface % Test)
@@ -325,9 +325,9 @@ lazy val nscplugin =
       scalaVersion := libScalaVersion,
       crossScalaVersions := libCrossScalaVersions,
       crossVersion := CrossVersion.full,
-      unmanagedSourceDirectories in Compile ++= Seq(
-        (scalaSource in (nir, Compile)).value,
-        (scalaSource in (util, Compile)).value
+      Compile / unmanagedSourceDirectories ++= Seq(
+        (nir / Compile / scalaSource).value,
+        (util / Compile / scalaSource).value
       ),
       libraryDependencies ++= Seq(
         "org.scala-lang" % "scala-compiler" % scalaVersion.value,
@@ -357,16 +357,16 @@ lazy val sbtScalaNative =
     .settings(
       crossScalaVersions := libCrossScalaVersions,
       // fixed in https://github.com/sbt/sbt/pull/3397 (for sbt 0.13.17)
-      sbtBinaryVersion in update := (sbtBinaryVersion in pluginCrossBuild).value,
+      update / sbtBinaryVersion := (pluginCrossBuild / sbtBinaryVersion).value,
       addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0"),
-      sbtTestDirectory := (baseDirectory in ThisBuild).value / "scripted-tests",
+      sbtTestDirectory := (ThisBuild / baseDirectory).value / "scripted-tests",
       // `testInterfaceSerialization` needs to be available from the sbt plugin,
       // but it's a Scala Native project (and thus 2.11), and the plugin is 2.10 or 2.12.
       // We simply add the sources to mimic cross-compilation.
-      sources in Compile ++= (sources in Compile in testInterfaceSerialization).value,
+      Compile / sources ++= (testInterfaceSerialization / Compile / sources).value,
       // publish the other projects before running scripted tests.
       publishLocal := publishLocal
-        .dependsOn(publishLocal in tools, publishLocal in testRunner)
+        .dependsOn(tools / publishLocal, testRunner / publishLocal)
         .value
     )
     .dependsOn(tools, testRunner)
@@ -379,7 +379,7 @@ lazy val nativelib =
     .settings(
       libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       publishLocal := publishLocal
-        .dependsOn(publishLocal in nscplugin)
+        .dependsOn(nscplugin / publishLocal)
         .value
     )
 
@@ -390,7 +390,7 @@ lazy val clib =
     .settings(mavenPublishSettings)
     .settings(
       publishLocal := publishLocal
-        .dependsOn(publishLocal in nativelib)
+        .dependsOn(nativelib / publishLocal)
         .value
     )
     .dependsOn(nativelib)
@@ -402,7 +402,7 @@ lazy val posixlib =
     .settings(mavenPublishSettings)
     .settings(
       publishLocal := publishLocal
-        .dependsOn(publishLocal in clib)
+        .dependsOn(clib / publishLocal)
         .value
     )
     .dependsOn(clib)
@@ -413,28 +413,28 @@ lazy val javalib =
     .settings(libSettings)
     .settings(mavenPublishSettings)
     .settings(
-      sources in doc in Compile := Nil, // doc generation currently broken
+      Compile / doc / sources := Nil, // doc generation currently broken
       // This is required to have incremental compilation to work in javalib.
       // We put our classes on scalac's `javabootclasspath` so that it uses them
       // when compiling rather than the definitions from the JDK.
-      scalacOptions in Compile := {
-        val previous = (scalacOptions in Compile).value
+      Compile / scalacOptions := {
+        val previous = (Compile / scalacOptions).value
         val javaBootClasspath =
           scala.tools.util.PathResolver.Environment.javaBootClassPath
-        val classDir  = (classDirectory in Compile).value.getAbsolutePath()
+        val classDir  = (Compile / classDirectory).value.getAbsolutePath()
         val separator = sys.props("path.separator")
         "-javabootclasspath" +: s"$classDir$separator$javaBootClasspath" +: previous
       },
       // Don't include classfiles for javalib in the packaged jar.
-      mappings in packageBin in Compile := {
-        val previous = (mappings in packageBin in Compile).value
+      Compile / packageBin / mappings := {
+        val previous = (Compile / packageBin / mappings).value
         previous.filter {
           case (file, path) =>
             !path.endsWith(".class")
         }
       },
       publishLocal := publishLocal
-        .dependsOn(publishLocal in nativelib, publishLocal in posixlib)
+        .dependsOn(nativelib / publishLocal, posixlib / publishLocal)
         .value
     )
     .dependsOn(nativelib, posixlib)
@@ -449,7 +449,7 @@ lazy val auxlib =
     .settings(mavenPublishSettings)
     .settings(
       publishLocal := publishLocal
-        .dependsOn(publishLocal in javalib)
+        .dependsOn(javalib / publishLocal)
         .value
     )
     .dependsOn(nativelib)
@@ -503,19 +503,19 @@ lazy val scalalib =
         // of code that was previously in Java but is in Scala now.
         (file("scalalib/src/main/scala") ** "*.java").get.foreach(IO.delete)
       },
-      compile in Compile := (compile in Compile)
+      Compile / compile := (Compile / compile)
         .dependsOn(assembleScalaLibrary)
         .value,
       // Don't include classfiles for scalalib in the packaged jar.
-      mappings in packageBin in Compile := {
-        val previous = (mappings in packageBin in Compile).value
+      Compile / packageBin / mappings := {
+        val previous = (Compile / packageBin / mappings).value
         previous.filter {
           case (file, path) =>
             !path.endsWith(".class")
         }
       },
       publishLocal := publishLocal
-        .dependsOn(assembleScalaLibrary, publishLocal in auxlib)
+        .dependsOn(assembleScalaLibrary, auxlib / publishLocal)
         .value
     )
     .dependsOn(auxlib, nativelib, javalib)
@@ -532,7 +532,7 @@ lazy val tests =
       //   target.value / "out.dot"),
       libraryDependencies += "org.scala-native" %%% "test-interface" % nativeVersion,
       testFrameworks += new TestFramework("tests.NativeFramework"),
-      envVars in (Test, test) ++= Map(
+      Test / test / envVars ++= Map(
         "USER"                           -> "scala-native",
         "HOME"                           -> baseDirectory.value.getAbsolutePath,
         "SCALA_NATIVE_ENV_WITH_EQUALS"   -> "1+1=2",
@@ -590,7 +590,7 @@ lazy val testInterface =
       libraryDependencies += "org.scala-sbt"    % "test-interface"   % "1.0",
       libraryDependencies -= "org.scala-native" %%% "test-interface" % version.value % Test,
       publishLocal := publishLocal
-        .dependsOn(publishLocal in testInterfaceSerialization)
+        .dependsOn(testInterfaceSerialization / publishLocal)
         .value
     )
     .enablePlugins(ScalaNativePlugin)
@@ -605,7 +605,7 @@ lazy val testInterfaceSerialization =
     .settings(
       libraryDependencies -= "org.scala-native" %%% "test-interface" % version.value % Test,
       publishLocal := publishLocal
-        .dependsOn(publishLocal in testInterfaceSbtDefs)
+        .dependsOn(testInterfaceSbtDefs / publishLocal)
         .value
     )
     .dependsOn(testInterfaceSbtDefs)
@@ -630,6 +630,6 @@ lazy val testRunner =
     .settings(
       crossScalaVersions := Seq(sbt13ScalaVersion, sbt10ScalaVersion),
       libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0",
-      sources in Compile ++= (sources in testInterfaceSerialization in Compile).value
+      Compile / sources ++= (testInterfaceSerialization / Compile / sources).value
     )
     .dependsOn(tools)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.18
+sbt.version = 1.3.7

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,4 +1,4 @@
-unmanagedSourceDirectories in Compile ++= {
+Compile / unmanagedSourceDirectories ++= {
   val root = baseDirectory.value.getParentFile
 
   (root / "sbt-scala-native/src/main/scala-sbt-1.0") +:

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,7 +1,7 @@
 unmanagedSourceDirectories in Compile ++= {
   val root = baseDirectory.value.getParentFile
 
-  (root / "sbt-scala-native/src/main/scala-sbt-0.13") +:
+  (root / "sbt-scala-native/src/main/scala-sbt-1.0") +:
     Seq(
     "util",
     "nir",
@@ -13,15 +13,14 @@ unmanagedSourceDirectories in Compile ++= {
 }
 
 libraryDependencies ++= Seq(
-  "org.scala-sbt"    % "scripted-plugin"      % sbtVersion.value,
-  "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.7.1.201504261725-r"
+  "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "4.5.1.201703201650-r"
 )
 
 addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-dirty-money"   % "0.2.0")
-addSbtPlugin("org.foundweekends"  % "sbt-bintray"       % "0.5.4")
-addSbtPlugin("com.jsuereth"       % "sbt-pgp"           % "1.0.0")
-addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"   % "0.3.0")
+addSbtPlugin("org.foundweekends"  % "sbt-bintray"       % "0.5.6")
+addSbtPlugin("com.jsuereth"       % "sbt-pgp"           % "2.0.1")
+addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"   % "0.6.1")
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/scripted-tests/run/execution-context/build.sbt
+++ b/scripted-tests/run/execution-context/build.sbt
@@ -7,7 +7,7 @@ lazy val runAndCheck = taskKey[Unit]("...")
 runAndCheck := {
   import scala.sys.process._
 
-  val bin = (nativeLink in Compile).value
+  val bin = (Compile / nativeLink).value
   val out = Process(bin.getAbsolutePath).lines_!.toList
   assert(
     out == List(

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -4,9 +4,9 @@ import scala.sys.process._
 
 scalaVersion := "2.11.12"
 
-nativeLinkingOptions in Compile += s"-L${target.value.getAbsoluteFile}"
+Compile / nativeLinkingOptions += s"-L${target.value.getAbsoluteFile}"
 
-compile in Compile := {
+Compile / compile := {
   val log            = streams.value.log
   val cwd            = target.value
   val compileOptions = nativeCompileOptions.value
@@ -45,5 +45,5 @@ compile in Compile := {
     sys.error(s"Failed to create archive $archivePath")
   }
 
-  (compile in Compile).value
+  (Compile / compile).value
 }

--- a/scripted-tests/run/shutdown/build.sbt
+++ b/scripted-tests/run/shutdown/build.sbt
@@ -8,7 +8,7 @@ val runTest = taskKey[Unit]("run test")
 
 enablePlugins(ScalaNativePlugin)
 runTest := {
-  val cmd  = (nativeLink in Compile).value.toString
+  val cmd  = (Compile / nativeLink).value.toString
   val file = Files.createTempFile("foo", "")
   assert(Files.exists(file))
   val proc = new ProcessBuilder(cmd, file.toString).start()


### PR DESCRIPTION
We are currently building scala-native with sbt 0.13. This makes it hard to work with Metals and bloop. Bumping the sbt version for the build to 1.3.7 allows working with Metals out-of-the-box.

For this PR, I have followed the [recommendations](https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html) for migrating from sbt 0.13.

I have also bumped the plugin versions in `build.sbt`. Everything seems to work, at least for importing and building the project.

Comments are welcome!

**Edit:** I just noticed #1712 attempts to do the same, maybe in a more complete way.