### PR TITLE
testinterface: specify reduced backlog for ServerSocket

### DIFF
--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
@@ -35,7 +35,7 @@ class ComRunner(bin: File,
   private[this] var serverSocket: ServerSocket = _
   private[this] val socket =
     try {
-      serverSocket = new ServerSocket(0)
+      serverSocket = new ServerSocket(0, 1)
 
       runner.start()
 

--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
@@ -35,7 +35,7 @@ class ComRunner(bin: File,
   private[this] var serverSocket: ServerSocket = _
   private[this] val socket =
     try {
-      serverSocket = new ServerSocket(0, 1)
+      serverSocket = new ServerSocket( /* port = */ 0, /* backlog = */ 1)
 
       runner.start()
 


### PR DESCRIPTION
  * Issue #1585 described a number of opportunities to improve
    the SN testinterface.  A number of these changes are in the
    same file: ComRunner.scala.  I believe that review & merge
    will be easier if the changes are submitted as a series of PRs.

  * This PR fixes a small, easily identifiable change, suitable to
    the small amount of time I had available. If the backlog
    parameter (number of possible/expected inbound connections) is
    not specified when the ServerSocket is instantiated, it defaults
    to 50.  It is clear that only one inbound connection is ever
    expected.  Specifying that expectation reduces the amount of
    resources used at that point, and quickly freed.

    This is not the biggest, nor most important improvement but it
    is the direction of progress and reduces cognitive overhead
    whilst the dreaded "EOF handshake" nest of bugs is addressed.

#### Documentation:

  * The affected file is internal to the Scala Native build itself.
    No documentation change needed.

#### Testing:

###### Safety
  * Built ("rebuild")and tested ("test-all") in debug mode using sbt 1.3.10
    & Java 8 on X86_64 only . All tests pass.
###### Efficacy
  * No cost effective way to test for efficacy.