### PR TITLE
Build.sbt: restore consistent sbt slash scope specification.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -462,7 +462,7 @@ lazy val scalalib =
       // than Scala.js. See commented starting with "SN Port:" below.
       libraryDependencies +=
         "org.scala-lang" % "scala-library" % scalaVersion.value classifier "sources",
-      artifactPath in fetchScalaSource :=
+      fetchScalaSource / artifactPath :=
         target.value / "scalaSources" / scalaVersion.value,
       // Scala.js original comment modified to clarify issue is Scala.js.
       /* Work around for https://github.com/scala-js/scala-js/issues/2649
@@ -472,7 +472,7 @@ lazy val scalalib =
        * which we work around here by using `updateClassifiers` instead in
        * that case.
        */
-      update in fetchScalaSource := Def.taskDyn {
+      fetchScalaSource / update := Def.taskDyn {
         if (scalaVersion.value == scala.util.Properties.versionNumberString)
           updateClassifiers
         else
@@ -482,9 +482,9 @@ lazy val scalalib =
         val s        = streams.value
         val cacheDir = s.cacheDirectory
         val ver      = scalaVersion.value
-        val trgDir   = (artifactPath in fetchScalaSource).value
+        val trgDir   = (fetchScalaSource / artifactPath).value
 
-        val report = (update in fetchScalaSource).value
+        val report = (fetchScalaSource / update).value
         val scalaLibSourcesJar = report
           .select(configuration = configurationFilter("compile"),
                   module = moduleFilter(name = "scala-library"),
@@ -508,7 +508,7 @@ lazy val scalalib =
 
         trgDir
       },
-      unmanagedSourceDirectories in Compile := {
+      Compile / unmanagedSourceDirectories := {
         // Calculates all prefixes of the current Scala version
         // (including the empty prefix) to construct override
         // directories like the following:
@@ -535,13 +535,13 @@ lazy val scalalib =
       },
       // Compute sources
       // Files in earlier src dirs shadow files in later dirs
-      sources in Compile := {
+      Compile / sources := {
         // Sources coming from the sources of Scala
         val scalaSrcDir = fetchScalaSource.value
 
         // All source directories (overrides shadow scalaSrcDir)
         val sourceDirectories =
-          (unmanagedSourceDirectories in Compile).value :+ scalaSrcDir
+          (Compile / unmanagedSourceDirectories).value :+ scalaSrcDir
 
         // Filter sources with overrides
         def normPath(f: File): String =


### PR DESCRIPTION
  * Ekrich noted in his review of PR #1804 that in adhering to a strict
    port from Scala.js, PR #1799 had introduced old style sbt scope
    specification (i.e. "artifact in fetchScalaScope") where the rest
    of build.sbt had been painstakingly crafted to use the current
    style (i.e. "fetchScalaScope / artifact").

    This PR should introduce no semantic change but fulfills my
    promise to Ekrich to restore consistent style.

    Thank you Ekrich for your careful review and not letting me
    disturb established practice.

  * Enquiring minds could properly ask: Is this PR a candidate to be
    ported back to Scala.js.  A quick study of Scala.js project/Build.scala
    indicates that it consistently uses the old style, so the answer is:
    "Good question. The data indicate no back port needed."

Documentation:

  * The affected file are all internal to the Scala Native build itself.
    This change restores the dependency chain as prior to PR #1799.

Testing:

  * Built ("rebuild")and tested ("test-all") in debug mode using sbt 1.3.10
    & Java 8 on X86_64 only .