### PR TITLE
Fix warning with musl libc due to wrong include

### DIFF
--- a/nativelib/src/main/resources/dirent.c
+++ b/nativelib/src/main/resources/dirent.c
@@ -1,7 +1,7 @@
 #include <dirent.h>
 #include <string.h>
 #include <stdio.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #define NAME_MAX 255
 


### PR DESCRIPTION
Source of the warning can be found [here](https://git.musl-libc.org/cgit/musl/tree/include/sys/errno.h?h=v1.2.0#n1)