### PR TITLE
Fix runtime/tests with disabled Interflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,20 @@ env:
   matrix:
     - MODE=source-checks
     - MODE=test-tools
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
+    # without the Interflow optimiser
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
+    # with the Interflow optimiser
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
 
   global:
     - MAVEN_REALM="Sonatype Nexus Repository Manager"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,16 @@ env:
   matrix:
     - MODE=source-checks
     - MODE=test-tools
-    # without the Interflow optimiser
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=false SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
-    # with the Interflow optimiser
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
-    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMISE=true SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
+    # without the Interflow optimizer (only Immix GC)
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMIZE=false SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMIZE=false SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
+    # with the Interflow optimizer
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMIZE=true SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMIZE=true SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=debug SCALANATIVE_OPTIMIZE=true SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMIZE=true SCALANATIVE_GC=boehm TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMIZE=true SCALANATIVE_GC=immix TEST_COMMAND="test-runtime"
+    - MODE=test-runtime TARGET_DOCKER_PLATFORM=library SCALANATIVE_MODE=release-fast SCALANATIVE_OPTIMIZE=true SCALANATIVE_GC=commix TEST_COMMAND="test-runtime"
 
   global:
     - MAVEN_REALM="Sonatype Nexus Repository Manager"

--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -103,6 +103,10 @@ whereas the `release` mode performs additional optimizations and takes longer
 to compile. The `release-fast` mode builds faster, performs less optimizations,
 but may perform better than `release`.
 
+The `optimise` setting is controlled via the `SCALANATIVE_OPTIMISE` environment
+variable. Valid values are `true` and `false`. The default value is `true`.
+This setting controls whether the Interflow optimiser is enabled or not.
+
 Setting the GC setting via `sbt`
 --------------------------------
 The GC setting is only used during the link phase of the Scala Native

--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -103,9 +103,9 @@ whereas the `release` mode performs additional optimizations and takes longer
 to compile. The `release-fast` mode builds faster, performs less optimizations,
 but may perform better than `release`.
 
-The `optimise` setting is controlled via the `SCALANATIVE_OPTIMISE` environment
+The `optimize` setting is controlled via the `SCALANATIVE_OPTIMISE` environment
 variable. Valid values are `true` and `false`. The default value is `true`.
-This setting controls whether the Interflow optimiser is enabled or not.
+This setting controls whether the Interflow optimizer is enabled or not.
 
 Setting the GC setting via `sbt`
 --------------------------------

--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -103,7 +103,7 @@ whereas the `release` mode performs additional optimizations and takes longer
 to compile. The `release-fast` mode builds faster, performs less optimizations,
 but may perform better than `release`.
 
