### PR TITLE
Fix #1792: Close the Git object after cloning the scalalib sources.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -470,6 +470,7 @@ lazy val scalalib =
             .setDirectory(trgDir)
             .setURI(scalaRepo)
             .call()
+            .close()
         }
 
         // Checkout proper ref. We do this anyway so we fail if


### PR DESCRIPTION
  * This PR was motivated by Issue #1792 "build.sbt scalalib compile
    should close Git object after clone"

    That issue is now fixed.

   * I have not seen the issue in the wild, but easier to fix it and
     let it take its place in the queue awaiting the fullness of time
     than to remember the fix.

Documentation:

  * Internal interface, I believe no documentation is necessary.

Testing:

  * Tested for safety only. Did not check efficacy. Complying with
    the jgit API documentation is worthwhile even if no current defect
    is visible.

  * Built and tested ("test-all") in debug mode using sbt 1.3.10 & Java 8 on
    X86_64 only . All tests pass.

  * Future developers should be aware of a non-obvious requirement.
    + The easiest way to setup for testing is to do a fresh clone of the
      SN master directory. scalalib/target/scalaSources will not exist
      in this case, good.

    + If not doing a fresh clone, sbt "scalalib / clean" will do the
      necessary delete of scalalib/target/scalaSources.  This is probably
      easier to remember than figuring out the necessary directory
      (scalalib/target/scalaSources) and doing a manual delete (rm -r).