### PR TITLE
Fix #1796: fromCString(null) now returns proper NullPointerException.

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -140,6 +140,10 @@ package object unsafe {
   /** Convert a CString to a String using given charset. */
   def fromCString(cstr: CString,
                   charset: Charset = Charset.defaultCharset()): String = {
+    // guard libc.strlen(null). It will raise uncatchable C signal not throw.
+    if (cstr == null)
+      throw new NullPointerException()
+
     val len   = libc.strlen(cstr).toInt
     val bytes = new Array[Byte](len)
 

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
@@ -35,6 +35,13 @@ object CStringSuite extends tests.Suite {
     assertEquals("\u0020\u0020\u0061\u0062", fromCString(c"\040\40\141\x62"))
   }
 
+  // Issue 1796
+  test("fromCString(null)") {
+    assertThrows[NullPointerException] {
+      val unused = fromCString(null.asInstanceOf[CString])
+    }
+  }
+
   test("fromCString") {
     val cstrFrom = c"1234"
     val szTo     = fromCString(cstrFrom)
@@ -44,6 +51,14 @@ object CStringSuite extends tests.Suite {
     assert(szTo.charAt(1) == '2')
     assert(szTo.charAt(2) == '3')
     assert(szTo.charAt(3) == '4')
+  }
+
+  test("toCString(null)") {
+    Zone { implicit z =>
+      assertThrows[NullPointerException] {
+        val unused = toCString(null.asInstanceOf[String])
+      }
+    }
   }
 
   test("toCString") {


### PR DESCRIPTION
  * This PR was motivated by Issue #1796 "fromCString(null) returns
    java.lang.RuntimeException not NullPointerException".

    The originating issue was reported in user code in the wild.

    That issue is now fixed. The fix is minimal and follows existing
    practices and conventions. It does not introduce new concepts or
    null special casing.

    Two unit-tests were added to an existing Suite to verify the change.

  * Putting aside for a while the suggestion "just say NO! to
    nulls"...

    `fromCString(null)` follows the general Scala convention of the
    first code attempting to access a null pointer throwing a
    `NullPointerException`. This convention is the one used by
    its inverse/dual `toCString(null)`.

    The previous situation of having two slightly different (apparent)
    Scala Native exceptions was annoying and carried support & cognitive
    complexity costs. It might be considered "that is the way it is"
    except for the fact that the displayed `RuntimeException` was not
    catchable where other apparently identical `RunTimeExceptions` are.

    Turns out that the choice was not between two slightly different
    Scala Native exceptions but between a proper SN exception and a
    C signal. Code to detect a null argument and not pass it
    to `libc.strlen` needed to be added to keep all the exception/signal
    handling in the SN domain and catchable. It made sense to return the
    conventional, expected `NullPointerException` rather than a
    less informative `j.l.RuntimeException`.

  * Investigation of Issue #1796 revealed that a call to
    `fromCString()` resulted in a call to `libc.strlen(null)` and that
    `libc.strlen()` raised a C SEGFAULT signal. Scala Native was specifically
    designed and implemented to be able to catch C++ exceptions, but
    it does not catch C signals.

    After the fact it is entirely understandable that C code would
    use the C signaling mechanism for severe errors.

    I did not explore the difference between how C signals and C++
    exceptions are implemented and why Scala Native and/or libunwind
    does/do not catch them.

    The TestMain Scala Native executable does not establish C signal handlers,
     see Issue #1828.  Any C signal raised in code at or
    below TestMain will continue up past TestMain to some handler which
    converts it to the displayed `java.lang.RuntimeException`. I did
    not identify that exception handler.

Documentation:

  * The standard changelog entry is requested. There should be no
    user-visible changes in the success case.

Testing:

  Safety:

  * Built and tested ("test-all") in debug mode using sbt 1.3.12 on
    X86_64 only . All tests pass.

  Efficacy:

  * Two test cases, one for each method, were added to CStringSuite.scala.