### PR TITLE
Upgrade to sbt 1.3.12.

### DIFF
--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -20,7 +20,7 @@ This generates the following files:
 
 * ``project/build.properties`` to specify the sbt version::
 
-    sbt.version = 1.3.10
+    sbt.version = 1.3.12
 
 * ``build.sbt`` to enable the plugin and specify Scala version::
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.10
+sbt.version = 1.3.12


### PR DESCRIPTION
This PR updates the sbt version used in the build to the now current
1.3.12.  Sbt release notes are at URL:https://github.com/sbt/sbt/releases/tag/v1.3.12.

Those release notes mention one small change to the location of the Coursier
cache on MacOS. @ekrich, is that likely to cause you or other MacOS users 
any problem?  Thank you.

I have been giving sbt version 1.3.12 heavy use over the past 24 or
so hours. I have seen no problems.

The observant student of the Scala Native build might remember that
there is an sbt version buried somewhere else, perhaps Travis setup.
I have a faint recollection that it is something like sbt 1.2.mumble
and needs to remain that (to provide a minimal version that the
SN plugin will work with?).

Based on prior PRs upgrading sbt to 1.3.8, 1.3.10, etc, I believe that only
the `project/build.properties` of this PR needs to change now.