### PR TITLE
Fix #1750: Build.sbt should automagically reload.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import scala.util.Try
 import scalanative.sbtplugin.ScalaNativePluginInternal._
 import scalanative.io.packageNameFromPath
 
+Global / onChangedBuildSource := ReloadOnSourceChanges
+
 val sbt10Version          = "1.1.6"
 val sbt10ScalaVersion     = "2.12.10"
 val libScalaVersion       = "2.11.12"


### PR DESCRIPTION
  * This PR was motivated by Issue #1750 "Build.sbt should automagically
    reload."

    The Scala Native build now uses a version of sbt (>= 1.3.8) which
    supports `ReloadOnSourceChanges` so the issue is now resolved in
    the manner recommended by sbt itself.

 *  I invite review.  The placement of the one line, two if you count
    blank lines, is open for discussion.  I picked what I thought was
    a reasonable place. I am more concerned with the reload concept
    saving development time than I am with the absolute location of the
    edit in the file.  If a reviewer can suggest a better place, I will
    move the line.

#### Documentation:

  * None needed, probably not even a Release Note.

    The changed file is internal to the Scala Native build itself.
    Any change visible to a developer using Scala Native artifacts
    is unintentional and a bug.

#### Testing:

##### Safety

  * Built ("rebuild")and tested ("test-all") in debug mode using sbt 1.3.10
    & Java 8 on X86_64 only . All tests pass. 

##### Efficacy

  * Manually tested:

    + clone the Scala Native project into a clean repository

    + Execute sbt and get to the prompt. Enter a carriage return.
      Sbt should quickly display the prompt.

    + In another window make an edit to build.sbt in the project root.
      This needs to be a real edit, adding or deleting a character, not
      just a touch.  Write out the change.

    + In the sbt window, enter a newline or valid sbt command.
      Sbt should reload, then execute the command, empty or full.
      Enter another newline or command and sbt should execute it
      immediately, without a reload.