### PR TITLE
Upgrade to sbt 1.3.13.

### DIFF
--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -20,7 +20,7 @@ This generates the following files:
 
 * ``project/build.properties`` to specify the sbt version::
 
-    sbt.version = 1.3.12
+    sbt.version = 1.3.13
 
 * ``build.sbt`` to enable the plugin and specify Scala version::
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.12
+sbt.version = 1.3.13


### PR DESCRIPTION
This PR updates the sbt version used in the build to the now current
1.3.13. Sbt release notes are at URL:https://github.com/sbt/sbt/releases/tag/v1.3.13.

This is a follow-on to PR #1818. That PR describes the lack of need
to change the Travis CI environment.