### PR TITLE
Fix scala-js#4088: Avoid an Int overflow in BigDecimal.toString().

### DIFF
--- a/javalib/src/main/scala/java/math/Conversion.scala
+++ b/javalib/src/main/scala/java/math/Conversion.scala
@@ -284,10 +284,10 @@ private[math] object Conversion {
         result = (48 + (prev - v * 10)).toChar + result
       } while (v != 0)
 
-      val exponent = resLengthInChars - currentChar - scale - 1
+      val exponent: Long = resLengthInChars - currentChar - scale.toLong - 1
 
-      if (scale > 0 && exponent >= -6) {
-        val index = exponent + 1
+      if (scale > 0 && exponent >= -6L) {
+        val index = exponent.toInt + 1
         if (index > 0) {
           // special case 1
           result = result.substring(0, index) + "." + result.substring(index)
@@ -299,16 +299,15 @@ private[math] object Conversion {
           result = "0." + result
         }
       } else if (scale != 0) {
-        var result1 = exponent.toString
-        if (exponent > 0)
-          result1 = '+' + result1
-        result1 = 'E' + result1
+        val exponentStr =
+          if (exponent > 0) "E+" + exponent
+          else "E" + exponent
 
         result =
           if (resLengthInChars - currentChar > 1)
-            result(0) + "." + result.substring(1) + result1
+            result.substring(0, 1) + "." + result.substring(1) + exponentStr
           else
-            result + result1
+            result + exponentStr
       }
 
       if (negNumber) '-' + result

--- a/unit-tests/src/test/scala/java/math/BigDecimalToStringSuite.scala
+++ b/unit-tests/src/test/scala/java/math/BigDecimalToStringSuite.scala
@@ -1,0 +1,68 @@
+// Ported from Scala.js original and adapted for Scala Native.
+// BigDecimalToStringTesT.scala, commit 3851c2d, dated: 2020-06-19.
+//     https://raw.githubusercontent.com/scala-js/scala-js/\
+//         83056e39d54c4546a11372add54abb1ece6c5df1/test-suite/\
+//         shared/src/test/scala/org/scalajs/testsuite/\
+//         javalib/math/BigDecimalToStringTest.scala
+
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.math
+
+object BigDecimalToStringSuite extends tests.Suite {
+
+  test("testToStringWithCornerCaseScales") {
+    val bigIntOne = BigInteger.valueOf(1)
+
+    assertEquals("1", new BigDecimal(bigIntOne, 0).toString())
+
+    assertEquals("0.01", new BigDecimal(bigIntOne, 2).toString())
+    assertEquals("0.000001", new BigDecimal(bigIntOne, 6).toString())
+    assertEquals("1E-7", new BigDecimal(bigIntOne, 7).toString())
+    assertEquals("1E-2147483647",
+                 new BigDecimal(bigIntOne, 2147483647).toString())
+
+    assertEquals("1E+1", new BigDecimal(bigIntOne, -1).toString())
+    assertEquals("1E+2", new BigDecimal(bigIntOne, -2).toString())
+    assertEquals("1E+15", new BigDecimal(bigIntOne, -15).toString())
+    assertEquals("1E+2147483647",
+                 new BigDecimal(bigIntOne, -2147483647).toString())
+    assertEquals(
+      "1E+2147483648",
+      new BigDecimal(bigIntOne, -2147483648).toString()
+    ) // Scala.js Issue #4088
+
+    val bigInt123 = BigInteger.valueOf(123)
+
+    assertEquals("123", new BigDecimal(bigInt123, 0).toString())
+
+    assertEquals("1.23", new BigDecimal(bigInt123, 2).toString())
+    assertEquals("0.000123", new BigDecimal(bigInt123, 6).toString())
+    assertEquals("0.00000123", new BigDecimal(bigInt123, 8).toString())
+    assertEquals("1.23E-7", new BigDecimal(bigInt123, 9).toString())
+    assertEquals("1.23E-2147483645",
+                 new BigDecimal(bigInt123, 2147483647).toString())
+
+    assertEquals("1.23E+3", new BigDecimal(bigInt123, -1).toString())
+    assertEquals("1.23E+4", new BigDecimal(bigInt123, -2).toString())
+    assertEquals("1.23E+17", new BigDecimal(bigInt123, -15).toString())
+    assertEquals(
+      "1.23E+2147483649",
+      new BigDecimal(bigInt123, -2147483647).toString()
+    ) //  Scala.js Issue #4088
+    assertEquals(
+      "1.23E+2147483650",
+      new BigDecimal(bigInt123, -2147483648).toString()
+    ) //  Scala.js Issue #4088
+  }
+}


### PR DESCRIPTION
  * This PR was motivated by Scala.js Issue #4088
    "BigDecimal(1, -2147483648).toString returns "1E-2147483648""

    The Scala.js 1.1.1 [Release Announcement](
    https://www.scala-js.org/news/2020/07/02/announcing-scalajs-1.1.1/)
    described that issue as having been fixed.

    Scala Native Conversion.scala is derived from Scala.js and
    had the same bug. The same fix was relevant and applied neatly.

    The presenting issue is now fixed.

  * The test suite from the Scala.js fix was ported to Scala Native.

  * The Scala Native instance of Conversions.scala had diverged from
    its Scala.js progenitor.  Only the changes for the presenting
    problem were ported.

Documentation:

  * The standard changelog entry is requested.

Testing:

  Safety:

  * Built and tested ("test-all") in debug mode using sbt 1.3.13 on
    X86_64 only . All tests pass.

  Efficacy:

  * The test suite ported from Scala.js failed before this PR and now
    passes.