### PR TITLE
Fix #1858: User-facing documentation is now free of warnings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,20 +4,20 @@ Changelog
 =========
 
 0.4.0-M2 (May 23, 2019)
-----------------------
+-------------------------
 
 `Read release notes for 0.4.0-M2 on GitHub <https://github.com/scala-native/scala-native/releases/tag/v0.4.0-M2>`_.
 
 
 0.4.0-M1 (May 23, 2019)
-----------------------
+-------------------------
 
 `Read release notes for 0.4.0-M1 on GitHub <https://github.com/scala-native/scala-native/releases/tag/v0.4.0-M1>`_.
 
 0.3.9 (Apr 23, 2019)
-----------------------
+--------------------
 
-`Read release notes for 0.3.8 on GitHub <https://github.com/scala-native/scala-native/releases/tag/v0.3.9>`_.
+`Read release notes for 0.3.9 on GitHub <https://github.com/scala-native/scala-native/releases/tag/v0.3.9>`_.
 
 
 0.3.8 (Jul 16, 2018)

--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -680,36 +680,41 @@ Some notes on the implementation:
 2. This implementation of RE2 does not support:
 
    * Character classes:
-    * Unions: ``[a-d[m-p]]``
-    * Intersections: ``[a-z&&[^aeiou]]``
+
+     * Unions: ``[a-d[m-p]]``
+     * Intersections: ``[a-z&&[^aeiou]]``
 
    * Predefined character classes: ``\h``, ``\H``, ``\v``, ``\V``
 
    * Patterns:
-    * Octal: ``\0100`` - use decimal or hexadecimal instead.
-    * Two character Hexadecimal: ``\xFF`` - use ``\x00FF`` instead.
-    * All alphabetic Unicode: ``\uBEEF`` - use hex ``\xBEEF`` instead.
-    * Escape: ``\e`` - use ``\u001B`` instead.
+
+     * Octal: ``\0100`` - use decimal or hexadecimal instead.
+     * Two character Hexadecimal: ``\xFF`` - use ``\x00FF`` instead.
+     * All alphabetic Unicode: ``\uBEEF`` - use hex ``\xBEEF`` instead.
+     * Escape: ``\e`` - use ``\u001B`` instead.
 
    * Java character function classes:
-    * ``\p{javaLowerCase}``
-    * ``\p{javaUpperCase}``
-    * ``\p{javaWhitespace}``
-    * ``\p{javaMirrored}``
+
+     * ``\p{javaLowerCase}``
+     * ``\p{javaUpperCase}``
+     * ``\p{javaWhitespace}``
+     * ``\p{javaMirrored}``
 
    * Boundary matchers: ``\G``, ``\R``, ``\Z``
 
    * Possessive quantifiers: ``X?+``, ``X*+``, ``X++``, ``X{n}+``,
      ``X{n,}+``, ``X{n,m}+``
+
    * Lookaheads: ``(?=X)``, ``(?!X)``, ``(?<=X)``, ``(?<!X)``, ``(?>X)``
 
    * Options
-    *  CANON_EQ
-    *  COMMENTS
-    *  LITERAL
-    *  UNICODE_CASE
-    *  UNICODE_CHARACTER_CLASS
-    *  UNIX_LINES
+
+     *  CANON_EQ
+     *  COMMENTS
+     *  LITERAL
+     *  UNICODE_CASE
+     *  UNICODE_CHARACTER_CLASS
+     *  UNIX_LINES
 
    * Patterns to match a Unicode binary property, such as
      ``\p{isAlphabetic}`` for a codepoint with the 'alphabetic' property,

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -48,29 +48,29 @@ C Type                    Scala Type
 ``bool``                  ``unsafe.CBool``
 ``char``                  ``unsafe.CChar``
 ``signed char``           ``unsafe.CSignedChar``
-``unsigned char``         ``unsafe.CUnsignedChar`` [1_]
+``unsigned char``         ``unsafe.CUnsignedChar`` [1]_
 ``short``                 ``unsafe.CShort``
-``unsigned short``        ``unsafe.CUnsignedShort`` [1_]
+``unsigned short``        ``unsafe.CUnsignedShort`` [1]_
 ``int``                   ``unsafe.CInt``
 ``long int``              ``unsafe.CLongInt``
-``unsigned int``          ``unsafe.CUnsignedInt`` [1_]
-``unsigned long int``     ``unsafe.CUnsignedLongInt`` [1_]
+``unsigned int``          ``unsafe.CUnsignedInt`` [1]_
+``unsigned long int``     ``unsafe.CUnsignedLongInt`` [1]_
 ``long``                  ``unsafe.CLong``
