### PR TITLE
Fix #1279: Enable reflective instantiation via static initializers

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
+++ b/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
@@ -6,6 +6,7 @@ final class LoadableModuleClass private[reflect] (
     val runtimeClass: Class[_],
     loadModuleFun: Function0[Any]
 ) {
+
   /** Loads the module instance and returns it. */
   def loadModule(): Any = loadModuleFun()
 }
@@ -14,6 +15,7 @@ final class InstantiatableClass private[reflect] (
     val runtimeClass: Class[_],
     val declaredConstructors: List[InvokableConstructor]
 ) {
+
   /** Instantiates a new instance of this class using the zero-argument
    *  constructor.
    *
@@ -24,7 +26,7 @@ final class InstantiatableClass private[reflect] (
   def newInstance(): Any = {
     getConstructor().fold[Any] {
       throw new InstantiationException(runtimeClass.getName).initCause(
-          new NoSuchMethodException(runtimeClass.getName + ".<init>()"))
+        new NoSuchMethodException(runtimeClass.getName + ".<init>()"))
     } { ctor =>
       ctor.newInstance()
     }
@@ -39,9 +41,9 @@ final class InstantiatableClass private[reflect] (
     declaredConstructors.find(_.parameterTypes.sameElements(parameterTypes))
 }
 
-final class InvokableConstructor private[reflect]  (
+final class InvokableConstructor private[reflect] (
     val parameterTypes: List[Class[_]],
-    newInstanceFun: Any  // TODO: replace Any with Function
+    newInstanceFun: Any // TODO: replace Any with Function
 ) {
   def newInstance(args: Any*): Any = {
     /* Check the number of actual arguments. We let the casts and unbox
@@ -63,7 +65,8 @@ object Reflect {
 
   // `protected[reflect]` makes it public in the IR
   protected[reflect] def registerLoadableModuleClass[T](
-      fqcn: String, runtimeClass: Class[T],
+      fqcn: String,
+      runtimeClass: Class[T],
       loadModuleFun: Function0[T]): Unit = {
     println("+++ registerLoadableModuleClass called")
     loadableModuleClasses(fqcn) =
@@ -71,8 +74,10 @@ object Reflect {
   }
 
   protected[reflect] def registerInstantiatableClass[T](
-      fqcn: String, runtimeClass: Class[T],
-      constructors: Seq[(Seq[Class[_]], Any)]): Unit = {  // TODO: replace Any with Function
+      fqcn: String,
+      runtimeClass: Class[T],
+      constructors: Seq[(Seq[Class[_]], Any)]) // TODO: replace Any with Function
+    : Unit = {
     val invokableConstructors = constructors.map { c =>
       new InvokableConstructor(c._1.toList, c._2)
     }

--- a/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
+++ b/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
@@ -43,7 +43,7 @@ final class InstantiatableClass private[reflect] (
 
 final class InvokableConstructor private[reflect] (
     val parameterTypes: List[Class[_]],
-    newInstanceFun: Function0[Any]
+    newInstanceFun: Function1[Any, Any]
 ) {
   def newInstance(args: Any*): Any = {
     /* Check the number of actual arguments. We let the casts and unbox
@@ -75,7 +75,7 @@ object Reflect {
   protected[reflect] def registerInstantiatableClass[T](
       fqcn: String,
       runtimeClass: Class[T],
-      constructors: Seq[(Seq[Class[_]], Function1[Any])]): Unit = {
+      constructors: Seq[(Seq[Class[_]], Function1[Any, Any])]): Unit = {
     val invokableConstructors = constructors.map { c =>
       new InvokableConstructor(c._1.toList, c._2)
     }

--- a/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
+++ b/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
@@ -50,7 +50,7 @@ final class InvokableConstructor private[reflect] (
      * operations inside `newInstanceFun` take care of the rest.
      */
     require(args.size == parameterTypes.size)
-    ???  // TODO: Implement
+    ??? // TODO: Implement
     // newInstanceFun.asInstanceOf[js.Dynamic].apply(
     //     args.asInstanceOf[Seq[js.Any]]: _*)
   }
@@ -75,8 +75,7 @@ object Reflect {
   protected[reflect] def registerInstantiatableClass[T](
       fqcn: String,
       runtimeClass: Class[T],
-      constructors: Seq[(Seq[Class[_]], Function0[Any])])
-    : Unit = {
+      constructors: Seq[(Seq[Class[_]], Function1[Any])]): Unit = {
     val invokableConstructors = constructors.map { c =>
       new InvokableConstructor(c._1.toList, c._2)
     }

--- a/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
+++ b/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
@@ -1,0 +1,120 @@
+package scala.scalanative.reflect
+
+import scala.collection.mutable
+
+final class LoadableModuleClass private[reflect] (
+    val runtimeClass: Class[_],
+    loadModuleFun: Function0[Any]
+) {
+  /** Loads the module instance and returns it. */
+  def loadModule(): Any = loadModuleFun()
+}
+
+final class InstantiatableClass private[reflect] (
+    val runtimeClass: Class[_],
+    val declaredConstructors: List[InvokableConstructor]
+) {
+  /** Instantiates a new instance of this class using the zero-argument
+   *  constructor.
+   *
+   *  @throws java.lang.InstantiationException (caused by a
+   *    `NoSuchMethodException`)
+   *    If this class does not have a public zero-argument constructor.
+   */
+  def newInstance(): Any = {
+    getConstructor().fold[Any] {
+      throw new InstantiationException(runtimeClass.getName).initCause(
+          new NoSuchMethodException(runtimeClass.getName + ".<init>()"))
+    } { ctor =>
+      ctor.newInstance()
+    }
+  }
+
+  /** Looks up a public constructor identified by the types of its formal
+   *  parameters.
+   *
+   *  If no such public constructor exists, returns `None`.
+   */
+  def getConstructor(parameterTypes: Class[_]*): Option[InvokableConstructor] =
+    declaredConstructors.find(_.parameterTypes.sameElements(parameterTypes))
+}
+
+final class InvokableConstructor private[reflect]  (
+    val parameterTypes: List[Class[_]],
+    newInstanceFun: Any  // TODO: replace Any with Function
+) {
+  def newInstance(args: Any*): Any = {
+    /* Check the number of actual arguments. We let the casts and unbox
+     * operations inside `newInstanceFun` take care of the rest.
+     */
+    require(args.size == parameterTypes.size)
+    ???
+    // newInstanceFun.asInstanceOf[js.Dynamic].apply(
+    //     args.asInstanceOf[Seq[js.Any]]: _*)
+  }
+}
+
+object Reflect {
+  private val loadableModuleClasses =
+    mutable.Map.empty[String, LoadableModuleClass]
+
+  private val instantiatableClasses =
+    mutable.Map.empty[String, InstantiatableClass]
+
+  // `protected[reflect]` makes it public in the IR
+  protected[reflect] def registerLoadableModuleClass[T](
+      fqcn: String, runtimeClass: Class[T],
+      loadModuleFun: Function0[T]): Unit = {
+    println("+++ registerLoadableModuleClass called")
+    loadableModuleClasses(fqcn) =
+      new LoadableModuleClass(runtimeClass, loadModuleFun)
+  }
+
+  protected[reflect] def registerInstantiatableClass[T](
+      fqcn: String, runtimeClass: Class[T],
+      constructors: Seq[(Seq[Class[_]], Any)]): Unit = {  // TODO: replace Any with Function
+    val invokableConstructors = constructors.map { c =>
+      new InvokableConstructor(c._1.toList, c._2)
+    }
+    instantiatableClasses(fqcn) =
+      new InstantiatableClass(runtimeClass, invokableConstructors.toList)
+  }
+
+  /** Reflectively looks up a loadable module class.
+   *
+   *  A module class is the technical term referring to the class of a Scala
+   *  `object`. The object or one of its super types (classes or traits) must
+   *  be annotated with
+   *  [[scala.scalajs.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the object must be "static", i.e., declared at the top-level of
+   *  a package or inside a static object.
+   *
+   *  If the module class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was not static, this method
+   *  returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the module class, including its trailing `$`
+   */
+  def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] =
+    loadableModuleClasses.get(fqcn)
+
+  /** Reflectively looks up an instantiable class.
+   *
+   *  The class or one of its super types (classes or traits) must be annotated
+   *  with
+   *  [[scala.scalajs.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the class must not be abstract, nor be a local class (i.e., a
+   *  class defined inside a `def`). Inner classes (defined inside another
+   *  class) are supported.
+   *
+   *  If the class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was abstract or local, this
+   *  method returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the class
+   */
+  def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] =
+    instantiatableClasses.get(fqcn)
+}

--- a/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
+++ b/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
@@ -53,7 +53,62 @@ final class InvokableConstructor private[reflect] (
       args.size == parameterTypes.size,
       "Reflect: wrong number of arguments for InvokableConstructor"
     )
