### PR TITLE
testinterface: Provide better clues when SN test program abnormally ends

### DIFF
--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
@@ -7,12 +7,12 @@ import java.net.{ServerSocket, SocketTimeoutException}
 import scala.annotation.tailrec
 import scala.sys.process._
 
-import scalanative.build.{BuildException, Logger}
-import scalanative.testinterface.serialization.Log.Level
+import scalanative.build.Logger
 import scalanative.testinterface.serialization._
+import scalanative.testinterface.serialization.Log.Level
 
 /**
- * Represents a distant program with whom we communicate over the network.
+ * Represents a program with whom we communicate over the network.
  * @param bin    The program to run
  * @param args   Arguments to pass to the program
  * @param logger Logger to log to.
@@ -21,76 +21,161 @@ class ComRunner(bin: File,
                 envVars: Map[String, String],
                 args: Seq[String],
                 logger: Logger) {
+  private[this] class Partner() {
+    var process: Option[Process] = None
 
-  private[this] val runner = new Thread {
-    override def run(): Unit = {
-      val port = serverSocket.getLocalPort
+    def startOn(port: Int): Unit = {
       logger.info(s"Starting process '$bin' on port '$port'.")
-      Process(bin.toString +: port.toString +: args, None, envVars.toSeq: _*) ! Logger
-        .toProcessLogger(logger)
+
+      val pb =
+        Process(bin.toString +: port.toString +: args, None, envVars.toSeq: _*)
+
+      val rmtLogger = ProcessLogger(
+        out => System.out.printf(s"snO: ${out}\n"),
+        err => System.err.printf(s"snE: ${err}\n")
+      )
+
+      this.process = Some(pb.run(rmtLogger))
+
+      // No need to wait here for Process to exit.
+      // Exit code will be synchronously checked only as needed.
+      //
+      // Child process will execute until either it or this process exits.
+      //
+      // On successful completion of Suites, the former should happen due
+      // to the "RunnerDone" handshake in ScalaNativeRunner.scala.
+      //
+      // On grevious I/O error conditions, exception handling will flow
+      // through fatalError() below and terminate the partner, if necessary.
+    }
+
+    def exitCode(timeoutSeconds: Int = 14): Option[Int] = {
+      // exitCode is valuable enough that it is worthwhile waiting
+      // a decent, but not infinite, interval for it to become available.
+      Thread.`yield`()
+      process.flatMap(p => {
+        val step  = 500 // milliseconds
+        var count = timeoutSeconds * 1000
+        while ((count > 0) && p.isAlive()) {
+          Thread.sleep(step)
+          count -= step
+        }
+        if (count <= 0) None else Some(p.exitValue())
+      })
+    }
+
+    def exit(): Unit = {
+      this.exitCode() match {
+        case None =>
+          logger.error(
+            "Partner exit code is not available: forcing partner to exit.")
+          process.map(p => p.destroy())
+
+        case Some(c) =>
+          // Provide any available clues as to what might have gone wrong.
+          if (c == 0)
+            logger.info("Partner exited with success code: 0")
+          else {
+            logger.error(s"Partner exited with error code: ${c}")
+            // Guess/hope that shell is Unix compatible.
+            if (c > 128) {
+              // This code runs in the JVM, so no easy way to call
+              // strerror() to translate errno code to text. The
+              // downshifted errno as a hint of what went wrong has
+              // a sporting chance of being better than nothing at all.
+              logger.error(s"May be Unix fatal error signal: ${c - 128}")
+            }
+          }
+      }
     }
   }
 
-  private[this] var serverSocket: ServerSocket = _
-  private[this] val socket =
+  private[this] val partner = new Partner()
+
+  def fatalError(message: String): Unit = {
+    logger.error(message)
+
+    partner.exit()
+
+    logger.error("BEWARE: Inconsistent state.")
+    logger.error("- Fault may be in next test in Suite containing last [ok].")
+    logger.error("- Not all tests in Suites may have run.")
+    logger.error("- Suite reported as having error may be wrong.")
+    logger.error("- Not all Suites may have run.")
+    logger.error(
+      "- Reports may be more accurate if Sbt parallelExecution is false.")
+
+    // Sbt TestFramework considers InterruptedException to be fatal and
+    // will not catch it.
+    throw new InterruptedException("Fatal error on partner socket")
+  }
+
+  private[this] val socket = {
+    val serverSocket = new ServerSocket( /* port = */ 0, /* backlog = */ 1)
     try {
-      serverSocket = new ServerSocket( /* port = */ 0, /* backlog = */ 1)
-
-      runner.start()
-
+      // 40 seconds is an arbitrary small, but not too small, time to wait.
       serverSocket.setSoTimeout(40 * 1000)
+      partner.startOn(serverSocket.getLocalPort)
       serverSocket.accept()
     } catch {
-      case _: SocketTimeoutException =>
-        throw new BuildException(
-          "The test program never connected to the test runner.")
+      case ex: SocketTimeoutException =>
+        fatalError(
+          "Sbt test runner timed out waiting for connection"
+            + " from native program.")
+        throw ex // Never gets here after fatalError(), keep compiler happy.
     } finally {
-      // We can close it immediately, since we won't receive another connection.
+      // Close immediately; only one connection is expected.
       serverSocket.close()
     }