-``unsigned long``         ``unsafe.CUnsignedLong`` [1_]
+``unsigned long``         ``unsafe.CUnsignedLong`` [1]_
 ``long long``             ``unsafe.CLongLong``
-``unsigned long long``    ``unsafe.CUnsignedLongLong`` [1_]
+``unsigned long long``    ``unsafe.CUnsignedLongLong`` [1]_
 ``size_t``                ``unsafe.CSize``
-``ptrdiff_t``             ``unsafe.CPtrDiff`` [2_]
+``ptrdiff_t``             ``unsafe.CPtrDiff`` [2]_
 ``wchar_t``               ``unsafe.CWideChar``
 ``char16_t``              ``unsafe.CChar16``
 ``char32_t``              ``unsafe.CChar32``
 ``float``                 ``unsafe.CFloat``
 ``double``                ``unsafe.CDouble``
-``void*``                 ``unsafe.Ptr[Byte]`` [2_]
-``int*``                  ``unsafe.Ptr[unsafe.CInt]`` [2_]
-``char*``                 ``unsafe.CString`` [2_] [3_]
-``int (*)(int)``          ``unsafe.CFuncPtr1[unsafe.CInt, unsafe.CInt]`` [2_] [4_]
-``struct { int x, y; }*`` ``unsafe.Ptr[unsafe.CStruct2[unsafe.CInt, unsafe.CInt]]`` [2_] [5_]
+``void*``                 ``unsafe.Ptr[Byte]`` [2]_
+``int*``                  ``unsafe.Ptr[unsafe.CInt]`` [2]_
+``char*``                 ``unsafe.CString`` [2]_ [3]_
+``int (*)(int)``          ``unsafe.CFuncPtr1[unsafe.CInt, unsafe.CInt]`` [2]_ [4]_
+``struct { int x, y; }*`` ``unsafe.Ptr[unsafe.CStruct2[unsafe.CInt, unsafe.CInt]]`` [2]_ [5]_
 ``struct { int x, y; }``  Not supported
 ========================= =========================
 
@@ -325,17 +325,13 @@ pointers and do not have a corresponding first-class values backing them.
   a type-level natural number. Natural numbers are types that are composed of
   base naturals ``Nat._0, ... Nat._9`` and an additional ``Nat.DigitN``
   constructors, where ``N`` refers to number of digits in the given number. 
-  So for example number ``1024`` is going to be encoded as following:
-
-  .. code-block:: scala
+  So for example number ``1024`` is going to be encoded as following::
 
       import scalanative.unsafe._, Nat._
 
       type _1024 = Digit4[_1, _0, _2, _4]
 
-  Once you have a natural for the length, it can be used as an array length:
-
-  .. code-block:: scala
+  Once you have a natural for the length, it can be used as an array length::
 
       val arrptr = unsafe.stackalloc[CArray[Byte, _1024]]
 

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -321,6 +321,12 @@ pointers and do not have a corresponding first-class values backing them.
 
 * ``unsafe.Ptr[unsafe.CArray[T, N]]``
 
+  .. Wizardry and lore ahead!
+  ..
+  .. Sphinx & Pygments warn that they can not parse & highlight next code-block
+  .. as Scala. Use double colon code-block idiom to avoid build warning.
+  .. Default Python style will highlight code-block "close enough" to Scala.
+
   Pointer to a C array with statically-known length ``N``. Length is encoded as
   a type-level natural number. Natural numbers are types that are composed of
   base naturals ``Nat._0, ... Nat._9`` and an additional ``Nat.DigitN``
@@ -330,6 +336,11 @@ pointers and do not have a corresponding first-class values backing them.
       import scalanative.unsafe._, Nat._
 
       type _1024 = Digit4[_1, _0, _2, _4]
+
+  .. Sphinx & Pygments warn that they can not parse & highlight next code-block
+  .. as Scala. Use double colon code-block idiom to avoid build warning.
+  .. There will be a slight visual glitch because default Python will not.
+  .. highlight it.
 
   Once you have a natural for the length, it can be used as an array length::
 


### PR DESCRIPTION
In order to make progress on long standing issue #1260
I needed to eliminate warnings in the Sphinx build of the user-facing
documentation.

That way, any errors that I introduce will stand out.

This PR worthwhile because without it other developers will experience
the same dis-incentive and make proper documentation unlikely.