### PR TITLE
build: Add explicit root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -184,6 +184,11 @@ lazy val toolSettings: Seq[Setting[_]] =
     javacOptions ++= Seq("-encoding", "utf8")
   )
 
+lazy val root =
+  project
+    .in(file("."))
+    .settings(noPublishSettings)
+
 lazy val util =
   project
     .in(file("util"))


### PR DESCRIPTION
Moved to WIP status.  In working with an implementation, I found that
"sbt clean" no longer  worked correctly.  Looks like what I though I knew
about how sbt aggregates projects is wrong. 

 * This PR adds an explicit project, named "root", in the
    baseDirectory for all the other projects.

    I think this PR is transparent to almost all users. It
    removes some barriers-to-entry wizardry so it is beneficial
    to some.

    I believe that if not project is defined for the baseDirectory
    then SBT creates a project and uses the full name of the directory.

    An explicit root project has several benefits, in addition to being
    somewhat of a convention.

  * Prior to PR #1810 15 artifact directories would be created in
    ~/.ivy2/local/org.scala-native.  Since PR #1810, 16 directories
    are created.  The additional directory has the full name of the
    synthesized root project. This leads the enquiring mind  to ask
    "What is this and why is it being published?".

    The explicit root project of this PR specifies "noPublishSettings".
    As of this PR, the number of artifact directories is back to the
    historical 15.

    One can ask is all those directories need to be published, local or
    not, but that is beyond the scope of this PR.

  * As of this PR, commands such as "sbt projects" will show a root
    project named "root" rather than a synthesized name.  This created
    an environment that is familiar to people either coming from
    a different SBT environment or who work on multiple projects.
    It also conforms to an often used convention in documentation on
    the Web.

  * I believe with recent sbt versions, the current publishLocal
    section can profitably & correctly be reduced from:

  ```
lazy val noPublishSettings: Seq[Setting[_]] = Seq(
  publishArtifact := false,
  packagedArtifacts := Map.empty,
  publish := {},
  publishLocal := {},
  publishSnapshot := { println("no publish") },
  publish / skip := true
) ++ nameSettings

  ```
  to:
  ```
lazy val noPublishSettings: Seq[Setting[_]] = Seq(
  publishSnapshot := { println("no publish") },
  publish / skip := true
) ++ nameSettings
  ```
  It might be possible to remove the seldom, if ever, used publishSnapshot,
  but that gets involved in a tangle I did not want to enter.

  If reviewers encourage, I can, to separate concerns,
  create another PR with those edits. The suggested edit works in my sandbox.

Documentation:

  * Internal interface, I believe no documentation is necessary.

Testing:

  Safety

  * Built and tested ("test-all") in debug mode using sbt 1.3.10 & Java 8 on
    X86_64 only . All tests pass.

  Efficacy

  * Visual observation: count directories in
    ~/.iv2/local/org.scalanative after "test-all". Was 16, is now
    the previous 15.

  * Visual observation: "sbt projects" now shows a project named "root".