### PR TITLE
Give testinterface ComRunner better receive() handling, remove timeout and associated bug

### DIFF
--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
@@ -26,9 +26,7 @@ class ComRunner(bin: File,
     override def run(): Unit = {
       val port = serverSocket.getLocalPort
       logger.info(s"Starting process '$bin' on port '$port'.")
-      Process(bin.toString +: port.toString +: args,
-              None,
-              envVars.toSeq: _*) ! Logger
+      Process(bin.toString +: port.toString +: args, None, envVars.toSeq: _*) ! Logger
         .toProcessLogger(logger)
     }
   }


### PR DESCRIPTION
Note:
	This is the third in a series of at least five trying to improve
	the sbt side of the testinterface, so that errors on the SN binary
	side may shine through.

The existing unit-test ensemble shows that the proposed changes are
safe.  I currently do not have a unit-test to show that they are
effective.  One issue is where in the directory tree to put such a unit-test.
Another is what to call it.  Issues for another day.

Scope:

* This PR addresses code on the SBT side doing something ill-designed
  which presents an inscrutable socket error to the end user. It does
  not directly address issues in the SN binary.

  The idea is to reduce protocol or handshake errors, so that errors on
  the SN binary side become more evident.

* All in receive():

    - Eliminate the complexity of timeout handling in `ComRunner#receive`. That
      method had one caller, which used the default timeout of Infinity. 

     There is no longer a need to make multiple trips through javalib and into the kernel
      to set & restore timeout to a value already current. 

    - Simplify recursion and make it evident that scope is entirely within the try block.

    - Remove the offending finally{} which previously would, after an exception,
      set the socket timeout on a closed socket. This caused
      the Exception displayed to the user to be one about a closed
      socket rather that any meager original information.

  - Mark was never set or used, so that code is now deleted.