### PR TITLE
Eliminate deprecation error in scripted execution-context

### DIFF
--- a/scripted-tests/run/execution-context/build.sbt
+++ b/scripted-tests/run/execution-context/build.sbt
@@ -8,7 +8,7 @@ runAndCheck := {
   import scala.sys.process._
 
   val bin = (Compile / nativeLink).value
-  val out = Process(bin.getAbsolutePath).lines_!.toList
+  val out = Process(bin.getAbsolutePath).lineStream_!.toList
   assert(
     out == List(
       "start main",


### PR DESCRIPTION
  * A deprecation error hiding in the build log file became evident
    whilst I was debugging PR #1853.

    That error is now removed so that true errors have a better chance
    of being recognized by people reading build logs.

Documentation:

  * None needed, this is an internal re-organization & simplification.

Testing:

  * Built ("rebuild")and tested ("test-all") in debug mode using sbt 1.3.13
    & Java 8 on X86_64 only . All tests pass.