### PR TITLE
Simplify `AddCommandAlias` in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ addCommandAlias(
     "cleanCache",
     "cleanLocal",
     "dirty-rebuild"
-  ).mkString(";", ";", "")
+  ).mkString(";")
 )
 
 addCommandAlias(
@@ -55,7 +55,7 @@ addCommandAlias(
     "testRunner/publishLocal",
     "sbtScalaNative/publishLocal",
     "testInterface/publishLocal"
-  ).mkString(";", ";", "")
+  ).mkString(";")
 )
 
 addCommandAlias(
@@ -67,7 +67,7 @@ addCommandAlias(
     "nirparser/test",
     "sbtScalaNative/scripted",
     "tools/mimaReportBinaryIssues"
-  ).mkString(";", ";", "")
+  ).mkString(";")
 )
 
 addCommandAlias(
@@ -76,7 +76,7 @@ addCommandAlias(
     "tools/test",
     "nirparser/test",
     "tools/mimaReportBinaryIssues"
-  ).mkString(";", ";", "")
+  ).mkString(";")
 )
 
 addCommandAlias(
@@ -85,7 +85,7 @@ addCommandAlias(
     "sandbox/run",
     "tests/test",
     "sbtScalaNative/scripted"
-  ).mkString(";", ";", "")
+  ).mkString(";")
 )
 
 lazy val publishSnapshot =


### PR DESCRIPTION
- Leading semicolon is no more needed with in sbt 1.3+