### PR TITLE
Fix #1758: Accept a non-directory file in Files.walk()

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -580,7 +580,7 @@ object Files {
                    visited: SSet[Path]): SStream[Path] = {
     start #:: {
       if (!isDirectory(start, linkOptsFromFileVisitOpts(options))) SStream.empty
-      else
+      else {
         FileHelpers
           .list(start.toString, (n, t) => (n, t))
           .toStream
@@ -604,6 +604,7 @@ object Files {
             case (name, _) =>
               start.resolve(name) #:: SStream.Empty
           }
+      }
     }
 
   }

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -638,7 +638,7 @@ object Files {
                             options: Set[FileVisitOption],
                             maxDepth: Int,
                             visitor: FileVisitor[_ >: Path]): Path = {
-    val optsArray  = options.toArray.asInstanceOf[Array[FileVisitOption]]
+    val optsArray  = options.toArray(new Array[FileVisitOption](options.size()))
     val stream     = walk(start, maxDepth, 0, optsArray, SSet.empty)
     val dirsToSkip = scala.collection.mutable.Set.empty[Path]
     val openDirs   = scala.collection.mutable.Stack.empty[Path]

--- a/unit-tests/src/test/scala/java/nio/file/FilesSuite.scala
+++ b/unit-tests/src/test/scala/java/nio/file/FilesSuite.scala
@@ -649,7 +649,7 @@ object FilesSuite extends tests.Suite {
     }
   }
 
-  test("Files.walk walks files") {
+  test("Files.walk walks directory") {
     withTemporaryDirectory { dirFile =>
       val dir = dirFile.toPath()
       val f0  = dir.resolve("f0")
@@ -677,6 +677,23 @@ object FilesSuite extends tests.Suite {
       assert(files contains f2)
       assert(files contains f0)
       assert(files contains f1)
+    }
+  }
+
+  test("Files.walk walks single file") {
+    withTemporaryDirectory { dirFile =>
+      val f0 = dirFile.toPath.resolve("f0")
+
+      Files.createFile(f0)
+      assert(Files.exists(f0) && Files.isRegularFile(f0))
+
+      val it    = Files.walk(f0).iterator()
+      val files = scala.collection.mutable.Set.empty[Path]
+      while (it.hasNext) {
+        files += it.next()
+      }
+      assert(files.size == 1)
+      assert(files contains f0)
     }
   }
 


### PR DESCRIPTION
Resolves #1758 bug. 
In cases when `Files.walk` was used with path directing to file instead of directory second element of stream resulted in throwing exceptions. 
Also extracted conversion between `FileVisitOption[]` -> `LinkOption[]` used in several places. 