### PR TITLE
Fix #1733: SN build should be upgraded to current sbt 1.3.8

### DIFF
--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -23,7 +23,7 @@ RUN sed -i -e "s/deb http/deb [arch=$HOST_ARCHITECTURE] http/g" /etc/apt/host-so
 RUN apt-get update && apt-get install -y openjdk-8-jdk-headless:$HOST_ARCHITECTURE
 ENV PATH "/usr/lib/jvm/java-8-openjdk-$HOST_ARCHITECTURE/bin:$PATH"
 
-ENV SBT_LAUNCHER_VERSION 1.3.7
+ENV SBT_LAUNCHER_VERSION 1.3.8
 
 RUN apt-get install -y curl
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.7
+sbt.version = 1.3.8


### PR DESCRIPTION
  * This PR was motivated by Issue #1733 "SN build should be upgraded to current sbt 1.3.8."

    That issue is now fixed.

  * The sbt version in the g8 template in the scala-native/scala-native.g8
    repository and the description of the sbt version used in that
    template in this repositories docs/user/sbt.rst file were considered
    for this PR but NOT changed because that template uses the SN 0.3.9
    plugin and I did not want to make large changes to that branch.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in debug mode using sbt 1.3.8 & Java 8 on
    X86_64 only . All tests pass.

  * Built and tested ("test-all") in release-fast mode using
    sbt 1.3.8 & Java 8 on X86_64 only . All tests pass.

  * Built and tested ("test-all") in both debug & release-fast modes using
    sbt 1.3.8 & Java 11 on X86_64 only . All tests pass.

  * NOTE WELL: Release-full (a.k.a: release) mode is currently broken
               on both Java 8 and Java 11: out-of-memory (> 3Gb) and
	       self-reflection errors. So, this PR was not tested with
	       that option.