### PR TITLE
Fix #1681: Add String methods introduced in JDK 11

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -9,6 +9,7 @@ import java.util.regex._
 import java.nio._
 import java.nio.charset._
 import java.util.Objects
+import java.util.stream.Stream
 
 final class _String()
     extends Serializable
@@ -844,6 +845,37 @@ final class _String()
     val r =
       Character.offsetByCodePoints(value, offset, count, s, codePointOffset)
     r - offset
+  }
+
+  // Added in JDK 11.
+  def strip(): _String = {
+    this.stripTrailing().stripLeading()
+  }
+
+  // Added in JDK 11.
+  def stripLeading(): _String = {
+    new _String(value.dropWhile(_.isWhitespace))
+  }
+
+  // Added in JDK 11.
+  def stripTrailing(): _String = {
+    new _String(value.reverse.dropWhile(_.isWhitespace).reverse)
+  }
+
+  // Added in JDK 11.
+  def isBlank: scala.Boolean = {
+    value.isEmpty || value.forall(_.isWhitespace)
+  }
+
+  // Added in JDK 11.
+  def lines(): Stream[_String] = {
+    val split = this.split("\r\n").flatMap(_.split("\r")).flatMap(_.split("\n"))
+    Stream.of(split.asInstanceOf[Array[AnyRef]])
+  }
+
+  // Added in JDK 11.
+  def repeat(count: Int): _String = {
+    new _String((0 until count).foldRight(Array.empty[Char])((_, soFar) => soFar ++ value ))
   }
 
   def getValue(): Array[Char] = value

--- a/unit-tests/src/test/scala/java/lang/StringSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/StringSuite.scala
@@ -393,4 +393,34 @@ object StringSuite extends tests.Suite {
         .toString
         .toLowerCase equals "scala native")
   }
+
+  test("strip") {
+    assert("".strip() equals "")
+    assert("   hallo".stripLeading() equals "hallo")
+    assert("hallo   ".stripTrailing() equals "hallo")
+    assert("   hallo   ".strip() equals "hallo")
+    assert("\t\t\t  hallo\nwelt\r\n  \t".strip() equals "hallo\nwelt")
+  }
+
+  test("isBlank") {
+    assert("".isBlank equals true)
+    assert(" \t\n\u000B\f\r\u001C\u001D\u001E\u001F".isBlank equals true)
+    assert(" \t\n\u000B\f\r\u001C a \u001D\u001E\u001F".isBlank equals false)
+  }
+
+  test("lines") {
+    import scala.collection.JavaConverters._
+    assert("".lines.iterator.asScala.toSeq equals Seq(""))
+    assert("hallo\r\nwelt".lines.iterator.asScala.toSeq equals Seq("hallo", "welt"))
+    assert("hallo\rwelt".lines.iterator.asScala.toSeq equals Seq("hallo", "welt"))
+    assert("hallo\nwelt".lines.iterator.asScala.toSeq equals Seq("hallo", "welt"))
+    assert("hallo\rschöne\nwelt".lines.iterator.asScala.toSeq equals Seq("hallo", "schöne", "welt"))
+    assert("hallo\rschöne\r\ngroße\nwelt".lines.iterator.asScala.toSeq equals Seq("hallo", "schöne", "große", "welt"))
+  }
+
+  test("repeat") {
+    assert("".repeat(10) equals "")
+    assert("hallo".repeat(0) equals "")
+    assert("foo".repeat(3) equals "foofoofoo")
+  }
 }


### PR DESCRIPTION
JDK 11 introduced a few new methods in the `java.lang.String` class.

Although JDK 8 is still the officially supported version, implement those methods so that users using JDK 11 don't stumble upon time consuming bugs (see #1681 for an example) and have to switch the JDK version.

Plus, they will have to be implemented at some point!

### New methods:
- strip
- stripLeading
- stripTrailing
- isBlank
- lines
- repeat