### PR TITLE
Throwables: Use nameMax variable instead of literal

### DIFF
--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -14,7 +14,7 @@ private[lang] object StackTrace {
     val name    = stackalloc[CChar](nameMax)
     val offset  = stackalloc[scala.Byte](8)
 
-    unwind.get_proc_name(cursor, name, 1024, offset)
+    unwind.get_proc_name(cursor, name, nameMax, offset)
 
     // Make sure the name is definitely 0-terminated.
     // Unmangler is going to use strlen on this name and it's


### PR DESCRIPTION
Not using `nameMax` is most likely just an oversight from https://github.com/scala-native/scala-native/pull/1688
/cc @LeeTibbert
