### PR TITLE
Fix "too many open files" after consecutive runs

### DIFF
--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -79,9 +79,11 @@ object VirtualDirectory {
 
     override def read(path: Path, len: Int): ByteBuffer = {
       val stream = Files.newInputStream(resolve(path))
-      val bytes  = new Array[Byte](len)
-      val read   = stream.read(bytes)
-      ByteBuffer.wrap(bytes, 0, read)
+      try {
+        val bytes = new Array[Byte](len)
+        val read  = stream.read(bytes)
+        ByteBuffer.wrap(bytes, 0, read)
+      } finally stream.close()
     }
 
     override def write(path: Path, buffer: ByteBuffer): Unit = {


### PR DESCRIPTION
This bug was introduced by PR #1728. It basically leaves
the files open in the VirtualDirectory.read(path, len) method.
After 3-4 consecutive runs in sbt, the build would complain with
"too many open files", which makes sense since the above method
is used to look for classes with entry points, so it is essentially
used to open every single .nir file in the build.