### PR TITLE
Add `local.sbt` to gitignore, allowing custom configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _build/
 scripts/.coursier
 scripts/.scalafmt*
 sbt-crossproject/
+local.sbt
 
 CMakeLists.txt
 cmake-build-debug/


### PR DESCRIPTION
  * This PR was motivated by Issue #1750 "Build should have local option
    to automagically reload changed build files."

    The Scala Native build now uses a version of sbt (>= 1.3.8) which
    supports `ReloadOnSourceChanges` Individual developers
    can opt in to using the feature by creating a file called
    local.sbt in the project root containing at least the line:
    `Global / onChangedBuildSource := ReloadOnSourceChanges`.

    No file with the name `local.sbt` exists in the GitHub master
    repository for Scala Native, so the default is opt-out, same
    as previously.

    Developers who frequently work on the Scala Native plugin itself may not
    want to use `ReloadOnSourceChanges`.

    This approach is general for other site local customization.
    Developers should be aware that local customization will not be
    available in the official build environment. Tests and such
    might run locally but fail in Travis CI or on other systems.

#### Documentation:

  * None immediately. Someday a note should be added to the
    Contributor's Guide.

    The changed file is internal to the Scala Native build itself.
    Any change visible to a developer using Scala Native artifacts
    is unintentional and a bug.

#### Testing:

###### Safety
  * Built ("rebuild")and tested ("test-all") in debug mode using sbt 1.3.10
    & Java 8 on X86_64 only . All tests pass.

###### Efficacy
  * Manually tested:

    + Clone the Scala Native project into a clean repository.

    + sbt should not be running.

    + Create a local.sbt file in the project root containing the
      line 'Global / onChangedBuildSource := ReloadOnSourceChanges'.

    + "git status" should not show local.sbt, neither as tracked nor
       untracked.

    + Start sbt.

    + In another window make an edit to build.sbt in the project root.
      This needs to be a real edit, adding or deleting a character, not
      just a touch.  Write out the change.

    + In the sbt window, enter a newline or valid sbt command.
      Sbt should reload, then execute the command, empty or full.
      Enter another newline or command and sbt should execute it
      immediately, without a reload.
