### PR TITLE
Fix 1822: Unit-test fails when built with Release-Fast & LTO

### DIFF
--- a/javalib/src/main/scala/java/lang/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/UnixProcess.scala
@@ -77,7 +77,7 @@ private[lang] class UnixProcess private (
       case _ => true
     }
 
-  @inline private def waitImpl(f: () => Int) = {
+  private[this] def waitImpl(f: () => Int) = {
     var res = 1
     do res = f() while (if (res == 0) _exitValue == -1 else res != ETIMEDOUT)
     res


### PR DESCRIPTION
  * This PR addresses Issue #1822 "Unit-test fails when built with
    Release-Fast & LTO".

    That issue is now bypassed. Notice that I say bypassed, not fixed.
    The underlying defect remains but the code of this PR does not
    execute it.

    Agreed, such avoided defects are almost certain to surface
    in the future.

  * The effective change was to remove the `@inline` annotation from
    method `waitImpl()`.

  * Although it does not address the base Issue, I added `[this]` to
    the method signature in order to give it the proper most limited scope.

  * Even though it cried out for simplification & de-obfuscation, I did
    not touch the body of the method.  This was to highlight the
    effective change.

  * Similarly, I did not remove unused imports, etc. from the rest of the
    file.  They are all over the place.  At this point, I just want a
    dog that sings, and do not require one which sings and also has no
    fleas.

  * I wish I could say better, but I discovered this bypass by thrashing
    around. On one of those thrashes, I commented out the `@inline`
    out of a general suspicion of inlining and a discomfort with having
    class private code inlined in public methods.  I guessed that if
    I was confused/discomforted by such, either or both of the
    Scala Native or LLVM inliners might be also.  Luck trumps skill.

  * `Git blame` will show my finger prints all over the racy tests under
    examination in ProcessSuite.

    From doing timing and other studies on the failing test,
    I believe this bypass is effective because it changes the generated
    code, and not solely because is changes the known racy timing in
    the failing test.

    I did not examine the generated code, before & after.  Also, I
    did not attempt to determine if the now bypassed flaw is in
    Scala Native or LLVM.

Documentation:

  * The standard ChangeLog entry is requested. The results of this
    change are visible to end users under the right conditions.

Testing:
###### Efficacy 
  * Built ("rebuild")and tested ("test-all") in `release-fast` mode
    and specifying SCALANATIVE_LTO="thin" using sbt 1.3.12
    & Java 8 on X86_64 only . All tests pass.

###### Safety
  * Travis CI is all green.