### PR TITLE
Discover and use clang 11 if present, and drop clang < 5.0.

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -137,17 +137,13 @@ object Discover {
   /** Versions of clang which are known to work with Scala Native. */
   private[scalanative] val clangVersions =
     Seq(
+      ("11", ""),
       ("10", ""),
       ("9", ""),
       ("8", ""),
       ("7", ""),
-      ("7", "0"), // LLVM changed version numbering scheme, try both.
       ("6", "0"),
-      ("5", "0"),
-      ("4", "0"),
-      ("3", "9"),
-      ("3", "8"),
-      ("3", "7")
+      ("5", "0")
     )
 
   /** Discover concrete binary path using command name and


### PR DESCRIPTION
  * clang-11 will soon be available available. Discover and use the highest
    installed clang on the build system.  This is the next semi-annual
    installment in a long series of clang update PRs.

  * This PR does not conflict with pending PR #1864.

  * This PR is intended as a "minimal" fix to provide clang-11.
    There are interesting, pending, unresolved discussions in
    PR #1848 and Issue #1849. Both are, IMHO, worthy. Trying to
    drive those discussions to fruition during an August and the
    presence of more important issues is unlikely.  To the best of
    my understanding, this PR does nothing to complicate those
    discussions. It merely kicks the existing situation down the road,
    to my minor professional disparagement.

  * An uncontroversial change:

    I removed the line `("7", "0")` because a number of years have gone
    by and that bit of defensive programming to be unneeded.
    It has served its purpose.
    The resultant code will contain less lore and execute slightly quicker.
    clang-7 will still be discovered, if it is the highest installed version.

  * A possibly controversial change:

    I removed discovery lines for clang versions before the 5.0 currently
    exercised by Travis CI. That is clang 4.0 and various 3.7 versions.
    Those version will still be recognized if they are known as "clang"
    but will no longer be discovered. There "might" be someone out there
    running the 3+ year old clang 4.0 as an alternate version but it
    is highly unlikely.  Here I rely upon Scala Native being a 0.n version,
    not a 1.0 version.

    My overall concern is speeding up the build by a few milliseconds
    by not looking for ancient clang versions.

  * I left the "is clang recent enough?" code in place, even though
    it was relevant only in the clang 3.n timeframe.  There might
    be someone out there attempting to clang 3.1, as "clang".

    If reviewers recommend/encourage, I would gladly remove that code,
    to reduce both execution speed and, especially, complexity for the
    people who have to read that section.

    I believe that the discovery mechanism should be changed to a
    "specification" mechanism.  That is, require developers to
    specify any desired clang version other than the system default "clang".
    I did not make this change to minimize churn whilst Scala Native is
    undergoing re-organization.

  * The Discovery code does not, and has not for years, discover
    llvm-config of the form llvm-config-N, where N is [3-9]. The current
    PR does no worse that prior art.  A PR for another day.

Documentation:

    * The standard changelog entry is requested.

Testing:

  * Testing needs to show first safety, then efficacy.

  * Safety, not breaking when neither clang-10 nor clang-9 is installed,
    will be shown by Travis CI.

  * To show that the code change was effective on a system with both
    clang-11 and clang-10 installed, I manually added
    'nativeCompileOptions ++= Seq("-v")'to the settings in build.sbt for
    the sandbox project and then running that project.

    The log file showed clang-11 in use:
    `[error] clang -cc1 version 11.0.0 based upon LLVM 11.0.0`

    I then ran "test-all" using clang-11 and all tests passed.