### PR TITLE
Fix #1735: Discover and use clang-10 or clang-9, if present.

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -137,17 +137,18 @@ object Discover {
   /** Versions of clang which are known to work with Scala Native. */
   private[scalanative] val clangVersions =
     Seq(
-        ("10", ""),
-        ("9", ""),
-        ("8", ""),
-        ("7", ""),
-        ("7", "0"), // LLVM changed version numbering scheme, try both.
-        ("6", "0"),
-        ("5", "0"),
-        ("4", "0"),
-        ("3", "9"),
-        ("3", "8"),
-        ("3", "7"))
+      ("10", ""),
+      ("9", ""),
+      ("8", ""),
+      ("7", ""),
+      ("7", "0"), // LLVM changed version numbering scheme, try both.
+      ("6", "0"),
+      ("5", "0"),
+      ("4", "0"),
+      ("3", "9"),
+      ("3", "8"),
+      ("3", "7")
+    )
 
   /** Discover concrete binary path using command name and
    *  a sequence of potential supported versions.

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -136,8 +136,10 @@ object Discover {
 
   /** Versions of clang which are known to work with Scala Native. */
   private[scalanative] val clangVersions =
-    Seq(("8", ""),
-        ("8", "0"),
+    Seq(
+        ("10", ""),
+        ("9", ""),
+        ("8", ""),
         ("7", ""),
         ("7", "0"), // LLVM changed version numbering scheme, try both.
         ("6", "0"),


### PR DESCRIPTION
  * clang-10 and clang-9 are now available. Discover and use the highest
    installed clang on the build system.  This is the next
    in a long series of clang update PRs. It supersedes pending PR #1686.

  * Scala Native appears to build and run test-all without notice using
    either clang-10 or clang-9.  The only difference is the audible
    sizzle of Cool.

  * I removed the line `("8", "0")` because a year has gone by and shown that
    bit of defensive programming to be unneeded.  It has served its purpose.
    The resultant code will contain less lore and execute slightly quicker.
    clang-8 will still be discovered, if it is the highest installed version.

  * The Discovery code does not, and has not for years, discover
    llvm-config of the form llvm-config-N, where N is [3-9]. The current
    PR does no worse that prior art.  A PR for another day.

  * This PR adds two clang version to the current discovery mechanism.
    That mechanism is now checking quite a load of ancient clang versions.

    I believe that the discovery mechanism should be changed to a
    "specification" mechanism.  That is, require developers to
    specify any desired clang version other than the system default "clang".
    I did not make this change to minimize churn whilst ScalaNative is
    undergoing re-organization.

Documentation:

    * The standard changelog entry is requested.

Testing:

  * Testing needs to show first safety, then efficacy.

  * Safety, not breaking when neither clang-10 nor clang-9 is installed,
    will be shown by Travis CI.

  * To show that the code change was effective on a system with both
    clang-10 and clang-9 installed, I manually added
    'nativeCompileOptions ++= Seq("-v")'to the settings in build.sbt for
    the sandbox project and then running that project.

    The log file showed clang-10 in use.

    I then ran "test-all" using clang-10 and all tests passed.

  * I manually tested as above on the same system with only clang-9 (and
    clang itself) installed.  clang-9 was used and all tests passed.