### PR TITLE
Fix #1801: Store the already processed byte string in Val.Chars

### DIFF
--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -357,6 +357,9 @@ strings (similarly to C):
     val msg: CString = c"Hello, world!"
     stdio.printf(msg)
 
+It does not allow any octal values or escape characters not supported by Scala compiler, like ``\a`` or ``\?``.
+It is possible to use C-style hex values up to value 0xFF, eg. ``c"Hello \x61\x62\x63"``
+
 Additionally, we also expose two helper functions ``unsafe.toCString`` and
 ``unsafe.fromCString`` to convert between C-style and Java-style strings.
 

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -357,11 +357,17 @@ strings (similarly to C):
     val msg: CString = c"Hello, world!"
     stdio.printf(msg)
 
-It does not allow any octal values or escape characters not supported by Scala compiler, like ``\a`` or ``\?``.
+It does not allow any octal values or escape characters not supported by Scala compiler, like ``\a`` or ``\?``, but also unicode escapes.
 It is possible to use C-style hex values up to value 0xFF, eg. ``c"Hello \x61\x62\x63"``
 
-Additionally, we also expose two helper functions ``unsafe.toCString`` and
-``unsafe.fromCString`` to convert between C-style and Java-style strings.
+Additionally, we also expose two helper functions ``unsafe.fromCString`` and ``unsafe.toCString``
+to convert between C-style `CString` (sequence of Bytes, usually interpreted as UTF-8 or ASCII)
+and Java-style `String` (sequence of 2-byte Chars usually interpreted as UTF-16).
+
+It's worth to remember that ``unsafe.toCString`` and `c"..."` interpreter cannot be used interchangeably as they handle literals differently.
+Helper methods ``unsafe.fromCString` and ``unsafe.toCString`` are charset aware.
+They will always assume `String` is UTF-16, and take a `Charset` parameter to know what encoding to assume for the byte string (`CString`) - if not present it is UTF-8.
+
 
 Platform-specific types
 -----------------------

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -1,8 +1,9 @@
 package scala.scalanative
 package nir
 
+import java.nio.charset.StandardCharsets
 import scala.collection.mutable
-import scalanative.util.{unreachable, ShowBuilder}
+import scalanative.util.{ShowBuilder, unreachable}
 
 object Show {
   def newBuilder: NirShowBuilder = new NirShowBuilder(new ShowBuilder)
@@ -460,7 +461,9 @@ object Show {
         str("}")
       case v: Val.Chars =>
         str("c\"")
-        str(escapeNewLine(escapeQuotes(v.stringValue)))
+        val stringValue =
+          new java.lang.String(v.bytes, StandardCharsets.ISO_8859_1)
+        str(escapeNewLine(escapeQuotes(stringValue)))
         str("\"")
       case Val.Local(name, ty) =>
         local_(name)

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -458,10 +458,9 @@ object Show {
         str(" {")
         rep(values, sep = ", ")(val_)
         str("}")
-      case Val.Chars(v) =>
+      case v: Val.Chars =>
         str("c\"")
-        val strVal = new String(v, "UTF-8")
-        str(escapeNewLine(escapeQuotes(strVal)))
+        str(escapeNewLine(escapeQuotes(v.stringValue)))
         str("\"")
       case Val.Local(name, ty) =>
         local_(name)

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -460,7 +460,8 @@ object Show {
         str("}")
       case Val.Chars(v) =>
         str("c\"")
-        str(escapeNewLine(escapeQuotes(v)))
+        val strVal = new String(v, "UTF-8")
+        str(escapeNewLine(escapeQuotes(strVal)))
         str("\"")
       case Val.Local(name, ty) =>
         local_(name)

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -176,7 +176,6 @@ object Val {
   final case class Chars(value: Seq[scala.Byte]) extends Val {
     lazy val byteCount: scala.Int     = value.length + 1
     lazy val bytes: Array[scala.Byte] = value.toArray
-    lazy val stringValue              = new java.lang.String(bytes, "UTF-8")
   }
   final case class Local(name: nir.Local, valty: nir.Type)   extends Val
   final case class Global(name: nir.Global, valty: nir.Type) extends Val

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -174,8 +174,10 @@ object Val {
   }
   final case class StructValue(values: Seq[Val])                  extends Val
   final case class ArrayValue(elemty: nir.Type, values: Seq[Val]) extends Val
-  final case class Chars(value: Array[scala.Byte]) extends Val {
+  final case class Chars(value: Seq[scala.Byte]) extends Val {
     lazy val byteCount: scala.Int = value.length + 1
+    lazy val bytes: Array[scala.Byte] = value.toArray
+    lazy val stringValue = new java.lang.String(bytes, "UTF-8")
   }
   final case class Local(name: nir.Local, valty: nir.Type)   extends Val
   final case class Global(name: nir.Global, valty: nir.Type) extends Val

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -3,7 +3,6 @@ package nir
 
 import java.lang.Float.floatToRawIntBits
 import java.lang.Double.doubleToRawLongBits
-import scala.annotation.tailrec
 
 sealed abstract class Val {
   final def ty: Type = this match {
@@ -175,9 +174,9 @@ object Val {
   final case class StructValue(values: Seq[Val])                  extends Val
   final case class ArrayValue(elemty: nir.Type, values: Seq[Val]) extends Val
   final case class Chars(value: Seq[scala.Byte]) extends Val {
-    lazy val byteCount: scala.Int = value.length + 1
+    lazy val byteCount: scala.Int     = value.length + 1
     lazy val bytes: Array[scala.Byte] = value.toArray
-    lazy val stringValue = new java.lang.String(bytes, "UTF-8")
+    lazy val stringValue              = new java.lang.String(bytes, "UTF-8")
   }
   final case class Local(name: nir.Local, valty: nir.Type)   extends Val
   final case class Global(name: nir.Global, valty: nir.Type) extends Val

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -175,59 +175,7 @@ object Val {
   final case class StructValue(values: Seq[Val])                  extends Val
   final case class ArrayValue(elemty: nir.Type, values: Seq[Val]) extends Val
   final case class Chars(value: java.lang.String) extends Val {
-    lazy val byteCount: scala.Int = {
-      import Character.isDigit
-
-      def isOct(c: scala.Char): Boolean =
-        isDigit(c) && c != '8' && c != '9'
-      def isHex(c: scala.Char): Boolean =
-        isDigit(c) ||
-          c == 'a' || c == 'b' || c == 'c' || c == 'd' || c == 'e' || c == 'f' ||
-          c == 'A' || c == 'B' || c == 'C' || c == 'D' || c == 'E' || c == 'F'
-      def malformed() =
-        throw new IllegalArgumentException("malformed C string: " + value)
-
-      // Subtracts from the length of the bytes for each escape sequence
-      // uses String, not Seq[Byte], but should be okay since we handle ASCII only
-      val chars = value.toArray
-      var accum = chars.length + 1
-      var idx   = 0
-
-      while (idx < chars.length) {
-        if (chars(idx) == '\\') {
-          if (idx == chars.length - 1) {
-            malformed()
-          } else {
-            chars(idx + 1) match {
-              case d if isOct(d) =>
-                // octal ("\O", "\OO", "\OOO")
-                val digitNum =
-                  chars.drop(idx + 1).take(3).takeWhile(isOct).length
-                idx += digitNum
-                accum -= digitNum
-              case 'x' =>
-                // hexademical ("\xH", "\xHH")
-                val digitNum = chars.drop(idx + 2).takeWhile(isHex).length
-                // mimic clang, which reports compilation error against too many hex digits
-                if (digitNum >= 3) {
-                  malformed()
-                }
-                idx += digitNum + 1
-                accum -= digitNum + 1
-              // TODO: support unicode?
-              // case 'u' =>
-              // case 'U' =>
-              case _ =>
-                idx += 1
-                accum -= 1
-            }
-          }
-        }
-        idx += 1
-      }
-
-      accum
-    }
+    lazy val byteCount: scala.Int = value.length + 1
   }
   final case class Local(name: nir.Local, valty: nir.Type)   extends Val
   final case class Global(name: nir.Global, valty: nir.Type) extends Val

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -174,7 +174,7 @@ object Val {
   }
   final case class StructValue(values: Seq[Val])                  extends Val
   final case class ArrayValue(elemty: nir.Type, values: Seq[Val]) extends Val
-  final case class Chars(value: java.lang.String) extends Val {
+  final case class Chars(value: Array[scala.Byte]) extends Val {
     lazy val byteCount: scala.Int = value.length + 1
   }
   final case class Local(name: nir.Local, valty: nir.Type)   extends Val

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -271,7 +271,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
     case T.CharsVal =>
       Val.Chars {
         if (prelude.revision < 7)
-          StringUtils.processEscapes(getString()).getBytes("UTF-8")
+          StringUtils.processEscapes(getString())
         else getBytes()
       }
     case T.LocalVal  => Val.Local(getLocal, getType)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -3,21 +3,21 @@ package nir
 package serialization
 
 import java.nio.ByteBuffer
-
 import scala.collection.mutable
 import scala.scalanative.nir.serialization.{Tags => T}
+import scala.scalanative.util.StringUtils
 
 final class BinaryDeserializer(buffer: ByteBuffer) {
   import buffer._
 
-  private val header: Map[Global, Int] = {
+  private val (prelude, header): (Prelude, Map[Global, Int]) = {
     buffer.position(0)
 
-    Prelude.readFrom(buffer)
+    val prelude = Prelude.readFrom(buffer)
 
     val pairs = getSeq((getGlobal, getInt))
     val map   = pairs.toMap
-    map
+    prelude -> map
   }
 
   final def globals: Set[Global] = header.keySet
@@ -268,9 +268,14 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
     case T.DoubleVal      => Val.Double(getDouble)
     case T.StructValueVal => Val.StructValue(getVals)
     case T.ArrayValueVal  => Val.ArrayValue(getType, getVals)
-    case T.CharsVal       => Val.Chars(getBytes())
-    case T.LocalVal       => Val.Local(getLocal, getType)
-    case T.GlobalVal      => Val.Global(getGlobal, getType)
+    case T.CharsVal =>
+      Val.Chars {
+        if (prelude.revision < 7)
+          StringUtils.processEscapes(getString()).getBytes("UTF-8")
+        else getBytes()
+      }
+    case T.LocalVal  => Val.Local(getLocal, getType)
+    case T.GlobalVal => Val.Global(getGlobal, getType)
 
     case T.UnitVal    => Val.Unit
     case T.ConstVal   => Val.Const(getVal)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -42,9 +42,12 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
 
   private def getStrings(): Seq[String] = getSeq(getString)
   private def getString(): String = {
+    new String(getBytes(), "UTF-8")
+  }
+  private def getBytes(): Array[Byte] = {
     val arr = new Array[Byte](getInt)
     get(arr)
-    new String(arr, "UTF-8")
+    arr
   }
 
   private def getBool(): Boolean = get != 0
@@ -265,7 +268,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
     case T.DoubleVal      => Val.Double(getDouble)
     case T.StructValueVal => Val.StructValue(getVals)
     case T.ArrayValueVal  => Val.ArrayValue(getType, getVals)
-    case T.CharsVal       => Val.Chars(getString)
+    case T.CharsVal       => Val.Chars(getBytes())
     case T.LocalVal       => Val.Local(getLocal, getType)
     case T.GlobalVal      => Val.Global(getGlobal, getType)
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -482,7 +482,7 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Val.StructValue(vs) => putInt(T.StructValueVal); putVals(vs)
     case Val.ArrayValue(ty, vs) =>
       putInt(T.ArrayValueVal); putType(ty); putVals(vs)
-    case Val.Chars(b)      => putInt(T.CharsVal); putBytes(b.toArray)
+    case v: Val.Chars      => putInt(T.CharsVal); putBytes(v.bytes)
     case Val.Local(n, ty)  => putInt(T.LocalVal); putLocal(n); putType(ty)
     case Val.Global(n, ty) => putInt(T.GlobalVal); putGlobal(n); putType(ty)
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -482,7 +482,7 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Val.StructValue(vs) => putInt(T.StructValueVal); putVals(vs)
     case Val.ArrayValue(ty, vs) =>
       putInt(T.ArrayValueVal); putType(ty); putVals(vs)
-    case Val.Chars(b)      => putInt(T.CharsVal); putBytes(b)
+    case Val.Chars(b)      => putInt(T.CharsVal); putBytes(b.toArray)
     case Val.Local(n, ty)  => putInt(T.LocalVal); putLocal(n); putType(ty)
     case Val.Global(n, ty) => putInt(T.GlobalVal); putGlobal(n); putType(ty)
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -54,8 +54,10 @@ final class BinarySerializer(buffer: ByteBuffer) {
   private def putInts(ints: Seq[Int]) = putSeq[Int](ints)(putInt(_))
 
   private def putStrings(vs: Seq[String]) = putSeq(vs)(putString)
-  private def putString(v: String) = {
-    val bytes = v.getBytes("UTF-8")
+  private def putString(v: String) = putBytes {
+    v.getBytes("UTF-8")
+  }
+  private def putBytes(bytes: Array[Byte]) = {
     putInt(bytes.length); put(bytes)
   }
 
@@ -480,7 +482,7 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Val.StructValue(vs) => putInt(T.StructValueVal); putVals(vs)
     case Val.ArrayValue(ty, vs) =>
       putInt(T.ArrayValueVal); putType(ty); putVals(vs)
-    case Val.Chars(s)      => putInt(T.CharsVal); putString(s)
+    case Val.Chars(b)      => putInt(T.CharsVal); putBytes(b)
     case Val.Local(n, ty)  => putInt(T.LocalVal); putLocal(n); putType(ty)
     case Val.Global(n, ty) => putInt(T.GlobalVal); putGlobal(n); putType(ty)
 

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Val.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Val.scala
@@ -28,7 +28,7 @@ object Val extends Base[nir.Val] {
     P("arrayvalue" ~ Type.parser ~ "{" ~ Val.parser.rep(sep = ",") ~ "}" map {
       case (ty, values) => nir.Val.ArrayValue(ty, values)
     })
-  val Chars = P("c" ~ stringLit map (nir.Val.Chars(_)))
+  val Chars = P("c" ~ stringLit map (_.getBytes("UTF-8")) map (nir.Val.Chars(_)))
   val Local =
     P(nir.parser.Local.parser ~ ":" ~ Type.parser map {
       case (name, ty) => nir.Val.Local(name, ty)

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Val.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Val.scala
@@ -28,7 +28,8 @@ object Val extends Base[nir.Val] {
     P("arrayvalue" ~ Type.parser ~ "{" ~ Val.parser.rep(sep = ",") ~ "}" map {
       case (ty, values) => nir.Val.ArrayValue(ty, values)
     })
-  val Chars = P("c" ~ stringLit map (_.getBytes("UTF-8")) map (nir.Val.Chars(_)))
+  val Chars = P(
+    "c" ~ stringLit map (_.getBytes("UTF-8")) map (nir.Val.Chars(_)))
   val Local =
     P(nir.parser.Local.parser ~ ":" ~ Type.parser map {
       case (name, ty) => nir.Val.Local(name, ty)

--- a/nirparser/src/test/scala/scala/scalanative/nir/ValParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/ValParserTest.scala
@@ -25,7 +25,7 @@ class ValParserTest extends AnyFunSuite {
     Val.StructValue(Seq(Val.Int(32), Val.Long(64))),
     Val.ArrayValue(Type.Int, Seq.empty),
     Val.ArrayValue(Type.Int, Seq(Val.Int(32))),
-    Val.Chars("foobar"),
+    Val.Chars("foobar".getBytes("UTF-8")),
     Val.Local(Local(0), Type.Int),
     Val.Global(global, Type.Ptr),
     Val.Unit,

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1,6 +1,8 @@
 package scala.scalanative
 package nscplugin
 
+import scala.StringContext.InvalidEscapeException
+import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.reflect.internal.Flags._
 import scalanative.nir._
@@ -1277,7 +1279,8 @@ trait NirGenExpr { self: NirGenPhase =>
                               _))))))),
             _),
             _) =>
-          val chars = Val.Chars(str.replace("\\n", "\n").replace("\\r", "\r"))
+
+          val chars = Val.Chars(treatEscapes(str))
           val const = Val.Const(chars)
           buf.box(nir.Rt.BoxedPtr, const, unwind)
 
@@ -1658,6 +1661,54 @@ trait NirGenExpr { self: NirGenPhase =>
 
     def genSimpleArgs(argsp: Seq[Tree]): Seq[Val] = {
       argsp.map(genExpr)
+    }
+
+    private def treatEscapes(str: String): String = {
+      val len = str.length
+      val b = new java.lang.StringBuilder()
+
+      // replace escapes with given first escape
+      import Character.isDigit
+      def isOct(c: Char): Boolean = isDigit(c) && c != '8' && c != '9'
+
+      def isHex(c: Char): Boolean =
+        isDigit(c) ||
+          c == 'a' || c == 'b' || c == 'c' || c == 'd' || c == 'e' || c == 'f' ||
+          c == 'A' || c == 'B' || c == 'C' || c == 'D' || c == 'E' || c == 'F'
+
+      // append replacement starting at index `i`, with `next` backslash
+      @tailrec def loop(from: Int): java.lang.StringBuilder = {
+
+        str.indexOf('\\', from) match {
+          case -1 => b.append(str.substring(from))
+          case idx => b.append(str.substring(from, idx))
+            if (idx >= len) throw new InvalidEscapeException(str, from)
+            str(idx + 1) match {
+              case 'b' => b.append('\b'); loop(idx + 2)
+              case 't' => b.append('\t'); loop(idx + 2)
+              case 'n' => b.append('\n'); loop(idx + 2)
+              case 'f' => b.append('\f'); loop(idx + 2)
+              case 'r' => b.append('\r'); loop(idx + 2)
+              case '"' => b.append('\"'); loop(idx + 2)
+              case '\'' => b.append('\''); loop(idx + 2)
+              case '\\' => b.append('\\'); loop(idx + 2)
+              case o if isOct(o) =>
+                val oct = str.drop(idx + 1).take(3).takeWhile(isOct)
+                b.append(Integer.parseInt(oct, 8).toChar)
+                loop(idx + 1 + oct.length)
+              case 'x' =>
+                val hex = str.drop(idx + 2).takeWhile(isHex)
+                b.append(Integer.parseInt(hex, 16).toChar)
+                loop(idx + 2 + hex.length)
+              case c => b
+                .append('\\')
+                .append(c)
+                loop(idx + 2)
+            }
+        }
+      }
+
+      loop(0).toString
     }
   }
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -10,7 +10,9 @@ import scalanative.util.unsupported
 import scalanative.util.ScopedVar.scoped
 import scalanative.nscplugin.NirPrimitives._
 
-trait NirGenExpr { self: NirGenPhase =>
+trait NirGenExpr {
+  self: NirGenPhase =>
+
   import global._
   import definitions._
   import treeInfo.hasSynthCaseSymbol
@@ -18,7 +20,8 @@ trait NirGenExpr { self: NirGenPhase =>
   import nirDefinitions._
   import SimpleType.{fromType, fromSymbol}
 
-  final case class ValTree(value: nir.Val)    extends Tree
+  final case class ValTree(value: nir.Val) extends Tree
+
   final case class ContTree(f: () => nir.Val) extends Tree
 
   class FixupBuffer(implicit fresh: Fresh) extends nir.Buffer {
@@ -56,7 +59,8 @@ trait NirGenExpr { self: NirGenPhase =>
       this ++= other.toSeq
   }
 
-  class ExprBuffer(implicit fresh: Fresh) extends FixupBuffer { buf =>
+  class ExprBuffer(implicit fresh: Fresh) extends FixupBuffer {
+    buf =>
     def genExpr(tree: Tree): Val = tree match {
       case EmptyTree =>
         Val.Unit
@@ -114,7 +118,7 @@ trait NirGenExpr { self: NirGenPhase =>
 
       def translateMatch(last: LabelDef) = {
         val (prologue, cases) = stats.span(s => !isCaseLabelDef(s))
-        val labels            = cases.map { case label: LabelDef => label }
+        val labels = cases.map { case label: LabelDef => label }
         genMatch(prologue, labels :+ last)
       }
 
@@ -123,7 +127,7 @@ trait NirGenExpr { self: NirGenPhase =>
           translateMatch(label)
 
         case Apply(TypeApply(Select(label: LabelDef, nme.asInstanceOf_Ob), _),
-                   _) if isCaseLabelDef(label) =>
+        _) if isCaseLabelDef(label) =>
           translateMatch(label)
 
         case _ =>
@@ -171,7 +175,7 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def genValDef(vd: ValDef): Val = {
-      val rhs       = genExpr(vd.rhs)
+      val rhs = genExpr(vd.rhs)
       val isMutable = curMethodInfo.mutableVars.contains(vd.symbol)
       if (!isMutable) {
         curMethodEnv.enter(vd.symbol, rhs)
@@ -184,13 +188,13 @@ trait NirGenExpr { self: NirGenPhase =>
 
     def genIf(tree: If): Val = {
       val If(cond, thenp, elsep) = tree
-      val retty                  = genType(tree.tpe)
+      val retty = genType(tree.tpe)
       genIf(retty, cond, thenp, elsep)
     }
 
     def genIf(retty: nir.Type, condp: Tree, thenp: Tree, elsep: Tree): Val = {
       val thenn, elsen, mergen = fresh()
-      val mergev               = Val.Local(fresh(), retty)
+      val mergev = Val.Local(fresh(), retty)
 
       val cond = genExpr(condp)
       buf.branch(cond, Next(thenn), Next(elsen))
@@ -232,15 +236,15 @@ trait NirGenExpr { self: NirGenPhase =>
 
       // Extract default case.
       val defaultp: Tree = allcaseps.collectFirst {
-        case c @ CaseDef(Ident(nme.WILDCARD), _, body) => body
+        case c@CaseDef(Ident(nme.WILDCARD), _, body) => body
       }.get
 
       // Generate some more fresh names and types.
-      val retty       = genType(m.tpe)
-      val casenexts   = caseps.map { case (n, v, _) => Next.Case(v, n) }
+      val retty = genType(m.tpe)
+      val casenexts = caseps.map { case (n, v, _) => Next.Case(v, n) }
       val defaultnext = Next(fresh())
-      val merge       = fresh()
-      val mergev      = Val.Local(fresh(), retty)
+      val merge = fresh()
+      val mergev = Val.Local(fresh(), retty)
 
       // Generate code for the switch and its cases.
       val scrut = genExpr(scrutp)
@@ -272,7 +276,7 @@ trait NirGenExpr { self: NirGenPhase =>
 
     def genTry(tree: Try): Val = tree match {
       case Try(expr, catches, finalizer)
-          if catches.isEmpty && finalizer.isEmpty =>
+        if catches.isEmpty && finalizer.isEmpty =>
         genExpr(expr)
       case Try(expr, catches, finalizer) =>
         val retty = genType(tree.tpe)
@@ -280,15 +284,15 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def genTry(retty: nir.Type,
-               expr: Tree,
-               catches: List[Tree],
-               finallyp: Tree): Val = {
+      expr: Tree,
+      catches: List[Tree],
+      finallyp: Tree): Val = {
       val handler = fresh()
-      val excn    = fresh()
+      val excn = fresh()
       val normaln = fresh()
-      val mergen  = fresh()
-      val excv    = Val.Local(fresh(), Rt.Object)
-      val mergev  = Val.Local(fresh(), retty)
+      val mergen = fresh()
+      val excv = Val.Local(fresh(), Rt.Object)
+      val mergev = Val.Local(fresh(), retty)
 
       // Nested code gen to separate out try/catch-related instructions.
       val nested = new ExprBuffer
@@ -321,9 +325,9 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def genTryCatch(retty: nir.Type,
-                    exc: Val,
-                    mergen: Local,
-                    catches: List[Tree]): Val = {
+      exc: Val,
+      mergen: Local,
+      catches: List[Tree]): Val = {
       val cases = catches.map {
         case CaseDef(pat, _, body) =>
           val (excty, symopt) = pat match {
@@ -354,9 +358,9 @@ trait NirGenExpr { self: NirGenPhase =>
           case (excty, f) +: rest =>
             val cond = buf.is(excty, exc, unwind)
             genIf(retty,
-                  ValTree(cond),
-                  ContTree(f),
-                  ContTree(() => wrap(rest)))
+              ValTree(cond),
+              ContTree(f),
+              ContTree(() => wrap(rest)))
         }
 
       wrap(cases)
@@ -367,14 +371,15 @@ trait NirGenExpr { self: NirGenPhase =>
         insts.collect {
           case Inst.Label(n, _) => n
         }.toSet
+
       def internal(cf: Inst.Cf) = cf match {
-        case inst @ Inst.Jump(n) =>
+        case inst@Inst.Jump(n) =>
           labels.contains(n.name)
-        case inst @ Inst.If(_, n1, n2) =>
+        case inst@Inst.If(_, n1, n2) =>
           labels.contains(n1.name) && labels.contains(n2.name)
-        case inst @ Inst.Switch(_, n, ns) =>
+        case inst@Inst.Switch(_, n, ns) =>
           labels.contains(n.name) && ns.forall(n => labels.contains(n.name))
-        case inst @ Inst.Throw(_, n) =>
+        case inst@Inst.Throw(_, n) =>
           (n ne Next.None) && labels.contains(n.name)
         case _ =>
           false
@@ -403,7 +408,7 @@ trait NirGenExpr { self: NirGenPhase =>
 
     def genThrow(tree: Throw): Val = {
       val Throw(exprp) = tree
-      val res          = genExpr(exprp)
+      val res = genExpr(exprp)
       buf.raise(res, unwind)
       Val.Unit
     }
@@ -429,7 +434,7 @@ trait NirGenExpr { self: NirGenPhase =>
       val value = lit.value
       value.tag match {
         case UnitTag | NullTag | BooleanTag | ByteTag | ShortTag | CharTag |
-            IntTag | LongTag | FloatTag | DoubleTag | StringTag =>
+             IntTag | LongTag | FloatTag | DoubleTag | StringTag =>
           genLiteralValue(lit)
 
         case ClazzTag =>
@@ -512,7 +517,7 @@ trait NirGenExpr { self: NirGenPhase =>
     def genSelect(tree: Select): Val = {
       val Select(qualp, selp) = tree
 
-      val sym   = tree.symbol
+      val sym = tree.symbol
       val owner = sym.owner
       if (sym.isModule) {
         genModule(sym)
@@ -522,10 +527,10 @@ trait NirGenExpr { self: NirGenPhase =>
         genApplyMethod(sym, statically = false, qualp, Seq())
       } else if (owner.isStruct) {
         val index = owner.info.decls.filter(_.isField).toList.indexOf(sym)
-        val qual  = genExpr(qualp)
+        val qual = genExpr(qualp)
         buf.extract(qual, Seq(index), unwind)
       } else {
-        val ty   = genType(tree.symbol.tpe)
+        val ty = genType(tree.symbol.tpe)
         val qual = genExpr(qualp)
         val name = genFieldName(tree.symbol)
         if (sym.owner.isExternModule) {
@@ -541,7 +546,7 @@ trait NirGenExpr { self: NirGenPhase =>
       if (sym == BoxedUnit_UNIT) {
         Val.Unit
       } else {
-        val ty     = genType(sym.tpe)
+        val ty = genType(sym.tpe)
         val module = genModule(sym.owner)
         genApplyMethod(sym, statically = true, module, Seq())
       }
@@ -551,10 +556,10 @@ trait NirGenExpr { self: NirGenPhase =>
       val Assign(lhsp, rhsp) = tree
 
       lhsp match {
-        case sel @ Select(qualp, _) =>
-          val ty   = genType(sel.tpe)
+        case sel@Select(qualp, _) =>
+          val ty = genType(sel.tpe)
           val qual = genExpr(qualp)
-          val rhs  = genExpr(rhsp)
+          val rhs = genExpr(rhsp)
           val name = genFieldName(sel.symbol)
           if (sel.symbol.owner.isExternModule) {
             val externTy = genExternType(sel.tpe)
@@ -564,8 +569,8 @@ trait NirGenExpr { self: NirGenPhase =>
           }
 
         case id: Ident =>
-          val ty   = genType(id.tpe)
-          val rhs  = genExpr(rhsp)
+          val ty = genType(id.tpe)
+          val rhs = genExpr(rhsp)
           val slot = curMethodEnv.resolve(id.symbol)
           buf.varstore(slot, rhs, unwind)
       }
@@ -583,7 +588,7 @@ trait NirGenExpr { self: NirGenPhase =>
 
     def genApplyDynamic(app: ApplyDynamic): Val = {
       val ApplyDynamic(obj, args) = app
-      val sym                     = app.symbol
+      val sym = app.symbol
 
       val params = sym.tpe.params
 
@@ -592,7 +597,7 @@ trait NirGenExpr { self: NirGenPhase =>
 
       // If the method is '=='or '!=' generate class equality instead of dyn-call
       if (isEqEqOrBangEq) {
-        val neg  = sym.name == nme.ne || sym.name == NotEqMethodName
+        val neg = sym.name == nme.ne || sym.name == NotEqMethodName
         val last = genClassEquality(obj, args.head, ref = false, negated = neg)
         buf.box(nir.Type.Ref(nir.Global.Top("java.lang.Boolean")), last, unwind)
       } else {
@@ -603,11 +608,11 @@ trait NirGenExpr { self: NirGenPhase =>
 
     def genApplyDynamic(sym: Symbol, self: Val, argsp: Seq[Tree]): Val = {
       val methodSig = genMethodSig(sym).asInstanceOf[Type.Function]
-      val params    = sym.tpe.params
+      val params = sym.tpe.params
 
       def isArrayLikeOp = {
         sym.name == nme.update &&
-        params.size == 2 && params.head.tpe.typeSymbol == IntClass
+          params.size == 2 && params.head.tpe.typeSymbol == IntClass
       }
 
       def genDynCall(arrayUpdate: Boolean) = {
@@ -631,9 +636,9 @@ trait NirGenExpr { self: NirGenPhase =>
         val boxedArgTypes =
           methodSig.args.tail.map(ty => nir.Type.box.getOrElse(ty, ty)).toList
 
-        val retType   = nir.Type.Ref(nir.Global.Top("java.lang.Object"))
+        val retType = nir.Type.Ref(nir.Global.Top("java.lang.Object"))
         val signature = nir.Type.Function(callerType :: boxedArgTypes, retType)
-        val args      = genMethodArgs(sym, argsp)
+        val args = genMethodArgs(sym, argsp)
 
         val method = buf.dynmethod(self, methodName, unwind)
         val values = self +: args
@@ -646,8 +651,8 @@ trait NirGenExpr { self: NirGenPhase =>
       if (isArrayLikeOp) {
         val cond = ContTree { () =>
           buf.is(nir.Type.Ref(
-                   nir.Global.Top("scala.scalanative.runtime.ObjectArray")),
-                 self, unwind)
+            nir.Global.Top("scala.scalanative.runtime.ObjectArray")),
+            self, unwind)
         }
         val thenp = ContTree { () =>
           genDynCall(arrayUpdate = true)
@@ -656,9 +661,9 @@ trait NirGenExpr { self: NirGenPhase =>
           genDynCall(arrayUpdate = false)
         }
         genIf(nir.Type.Ref(nir.Global.Top("java.lang.Object")),
-              cond,
-              thenp,
-              elsep)
+          cond,
+          thenp,
+          elsep)
 
       } else {
         genDynCall(arrayUpdate = false)
@@ -673,9 +678,9 @@ trait NirGenExpr { self: NirGenPhase =>
           genApplyTypeApply(app)
         case Select(Super(_, _), _) =>
           genApplyMethod(fun.symbol,
-                        statically = true,
-                        curMethodThis.get.get,
-                        args)
+            statically = true,
+            curMethodThis.get.get,
+            args)
         case Select(New(_), nme.CONSTRUCTOR) =>
           genApplyNew(app)
         case _ =>
@@ -698,9 +703,9 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def genApplyLabel(tree: Tree): Val = {
-      val Apply(fun, argsp)   = tree
+      val Apply(fun, argsp) = tree
       val Val.Local(label, _) = curMethodEnv.resolve(fun.symbol)
-      val args                = genSimpleArgs(argsp)
+      val args = genSimpleArgs(argsp)
       buf.jump(label, args)
       Val.Unit
     }
@@ -726,9 +731,9 @@ trait NirGenExpr { self: NirGenPhase =>
     def genApplyPrimitive(app: Apply): Val = {
       import scalaPrimitives._
 
-      val Apply(fun @ Select(receiver, _), args) = app
+      val Apply(fun@Select(receiver, _), args) = app
 
-      val sym  = app.symbol
+      val sym = app.symbol
       val code = scalaPrimitives.getPrimitive(sym, receiver.tpe)
 
       if (isArithmeticOp(code) || isLogicalOp(code) || isComparisonOp(code)) {
@@ -764,8 +769,8 @@ trait NirGenExpr { self: NirGenPhase =>
       }
     }
 
-    lazy val jlClassName     = nir.Global.Top("java.lang.Class")
-    lazy val jlClass         = nir.Type.Ref(jlClassName)
+    lazy val jlClassName = nir.Global.Top("java.lang.Class")
+    lazy val jlClass = nir.Type.Ref(jlClassName)
     lazy val jlClassCtorName = jlClassName.member(nir.Sig.Ctor(Seq(nir.Type.Ptr)))
     lazy val jlClassCtorSig =
       nir.Type.Function(Seq(jlClass, Type.Ptr), nir.Type.Unit)
@@ -778,55 +783,58 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def numOfType(num: Int, ty: nir.Type): Val = ty match {
-      case Type.Byte                => Val.Byte(num.toByte)
-      case Type.Short  | Type.Char => Val.Short(num.toShort)
-      case Type.Int                  => Val.Int(num)
-      case Type.Long                => Val.Long(num.toLong)
-      case Type.Float                           => Val.Float(num.toFloat)
-      case Type.Double                          => Val.Double(num.toDouble)
-      case _                                    => unsupported(s"num = $num, ty = ${ty.show}")
+      case Type.Byte => Val.Byte(num.toByte)
+      case Type.Short | Type.Char => Val.Short(num.toShort)
+      case Type.Int => Val.Int(num)
+      case Type.Long => Val.Long(num.toLong)
+      case Type.Float => Val.Float(num.toFloat)
+      case Type.Double => Val.Double(num.toDouble)
+      case _ => unsupported(s"num = $num, ty = ${ty.show}")
     }
 
     def genSimpleOp(app: Apply, args: List[Tree], code: Int): Val = {
       val retty = genType(app.tpe)
 
       args match {
-        case List(right)       => genUnaryOp(code, right, retty)
+        case List(right) => genUnaryOp(code, right, retty)
         case List(left, right) => genBinaryOp(code, left, right, retty)
-        case _                 => abort("Too many arguments for primitive function: " + app)
+        case _ => abort("Too many arguments for primitive function: " + app)
       }
     }
 
     def negateInt(value: nir.Val): Val =
       buf.bin(Bin.Isub, value.ty, numOfType(0, value.ty), value, unwind)
+
     def negateFloat(value: nir.Val): Val =
       buf.bin(Bin.Fsub, value.ty, numOfType(0, value.ty), value, unwind)
+
     def negateBits(value: nir.Val): Val =
       buf.bin(Bin.Xor, value.ty, numOfType(-1, value.ty), value, unwind)
+
     def negateBool(value: nir.Val): Val =
       buf.bin(Bin.Xor, Type.Bool, Val.True, value, unwind)
 
     def genUnaryOp(code: Int, rightp: Tree, opty: nir.Type): Val = {
       import scalaPrimitives._
 
-      val right   = genExpr(rightp)
+      val right = genExpr(rightp)
       val coerced = genCoercion(right, right.ty, opty)
 
       (opty, code) match {
         case (_: Type.I | _: Type.F, POS) => coerced
-        case (_: Type.I, NOT)             => negateBits(coerced)
-        case (_: Type.F, NEG)             => negateFloat(coerced)
-        case (_: Type.I, NEG)             => negateInt(coerced)
-        case (Type.Bool, ZNOT)            => negateBool(coerced)
-        case _                            => abort("Unknown unary operation code: " + code)
+        case (_: Type.I, NOT) => negateBits(coerced)
+        case (_: Type.F, NEG) => negateFloat(coerced)
+        case (_: Type.I, NEG) => negateInt(coerced)
+        case (Type.Bool, ZNOT) => negateBool(coerced)
+        case _ => abort("Unknown unary operation code: " + code)
       }
     }
 
     def genBinaryOp(code: Int, left: Tree, right: Tree, retty: nir.Type): Val = {
       import scalaPrimitives._
 
-      val lty  = genType(left.tpe)
-      val rty  = genType(right.tpe)
+      val lty = genType(left.tpe)
+      val rty = genType(right.tpe)
       val opty =
         if (isShiftOp(code)) {
           if (lty == nir.Type.Long) {
@@ -924,7 +932,7 @@ trait NirGenExpr { self: NirGenPhase =>
             // generate reference equality, regardless of where it
             // was called with == or eq. This shortcut is not optional.
             case (Literal(Constant(null)), _)
-               | (_, Literal(Constant(null))) =>
+                 | (_, Literal(Constant(null))) =>
               genClassEquality(left, right, ref = true, negated = negated)
             case _ =>
               genClassEquality(left, right, ref = ref, negated = negated)
@@ -960,32 +968,32 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def genBinaryOp(op: (nir.Type, Val, Val) => Op,
-                    leftp: Tree,
-                    rightp: Tree,
-                    opty: nir.Type): Val = {
-      val leftty       = genType(leftp.tpe)
-      val left         = genExpr(leftp)
-      val leftcoerced  = genCoercion(left, leftty, opty)
-      val rightty      = genType(rightp.tpe)
-      val right        = genExpr(rightp)
+      leftp: Tree,
+      rightp: Tree,
+      opty: nir.Type): Val = {
+      val leftty = genType(leftp.tpe)
+      val left = genExpr(leftp)
+      val leftcoerced = genCoercion(left, leftty, opty)
+      val rightty = genType(rightp.tpe)
+      val right = genExpr(rightp)
       val rightcoerced = genCoercion(right, rightty, opty)
 
       buf.let(op(opty, leftcoerced, rightcoerced), unwind)
     }
 
     def genClassEquality(leftp: Tree,
-                         rightp: Tree,
-                         ref: Boolean,
-                         negated: Boolean): Val = {
+      rightp: Tree,
+      ref: Boolean,
+      negated: Boolean): Val = {
       val left = genExpr(leftp)
 
       if (ref) {
         val right = genExpr(rightp)
-        val comp  = if (negated) Comp.Ine else Comp.Ieq
+        val comp = if (negated) Comp.Ine else Comp.Ieq
         buf.comp(comp, Rt.Object, left, right, unwind)
       } else {
         val thenn, elsen, mergen = fresh()
-        val mergev               = Val.Local(fresh(), nir.Type.Bool)
+        val mergev = Val.Local(fresh(), nir.Type.Bool)
 
         val isnull = buf.comp(Comp.Ieq, Rt.Object, left, Val.Null, unwind)
         buf.branch(isnull, Next(thenn), Next(elsen))
@@ -998,9 +1006,9 @@ trait NirGenExpr { self: NirGenPhase =>
         locally {
           buf.label(elsen)
           val elsev = genApplyMethod(NObjectEqualsMethod,
-                                    statically = false,
-                                    left,
-                                    Seq(rightp))
+            statically = false,
+            left,
+            Seq(rightp))
           buf.jump(mergen, Seq(elsev))
         }
         buf.label(mergen, Seq(mergev))
@@ -1019,7 +1027,7 @@ trait NirGenExpr { self: NirGenPhase =>
       case (nir.Type.Bool, nir.Type.Bool) =>
         nir.Type.Bool
       case (nir.Type.I(lwidth, _), nir.Type.I(rwidth, _))
-          if lwidth < 32 && rwidth < 32 =>
+        if lwidth < 32 && rwidth < 32 =>
         nir.Type.Int
       case (nir.Type.I(lwidth, _), nir.Type.I(rwidth, _)) =>
         if (lwidth >= rwidth) lty else rty
@@ -1059,13 +1067,13 @@ trait NirGenExpr { self: NirGenPhase =>
       val left = {
         val typesym = leftp.tpe.typeSymbol
         val unboxed = genExpr(leftp)
-        val boxed   = boxValue(typesym, unboxed)
+        val boxed = boxValue(typesym, unboxed)
         stringify(typesym, boxed)
       }
 
       val right = {
         val typesym = rightp.tpe.typeSymbol
-        val boxed   = genExpr(rightp)
+        val boxed = genExpr(rightp)
         stringify(typesym, boxed)
       }
 
@@ -1073,11 +1081,11 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def genHashCode(argp: Tree): Val = {
-      val arg    = boxValue(argp.tpe, genExpr(argp))
+      val arg = boxValue(argp.tpe, genExpr(argp))
       val isnull = buf.comp(Comp.Ieq, Rt.Object, arg, Val.Null, unwind)
-      val cond   = ValTree(isnull)
-      val thenp  = ValTree(Val.Int(0))
-      val elsep  = ContTree { () =>
+      val cond = ValTree(isnull)
+      val thenp = ValTree(Val.Int(0))
+      val elsep = ContTree { () =>
         val meth = NObjectHashCodeMethod
         genApplyMethod(meth, statically = false, arg, Seq())
       }
@@ -1092,16 +1100,17 @@ trait NirGenExpr { self: NirGenPhase =>
       val Type.Array(elemty, _) = genType(arrayp.tpe)
 
       def elemcode = genArrayCode(arrayp.tpe)
-      val array    = genExpr(arrayp)
+
+      val array = genExpr(arrayp)
 
       if (code == ARRAY_CLONE) {
         val method = RuntimeArrayCloneMethod(elemcode)
         genApplyMethod(method, statically = true, array, argsp)
       } else if (scalaPrimitives.isArrayGet(code)) {
-        val idx    = genExpr(argsp(0))
+        val idx = genExpr(argsp(0))
         buf.arrayload(elemty, array, idx, unwind)
       } else if (scalaPrimitives.isArraySet(code)) {
-        val idx   = genExpr(argsp(0))
+        val idx = genExpr(argsp(0))
         val value = genExpr(argsp(1))
         buf.arraystore(elemty, array, idx, value, unwind)
       } else {
@@ -1112,8 +1121,8 @@ trait NirGenExpr { self: NirGenPhase =>
     def boxValue(st: SimpleType, value: Val): Val = st.sym match {
       case UByteClass | UShortClass | UIntClass | ULongClass =>
         genApplyModuleMethod(RuntimeBoxesModule,
-                             BoxUnsignedMethod(st.sym),
-                             Seq(ValTree(value)))
+          BoxUnsignedMethod(st.sym),
+          Seq(ValTree(value)))
       case _ =>
         if (genPrimCode(st.sym) == 'O') {
           value
@@ -1130,8 +1139,8 @@ trait NirGenExpr { self: NirGenPhase =>
           value
         } else {
           genApplyModuleMethod(RuntimeBoxesModule,
-                               UnboxUnsignedMethod(st.sym),
-                               Seq(ValTree(value)))
+            UnboxUnsignedMethod(st.sym),
+            Seq(ValTree(value)))
         }
       case _ =>
         if (genPrimCode(st) == 'O') {
@@ -1160,16 +1169,16 @@ trait NirGenExpr { self: NirGenPhase =>
       val ptr = genExpr(ptrp)
 
       val ty = code match {
-        case LOAD_BOOL    => nir.Type.Bool
-        case LOAD_CHAR    => nir.Type.Char
-        case LOAD_BYTE    => nir.Type.Byte
-        case LOAD_SHORT   => nir.Type.Short
-        case LOAD_INT     => nir.Type.Int
-        case LOAD_LONG    => nir.Type.Long
-        case LOAD_FLOAT   => nir.Type.Float
-        case LOAD_DOUBLE  => nir.Type.Double
+        case LOAD_BOOL => nir.Type.Bool
+        case LOAD_CHAR => nir.Type.Char
+        case LOAD_BYTE => nir.Type.Byte
+        case LOAD_SHORT => nir.Type.Short
+        case LOAD_INT => nir.Type.Int
+        case LOAD_LONG => nir.Type.Long
+        case LOAD_FLOAT => nir.Type.Float
+        case LOAD_DOUBLE => nir.Type.Double
         case LOAD_RAW_PTR => nir.Type.Ptr
-        case LOAD_OBJECT  => Rt.Object
+        case LOAD_OBJECT => Rt.Object
       }
 
       buf.load(ty, ptr, unwind)
@@ -1178,20 +1187,20 @@ trait NirGenExpr { self: NirGenPhase =>
     def genRawPtrStoreOp(app: Apply, code: Int): Val = {
       val Apply(_, Seq(ptrp, valuep)) = app
 
-      val ptr   = genExpr(ptrp)
+      val ptr = genExpr(ptrp)
       val value = genExpr(valuep)
 
       val ty = code match {
-        case STORE_BOOL    => nir.Type.Bool
-        case STORE_CHAR    => nir.Type.Char
-        case STORE_BYTE    => nir.Type.Byte
-        case STORE_SHORT   => nir.Type.Short
-        case STORE_INT     => nir.Type.Int
-        case STORE_LONG    => nir.Type.Long
-        case STORE_FLOAT   => nir.Type.Float
-        case STORE_DOUBLE  => nir.Type.Double
+        case STORE_BOOL => nir.Type.Bool
+        case STORE_CHAR => nir.Type.Char
+        case STORE_BYTE => nir.Type.Byte
+        case STORE_SHORT => nir.Type.Short
+        case STORE_INT => nir.Type.Int
+        case STORE_LONG => nir.Type.Long
+        case STORE_FLOAT => nir.Type.Float
+        case STORE_DOUBLE => nir.Type.Double
         case STORE_RAW_PTR => nir.Type.Ptr
-        case STORE_OBJECT  => Rt.Object
+        case STORE_OBJECT => Rt.Object
       }
 
       buf.store(ty, ptr, value, unwind)
@@ -1200,7 +1209,7 @@ trait NirGenExpr { self: NirGenPhase =>
     def genRawPtrElemOp(app: Apply, code: Int): Val = {
       val Apply(_, Seq(ptrp, offsetp)) = app
 
-      val ptr    = genExpr(ptrp)
+      val ptr = genExpr(ptrp)
       val offset = genExpr(offsetp)
 
       buf.elem(Type.Byte, ptr, Seq(offset), unwind)
@@ -1210,24 +1219,24 @@ trait NirGenExpr { self: NirGenPhase =>
       val Apply(_, Seq(argp)) = app
 
       val fromty = genType(argp.tpe)
-      val toty   = genType(app.tpe)
-      val value  = genExpr(argp)
+      val toty = genType(app.tpe)
+      val value = genExpr(argp)
 
       genCastOp(fromty, toty, value)
     }
 
     def castConv(fromty: nir.Type, toty: nir.Type): Option[nir.Conv] =
       (fromty, toty) match {
-        case (_: Type.I, Type.Ptr)                   => Some(nir.Conv.Inttoptr)
-        case (Type.Ptr, _: Type.I)                   => Some(nir.Conv.Ptrtoint)
-        case (_: Type.RefKind, Type.Ptr)             => Some(nir.Conv.Bitcast)
-        case (Type.Ptr, _: Type.RefKind)             => Some(nir.Conv.Bitcast)
-        case (_: Type.RefKind, _: Type.RefKind)      => Some(nir.Conv.Bitcast)
-        case (_: Type.RefKind, _: Type.I)            => Some(nir.Conv.Ptrtoint)
-        case (_: Type.I, _: Type.RefKind)            => Some(nir.Conv.Inttoptr)
+        case (_: Type.I, Type.Ptr) => Some(nir.Conv.Inttoptr)
+        case (Type.Ptr, _: Type.I) => Some(nir.Conv.Ptrtoint)
+        case (_: Type.RefKind, Type.Ptr) => Some(nir.Conv.Bitcast)
+        case (Type.Ptr, _: Type.RefKind) => Some(nir.Conv.Bitcast)
+        case (_: Type.RefKind, _: Type.RefKind) => Some(nir.Conv.Bitcast)
+        case (_: Type.RefKind, _: Type.I) => Some(nir.Conv.Ptrtoint)
+        case (_: Type.I, _: Type.RefKind) => Some(nir.Conv.Inttoptr)
         case (Type.I(w1, _), Type.F(w2)) if w1 == w2 => Some(nir.Conv.Bitcast)
         case (Type.F(w1), Type.I(w2, _)) if w1 == w2 => Some(nir.Conv.Bitcast)
-        case _ if fromty == toty                     => None
+        case _ if fromty == toty => None
         case _ =>
           unsupported(s"cast from $fromty to $toty")
       }
@@ -1263,25 +1272,24 @@ trait NirGenExpr { self: NirGenPhase =>
         //   ).c()
         // """ =>
         case Apply(
-            Select(
-            Apply(
-            _,
-            List(
-            Apply(_,
-                  List(
-                  Apply(_,
-                        List(
-                        Apply(TypeApply(
-                              Select(ArrayValue(
-                                     _, List(Literal(Constant(str: String)))),
-                                     _),
-                              _),
-                              _))))))),
-            _),
-            _) =>
+        Select(
+        Apply(
+        _,
+        List(
+        Apply(_,
+        List(
+        Apply(_,
+        List(
+        Apply(TypeApply(
+        Select(ArrayValue(
+        _, List(Literal(Constant(str: String)))),
+        _),
+        _),
+        _))))))),
+        _),
+        _) =>
 
-          val processedString = StringContext.processEscapes(processHexValues(str))
-          val chars = Val.Chars(processedString.getBytes("UTF-8"))
+          val chars = Val.Chars(processEscapes(str).getBytes("UTF-8"))
           val const = Val.Const(chars)
           buf.box(nir.Rt.BoxedPtr, const, unwind)
 
@@ -1292,13 +1300,13 @@ trait NirGenExpr { self: NirGenPhase =>
 
     def genUnsignedOp(app: Tree, code: Int): Val = app match {
       case Apply(_, Seq(argp)) if code >= BYTE_TO_UINT && code <= INT_TO_ULONG =>
-        val ty  = genType(app.tpe)
+        val ty = genType(app.tpe)
         val arg = genExpr(argp)
 
         buf.conv(Conv.Zext, ty, arg, unwind)
 
       case Apply(_, Seq(argp)) if code >= UINT_TO_FLOAT && code <= ULONG_TO_DOUBLE =>
-        val ty  = genType(app.tpe)
+        val ty = genType(app.tpe)
         val arg = genExpr(argp)
 
         buf.conv(Conv.Uitofp, ty, arg, unwind)
@@ -1308,8 +1316,8 @@ trait NirGenExpr { self: NirGenPhase =>
           case DIV_UINT | DIV_ULONG => nir.Bin.Udiv
           case REM_UINT | REM_ULONG => nir.Bin.Urem
         }
-        val ty    = genType(leftp.tpe)
-        val left  = genExpr(leftp)
+        val ty = genType(leftp.tpe)
+        val left = genExpr(leftp)
         val right = genExpr(rightp)
 
         buf.bin(bin, ty, left, right, unwind)
@@ -1321,20 +1329,20 @@ trait NirGenExpr { self: NirGenPhase =>
       val monitor =
         genApplyModuleMethod(RuntimeModule, GetMonitorMethod, Seq(receiverp))
       val enter = genApplyMethod(RuntimeMonitorEnterMethod,
-                                statically = true,
-                                monitor,
-                                Seq())
+        statically = true,
+        monitor,
+        Seq())
       val arg = genExpr(argp)
       val exit = genApplyMethod(RuntimeMonitorExitMethod,
-                               statically = true,
-                               monitor,
-                               Seq())
+        statically = true,
+        monitor,
+        Seq())
 
       arg
     }
 
     def genCoercion(app: Apply, receiver: Tree, code: Int): Val = {
-      val rec            = genExpr(receiver)
+      val rec = genExpr(receiver)
       val (fromty, toty) = coercionTypes(code)
 
       genCoercion(rec, fromty, toty)
@@ -1449,13 +1457,16 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def genApplyTypeApply(app: Apply): Val = {
-      val Apply(TypeApply(fun @ Select(receiverp, _), targs), _) = app
+      val Apply(TypeApply(fun@Select(receiverp, _), targs), _) = app
 
       val fromty = genType(receiverp.tpe)
-      val toty   = genType(targs.head.tpe)
-      def boxty  = genBoxType(targs.head.tpe)
-      val value  = genExpr(receiverp)
-      def boxed  = boxValue(receiverp.tpe, value)
+      val toty = genType(targs.head.tpe)
+
+      def boxty = genBoxType(targs.head.tpe)
+
+      val value = genExpr(receiverp)
+
+      def boxed = boxValue(receiverp.tpe, value)
 
       fun.symbol match {
         case Object_isInstanceOf =>
@@ -1487,7 +1498,7 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def genApplyNew(app: Apply): Val = {
-      val Apply(fun @ Select(New(tpt), nme.CONSTRUCTOR), args) = app
+      val Apply(fun@Select(New(tpt), nme.CONSTRUCTOR), args) = app
 
       SimpleType.fromType(tpt.tpe) match {
         case SimpleType(ArrayClass, Seq(targ)) =>
@@ -1505,8 +1516,8 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def genApplyNewStruct(st: SimpleType, argsp: Seq[Tree]): Val = {
-      val ty       = genType(st)
-      val args     = genSimpleArgs(argsp)
+      val ty = genType(st)
+      val args = genSimpleArgs(argsp)
       var res: Val = Val.Zero(ty)
 
       args.zipWithIndex.foreach {
@@ -1526,13 +1537,13 @@ trait NirGenExpr { self: NirGenPhase =>
 
     def genApplyNew(clssym: Symbol, ctorsym: Symbol, args: List[Tree]): Val = {
       val alloc = buf.classalloc(genTypeName(clssym), unwind)
-      val call  = genApplyMethod(ctorsym, statically = true, alloc, args)
+      val call = genApplyMethod(ctorsym, statically = true, alloc, args)
       alloc
     }
 
     def genApplyModuleMethod(module: Symbol,
-                            method: Symbol,
-                            args: Seq[Tree]): Val = {
+      method: Symbol,
+      args: Seq[Tree]): Val = {
       val self = genModule(module)
       genApplyMethod(method, statically = true, self, args)
     }
@@ -1541,9 +1552,9 @@ trait NirGenExpr { self: NirGenPhase =>
       sym.isModuleClass && nme.isImplClassName(sym.name)
 
     def genApplyMethod(sym: Symbol,
-                      statically: Boolean,
-                      selfp: Tree,
-                      argsp: Seq[Tree]): Val = {
+      statically: Boolean,
+      selfp: Tree,
+      argsp: Seq[Tree]): Val = {
       if (sym.owner.isExternModule && sym.isAccessor) {
         genApplyExternAccessor(sym, argsp)
       } else if (isImplClass(sym.owner)) {
@@ -1577,7 +1588,7 @@ trait NirGenExpr { self: NirGenPhase =>
     def genStoreExtern(externTy: nir.Type, sym: Symbol, value: Val): Val = {
       assert(sym.owner.isExternModule)
 
-      val name        = Val.Global(genName(sym), Type.Ptr)
+      val name = Val.Global(genName(sym), Type.Ptr)
       val externValue = toExtern(externTy, value)
 
       buf.store(externTy, name, externValue, unwind)
@@ -1586,7 +1597,7 @@ trait NirGenExpr { self: NirGenPhase =>
     def toExtern(expectedTy: nir.Type, value: Val): Val =
       (expectedTy, value.ty) match {
         case (_, refty: Type.Ref)
-            if Type.boxClasses.contains(refty.name)
+          if Type.boxClasses.contains(refty.name)
             && Type.unbox(Type.Ref(refty.name)) == expectedTy =>
           buf.unbox(Type.Ref(refty.name), value, unwind)
         case (Type.Ptr, refty: Type.Ref) =>
@@ -1598,7 +1609,7 @@ trait NirGenExpr { self: NirGenPhase =>
     def fromExtern(expectedTy: nir.Type, value: Val): Val =
       (expectedTy, value.ty) match {
         case (refty: nir.Type.Ref, ty)
-            if Type.boxClasses.contains(refty.name)
+          if Type.boxClasses.contains(refty.name)
             && Type.unbox(Type.Ref(refty.name)) == ty =>
           buf.box(Type.Ref(refty.name), value, unwind)
         case (Type.Ptr, refty: Type.Ref) =>
@@ -1608,11 +1619,11 @@ trait NirGenExpr { self: NirGenPhase =>
       }
 
     def genApplyMethod(sym: Symbol,
-                       statically: Boolean,
-                       self: Val,
-                       argsp: Seq[Tree]): Val = {
-      val owner   = sym.owner
-      val name    = genMethodName(sym)
+      statically: Boolean,
+      self: Val,
+      argsp: Seq[Tree]): Val = {
+      val owner = sym.owner
+      val name = genMethodName(sym)
       val origSig = genMethodSig(sym)
       val sig =
         if (owner.isExternModule) {
@@ -1645,7 +1656,7 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def genMethodArgs(sym: Symbol,
-                      argsp: Seq[Tree]): Seq[Val] =
+      argsp: Seq[Tree]): Seq[Val] =
       if (!sym.owner.isExternModule) {
         genSimpleArgs(argsp)
       } else {
@@ -1664,15 +1675,52 @@ trait NirGenExpr { self: NirGenPhase =>
       argsp.map(genExpr)
     }
 
-    private def processHexValues(str: String): String = {
-      val regex = "\\\\[xX]([0-9A-Fa-f]+)".r
-      regex.replaceAllIn(str, m => {
-        val hexValue = Integer.parseInt(m.group(1), 16)
-        if(hexValue > 255){
-          throw new IllegalArgumentException(s"malformed C string - hex value greater then 0xFF: $str")
+    private def processEscapes(str: String): String = {
+      val len = str.length
+      val b = new java.lang.StringBuilder()
+
+      // replace escapes with given first escape
+      def isHex(c: Char): Boolean = Character.isDigit(c) ||
+        (c >= 'a' && c <= 'f') ||
+        (c >= 'A' && c <= 'F')
+
+      // append replacement starting at index `i`, with `next` backslash
+      @tailrec def loop(from: Int): java.lang.StringBuilder = {
+
+        str.indexOf('\\', from) match {
+          case -1 => b.append(str.substring(from))
+          case idx => b.append(str.substring(from, idx))
+            if (idx >= len) throw new InvalidEscapeException(str, from)
+            str(idx + 1) match {
+              case 'b' => b.append('\b'); loop(idx + 2)
+              case 't' => b.append('\t'); loop(idx + 2)
+              case 'n' => b.append('\n'); loop(idx + 2)
+              case 'f' => b.append('\f'); loop(idx + 2)
+              case 'r' => b.append('\r'); loop(idx + 2)
+              case '"' => b.append('\"'); loop(idx + 2)
+              case '\'' => b.append('\''); loop(idx + 2)
+              case '\\' => b.append('\\'); loop(idx + 2)
+              case o if '0' <= o && o <= '7' =>
+                throw new InvalidEscapeException(str, idx)
+              case 'x' =>
+                val hex = str.drop(idx + 2).takeWhile(isHex)
+                val hexValue = Integer.parseInt(hex, 16).toChar
+                if (hexValue > 255) {
+                  throw new IllegalArgumentException(s"malformed C string - hex value greater then 0xFF: $str")
+                }
+                b.append(hexValue.toChar)
+                loop(idx + 2 + hex.length)
+              case c => b
+                .append('\\')
+                .append(c)
+                loop(idx + 2)
+            }
         }
-        hexValue.toChar.toString
-      })
+      }
+
+      loop(0).toString
     }
+
   }
+
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1280,7 +1280,7 @@ trait NirGenExpr { self: NirGenPhase =>
             _),
             _) =>
 
-          val chars = Val.Chars(treatEscapes(str))
+          val chars = Val.Chars(treatEscapes(str).getBytes("UTF-8"))
           val const = Val.Const(chars)
           buf.box(nir.Rt.BoxedPtr, const, unwind)
 

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -536,7 +536,7 @@ object CodeGen {
     def genChars(bytes: Array[Byte]): Unit = {
       str("c\"")
       bytes.foreach {
-        case '\\' => str("\\" * 2)
+        case '\\' => str("\\\\")
         case c if c < 0x20 || c == '"' || c >= 0x7f =>
           val hex = Integer.toHexString(c)
           str {

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -518,8 +518,8 @@ object CodeGen {
         str("[ ")
         rep(vs, sep = ", ")(genVal)
         str(" ]")
-      case Val.Chars(v) =>
-        genChars(v)
+      case v: Val.Chars =>
+        genChars(v.bytes)
       case Val.Local(n, ty) =>
         str("%")
         genLocal(n)

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -534,13 +534,16 @@ object CodeGen {
     }
 
     def genChars(bytes: Array[Byte]): Unit = {
-      // `value` should contain a content of a CString literal as is in its source file parsed with parsed escaped characters
-      // malformed literals are assumed absent
       str("c\"")
-      bytes.foreach {
+      bytes.map(_.toChar).foreach {
         case '\\' => str("\\" * 2)
-        case '"'  => str("\\22")
-        case c    => str(c.toChar)
+        case c if c.isLetterOrDigit => str(c.toChar)
+        case c =>
+          val hex = Integer.toHexString(c)
+          str {
+            if (hex.length < 2) "\\0" + hex
+            else "\\" + hex
+          }
       }
       str("\\00\"")
     }

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -535,15 +535,15 @@ object CodeGen {
 
     def genChars(bytes: Array[Byte]): Unit = {
       str("c\"")
-      bytes.map(_.toChar).foreach {
+      bytes.foreach {
         case '\\' => str("\\" * 2)
-        case c if c.isLetterOrDigit => str(c.toChar)
-        case c =>
+        case c if c < 0x20 || c == '"' || c >= 0x7f =>
           val hex = Integer.toHexString(c)
           str {
             if (hex.length < 2) "\\0" + hex
             else "\\" + hex
           }
+        case c => str(c.toChar)
       }
       str("\\00\"")
     }

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -533,14 +533,14 @@ object CodeGen {
         unsupported(v)
     }
 
-    def genChars(value: String): Unit = {
+    def genChars(bytes: Array[Byte]): Unit = {
       // `value` should contain a content of a CString literal as is in its source file parsed with parsed escaped characters
       // malformed literals are assumed absent
       str("c\"")
-      value.foreach {
+      bytes.foreach {
         case '\\' => str("\\" * 2)
         case '"'  => str("\\22")
-        case c    => str(c)
+        case c    => str(c.toChar)
       }
       str("\\00\"")
     }

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -534,52 +534,10 @@ object CodeGen {
     }
 
     def genChars(value: String): Unit = {
-      // `value` should contain a content of a CString literal as is in its source file
+      // `value` should contain a content of a CString literal as is in its source file parsed with parsed escaped characters
       // malformed literals are assumed absent
       str("c\"")
-      @tailrec def loop(from: Int): Unit =
-        value.indexOf('\\', from) match {
-          case -1 => str(value.substring(from))
-          case idx =>
-            str(value.substring(from, idx))
-            import Character.isDigit
-            def isOct(c: Char): Boolean = isDigit(c) && c != '8' && c != '9'
-            def isHex(c: Char): Boolean =
-              isDigit(c) ||
-                c == 'a' || c == 'b' || c == 'c' || c == 'd' || c == 'e' || c == 'f' ||
-                c == 'A' || c == 'B' || c == 'C' || c == 'D' || c == 'E' || c == 'F'
-            value(idx + 1) match {
-              case c @ ('\'' | '"' | '?') => str(c); loop(idx + 2)
-              case '\\'                   => str("\\\\"); loop(idx + 2)
-              case 'a'                    => str("\\07"); loop(idx + 2)
-              case 'b'                    => str("\\08"); loop(idx + 2)
-              case 'f'                    => str("\\0C"); loop(idx + 2)
-              case 'n'                    => str("\\0A"); loop(idx + 2)
-              case 'r'                    => str("\\0D"); loop(idx + 2)
-              case 't'                    => str("\\09"); loop(idx + 2)
-              case 'v'                    => str("\\0B"); loop(idx + 2)
-              case d if isOct(d) =>
-                val oct = value.drop(idx + 1).take(3).takeWhile(isOct)
-                val hex =
-                  Integer.toHexString(Integer.parseInt(oct, 8)).toUpperCase
-                str {
-                  if (hex.length < 2) "\\0" + hex
-                  else "\\" + hex
-                }
-                loop(idx + 1 + oct.length)
-              case 'x' =>
-                val hex = value.drop(idx + 2).takeWhile(isHex).toUpperCase
-                str {
-                  if (hex.length < 2) "\\0" + hex
-                  else "\\" + hex
-                }
-                loop(idx + 2 + hex.length)
-              case unknown =>
-                // clang warns but allows unknown escape sequences, while java emits errors
-                str(unknown); loop(idx + 2)
-            }
-        }
-      loop(0)
+      str(value.replace("\\", "\\" * 2))
       str("\\00\"")
     }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -537,7 +537,11 @@ object CodeGen {
       // `value` should contain a content of a CString literal as is in its source file parsed with parsed escaped characters
       // malformed literals are assumed absent
       str("c\"")
-      str(value.replace("\\", "\\" * 2))
+      value.foreach {
+        case '\\' => str("\\" * 2)
+        case '"'  => str("\\22")
+        case c    => str(c)
+      }
       str("\\00\"")
     }
 

--- a/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
@@ -35,7 +35,7 @@ object NIRCompiler {
   def getCompiler(): api.NIRCompiler = {
     val clazz =
       classLoader.loadClass("scala.scalanative.NIRCompiler")
-    clazz.getConstructor().newInstance() match {
+    clazz.newInstance match {
       case compiler: api.NIRCompiler => compiler
       case other =>
         throw new ReflectiveOperationException(

--- a/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
@@ -35,7 +35,7 @@ object NIRCompiler {
   def getCompiler(): api.NIRCompiler = {
     val clazz =
       classLoader.loadClass("scala.scalanative.NIRCompiler")
-    clazz.newInstance match {
+    clazz.getConstructor().newInstance() match {
       case compiler: api.NIRCompiler => compiler
       case other =>
         throw new ReflectiveOperationException(

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
@@ -33,6 +33,7 @@ object CStringSuite extends tests.Suite {
     assertEquals("\t", fromCString(c"\t"))
     assertEquals("\\t", fromCString(c"\\t"))
     assertEquals("\u0020\u0020\u0061\u0062", fromCString(c"\040\40\141\x62"))
+    assertEquals("\\\\v\t\\abc", fromCString(c"\\\v\t\\abc"))
   }
 
   test("fromCString") {

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
@@ -1,6 +1,7 @@
 package scala.scalanative
 package unsafe
 
+import java.nio.charset.Charset
 import scalanative.libc.string._
 
 object CStringSuite extends tests.Suite {
@@ -37,11 +38,11 @@ object CStringSuite extends tests.Suite {
     assertEquals("\t", fromCString(c"\t"))
     assertEquals("\\t", fromCString(c"\\t"))
 
-    assertEquals("\\n", fromCString(c"\\n"))
     assertEquals("\n", fromCString(c"\n"))
+    assertEquals("\\n", fromCString(c"\\n"))
 
-    assertEquals("\\r", fromCString(c"\\r"))
     assertEquals("\r", fromCString(c"\r"))
+    assertEquals("\\r", fromCString(c"\\r"))
 
     assertEquals("""
     {
@@ -73,7 +74,6 @@ object CStringSuite extends tests.Suite {
     Zone { implicit z =>
       val szFrom = "abcde"
       val cstrTo = toCString(szFrom)
-
       assert(strlen(cstrTo) == 5)
       assert(cstrTo(0) == 'a'.toByte)
       assert(cstrTo(1) == 'b'.toByte)
@@ -81,6 +81,40 @@ object CStringSuite extends tests.Suite {
       assert(cstrTo(3) == 'd'.toByte)
       assert(cstrTo(4) == 'e'.toByte)
       assert(cstrTo(5) == '\u0000'.toByte)
+
+      val piArr = Charset.forName("UTF-8").encode("\u03c0")
+      val cstr2 = toCString("2\u03c0r")
+//    val cstr3 = c"2\u03c0r" //would result in error at NIR
+      assertEquals(strlen(cstr2), 4)
+      assertEquals(cstr2(0), '2')
+      assertEquals(cstr2(1), piArr.get(0))
+      assertEquals(cstr2(2), piArr.get(1))
+      assertEquals(cstr2(3), 'r')
+      assertEquals(cstr2(4), 0)
+    }
+  }
+
+  test("to/from CString") {
+    Zone { implicit z =>
+      type _11 = Nat.Digit2[Nat._1, Nat._1]
+      val arr = unsafe.stackalloc[CArray[Byte, _11]]
+
+      val jstr1 = "a\b\\c\u0064"
+      val cstr1 = c"a\b\\c\x64"
+      val cstr2 = toCString(jstr1)
+
+      strcat(arr.at(0), cstr1)
+      strcat(arr.at(0), cstr2)
+
+      val jstr2: String = fromCString(arr.at(0))
+
+      assertEquals(strcmp(cstr1, cstr2), 0)
+      assertEquals(strlen(arr.at(0)), 10)
+
+      assertEquals(jstr2, jstr1 * 2)
+      assertEquals(jstr2.last, 'd')
+      assertEquals(!(cstr1 + 4), 'd')
+      assertEquals(!(cstr1 + 5), 0)
     }
   }
 }

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
@@ -1,7 +1,6 @@
 package scala.scalanative
 package unsafe
 
-import scalanative.libc.stdio._
 import scalanative.libc.string._
 
 object CStringSuite extends tests.Suite {
@@ -11,20 +10,24 @@ object CStringSuite extends tests.Suite {
     fromCString(c"")
     fromCString(c"no escapes")
     fromCString(c"\'"); fromCString(c"\\'")
-    fromCString(c"\?"); fromCString(c"\\?")
+    fromCString(c"\\?")
     fromCString(c"\\")
-    fromCString(c"\a"); fromCString(c"\\a")
-    fromCString(c"\v"); fromCString(c"\\v")
-    fromCString(c"\012\x6a")
-    fromCString(c"%s \\t %.2f %s/s\00")
+    fromCString(c"\\a")
+    fromCString(c"\\v")
+    fromCString(c"%s \\t %.2f %s/s\x00")
 
     // uncomment the following to trigger compilation errors for testing
     // fromCString(c"\")     // error at NIR
     // fromCString(c"\x2ae") // error at NIR
     // fromCString(c"\"")    // error at Scala compiler
+    // fromCString(c"\?")
+    // fromCString(c"\v")
+    // fromCString(c"\a")
+    // fromCString(c"\012")
   }
 
   test("""the value of c"..." literals""") {
+
     assertEquals("\b", fromCString(c"\b"))
     assertEquals("\\b", fromCString(c"\\b"))
 
@@ -44,17 +47,15 @@ object CStringSuite extends tests.Suite {
     {
       "greeting": "Hello world!"
     }""",
-      fromCString(c"""
+                 fromCString(c"""
     {
       "greeting": "Hello world!"
     }"""))
 
-    assertEquals("\u0020\u0020\u0061\u0062", fromCString(c"\040\40\141\x62"))
-    assertEquals("\\\\v\t\\abc", fromCString(c"\\\v\t\\abc"))
+    assertEquals("\u0020\u0020\u006a\u006b", fromCString(c"\x20\X20\x6a\x6B"))
 
-  assertEquals("\'", fromCString(c"\'"))
-  assertEquals("\\'", fromCString(c"\\'"))
-
+    assertEquals("\'", fromCString(c"\'"))
+    assertEquals("\\'", fromCString(c"\\'"))
   }
 
   test("fromCString") {

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
@@ -14,11 +14,6 @@ object CStringSuite extends tests.Suite {
     fromCString(c"\?"); fromCString(c"\\?")
     fromCString(c"\\")
     fromCString(c"\a"); fromCString(c"\\a")
-    fromCString(c"\b"); fromCString(c"\\b")
-    fromCString(c"\f"); fromCString(c"\\f")
-    fromCString(c"\n"); fromCString(c"\\n")
-    fromCString(c"\r"); fromCString(c"\\r")
-    fromCString(c"\t"); fromCString(c"\\t")
     fromCString(c"\v"); fromCString(c"\\v")
     fromCString(c"\012\x6a")
     fromCString(c"%s \\t %.2f %s/s\00")
@@ -30,10 +25,36 @@ object CStringSuite extends tests.Suite {
   }
 
   test("""the value of c"..." literals""") {
+    assertEquals("\b", fromCString(c"\b"))
+    assertEquals("\\b", fromCString(c"\\b"))
+
+    assertEquals("\f", fromCString(c"\f"))
+    assertEquals("\\f", fromCString(c"\\f"))
+
     assertEquals("\t", fromCString(c"\t"))
     assertEquals("\\t", fromCString(c"\\t"))
+
+    assertEquals("\\n", fromCString(c"\\n"))
+    assertEquals("\n", fromCString(c"\n"))
+
+    assertEquals("\\r", fromCString(c"\\r"))
+    assertEquals("\r", fromCString(c"\r"))
+
+    assertEquals("""
+    {
+      "greeting": "Hello world!"
+    }""",
+      fromCString(c"""
+    {
+      "greeting": "Hello world!"
+    }"""))
+
     assertEquals("\u0020\u0020\u0061\u0062", fromCString(c"\040\40\141\x62"))
     assertEquals("\\\\v\t\\abc", fromCString(c"\\\v\t\\abc"))
+
+  assertEquals("\'", fromCString(c"\'"))
+  assertEquals("\\'", fromCString(c"\\'"))
+
   }
 
   test("fromCString") {

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
@@ -44,6 +44,9 @@ object CStringSuite extends tests.Suite {
     assertEquals("\r", fromCString(c"\r"))
     assertEquals("\\r", fromCString(c"\\r"))
 
+    assertEquals("\u0065", fromCString(c"\x65"))
+    assertEquals("\\x65", fromCString(c"\\x65"))
+
     assertEquals("""
     {
       "greeting": "Hello world!"
@@ -53,7 +56,7 @@ object CStringSuite extends tests.Suite {
       "greeting": "Hello world!"
     }"""))
 
-    assertEquals("\u0020\u0020\u006a\u006b", fromCString(c"\x20\X20\x6a\x6B"))
+    assertEquals("\u0020\\X20\u006a\u006b", fromCString(c"\x20\X20\x6a\x6B"))
 
     assertEquals("\'", fromCString(c"\'"))
     assertEquals("\\'", fromCString(c"\\'"))

--- a/util/src/main/scala/scala/scalanative/util/StringUtils.scala
+++ b/util/src/main/scala/scala/scalanative/util/StringUtils.scala
@@ -1,0 +1,62 @@
+package scala.scalanative.util
+
+import scala.StringContext.InvalidEscapeException
+import scala.annotation.tailrec
+
+object StringUtils {
+
+  /**
+   * Custom implementation of StringContext.processEscapes which also parses hex values
+   * @param str UTF-8 encoded input string optionally containing literal escapes and hex values
+   * @return UTF-8 representation of escaped ByteString
+   */
+  def processEscapes(str: String): String = {
+    val len = str.length
+    val b   = new java.lang.StringBuilder()
+
+    // replace escapes with given first escape
+    def isHex(c: Char): Boolean =
+      Character.isDigit(c) ||
+        (c >= 'a' && c <= 'f') ||
+        (c >= 'A' && c <= 'F')
+
+    // append replacement starting at index `i`, with `next` backslash
+    @tailrec def loop(from: Int): java.lang.StringBuilder = {
+
+      str.indexOf('\\', from) match {
+        case -1 => b.append(str.substring(from))
+        case idx =>
+          b.append(str.substring(from, idx))
+          if (idx >= len) throw new InvalidEscapeException(str, from)
+          str(idx + 1) match {
+            case 'b'  => b.append('\b'); loop(idx + 2)
+            case 't'  => b.append('\t'); loop(idx + 2)
+            case 'n'  => b.append('\n'); loop(idx + 2)
+            case 'f'  => b.append('\f'); loop(idx + 2)
+            case 'r'  => b.append('\r'); loop(idx + 2)
+            case '"'  => b.append('\"'); loop(idx + 2)
+            case '\'' => b.append('\''); loop(idx + 2)
+            case '\\' => b.append('\\'); loop(idx + 2)
+            case o if '0' <= o && o <= '7' =>
+              throw new InvalidEscapeException(str, idx)
+            case 'x' =>
+              val hex      = str.drop(idx + 2).takeWhile(isHex)
+              val hexValue = Integer.parseInt(hex, 16).toChar
+              if (hexValue > 255) {
+                throw new IllegalArgumentException(
+                  s"malformed C string - hex value greater then 0xFF: $str")
+              }
+              b.append(hexValue.toChar)
+              loop(idx + 2 + hex.length)
+            case c =>
+              b.append('\\')
+                .append(c)
+              loop(idx + 2)
+          }
+      }
+    }
+
+    loop(0).toString
+  }
+
+}


### PR DESCRIPTION
Resolves #1801 
This PR may break NIR compability. I think there is no need to updated versioning due to other breaking changes which already updated version, since there was no release in between. 
 
Each string in Val.Chars is already escaped literal