### PR TITLE
Ignore bloop/metals directories/files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ bin/
 .settings/
 .externalToolBuilders/
 .cache*
+
+# metals
+/.bloop/
+/.metals/
+/project/metals.sbt


### PR DESCRIPTION
Add metals/bloop files/directories to `.gitignore`.