### PR TITLE
Partial Fix #1260: Document steps to build SN user-facing documentation.

### DIFF
--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -209,6 +209,11 @@ Its content is shared as unmanaged source dependency between JVM and Native side
 
 The next section has more build and development information for those wanting
 to work on :ref:`compiler`.
+=======
+The :ref:`compiler` section has more build and development information for
+those wanting to work in those areas.
 
-.. [1] http://www.scala-native.org/en/latest/user/setup.html
-.. [2] http://www.scala-native.org/en/latest/user/sbt.html
+Continue to :ref:`docbuild`.
+
+.. [1] :ref:`setup`
+.. [2] :ref:`sbt`

--- a/docs/contrib/compiler.rst
+++ b/docs/contrib/compiler.rst
@@ -34,7 +34,7 @@ After compiling the sandbox project you can inspect the ``.ll`` files inside
 ``sandbox/target/scala-<version>/ll``. The files are grouped by the package name.
 By default the ``Test.scala`` file doesn't define a package, so the resulting file
 will be ``__empty.ll``. Locating the code you are interested in might require that
-you get more familiar with the `LLVM assembly language <http://llvm.org/docs/LangRef.html>`_.
+you get more familiar with the `LLVM assembly language <https://llvm.org/docs/LangRef.html>`_.
 
 When working on the compiler plugin you'll need to clean the sandbox (or other
 Scala Native projects) if you want it to be recompiled with the newer version

--- a/docs/contrib/contributing.rst
+++ b/docs/contrib/contributing.rst
@@ -28,9 +28,9 @@ relevant copyright / license information.
 Coding style
 ------------
 
-Scala Native is formatted via `./scripts/scalafmt` and `./scripts/clangfmt`.
-Make sure that all of your contributions are properly formatted before
-suggesting any changes.
+Scala Native source code is formatted via `./scripts/scalafmt` and
+`./scripts/clangfmt`. Make sure that all of your contributions are properly
+formatted before suggesting any changes.
 
 Formatting Scala via `scalafmt` downloads and runs the correct version and
 uses the `.scalafmt.conf` file at the root of the project. No configuration
