### PR TITLE
Fix #1780: Fix an ambiguous overload about java.nio.FileSystems.newFileSystem on JDK 13+.

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/IO.scala
+++ b/tools/src/main/scala/scala/scalanative/build/IO.scala
@@ -161,7 +161,7 @@ private[scalanative] object IO {
   /** Unzip all members of the ZIP archive `archive` to `target`. */
   def unzip(archive: Path, target: Path): Unit = {
     Files.createDirectories(target)
-    val zipFS = FileSystems.newFileSystem(archive, null)
+    val zipFS = FileSystems.newFileSystem(archive, null: ClassLoader)
     try {
       val rootDirectories = zipFS.getRootDirectories().iterator
       while (rootDirectories.hasNext) {


### PR DESCRIPTION
This PR resolves #1780 
Some (currently unknown) Java distribution contains definition of `FileSystems.newFileSystem(Path, Map[String,String]) which creates ambiguous reference call within IO FileSystems.newFileSystem(archive: Path, null)

Fix provides cast of `null` argument to expected `ClassLoader` type in order to remove ambiguity. 