### PR TITLE
Update mangling.rst due to changes in #1840

### DIFF
--- a/docs/contrib/mangling.rst
+++ b/docs/contrib/mangling.rst
@@ -54,4 +54,4 @@ that uses a notation inspired by
         j                              // scala.Long
 
     <name> ::=
-        <length number> <chars>        // raw identifier of given length
+        <length number> [-] <chars>    // raw identifier of given length; `-` separator is only used when <chars> starts with digit or `-` itself


### PR DESCRIPTION
Resolves #1857 
Added information about optional `-` separator for <name>  in mangling.rst