### PR TITLE
Fix #1740: Two PatternSuite.scala files missing logical and

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
@@ -852,7 +852,7 @@ class Parser(wholeRegexp: String, _flags: Int) {
 
       val n = stack.size()
       if (n != 1) {
-        throw new PatternSyntaxException(ERR_MISSING_PAREN,
+        throw new PatternSyntaxException(ERR_UNCLOSED_GROUP,
                                          wholeRegexp,
                                          t.pos())
       }
@@ -953,8 +953,8 @@ class Parser(wholeRegexp: String, _flags: Int) {
 
       if (!parseCompleted) {
         throw new PatternSyntaxException(ERR_INVALID_PERL_OP,
-                                         t.from(startPos),
-                                         0)
+                                         t.from(startPos) + t.rest,
+                                         t.pos - 1)
       }
     }
   }
@@ -1026,14 +1026,16 @@ class Parser(wholeRegexp: String, _flags: Int) {
 
     val n = stack.size()
     if (n < 2) {
-      throw new PatternSyntaxException(ERR_MISSING_BRACKET,
+      throw new PatternSyntaxException(ERR_UNMATCHED_CLOSING_PAREN,
                                        wholeRegexp,
                                        pos - 1)
     }
     val re1 = pop()
     val re2 = pop()
     if (re2.op != ROP.LEFT_PAREN) {
-      throw new PatternSyntaxException(ERR_MISSING_PAREN, wholeRegexp, pos - 1)
+      throw new PatternSyntaxException(ERR_UNMATCHED_CLOSING_PAREN,
+                                       wholeRegexp,
+                                       pos - 1)
     }
     // Restore flags at time of paren.
     this.flags = re2.flags
@@ -1277,8 +1279,11 @@ object Parser {
     "regexp/syntax: internal error"
 
   // Parse errors
+  // For sanity & matching to equivalent JVM text, please keep in
+  // alphabetical order of val name.
+
   private final val ERR_INVALID_CHAR_CLASS =
-    "Illegal/unsupported character class"
+    "Unclosed character class"
 
   private final val ERR_INVALID_CHAR_RANGE =
     "Illegal character range"
@@ -1290,25 +1295,25 @@ object Parser {
     "Bad named capture group"
 
   private final val ERR_INVALID_PERL_OP =
-    "Bad perl operator"
+    "Unknown inline modifier"
 
   private final val ERR_INVALID_REPEAT_OP =
     "invalid nested repetition operator"
 
   private final val ERR_INVALID_REPEAT_SIZE =
-    "Bad repetition argument"
-
-  private final val ERR_MISSING_BRACKET =
-    "Unclosed character class"
-
-  private final val ERR_MISSING_PAREN =
-    "Missing parenthesis"
-
-  private final val ERR_MISSING_REPEAT_ARGUMENT =
-    "Bad repetition operator"
+    "Dangling meta character '*'"
 
   private final val ERR_TRAILING_BACKSLASH =
     "Trailing Backslash"
+
+  private final val ERR_MISSING_REPEAT_ARGUMENT =
+    "Dangling meta character '*'"
+
+  private final val ERR_UNCLOSED_GROUP =
+    "Unclosed group"
+
+  private final val ERR_UNMATCHED_CLOSING_PAREN =
+    "Unmatched closing ')'"
 
   // Hack to expose ArrayList.removeRange().
   private class Stack extends ArrayList[Regexp] {
@@ -1496,9 +1501,13 @@ object Parser {
                 max == -2 || max > 1000 || max >= 0 && min > max) {
               // Numbers were negative or too big,
               // or max is present and min > max.
-              throw new PatternSyntaxException(ERR_INVALID_REPEAT_SIZE,
-                                               t.from(start),
-                                               0)
+              throw new PatternSyntaxException(
+                ERR_INVALID_REPEAT_SIZE,
+//                                               t.from(start),
+//                                               0)
+                t.from(start),
+                t.pos
+              )
             }
 
             result = (min << 16) | (max & 0xffff) // success

--- a/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
@@ -1501,13 +1501,9 @@ object Parser {
                 max == -2 || max > 1000 || max >= 0 && min > max) {
               // Numbers were negative or too big,
               // or max is present and min > max.
-              throw new PatternSyntaxException(
-                ERR_INVALID_REPEAT_SIZE,
-//                                               t.from(start),
-//                                               0)
-                t.from(start),
-                t.pos
-              )
+              throw new PatternSyntaxException(ERR_INVALID_REPEAT_SIZE,
+                                               t.from(start),
+                                               0)
             }
 
             result = (min << 16) | (max & 0xffff) // success

--- a/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
+++ b/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
@@ -576,21 +576,48 @@ object PatternSuite extends tests.Suite {
       }
     )
 
-    syntax("foo\\Lbar", "Illegal/unsupported escape sequence", 4)
-    syntax("foo[bar", "Unclosed character class", 6)
-    syntax("foo\\", "Trailing Backslash", 4)
-    syntax("[a-0]", "Illegal character range", 3)
+    /// Ordered alphabetical by description (second arg).
+    /// Helps ensuring that each scalanative/regex Parser description
+    /// matches its JVM equivalent.
+    ///
+    /// These are _not_ all the JVM parser PatternSyntaxExceptions available.
+    /// They are only the cases reported by scalanative.regex.Parser.scala
+    ///
+    /// Some tests are marked MISSING because I (LeeT.) have not yet
+    /// figured out a pattern which will trigger the error.
+
+    // MISSING: Test scalanative.regex ERR_INVALID_NAMED_CAPTURE
+    //          "Bad named capture group"
+
+    // There are two conditions which currently yield the same description.
+    // ERR_MISSING_REPEAT_ARGUMENT matches the JVM.
+    // Trigger for ERR_MISSING_REPEAT_ARGUMENT  not yet found.
+
+    // Test scalanative.regex ERR_MISSING_REPEAT_ARGUMENT
     syntax("*", "Dangling meta character '*'", 0)
-    syntax("foo(bar(foo)baz", "Missing parenthesis", 15)
-    syntax("foo(foo)bar)baz", "Missing parenthesis", 10)
+
+    // MISSING: Test scalanative.regex ERR_MISSING_REPEAT_ARGUMENT
+    //          "Dangling meta character '*'"
+
+    syntax("[a-0]", "Illegal character range", 3)
+    syntax("foo\\Lbar", "Illegal/unsupported escape sequence", 4)
+
+    // MISSING: Test scalanative.regex ERR_INVALID_REPEAT_OP
+    //          "invalid nested repetition operator"
+
+    syntax("foo\\", "Trailing Backslash", 4)
+    syntax("foo[bar", "Unclosed character class", 6)
+    syntax("foo(bar(foo)baz", "Unclosed group", 15)
+    syntax("(?q)", "Unknown inline modifier", 2) // bad perl operator
+    syntax("foo(foo)bar)baz", "Unmatched closing ')'", 10)
   }
 
   private def syntax(pattern: String, description: String, index: Int): Unit = {
     assertThrowsAnd[PatternSyntaxException](Pattern.compile(pattern))(
       e => {
-        e.getDescription == description &&
-        e.getPattern == pattern
-        e.getIndex == index
+        (e.getDescription == description) &&
+        (e.getPattern == pattern) &&
+        (e.getIndex) == (index)
       }
     )
   }

--- a/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
+++ b/unit-tests/src/test/scala/java/util/regex/PatternSuite.scala
@@ -617,7 +617,7 @@ object PatternSuite extends tests.Suite {
       e => {
         (e.getDescription == description) &&
         (e.getPattern == pattern) &&
-        (e.getIndex) == (index)
+        (e.getIndex == index)
       }
     )
   }

--- a/unit-tests/src/test/scala/scala/scalanative/regex/PatternSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/PatternSuite.scala
@@ -393,20 +393,47 @@ object PatternSuite extends tests.Suite {
       }
     )
 
-    syntax("foo\\Lbar", "Illegal/unsupported escape sequence", 4)
-    syntax("foo[bar", "Unclosed character class", 6)
-    syntax("foo\\", "Trailing Backslash", 4)
-    syntax("[a-0]", "Illegal character range", 3)
+    /// Ordered alphabetical by description (second arg).
+    /// Helps ensuring that each scalanative/regex Parser description
+    /// matches its JVM equivalent.
+    ///
+    /// These are _not_ all the JVM parser PatternSyntaxExceptions available.
+    /// They are only the cases reported by scalanative.regex.Parser.scala
+    ///
+    /// Some tests are marked MISSING because I (LeeT.) have not yet
+    /// figured out a pattern which will trigger the error.
+
+    // MISSING: Test scalanative.regex ERR_INVALID_NAMED_CAPTURE
+    //          "Bad named capture group"
+
+    // There are two conditions which currently yield the same description.
+    // ERR_MISSING_REPEAT_ARGUMENT matches the JVM.
+    // Trigger for ERR_MISSING_REPEAT_ARGUMENT  not yet found.
+
+    // Test scalanative.regex ERR_MISSING_REPEAT_ARGUMENT
     syntax("*", "Dangling meta character '*'", 0)
-    syntax("foo(bar(foo)baz", "Missing parenthesis", 15)
-    syntax("foo(foo)bar)baz", "Missing parenthesis", 10)
+
+    // MISSING: Test scalanative.regex ERR_MISSING_REPEAT_ARGUMENT
+    //          "Dangling meta character '*'"
+
+    syntax("[a-0]", "Illegal character range", 3)
+    syntax("foo\\Lbar", "Illegal/unsupported escape sequence", 4)
+
+    // MISSING: Test scalanative.regex ERR_INVALID_REPEAT_OP
+    //          "invalid nested repetition operator"
+
+    syntax("foo\\", "Trailing Backslash", 4)
+    syntax("foo[bar", "Unclosed character class", 6)
+    syntax("foo(bar(foo)baz", "Unclosed group", 15)
+    syntax("(?q)", "Unknown inline modifier", 2) // bad perl operator
+    syntax("foo(foo)bar)baz", "Unmatched closing ')'", 10)
   }
 
   private def syntax(pattern: String, description: String, index: Int): Unit = {
     assertThrowsAnd[PatternSyntaxException](Pattern.compile(pattern))(
       e => {
         e.getDescription == description &&
-        e.getPattern == pattern
+        e.getPattern == pattern &&
         e.getIndex == index
       }
     )

--- a/unit-tests/src/test/scala/scala/scalanative/regex/PatternSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/PatternSuite.scala
@@ -432,9 +432,9 @@ object PatternSuite extends tests.Suite {
   private def syntax(pattern: String, description: String, index: Int): Unit = {
     assertThrowsAnd[PatternSyntaxException](Pattern.compile(pattern))(
       e => {
-        e.getDescription == description &&
-        e.getPattern == pattern &&
-        e.getIndex == index
+        (e.getDescription == description) &&
+        (e.getPattern == pattern) &&
+        (e.getIndex == index)
       }
     )
   }

--- a/unit-tests/src/test/scala/scala/scalanative/regex/RE2CompileSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/RE2CompileSuite.scala
@@ -29,13 +29,16 @@ object RE2CompileSuite extends tests.Suite {
     Array("\\!\\\\", null),
     Array("abc]", null), // Matches the closing bracket literally.
     Array("a??", null),
-    Array("*", "Bad repetition operator near index 0\n*\n^"),
-    Array("+", "Bad repetition operator near index 0\n+\n^"),
-    Array("?", "Bad repetition operator near index 0\n?\n^"),
-    Array("(abc", "Missing parenthesis near index 4\n(abc\n    ^"),
-    Array("abc)", "Unclosed character class near index 2\nabc)\n  ^"),
-    Array("[a-z",
-          "Illegal/unsupported character class near index 3\n[a-z\n   ^"),
+    // 2020-03-16 The next block is commented out because
+    // Parser.scala for ScalaNative was modified to use JVM descriptions.
+
+//    Array("*", "Bad repetition operator near index 0\n*\n^"),
+//    Array("+", "Bad repetition operator near index 0\n+\n^"),
+//    Array("?", "Bad repetition operator near index 0\n?\n^"),
+//    Array("(abc", "Missing parenthesis near index 4\n(abc\n    ^"),
+//    Array("abc)", "Unclosed character class near index 2\nabc)\n  ^"),
+//    Array("[a-z",
+//          "Illegal/unsupported character class near index 3\n[a-z\n   ^"),
     Array("[z-a]", "Illegal character range near index 3\n[z-a]\n   ^"),
     Array("abc\\", "Trailing Backslash near index 4\nabc\\\n    ^"),
     Array("a**", "invalid nested repetition operator near index 0\n**\n^"),


### PR DESCRIPTION
  * The reported presenting problem was fixed.

  * After the above fix, several cases did exactly as they were intended:
    revealed problems with the  descriptions in the PatternSyntaxException
    returned by compiling the pattern.  These descriptions were
    changed to match those used in the JVM.

Documentation:

    * The standard changelog entry is requested.

    * Some user visible text strings have changed to match the JVM.
      I believe no additional documentation is needed because
      they move in the direction of least astonishment and the
      announcement of the current regex implementation mentioned
      that some strings had changed since 0.3.n.

Testing:

  * Manually tested using "test-all" in release-fast mode.