### PR TITLE
Add loopRunOnce to runtime and ExecutionContext

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/ExecutionContext.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ExecutionContext.scala
@@ -25,4 +25,17 @@ object ExecutionContext {
       }
     }
   }
+
+  private[runtime] def loopRunOnce(): Int = {
+    if (queue.nonEmpty) {
+      val runnable = queue.remove(0)
+      try {
+        runnable.run()
+      } catch {
+        case t: Throwable =>
+          QueueExecutionContext.reportFailure(t)
+      }
+    }
+    queue.size
+  }
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ExecutionContext.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ExecutionContext.scala
@@ -14,27 +14,26 @@ object ExecutionContext {
 
   private val queue: ListBuffer[Runnable] = new ListBuffer
 
+  @inline
+  private def loopRunOnceUnsafe(): Unit = {
+    val runnable = queue.remove(0)
+    try {
+      runnable.run()
+    } catch {
+      case t: Throwable =>
+        QueueExecutionContext.reportFailure(t)
+    }
+  }
+
   private[runtime] def loop(): Unit = {
     while (queue.nonEmpty) {
-      val runnable = queue.remove(0)
-      try {
-        runnable.run()
-      } catch {
-        case t: Throwable =>
-          QueueExecutionContext.reportFailure(t)
-      }
+      loopRunOnceUnsafe()
     }
   }
 
   private[runtime] def loopRunOnce(): Int = {
     if (queue.nonEmpty) {
-      val runnable = queue.remove(0)
-      try {
-        runnable.run()
-      } catch {
-        case t: Throwable =>
-          QueueExecutionContext.reportFailure(t)
-      }
+      loopRunOnceUnsafe()
     }
     queue.size
   }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -72,7 +72,8 @@ package object runtime {
   @noinline def loop(): Unit =
     ExecutionContext.loop()
 
-  /** Run one iteration of the runtime's event loop. */
+  /** Run one iteration of the runtime's event loop and return
+   *  remaining runnables count. */
   def loopRunOnce(): Int =
     ExecutionContext.loopRunOnce()
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -72,6 +72,10 @@ package object runtime {
   @noinline def loop(): Unit =
     ExecutionContext.loop()
 
+  /** Run one iteration of the runtime's event loop. */
+  def loopRunOnce(): Int =
+    ExecutionContext.loopRunOnce()
+
   /** Called by the generated code in case of division by zero. */
   @noinline def throwDivisionByZero(): Nothing =
     throw new java.lang.ArithmeticException("/ by zero")

--- a/unit-tests/src/test/scala/scala/scalanative/runtime/LoopTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/runtime/LoopTest.scala
@@ -1,0 +1,22 @@
+package scala.scalanative
+package runtime
+
+import org.junit.Assert._
+import org.junit.Test
+
+class LoopTest {
+  @Test def loopRunOnceTest(): Unit = {
+    var i = 0
+    val runnable = new Runnable {
+      def run(): Unit = i += 1
+    }
+    ExecutionContext.global.execute(runnable)
+    ExecutionContext.global.execute(runnable)
+    assertEquals(loopRunOnce(), 1)
+    assertEquals(1, i)
+    assertEquals(loopRunOnce(), 0)
+    assertEquals(2, i)
+    assertEquals(loopRunOnce(), 0)
+    assertEquals(2, i)
+  }
+}


### PR DESCRIPTION
At the moment, it's hard to integrate with external event loops because:
  - You need to run all the `Runnable`s created by the event loop.
     Since one runnable can create other runnables it can create
     deadlocks situations when the resolving action is in the external
     event loop.
  - There is no way to know how many runnable are left. This is handy
    integrating external event loops.