### PR TITLE
WIP: Have testinterface give a better message when SN binary abends.

### DIFF
--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
@@ -102,10 +102,14 @@ class ComRunner(bin: File,
       }
     }
 
+  private[this] var runnerIsClosed = false
+  def isClosed                     = runnerIsClosed
+
   def close(): Unit = {
     in.close()
     out.close()
     socket.close()
+    runnerIsClosed = true
   }
 
   private def log(message: Log): Unit =
@@ -121,5 +125,4 @@ class ComRunner(bin: File,
         }
       case Level.Debug => logger.debug(message.message)
     }
-
 }

--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ScalaNativeRunner.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ScalaNativeRunner.scala
@@ -51,9 +51,17 @@ class ScalaNativeRunner(val framework: ScalaNativeFramework,
   }
 
   override def done(): String = {
-    send(Command.RunnerDone(""))
-    val Command.RunnerDone(summary) = receive()
-    master.close()
-    summary
+// 2020-05-22 LeeT - note to reviewers, not for final PR.
+// this.ensureNotDone has its own set of problems, so do not use it here.
+
+    if (master.isClosed) {
+      throw new IllegalStateException(
+        "Premature end of ComRunner, not all tests may have been run.")
+    } else {
+      send(Command.RunnerDone(""))
+      val Command.RunnerDone(summary) = receive()
+      master.close()
+      summary
+    }
   }
 }

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
@@ -35,6 +35,12 @@ object CStringSuite extends tests.Suite {
     assertEquals("\u0020\u0020\u0061\u0062", fromCString(c"\040\40\141\x62"))
   }
 
+  // Issue 1796
+  test("fromCString(null)") {
+    val szTo     = fromCString(null.asInstanceOf[CString])
+    assertEquals(szTo, null.asInstanceOf[String])
+  }
+
   test("fromCString") {
     val cstrFrom = c"1234"
     val szTo     = fromCString(cstrFrom)
@@ -44,6 +50,14 @@ object CStringSuite extends tests.Suite {
     assert(szTo.charAt(1) == '2')
     assert(szTo.charAt(2) == '3')
     assert(szTo.charAt(3) == '4')
+  }
+
+  // Issue 1796
+  test("toCString(null)") {
+    Zone { implicit z =>
+      val cstrTo = toCString(null.asInstanceOf[String])
+      assertEquals(cstrTo, null.asInstanceOf[CString])
+    }
   }
 
   test("toCString") {


### PR DESCRIPTION
This is a Work In Progress (WIP) Pull Request to provide a basis for
and to encourage discussion of a possible fix to one of the
annoying and misleading test-interface socket errors.

It presents a concept.  If the concept proves acceptable, the
details of which Exception and what message can be work-shopped.

This PR contains a unit-test CStringSuite.scala crafted for another
issue.  Until that other issue gets fixed, the unit-test provokes
the socket error under discussion.  The unit-test is provided
as an aid to reviewers. It is not intended to be in any final PR.

Scope:

* This PR presents a small and ugly fix to a problem which travels
  with a whole host of other problems.  It is intended to make
  the unit-test experience for developers a little better soon and
  not to fix everything in a complicated & fragile situation.

* This PR addresses code on the SBT side doing something ill-designed
  which presents an inscrutable socket error to the end user. It does
  not address how the SN binary addresses the RuntimeException intentionally
  created in the unit-test.  The idea is to reduce protocol or
  handshake errors, so that errors on the SN binary side become more
  evident.

Partial output before:

* scala.scalanative.unsafe.CStringSuite$
[info]   [ok] c"..." literals with various escapes
[info]   [ok] the value of c"..." literals
[error] stack trace is suppressed; run last tests / Test / testOnly for the full output
[error] (tests / Test / testOnly) java.net.SocketException: Socket closed

Partial output after:

[info] * scala.scalanative.unsafe.CStringSuite$
[info]   [ok] c"..." literals with various escapes
[info]   [ok] the value of c"..." literals
[error] stack trace is suppressed; run last tests / Test / testOnly for the full output
[error] (tests / Test / testOnly) java.lang.IllegalStateException: Premature end of ComRunner, not all tests may have been run.

As the scene opens:

* "sbt> tests/testOnly *CStringSuite" // hand crafted CStringSuite needed

* The SN binary completes the early parts of the communications handshake
  with the sbt side.

Act 1:

* The SN binary executes the "fromCString(null)" test in the Suite. That
  test causes a RuntimeException.

* The RuntimeException causes the SN binary to exit immediately, dropping
  the socket link.

* The sbt side correctly catches the EOFException, closes the ComRunner
  and its socket, and throws a BuildException.

* All good so far.

Act 2: Trouble begins

* Someone up the stack of exception handlers catches the BuildException
  and swallows it.  I believe that a year ago, I traced back up the
  chain and discovered that the BuildException was caught in a place
  that was hard to edit/fix.

  Re-establishing where the exception is caught might be worthwhile.

* The code catching the BuildException blindly calls ScalaNativeRunner
  method done().

Act 3: Stuff, in the Victorian sense, happens.

* ScalaNativeRunner#done() blindly calls send() on a closed socket and
  then continues to call receive() on the same closed socket.

  I did not trace it this year but I seem to remember from tracing it in
  detail a year ago that the send() access to the closed socket does
  not fail because an error return is never checked.  I think it is
  the second receive() access which causes the "Socket closed" exception
  to be thrown.  It does not really matter, both accesses are wrong.

* We probably all agree that a proper fix would be in the routine which
  actually caught the BuildException.  The fix here is designed
  to be as localized as feasible.

  Having ComRunner.send() & ComRunner.receive() check for the socket
  being open and silently refuse to operate on a close socket is an
  uglier alternative. That lengthens a hot code path to no benefit.