-The `optimize` setting is controlled via the `SCALANATIVE_OPTIMISE` environment
+The `optimize` setting is controlled via the `SCALANATIVE_OPTIMIZE` environment
 variable. Valid values are `true` and `false`. The default value is `true`.
 This setting controls whether the Interflow optimizer is enabled or not.
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -51,9 +51,6 @@ object ScalaNativePlugin extends AutoPlugin {
     val nativeDump =
       settingKey[Boolean](
         "Shall native toolchain dump intermediate NIR to disk during linking?")
-
-    val optimise =
-      settingKey[Boolean]("Shall we optimise the resulting NIR code? ")
   }
 
   @deprecated("use autoImport instead", "0.3.7")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -51,6 +51,9 @@ object ScalaNativePlugin extends AutoPlugin {
     val nativeDump =
       settingKey[Boolean](
         "Shall native toolchain dump intermediate NIR to disk during linking?")
+
+    val optimise =
+      settingKey[Boolean]("Shall we optimise the resulting NIR code? ")
   }
 
   @deprecated("use autoImport instead", "0.3.7")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -55,7 +55,9 @@ object ScalaNativePluginInternal {
       .getOrElse(build.GC.default.name),
     nativeLTO := Discover.LTO(),
     nativeCheck := false,
-    nativeDump := false
+    nativeDump := false,
+    optimise :=
+      System.getenv.getOrDefault("SCALANATIVE_OPTIMISE", "true").toBoolean
   )
 
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
@@ -138,6 +140,7 @@ object ScalaNativePluginInternal {
         .withLTO(nativeLTO.value)
         .withCheck(nativeCheck.value)
         .withDump(nativeDump.value)
+        .withOptimise(optimise.value)
     },
     nativeLink := {
       val logger  = streams.value.log.toLogger
@@ -156,7 +159,7 @@ object ScalaNativePluginInternal {
 
       logger.running(binary +: args)
       val exitCode = Process(binary +: args, None, env: _*)
-        .run(connectInput = true)
+        .run(connectInput = false)
         .exitValue
 
       val message =

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -55,9 +55,7 @@ object ScalaNativePluginInternal {
       .getOrElse(build.GC.default.name),
     nativeLTO := Discover.LTO(),
     nativeCheck := false,
-    nativeDump := false,
-    optimise :=
-      System.getenv.getOrDefault("SCALANATIVE_OPTIMISE", "true").toBoolean
+    nativeDump := false
   )
 
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
@@ -140,7 +138,7 @@ object ScalaNativePluginInternal {
         .withLTO(nativeLTO.value)
         .withCheck(nativeCheck.value)
         .withDump(nativeDump.value)
-        .withOptimise(optimise.value)
+        .withOptimize(Discover.optimize())
     },
     nativeLink := {
       val logger  = streams.value.log.toLogger

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -56,8 +56,8 @@ sealed trait Config {
   /** Shall linker dump intermediate NIR after every phase? */
   def dump: Boolean
 
-  /** Shall we optimise the resulting NIR code? */
-  def optimise: Boolean
+  /** Shall we optimize the resulting NIR code? */
+  def optimize: Boolean
 
   /** Create a new config with given garbage collector. */
   def withGC(value: GC): Config
@@ -107,8 +107,8 @@ sealed trait Config {
   /** Create a new config with given dump value. */
   def withDump(value: Boolean): Config
 
-  /** Create a new config with given optimise value. */
-  def withOptimise(value: Boolean): Config
+  /** Create a new config with given optimize value. */
+  def withOptimize(value: Boolean): Config
 }
 
 object Config {
@@ -132,7 +132,7 @@ object Config {
       LTO = "none",
       check = false,
       dump = false,
-      optimise = false
+      optimize = false
     )
 
   private final case class Impl(nativelib: Path,
@@ -151,7 +151,7 @@ object Config {
                                 LTO: String,
                                 check: Boolean,
                                 dump: Boolean,
-                                optimise: Boolean)
+                                optimize: Boolean)
       extends Config {
     def withNativelib(value: Path): Config =
       copy(nativelib = value)
@@ -201,7 +201,7 @@ object Config {
     def withDump(value: Boolean): Config =
       copy(dump = value)
 
-    def withOptimise(value: Boolean): Config =
-      copy(optimise = value)
+    def withOptimize(value: Boolean): Config =
+      copy(optimize = value)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -56,6 +56,9 @@ sealed trait Config {
   /** Shall linker dump intermediate NIR after every phase? */
   def dump: Boolean
 
+  /** Shall we optimise the resulting NIR code? */
+  def optimise: Boolean
+
   /** Create a new config with given garbage collector. */
   def withGC(value: GC): Config
 
@@ -103,6 +106,9 @@ sealed trait Config {
 
   /** Create a new config with given dump value. */
   def withDump(value: Boolean): Config
+
+  /** Create a new config with given optimise value. */
+  def withOptimise(value: Boolean): Config
 }
 
 object Config {
@@ -125,7 +131,8 @@ object Config {
       logger = Logger.default,
       LTO = "none",
       check = false,
-      dump = false
+      dump = false,
+      optimise = false
     )
 
   private final case class Impl(nativelib: Path,
@@ -143,7 +150,8 @@ object Config {
                                 logger: Logger,
                                 LTO: String,
                                 check: Boolean,
-                                dump: Boolean)
+                                dump: Boolean,
+                                optimise: Boolean)
       extends Config {
     def withNativelib(value: Path): Config =
       copy(nativelib = value)
@@ -192,5 +200,8 @@ object Config {
 
     def withDump(value: Boolean): Config =
       copy(dump = value)
+
+    def withOptimise(value: Boolean): Config =
+      copy(optimise = value)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -16,6 +16,9 @@ object Discover {
   def mode(): String =
     getenv("SCALANATIVE_MODE").getOrElse(build.Mode.default.name)
 
+  def optimize(): Boolean =
+    getenv("SCALANATIVE_OPTIMIZE").forall(_.toBoolean)
+
   /** LTO variant used for release mode. */
   def LTO(): String =
     getenv("SCALANATIVE_LTO").getOrElse("none")

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -72,11 +72,15 @@ private[scalanative] object ScalaNative {
   def optimize(config: Config, linked: linker.Result): linker.Result =
     dump(config, "optimized") {
       check(config) {
-        config.logger.time(s"Optimizing (${config.mode} mode)") {
-          val optimized =
-            interflow.Interflow(config, linked)
+        if (config.optimise) {
+          config.logger.time(s"Optimizing (${config.mode} mode)") {
+            val optimized =
+              interflow.Interflow(config, linked)
 
-          linker.Link(config, linked.entries, optimized)
+            linker.Link(config, linked.entries, optimized)
+          }
+        } else {
+          linked
         }
       }
     }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -72,7 +72,7 @@ private[scalanative] object ScalaNative {
   def optimize(config: Config, linked: linker.Result): linker.Result =
     dump(config, "optimized") {
       check(config) {
-        if (config.optimise) {
+        if (config.optimize) {
           config.logger.time(s"Optimizing (${config.mode} mode)") {
             val optimized =
               interflow.Interflow(config, linked)

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -857,19 +857,21 @@ object Lower {
       val Op.Arrayalloc(ty, init) = op
       init match {
         case len if len.ty == Type.Int =>
-          val sig  = arrayAllocSig.getOrElse(ty, arrayAllocSig(Rt.Object))
-          val func = arrayAlloc.getOrElse(ty, arrayAlloc(Rt.Object))
+          val sig    = arrayAllocSig.getOrElse(ty, arrayAllocSig(Rt.Object))
+          val func   = arrayAlloc.getOrElse(ty, arrayAlloc(Rt.Object))
+          val module = genModuleOp(buf, fresh(), Op.Module(func.owner))
           buf.let(n,
-                  Op.Call(sig, Val.Global(func, Type.Ptr), Seq(Val.Null, len)),
+                  Op.Call(sig, Val.Global(func, Type.Ptr), Seq(module, len)),
                   unwind)
         case arrval: Val.ArrayValue =>
-          val sig  = arraySnapshotSig.getOrElse(ty, arraySnapshotSig(Rt.Object))
-          val func = arraySnapshot.getOrElse(ty, arraySnapshot(Rt.Object))
-          val len  = Val.Int(arrval.values.length)
-          val init = Val.Const(arrval)
+          val sig    = arraySnapshotSig.getOrElse(ty, arraySnapshotSig(Rt.Object))
+          val func   = arraySnapshot.getOrElse(ty, arraySnapshot(Rt.Object))
+          val module = genModuleOp(buf, fresh(), Op.Module(func.owner))
+          val len    = Val.Int(arrval.values.length)
+          val init   = Val.Const(arrval)
           buf.let(
             n,
-            Op.Call(sig, Val.Global(func, Type.Ptr), Seq(Val.Null, len, init)),
+            Op.Call(sig, Val.Global(func, Type.Ptr), Seq(module, len, init)),
             unwind)
       }
     }

--- a/unit-tests/src/main/scala/tests/Suite.scala
+++ b/unit-tests/src/main/scala/tests/Suite.scala
@@ -88,15 +88,16 @@ abstract class Suite {
     throw AssertionFailed(s"expected to throw ${expected.getName} but didn't")
   }
 
-  def test(name: String)(body: => Unit): Unit =
-    tests += Test(name, { () =>
-      try {
-        body
-        TestResult(true, None)
-      } catch {
-        case thrown: Throwable => TestResult(false, Option(thrown))
-      }
-    })
+  def test(name: String, cond: Boolean = true)(body: => Unit): Unit =
+    if (cond)
+      tests += Test(name, { () =>
+        try {
+          body
+          TestResult(true, None)
+        } catch {
+          case thrown: Throwable => TestResult(false, Option(thrown))
+        }
+      })
 
   def testFails(name: String, issue: Int)(body: => Unit): Unit =
     tests += Test(name, { () =>

--- a/unit-tests/src/main/scala/tests/Suite.scala
+++ b/unit-tests/src/main/scala/tests/Suite.scala
@@ -89,7 +89,7 @@ abstract class Suite {
   }
 
   def test(name: String, cond: Boolean = true)(body: => Unit): Unit =
-    if (cond)
+    if (cond) {
       tests += Test(name, { () =>
         try {
           body
@@ -98,6 +98,7 @@ abstract class Suite {
           case thrown: Throwable => TestResult(false, Option(thrown))
         }
       })
+    }
 
   def testFails(name: String, issue: Int)(body: => Unit): Unit =
     tests += Test(name, { () =>

--- a/unit-tests/src/test/scala/java/util/DefaultFormatterSuite.scala
+++ b/unit-tests/src/test/scala/java/util/DefaultFormatterSuite.scala
@@ -59,8 +59,8 @@ object DefaultFormatterSuite extends tests.Suite {
     // TimeZone.setDefault(defaultTimeZone)
   }
 
-  override def test(name: String)(body: => Unit): Unit =
-    super.test(name) {
+  override def test(name: String, cond: Boolean = true)(body: => Unit): Unit =
+    super.test(name, cond) {
       setUp()
       try {
         body

--- a/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterUSSuite.scala
@@ -61,8 +61,8 @@ object FormatterUSSuite extends tests.Suite {
     // TimeZone.setDefault(defaultTimeZone)
   }
 
-  override def test(name: String)(body: => Unit): Unit =
-    super.test(name) {
+  override def test(name: String, cond: Boolean = true)(body: => Unit): Unit =
+    super.test(name, cond) {
       setUp()
       try {
         body

--- a/unit-tests/src/test/scala/java/util/MapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/MapSuite.scala
@@ -23,7 +23,8 @@ trait MapSuite extends tests.Suite {
     assertEquals("two", mp.get("TWO"))
   }
 
-  test("should store integers") {
+  test("should store integers",
+       cond = !factory.isInstanceOf[IdentityMapSuiteFactory]) {
     val mp = factory.empty[Int, Int]
 
     mp.put(100, 12345)
@@ -32,7 +33,8 @@ trait MapSuite extends tests.Suite {
     assertEquals(12345, one)
   }
 
-  test("should store doubles also in corner cases") {
+  test("should store doubles also in corner cases",
+       cond = !factory.isInstanceOf[IdentityMapSuiteFactory]) {
     val mp = factory.empty[Double, Double]
 
     mp.put(1.2345, 11111.0)
@@ -82,7 +84,8 @@ trait MapSuite extends tests.Suite {
     assertNull(mp.get("ONE"))
   }
 
-  test("should remove stored elements on double corner cases") {
+  test("should remove stored elements on double corner cases",
+       cond = !factory.isInstanceOf[IdentityMapSuiteFactory]) {
     val mp = factory.empty[Double, String]
 
     mp.put(1.2345, "11111.0")


### PR DESCRIPTION
Fix a `NullPointerException` that is thrown at runtime if compilation is done with the Interflow optimiser switched off.

The `NullPointerException` is thrown by the `snapshot` methods that can be found in the various implementations (`ByteArray`, `IntArray`, etc.) of the `Arrays` module in `nativelib`.

In particular, during the lowering phase, the `arrayalloc` operation generation would pass a `Val.Null` as the `this` pointer for the `snapshot` method. During Interflow, the `snapshot` method is always inline, so the problem would not reveal itself.

This PR introduces the following changes:
- Load and pass the correct object reference as `this` pointer in `arrayalloc` operation generation during lowering.
- Introduce extra runs in the CI, with Interflow disabled, to make sure we don't regress in the future.
- To accomplish the above, introduce a new boolean environment variable called `SCALANATIVE_OPTIMIZE` with valid values `true` and `false`, with the obvious meaning.
- Fix some errors in tests that surfaced with Interflow disabled:
  - In `IdentityHashMapSuite`, we used to test for primitive types as keys of the map. These tests are not correct for an `IdentityHashMap`, as each primitive is boxed to a different value and thus lookup would fail even if the underlying primitive is a valid key.