### PR TITLE
Fix #1782: Port ScalaSources unpacking from Scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -451,25 +451,22 @@ lazy val scalalib =
     )
     .settings(mavenPublishSettings)
     .settings(
-      // code to fetch scala sources adapted, with gratitude, from
-      // Scala.js Build.scala, lines 1125 to 1233, at the suggestion of
-      // @sjrd.
+      // Code to fetch scala sources adapted, with gratitude, from
+      // Scala.js Build.scala at the suggestion of @sjrd.
+      // https://github.com/scala-js/scala-js/blob/\
+      //    1761f94ee31902b61c579d5cb121117c9dc08295/\
+      //    project/Build.scala#L1125-L1233
       //
-      // By intent, the content is intended to be as similar as feasible.
-      // The forced differences are:
-      //   1) Scala Native build.sbt uses a slightly different baseDirectory
-      //      than Scala.js. See commented starting with "SN Port:" below.
-      //      This is the only intended change with meaning between the two.
-      //   2) This file is sbt, Scala.js uses a .scala file. Trailing commas
-      //      may differ.
-      //   3) The project scalafmt configuration differs between Scala Native
-      //      and the Scala.js so there are annoying but not meaningful
-      //      format differences.
+      // By intent, the Scala Native code below is as identical as feasible.
+      // Scala Native build.sbt uses a slightly different baseDirectory
+      // than Scala.js. See commented starting with "SN Port:" below.
       libraryDependencies +=
         "org.scala-lang" % "scala-library" % scalaVersion.value classifier "sources",
       artifactPath in fetchScalaSource :=
         target.value / "scalaSources" / scalaVersion.value,
-      /* Work around for #2649. We would like to always use `update`, but
+      // Scala.js original comment modified to clarify issue is Scala.js.
+      /* Work around for https://github.com/scala-js/scala-js/issues/2649
+       * We would like to always use `update`, but
        * that fails if the scalaVersion we're looking for happens to be the
        * version of Scala used by sbt itself. This is clearly a bug in sbt,
        * which we work around here by using `updateClassifiers` instead in

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import java.io.File.pathSeparator
 
+import scala.collection.mutable
 import scala.util.Try
 
 val sbt10Version          = "1.1.6" // minimum version
@@ -358,7 +359,7 @@ lazy val nativelib =
     .settings(mavenPublishSettings)
     .settings(
       libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      publishLocal := publishLocal
+      update := update
         .dependsOn(nscplugin / publishLocal)
         .value
     )
@@ -419,8 +420,8 @@ lazy val javalib =
     )
     .dependsOn(nativelib, posixlib)
 
-lazy val assembleScalaLibrary = taskKey[Unit](
-  "Checks out scala standard library from submodules/scala and then applies overrides.")
+val fetchScalaSource =
+  taskKey[File]("Fetches the scala source for the current scala version")
 
 lazy val auxlib =
   project
@@ -450,52 +451,130 @@ lazy val scalalib =
     )
     .settings(mavenPublishSettings)
     .settings(
-      assembleScalaLibrary := {
-        import org.eclipse.jgit.api._
+      // code to fetch scala sources adapted, with gratitude, from
+      // Scala.js Build.scala, lines 1125 to 1233, at the suggestion of
+      // @sjrd.
+      //
+      // By intent, the content is intended to be as similar as feasible.
+      // The forced differences are:
+      //   1) Scala Native build.sbt uses a slightly different baseDirectory
+      //      than Scala.js. See commented starting with "SN Port:" below.
+      //      This is the only intended change with meaning between the two.
+      //   2) This file is sbt, Scala.js uses a .scala file. Trailing commas
+      //      may differ.
+      //   3) The project scalafmt configuration differs between Scala Native
+      //      and the Scala.js so there are annoying but not meaningful
+      //      format differences.
+      libraryDependencies +=
+        "org.scala-lang" % "scala-library" % scalaVersion.value classifier "sources",
+      artifactPath in fetchScalaSource :=
+        target.value / "scalaSources" / scalaVersion.value,
+      /* Work around for #2649. We would like to always use `update`, but
+       * that fails if the scalaVersion we're looking for happens to be the
+       * version of Scala used by sbt itself. This is clearly a bug in sbt,
+       * which we work around here by using `updateClassifiers` instead in
+       * that case.
+       */
+      update in fetchScalaSource := Def.taskDyn {
+        if (scalaVersion.value == scala.util.Properties.versionNumberString)
+          updateClassifiers
+        else
+          update
+      }.value,
+      fetchScalaSource := {
+        val s        = streams.value
+        val cacheDir = s.cacheDirectory
+        val ver      = scalaVersion.value
+        val trgDir   = (artifactPath in fetchScalaSource).value
 
-        val s      = streams.value
-        val trgDir = target.value / "scalaSources" / scalaVersion.value
-        val scalaRepo = sys.env.getOrElse("SCALANATIVE_SCALAREPO",
-                                          "https://github.com/scala/scala.git")
+        val report = (update in fetchScalaSource).value
+        val scalaLibSourcesJar = report
+          .select(configuration = configurationFilter("compile"),
+                  module = moduleFilter(name = "scala-library"),
+                  artifact = artifactFilter(classifier = "sources"))
+          .headOption
+          .getOrElse {
+            throw new Exception(
+              s"Could not fetch scala-library sources for version $ver")
+          }
 
-        if (!trgDir.exists) {
-          s.log.info(
-            s"Fetching Scala source version ${scalaVersion.value} from $scalaRepo")
+        FileFunction.cached(cacheDir / s"fetchScalaSource-$ver",
+                            FilesInfo.lastModified,
+                            FilesInfo.exists) { dependencies =>
+          s.log.info(s"Unpacking Scala library sources to $trgDir...")
 
-          // Make parent dirs and stuff
+          if (trgDir.exists)
+            IO.delete(trgDir)
           IO.createDirectory(trgDir)
+          IO.unzip(scalaLibSourcesJar, trgDir)
+        }(Set(scalaLibSourcesJar))
 
-          // Clone scala source code
-          new CloneCommand()
-            .setDirectory(trgDir)
-            .setURI(scalaRepo)
-            .call()
-            .close()
+        trgDir
+      },
+      unmanagedSourceDirectories in Compile := {
+        // Calculates all prefixes of the current Scala version
+        // (including the empty prefix) to construct override
+        // directories like the following:
+        // - override-2.13.0-RC1
+        // - override-2.13.0
+        // - override-2.13
+        // - override-2
+        // - override
+
+        val ver = scalaVersion.value
+
+        // SN Port: sjs uses baseDirectory.value.getParentFile here.
+        val base  = baseDirectory.value
+        val parts = ver.split(Array('.', '-'))
+        val verList = parts.inits.map { ps =>
+          val len = ps.mkString(".").length
+          // re-read version, since we lost '.' and '-'
+          ver.substring(0, len)
+        }
+        def dirStr(v: String) =
+          if (v.isEmpty) "overrides" else s"overrides-$v"
+        val dirs = verList.map(base / dirStr(_)).filter(_.exists)
+        dirs.toSeq // most specific shadow less specific
+      },
+      // Compute sources
+      // Files in earlier src dirs shadow files in later dirs
+      sources in Compile := {
+        // Sources coming from the sources of Scala
+        val scalaSrcDir = fetchScalaSource.value
+
+        // All source directories (overrides shadow scalaSrcDir)
+        val sourceDirectories =
+          (unmanagedSourceDirectories in Compile).value :+ scalaSrcDir
+
+        // Filter sources with overrides
+        def normPath(f: File): String =
+          f.getPath.replace(java.io.File.separator, "/")
+
+        val sources = mutable.ListBuffer.empty[File]
+        val paths   = mutable.Set.empty[String]
+
+        val s = streams.value
+
+        for {
+          srcDir <- sourceDirectories
+          normSrcDir = normPath(srcDir)
+          src <- (srcDir ** "*.scala").get
+        } {
+          val normSrc = normPath(src)
+          val path    = normSrc.substring(normSrcDir.length)
+          val useless =
+            path.contains("/scala/collection/parallel/") ||
+              path.contains("/scala/util/parsing/")
+          if (!useless) {
+            if (paths.add(path))
+              sources += src
+            else
+              s.log.debug(s"not including $src")
+          }
         }
 
-        // Checkout proper ref. We do this anyway so we fail if
-        // something is wrong
-        val git = Git.open(trgDir)
-        s.log.info(s"Checking out Scala source version ${scalaVersion.value}")
-        git.checkout().setName(s"v${scalaVersion.value}").call()
-
-        IO.delete(file("scalalib/src/main/scala"))
-        IO.copyDirectory(trgDir / "src" / "library" / "scala",
-                         file("scalalib/src/main/scala/scala"))
-
-        val epoch :: major :: _ = scalaVersion.value.split("\\.").toList
-        IO.copyDirectory(file(s"scalalib/overrides-$epoch.$major/scala"),
-                         file("scalalib/src/main/scala/scala"),
-                         overwrite = true)
-
-        // Remove all java code, as it's not going to be available
-        // in the NIR anyway. This also resolves issues wrt overrides
-        // of code that was previously in Java but is in Scala now.
-        (file("scalalib/src/main/scala") ** "*.java").get.foreach(IO.delete)
+        sources.result()
       },
-      Compile / compile := (Compile / compile)
-        .dependsOn(assembleScalaLibrary)
-        .value,
       // Don't include classfiles for scalalib in the packaged jar.
       Compile / packageBin / mappings := {
         val previous = (Compile / packageBin / mappings).value
@@ -505,7 +584,7 @@ lazy val scalalib =
         }
       },
       publishLocal := publishLocal
-        .dependsOn(assembleScalaLibrary, auxlib / publishLocal)
+        .dependsOn(auxlib / publishLocal)
         .value
     )
     .dependsOn(auxlib, nativelib, javalib)
