### PR TITLE
Fix crash when HOME env variable is not set

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -604,7 +604,7 @@ lazy val tests =
       testFrameworks += new TestFramework("tests.NativeFramework"),
       Test / test / envVars ++= Map(
         "USER"                           -> "scala-native",
-        "HOME"                           -> baseDirectory.value.getAbsolutePath,
+        "HOME"                           -> System.getProperty("user.home"),
         "SCALA_NATIVE_ENV_WITH_EQUALS"   -> "1+1=2",
         "SCALA_NATIVE_ENV_WITHOUT_VALUE" -> "",
         "SCALA_NATIVE_ENV_WITH_UNICODE"  -> 0x2192.toChar.toString,

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -63,13 +63,14 @@ object System {
         sysProps.setProperty("user.language", userLang)
         sysProps.setProperty("user.country", userCountry)
       }
-      val home = {
+      {
         val buf = stackalloc[pwd.passwd]
         val uid = unistd.getuid()
-        pwd.getpwuid(uid, buf)
-        fromCString(buf.pw_dir)
+        val res = pwd.getpwuid(uid, buf)
+        if (res == 0 && buf.pw_dir != null) {
+          sysProps.setProperty("user.home", fromCString(buf.pw_dir))
+        }
       }
-      sysProps.setProperty("user.home", home)
       val buf = stackalloc[scala.Byte](1024)
       unistd.getcwd(buf, 1024) match {
         case null =>

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -61,7 +61,8 @@ object System {
         sysProps.setProperty("user.language", userLang)
         sysProps.setProperty("user.country", userCountry)
       }
-      sysProps.setProperty("user.home", getenv("HOME"))
+      val home = getenv("HOME")
+      if (home != null) sysProps.setProperty("user.home", home)
       val buf = stackalloc[scala.Byte](1024)
       unistd.getcwd(buf, 1024) match {
         case null =>

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -63,7 +63,7 @@ object System {
         sysProps.setProperty("user.language", userLang)
         sysProps.setProperty("user.country", userCountry)
       }
-      {
+      locally {
         val buf = stackalloc[pwd.passwd]
         val uid = unistd.getuid()
         val res = pwd.getpwuid(uid, buf)
@@ -71,10 +71,13 @@ object System {
           sysProps.setProperty("user.home", fromCString(buf.pw_dir))
         }
       }
-      val buf = stackalloc[scala.Byte](1024)
-      unistd.getcwd(buf, 1024) match {
-        case null =>
-        case b    => sysProps.setProperty("user.dir", fromCString(b))
+      locally {
+        val bufSize = 1024
+        val buf     = stackalloc[scala.Byte](bufSize)
+        val cwd     = unistd.getcwd(buf, bufSize)
+        if (cwd != null) {
+          sysProps.setProperty("user.dir", fromCString(cwd))
+        }
       }
     }
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
@@ -24,15 +24,15 @@ object pwdOps {
   import pwd._
 
   implicit class passwdOps(val ptr: Ptr[passwd]) extends AnyVal {
-    def pw_name: CString = ptr._1
-    def pw_name_=(value: CString): Unit = ptr._1 = value
-    def pw_uid: uid_t = ptr._2
-    def pw_uid_=(value: uid_t): Unit = ptr._2 = value
-    def pw_gid: gid_t = ptr._3
-    def pw_gid_=(value: gid_t): Unit = ptr._3 = value
-    def pw_dir: CString = ptr._4
-    def pw_dir_=(value: CString): Unit = ptr._4 = value
-    def pw_shell: CString = ptr._5
+    def pw_name: CString                 = ptr._1
+    def pw_name_=(value: CString): Unit  = ptr._1 = value
+    def pw_uid: uid_t                    = ptr._2
+    def pw_uid_=(value: uid_t): Unit     = ptr._2 = value
+    def pw_gid: gid_t                    = ptr._3
+    def pw_gid_=(value: gid_t): Unit     = ptr._3 = value
+    def pw_dir: CString                  = ptr._4
+    def pw_dir_=(value: CString): Unit   = ptr._4 = value
+    def pw_shell: CString                = ptr._5
     def pw_shell_=(value: CString): Unit = ptr._5 = value
   }
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
@@ -19,3 +19,21 @@ object pwd {
   @name("scalanative_getpwnam")
   def getpwnam(name: CString, buf: Ptr[passwd]): CInt = extern
 }
+
+object pwdOps {
+  import pwd._
+
+  implicit class passwdOps(val ptr: Ptr[passwd]) extends AnyVal {
+    def pw_name: CString = ptr._1
+    def pw_name_=(value: CString): Unit = ptr._1 = value
+    def pw_uid: uid_t = ptr._2
+    def pw_uid_=(value: uid_t): Unit = ptr._2 = value
+    def pw_gid: gid_t = ptr._3
+    def pw_gid_=(value: gid_t): Unit = ptr._3 = value
+    def pw_dir: CString = ptr._4
+    def pw_dir_=(value: CString): Unit = ptr._4 = value
+    def pw_shell: CString = ptr._5
+    def pw_shell_=(value: CString): Unit = ptr._5 = value
+  }
+
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -23,6 +23,7 @@ object unistd {
   def getcwd(buf: CString, size: CSize): CString                  = extern
   def gethostname(name: CString, len: CSize): CInt                = extern
   def getpid(): CInt                                              = extern
+  def getuid(): uid_t                                             = extern
   def lseek(fildes: CInt, offset: off_t, whence: CInt): off_t     = extern
   def pipe(fildes: Ptr[CInt]): CInt                               = extern
   def read(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt         = extern

--- a/unit-tests/src/test/scala/java/lang/SystemSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/SystemSuite.scala
@@ -64,7 +64,7 @@ object SystemSuite extends tests.Suite {
     assert(delta <= tolerance)
   }
 
-  test("Property user.home should be set if env variable is set") {
+  test("Property user.home should be set") {
     assertEquals(System.getProperty("user.home"), System.getenv("HOME"))
   }
 

--- a/unit-tests/src/test/scala/java/lang/SystemSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/SystemSuite.scala
@@ -64,7 +64,7 @@ object SystemSuite extends tests.Suite {
     assert(delta <= tolerance)
   }
 
-  test("Property user.home should be set") {
+  test("Property user.home should be set if env variable is set") {
     assertEquals(System.getProperty("user.home"), System.getenv("HOME"))
   }
 


### PR DESCRIPTION
Steps to reproduce:
- Link any Scala Native binary using the `java.lang.System` object
- unset the `HOME` environment variable
- run the binary:
```bash
$ unset HOME
$ target/scala-2.11/hello-out
```
And it crashes with:
```
java.lang.NullPointerException
        at java.lang.Throwable.fillInStackTrace(Unknown Source)
        at java.util.Hashtable.put(Unknown Source)
        at java.util.Properties.setProperty(Unknown Source)
        at java.lang.System$.loadProperties(Unknown Source)
        at java.lang.System$.<init>(Unknown Source)
        at <none>._SM17java.lang.System$G4load(Unknown Source)
        at scala.sys.package$.env(Unknown Source)
        at JsonAction$class.main(Unknown Source)
        at Main$.main(Unknown Source)
        at <none>.main(Unknown Source)
```