### PR TITLE
WIP: Concurrent Immix and Commix

### DIFF
--- a/nativelib/src/main/resources/gc/commix/Allocator.c
+++ b/nativelib/src/main/resources/gc/commix/Allocator.c
@@ -239,7 +239,7 @@ word_t *Allocator_lazySweep(Heap *heap, uint32_t size) {
     return object;
 }
 
-NOINLINE word_t *Allocator_allocSlow(Heap *heap, uint32_t size) {
+NOINLINE word_t *Allocator_allocSlow(ThreadManager *threadManager, Heap *heap, uint32_t size) {
     word_t *object = Allocator_tryAlloc(&allocator, size);
 
     if (object != NULL) {
@@ -262,7 +262,7 @@ NOINLINE word_t *Allocator_allocSlow(Heap *heap, uint32_t size) {
             goto done;
     }
 
-    Heap_Collect(heap);
+    Heap_Collect(threadManager, heap);
     object = Allocator_tryAlloc(&allocator, size);
 
     if (object != NULL)

--- a/nativelib/src/main/resources/gc/commix/CommixGC.c
+++ b/nativelib/src/main/resources/gc/commix/CommixGC.c
@@ -33,7 +33,7 @@ void scalanative_afterexit() {
 
 NOINLINE void scalanative_init() {
     Heap_Init(&heap, Settings_MinHeapSize(), Settings_MaxHeapSize());
-    ThreadManager_Init();
+    ThreadManager_Init(&threadManager);
     ThreadManager_RegisterThread(__stack_bottom);
 #ifdef ENABLE_GC_STATS
     atexit(scalanative_afterexit);
@@ -45,7 +45,7 @@ INLINE void *scalanative_alloc(void *info, size_t size) {
     assert(size % ALLOCATION_ALIGNMENT == 0);
 
     void **alloc;
-    pthread_mutex_lock(&mutex);
+    pthread_mutex_lock(&threadManager.mutex);
     if (size >= LARGE_BLOCK_SIZE) {
         alloc = (void **)LargeAllocator_Alloc(&heap, size);
     } else {
@@ -53,27 +53,27 @@ INLINE void *scalanative_alloc(void *info, size_t size) {
     }
 
     *alloc = info;
-    pthread_mutex_unlock(&mutex);
+    pthread_mutex_unlock(&threadManager.mutex);
     return (void *)alloc;
 }
 
 INLINE void *scalanative_alloc_small(void *info, size_t size) {
     size = MathUtils_RoundToNextMultiple(size, ALLOCATION_ALIGNMENT);
 
-    pthread_mutex_lock(&mutex);
+    pthread_mutex_lock(&threadManager.mutex);
     void **alloc = (void **)Allocator_Alloc(&heap, size);
     *alloc = info;
-    pthread_mutex_unlock(&mutex);
+    pthread_mutex_unlock(&threadManager.mutex);
     return (void *)alloc;
 }
 
 INLINE void *scalanative_alloc_large(void *info, size_t size) {
     size = MathUtils_RoundToNextMultiple(size, ALLOCATION_ALIGNMENT);
 
-    pthread_mutex_lock(&mutex);
+    pthread_mutex_lock(&threadManager.mutex);
     void **alloc = (void **)LargeAllocator_Alloc(&heap, size);
     *alloc = info;
-    pthread_mutex_unlock(&mutex);
+    pthread_mutex_unlock(&threadManager.mutex);
     return (void *)alloc;
 }
 
@@ -82,14 +82,14 @@ INLINE void *scalanative_alloc_atomic(void *info, size_t size) {
 }
 
 INLINE void scalanative_collect() { 
-    pthread_mutex_lock(&mutex);
-    Heap_Collect(&heap);
-    pthread_mutex_unlock(&mutex);
+    pthread_mutex_lock(&threadManager.mutex);
+    Heap_Collect(&threadManager, &heap);
+    pthread_mutex_unlock(&threadManager.mutex);
 }
 
 INLINE void scalanative_register_thread() {
-    pthread_mutex_lock(&mutex);
+    pthread_mutex_lock(&threadManager.mutex);
     word_t *dummy;
-    ThreadManager_RegisterThread(&dummy);
-    pthread_mutex_unlock(&mutex);
+    ThreadManager_RegisterThread(&threadManager, &dummy);
+    pthread_mutex_unlock(&threadManager.mutex);
 }

--- a/nativelib/src/main/resources/gc/commix/Heap.c
+++ b/nativelib/src/main/resources/gc/commix/Heap.c
@@ -17,6 +17,7 @@
 #include <memory.h>
 #include <time.h>
 #include <inttypes.h>
+#include "ThreadManager.h"
 
 // Allow read and write
 #define HEAP_MEM_PROT (PROT_READ | PROT_WRITE)
@@ -209,6 +210,7 @@ void Heap_Init(Heap *heap, size_t minHeapSize, size_t maxHeapSize) {
 }
 
 void Heap_Collect(Heap *heap) {
+    ThreadManager_SuspendAllThreads();
     Stats *stats = Stats_OrNull(heap->stats);
     Stats_CollectionStarted(stats);
     assert(Sweeper_IsSweepDone(heap));
@@ -223,6 +225,7 @@ void Heap_Collect(Heap *heap) {
     Stats_RecordEvent(stats, event_mark, heap->mark.currentStart_ns,
                       heap->mark.currentEnd_ns);
     Phase_StartSweep(heap);
+    ThreadManager_ResumeAllThreads();
 }
 
 bool Heap_shouldGrow(Heap *heap) {

--- a/nativelib/src/main/resources/gc/commix/Heap.c
+++ b/nativelib/src/main/resources/gc/commix/Heap.c
@@ -209,8 +209,8 @@ void Heap_Init(Heap *heap, size_t minHeapSize, size_t maxHeapSize) {
     pthread_mutex_init(&heap->sweep.growMutex, NULL);
 }
 
-void Heap_Collect(Heap *heap) {
-    ThreadManager_SuspendAllThreads();
+void Heap_Collect(ThreadManager *threadManager, Heap *heap) {
+    ThreadManager_SuspendAllThreads(threadManager);
     Stats *stats = Stats_OrNull(heap->stats);
     Stats_CollectionStarted(stats);
     assert(Sweeper_IsSweepDone(heap));
@@ -219,13 +219,13 @@ void Heap_Collect(Heap *heap) {
     Sweeper_AssertIsConsistent(heap);
 #endif
     Phase_StartMark(heap);
-    Marker_MarkRoots(heap, stats);
+    Marker_MarkRoots(threadManager, heap, stats);
     Marker_MarkUntilDone(heap, stats);
     Phase_MarkDone(heap);
     Stats_RecordEvent(stats, event_mark, heap->mark.currentStart_ns,
                       heap->mark.currentEnd_ns);
     Phase_StartSweep(heap);
-    ThreadManager_ResumeAllThreads();
+    ThreadManager_ResumeAllThreads(threadManager);
 }
 
 bool Heap_shouldGrow(Heap *heap) {

--- a/nativelib/src/main/resources/gc/commix/Heap.h
+++ b/nativelib/src/main/resources/gc/commix/Heap.h
@@ -85,7 +85,7 @@ static inline LineMeta *Heap_LineMetaForWord(Heap *heap, word_t *word) {
 
 void Heap_Init(Heap *heap, size_t minHeapSize, size_t maxHeapSize);
 
-void Heap_Collect(Heap *heap);
+void Heap_Collect(ThreadManager *threadManager, Heap *heap);
 void Heap_GrowIfNeeded(Heap *heap);
 void Heap_Grow(Heap *heap, uint32_t increment);
 

--- a/nativelib/src/main/resources/gc/commix/LargeAllocator.c
+++ b/nativelib/src/main/resources/gc/commix/LargeAllocator.c
@@ -213,7 +213,7 @@ word_t *LargeAllocator_lazySweep(Heap *heap, uint32_t size) {
     return object;
 }
 
-word_t *LargeAllocator_Alloc(Heap *heap, uint32_t size) {
+word_t *LargeAllocator_Alloc(ThreadManager *threadManager, Heap *heap, uint32_t size) {
 
     assert(size % ALLOCATION_ALIGNMENT == 0);
     assert(size >= MIN_BLOCK_SIZE);
@@ -232,7 +232,7 @@ word_t *LargeAllocator_Alloc(Heap *heap, uint32_t size) {
             goto done;
     }
 
-    Heap_Collect(heap);
+    Heap_Collect(threadManager, heap);
 
     object = LargeAllocator_tryAlloc(&largeAllocator, size);
     if (object != NULL)

--- a/nativelib/src/main/resources/gc/commix/Marker.c
+++ b/nativelib/src/main/resources/gc/commix/Marker.c
@@ -368,17 +368,18 @@ void Marker_markProgramStack(Heap *heap, Stats *stats, GreyPacket **outHolder) {
     jmp_buf regs;
     setjmp(regs);
     word_t *dummy;
+    for (ThreadList *tl = threadList; tl != NULL; tl = tl->next) {
+        word_t **stackBottom = tl->stackBottom;
+        word_t **current =
+            pthread_equal(pthread_self(), tl->thread) ? &dummy : tl->stackTop;
 
-    word_t **current = &dummy;
-    word_t **stackBottom = __stack_bottom;
-
-    while (current <= stackBottom) {
-
-        word_t *stackObject = *current;
-        if (Heap_IsWordInHeap(heap, stackObject)) {
-            Marker_markConservative(heap, stats, outHolder, stackObject);
+        while (current <= stackBottom) {
+            word_t *stackObject = *current;
+            if (Heap_IsWordInHeap(heap, stackObject)) {
+                Marker_markConservative(heap, stats, outHolder, stackObject);
+            }
+            current += 1;
         }
-        current += 1;
     }
 }
 

--- a/nativelib/src/main/resources/gc/commix/Marker.c
+++ b/nativelib/src/main/resources/gc/commix/Marker.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <setjmp.h>
+#include <sched.h>
 #include "Marker.h"
 #include "Object.h"
 #include "Log.h"
@@ -7,7 +8,7 @@
 #include "headers/ObjectHeader.h"
 #include "datastructures/GreyPacket.h"
 #include "GCThread.h"
-#include <sched.h>
+#include "ThreadManager.h"
 
 extern word_t *__modules;
 extern int __modules_size;
@@ -363,12 +364,12 @@ void Marker_MarkUntilDone(Heap *heap, Stats *stats) {
     }
 }
 
-void Marker_markProgramStack(Heap *heap, Stats *stats, GreyPacket **outHolder) {
+void Marker_markProgramStack(ThreadManager *threadManager, Heap *heap, Stats *stats, GreyPacket **outHolder) {
     // Dumps registers into 'regs' which is on stack
     jmp_buf regs;
     setjmp(regs);
     word_t *dummy;
-    for (ThreadList *tl = threadList; tl != NULL; tl = tl->next) {
+    for (ThreadList *tl = threadManager->threadList; tl != NULL; tl = tl->next) {
         word_t **stackBottom = tl->stackBottom;
         word_t **current =
             pthread_equal(pthread_self(), tl->thread) ? &dummy : tl->stackTop;
@@ -401,9 +402,9 @@ void Marker_markModules(Heap *heap, Stats *stats, GreyPacket **outHolder) {
     }
 }
 
-void Marker_MarkRoots(Heap *heap, Stats *stats) {
+void Marker_MarkRoots(ThreadManager *threadManager, Heap *heap, Stats *stats) {
     GreyPacket *out = Marker_takeEmptyPacket(heap, stats);
-    Marker_markProgramStack(heap, stats, &out);
+    Marker_markProgramStack(threadManager, heap, stats, &out);
     Marker_markModules(heap, stats, &out);
     Marker_giveFullPacket(heap, stats, out);
 }

--- a/nativelib/src/main/resources/gc/commix/Marker.h
+++ b/nativelib/src/main/resources/gc/commix/Marker.h
@@ -4,7 +4,7 @@
 #include "Heap.h"
 #include "Stats.h"
 
-void Marker_MarkRoots(Heap *heap, Stats *stats);
+void Marker_MarkRoots(ThreadManager *threadManager, Heap *heap, Stats *stats);
 void Marker_Mark(Heap *heap, Stats *stats);
 void Marker_MarkUntilDone(Heap *heap, Stats *stats);
 void Marker_MarkAndScale(Heap *heap, Stats *stats);

--- a/nativelib/src/main/resources/gc/commix/State.c
+++ b/nativelib/src/main/resources/gc/commix/State.c
@@ -4,3 +4,7 @@ Heap heap;
 Allocator allocator;
 LargeAllocator largeAllocator;
 BlockAllocator blockAllocator;
+ThreadList *threadList;
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+void *suspendingThreadStackTop;
+Semaphore semaphore;

--- a/nativelib/src/main/resources/gc/commix/State.c
+++ b/nativelib/src/main/resources/gc/commix/State.c
@@ -4,7 +4,4 @@ Heap heap;
 Allocator allocator;
 LargeAllocator largeAllocator;
 BlockAllocator blockAllocator;
-ThreadList *threadList;
-pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-void *suspendingThreadStackTop;
-Semaphore semaphore;
+ThreadManager threadManager;

--- a/nativelib/src/main/resources/gc/commix/State.h
+++ b/nativelib/src/main/resources/gc/commix/State.h
@@ -5,10 +5,16 @@
 #include "Allocator.h"
 #include "LargeAllocator.h"
 #include "BlockAllocator.h"
+#include "datastructures/ThreadList.h"
+#include "semaphore/Semaphore.h"
 
 extern Heap heap;
 extern Allocator allocator;
 extern LargeAllocator largeAllocator;
 extern BlockAllocator blockAllocator;
+extern ThreadList *threadList;
+extern pthread_mutex_t mutex;
+extern void *suspendingThreadStackTop;
+extern Semaphore semaphore;
 
 #endif // IMMIX_STATE_H

--- a/nativelib/src/main/resources/gc/commix/State.h
+++ b/nativelib/src/main/resources/gc/commix/State.h
@@ -5,16 +5,12 @@
 #include "Allocator.h"
 #include "LargeAllocator.h"
 #include "BlockAllocator.h"
-#include "datastructures/ThreadList.h"
-#include "semaphore/Semaphore.h"
+#include "ThreadManager.h"
 
 extern Heap heap;
 extern Allocator allocator;
 extern LargeAllocator largeAllocator;
 extern BlockAllocator blockAllocator;
-extern ThreadList *threadList;
-extern pthread_mutex_t mutex;
-extern void *suspendingThreadStackTop;
-extern Semaphore semaphore;
+extern ThreadManager threadManager;
 
 #endif // IMMIX_STATE_H

--- a/nativelib/src/main/resources/gc/commix/ThreadManager.c
+++ b/nativelib/src/main/resources/gc/commix/ThreadManager.c
@@ -1,0 +1,86 @@
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+
+#include "ThreadManager.h"
+#include "State.h"
+
+#define SIG_SUSPEND SIGXFSZ
+#define SIG_RESUME SIGXCPU
+
+void ThreadManager_suspendHandler(int sig) {
+    sigset_t sigset;
+
+    jmp_buf regs;
+    setjmp(regs);
+    word_t *dummy;
+
+    suspendingThreadStackTop = &dummy;
+
+    sigfillset(&sigset);
+    sigdelset(&sigset, SIG_RESUME);
+    Semaphore_Post(&semaphore);
+    sigsuspend(&sigset);
+}
+
+void ThreadManager_resumeHandler(int sig) {}
+
+void ThreadManager_Init() {
+    Semaphore_Init(&semaphore, 0);
+    threadList = NULL;
+
+    struct sigaction suspend_action;
+    sigemptyset(&suspend_action.sa_mask);
+    sigaddset(&suspend_action.sa_mask, SIG_RESUME);
+    suspend_action.sa_flags = 0;
+    suspend_action.sa_handler = ThreadManager_suspendHandler;
+    sigaction(SIG_SUSPEND, &suspend_action, NULL);
+
+    struct sigaction resume_action;
+    sigemptyset(&resume_action.sa_mask);
+    resume_action.sa_flags = 0;
+    resume_action.sa_handler = ThreadManager_resumeHandler;
+    sigaction(SIG_RESUME, &resume_action, NULL);
+}
+
+void ThreadManager_RegisterThread(void *stackBottom) {
+    threadList = ThreadList_Cons(pthread_self(), stackBottom, threadList);
+}
+
+void ThreadManager_suspendThread(pthread_t thread) {
+    if (pthread_equal(pthread_self(), thread))
+        return;
+    int res = pthread_kill(thread, SIG_SUSPEND);
+    if (res == 0) {
+        Semaphore_Wait(&semaphore);
+        ThreadList_SetStackTopForThread(thread, suspendingThreadStackTop,
+                                        threadList);
+    } else {
+        threadList = ThreadList_Remove(thread, threadList);
+    }
+}
+
+void ThreadManager_resumeThread(pthread_t thread) {
+    if (pthread_equal(pthread_self(), thread))
+        return;
+    int res = pthread_kill(thread, SIG_RESUME);
+    if (res != 0) {
+        threadList = ThreadList_Remove(thread, threadList);
+    }
+}
+
+void ThreadManager_SuspendAllThreads() {
+    ThreadList *current = threadList;
+    while (current != NULL) {
+        ThreadManager_suspendThread(current->thread);
+        current = current->next;
+    }
+}
+
+void ThreadManager_ResumeAllThreads() {
+    ThreadList *current = threadList;
+    while (current != NULL) {
+        ThreadManager_resumeThread(current->thread);
+        current = current->next;
+    }
+}

--- a/nativelib/src/main/resources/gc/commix/ThreadManager.h
+++ b/nativelib/src/main/resources/gc/commix/ThreadManager.h
@@ -1,0 +1,12 @@
+#ifndef IMMIX_THREADMANAGER_H
+#define IMMIX_THREADMANAGER_H
+
+void ThreadManager_Init();
+
+void ThreadManager_RegisterThread(void *stackBottom);
+
+void ThreadManager_SuspendAllThreads();
+
+void ThreadManager_ResumeAllThreads();
+
+#endif // IMMIX_THREADMANAGER_H

--- a/nativelib/src/main/resources/gc/commix/ThreadManager.h
+++ b/nativelib/src/main/resources/gc/commix/ThreadManager.h
@@ -1,12 +1,20 @@
 #ifndef IMMIX_THREADMANAGER_H
 #define IMMIX_THREADMANAGER_H
 
-void ThreadManager_Init();
+#include <pthread.h>
+#include "datastructures/ThreadList.h"
 
-void ThreadManager_RegisterThread(void *stackBottom);
+typedef struct {
+    ThreadList *threadList;
+    pthread_mutex_t mutex;
+} ThreadManager;
 
-void ThreadManager_SuspendAllThreads();
+void ThreadManager_Init(ThreadManager *threadManager);
 
-void ThreadManager_ResumeAllThreads();
+void ThreadManager_RegisterThread(ThreadManager *threadManager, void *stackBottom);
+
+void ThreadManager_SuspendAllThreads(ThreadManager *threadManager);
+
+void ThreadManager_ResumeAllThreads(ThreadManager *threadManager);
 
 #endif // IMMIX_THREADMANAGER_H

--- a/nativelib/src/main/resources/gc/commix/datastructures/ThreadList.c
+++ b/nativelib/src/main/resources/gc/commix/datastructures/ThreadList.c
@@ -1,0 +1,57 @@
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include "ThreadList.h"
+
+ThreadList *ThreadList_Cons(pthread_t thread, void *stackBottom, ThreadList *threadList) {
+    ThreadList *current = threadList;
+    while (current != NULL) {
+        if (pthread_equal(current->thread, thread)) {
+            return threadList;
+        }
+        current = current->next;
+    }
+    ThreadList *res = malloc(sizeof(ThreadList));
+    res->thread = thread;
+    res->stackBottom = stackBottom;
+    res->next = threadList;
+    return res;
+}
+
+ThreadList *ThreadList_Remove(pthread_t thread, ThreadList *threadList) {
+    if (threadList == NULL)
+        return NULL;
+    if (pthread_equal(threadList->thread, thread)) {
+        ThreadList *res = threadList->next;
+        free(threadList);
+        return res;
+    }
+    ThreadList *current = threadList;
+    while (current->next != NULL &&
+           !pthread_equal(current->next->thread, thread))
+        current = current->next;
+    if (current != NULL) {
+        ThreadList *toRemove = current->next;
+        current->next = current->next->next;
+        free(toRemove);
+    }
+    return threadList;
+}
+
+void ThreadList_Free(ThreadList *threadList) {
+    ThreadList *current = threadList;
+    while (current != NULL) {
+        ThreadList *toFree = current;
+        current = current->next;
+        free(toFree);
+    }
+}
+
+void ThreadList_SetStackTopForThread(pthread_t thread, void *stackTop, ThreadList *threadList) {
+    for (ThreadList *list = threadList; list != NULL; list = list->next) {
+        if (pthread_equal(list->thread, thread)) {
+            list->stackTop = stackTop;
+            break;
+        }
+    }
+}

--- a/nativelib/src/main/resources/gc/commix/datastructures/ThreadList.h
+++ b/nativelib/src/main/resources/gc/commix/datastructures/ThreadList.h
@@ -1,0 +1,41 @@
+#ifndef IMMIX_THREADLIST_H
+#define IMMIX_THREADLIST_H
+
+#include <pthread.h>
+
+/**
+ * Mutable LinkedList of pthreads.
+ */
+typedef struct ThreadList {
+    pthread_t thread;
+    void *stackBottom;
+    void *stackTop;
+    struct ThreadList *next;
+} ThreadList;
+
+/**
+ * Adds @thread with @stackBottom as head of @threadList if it is not already present.
+ * Returns the list with prepended element.
+ */
+ThreadList *ThreadList_Cons(pthread_t thread, void *stackBottom, ThreadList *threadList);
+
+/**
+ * Removes @thread from @threadList.
+ * Returns the list with the element removed.
+ * It is needed to update the list pointer with the returned pointer
+ * since the head can be removed.
+ */
+ThreadList *ThreadList_Remove(pthread_t thread, ThreadList *threadList);
+
+/**
+ * Frees @threadList.
+ * The contained threads are not freed.
+ */
+void ThreadList_Free(ThreadList *threadList);
+
+/**
+ * Sets @stackTop pointer for @thread in @threadList.
+ */
+void ThreadList_SetStackTopForThread(pthread_t thread, void *stackTop, ThreadList *threadList);
+
+#endif // IMMIX_THREADLIST_H

--- a/nativelib/src/main/resources/gc/commix/semaphore/Semaphore.h
+++ b/nativelib/src/main/resources/gc/commix/semaphore/Semaphore.h
@@ -1,0 +1,46 @@
+#ifdef __APPLE__
+#include <dispatch/dispatch.h>
+#else
+#include <errno.h>
+#include <semaphore.h>
+#endif
+
+typedef struct {
+#ifdef __APPLE__
+    dispatch_semaphore_t sem;
+#else
+    sem_t sem;
+#endif
+} Semaphore;
+
+static inline void Semaphore_Init(Semaphore *s, int value) {
+#ifdef __APPLE__
+    dispatch_semaphore_t *sem = &s->sem;
+
+    *sem = dispatch_semaphore_create(value);
+#else
+    sem_init(&s->sem, 0, value);
+#endif
+}
+
+static inline void Semaphore_Wait(Semaphore *s) {
+
+#ifdef __APPLE__
+    dispatch_semaphore_wait(s->sem, DISPATCH_TIME_FOREVER);
+#else
+    int r;
+
+    do {
+        r = sem_wait(&s->sem);
+    } while (r == -1 && errno == EINTR);
+#endif
+}
+
+static inline void Semaphore_Post(Semaphore *s) {
+
+#ifdef __APPLE__
+    dispatch_semaphore_signal(s->sem);
+#else
+    sem_post(&s->sem);
+#endif
+}

--- a/nativelib/src/main/resources/gc/commix/semaphore/Semaphore.h
+++ b/nativelib/src/main/resources/gc/commix/semaphore/Semaphore.h
@@ -1,3 +1,6 @@
+#ifndef IMMIX_SEMAPHORE_H
+#define IMMIX_SEMAPHORE_H
+
 #ifdef __APPLE__
 #include <dispatch/dispatch.h>
 #else
@@ -44,3 +47,5 @@ static inline void Semaphore_Post(Semaphore *s) {
     sem_post(&s->sem);
 #endif
 }
+
+#endif // IMMIX_SEMAPHORE_H

--- a/nativelib/src/main/resources/gc/immix/Heap.c
+++ b/nativelib/src/main/resources/gc/immix/Heap.c
@@ -246,7 +246,7 @@ word_t *Heap_Alloc(Heap *heap, uint32_t objectSize) {
     }
 }
 
-void Heap_Collect(Heap *heap, Stack *stack) {
+void Heap_Collect(ThreadManager *threadManager, Heap *heap, Stack *stack) {
     uint64_t start_ns, sweep_start_ns, end_ns;
     Stats *stats = heap->stats;
 #ifdef DEBUG_PRINT
@@ -256,7 +256,7 @@ void Heap_Collect(Heap *heap, Stack *stack) {
     if (stats != NULL) {
         start_ns = scalanative_nano_time();
     }
-    Marker_MarkRoots(heap, stack);
+    Marker_MarkRoots(threadManager, heap, stack);
     if (stats != NULL) {
         sweep_start_ns = scalanative_nano_time();
     }

--- a/nativelib/src/main/resources/gc/immix/Heap.h
+++ b/nativelib/src/main/resources/gc/immix/Heap.h
@@ -46,7 +46,7 @@ word_t *Heap_Alloc(Heap *heap, uint32_t objectSize);
 word_t *Heap_AllocSmall(Heap *heap, uint32_t objectSize);
 word_t *Heap_AllocLarge(Heap *heap, uint32_t objectSize);
 
-void Heap_Collect(Heap *heap, Stack *stack);
+void Heap_Collect(ThreadManager *threadManager, Heap *heap, Stack *stack);
 
 void Heap_Recycle(Heap *heap);
 void Heap_Grow(Heap *heap, uint32_t increment);

--- a/nativelib/src/main/resources/gc/immix/ImmixGC.c
+++ b/nativelib/src/main/resources/gc/immix/ImmixGC.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <memory.h>
+#include <pthread.h>
 #include "GCTypes.h"
 #include "Heap.h"
 #include "datastructures/Stack.h"
@@ -11,6 +12,9 @@
 #include "utils/MathUtils.h"
 #include "Constants.h"
 #include "Settings.h"
+#include "ThreadManager.h"
+
+extern word_t **__stack_bottom;
 
 void scalanative_collect();
 
@@ -21,30 +25,38 @@ void scalanative_afterexit() {
 NOINLINE void scalanative_init() {
     Heap_Init(&heap, Settings_MinHeapSize(), Settings_MaxHeapSize());
     Stack_Init(&stack, INITIAL_STACK_SIZE);
+    ThreadManager_Init();
+    ThreadManager_RegisterThread(__stack_bottom);
     atexit(scalanative_afterexit);
 }
 
 INLINE void *scalanative_alloc(void *info, size_t size) {
+    pthread_mutex_lock(&mutex);
     size = MathUtils_RoundToNextMultiple(size, ALLOCATION_ALIGNMENT);
 
     void **alloc = (void **)Heap_Alloc(&heap, size);
     *alloc = info;
+    pthread_mutex_unlock(&mutex);
     return (void *)alloc;
 }
 
 INLINE void *scalanative_alloc_small(void *info, size_t size) {
     size = MathUtils_RoundToNextMultiple(size, ALLOCATION_ALIGNMENT);
 
+    pthread_mutex_lock(&mutex);
     void **alloc = (void **)Heap_AllocSmall(&heap, size);
     *alloc = info;
+    pthread_mutex_unlock(&mutex);
     return (void *)alloc;
 }
 
 INLINE void *scalanative_alloc_large(void *info, size_t size) {
+    pthread_mutex_lock(&mutex);
     size = MathUtils_RoundToNextMultiple(size, ALLOCATION_ALIGNMENT);
 
     void **alloc = (void **)Heap_AllocLarge(&heap, size);
     *alloc = info;
+    pthread_mutex_unlock(&mutex);
     return (void *)alloc;
 }
 
@@ -52,4 +64,15 @@ INLINE void *scalanative_alloc_atomic(void *info, size_t size) {
     return scalanative_alloc(info, size);
 }
 
-INLINE void scalanative_collect() { Heap_Collect(&heap, &stack); }
+INLINE void scalanative_collect() {
+    pthread_mutex_lock(&mutex);
+    Heap_Collect(&heap, &stack);
+    pthread_mutex_unlock(&mutex);
+}
+
+INLINE void scalanative_register_thread() {
+    pthread_mutex_lock(&mutex);
+    word_t *dummy;
+    ThreadManager_RegisterThread(&dummy);
+    pthread_mutex_unlock(&mutex);
+}

--- a/nativelib/src/main/resources/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/gc/immix/Marker.c
@@ -76,12 +76,12 @@ void Marker_Mark(Heap *heap, Stack *stack) {
     }
 }
 
-void Marker_markProgramStack(Heap *heap, Stack *stack) {
+void Marker_markProgramStack(ThreadManager *threadManager, Heap *heap, Stack *stack) {
     // Dumps registers into 'regs' which is on stack
     jmp_buf regs;
     setjmp(regs);
     word_t *dummy;
-    for (ThreadList *tl = threadList; tl != NULL; tl = tl->next) {
+    for (ThreadList *tl = threadManager->threadList; tl != NULL; tl = tl->next) {
         word_t **stackBottom = tl->stackBottom;
         word_t **current =
             pthread_equal(pthread_self(), tl->thread) ? &dummy : tl->stackTop;
@@ -112,14 +112,14 @@ void Marker_markModules(Heap *heap, Stack *stack) {
     }
 }
 
-void Marker_MarkRoots(Heap *heap, Stack *stack) {
-    ThreadManager_SuspendAllThreads();
+void Marker_MarkRoots(ThreadManager *threadManager, Heap *heap, Stack *stack) {
+    ThreadManager_SuspendAllThreads(threadManager);
 
-    Marker_markProgramStack(heap, stack);
+    Marker_markProgramStack(threadManager, heap, stack);
 
     Marker_markModules(heap, stack);
 
     Marker_Mark(heap, stack);
 
-    ThreadManager_ResumeAllThreads();
+    ThreadManager_ResumeAllThreads(threadManager);
 }

--- a/nativelib/src/main/resources/gc/immix/Marker.c
+++ b/nativelib/src/main/resources/gc/immix/Marker.c
@@ -7,10 +7,10 @@
 #include "datastructures/Stack.h"
 #include "headers/ObjectHeader.h"
 #include "Block.h"
+#include "ThreadManager.h"
 
 extern word_t *__modules;
 extern int __modules_size;
-extern word_t **__stack_bottom;
 
 #define LAST_FIELD_OFFSET -1
 
@@ -81,17 +81,18 @@ void Marker_markProgramStack(Heap *heap, Stack *stack) {
     jmp_buf regs;
     setjmp(regs);
     word_t *dummy;
+    for (ThreadList *tl = threadList; tl != NULL; tl = tl->next) {
+        word_t **stackBottom = tl->stackBottom;
+        word_t **current =
+            pthread_equal(pthread_self(), tl->thread) ? &dummy : tl->stackTop;
 
-    word_t **current = &dummy;
-    word_t **stackBottom = __stack_bottom;
-
-    while (current <= stackBottom) {
-
-        word_t *stackObject = *current;
-        if (Heap_IsWordInHeap(heap, stackObject)) {
-            Marker_markConservative(heap, stack, stackObject);
+        while (current <= stackBottom) {
+            word_t *stackObject = *current;
+            if (Heap_IsWordInHeap(heap, stackObject)) {
+                Marker_markConservative(heap, stack, stackObject);
+            }
+            current += 1;
         }
-        current += 1;
     }
 }
 
@@ -112,10 +113,13 @@ void Marker_markModules(Heap *heap, Stack *stack) {
 }
 
 void Marker_MarkRoots(Heap *heap, Stack *stack) {
+    ThreadManager_SuspendAllThreads();
 
     Marker_markProgramStack(heap, stack);
 
     Marker_markModules(heap, stack);
 
     Marker_Mark(heap, stack);
+
+    ThreadManager_ResumeAllThreads();
 }

--- a/nativelib/src/main/resources/gc/immix/Marker.h
+++ b/nativelib/src/main/resources/gc/immix/Marker.h
@@ -4,7 +4,7 @@
 #include "Heap.h"
 #include "datastructures/Stack.h"
 
-void Marker_MarkRoots(Heap *heap, Stack *stack);
+void Marker_MarkRoots(ThreadManager *threadManager, Heap *heap, Stack *stack);
 void Marker_Mark(Heap *heap, Stack *stack);
 
 #endif // IMMIX_MARKER_H

--- a/nativelib/src/main/resources/gc/immix/State.c
+++ b/nativelib/src/main/resources/gc/immix/State.c
@@ -5,3 +5,7 @@ Stack stack;
 Allocator allocator;
 LargeAllocator largeAllocator;
 BlockAllocator blockAllocator;
+ThreadList *threadList;
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+void *suspendingThreadStackTop;
+Semaphore semaphore;

--- a/nativelib/src/main/resources/gc/immix/State.c
+++ b/nativelib/src/main/resources/gc/immix/State.c
@@ -5,7 +5,4 @@ Stack stack;
 Allocator allocator;
 LargeAllocator largeAllocator;
 BlockAllocator blockAllocator;
-ThreadList *threadList;
-pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-void *suspendingThreadStackTop;
-Semaphore semaphore;
+ThreadManager threadManager;

--- a/nativelib/src/main/resources/gc/immix/State.h
+++ b/nativelib/src/main/resources/gc/immix/State.h
@@ -2,11 +2,17 @@
 #define IMMIX_STATE_H
 
 #include "Heap.h"
+#include "datastructures/ThreadList.h"
+#include "semaphore/Semaphore.h"
 
 extern Heap heap;
 extern Stack stack;
 extern Allocator allocator;
 extern LargeAllocator largeAllocator;
 extern BlockAllocator blockAllocator;
+extern ThreadList *threadList;
+extern pthread_mutex_t mutex;
+extern void *suspendingThreadStackTop;
+extern Semaphore semaphore;
 
 #endif // IMMIX_STATE_H

--- a/nativelib/src/main/resources/gc/immix/State.h
+++ b/nativelib/src/main/resources/gc/immix/State.h
@@ -2,17 +2,13 @@
 #define IMMIX_STATE_H
 
 #include "Heap.h"
-#include "datastructures/ThreadList.h"
-#include "semaphore/Semaphore.h"
+#include "ThreadManager.h"
 
 extern Heap heap;
 extern Stack stack;
 extern Allocator allocator;
 extern LargeAllocator largeAllocator;
 extern BlockAllocator blockAllocator;
-extern ThreadList *threadList;
-extern pthread_mutex_t mutex;
-extern void *suspendingThreadStackTop;
-extern Semaphore semaphore;
+extern ThreadManager threadManager;
 
 #endif // IMMIX_STATE_H

--- a/nativelib/src/main/resources/gc/immix/ThreadManager.c
+++ b/nativelib/src/main/resources/gc/immix/ThreadManager.c
@@ -1,0 +1,86 @@
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+
+#include "ThreadManager.h"
+#include "State.h"
+
+#define SIG_SUSPEND SIGXFSZ
+#define SIG_RESUME SIGXCPU
+
+void ThreadManager_suspendHandler(int sig) {
+    sigset_t sigset;
+
+    jmp_buf regs;
+    setjmp(regs);
+    word_t *dummy;
+
+    suspendingThreadStackTop = &dummy;
+
+    sigfillset(&sigset);
+    sigdelset(&sigset, SIG_RESUME);
+    Semaphore_Post(&semaphore);
+    sigsuspend(&sigset);
+}
+
+void ThreadManager_resumeHandler(int sig) {}
+
+void ThreadManager_Init() {
+    Semaphore_Init(&semaphore, 0);
+    threadList = NULL;
+
+    struct sigaction suspend_action;
+    sigemptyset(&suspend_action.sa_mask);
+    sigaddset(&suspend_action.sa_mask, SIG_RESUME);
+    suspend_action.sa_flags = 0;
+    suspend_action.sa_handler = ThreadManager_suspendHandler;
+    sigaction(SIG_SUSPEND, &suspend_action, NULL);
+
+    struct sigaction resume_action;
+    sigemptyset(&resume_action.sa_mask);
+    resume_action.sa_flags = 0;
+    resume_action.sa_handler = ThreadManager_resumeHandler;
+    sigaction(SIG_RESUME, &resume_action, NULL);
+}
+
+void ThreadManager_RegisterThread(void *stackBottom) {
+    threadList = ThreadList_Cons(pthread_self(), stackBottom, threadList);
+}
+
+void ThreadManager_suspendThread(pthread_t thread) {
+    if (pthread_equal(pthread_self(), thread))
+        return;
+    int res = pthread_kill(thread, SIG_SUSPEND);
+    if (res == 0) {
+        Semaphore_Wait(&semaphore);
+        ThreadList_SetStackTopForThread(thread, suspendingThreadStackTop,
+                                        threadList);
+    } else {
+        threadList = ThreadList_Remove(thread, threadList);
+    }
+}
+
+void ThreadManager_resumeThread(pthread_t thread) {
+    if (pthread_equal(pthread_self(), thread))
+        return;
+    int res = pthread_kill(thread, SIG_RESUME);
+    if (res != 0) {
+        threadList = ThreadList_Remove(thread, threadList);
+    }
+}
+
+void ThreadManager_SuspendAllThreads() {
+    ThreadList *current = threadList;
+    while (current != NULL) {
+        ThreadManager_suspendThread(current->thread);
+        current = current->next;
+    }
+}
+
+void ThreadManager_ResumeAllThreads() {
+    ThreadList *current = threadList;
+    while (current != NULL) {
+        ThreadManager_resumeThread(current->thread);
+        current = current->next;
+    }
+}

--- a/nativelib/src/main/resources/gc/immix/ThreadManager.h
+++ b/nativelib/src/main/resources/gc/immix/ThreadManager.h
@@ -1,0 +1,12 @@
+#ifndef IMMIX_THREADMANAGER_H
+#define IMMIX_THREADMANAGER_H
+
+void ThreadManager_Init();
+
+void ThreadManager_RegisterThread(void *stackBottom);
+
+void ThreadManager_SuspendAllThreads();
+
+void ThreadManager_ResumeAllThreads();
+
+#endif // IMMIX_THREADMANAGER_H

--- a/nativelib/src/main/resources/gc/immix/ThreadManager.h
+++ b/nativelib/src/main/resources/gc/immix/ThreadManager.h
@@ -1,12 +1,20 @@
 #ifndef IMMIX_THREADMANAGER_H
 #define IMMIX_THREADMANAGER_H
 
-void ThreadManager_Init();
+#include <pthread.h>
+#include "datastructures/ThreadList.h"
 
-void ThreadManager_RegisterThread(void *stackBottom);
+typedef struct {
+    ThreadList *threadList;
+    pthread_mutex_t mutex;
+} ThreadManager;
 
-void ThreadManager_SuspendAllThreads();
+void ThreadManager_Init(ThreadManager *threadManager);
 
-void ThreadManager_ResumeAllThreads();
+void ThreadManager_RegisterThread(ThreadManager *threadManager, void *stackBottom);
+
+void ThreadManager_SuspendAllThreads(ThreadManager *threadManager);
+
+void ThreadManager_ResumeAllThreads(ThreadManager *threadManager);
 
 #endif // IMMIX_THREADMANAGER_H

--- a/nativelib/src/main/resources/gc/immix/datastructures/ThreadList.c
+++ b/nativelib/src/main/resources/gc/immix/datastructures/ThreadList.c
@@ -1,0 +1,57 @@
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include "ThreadList.h"
+
+ThreadList *ThreadList_Cons(pthread_t thread, void *stackBottom, ThreadList *threadList) {
+    ThreadList *current = threadList;
+    while (current != NULL) {
+        if (pthread_equal(current->thread, thread)) {
+            return threadList;
+        }
+        current = current->next;
+    }
+    ThreadList *res = malloc(sizeof(ThreadList));
+    res->thread = thread;
+    res->stackBottom = stackBottom;
+    res->next = threadList;
+    return res;
+}
+
+ThreadList *ThreadList_Remove(pthread_t thread, ThreadList *threadList) {
+    if (threadList == NULL)
+        return NULL;
+    if (pthread_equal(threadList->thread, thread)) {
+        ThreadList *res = threadList->next;
+        free(threadList);
+        return res;
+    }
+    ThreadList *current = threadList;
+    while (current->next != NULL &&
+           !pthread_equal(current->next->thread, thread))
+        current = current->next;
+    if (current != NULL) {
+        ThreadList *toRemove = current->next;
+        current->next = current->next->next;
+        free(toRemove);
+    }
+    return threadList;
+}
+
+void ThreadList_Free(ThreadList *threadList) {
+    ThreadList *current = threadList;
+    while (current != NULL) {
+        ThreadList *toFree = current;
+        current = current->next;
+        free(toFree);
+    }
+}
+
+void ThreadList_SetStackTopForThread(pthread_t thread, void *stackTop, ThreadList *threadList) {
+    for (ThreadList *list = threadList; list != NULL; list = list->next) {
+        if (pthread_equal(list->thread, thread)) {
+            list->stackTop = stackTop;
+            break;
+        }
+    }
+}

--- a/nativelib/src/main/resources/gc/immix/datastructures/ThreadList.h
+++ b/nativelib/src/main/resources/gc/immix/datastructures/ThreadList.h
@@ -1,0 +1,41 @@
+#ifndef IMMIX_THREADLIST_H
+#define IMMIX_THREADLIST_H
+
+#include <pthread.h>
+
+/**
+ * Mutable LinkedList of pthreads.
+ */
+typedef struct ThreadList {
+    pthread_t thread;
+    void *stackBottom;
+    void *stackTop;
+    struct ThreadList *next;
+} ThreadList;
+
+/**
+ * Adds @thread with @stackBottom as head of @threadList if it is not already present.
+ * Returns the list with prepended element.
+ */
+ThreadList *ThreadList_Cons(pthread_t thread, void *stackBottom, ThreadList *threadList);
+
+/**
+ * Removes @thread from @threadList.
+ * Returns the list with the element removed.
+ * It is needed to update the list pointer with the returned pointer
+ * since the head can be removed.
+ */
+ThreadList *ThreadList_Remove(pthread_t thread, ThreadList *threadList);
+
+/**
+ * Frees @threadList.
+ * The contained threads are not freed.
+ */
+void ThreadList_Free(ThreadList *threadList);
+
+/**
+ * Sets @stackTop pointer for @thread in @threadList.
+ */
+void ThreadList_SetStackTopForThread(pthread_t thread, void *stackTop, ThreadList *threadList);
+
+#endif // IMMIX_THREADLIST_H

--- a/nativelib/src/main/resources/gc/immix/semaphore/Semaphore.h
+++ b/nativelib/src/main/resources/gc/immix/semaphore/Semaphore.h
@@ -1,0 +1,46 @@
+#ifdef __APPLE__
+#include <dispatch/dispatch.h>
+#else
+#include <errno.h>
+#include <semaphore.h>
+#endif
+
+typedef struct {
+#ifdef __APPLE__
+    dispatch_semaphore_t sem;
+#else
+    sem_t sem;
+#endif
+} Semaphore;
+
+static inline void Semaphore_Init(Semaphore *s, int value) {
+#ifdef __APPLE__
+    dispatch_semaphore_t *sem = &s->sem;
+
+    *sem = dispatch_semaphore_create(value);
+#else
+    sem_init(&s->sem, 0, value);
+#endif
+}
+
+static inline void Semaphore_Wait(Semaphore *s) {
+
+#ifdef __APPLE__
+    dispatch_semaphore_wait(s->sem, DISPATCH_TIME_FOREVER);
+#else
+    int r;
+
+    do {
+        r = sem_wait(&s->sem);
+    } while (r == -1 && errno == EINTR);
+#endif
+}
+
+static inline void Semaphore_Post(Semaphore *s) {
+
+#ifdef __APPLE__
+    dispatch_semaphore_signal(s->sem);
+#else
+    sem_post(&s->sem);
+#endif
+}

--- a/nativelib/src/main/resources/gc/immix/semaphore/Semaphore.h
+++ b/nativelib/src/main/resources/gc/immix/semaphore/Semaphore.h
@@ -1,3 +1,6 @@
+#ifndef IMMIX_SEMAPHORE_H
+#define IMMIX_SEMAPHORE_H
+
 #ifdef __APPLE__
 #include <dispatch/dispatch.h>
 #else
@@ -44,3 +47,5 @@ static inline void Semaphore_Post(Semaphore *s) {
     sem_post(&s->sem);
 #endif
 }
+
+#endif // IMMIX_SEMAPHORE_H


### PR DESCRIPTION
This PR adds support for allocating memory from multiple threads to the Immix and Commix garbage collectors.
It implements stop-the-world collection, stopping all registered threads using async signal passing.
Every garbage collected thread should register itself to the GC by calling the `scalanative_register_thread` function. It adds the thread to a linked list of threads (that contains the main thread too, registered at startup).
Every allocation/collection is performed in a critical section.
Collection can happen from any thread.
It begins stopping all registered threads: sending a signal using `pthread_kill` and waiting on a semaphore while the signalled thread sets its stack top pointer (an approximation taken from the signal handler) and stops itself.
Then the collection marks the stacks of all the registered threads.
Then it resumes all the threads by sending a resume signal.

### Edits:
- The actual step that requires stopping the world is the marking phase, since sweeping happens through no more reachable memory. So the GC resumes all the threads after the marking phase.
- The Commix garbage collector implements parallel marking and concurrent sweeping. The marking phase stops the world as Immix. The sweeping phase happens concurrently with all the application threads. So the concurrent behaviour of the collector is unchanged.