-    newInstanceFun.apply(args.toArray)
+    val adaptedArgs = (args zip parameterTypes).map {
+      case (arg, tpe) => wideningPrimConversionIfRequired(arg, tpe)
+    }
+    newInstanceFun.apply(adaptedArgs.toArray)
+  }
+
+  /** Perform a widening primitive conversion if required.
+   *
+   *  According to
+   *  https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.2
+   */
+  private def wideningPrimConversionIfRequired(arg: Any,
+                                               paramType: Class[_]): Any = {
+    paramType match {
+      case java.lang.Short.TYPE =>
+        arg match {
+          case arg: Byte => arg.toShort
+          case _         => arg
+        }
+      case java.lang.Integer.TYPE =>
+        arg match {
+          case arg: Byte  => arg.toInt
+          case arg: Short => arg.toInt
+          case arg: Char  => arg.toInt
+          case _          => arg
+        }
+      case java.lang.Long.TYPE =>
+        arg match {
+          case arg: Byte  => arg.toLong
+          case arg: Short => arg.toLong
+          case arg: Int   => arg.toLong
+          case arg: Char  => arg.toLong
+          case _          => arg
+        }
+      case java.lang.Float.TYPE =>
+        arg match {
+          case arg: Byte  => arg.toFloat
+          case arg: Short => arg.toFloat
+          case arg: Int   => arg.toFloat
+          case arg: Long  => arg.toFloat
+          case arg: Char  => arg.toFloat
+          case _          => arg
+        }
+      case java.lang.Double.TYPE =>
+        arg match {
+          case arg: Byte  => arg.toDouble
+          case arg: Short => arg.toDouble
+          case arg: Int   => arg.toDouble
+          case arg: Long  => arg.toDouble
+          case arg: Float => arg.toDouble
+          case arg: Char  => arg.toDouble
+          case _          => arg
+        }
+      case _ =>
+        arg
+    }
   }
 
   override def toString: String = {

--- a/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
+++ b/nativelib/src/main/scala/scala/scalanative/reflect/Reflect.scala
@@ -43,14 +43,14 @@ final class InstantiatableClass private[reflect] (
 
 final class InvokableConstructor private[reflect] (
     val parameterTypes: List[Class[_]],
-    newInstanceFun: Any // TODO: replace Any with Function
+    newInstanceFun: Function0[Any]
 ) {
   def newInstance(args: Any*): Any = {
     /* Check the number of actual arguments. We let the casts and unbox
      * operations inside `newInstanceFun` take care of the rest.
      */
     require(args.size == parameterTypes.size)
-    ???
+    ???  // TODO: Implement
     // newInstanceFun.asInstanceOf[js.Dynamic].apply(
     //     args.asInstanceOf[Seq[js.Any]]: _*)
   }
@@ -68,7 +68,6 @@ object Reflect {
       fqcn: String,
       runtimeClass: Class[T],
       loadModuleFun: Function0[T]): Unit = {
-    println("+++ registerLoadableModuleClass called")
     loadableModuleClasses(fqcn) =
       new LoadableModuleClass(runtimeClass, loadModuleFun)
   }
@@ -76,7 +75,7 @@ object Reflect {
   protected[reflect] def registerInstantiatableClass[T](
       fqcn: String,
       runtimeClass: Class[T],
-      constructors: Seq[(Seq[Class[_]], Any)]) // TODO: replace Any with Function
+      constructors: Seq[(Seq[Class[_]], Function0[Any])])
     : Unit = {
     val invokableConstructors = constructors.map { c =>
       new InvokableConstructor(c._1.toList, c._2)

--- a/nativelib/src/main/scala/scala/scalanative/reflect/annotation/EnableReflectiveInstantiation.scala
+++ b/nativelib/src/main/scala/scala/scalanative/reflect/annotation/EnableReflectiveInstantiation.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package reflect.annotation
 
- /** Enables reflective instantiation for the annotated class, trait or object,
+/** Enables reflective instantiation for the annotated class, trait or object,
  *  and all its descendants.
  *
  *  Affected classes can be identified at run-time through methods of

--- a/nativelib/src/main/scala/scala/scalanative/reflect/annotation/EnableReflectiveInstantiation.scala
+++ b/nativelib/src/main/scala/scala/scalanative/reflect/annotation/EnableReflectiveInstantiation.scala
@@ -1,0 +1,10 @@
+package scala.scalanative
+package reflect.annotation
+
+ /** Enables reflective instantiation for the annotated class, trait or object,
+ *  and all its descendants.
+ *
+ *  Affected classes can be identified at run-time through methods of
+ *  [[scala.scalanative.reflect.Reflect]].
+ */
+class EnableReflectiveInstantiation extends scala.annotation.StaticAnnotation

--- a/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
@@ -51,6 +51,9 @@ object Mangle {
         str("R")
         types.foreach(mangleType)
         str("E")
+      case Sig.Clinit() =>
+        str("A")
+        str("E")
       case Sig.Method(id, types) =>
         str("D")
         mangleIdent(id)

--- a/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
@@ -52,7 +52,7 @@ object Mangle {
         types.foreach(mangleType)
         str("E")
       case Sig.Clinit() =>
-        str("A")
+        str("I")
         str("E")
       case Sig.Method(id, types) =>
         str("D")

--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -27,7 +27,7 @@ final class Sig(val mangle: String) {
 
   final def isField: Boolean     = mangle(0) == 'F'
   final def isCtor: Boolean      = mangle(0) == 'R'
-  final def isClinit: Boolean    = mangle(0) == 'A'
+  final def isClinit: Boolean    = mangle(0) == 'I'
   final def isImplCtor: Boolean  = mangle.startsWith("M6$init$")
   final def isMethod: Boolean    = mangle(0) == 'D'
   final def isProxy: Boolean     = mangle(0) == 'P'

--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -27,6 +27,7 @@ final class Sig(val mangle: String) {
 
   final def isField: Boolean     = mangle(0) == 'F'
   final def isCtor: Boolean      = mangle(0) == 'R'
+  final def isClinit: Boolean    = mangle(0) == 'A'
   final def isImplCtor: Boolean  = mangle.startsWith("M6$init$")
   final def isMethod: Boolean    = mangle(0) == 'D'
   final def isProxy: Boolean     = mangle(0) == 'P'
@@ -40,6 +41,7 @@ object Sig {
   }
   final case class Field(id: String)                    extends Unmangled
   final case class Ctor(types: Seq[Type])               extends Unmangled
+  final case class Clinit()                             extends Unmangled
   final case class Method(id: String, types: Seq[Type]) extends Unmangled
   final case class Proxy(id: String, types: Seq[Type])  extends Unmangled
   final case class Extern(id: String)                   extends Unmangled

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -153,4 +153,28 @@ object Type {
     isArray(clsTy.name)
   def isArray(clsName: Global): Boolean =
     arrayToType.contains(clsName)
+
+  def typeToName(tpe: Type): Global = tpe match {
+    case Rt.BoxedUnit       => Global.Top("scala.scalanative.runtime.PrimitiveUnit")
+    case Bool               => Global.Top("scala.scalanative.runtime.PrimitiveBoolean")
+    case Char               => Global.Top("scala.scalanative.runtime.PrimitiveChar")
+    case Byte               => Global.Top("scala.scalanative.runtime.PrimitiveByte")
+    case Short              => Global.Top("scala.scalanative.runtime.PrimitiveShort")
+    case Int                => Global.Top("scala.scalanative.runtime.PrimitiveInt")
+    case Long               => Global.Top("scala.scalanative.runtime.PrimitiveLong")
+    case Float              => Global.Top("scala.scalanative.runtime.PrimitiveFloat")
+    case Double             => Global.Top("scala.scalanative.runtime.PrimitiveDouble")
+    case Ref(name, _, _)    => name
+    case Array(tpe, _)      => toArrayClass(tpe)
+    case ArrayValue(tpe, _) => toArrayClass(tpe)
+    case Function(args, _)  => Global.Top(s"scala.Function${args.length}")
+  }
+
+  def primConvSig(tpe: Type): Sig.Method = tpe match {
+    case Short  => Sig.Method("shortValue", Seq(tpe))
+    case Int    => Sig.Method("intValue", Seq(tpe))
+    case Long   => Sig.Method("longValue", Seq(tpe))
+    case Float  => Sig.Method("floatValue", Seq(tpe))
+    case Double => Sig.Method("doubleValue", Seq(tpe))
+  }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
@@ -24,7 +24,7 @@ object Unmangle {
         Sig.Field(readIdent())
       case 'R' =>
         Sig.Ctor(readTypes())
-      case 'A' =>
+      case 'I' =>
         Sig.Clinit()
       case 'D' =>
         Sig.Method(readIdent(), readTypes())

--- a/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
@@ -24,6 +24,8 @@ object Unmangle {
         Sig.Field(readIdent())
       case 'R' =>
         Sig.Ctor(readTypes())
+      case 'A' =>
+        Sig.Clinit()
       case 'D' =>
         Sig.Method(readIdent(), readTypes())
       case 'P' =>

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -12,7 +12,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
   private val header: Map[Global, Int] = {
     buffer.position(0)
 
-    val hasClInit = getBool
+    val hasEntryPoint = getBool
 
     val magic    = getInt
     val compat   = getInt

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -12,6 +12,8 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
   private val header: Map[Global, Int] = {
     buffer.position(0)
 
+    val hasClInit = getBool
+
     val magic    = getInt
     val compat   = getInt
     val revision = getInt

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -13,13 +13,13 @@ final class BinarySerializer(buffer: ByteBuffer) {
     val names     = defns.map(_.name)
     val positions = mutable.UnrolledBuffer.empty[Int]
 
-    val hasClInit = defns.exists {
+    val hasEntryPoint = defns.exists {
       case defn: Defn.Define =>
         val Global.Member(_, sig) = defn.name
         sig.isClinit
       case _ => false
     }
-    putBool(hasClInit)
+    putBool(hasEntryPoint)
 
     putInt(Versions.magic)
     putInt(Versions.compat)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -13,6 +13,14 @@ final class BinarySerializer(buffer: ByteBuffer) {
     val names     = defns.map(_.name)
     val positions = mutable.UnrolledBuffer.empty[Int]
 
+    val hasClInit = defns.exists {
+      case defn: Defn.Define =>
+        val Global.Member(_, sig) = defn.name
+        sig.isClinit
+      case _ => false
+    }
+    putBool(hasClInit)
+
     putInt(Versions.magic)
     putInt(Versions.compat)
     putInt(Versions.revision)

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -327,5 +327,11 @@ trait NirDefinitions { self: NirGlobalAddons =>
     lazy val AnyRefClassTag  = getDecl(ClassTagModule, TermName("AnyRef"))
     lazy val NothingClassTag = getDecl(ClassTagModule, TermName("Nothing"))
     lazy val NullClassTag    = getDecl(ClassTagModule, TermName("Null"))
+
+    lazy val ReflectModule =
+      getRequiredModule("scala.scalanative.reflect.Reflect")
+    lazy val EnableReflectiveInstantiationAnnotation =
+      getRequiredClass(
+        "scala.scalanative.reflect.annotation.EnableReflectiveInstantiation")
   }
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -330,6 +330,11 @@ trait NirDefinitions { self: NirGlobalAddons =>
 
     lazy val ReflectModule =
       getRequiredModule("scala.scalanative.reflect.Reflect")
+    lazy val Reflect_registerLoadableModuleClass =
+      getMemberMethod(ReflectModule, newTermName("registerLoadableModuleClass"))
+    lazy val Reflect_registerInstantiatableClass =
+      getMemberMethod(ReflectModule, newTermName("registerInstantiatableClass"))
+
     lazy val EnableReflectiveInstantiationAnnotation =
       getRequiredClass(
         "scala.scalanative.reflect.annotation.EnableReflectiveInstantiation")

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenFile.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenFile.scala
@@ -12,10 +12,13 @@ trait NirGenFile { self: NirGenPhase =>
   import global._
 
   def genPathFor(cunit: CompilationUnit, sym: Symbol): Path = {
+    val nir.Global.Top(id) = genTypeName(sym)
+    genPathFor(cunit, id)
+  }
+
+  def genPathFor(cunit: CompilationUnit, id: String): Path = {
     val baseDir: AbstractFile =
       settings.outputDirs.outputDirFor(cunit.source.file)
-
-    val nir.Global.Top(id) = genTypeName(sym)
 
     val pathParts = id.split("[./]")
     val dir       = (baseDir /: pathParts.init)(_.subdirectoryNamed(_))

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -81,7 +81,8 @@ abstract class NirGenPhase
 
         scoped(
           curStatBuffer := buffer,
-          curReflectiveInstBuffer := new ReflectiveInstantiationBuffer(cd.symbol.fullNameString)
+          curReflectiveInstBuffer := new ReflectiveInstantiationBuffer(
+            cd.symbol.fullNameString)
         ) {
           buffer.genClass(cd)
           files += ((path, buffer.toSeq))

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -38,8 +38,8 @@ abstract class NirGenPhase
   protected val curUnwindHandler  = new util.ScopedVar[Option[nir.Local]]
   protected val curStatBuffer     = new util.ScopedVar[StatBuffer]
 
-  protected val reflectiveInstInfo =
-    new util.ScopedVar[ReflectiveInstantiationInfo]
+  protected val curReflectiveInstBuffer =
+    new util.ScopedVar[ReflectiveInstantiationBuffer]
 
   protected def unwind(implicit fresh: Fresh): Next =
     curUnwindHandler.get.fold[Next](Next.None) { handler =>
@@ -61,8 +61,6 @@ abstract class NirGenPhase
       val classDefs = mutable.UnrolledBuffer.empty[ClassDef]
       val files     = mutable.UnrolledBuffer.empty[(Path, Seq[nir.Defn])]
 
-      val reflectiveInstantiationInfo = new ReflectiveInstantiationInfo
-
       def collectClassDefs(tree: Tree): Unit = tree match {
         case EmptyTree =>
           ()
@@ -83,20 +81,20 @@ abstract class NirGenPhase
 
         scoped(
           curStatBuffer := buffer,
-          reflectiveInstInfo := reflectiveInstantiationInfo
+          curReflectiveInstBuffer := new ReflectiveInstantiationBuffer(cd.symbol.fullNameString)
         ) {
           buffer.genClass(cd)
           files += ((path, buffer.toSeq))
+          // Add the reflective instantiation loaders to the file list
+          if (curReflectiveInstBuffer.get.nonEmpty) {
+            val path = genPathFor(cunit, curReflectiveInstBuffer.get.name.id)
+            files += ((path, curReflectiveInstBuffer.get.toSeq))
+          }
         }
       }
 
       collectClassDefs(cunit.body)
       classDefs.foreach(genClass)
-
-      if (reflectiveInstantiationInfo.nonEmpty) {
-        val path = genPathFor(cunit, reflectiveInstantiationInfo.name.id)
-        files += ((path, reflectiveInstantiationInfo.toSeqCompleted))
-      }
 
       files.par.foreach {
         case (path, stats) =>

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -82,7 +82,8 @@ abstract class NirGenPhase
         scoped(
           curStatBuffer := buffer,
           curReflectiveInstBuffer := new ReflectiveInstantiationBuffer(
-            cd.symbol.fullNameString)
+            cd.symbol.fullNameString + (if (isStaticModule(cd.symbol)) "$"
+                                        else ""))
         ) {
           buffer.genClass(cd)
           files += ((path, buffer.toSeq))

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -88,7 +88,7 @@ abstract class NirGenPhase
       classDefs.foreach(genClass)
 
       // Add the reflective instantiation loaders to the file list
-      ReflectiveInstantiationInfo.foreach { reflInstBuf =>
+      reflectiveInstantiationInfo.foreach { reflInstBuf =>
         val path = genPathFor(cunit, reflInstBuf.name.id)
         files += ((path, reflInstBuf.toSeq))
       }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -38,7 +38,8 @@ abstract class NirGenPhase
   protected val curUnwindHandler  = new util.ScopedVar[Option[nir.Local]]
   protected val curStatBuffer     = new util.ScopedVar[StatBuffer]
 
-  protected val reflectiveInstInfo = new util.ScopedVar[ReflectiveInstantiationInfo]
+  protected val reflectiveInstInfo =
+    new util.ScopedVar[ReflectiveInstantiationInfo]
 
   protected def unwind(implicit fresh: Fresh): Next =
     curUnwindHandler.get.fold[Next](Next.None) { handler =>

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -336,6 +336,14 @@ trait NirGenStat { self: NirGenPhase =>
 
     def genRegisterReflectiveInstantiationForNormalClass(
         cd: ClassDef): Seq[Inst] = {
+      val ctors =
+        if (curClassSym.isAbstractClass) Nil
+        else
+          curClassSym.info
+            .member(nme.CONSTRUCTOR)
+            .alternatives
+            .filter(_.isPublic)
+
       unsupported(cd)
     }
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -261,7 +261,7 @@ trait NirGenStat { self: NirGenPhase =>
           nir.Type.Function(Seq(Type.Ref(predefGlobal), Type.Ref(objectGlobal)),
                             Type.Unit),
           methodVal,
-          Seq(moduleVal, Val.String("Static initializer called")),
+          Seq(moduleVal, Val.String(s"${cd.name}: static initializer called")),
           unwind(curFresh)
         )
         exprBuf.ret(Val.Unit)

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -402,7 +402,7 @@ trait NirGenStat { self: NirGenPhase =>
       def genLazyClassInstantiationMethod(exprBuf: ExprBuffer,
                                           ctors: Seq[global.Symbol]): Val = {
         val applyMethodSig =
-          Sig.Method("apply", Seq(Type.Array(jlObjectType), jlObjectType))
+          Sig.Method("apply", Seq(jlObjectType, jlObjectType))
 
         val tuple2Name = Global.Top("scala.Tuple2")
         val tuple2Type = Type.Ref(tuple2Name)
@@ -452,7 +452,8 @@ trait NirGenStat { self: NirGenPhase =>
               nir.Type.Function(Seq(Type.Ref(reflInstBuffer.name),
                                     Type.Array(jlObjectType)),
                                 jlObjectType),
-              body)
+              body
+            )
           }
 
           // Generate the class instantiator constructor.

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -282,7 +282,7 @@ trait NirGenStat { self: NirGenPhase =>
 
     // Generate the constructor for the class instantiator class,
     // which is expected to extend one of scala.runtime.AbstractFunctionX.
-    def genReflectiveInstantiationConstructor(
+    private def genReflectiveInstantiationConstructor(
         reflInstBuffer: ReflectiveInstantiationBuffer,
         superClass: Global): Unit = {
       withFreshExprBuffer { exprBuf =>
@@ -310,6 +310,21 @@ trait NirGenStat { self: NirGenPhase =>
           body
         )
       }
+    }
+
+    // Allocate and construct an object, using the provided ExprBuffer.
+    private def allocAndConstruct(exprBuf: ExprBuffer,
+                                  name: Global,
+                                  argTypes: Seq[nir.Type],
+                                  args: Seq[Val]): Val = {
+      val alloc = exprBuf.classalloc(name, unwind(curFresh))
+      exprBuf.call(
+        Type.Function(Type.Ref(name) +: argTypes, Type.Unit),
+        Val.Global(name.member(Sig.Ctor(argTypes)), Type.Ptr),
+        alloc +: args,
+        unwind(curFresh)
+      )
+      alloc
     }
 
     def genRegisterReflectiveInstantiationForModuleClass(
@@ -361,14 +376,7 @@ trait NirGenStat { self: NirGenPhase =>
           Seq(Global.Top("scala.Serializable")))
 
         // Allocate and return an instance of the generated class.
-        val alloc = exprBuf.classalloc(reflInstBuffer.name, unwind(curFresh))
-        exprBuf.call(
-          Type.Function(Seq(Type.Ref(reflInstBuffer.name)), Type.Unit),
-          Val.Global(reflInstBuffer.name.member(Sig.Ctor(Seq())), Type.Ptr),
-          Seq(alloc),
-          unwind(curFresh)
-        )
-        alloc
+        allocAndConstruct(exprBuf, reflInstBuffer.name, Seq(), Seq())
       }
 
       withFreshExprBuffer { exprBuf =>
@@ -399,13 +407,21 @@ trait NirGenStat { self: NirGenPhase =>
       val srAbstractFunction1Name =
         Global.Top("scala.runtime.AbstractFunction1")
 
+      val tuple2Name = Global.Top("scala.Tuple2")
+      val tuple2Type = Type.Ref(tuple2Name)
+
+      // Create a new Tuple2 and initialise it with the provided values.
+      def createTuple2(exprBuf: ExprBuffer, _1: Val, _2: Val): Val = {
+        allocAndConstruct(exprBuf,
+                          tuple2Name,
+                          Seq(jlObjectType, jlObjectType),
+                          Seq(_1, _2))
+      }
+
       def genLazyClassInstantiationMethod(exprBuf: ExprBuffer,
                                           ctors: Seq[global.Symbol]): Val = {
         val applyMethodSig =
           Sig.Method("apply", Seq(jlObjectType, jlObjectType))
-
-        val tuple2Name = Global.Top("scala.Tuple2")
-        val tuple2Type = Type.Ref(tuple2Name)
 
         // Constructors info is an array of Tuple2 (tpes, inst), where:
         // - tpes is an array with the runtime classes of the constructor arguments.
@@ -456,14 +472,10 @@ trait NirGenStat { self: NirGenPhase =>
                 })
 
               // Allocate a new instance and call C.
-              val alloc = exprBuf.classalloc(fqSymName, unwind(curFresh))
-              exprBuf.call(
-                Type.Function(ctorSig.args, Type.Unit),
-                Val.Global(fqSymName.member(Sig.Ctor(ctorSig.args.tail)),
-                           Type.Ptr),
-                alloc +: argsVals,
-                unwind(curFresh)
-              )
+              val alloc = allocAndConstruct(exprBuf,
+                                            fqSymName,
+                                            ctorSig.args.tail,
+                                            argsVals)
 
               exprBuf.ret(alloc)
               exprBuf.toSeq
@@ -491,13 +503,7 @@ trait NirGenStat { self: NirGenPhase =>
 
           // Allocate an instance of the generated class.
           val instantiator =
-            exprBuf.classalloc(reflInstBuffer.name, unwind(curFresh))
-          exprBuf.call(
-            Type.Function(Seq(Type.Ref(reflInstBuffer.name)), Type.Unit),
-            Val.Global(reflInstBuffer.name.member(Sig.Ctor(Seq())), Type.Ptr),
-            Seq(instantiator),
-            unwind(curFresh)
-          )
+            allocAndConstruct(exprBuf, reflInstBuffer.name, Seq(), Seq())
 
           // Create the current constructor's info. We need:
           // - an array with the runtime classes of the ctor parameters.
@@ -513,13 +519,11 @@ trait NirGenStat { self: NirGenPhase =>
             // Extract the argument type name.
             val Type.Ref(typename, _, _) = Type.box.getOrElse(arg, arg)
             // Allocate and instantiate a java.lang.Class object for the arg.
-            val co = exprBuf.classalloc(exprBuf.jlClassName, unwind(curFresh))
-            exprBuf.call(
-              Type.Function(Seq(exprBuf.jlClass, Type.Ptr), Type.Unit),
-              Val.Global(exprBuf.jlClassName.member(Sig.Ctor(Seq(Type.Ptr))),
-                         Type.Ptr),
-              Seq(co, Val.Global(typename, Type.Ptr)),
-              unwind(curFresh)
+            val co = allocAndConstruct(
+              exprBuf,
+              exprBuf.jlClassName,
+              Seq(Type.Ptr),
+              Seq(Val.Global(typename, Type.Ptr))
             )
             // Store the runtime class in the array.
             exprBuf.arraystore(exprBuf.jlClass,
@@ -530,16 +534,7 @@ trait NirGenStat { self: NirGenPhase =>
           }
 
           // Allocate a tuple to store the current constructor's info
-          val to = exprBuf.classalloc(tuple2Name, unwind(curFresh))
-          exprBuf.call(
-            Type.Function(Seq(tuple2Type, jlObjectType, jlObjectType),
-                          Type.Unit),
-            Val.Global(
-              tuple2Name.member(Sig.Ctor(Seq(jlObjectType, jlObjectType))),
-              Type.Ptr),
-            Seq(to, rtClasses, instantiator),
-            unwind(curFresh)
-          )
+          val to = createTuple2(exprBuf, rtClasses, instantiator)
 
           exprBuf.arraystore(tuple2Type,
                              ctorsInfo,

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -287,7 +287,8 @@ trait NirGenStat { self: NirGenPhase =>
       val fqSymName      = Global.Top(fqSymId)
 
       val jlObjectName = Global.Top("java.lang.Object")
-      val srAbstractFunction0Name = Global.Top("scala.runtime.AbstractFunction0")
+      val srAbstractFunction0Name =
+        Global.Top("scala.runtime.AbstractFunction0")
 
       def genLazyModuleLoaderMethod(exprBuf: ExprBuffer): Val = {
         val methodSig =
@@ -310,13 +311,14 @@ trait NirGenStat { self: NirGenPhase =>
           reflInstBuffer += Defn.Define(
             Attrs(),
             reflInstBuffer.name.member(methodSig),
-            nir.Type.Function(Seq(Type.Ref(reflInstBuffer.name)), Type.Ref(jlObjectName)),
+            nir.Type.Function(Seq(Type.Ref(reflInstBuffer.name)),
+                              Type.Ref(jlObjectName)),
             body)
         }
 
         // Generate the module loader class constructor.
         // We need a fresh ExprBuffer for this, since it is different scope.
-        withFreshExprBuffer { exprBuf => 
+        withFreshExprBuffer { exprBuf =>
           val body = {
             // first argument is this
             val thisArg = Val.Local(curFresh(), Type.Ref(reflInstBuffer.name))
@@ -325,7 +327,8 @@ trait NirGenStat { self: NirGenPhase =>
             // call to super constructor
             exprBuf.call(
               Type.Function(Seq(Type.Ref(srAbstractFunction0Name)), Type.Unit),
-              Val.Global(srAbstractFunction0Name.member(Sig.Ctor(Seq())), Type.Ptr),
+              Val.Global(srAbstractFunction0Name.member(Sig.Ctor(Seq())),
+                         Type.Ptr),
               Seq(thisArg),
               unwind(curFresh)
             )

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -92,7 +92,6 @@ trait NirGenStat { self: NirGenPhase =>
       val body   = cd.impl.body
 
       buf += Defn.Class(attrs, name, None, Seq.empty)
-      genReflectiveInstantiation(cd)
       genMethods(cd)
     }
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -437,12 +437,20 @@ trait NirGenStat { self: NirGenPhase =>
               val argsArg = Val.Local(curFresh(), Type.Array(jlObjectType))
               exprBuf.label(curFresh(), Seq(thisArg, argsArg))
 
-              for ((arg, argIdx) <- ctorSig.args.tail.zipWithIndex) {
-                // TODO: Extract and cast arguments to proper types
-              }
+              // Extract and cast arguments to proper types
+              val argsVals =
+                (for ((arg, argIdx) <- ctorSig.args.tail.zipWithIndex) yield {
+                  exprBuf.arrayload(Type.box.getOrElse(arg, arg),
+                                    argsArg,
+                                    Val.Int(argIdx),
+                                    unwind(curFresh))
+                })
 
+              val alloc = exprBuf.classalloc(fqSymName, unwind(curFresh))
               // TODO: Instantiate an object based on C.
-              exprBuf.ret(Val.Unit)
+              // TODO: Call constructor.
+
+              exprBuf.ret(alloc)
               exprBuf.toSeq
             }
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -16,6 +16,9 @@ trait NirGenStat { self: NirGenPhase =>
   import nirDefinitions._
   import SimpleType.{fromType, fromSymbol}
 
+  val reflectiveInstantiationInfo =
+    mutable.UnrolledBuffer.empty[ReflectiveInstantiationBuffer]
+
   def isStaticModule(sym: Symbol): Boolean =
     sym.isModuleClass && !sym.isImplClass && !sym.isLifted
 
@@ -335,8 +338,8 @@ trait NirGenStat { self: NirGenPhase =>
       val fqSymId   = curClassSym.fullName + "$"
       val fqSymName = Global.Top(fqSymId)
 
-      ReflectiveInstantiationInfo += new ReflectiveInstantiationBuffer(fqSymId)
-      val reflInstBuffer = ReflectiveInstantiationInfo.last
+      reflectiveInstantiationInfo += ReflectiveInstantiationBuffer(fqSymId)
+      val reflInstBuffer = reflectiveInstantiationInfo.last
 
       def genModuleLoaderAnonFun(exprBuf: ExprBuffer): Val = {
         val applyMethodSig =
@@ -428,9 +431,9 @@ trait NirGenStat { self: NirGenPhase =>
           val ctorSig     = genMethodSig(ctor)
           val ctorArgsSig = ctorSig.args.map(_.mangle).mkString
 
-          ReflectiveInstantiationInfo += new ReflectiveInstantiationBuffer(
+          reflectiveInstantiationInfo += ReflectiveInstantiationBuffer(
             fqSymId + ctorArgsSig)
-          val reflInstBuffer = ReflectiveInstantiationInfo.last
+          val reflInstBuffer = reflectiveInstantiationInfo.last
 
           // Lambda generation consists of generating a class which extends
           // scala.runtime.AbstractFunction1, with an apply method that accepts

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -458,19 +458,8 @@ trait NirGenStat { self: NirGenPhase =>
                   // If the expected argument type can be boxed (i.e. is a primitive
                   // type), then we need to unbox it before passing it to C.
                   Type.box.get(arg) match {
-                    case Some(_) =>
-                      // first, cast the primitive type to java.lang.Number
-                      val num = exprBuf.as(jlNumberRef, elem, unwind(curFresh))
-                      // then, convert to the desired type
-                      val conv = exprBuf.method(num,
-                                                Type.primConvSig(arg),
-                                                unwind(curFresh))
-                      exprBuf.call(Type.Function(Seq(jlNumberRef), arg),
-                                   conv,
-                                   Seq(num),
-                                   unwind(curFresh))
-                    // we need to do the above, because we cannot directly
-                    // cast e.g. from Integer to Short
+                    case Some(bt) =>
+                      exprBuf.unbox(bt, elem, unwind(curFresh))
                     case None =>
                       exprBuf.as(arg, elem, unwind(curFresh))
                   }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -437,7 +437,7 @@ trait NirGenStat { self: NirGenPhase =>
               val argsArg = Val.Local(curFresh(), Type.Array(jlObjectType))
               exprBuf.label(curFresh(), Seq(thisArg, argsArg))
 
-              for (arg <- ctorSig.args) {
+              for ((arg, argIdx) <- ctorSig.args.tail.zipWithIndex) {
                 // TODO: Extract and cast arguments to proper types
               }
 
@@ -483,9 +483,9 @@ trait NirGenStat { self: NirGenPhase =>
             Sig.Method("getClass", Seq(exprBuf.jlClass)),
             unwind(curFresh))
           val rtClasses = exprBuf.arrayalloc(exprBuf.jlClass,
-                                             Val.Int(ctorSig.args.length),
+                                             Val.Int(ctorSig.args.tail.length),
                                              unwind(curFresh))
-          for ((arg, argIdx) <- ctorSig.args.zipWithIndex) {
+          for ((arg, argIdx) <- ctorSig.args.tail.zipWithIndex) {
             // Extract the argument type name.
             val Type.Ref(typename, _, _) = Type.box.getOrElse(arg, arg)
             // Allocate and instantiate a java.lang.Class object for the arg.

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -16,6 +16,9 @@ trait NirGenStat { self: NirGenPhase =>
   import nirDefinitions._
   import SimpleType.{fromType, fromSymbol}
 
+  def isStaticModule(sym: Symbol) =
+    sym.isModuleClass && !sym.isImplClass && !sym.isLifted
+
   class MethodEnv(val fresh: Fresh) {
     private val env = mutable.Map.empty[Symbol, Val]
 
@@ -258,9 +261,6 @@ trait NirGenStat { self: NirGenPhase =>
     def genRegisterReflectiveInstantiation(cd: ClassDef): Unit = {
       val owner = genTypeName(curClassSym)
       val name  = owner.member(nir.Sig.Clinit())
-
-      def isStaticModule(sym: Symbol) =
-        sym.isModuleClass && !sym.isImplClass && !sym.isLifted
 
       val staticInitBody =
         if (isStaticModule(curClassSym))

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenSymbols.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenSymbols.scala
@@ -6,21 +6,20 @@ import scala.scalanative.nir.Type
 object NirGenSymbols {
   val serializable = Global.Top("scala.Serializable")
 
-  val jlClass = Global.Top("java.lang.Class")
+  val jlClass    = Global.Top("java.lang.Class")
   val jlClassRef = Type.Ref(jlClass)
 
-  val jlObject = Global.Top("java.lang.Object")
+  val jlObject    = Global.Top("java.lang.Object")
   val jlObjectRef = Type.Ref(jlObject)
 
-  val jlNumber = Global.Top("java.lang.Number")
+  val jlNumber    = Global.Top("java.lang.Number")
   val jlNumberRef = Type.Ref(jlNumber)
 
-  val tuple2 = Global.Top("scala.Tuple2")
+  val tuple2    = Global.Top("scala.Tuple2")
   val tuple2Ref = Type.Ref(tuple2)
 
   val srAbstractFunction0 =
     Global.Top("scala.runtime.AbstractFunction0")
-
   val srAbstractFunction1 =
     Global.Top("scala.runtime.AbstractFunction1")
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenSymbols.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenSymbols.scala
@@ -12,9 +12,6 @@ object NirGenSymbols {
   val jlObject    = Global.Top("java.lang.Object")
   val jlObjectRef = Type.Ref(jlObject)
 
-  val jlNumber    = Global.Top("java.lang.Number")
-  val jlNumberRef = Type.Ref(jlNumber)
-
   val tuple2    = Global.Top("scala.Tuple2")
   val tuple2Ref = Type.Ref(tuple2)
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenSymbols.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenSymbols.scala
@@ -1,0 +1,26 @@
+package scala.scalanative
+
+import scala.scalanative.nir.Global
+import scala.scalanative.nir.Type
+
+object NirGenSymbols {
+  val serializable = Global.Top("scala.Serializable")
+
+  val jlClass = Global.Top("java.lang.Class")
+  val jlClassRef = Type.Ref(jlClass)
+
+  val jlObject = Global.Top("java.lang.Object")
+  val jlObjectRef = Type.Ref(jlObject)
+
+  val jlNumber = Global.Top("java.lang.Number")
+  val jlNumberRef = Type.Ref(jlNumber)
+
+  val tuple2 = Global.Top("scala.Tuple2")
+  val tuple2Ref = Type.Ref(tuple2)
+
+  val srAbstractFunction0 =
+    Global.Top("scala.runtime.AbstractFunction0")
+
+  val srAbstractFunction1 =
+    Global.Top("scala.runtime.AbstractFunction1")
+}

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationBuffer.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationBuffer.scala
@@ -5,19 +5,15 @@ package nscplugin
 import scala.collection.mutable
 import scala.scalanative.nir._
 
-class ReflectiveInstantiationInfo {
+class ReflectiveInstantiationBuffer(val fqcn: String) {
   private val buf = mutable.UnrolledBuffer.empty[nir.Defn]
 
   def +=(defn: nir.Defn): Unit = {
     buf += defn
   }
 
-  val name = nir.Global.Top("SN$LazyModuleLoaders__$")
+  val name = nir.Global.Top("SN$ReflectivelyInstantiate$" + fqcn)
 
   def nonEmpty = buf.nonEmpty
   def toSeq    = buf.toSeq
-
-  def toSeqCompleted: Seq[nir.Defn] = {
-    buf :+ nir.Defn.Module(Attrs(), name, None, Seq())
-  }
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
@@ -6,18 +6,18 @@ import scala.collection.mutable
 import scala.scalanative.nir._
 
 class ReflectiveInstantiationInfo {
-    private val buf = mutable.UnrolledBuffer.empty[nir.Defn]
+  private val buf = mutable.UnrolledBuffer.empty[nir.Defn]
 
-    def +=(defn: nir.Defn): Unit = {
-        buf += defn
-    }
+  def +=(defn: nir.Defn): Unit = {
+    buf += defn
+  }
 
-    val name = nir.Global.Top("SN$LazyModuleLoaders__$")
+  val name = nir.Global.Top("SN$LazyModuleLoaders__$")
 
-    def nonEmpty = buf.nonEmpty
-    def toSeq = buf.toSeq
+  def nonEmpty = buf.nonEmpty
+  def toSeq    = buf.toSeq
 
-    def toSeqCompleted: Seq[nir.Defn] = {
-        buf :+ nir.Defn.Module(Attrs(), name, None, Seq())
-    }
+  def toSeqCompleted: Seq[nir.Defn] = {
+    buf :+ nir.Defn.Module(Attrs(), name, None, Seq())
+  }
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
@@ -17,3 +17,20 @@ class ReflectiveInstantiationBuffer(val fqcn: String) {
   def nonEmpty = buf.nonEmpty
   def toSeq    = buf.toSeq
 }
+
+object ReflectiveInstantiationInfo {
+  private val bufs =
+    mutable.UnrolledBuffer.empty[ReflectiveInstantiationBuffer]
+
+  def +=(buf: ReflectiveInstantiationBuffer): Unit = {
+    bufs += buf
+  }
+
+  def nonEmpty = bufs.nonEmpty
+  def toSeq    = bufs.toSeq
+  def last = bufs.last
+
+  def foreach(f: ReflectiveInstantiationBuffer => Unit): Unit = {
+    bufs.foreach(f)
+  }
+}

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
@@ -1,0 +1,23 @@
+package scala.scalanative
+
+package nscplugin
+
+import scala.collection.mutable
+import scala.scalanative.nir._
+
+class ReflectiveInstantiationInfo {
+    private val buf = mutable.UnrolledBuffer.empty[nir.Defn]
+
+    def +=(defn: nir.Defn): Unit = {
+        buf += defn
+    }
+
+    val name = nir.Global.Top("SN$LazyModuleLoaders__$")
+
+    def nonEmpty = buf.nonEmpty
+    def toSeq = buf.toSeq
+
+    def toSeqCompleted: Seq[nir.Defn] = {
+        buf :+ nir.Defn.Module(Attrs(), name, None, Seq())
+    }
+}

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
@@ -18,19 +18,6 @@ class ReflectiveInstantiationBuffer(val fqcn: String) {
   def toSeq    = buf.toSeq
 }
 
-object ReflectiveInstantiationInfo {
-  private val bufs =
-    mutable.UnrolledBuffer.empty[ReflectiveInstantiationBuffer]
-
-  def +=(buf: ReflectiveInstantiationBuffer): Unit = {
-    bufs += buf
-  }
-
-  def nonEmpty = bufs.nonEmpty
-  def toSeq    = bufs.toSeq
-  def last     = bufs.last
-
-  def foreach(f: ReflectiveInstantiationBuffer => Unit): Unit = {
-    bufs.foreach(f)
-  }
+object ReflectiveInstantiationBuffer {
+  def apply(fqcn: String) = new ReflectiveInstantiationBuffer(fqcn)
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
@@ -28,7 +28,7 @@ object ReflectiveInstantiationInfo {
 
   def nonEmpty = bufs.nonEmpty
   def toSeq    = bufs.toSeq
-  def last = bufs.last
+  def last     = bufs.last
 
   def foreach(f: ReflectiveInstantiationBuffer => Unit): Unit = {
     bufs.foreach(f)

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/ReflectiveInstantiationInfo.scala
@@ -12,7 +12,7 @@ class ReflectiveInstantiationBuffer(val fqcn: String) {
     buf += defn
   }
 
-  val name = nir.Global.Top("SN$ReflectivelyInstantiate$" + fqcn)
+  val name = nir.Global.Top(fqcn + "$SN$ReflectivelyInstantiate$")
 
   def nonEmpty = buf.nonEmpty
   def toSeq    = buf.toSeq

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -563,15 +563,15 @@ object CodeGen {
                 c == 'a' || c == 'b' || c == 'c' || c == 'd' || c == 'e' || c == 'f' ||
                 c == 'A' || c == 'B' || c == 'C' || c == 'D' || c == 'E' || c == 'F'
             value(idx + 1) match {
-              case c @ (''' | '"' | '?') => str(c); loop(idx + 2)
-              case '\\'                  => str("\\\\"); loop(idx + 2)
-              case 'a'                   => str("\\07"); loop(idx + 2)
-              case 'b'                   => str("\\08"); loop(idx + 2)
-              case 'f'                   => str("\\0C"); loop(idx + 2)
-              case 'n'                   => str("\\0A"); loop(idx + 2)
-              case 'r'                   => str("\\0D"); loop(idx + 2)
-              case 't'                   => str("\\09"); loop(idx + 2)
-              case 'v'                   => str("\\0B"); loop(idx + 2)
+              case c @ ('\'' | '"' | '?') => str(c); loop(idx + 2)
+              case '\\'                   => str("\\\\"); loop(idx + 2)
+              case 'a'                    => str("\\07"); loop(idx + 2)
+              case 'b'                    => str("\\08"); loop(idx + 2)
+              case 'f'                    => str("\\0C"); loop(idx + 2)
+              case 'n'                    => str("\\0A"); loop(idx + 2)
+              case 'r'                    => str("\\0D"); loop(idx + 2)
+              case 't'                    => str("\\09"); loop(idx + 2)
+              case 'v'                    => str("\\0B"); loop(idx + 2)
               case d if isOct(d) =>
                 val oct = value.drop(idx + 1).take(3).takeWhile(isOct)
                 val hex =

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -154,13 +154,13 @@ object Generate {
                             stackBottom),
                    unwind),
           Inst.Let(Op.Call(InitSig, Init, Seq()), unwind),
-          Inst.Let(rt.name, Op.Module(Runtime.name), unwind),
-          Inst.Let(arr.name,
-                   Op.Call(RuntimeInitSig, RuntimeInit, Seq(rt, argc, argv)),
-                   unwind)
+          Inst.Let(rt.name, Op.Module(Runtime.name), unwind)
         )
           ++ clinitCalls // call the class initializers before calling main
           ++ Seq(
+            Inst.Let(arr.name,
+                     Op.Call(RuntimeInitSig, RuntimeInit, Seq(rt, argc, argv)),
+                     unwind),
             Inst.Let(module.name, Op.Module(entry.top), unwind),
             Inst.Let(Op.Call(entryMainTy, entryMain, Seq(module, arr)), unwind),
             Inst.Let(Op.Call(RuntimeLoopSig, RuntimeLoop, Seq(module)), unwind),

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -151,8 +151,7 @@ object Generate {
                             Val.Global(stackBottomName, Type.Ptr),
                             stackBottom),
                    unwind),
-          Inst.Let(Op.Call(InitSig, Init, Seq()), unwind),
-          Inst.Let(rt.name, Op.Module(Runtime.name), unwind)
+          Inst.Let(Op.Call(InitSig, Init, Seq()), unwind)
         )
           ++ // generate the class initialisers
             defns.collect {
@@ -164,6 +163,7 @@ object Generate {
                          unwind)
             }
           ++ Seq(
+            Inst.Let(rt.name, Op.Module(Runtime.name), unwind),
             Inst.Let(arr.name,
                      Op.Call(RuntimeInitSig, RuntimeInit, Seq(rt, argc, argv)),
                      unwind),

--- a/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
@@ -7,7 +7,7 @@ import scalanative.io.VirtualDirectory
 import scalanative.util.Scope
 
 sealed abstract class ClassLoader {
-  def classesWithEntryPoints(): Iterable[Global]
+  def classesWithEntryPoints: Iterable[Global]
 
   def load(global: Global): Option[Seq[Defn]]
 }
@@ -25,8 +25,8 @@ object ClassLoader {
     new FromMemory(defns)
 
   final class FromDisk(classpath: Seq[ClassPath]) extends ClassLoader {
-    def classesWithEntryPoints(): Iterable[Global] = {
-      classpath.flatMap(_.classesWithEntryPoints())
+    lazy val classesWithEntryPoints: Iterable[Global] = {
+      classpath.flatMap(_.classesWithEntryPoints)
     }
 
     def load(global: Global) =
@@ -47,7 +47,7 @@ object ClassLoader {
       out
     }
 
-    def classesWithEntryPoints(): Iterable[Global] = {
+    lazy val classesWithEntryPoints: Iterable[Global] = {
       scopes.filter {
         case (top, defns) =>
           defns.exists {

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -16,7 +16,7 @@ sealed trait ClassPath {
   /** Load given global and info about its dependencies. */
   private[scalanative] def load(name: Global): Option[Seq[Defn]]
 
-  private[scalanative] def classesWithEntryPoints(): Iterable[Global.Top]
+  private[scalanative] def classesWithEntryPoints: Iterable[Global.Top]
 }
 
 object ClassPath {
@@ -53,7 +53,7 @@ object ClassPath {
         }
       })
 
-    def classesWithEntryPoints(): Iterable[Global.Top] = {
+    lazy val classesWithEntryPoints: Iterable[Global.Top] = {
       files.filter {
         case (top, file) =>
           val buffer = directory.read(file, len = 1)

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -57,7 +57,7 @@ object ClassPath {
       files.filter {
         case (top, file) =>
           val buffer = directory.read(file, len = 1)
-          buffer.get != 0
+          buffer.get() != 0
       }.keySet
     }
   }

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -7,8 +7,6 @@ import nir.serialization.deserializeBinary
 import java.nio.file.{FileSystems, Path}
 import scalanative.io.VirtualDirectory
 import scalanative.util.Scope
-import java.io.FileInputStream
-import java.nio.ByteBuffer
 
 sealed trait ClassPath {
 

--- a/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassPath.scala
@@ -7,6 +7,8 @@ import nir.serialization.deserializeBinary
 import java.nio.file.{FileSystems, Path}
 import scalanative.io.VirtualDirectory
 import scalanative.util.Scope
+import java.io.FileInputStream
+import java.nio.ByteBuffer
 
 sealed trait ClassPath {
 
@@ -15,6 +17,8 @@ sealed trait ClassPath {
 
   /** Load given global and info about its dependencies. */
   private[scalanative] def load(name: Global): Option[Seq[Defn]]
+
+  private[scalanative] def classesWithEntryPoints(): Iterable[Global.Top]
 }
 
 object ClassPath {
@@ -50,5 +54,13 @@ object ClassPath {
           deserializeBinary(directory.read(file))
         }
       })
+
+    def classesWithEntryPoints(): Iterable[Global.Top] = {
+      files.filter {
+        case (top, file) =>
+          val buffer = directory.read(file, len = 1)
+          buffer.get != 0
+      }.keySet
+    }
   }
 }

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -21,7 +21,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
   val dynimpls      = mutable.Set.empty[Global]
 
   entries.foreach(reachEntry)
-  loader.classesWithEntryPoints.foreach(reachEntry)
+  loader.classesWithEntryPoints.foreach(reachClinit)
 
   def result(): Result = {
     cleanup()
@@ -139,12 +139,18 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
             }
           }
         }
-        val clinit = cls.name.member(Sig.Clinit())
-        if (loaded(cls.name).contains(clinit)) {
-          reachGlobal(clinit)
-        }
       case _ =>
         ()
+    }
+  }
+
+  def reachClinit(name: Global): Unit = {
+    reachGlobalNow(name)
+    infos.get(name).map { cls =>
+      val clinit = cls.name.member(Sig.Clinit())
+      if (loaded(cls.name).contains(clinit)) {
+        reachGlobal(clinit)
+      }
     }
   }
 

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -21,6 +21,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
   val dynimpls      = mutable.Set.empty[Global]
 
   entries.foreach(reachEntry)
+  loader.classesWithEntryPoints().foreach(reachEntry)
 
   def result(): Result = {
     cleanup()
@@ -138,6 +139,10 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
             }
           }
         }
+        val clinit = cls.name.member(Sig.Clinit())
+        if (loaded(cls.name).contains(clinit)) {
+          reachGlobal(clinit)
+        }
       case _ =>
         ()
     }
@@ -218,6 +223,8 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
                 update(Rt.ScalaHashCodeSig)
                 update(Rt.JavaHashCodeSig)
               case sig if sig.isMethod || sig.isCtor || sig.isGenerated =>
+                update(sig)
+              case sig if sig.isClinit =>
                 update(sig)
               case _ =>
                 ()

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -21,7 +21,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
   val dynimpls      = mutable.Set.empty[Global]
 
   entries.foreach(reachEntry)
-  loader.classesWithEntryPoints().foreach(reachEntry)
+  loader.classesWithEntryPoints.foreach(reachEntry)
 
   def result(): Result = {
     cleanup()

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -222,9 +222,8 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
               case Rt.JavaHashCodeSig =>
                 update(Rt.ScalaHashCodeSig)
                 update(Rt.JavaHashCodeSig)
-              case sig if sig.isMethod || sig.isCtor || sig.isGenerated =>
-                update(sig)
-              case sig if sig.isClinit =>
+              case sig
+                  if sig.isMethod || sig.isCtor || sig.isClinit || sig.isGenerated =>
                 update(sig)
               case _ =>
                 ()

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -146,7 +146,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachClinit(name: Global): Unit = {
     reachGlobalNow(name)
-    infos.get(name).map { cls =>
+    infos.get(name).foreach { cls =>
       val clinit = cls.name.member(Sig.Clinit())
       if (loaded(cls.name).contains(clinit)) {
         reachGlobal(clinit)

--- a/unit-tests/src/main/scala/tests/Suite.scala
+++ b/unit-tests/src/main/scala/tests/Suite.scala
@@ -33,6 +33,11 @@ abstract class Suite {
       throw AssertionFailed(s"condition is true")
     }
 
+  def assertFalse(message: String, cond: Boolean): Unit =
+    if (cond) {
+      throw AssertionFailed(message)
+    }
+
   def assertNull[A](a: A): Unit =
     if (a != null) {
       throw AssertionFailed(s"$a != null")

--- a/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationSuite.scala
@@ -7,7 +7,6 @@ package reflect
 import scala.scalanative.reflect._
 import scala.scalanative.reflect.annotation._
 import scala.scalanative.unsafe._
-import java.nio.file.AccessMode
 
 object ReflectiveInstantiationSuite extends tests.Suite {
   import ReflectTest.{Accessors, PtrAccessors, VC}
@@ -219,13 +218,17 @@ object ReflectiveInstantiationSuite extends tests.Suite {
         buffer(i) = (size - i).toByte
       }
 
-      val instance =
+      val instance1 =
         optCtorPtrInt.get.newInstance(buffer, size).asInstanceOf[PtrAccessors]
-      assertEquals(64, instance.n)
+      assertEquals(64, instance1.n)
 
       for (i <- 0 until size) {
-        assertEquals(size - i, instance.p(i))
+        assertEquals(size - i, instance1.p(i))
       }
+
+      val instance2 = classData.newInstance().asInstanceOf[PtrAccessors]
+      assertEquals(0, instance2.n)
+      assertEquals(null, instance2.p)
     }
   }
 

--- a/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationSuite.scala
@@ -211,12 +211,10 @@ object ReflectiveInstantiationSuite extends tests.Suite {
       val size   = 64
       val buffer = alloc[Byte](size)
 
-      val fn = { idx: Int =>
-        size - idx
-      }
+      def fn(idx: Int) = size - idx
 
       for (i <- 0 until size) {
-        buffer(i) = (fn(i)).toByte
+        buffer(i) = fn(i).toByte
       }
 
       val optCtorPtrInt =

--- a/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationSuite.scala
@@ -27,7 +27,7 @@ object ReflectiveInstantiationSuite extends tests.Suite {
 
   private final val NameInnerClass = {
     Prefix + "ClassWithInnerClassWithEnableReflectiveInstantiation$" +
-    "InnerClassWithEnableReflectiveInstantiation"
+      "InnerClassWithEnableReflectiveInstantiation"
   }
 
   private final val NameClassEnableIndirect =
@@ -52,13 +52,15 @@ object ReflectiveInstantiationSuite extends tests.Suite {
 
   private final val NameInnerObject = {
     Prefix + "ClassWithInnerObjectWithEnableReflectiveInstantiation$" +
-    "InnerObjectWithEnableReflectiveInstantiation"
+      "InnerObjectWithEnableReflectiveInstantiation"
   }
 
   test("testClassRuntimeClass") {
     for {
-      name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
-          NameClassEnableIndirect, NameClassEnableIndirectNoZeroArgCtor)
+      name <- Seq(NameClassEnableDirect,
+                  NameClassEnableDirectNoZeroArgCtor,
+                  NameClassEnableIndirect,
+                  NameClassEnableIndirectNoZeroArgCtor)
     } {
       val optClassData = Reflect.lookupInstantiatableClass(name)
       assertTrue(optClassData.isDefined)
@@ -84,29 +86,44 @@ object ReflectiveInstantiationSuite extends tests.Suite {
 
   test("testClassCannotBeFound") {
     for {
-      name <- Seq(NameObjectEnableDirect, NameTraitEnableDirect,
-          NameAbstractClassEnableDirect,
-          NameClassNoPublicConstructorEnableDirect, NameObjectEnableIndirect,
-          NameTraitEnableIndirect, NameAbstractClassEnableIndirect,
-          NameClassNoPublicConstructorEnableIndirect, NameClassDisable,
-          NameObjectDisable, NameTraitDisable)
+      name <- Seq(
+        NameObjectEnableDirect,
+        NameTraitEnableDirect,
+        NameAbstractClassEnableDirect,
+        NameClassNoPublicConstructorEnableDirect,
+        NameObjectEnableIndirect,
+        NameTraitEnableIndirect,
+        NameAbstractClassEnableIndirect,
+        NameClassNoPublicConstructorEnableIndirect,
+        NameClassDisable,
+        NameObjectDisable,
+        NameTraitDisable
+      )
     } {
       assertFalse(s"$name should not be found",
-          Reflect.lookupInstantiatableClass(name).isDefined)
+                  Reflect.lookupInstantiatableClass(name).isDefined)
     }
   }
 
   test("testObjectCannotBeFound") {
     for {
-      name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
-          NameTraitEnableDirect, NameAbstractClassEnableDirect,
-          NameClassNoPublicConstructorEnableDirect, NameClassEnableIndirect,
-          NameTraitEnableIndirect, NameAbstractClassEnableIndirect,
-          NameClassNoPublicConstructorEnableIndirect, NameClassDisable,
-          NameObjectDisable, NameTraitDisable)
+      name <- Seq(
+        NameClassEnableDirect,
+        NameClassEnableDirectNoZeroArgCtor,
+        NameTraitEnableDirect,
+        NameAbstractClassEnableDirect,
+        NameClassNoPublicConstructorEnableDirect,
+        NameClassEnableIndirect,
+        NameTraitEnableIndirect,
+        NameAbstractClassEnableIndirect,
+        NameClassNoPublicConstructorEnableIndirect,
+        NameClassDisable,
+        NameObjectDisable,
+        NameTraitDisable
+      )
     } {
       assertFalse(s"$name should not be found",
-          Reflect.lookupLoadableModuleClass(name).isDefined)
+                  Reflect.lookupLoadableModuleClass(name).isDefined)
     }
   }
 
@@ -124,7 +141,7 @@ object ReflectiveInstantiationSuite extends tests.Suite {
 
   test("testClassNoArgCtorErrorCase") {
     for (name <- Seq(NameClassEnableDirectNoZeroArgCtor,
-        NameClassEnableIndirectNoZeroArgCtor)) {
+                     NameClassEnableIndirectNoZeroArgCtor)) {
       val optClassData = Reflect.lookupInstantiatableClass(name)
       assertTrue(optClassData.isDefined)
       val classData = optClassData.get
@@ -136,8 +153,10 @@ object ReflectiveInstantiationSuite extends tests.Suite {
   }
 
   test("testClassCtorWithArgs") {
-    for (name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
-        NameClassEnableIndirect, NameClassEnableIndirectNoZeroArgCtor)) {
+    for (name <- Seq(NameClassEnableDirect,
+                     NameClassEnableDirectNoZeroArgCtor,
+                     NameClassEnableIndirect,
+                     NameClassEnableIndirectNoZeroArgCtor)) {
       val optClassData = Reflect.lookupInstantiatableClass(name)
       assertTrue(optClassData.isDefined)
       val classData = optClassData.get
@@ -199,7 +218,7 @@ object ReflectiveInstantiationSuite extends tests.Suite {
 
     val fqcn = classOf[LocalClassWithEnableReflectiveInstantiation].getName
     assertFalse(s"$fqcn should not be found",
-        Reflect.lookupInstantiatableClass(fqcn).isDefined)
+                Reflect.lookupInstantiatableClass(fqcn).isDefined)
   }
 
   test("testObjectLoad") {
@@ -302,7 +321,8 @@ object ReflectTest {
   trait EnablingTrait
 
   class ClassEnableIndirect(val x: Int, val y: String)
-      extends EnablingTrait with Accessors {
+      extends EnablingTrait
+      with Accessors {
 
     def this(x: Int) = this(x, "ClassEnableIndirect")
     def this() = this(-1)
@@ -313,7 +333,8 @@ object ReflectTest {
   }
 
   class ClassEnableIndirectNoZeroArgCtor(val x: Int, val y: String)
-      extends EnablingTrait with Accessors {
+      extends EnablingTrait
+      with Accessors {
     def this(x: Int) = this(x, "ClassEnableIndirectNoZeroArgCtor")
     def this(vc: VC) = this(vc.self.toInt * 2)
 
@@ -329,7 +350,8 @@ object ReflectTest {
   trait TraitEnableIndirect extends EnablingTrait with Accessors
 
   abstract class AbstractClassEnableIndirect(val x: Int, val y: String)
-      extends EnablingTrait with Accessors {
+      extends EnablingTrait
+      with Accessors {
 
     def this(x: Int) = this(x, "AbstractClassEnableIndirect")
     def this() = this(-1)
@@ -339,9 +361,10 @@ object ReflectTest {
     private def this(d: Double) = this(d.toInt)
   }
 
-  class ClassNoPublicConstructorEnableIndirect private (
-      val x: Int, val y: String)
-      extends EnablingTrait with Accessors {
+  class ClassNoPublicConstructorEnableIndirect private (val x: Int,
+                                                        val y: String)
+      extends EnablingTrait
+      with Accessors {
 
     protected def this(y: String) = this(-5, y)
   }

--- a/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationSuite.scala
@@ -1,0 +1,366 @@
+package scala.scalanative
+
+package reflect
+
+// Ported from Scala.js.
+
+import scala.scalanative.reflect._
+import scala.scalanative.reflect.annotation._
+
+object ReflectiveInstantiationSuite extends tests.Suite {
+  import ReflectTest.{Accessors, VC}
+
+  private final val Prefix = "scala.scalanative.reflect.ReflectTest$"
+
+  private final val NameClassEnableDirect =
+    Prefix + "ClassEnableDirect"
+  private final val NameClassEnableDirectNoZeroArgCtor =
+    Prefix + "ClassEnableDirectNoZeroArgCtor"
+  private final val NameObjectEnableDirect =
+    Prefix + "ObjectEnableDirect$"
+  private final val NameTraitEnableDirect =
+    Prefix + "TraitEnableDirect"
+  private final val NameAbstractClassEnableDirect =
+    Prefix + "AbstractClassEnableDirect"
+  private final val NameClassNoPublicConstructorEnableDirect =
+    Prefix + "ClassNoPublicConstructorEnableDirect"
+
+  private final val NameInnerClass = {
+    Prefix + "ClassWithInnerClassWithEnableReflectiveInstantiation$" +
+    "InnerClassWithEnableReflectiveInstantiation"
+  }
+
+  private final val NameClassEnableIndirect =
+    Prefix + "ClassEnableIndirect"
+  private final val NameClassEnableIndirectNoZeroArgCtor =
+    Prefix + "ClassEnableIndirectNoZeroArgCtor"
+  private final val NameObjectEnableIndirect =
+    Prefix + "ObjectEnableIndirect$"
+  private final val NameTraitEnableIndirect =
+    Prefix + "TraitEnableIndirect"
+  private final val NameAbstractClassEnableIndirect =
+    Prefix + "AbstractClassEnableIndirect"
+  private final val NameClassNoPublicConstructorEnableIndirect =
+    Prefix + "ClassNoPublicConstructorEnableIndirect"
+
+  private final val NameClassDisable =
+    Prefix + "ClassDisable"
+  private final val NameObjectDisable =
+    Prefix + "ObjectDisable$"
+  private final val NameTraitDisable =
+    Prefix + "TraitDisable"
+
+  private final val NameInnerObject = {
+    Prefix + "ClassWithInnerObjectWithEnableReflectiveInstantiation$" +
+    "InnerObjectWithEnableReflectiveInstantiation"
+  }
+
+  test("testClassRuntimeClass") {
+    for {
+      name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
+          NameClassEnableIndirect, NameClassEnableIndirectNoZeroArgCtor)
+    } {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val runtimeClass = optClassData.get.runtimeClass
+      assertEquals(name, runtimeClass.getName)
+    }
+  }
+
+  test("testObjectRuntimeClass") {
+    for {
+      name <- Seq(NameObjectEnableDirect, NameObjectEnableIndirect)
+    } {
+      val optClassData = Reflect.lookupLoadableModuleClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val runtimeClass = optClassData.get.runtimeClass
+      assertEquals(name, runtimeClass.getName)
+    }
+  }
+
+  test("testClassCannotBeFound") {
+    for {
+      name <- Seq(NameObjectEnableDirect, NameTraitEnableDirect,
+          NameAbstractClassEnableDirect,
+          NameClassNoPublicConstructorEnableDirect, NameObjectEnableIndirect,
+          NameTraitEnableIndirect, NameAbstractClassEnableIndirect,
+          NameClassNoPublicConstructorEnableIndirect, NameClassDisable,
+          NameObjectDisable, NameTraitDisable)
+    } {
+      assertFalse(s"$name should not be found",
+          Reflect.lookupInstantiatableClass(name).isDefined)
+    }
+  }
+
+  test("testObjectCannotBeFound") {
+    for {
+      name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
+          NameTraitEnableDirect, NameAbstractClassEnableDirect,
+          NameClassNoPublicConstructorEnableDirect, NameClassEnableIndirect,
+          NameTraitEnableIndirect, NameAbstractClassEnableIndirect,
+          NameClassNoPublicConstructorEnableIndirect, NameClassDisable,
+          NameObjectDisable, NameTraitDisable)
+    } {
+      assertFalse(s"$name should not be found",
+          Reflect.lookupLoadableModuleClass(name).isDefined)
+    }
+  }
+
+  test("testClassNoArgCtor") {
+    for (name <- Seq(NameClassEnableDirect, NameClassEnableIndirect)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val instance = classData.newInstance().asInstanceOf[Accessors]
+      assertEquals(-1, instance.x)
+      assertEquals(name.stripPrefix(Prefix), instance.y)
+    }
+  }
+
+  test("testClassNoArgCtorErrorCase") {
+    for (name <- Seq(NameClassEnableDirectNoZeroArgCtor,
+        NameClassEnableIndirectNoZeroArgCtor)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      expectThrows(classOf[InstantiationException], {
+        classData.newInstance()
+      })
+    }
+  }
+
+  test("testClassCtorWithArgs") {
+    for (name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
+        NameClassEnableIndirect, NameClassEnableIndirectNoZeroArgCtor)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val optCtorIntString =
+        classData.getConstructor(classOf[Int], classOf[String])
+      assertTrue(optCtorIntString.isDefined)
+      val instanceIntString =
+        optCtorIntString.get.newInstance(543, "foobar").asInstanceOf[Accessors]
+      assertEquals(543, instanceIntString.x)
+      assertEquals("foobar", instanceIntString.y)
+
+      val optCtorInt = classData.getConstructor(classOf[Int])
+      assertTrue(optCtorInt.isDefined)
+      val instanceInt =
+        optCtorInt.get.newInstance(123).asInstanceOf[Accessors]
+      assertEquals(123, instanceInt.x)
+      assertEquals(name.stripPrefix(Prefix), instanceInt.y)
+
+      // Value class is seen as its underlying
+      val optCtorShort = classData.getConstructor(classOf[Short])
+      assertTrue(optCtorShort.isDefined)
+      val instanceShort =
+        optCtorShort.get.newInstance(21).asInstanceOf[Accessors]
+      assertEquals(42, instanceShort.x)
+      assertEquals(name.stripPrefix(Prefix), instanceShort.y)
+
+      // Non-existent
+      assertFalse(classData.getConstructor(classOf[Boolean]).isDefined)
+      assertFalse(classData.getConstructor(classOf[VC]).isDefined)
+
+      // Non-public
+      assertFalse(classData.getConstructor(classOf[String]).isDefined)
+      assertFalse(classData.getConstructor(classOf[Double]).isDefined)
+    }
+  }
+
+  test("testInnerClass") {
+    import ReflectTest.ClassWithInnerClassWithEnableReflectiveInstantiation
+
+    val outer = new ClassWithInnerClassWithEnableReflectiveInstantiation(15)
+
+    val optClassData = Reflect.lookupInstantiatableClass(NameInnerClass)
+    assertTrue(optClassData.isDefined)
+    val classData = optClassData.get
+
+    val optCtorOuterString =
+      classData.getConstructor(outer.getClass, classOf[String])
+    assertTrue(optCtorOuterString.isDefined)
+    val instanceOuterString =
+      optCtorOuterString.get.newInstance(outer, "babar").asInstanceOf[Accessors]
+    assertEquals(15, instanceOuterString.x)
+    assertEquals("babar", instanceOuterString.y)
+  }
+
+  test("testLocalClass") {
+    @EnableReflectiveInstantiation
+    class LocalClassWithEnableReflectiveInstantiation
+
+    val fqcn = classOf[LocalClassWithEnableReflectiveInstantiation].getName
+    assertFalse(s"$fqcn should not be found",
+        Reflect.lookupInstantiatableClass(fqcn).isDefined)
+  }
+
+  test("testObjectLoad") {
+    for (name <- Seq(NameObjectEnableDirect, NameObjectEnableIndirect)) {
+      val optClassData = Reflect.lookupLoadableModuleClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val instance = classData.loadModule().asInstanceOf[Accessors]
+      assertEquals(101, instance.x)
+      assertEquals(name.stripPrefix(Prefix), instance.y)
+    }
+  }
+
+  test("testInnerObjectWithEnableReflectiveInstantiation_issue_3228") {
+    assertFalse(Reflect.lookupLoadableModuleClass(NameInnerObject).isDefined)
+    assertFalse(Reflect.lookupInstantiatableClass(NameInnerObject).isDefined)
+  }
+
+  test("testLocalClassWithReflectiveInstantiationInLambda_issue_3227") {
+    // Test that the presence of the following code does not prevent linking
+    { () =>
+      @EnableReflectiveInstantiation
+      class Foo
+    }
+  }
+
+}
+
+object ReflectTest {
+  trait Accessors {
+    val x: Int
+    val y: String
+  }
+
+  final class VC(val self: Short) extends AnyVal
+
+  // Entities with directly enabled reflection
+
+  @EnableReflectiveInstantiation
+  class ClassEnableDirect(val x: Int, val y: String) extends Accessors {
+    def this(x: Int) = this(x, "ClassEnableDirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  class ClassEnableDirectNoZeroArgCtor(val x: Int, val y: String)
+      extends Accessors {
+    def this(x: Int) = this(x, "ClassEnableDirectNoZeroArgCtor")
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  object ObjectEnableDirect extends Accessors {
+    val x = 101
+    val y = "ObjectEnableDirect$"
+  }
+
+  @EnableReflectiveInstantiation
+  trait TraitEnableDirect extends Accessors
+
+  @EnableReflectiveInstantiation
+  abstract class AbstractClassEnableDirect(val x: Int, val y: String)
+      extends Accessors {
+
+    def this(x: Int) = this(x, "AbstractClassEnableDirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  class ClassNoPublicConstructorEnableDirect private (val x: Int, val y: String)
+      extends Accessors {
+
+    protected def this(y: String) = this(-5, y)
+  }
+
+  class ClassWithInnerClassWithEnableReflectiveInstantiation(_x: Int) {
+    @EnableReflectiveInstantiation
+    class InnerClassWithEnableReflectiveInstantiation(_y: String)
+        extends Accessors {
+      val x = _x
+      val y = _y
+    }
+  }
+
+  // Entities with reflection enabled by inheritance
+
+  @EnableReflectiveInstantiation
+  trait EnablingTrait
+
+  class ClassEnableIndirect(val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+
+    def this(x: Int) = this(x, "ClassEnableIndirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  class ClassEnableIndirectNoZeroArgCtor(val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+    def this(x: Int) = this(x, "ClassEnableIndirectNoZeroArgCtor")
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  object ObjectEnableIndirect extends EnablingTrait with Accessors {
+    val x = 101
+    val y = "ObjectEnableIndirect$"
+  }
+
+  trait TraitEnableIndirect extends EnablingTrait with Accessors
+
+  abstract class AbstractClassEnableIndirect(val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+
+    def this(x: Int) = this(x, "AbstractClassEnableIndirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  class ClassNoPublicConstructorEnableIndirect private (
+      val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+
+    protected def this(y: String) = this(-5, y)
+  }
+
+  // Entities with reflection disabled
+
+  class ClassDisable(val x: Int, val y: String) extends Accessors
+
+  object ObjectDisable extends Accessors {
+    val x = 101
+    val y = "ObjectDisable$"
+  }
+
+  trait TraitDisable extends Accessors
+
+  // Regression cases
+
+  class ClassWithInnerObjectWithEnableReflectiveInstantiation {
+    @EnableReflectiveInstantiation
+    object InnerObjectWithEnableReflectiveInstantiation
+  }
+}

--- a/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationSuite.scala
@@ -185,7 +185,7 @@ object ReflectiveInstantiationSuite extends tests.Suite {
       val optCtorShort = classData.getConstructor(classOf[Short])
       assertTrue(optCtorShort.isDefined)
       val instanceShort =
-        optCtorShort.get.newInstance(21).asInstanceOf[Accessors]
+        optCtorShort.get.newInstance(21.toShort).asInstanceOf[Accessors]
       assertEquals(42, instanceShort.x)
       assertEquals(name.stripPrefix(Prefix), instanceShort.y)
 

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -18,6 +18,9 @@ sealed trait VirtualDirectory {
   /** Reads a contents of file with given path. */
   def read(path: Path): ByteBuffer
 
+  /** Reads up to len bytes from the file with the given path. */
+  def read(path: Path, len: Int): ByteBuffer
+
   /** Replaces contents of file with given value. */
   def write(path: Path, buffer: ByteBuffer): Unit
 
@@ -74,6 +77,13 @@ object VirtualDirectory {
       buffer
     }
 
+    override def read(path: Path, len: Int): ByteBuffer = {
+      val stream = Files.newInputStream(resolve(path))
+      val bytes  = new Array[Byte](len)
+      stream.read(bytes)
+      ByteBuffer.wrap(bytes)
+    }
+
     override def write(path: Path, buffer: ByteBuffer): Unit = {
       val channel = open(resolve(path))
       try channel.write(buffer)
@@ -126,6 +136,8 @@ object VirtualDirectory {
     override def read(path: Path): ByteBuffer =
       throw new UnsupportedOperationException(
         "Can't read from empty directory.")
+
+    override def read(path: Path, len: Int): ByteBuffer = read(path)
 
     override def write(path: Path, buffer: ByteBuffer): Unit =
       throw new UnsupportedOperationException("Can't write to empty directory.")

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -81,9 +81,7 @@ object VirtualDirectory {
       val stream = Files.newInputStream(resolve(path))
       val bytes  = new Array[Byte](len)
       val read   = stream.read(bytes)
-      val buffer = ByteBuffer.wrap(bytes).limit(read)
-      // we need to cast in case JDK 8 is used for the compiler
-      buffer.asInstanceOf[ByteBuffer]
+      ByteBuffer.wrap(bytes, 0, read)
     }
 
     override def write(path: Path, buffer: ByteBuffer): Unit = {

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -80,8 +80,10 @@ object VirtualDirectory {
     override def read(path: Path, len: Int): ByteBuffer = {
       val stream = Files.newInputStream(resolve(path))
       val bytes  = new Array[Byte](len)
-      stream.read(bytes)
-      ByteBuffer.wrap(bytes)
+      val read   = stream.read(bytes)
+      val buffer = ByteBuffer.wrap(bytes).limit(read)
+      // we need to cast in case JDK 8 is used for the compiler
+      buffer.asInstanceOf[ByteBuffer]
     }
 
     override def write(path: Path, buffer: ByteBuffer): Unit = {


### PR DESCRIPTION
This PR enables users to reflectively instantiate objects, by making use of static class initialisers (not to be confused with JVM class initialisers). Related issue is https://github.com/scala-native/scala-native/issues/1279.

To achieve the above:
- The NIR member signatures are enhanced with an extra attribute, called `clinit`, which is mangled with `I`. Static initialiser functions take no arguments and return `Unit`.
- For the static initialiser functions to be called, they must be made reachable. For this to work, we need to iterate over all program classes (each of them in a separate `.nir` file) and check whether they contain a `clinit` function. To avoid deserialising the whole file for each class, I added a single byte at the beginning of each file, to indicate whether the type it contains has a `clinit` function. If that byte is set, then the `clinit` function of the type in that file is added to the reachable set.
- When generating the code for the `main` method (native), we have to call the discovered `clinit` fuctions. We do this just before calling the main Scala method.

On top of that, we implement the same `Reflect` API and `@EnableReflectiveInstantiation`-based mechanism that Scala.js has.

Objectives list:
- [x] Add support for static initialisers to the NIR
- [x] Add the `@EnableReflectiveInstantiation` annotation
- [x] Implement the desired annotation behaviour for modules
- [x] Implement the desired annotation behaviour for normal classes