@@ -577,10 +656,10 @@ lazy val testingCompiler =
 
 lazy val testInterface =
   project
+    .in(file("test-interface"))
     .settings(toolSettings)
     .settings(scalaVersion := libScalaVersion)
     .settings(mavenPublishSettings)
-    .in(file("test-interface"))
     .settings(
       libraryDependencies += "org.scala-sbt"    % "test-interface"   % "1.0",
       libraryDependencies -= "org.scala-native" %%% "test-interface" % version.value % Test,
@@ -593,10 +672,10 @@ lazy val testInterface =
 
 lazy val testInterfaceSerialization =
   project
+    .in(file("test-interface-serialization"))
     .settings(toolSettings)
     .settings(scalaVersion := libScalaVersion)
     .settings(mavenPublishSettings)
-    .in(file("test-interface-serialization"))
     .settings(
       libraryDependencies -= "org.scala-native" %%% "test-interface" % version.value % Test,
       publishLocal := publishLocal
@@ -608,10 +687,10 @@ lazy val testInterfaceSerialization =
 
 lazy val testInterfaceSbtDefs =
   project
+    .in(file("test-interface-sbt-defs"))
     .settings(toolSettings)
     .settings(scalaVersion := libScalaVersion)
     .settings(mavenPublishSettings)
-    .in(file("test-interface-sbt-defs"))
     .settings(
       libraryDependencies -= "org.scala-native" %%% "test-interface" % version.value % Test
     )
@@ -619,9 +698,9 @@ lazy val testInterfaceSbtDefs =
 
 lazy val testRunner =
   project
+    .in(file("test-runner"))
     .settings(toolSettings)
     .settings(mavenPublishSettings)
-    .in(file("test-runner"))
     .settings(
       crossScalaVersions := Seq(sbt10ScalaVersion),
       libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0",

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -11,9 +11,9 @@ Compile / unmanagedSourceDirectories ++= {
   ).map(dir => root / s"$dir/src/main/scala")
 }
 
-libraryDependencies ++= Seq(
-  "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "5.5.1.201910021850-r"
-)
+// libraryDependencies ++= Seq(
+//   "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "5.5.1.201910021850-r"
+//)
 
 addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-dirty-money"   % "0.2.0")

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -11,10 +11,6 @@ Compile / unmanagedSourceDirectories ++= {
   ).map(dir => root / s"$dir/src/main/scala")
 }
 
-// libraryDependencies ++= Seq(
-//   "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "5.5.1.201910021850-r"
-//)
-
 addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-dirty-money"   % "0.2.0")
 addSbtPlugin("org.foundweekends"  % "sbt-bintray"       % "0.5.4")


### PR DESCRIPTION
  * This PR was motivated by Issue #1782 "Port ScalaSources
    unpacking from Scala.js" The original issue was from @hepin1989.
    In the issue, @sjrd recommended that the code to fetch
    scala sources be adopted & ported from Scala.js.

    That issue is now fixed.

   * @hepin1989 and I have worked on this issue together and, if Kerr agrees, should
     be considered co-authors.  The Issue contains most of that dialog.  
    All bugs introduced belong to me.

   * The port is almost one for one.  There was one small issue
     which I documented in the code about the relative location
     of the overrides directory or directories: the two projects
     differ by one level. There are some slight differences with
     trailing commas: SN uses a build.sbt, Scala.js uses a Build.scala.
     There are also some annoying scalafmt differences.

   * Besides the massive speed up, there is one small change to
     a seldom used Task available at the sbt prompt. SN code prior
     to this PR used `assembleScalaLibrary`. Scala.js and this PR
     use `fetchScalaSource`. I have an open question in the SN gitter
     to see if anybody objects to this change. I doubt it, but worth
     asking.

   * Because I was concerned about shadowing current scala sources with
     possibly obsolete and/or buggy code in `scalalib/overrides-2.11`
     I did a spot check of the code in that tree.

     The current PR leaves that tree exactly as previously, bug for bug
     compatible. If I remove the override-2.11 tree, I can build but
     test-all fails with the link being unable to resolve some
     javalib symbols, probably Java 8 things.  In my spot checking,
     the override edits seemed to be mostly adding @inline. There
     were, however, some places where the override code did not have
     things available in scala 2.11.12.  That will be a surprise for
     someone and hard to track down.  A problem for another day.

   * The first attempts to make the change of this PR ran aground
     with a missing dependency on nscplugin. I edited nativelib,
     which is the bottom dependency, to ensure that the required
     nscplugin is built before nativelib is built.  This allows
     nativelib and projects which depend upon it to build cleanly
     the first time after a root project is created or the first time
     after caches are cleaned.
   
   * I removed the now unnecessary dependency on jgit.

   * I also moved several `.in(file("foo"))` lines so that the file is consistent;
 ``` 
project
    .in(file("foo"))
```
    Not an essential change, but worthwhile.

#### Documentation:

  * Internal interface, I believe no documentation is necessary.

#### Testing:

######  Safety

  * Built and tested ("test-all") in debug mode using sbt 1.3.10 & Java 8 on
    X86_64 only . All tests pass.

###### Efficacy

  * Visual observation.  Previously the retrieval of the scala sources
    took approximately 60 seconds on my machine.  Now it is practically
    instantaneous.