### PR TITLE
Fix #1768: Handle segfault when current directory was unlinked

### DIFF
--- a/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystemProvider.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystemProvider.scala
@@ -138,9 +138,10 @@ class UnixFileSystemProvider extends FileSystemProvider {
 
   private def getUserDir(): String = {
     val buff = stackalloc[CChar](4096)
-    val res = unistd.getcwd(buff, 4095)
+    val res  = unistd.getcwd(buff, 4095)
     if (res == null)
-      throw UnixException("Could not determine current working directory", errno.errno)
+      throw UnixException("Could not determine current working directory",
+                          errno.errno)
     fromCString(res)
   }
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystemProvider.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystemProvider.scala
@@ -139,7 +139,8 @@ class UnixFileSystemProvider extends FileSystemProvider {
   private def getUserDir(): String = {
     val buff = stackalloc[CChar](4096)
     val res = unistd.getcwd(buff, 4095)
-    if (res == null) throw UnixException("Could not determine current working directory", errno.errno)
+    if (res == null)
+      throw UnixException("Could not determine current working directory", errno.errno)
     fromCString(res)
   }
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystemProvider.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystemProvider.scala
@@ -15,6 +15,7 @@ import java.nio.file.spi.FileSystemProvider
 import java.net.URI
 import java.util.concurrent.ExecutorService
 import java.util.{Map, Set}
+import scala.scalanative.libc.errno
 
 class UnixFileSystemProvider extends FileSystemProvider {
 
@@ -137,7 +138,8 @@ class UnixFileSystemProvider extends FileSystemProvider {
 
   private def getUserDir(): String = {
     val buff = stackalloc[CChar](4096)
-    val res  = unistd.getcwd(buff, 4095)
+    val res = unistd.getcwd(buff, 4095)
+    if (res == null) throw UnixException("Could not determine current working directory", errno.errno)
     fromCString(res)
   }
 


### PR DESCRIPTION
Resolves #1768 
I've imported fix of https://github.com/avdv/scala-native/commit/939a12916ba5e25e3d7b1603b5d65cfd4e23cbd9 mentioned in issue. 
I have no idea how to provide valid tests for this case. I don't think i can be done using scripted-tests either. 