### PR TITLE
Redesign the build to use dependsOn instead of publishLocal.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - java -version
   - if [ "$MODE" == "source-checks" ]; then ./scripts/source-checks; fi
   - if [ "$MODE" == "test-tools" ]; then
-      sbt "-no-colors" "-J-Xmx3G" nscplugin/publishLocal sbtScalaNative/publishLocal test-tools;
+      sbt "-no-colors" "-J-Xmx3G" test-tools;
     fi
   - if [ "$MODE" == "test-runtime" ]; then
       ./ci-docker/load-cached-images.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ def job(String OS, List<String> GCs) {
 
             advance("Building", OS) {
                 retry(2) {
-                    sh "sbt -Dsbt.ivy.home=$ivyHome -J-Xmx3G rebuild"
+                    sh "sbt -Dsbt.ivy.home=$ivyHome -J-Xmx3G scalalib/package"
                 }
             }
 

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -47,4 +47,4 @@ USER scala-native
 
 WORKDIR /home/scala-native/scala-native
 
-CMD sbt -no-colors -J-Xmx3G rebuild "set scriptedBufferLog in sbtScalaNative := false" "$TEST_COMMAND"
+CMD sbt -no-colors -J-Xmx3G "set scriptedBufferLog in sbtScalaNative := false" "$TEST_COMMAND"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM nixos/nix
- 
+
 RUN nix-channel --update
 
 RUN nix-env -i git
@@ -7,13 +7,13 @@ RUN nix-env -i git
 WORKDIR /tmp
 
 RUN git clone https://github.com/scala-native/scala-native.git native
-  
+
 WORKDIR /tmp/native
 
 RUN  nix-shell scripts/scala-native.nix -A clangEnv --run "echo 'clangEnv installed'"
 
 RUN  nix-shell scripts/scala-native.nix -A clangEnv --run "cd .. && sbt scalaVersion"
 
-RUN  nix-shell scripts/scala-native.nix -A clangEnv --run "sbt rebuild"
+RUN  nix-shell scripts/scala-native.nix -A clangEnv --run "sbt scalalib/package"
 
 CMD ["/bin/bash"]

--- a/docs/contrib/compiler.rst
+++ b/docs/contrib/compiler.rst
@@ -30,19 +30,17 @@ To compile the sandbox project run the following in the sbt shell::
 
     sbt> sandbox/clean;sandbox/nativeLink
 
-If the example code for the new intrinsic requires you to change APIs in ``nativelib``,
-then remember to also publish the changes with ``nativelib/publishLocal``.
-
 After compiling the sandbox project you can inspect the ``.ll`` files inside
 ``sandbox/target/scala-<version>/ll``. The files are grouped by the package name.
 By default the ``Test.scala`` file doesn't define a package, so the resulting file
 will be ``__empty.ll``. Locating the code you are interested in might require that
 you get more familiar with the `LLVM assembly language <http://llvm.org/docs/LangRef.html>`_.
 
-When working on the compile plugin you'll need to publish it and reload each time
-you want to recompile the sandbox project. This can be achieved with::
+When working on the compiler plugin you'll need to clean the sandbox (or other
+Scala Native projects) if you want it to be recompiled with the newer version
+of the compiler plugin. This can be achieved with::
 
-    sbt> nscplugin/publishLocal;reload;sandbox/clean;sandbox/run
+    sbt> sandbox/clean;sandbox/run
 
 Certain intrinsics might require adding new primitives to the compiler plugin.
 This can be done in ``NirPrimitives`` with an accompanying definition in

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -1,0 +1,22 @@
+package build
+
+import sbt._
+import sbt.Keys._
+
+import scala.scalanative.sbtplugin.ScalaNativePlugin
+import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
+
+object MyScalaNativePlugin extends AutoPlugin {
+  override def requires: Plugins = ScalaNativePlugin
+
+  override def projectSettings: Seq[Setting[_]] = Def.settings(
+    /* Remove libraryDependencies on ourselves; we use .dependsOn() instead
+     * inside this build.
+     */
+    libraryDependencies ~= { libDeps =>
+      libDeps.filterNot(_.organization == "org.scala-native")
+    },
+    nativeCheck := true,
+    nativeDump := true
+  )
+}

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -12,7 +12,6 @@ Compile / unmanagedSourceDirectories ++= {
 }
 
 addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
-addSbtPlugin("com.eed3si9n"       % "sbt-dirty-money"   % "0.2.0")
 addSbtPlugin("org.foundweekends"  % "sbt-bintray"       % "0.5.4")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"           % "2.0.0")
 addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"   % "0.6.1")

