### PR TITLE
Avoid defining NDEBUG if it's already defined

### DIFF
--- a/nativelib/src/main/resources/gc/commix/Log.h
+++ b/nativelib/src/main/resources/gc/commix/Log.h
@@ -2,8 +2,12 @@
 #define IMMIX_LOG_H
 
 #ifndef DEBUG_ASSERT
+
+#ifndef NDEBUG
 #define NDEBUG
-#endif
+#endif // NDEBUG
+
+#endif // DEBUG_ASSERT
 
 #include <assert.h>
 #include <inttypes.h>

--- a/nativelib/src/main/resources/gc/immix/Log.h
+++ b/nativelib/src/main/resources/gc/immix/Log.h
@@ -1,7 +1,10 @@
 #ifndef IMMIX_LOG_H
 #define IMMIX_LOG_H
 
+#ifndef NDEBUG
 #define NDEBUG
+#endif // NDEBUG
+
 #include <assert.h>
 
 //#define DEBUG_PRINT


### PR DESCRIPTION
I got warnings compiling a Scala Native executable with Zig CC clang frontend.
It already defined the `NDEBUG` variable.
Since it's a commonly used name we should check if the compiler has already defined it.