### PR TITLE
Build.sbt: Run unit-tests in single thread.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -562,6 +562,7 @@ lazy val tests =
         "SCALA_NATIVE_ENV_WITH_UNICODE"  -> 0x2192.toChar.toString,
         "SCALA_NATIVE_USER_DIR"          -> System.getProperty("user.dir")
       ),
+      parallelExecution := false, // TestMain is monothreaded.
       nativeLinkStubs := true
     )
     .dependsOn(nscplugin % "plugin", allCoreLibs, testInterface)

--- a/build.sbt
+++ b/build.sbt
@@ -562,7 +562,7 @@ lazy val tests =
         "SCALA_NATIVE_ENV_WITH_UNICODE"  -> 0x2192.toChar.toString,
         "SCALA_NATIVE_USER_DIR"          -> System.getProperty("user.dir")
       ),
-      parallelExecution := false, // TestMain is monothreaded.
+      Test / parallelExecution := false, // TestMain is monothreaded.
       nativeLinkStubs := true
     )
     .dependsOn(nscplugin % "plugin", allCoreLibs, testInterface)


### PR DESCRIPTION
  * This PR is another in my long series of PRs concerned with
    the Sbt/ScalaNative communications handshake in test-interface.

    It modifies project_root/build.sbt to run the unit-tests/test or
    kin in a single thread.  I believe that, by default, sbt runs
    tests in parallel on multi-core machines.

    TestMain.scala is run as a binary executable.  It is single
    threaded, using a read_socket/do_work/write_socket model
    with a single communications socket.

    Having the Sbt JVM side of the communications handshake queue
    up more than one "command" takes resources and adds neither
    parallel execution nor benefit (see below).

    The motivation for this PR is that having multiple Sbt "threads"
    feed a single communications channel generates _lots_ of hard to
    trace shrapnel when the communications link is interrupted/fails.

  * I have not quantified the resource reduction, but I have run
    a comparison of the execution times on a modest system before
    and after this PR.  This is a sample of one. I will monitor
    Travis CI and watch out for materially increased execution times.

  * I have been running the edit of this PR for about 10 days now.
    I have seen no negative effects and it has eased my debugging.
    Thought the resource reduction would be of use to others.
    Save where you can...

  * Timings, Debug build on modest 4 core machine, sample of one:
```
                Real:    User:      m = minutes s = seconds
    Before PR:  20m 27s  56m 40s
    With   PR:  19m  7s  52m 51s
```

Documentation:

  * The affected files are all internal to the Scala Native build itself.
    Any change visible to a developer using Scala Native artifacts
    is unintentional and a bug. Developers who use the SN TestFramework
    might see some reduction in resource usage.

Testing:

  * Built ("rebuild")and tested ("test-all") in debug mode using sbt 1.3.12
    & Java 8 on X86_64 only . All tests pass.