--- a/scripts/release
+++ b/scripts/release
@@ -2,7 +2,7 @@
 
 set -ex
 
-sbt rebuild test-all
+sbt test-all
 sbt "tools/mimaReportBinaryIssues"
 sbt \
     nativelib/publishSigned \

--- a/testing-compiler/src/main/scala/scalanative/compiler/NIRCompiler.scala
+++ b/testing-compiler/src/main/scala/scalanative/compiler/NIRCompiler.scala
@@ -91,8 +91,7 @@ class NIRCompiler(outputDir: Path) extends api.NIRCompiler {
   private case object ScalaNative
       extends CompilerPlugin(jarPath = sys props "scalanative.nscplugin.jar",
                              classpath = List(
-                               sys props "scalanative.testingcompiler.cp",
-                               sys props "scalanative.nscplugin.jar"))
+                               sys props "scalanative.nativeruntime.cp"))
 
   /**
    * Returns an instance of `Global` configured according to the given options.

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -17,16 +17,16 @@ object Build {
    *
    *  {{{
    *  val classpath: Seq[Path] = ...
+   *  val nativelib: Path      = ...
    *  val workdir: Path        = ...
    *  val main: String         = ...
    *
-   *  val clang     = Discover.clang()
-   *  val clangpp   = Discover.clangpp()
-   *  val linkopts  = Discover.linkingOptions()
-   *  val compopts  = Discover.compileOptions()
-   *  val triple    = Discover.targetTriple(clang, workdir)
-   *  val nativelib = Discover.nativelib(classpath).get
-   *  val outpath   = workdir.resolve("out")
+   *  val clang    = Discover.clang()
+   *  val clangpp  = Discover.clangpp()
+   *  val linkopts = Discover.linkingOptions()
+   *  val compopts = Discover.compileOptions()
+   *  val triple   = Discover.targetTriple(clang, workdir)
+   *  val outpath  = workdir.resolve("out")
    *
    *  val config =
    *    Config.empty

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -20,13 +20,6 @@ object Discover {
   def LTO(): String =
     getenv("SCALANATIVE_LTO").getOrElse("none")
 
-  /** Find nativelib jar on the classpath. */
-  def nativelib(classpath: Seq[Path]): Option[Path] =
-    classpath.find { path =>
-      val absolute = path.toAbsolutePath.toString
-      absolute.contains("scala-native") && absolute.contains("nativelib")
-    }
-
   /** Find the newest compatible clang binary. */
   def clang(): Path = {
     val path = discover("clang", clangVersions)


### PR DESCRIPTION
Previously, the build made heavy use of `publishLocal` to build and publish its artifacts, which were then used by other artifacts with `libraryDependencies`. This caused a lot of time spent in rebuilding and republishing artifacts all the time, and required the use of a special `rebuild` command to clean things up.

In this commit, we turn all those implicit dependencies into actual internal dependencies, using `dependsOn`. This allows sbt to correctly track internal dependencies itself, and rebuild when needed.

The only tricky aspects is that some artifacts must absolutely be exposed in their .jar form to the rest of the build:

* the compiler plugin, because scalac can only load compiler plugins from jars
* `nativelib`, because the linker assumes that it is a jar (it opens it to extract native C code from it)
* some other core libraries, because they manipulate their `products` (e.g., removing generated .class files)

We simply use `exportJars := true` to enforce that.

In order to cancel the `libraryDependencies` added by the `ScalaNativePlugin` on the artifacts built in the build itself, we create a custom `MyScalaNativePlugin` on top of it, which removes them. Instead of relying on those automatic `libraryDependencies`, we must explicitly tell all the required dependencies (and only those) as `dependsOn` clauses.

---

The above changes mean that most sbt commands, like `tests/test`, will not test the artifacts in their published form anymore. Instead, they will test the jars produced within the build. The published artifact are still tested through the scripted tests of the sbt plugin, so we are not losing any test coverage in the process.

---

In the process, we cleaned up several stale or dubious internal dependencies. This eventually led to rethink what classpaths are passed down to the `tools/test` task, so that was cleaned up as well.

---

The `rebuild` command is not necessary anymore. `clean` should be used instead.

The `dirty-rebuild` command is not necessary anymore. Simply do *nothing* instead.

The `cleanCache` and `cleanLocal` commands, provided by sbt-dirty-money, and which used to be used by `rebuild`, are not necessary anymore either. Therefore, we have completely removed sbt-dirty-money. If a developer still wants to use these commands for their own purposes, they can globally install sbt-dirty-money, as suggested in their readme.