### PR TITLE
Fix #1824: Upgrade CI environment and versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,16 @@
-sudo: required
-
 scala:
   - "2.11.12"
 
 os: linux
-dist: trusty
-jdk: oraclejdk8
+dist: bionic
+jdk: openjdk8
 language: scala
 
 services:
   - docker
 
 env:
-  matrix:
+  jobs:
     - MODE=source-checks
     - MODE=test-tools
     - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -35,7 +35,7 @@ RUN \
   apt-get update && \
   apt-get install -y sbt
 
-RUN apt-get update && apt-get install -y clang-5.0 zlib1g-dev libgc-dev
+RUN apt-get update && apt-get install -y clang-9 zlib1g-dev libgc-dev
 
 ENV LC_ALL "C.UTF-8"
 

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -23,7 +23,7 @@ RUN sed -i -e "s/deb http/deb [arch=$HOST_ARCHITECTURE] http/g" /etc/apt/host-so
 RUN apt-get update && apt-get install -y openjdk-8-jdk-headless:$HOST_ARCHITECTURE
 ENV PATH "/usr/lib/jvm/java-8-openjdk-$HOST_ARCHITECTURE/bin:$PATH"
 
-ENV SBT_LAUNCHER_VERSION 1.3.7
+ENV SBT_LAUNCHER_VERSION 1.3.13
 
 RUN apt-get install -y curl
 

--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -60,7 +60,7 @@ installation of macOS.
 
 .. code-block:: shell
 
-    $ sudo apt install clang
+    $ sudo apt install clang-9 build-essential
     $ sudo apt install libgc-dev # optional
 
 **Arch Linux**
@@ -77,7 +77,7 @@ installation of Arch Linux.
 
 .. code-block:: shell
 
-    $ sudo dnf install llvm clang
+    $ sudo dnf install llvm clang libstdc++-devel
     $ sudo dnf install gc-devel zlib-devel # both optional
 
 **FreeBSD**

--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -77,7 +77,8 @@ installation of Arch Linux.
 
 .. code-block:: shell
 
-    $ sudo dnf install llvm clang libstdc++-devel
+    $ sudo dnf install llvm clang
+    $ sudo dnf groupinstall "Development Tools"
     $ sudo dnf install gc-devel zlib-devel # both optional
 
 **FreeBSD**

--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -7,7 +7,7 @@ Scala Native has the following build dependencies:
 
 * Java 8 or newer
 * sbt 1.1.6 or newer
-* LLVM/Clang 3.7 or newer
+* LLVM/Clang 9 or newer
 
 And following completely optional runtime library dependencies:
 
@@ -26,7 +26,7 @@ Installing clang and runtime dependencies
 -----------------------------------------
 
 Scala Native requires Clang, which is part of the LLVM toolchain. The
-recommended LLVM version is 3.7 or newer, however, the Scala Native sbt
+recommended LLVM version is 9 or newer, however, the Scala Native sbt
 plugin uses feature detection to discover the installed version of Clang
 so older versions may also work.
 
@@ -84,7 +84,7 @@ installation of Arch Linux.
 
 .. code-block:: shell
 
-    $ pkg install llvm38
+    $ pkg install llvm9
     $ pkg install boehm-gc # optional
 
 *Note:* A version of zlib that is sufficiently recent comes with the


### PR DESCRIPTION
This PR aims to bring the CI environment up-to-date and upgrade some of the components/tools used (see #1824).

More specifically:
- remove deprecated `sudo: required` travis configuration
- rename deprecated `matrix` to `jobs` in travis configuration
- update travis distro from `trusty` (14.04) to `bionic` (18.04)
- switch from `oraclejdk8` to `openjdk8`
- update SBT launcher to 1.3.13
- update clang to version 9 in Dockerfile
- fix #1716