### PR TITLE
Build.sbt: restore nativelib / publishLocal handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -359,7 +359,7 @@ lazy val nativelib =
     .settings(mavenPublishSettings)
     .settings(
       libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      update := update
+      publishLocal := publishLocal
         .dependsOn(nscplugin / publishLocal)
         .value
     )


### PR DESCRIPTION
  * This PR reverts  a change introduced in PR #1799 which caused concern and discussion
     in the community.

    The purpose of PR #1799 was to adopt the proven Scala.js
    way of fetching Scala sources in order to speed up the fetch,
    especially over slow communications links.

    That PR accomplished its main goal. It also revealed a disharmony
    in the build.sbt dependency chain when one is using a -SNAPSHOT
    version and does a command such as "scalalib / compile" from a
    clean, perhaps newly created, Repository, with a clean local cache.
    The required nscplugin is not found in update, because it is not
    there in the described situation.  The initial total "rebuild"
    recommended in the Contributor's Guide works.

  * I can not convince myself that the change to the "nativelib"
    update and publishLocal handling did not introduce a defect
    which increases the build time. Something did, and I want to be
    innocent.  More importantly, I can not convince the community
    that I did not introduce a bug.  Hence, this PR reverts that
    small change and leaves the major intent of PR #1799 in place.

  * I think it to the better benefit to spend what time I can create for
    it understanding sjrd's suggestion to look at how the Scala.js
    build handles its dependency complexities.

  * To the best of my knowledge & intent, this PR does not introduce
    any unwarranted behavior: it restores prior long standing behavior.
    The "build from the egg without a full rebuild or local nscplugin"
    case gives a correct but unhelpful message. The lessor disharmony.

    It also does not fix the recent increase in build time, it merely
    gives me an alibi.

Documentation:

  * The affected file are all internal to the Scala Native build itself.
    This change restores the dependency chain as prior to PR #1799.

Testing:

  * Built ("rebuild")and tested ("test-all") in debug mode using sbt 1.3.7
    & Java 8 on X86_64 only . All tests pass. grep "\[warn\]" of the logfile
    reports zero occurrences.