@@ -121,7 +121,7 @@ This the general workflow for contributing to Scala Native.
 
 5.  After the review, you should resolve issues brought up by the reviewers as
     needed (amending or adding commits to address reviewers' comments),
-    iterating until the reviewers give their thumbs up, the "LGTM" (acronym for
+    iterating until the reviewers give their thumbs up, the "LONGTIME" (acronym for
     "Looks Good To Me").
 
 6.  Once the code has passed review the Pull Request can be merged into
@@ -158,18 +158,32 @@ In order for a Pull Request to be considered, it has to meet these requirements:
 
 2.  Be accompanied by appropriate tests.
 
-3.  Be issued from a branch *other than master* (PRs coming from master will not
+3.  Be accompanied by appropriate documentation
+    :ref:`documentation <project-documentation>`.
+
+4.  Be issued from a branch *other than master* (PRs coming from master will not
     be accepted.)
 
 If not *all* of these requirements are met then the code should **not** be
 merged into the distribution, and need not even be reviewed.
 
+
+.. _project-documentation:
+
 Documentation
 -------------
 
-All code contributed to the user-facing standard library (the `nativelib/`
-directory) should come accompanied with documentation.
-Pull requests containing undocumented code will not be accepted.
+Pull requests, other than the most trivial, without documentation
+will not be accepted. Imagine yourself as the person merging trying
+to understand, use, merge, or maintain the contribution.
+
+All code containing changes
+potentially visible to end users or developers contributed to user-facing
+standard libraries (nativelib, clib, javalib, etc.) should come accompanied
+with corresponding user-facing documentation, as described in
+the :ref:`docbuild`.
+Such documentation should be manually built, checked for the absence
+of build errors or warnings, and visually inspected before submission.
 
 Code contributed to the internals (nscplugin, tools, etc.)
 should come accompanied by internal documentation if the code is not
@@ -218,10 +232,10 @@ followed by details of the commit, in the form of free text, or bulleted list.
 
 .. _Scala.js: https://github.com/scala-js/scala-js/tree/master/javalib/src/main/scala/java
 .. _Apache Harmony project: https://github.com/apache/harmony
-.. _Scala CLA: http://typesafe.com/contribute/cla/scala
-.. _Pull Request: https://help.github.com/articles/using-pull-requests
-.. _DRY: http://programmer.97things.oreilly.com/wiki/index.php/Don%27t_Repeat_Yourself
-.. _Boy Scout Rule: http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule
-.. _Git Workflow: http://sandofsky.com/blog/git-workflow.html
+.. _Scala CLA: https
+.. _Pull Request: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
+.. _DRY: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
+.. _Boy Scout Rule: https://www.oreilly.com/library/view/97-things-every/9780596809515/ch08.html
+.. _Git Workflow: https://sandofsky.com/workflow/git-workflow/
 .. _GPL and Scala License are compatible: https://www.gnu.org/licenses/license-list.html#ModifiedBSD
 .. _GPL and Scala CLA are compatible: https://www.gnu.org/licenses/license-list.html#apache2

--- a/docs/contrib/contributing.rst
+++ b/docs/contrib/contributing.rst
@@ -6,7 +6,8 @@ Contributing guidelines
 Very important notice about Javalib
 -----------------------------------
 
-Scala Native contains a re-implementation of part of the JDK.
+Scala Native contains a re-implementation of part of the
+JDK (Java Development Kit).
 
 Although the `GPL and Scala License are compatible`_ and the `GPL and
 Scala CLA are compatible`_, EPFL wish to distribute scala native
@@ -121,8 +122,8 @@ This the general workflow for contributing to Scala Native.
 
 5.  After the review, you should resolve issues brought up by the reviewers as
     needed (amending or adding commits to address reviewers' comments),
-    iterating until the reviewers give their thumbs up, the "LONGTIME" (acronym for
-    "Looks Good To Me").
+    iterating until the reviewers give their thumbs up, the "LGTM"
+    (acronym for "Looks Good To Me").
 
 6.  Once the code has passed review the Pull Request can be merged into
     the distribution.
@@ -158,7 +159,7 @@ In order for a Pull Request to be considered, it has to meet these requirements:
 
 2.  Be accompanied by appropriate tests.
 
-3.  Be accompanied by appropriate documentation
+3.  Be accompanied by appropriate
     :ref:`documentation <project-documentation>`.
 
 4.  Be issued from a branch *other than master* (PRs coming from master will not
@@ -173,17 +174,16 @@ merged into the distribution, and need not even be reviewed.
 Documentation
 -------------
 
-Pull requests, other than the most trivial, without documentation
-will not be accepted. Imagine yourself as the person merging trying
+Pull requests without documentation will not be accepted, unless they are
+trivial. Imagine yourself as the person merging trying
 to understand, use, merge, or maintain the contribution.
 
-All code containing changes
-potentially visible to end users or developers contributed to user-facing
-standard libraries (nativelib, clib, javalib, etc.) should come accompanied
-with corresponding user-facing documentation, as described in
-the :ref:`docbuild`.
+All code containing changes to user-facing standard libraries (nativelib,
+clib, javalib [#]_, etc.) should come accompanied with corresponding
+user-facing documentation, as described in the :ref:`docbuild`.
 Such documentation should be manually built, checked for the absence
-of build errors or warnings, and visually inspected before submission.
+of build errors, warnings, or broken links, and visually inspected
+before submission.
 
 Code contributed to the internals (nscplugin, tools, etc.)
 should come accompanied by internal documentation if the code is not
@@ -232,10 +232,17 @@ followed by details of the commit, in the form of free text, or bulleted list.
 
 .. _Scala.js: https://github.com/scala-js/scala-js/tree/master/javalib/src/main/scala/java
 .. _Apache Harmony project: https://github.com/apache/harmony
-.. _Scala CLA: https
+.. _Scala CLA: https://www.lightbend.com/contribute/cla/scala
 .. _Pull Request: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
 .. _DRY: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
 .. _Boy Scout Rule: https://www.oreilly.com/library/view/97-things-every/9780596809515/ch08.html
 .. _Git Workflow: https://sandofsky.com/workflow/git-workflow/
 .. _GPL and Scala License are compatible: https://www.gnu.org/licenses/license-list.html#ModifiedBSD
 .. _GPL and Scala CLA are compatible: https://www.gnu.org/licenses/license-list.html#apache2
+
+.. rubric:: Footnotes
+
+.. [#] Scala Native :ref:`javalib` documents only where the
+       implementation differs from the
+       `Java API documentation <https://docs.oracle.com/javase/8/docs/api/>`_.
+

--- a/docs/contrib/index.rst
+++ b/docs/contrib/index.rst
@@ -8,6 +8,7 @@ Contributor's Guide
 
   contributing
   build
+  docbuild
   compiler
   nir
   mangling

--- a/docs/contrib/mangling.rst
+++ b/docs/contrib/mangling.rst
@@ -5,7 +5,7 @@ Scala Native toolchain mangles names for all definitions except
 the ones which have been explicitly exported to C using
 ``extern``. Mangling scheme is defined through a simple grammar
 that uses a notation inspired by
-`Itanium ABI <http://refspecs.linuxbase.org/cxxabi-1.83.html>`_::
+`Itanium ABI <https://refspecs.linuxbase.org/cxxabi-1.83.html>`_::
 
     <mangled-name> ::=
         _S <defn-name>

--- a/docs/contrib/nir.rst
+++ b/docs/contrib/nir.rst
@@ -75,7 +75,7 @@ Var
 
     ..$attrs var @$name: $ty = $value
 
-Corresponds to LLVM's `global variables <http://llvm.org/docs/LangRef.html#global-variables>`_
+Corresponds to LLVM's `global variables <https://llvm.org/docs/LangRef.html#global-variables>`_
 when used in the top-level scope and to fields, when used as a member of
 classes and modules.
 
@@ -85,7 +85,7 @@ Const
 
     ..$attrs const @$name: $type = $value
 
-Corresponds to LLVM's `global constant <http://llvm.org/docs/LangRef.html#global-variables>`_.
+Corresponds to LLVM's `global constant <https://llvm.org/docs/LangRef.html#global-variables>`_.
 Constants may only reside on the top-level and can not be members of classes and
 modules.
 
@@ -96,7 +96,7 @@ Declare
     ..$attrs def @$name: $type
 
 Correspond to LLVM's
-`declare <http://llvm.org/docs/LangRef.html#functions>`_
+`declare <https://llvm.org/docs/LangRef.html#functions>`_
 when used on the top-level of the compilation unit and
 to abstract methods when used inside classes and traits.
 
@@ -107,7 +107,7 @@ Define
     ..$attrs def @$name: $type { ..$blocks }
 
 Corresponds to LLVM's
-`define <http://llvm.org/docs/LangRef.html#functions>`_
+`define <https://llvm.org/docs/LangRef.html#functions>`_
 when used on the top-level of the compilation unit and
 to normal methods when used inside classes, traits and modules.
 
@@ -118,7 +118,7 @@ Struct
     ..$attrs struct @$name { ..$types }
 
 Corresponds to LLVM's
-`named struct <http://llvm.org/docs/LangRef.html#structure-types>`_.
+`named struct <https://llvm.org/docs/LangRef.html#structure-types>`_.
 
 Trait
 `````
@@ -154,7 +154,7 @@ Void
 
     void
 
-Corresponds to LLVM's `void <http://llvm.org/docs/LangRef.html#void-type>`_.
+Corresponds to LLVM's `void <https://llvm.org/docs/LangRef.html#void-type>`_.
 
 Vararg
 ``````
@@ -162,7 +162,7 @@ Vararg
 
     ...
 
-Corresponds to LLVM's `varargs <http://www.llvm.org/docs/LangRef.html#function-type>`_.
+Corresponds to LLVM's `varargs <https://www.llvm.org/docs/LangRef.html#function-type>`_.
 May only be nested inside function types.
 
 Pointer
@@ -171,7 +171,7 @@ Pointer
 
     ptr
 
-Corresponds to LLVM's `pointer type <http://llvm.org/docs/LangRef.html#pointer-type>`_
+Corresponds to LLVM's `pointer type <https://llvm.org/docs/LangRef.html#pointer-type>`_
 with a major distinction of not preserving the type of memory that's being
 pointed at. Pointers are going to become untyped in LLVM in near future too.
 
@@ -181,7 +181,7 @@ Boolean
 
     bool
 
-Corresponds to LLVM's `i1 <http://llvm.org/docs/LangRef.html#integer-type>`_.
+Corresponds to LLVM's `i1 <https://llvm.org/docs/LangRef.html#integer-type>`_.
 
 Integer
 ```````
@@ -192,7 +192,7 @@ Integer
     i32
     i64
 
-Corresponds to LLVM `integer types <http://llvm.org/docs/LangRef.html#integer-type>`_.
+Corresponds to LLVM `integer types <https://llvm.org/docs/LangRef.html#integer-type>`_.
 Unlike LLVM we do not support arbitrary width integer types at the moment.
 
 Float
@@ -202,7 +202,7 @@ Float
     f32
     f64
 
-Corresponds to LLVM's `floating point types <http://llvm.org/docs/LangRef.html#floating-point-types>`_.
+Corresponds to LLVM's `floating point types <https://llvm.org/docs/LangRef.html#floating-point-types>`_.
 
 Array
 `````
@@ -210,7 +210,7 @@ Array
 
     [$type x N]
 
-Corresponds to LLVM's `aggregate array type <http://llvm.org/docs/LangRef.html#array-type>`_.
+Corresponds to LLVM's `aggregate array type <https://llvm.org/docs/LangRef.html#array-type>`_.
 
 Function
 ````````
@@ -218,7 +218,7 @@ Function
 
     (..$args) => $ret
 
-Corresponds to LLVM's `function type <http://llvm.org/docs/LangRef.html#function-type>`_.
+Corresponds to LLVM's `function type <https://llvm.org/docs/LangRef.html#function-type>`_.
 
 Struct
 ``````
@@ -228,7 +228,7 @@ Struct
     struct { ..$types }
 
 Has two forms: named and anonymous. Corresponds to LLVM's
-`aggregate structure type <http://www.llvm.org/docs/LangRef.html#t-struct>`_.
+`aggregate structure type <https://www.llvm.org/docs/LangRef.html#t-struct>`_.
 
 Unit
 ````
@@ -281,7 +281,7 @@ unreachable
 
 If execution reaches undefined instruction the behaviour of execution is undefined
 starting from that point. Corresponds to LLVM's
-`unreachable <http://llvm.org/docs/LangRef.html#unreachable-instruction>`_.
+`unreachable <https://llvm.org/docs/LangRef.html#unreachable-instruction>`_.
 
 ret
 ```
@@ -290,7 +290,7 @@ ret
    ret $value
 
 Returns a value. Corresponds to LLVM's
-`ret <http://llvm.org/docs/LangRef.html#ret-instruction>`_.
+`ret <https://llvm.org/docs/LangRef.html#ret-instruction>`_.
 
 jump
 ````
@@ -300,7 +300,7 @@ jump
 
 Jumps to the next basic block with provided values for the parameters.
 Corresponds to LLVM's unconditional version of
-`br <http://llvm.org/docs/LangRef.html#br-instruction>`_.
+`br <https://llvm.org/docs/LangRef.html#br-instruction>`_.
 
 if
 ``
@@ -310,7 +310,7 @@ if
 
 Conditionally jumps to one of the basic blocks.
 Corresponds to LLVM's conditional form of
-`br <http://llvm.org/docs/LangRef.html#br-instruction>`_.
+`br <https://llvm.org/docs/LangRef.html#br-instruction>`_.
 
 switch
 ``````
@@ -324,7 +324,7 @@ switch
 
 Jumps to one of the basic blocks if ``$value`` is equal to
 corresponding ``$valueN``. Corresponds to LLVM's
-`switch <http://llvm.org/docs/LangRef.html#switch-instruction>`_.
+`switch <https://llvm.org/docs/LangRef.html#switch-instruction>`_.
 
 invoke
 ``````
@@ -334,7 +334,7 @@ invoke
 
 Invoke function pointer, jump to success in case value is returned,
 unwind to failure if exception was thrown. Corresponds to LLVM's
-`invoke <http://llvm.org/docs/LangRef.html#invoke-instruction>`_.
+`invoke <https://llvm.org/docs/LangRef.html#invoke-instruction>`_.
 
 throw
 `````
@@ -365,7 +365,7 @@ call
 
 Calls given function of given function type and argument values.
 Corresponds to LLVM's
-`call <http://llvm.org/docs/LangRef.html#call-instruction>`_.
+`call <https://llvm.org/docs/LangRef.html#call-instruction>`_.
 
 load
 ````
@@ -374,7 +374,7 @@ load
     load[$type] $ptr
 
 Load value of given type from memory. Corresponds to LLVM's
-`load <http://llvm.org/docs/LangRef.html#load-instruction>`_.
+`load <https://llvm.org/docs/LangRef.html#load-instruction>`_.
 
 store
 `````
@@ -383,7 +383,7 @@ store
     store[$type] $ptr, $value
 
 Store value of given type to memory. Corresponds to LLVM's
-`store <http://llvm.org/docs/LangRef.html#store-instruction>`_.
+`store <https://llvm.org/docs/LangRef.html#store-instruction>`_.
 
 elem
 ````
@@ -392,7 +392,7 @@ elem
     elem[$type] $ptr, ..$indexes
 
 Compute derived pointer starting from given pointer. Corresponds to LLVM's
-`getelementptr <http://llvm.org/docs/LangRef.html#getelementptr-instruction>`_.
+`getelementptr <https://llvm.org/docs/LangRef.html#getelementptr-instruction>`_.
 
 extract
 ```````
@@ -402,7 +402,7 @@ extract
 
 Extract element from aggregate value.
 Corresponds to LLVM's
-`extractvalue <http://llvm.org/docs/LangRef.html#extractvalue-instruction>`_.
+`extractvalue <https://llvm.org/docs/LangRef.html#extractvalue-instruction>`_.
 
 insert
 ``````
@@ -412,7 +412,7 @@ insert
 
 Create a new aggregate value based on existing one with element at index
 replaced with new value. Corresponds to LLVM's
-`insertvalue <http://llvm.org/docs/LangRef.html#insertvalue-instruction>`_.
+`insertvalue <https://llvm.org/docs/LangRef.html#insertvalue-instruction>`_.
 
 stackalloc
 ``````````
@@ -422,7 +422,7 @@ stackalloc
 
 Stack allocate a slot of memory big enough to store given type.
 Corresponds to LLVM's
-`alloca <http://llvm.org/docs/LangRef.html#alloca-instruction>`_.
+`alloca <https://llvm.org/docs/LangRef.html#alloca-instruction>`_.
 
 bin
 ```
@@ -436,7 +436,7 @@ Where ``$bin`` is one of the following:
 ``sdiv``, ``udiv``, ``fdiv``, ``srem``, ``urem``, ``frem``,
 ``shl``, ``lshr``, ``ashr`` , ``and``, ``or``, ``xor``.
 Depending on the type and signedness, maps to either integer or floating point
-`binary operations <http://llvm.org/docs/LangRef.html#binary-operations>`_ in LLVM.
+`binary operations <https://llvm.org/docs/LangRef.html#binary-operations>`_ in LLVM.
 
 comp
 ````
@@ -446,8 +446,8 @@ comp
 
 Where ``$comp`` is one of the following: ``eq``, ``neq``, ``lt``, ``lte``,
 ``gt``, ``gte``. Depending on the type, maps to either
-`icmp <http://llvm.org/docs/LangRef.html#icmp-instruction>`_ or
-`fcmp <http://llvm.org/docs/LangRef.html#fcmp-instruction>`_ with
+`icmp <https://llvm.org/docs/LangRef.html#icmp-instruction>`_ or
+`fcmp <https://llvm.org/docs/LangRef.html#fcmp-instruction>`_ with
 corresponding comparison flags in LLVM.
 
 conv
@@ -460,7 +460,7 @@ Where ``$conv`` is one of the following: ``trunc``, ``zext``, ``sext``, ``fptrun
 ``fpext``, ``fptoui``, ``fptosi``, ``uitofp``, ``sitofp``, ``ptrtoint``, ``inttoptr``,
 ``bitcast``.
 Corresponds to LLVM
-`conversion instructions <http://llvm.org/docs/LangRef.html#conversion-operations>`_
+`conversion instructions <https://llvm.org/docs/LangRef.html#conversion-operations>`_
 with the same name.
 
 sizeof


### PR DESCRIPTION
  * This PR fixes the major concern of Issue #1260. It describes and
    gives examples of building and inspecting html and pdf variants
    of user-facing documentation for Scala Native.

  * The idea is to encourage authors of Pull Requests, especially
    new contributors, to keep the user-facing documentation up-to-date
    by making it easy to view the output, rather than reading raw .rst files.

  * This PR also completes the changes in PR #1861 by removing
    warnings and relocations in `contrib/*.rst` revealed by Sphinx linkcheck.

  * I encourge review and iterative improvement by both native & non-native
    speakers of American English.  It is easy to see why I am a
    Software Engineer, not a professional documentation writer.

  * Descriptions of building on systems other than Ubuntu 20.04 would
     help new developers.

  * I am not happy that the `latexpdf` build contains warnings, but then latex & clan 
     always has warnings.   

Documentation:

  * The usual change note is requested.

Testing:

  * This PR was manually tested using the steps newly described in the
    `Contributor's Guide` to build both html and pdf output.