+  }
 
   private[this] val in = new DataInputStream(
     new BufferedInputStream(socket.getInputStream))
+
   private[this] val out = new DataOutputStream(
     new BufferedOutputStream(socket.getOutputStream))
 
-  /** Send message `msg` to the distant program. */
-  def send(msg: Message): Unit = synchronized {
-    try SerializedOutputStream(out)(_.writeMessage(msg))
-    catch {
-      case ex: Throwable =>
-        close()
-        throw ex
-    }
-  }
-
-  /** Wait for a message to arrive from the distant program. */
-  def receive(): Message = synchronized {
-    try {
-      @tailrec
-      def loop(): Message = {
-        SerializedInputStream.next(in)(_.readMessage()) match {
-          case logMsg: Log =>
-            log(logMsg)
-            loop()
-          case other =>
-            other
-        }
+  /** Send message `msg` to the partner native program. */
+  def send(msg: Message): Unit =
+    synchronized {
+      try SerializedOutputStream(out)(_.writeMessage(msg))
+      catch {
+        case ex: Throwable =>
+          fatalError(
+            "Fatal error while sending message" +
+              " to Scala Native test program.")
+          throw ex // Never gets here after fatalError(), keep compiler happy.
       }
-
-      loop()
-    } catch {
-      case _: EOFException =>
-        close()
-        throw new BuildException(
-          s"EOF on connection with remote runner on port ${serverSocket.getLocalPort}")
-      case ex: Throwable =>
-        close()
-        throw ex
     }
-  }
+
+  /** Wait for a message to arrive from the partner native program. */
+  def receive(): Message =
+    synchronized {
+      try {
+        @tailrec
+        def loop(): Message = {
+          SerializedInputStream.next(in)(_.readMessage()) match {
+            case logMsg: Log =>
+              log(logMsg)
+              loop()
+            case other =>
+              other
+          }
+        }
+        loop()
+      } catch {
+        case ex: Throwable =>
+          fatalError(
+            "Fatal error while receiving message" +
+              " from Scala Native test program.")
+          throw ex // Never gets here after fatalError(), keep compiler happy.
+
+      }
+    }
 
   def close(): Unit = {
+    // No partner.exit() needed here. Partner should be exiting on its own
+    // because sole caller has completed RunnerDone send & receive sequence.
     in.close()
     out.close()
     socket.close()


### PR DESCRIPTION
  * This PR is at least a local culmination in a long series of PRs
    attempting to provide better information when running tests
    which cause the Scala Native executable test program to abnormally end.

    It is presented for comments & review as "more useful and
    simpler than what exists today".

    This PR is the fruition of two or more years of work trying to
    understand and improve the communications handshake so that
    developers can understand the cause of failures.  The solution
    looks easy after the fact.

  * When all test Suites execute successfully, no change should be seen.
    The PR addresses error paths.

  * Previously some errors whilst executing tests in the Scala Native
    test program would display the expected stack trace. Determining
    whether the stack trace pertained to the sbt runner or the
    SN program required experience gained by pain. Once one learned
    to look at the bottom of the stack, it became easier to determine.

    On other occasions, test execution would halt with a SocketException
    and a message that the socket was closed.  True enough, but less
    than helpful. Why was there a socket error? Was it on the Sbt side
    or the SN side?  After a while and much pain, one could guess that
    the SocketException came from the SN program abnormally ending:
    But why?

    This PR makes a best, but not guaranteed, effort to determine if
    the SN program exit code is available and, if it is, retrieve
    and report it.

    It also prints out some information about the inconsistent state
    and some possible inconsistencies.

 * The Sbt TestFramework considers the InterruptedException thrown to be
   fatal and will not catch it. Execution will return to the Sbt shell
   or the command line. In the former case, the partner process will have
   been terminated, if possible. Execution environment should be clean.

 * The PR is related to and supersedes the Work In Progress PR #1812,
   which I will close.

   It is also related to Issue #1796 in that the uncaught C signal
   reported in that issue was used to exercise error paths in
   this PR.  At the time of that issue, its underlying problem
   was reported as RuntimeException. It is now known to be an
   issue with TestMain not catching C signals.

   It also adresses Issue #1809.
 * The PR stands alone but works better when tests are executed
   sequentially. See PR #1825.

 * Most Suites & tests in the world execute normally. Tests under development
   tend to be the ones which cause TestMain problems.

   One of the things which will cause TestMain to exhibit "dying silently
   in the darkness" is an uncaught C signal. It is beyond the scope
   of the current PR to fix TestMain. This PR fixes the silliness of
   repeatedly attempting to send or receive on a known closed socket.

 * It appears that the two files developed incrementally. There were
   at least three models in use: master/(implied slave), remote/local
   (where both were on the same system), & more runners than the
   Boston Marathon. An attempt was made to the consistent paradigm
   of a communicating partner. 

   This allowed the  incomplete, muddled, and offensive use of "master"
    to be replaced by the more useful and pertinent "comRunner".

   Some of the local/remote language persists, but the situation should be
   less confusing for the next generation of developers.

 * By both historical & recent design direction, the communications handshake
   does not contain a timeout. Someday, the Scala Native test environment
   may allowing specifying an expiry timeout for individual tests
   or Suites.  This feature exists in some other test frameworks and
   is quite useful.

   Until that day, the communications protocol implemented remains exposed to
   "infinite" loops in tests after the initial handshake.  Such loops
   will hang the Sbt JVM side, until manually canceled.

Documentation:

  * The standard changelog entry is requested. There should be no
    user-visible changes in the success case.

    There are a number of visible changes when tests have errors.

    I/O from the partner SN test program will be prefixed with "snO" from
    standard output and "snE" from standard error. This unobtrusive
    clue should make it easier & faster to determine which of the
    partners generated the I/O, such as stack traces.

    Sample output from an intentional error case with uncaught C signal:
```
     * scala.scalanative.unsafe.CStringSuite$
[info]   [ok] c"..." literals with various escapes
[info]   [ok] the value of c"..." literals
[error] Fatal error while receiving message from Scala Native test program.
[error] Partner exited with error code: 139
[error] May be Unix fatal error signal: 11
[error] BEWARE: Inconsistent state.
[error] - Fault may be in next test in Suite containing last [ok].
[error] - Not all tests in Suites may have run.
[error] - Suite reported as having error may be wrong.
[error] - Not all Suites may have run.
[error] - Reports may be more accurate if Sbt parallelExecution is false.
[error] stack trace is suppressed; run last tests / Test / testOnly for the full output
[error] (tests / Test / testOnly) java.lang.InterruptedException: Fatal error on partner socket
[error] Total time: 68 s (01:08), completed Jun 18, 2020 5:35:03 PM
 ```
  * While this PR is lagering awaiting its run in the review queue,  I will
    check the .rst documentation an see if anything needs to change or
    could profitably be added.

Testing:

  Safety:

  * Built and tested ("test-all") in debug mode using sbt 1.3.12 on
    X86_64 only . All tests pass.

  Efficacy:

  * Manually tested failing accept() & receive(). A special
    test Suite which causes a C SEGFAULT signal is needed to exercise
    the latter.  Testing send() with an error is hard, the PR does
    its work well.

    These error conditions should rarely be seen in Travis CI, since
    any test which reliably provoked them would, by definition, not
    be accepted into mainline.