### PR TITLE
Add Scala 2.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 
 scala:
-  - "2.11.12"
+  - "2.12.12"
 
 os: linux
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 
 scala:
+  - "2.11.12"
   - "2.12.12"
 
 os: linux
@@ -36,7 +37,7 @@ script:
   - java -version
   - if [ "$MODE" == "source-checks" ]; then ./scripts/source-checks; fi
   - if [ "$MODE" == "test-tools" ]; then
-      sbt "-no-colors" "-J-Xmx3G" test-tools;
+      sbt "++ $TRAVIS_SCALA_VERSION -v" "-no-colors" "-J-Xmx3G" test-tools;
     fi
   - if [ "$MODE" == "test-runtime" ]; then
       ./ci-docker/load-cached-images.sh

--- a/build.sbt
+++ b/build.sbt
@@ -731,6 +731,7 @@ lazy val junitTestOutputsJVM =
     .in(file("junit-test/output-jvm"))
     .settings(
       commonJUnitTestOutputsSettings,
+      crossScalaVersions := Seq(sbt10ScalaVersion),
       libraryDependencies ++= Seq(
         "com.novocode" % "junit-interface" % "0.11" % "test"
       )

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import scala.collection.mutable
 import scala.util.Try
 
 val sbt10Version          = "1.1.6" // minimum version
-val sbt10ScalaVersion     = "2.12.11"
-val libScalaVersion       = "2.12.11"
+val sbt10ScalaVersion     = "2.12.12"
+val libScalaVersion       = "2.12.12"
 val libCrossScalaVersions = Seq("2.11.8", "2.11.11", "2.11.12", libScalaVersion)
 
 // Convert "SomeName" to "some-name".
@@ -402,7 +402,9 @@ lazy val scalalib =
       // Keep the log file clean so that real issues stand out.
       // This futzing can probably removed for scala >= 2.12.
       scalacOptions -= "-deprecation",
-      scalacOptions += "-deprecation:false"
+      scalacOptions += "-deprecation:false",
+      // The option below is needed since Scala 2.12.12.
+      scalacOptions += "-language:postfixOps"
     )
     .settings(mavenPublishSettings)
     .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -194,7 +194,12 @@ lazy val buildInfoSettings: Seq[Setting[_]] =
   Def.settings(
     buildInfoPackage := "scala.scalanative.buildinfo",
     buildInfoObject := "ScalaNativeBuildInfo",
-    buildInfoKeys := Seq[BuildInfoKey](version, scalaVersion, sbtVersion)
+    buildInfoKeys := Seq[BuildInfoKey](
+      version,
+      sbtVersion,
+      scalaVersion,
+      "nativeScalaVersion" -> (nativelib / scalaVersion).value
+    )
   )
 
 lazy val util =
@@ -233,6 +238,8 @@ lazy val tools =
     .in(file("tools"))
     .settings(toolSettings)
     .settings(mavenPublishSettings)
+    .enablePlugins(BuildInfoPlugin)
+    .settings(buildInfoSettings)
     .settings(
       libraryDependencies ++= Seq(
         scalacheckDep,

--- a/build.sbt
+++ b/build.sbt
@@ -293,7 +293,8 @@ lazy val sbtPluginSettings: Seq[Setting[_]] =
         scriptedLaunchOpts.value ++
           Seq("-Xmx1024M",
               "-XX:MaxMetaspaceSize=256M",
-              "-Dplugin.version=" + version.value) ++
+              "-Dplugin.version=" + version.value,
+              "-Dscala.version=" + (nativelib / scalaVersion).value) ++
           ivyPaths.value.ivyHome.map(home => s"-Dsbt.ivy.home=$home").toSeq
       }
     )
@@ -304,7 +305,7 @@ lazy val sbtScalaNative =
     .enablePlugins(SbtPlugin)
     .settings(sbtPluginSettings)
     .settings(
-      crossScalaVersions := libCrossScalaVersions,
+      crossScalaVersions := Seq(sbt10ScalaVersion),
       addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0"),
       sbtTestDirectory := (ThisBuild / baseDirectory).value / "scripted-tests",
       // publish the other projects before running scripted tests.

--- a/build.sbt
+++ b/build.sbt
@@ -409,12 +409,11 @@ lazy val scalalib =
     .in(file("scalalib"))
     .enablePlugins(MyScalaNativePlugin)
     .settings(
-      // This build uses libScalaVersion, which is currently 2.11.12
-      // to compile what appears to be 2.11.0 sources. This yields 114
+      // This build uses Scala 2.11 version 2.11.12 to compile
+      // what appears to be 2.11.0 sources. This yields 114
       // deprecations. Editing those sources is not an option (long story),
       // so do not spend compile time looking for the deprecations.
       // Keep the log file clean so that real issues stand out.
-      // This futzing can probably removed for scala >= 2.12.
       scalacOptions -= "-deprecation",
       scalacOptions += "-deprecation:false",
       // The option below is needed since Scala 2.12.12.
@@ -614,7 +613,6 @@ lazy val testingCompilerInterface =
     .in(file("testing-compiler-interface"))
     .settings(noPublishSettings)
     .settings(
-      crossScalaVersions := libCrossScalaVersions,
       crossPaths := false,
       crossVersion := CrossVersion.disabled,
       autoScalaLibrary := false
@@ -625,7 +623,6 @@ lazy val testingCompiler =
     .in(file("testing-compiler"))
     .settings(noPublishSettings)
     .settings(
-      crossScalaVersions := libCrossScalaVersions,
       libraryDependencies ++= Seq(
         "org.scala-lang" % "scala-compiler" % scalaVersion.value,
         "org.scala-lang" % "scala-reflect"  % scalaVersion.value
@@ -734,7 +731,6 @@ lazy val junitTestOutputsJVM =
     .in(file("junit-test/output-jvm"))
     .settings(
       commonJUnitTestOutputsSettings,
-      scalaVersion := libScalaVersion,
       libraryDependencies ++= Seq(
         "com.novocode" % "junit-interface" % "0.11" % "test"
       )
@@ -755,7 +751,6 @@ lazy val junitAsyncJVM =
   project
     .in(file("junit-async/jvm"))
     .settings(
-      scalaVersion := libScalaVersion,
       crossScalaVersions := Seq(sbt10ScalaVersion),
       nameSettings,
       publishArtifact := false

--- a/build.sbt
+++ b/build.sbt
@@ -627,7 +627,12 @@ lazy val testInterfaceCommonSourcesSettings = Seq(
 lazy val testInterface =
   project
     .in(file("test-interface"))
-    .enablePlugins(MyScalaNativePlugin)
+    .enablePlugins(MyScalaNativePlugin, BuildInfoPlugin)
+    .settings(
+      buildInfoPackage := "scala.scalanative.buildinfo",
+      buildInfoObject := "ScalaNativeBuildInfo",
+      buildInfoKeys := Seq[BuildInfoKey](version, scalaVersion, sbtVersion)
+    )
     .settings(mavenPublishSettings)
     .settings(testInterfaceCommonSourcesSettings)
     .dependsOn(nscplugin   % "plugin",

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -47,4 +47,4 @@ USER scala-native
 
 WORKDIR /home/scala-native/scala-native
 
-CMD sbt -no-colors -J-Xmx3G "set scriptedBufferLog in sbtScalaNative := false" "$TEST_COMMAND"
+CMD sbt "++ $TRAVIS_SCALA_VERSION -v" -no-colors -J-Xmx3G "set scriptedBufferLog in sbtScalaNative := false" "$TEST_COMMAND"

--- a/ci-docker/run-test.sh
+++ b/ci-docker/run-test.sh
@@ -10,4 +10,5 @@ docker run -v $HOME/.ivy2:/home/scala-native/.ivy2 \
            -e SCALANATIVE_GC=$SCALANATIVE_GC \
            -e SCALANATIVE_OPTIMIZE=$SCALANATIVE_OPTIMIZE \
            -e TEST_COMMAND=$TEST_COMMAND \
+           -e TRAVIS_SCALA_VERSION=$TRAVIS_SCALA_VERSION \
            -it scala-native-testing:linux-$TARGET_DOCKER_PLATFORM;

--- a/javalib/src/main/scala/java/lang/Boolean.scala
+++ b/javalib/src/main/scala/java/lang/Boolean.scala
@@ -43,7 +43,8 @@ final class Boolean(val _value: scala.Boolean) extends Comparable[Boolean] {
 }
 
 object Boolean {
-  final val TYPE           = scala.Predef.classOf[scala.scalanative.runtime.PrimitiveBoolean]
+  final val TYPE =
+    scala.Predef.classOf[scala.scalanative.runtime.PrimitiveBoolean]
   final val TRUE: Boolean  = new Boolean(true)
   final val FALSE: Boolean = new Boolean(false)
 

--- a/javalib/src/main/scala/java/lang/Byte.scala
+++ b/javalib/src/main/scala/java/lang/Byte.scala
@@ -77,11 +77,11 @@ final class Byte(val _value: scala.Byte) extends Number with Comparable[Byte] {
   protected def +(x: String): String = _value + x
 
   protected def <<(x: scala.Int): scala.Int   = _value << x
-  protected def <<(x: scala.Long): scala.Int  = _value << x
+  protected def <<(x: scala.Long): scala.Int  = _value << x.toInt
   protected def >>>(x: scala.Int): scala.Int  = _value >>> x
-  protected def >>>(x: scala.Long): scala.Int = _value >>> x
+  protected def >>>(x: scala.Long): scala.Int = _value >>> x.toInt
   protected def >>(x: scala.Int): scala.Int   = _value >> x
-  protected def >>(x: scala.Long): scala.Int  = _value >> x
+  protected def >>(x: scala.Long): scala.Int  = _value >> x.toInt
 
   protected def <(x: scala.Byte): scala.Boolean   = _value < x
   protected def <(x: scala.Short): scala.Boolean  = _value < x

--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -65,11 +65,11 @@ class Character(val _value: scala.Char)
   protected def +(x: String): String = _value + x
 
   protected def <<(x: scala.Int): scala.Int   = _value << x
-  protected def <<(x: scala.Long): scala.Int  = _value << x
+  protected def <<(x: scala.Long): scala.Int  = _value << x.toInt
   protected def >>>(x: scala.Int): scala.Int  = _value >>> x
-  protected def >>>(x: scala.Long): scala.Int = _value >>> x
+  protected def >>>(x: scala.Long): scala.Int = _value >>> x.toInt
   protected def >>(x: scala.Int): scala.Int   = _value >> x
-  protected def >>(x: scala.Long): scala.Int  = _value >> x
+  protected def >>(x: scala.Long): scala.Int  = _value >> x.toInt
 
   protected def ==(x: scala.Byte): scala.Boolean   = _value == x
   protected def ==(x: scala.Short): scala.Boolean  = _value == x

--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -193,7 +193,8 @@ object Double {
   final val NEGATIVE_INFINITY = 1.0 / -0.0
   final val POSITIVE_INFINITY = 1.0 / 0.0
   final val SIZE              = 64
-  final val TYPE              = scala.Predef.classOf[scala.scalanative.runtime.PrimitiveDouble]
+  final val TYPE =
+    scala.Predef.classOf[scala.scalanative.runtime.PrimitiveDouble]
 
   @inline def compare(x: scala.Double, y: scala.Double): scala.Int =
     if (x > y) 1

--- a/javalib/src/main/scala/java/lang/Float.scala
+++ b/javalib/src/main/scala/java/lang/Float.scala
@@ -189,7 +189,8 @@ object Float {
   final val NEGATIVE_INFINITY = 1.0f / -0.0f
   final val POSITIVE_INFINITY = 1.0f / 0.0f
   final val SIZE              = 32
-  final val TYPE              = scala.Predef.classOf[scala.scalanative.runtime.PrimitiveFloat]
+  final val TYPE =
+    scala.Predef.classOf[scala.scalanative.runtime.PrimitiveFloat]
 
   @inline def compare(x: scala.Float, y: scala.Float): scala.Int =
     if (x > y) 1

--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -80,11 +80,11 @@ final class Integer(val _value: scala.Int)
   protected def +(x: String): String = _value + x
 
   protected def <<(x: scala.Int): scala.Int   = _value << x
-  protected def <<(x: scala.Long): scala.Int  = _value << x
+  protected def <<(x: scala.Long): scala.Int  = _value << x.toInt
   protected def >>>(x: scala.Int): scala.Int  = _value >>> x
-  protected def >>>(x: scala.Long): scala.Int = _value >>> x
+  protected def >>>(x: scala.Long): scala.Int = _value >>> x.toInt
   protected def >>(x: scala.Int): scala.Int   = _value >> x
-  protected def >>(x: scala.Long): scala.Int  = _value >> x
+  protected def >>(x: scala.Long): scala.Int  = _value >> x.toInt
 
   protected def <(x: scala.Byte): scala.Boolean   = _value < x
   protected def <(x: scala.Short): scala.Boolean  = _value < x

--- a/javalib/src/main/scala/java/lang/Short.scala
+++ b/javalib/src/main/scala/java/lang/Short.scala
@@ -176,7 +176,8 @@ final class Short(val _value: scala.Short)
 }
 
 object Short {
-  final val TYPE  = scala.Predef.classOf[scala.scalanative.runtime.PrimitiveShort]
+  final val TYPE =
+    scala.Predef.classOf[scala.scalanative.runtime.PrimitiveShort]
   final val SIZE  = 16
   final val BYTES = 2
 

--- a/javalib/src/main/scala/java/lang/Short.scala
+++ b/javalib/src/main/scala/java/lang/Short.scala
@@ -78,11 +78,11 @@ final class Short(val _value: scala.Short)
   protected def +(x: String): String = _value + x
 
   protected def <<(x: scala.Int): scala.Int   = _value << x
-  protected def <<(x: scala.Long): scala.Int  = _value << x
+  protected def <<(x: scala.Long): scala.Int  = _value << x.toInt
   protected def >>>(x: scala.Int): scala.Int  = _value >>> x
-  protected def >>>(x: scala.Long): scala.Int = _value >>> x
+  protected def >>>(x: scala.Long): scala.Int = _value >>> x.toInt
   protected def >>(x: scala.Int): scala.Int   = _value >> x
-  protected def >>(x: scala.Long): scala.Int  = _value >> x
+  protected def >>(x: scala.Long): scala.Int  = _value >> x.toInt
 
   protected def <(x: scala.Byte): scala.Boolean   = _value < x
   protected def <(x: scala.Short): scala.Boolean  = _value < x

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -735,8 +735,8 @@ object Files {
 
   private def setAttributes(path: Path, attrs: Array[FileAttribute[_]]): Unit =
     attrs.map(a => (a.name, a.value)).toMap.foreach {
-      case (name, value: Object) =>
-        setAttribute(path, name, value, Array.empty)
+      case (name, value) =>
+        setAttribute(path, name, value.asInstanceOf[AnyRef], Array.empty)
     }
 
   private val attributesClassesToViews

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/UInt.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/UInt.scala
@@ -49,7 +49,7 @@ final class UInt private[scalanative] (private[scalanative] val underlying: Int)
    *         filling in the new right bits with zeroes.
    * @example {{{ 6 << 3 == 48 // in binary: 0110 << 3 == 0110000 }}}
    */
-  @inline final def <<(x: Long): UInt = new UInt(underlying << x)
+  @inline final def <<(x: Long): UInt = new UInt(underlying << x.toInt)
 
   /**
    * Returns this value bit-shifted right by the specified number of bits,
@@ -73,7 +73,7 @@ final class UInt private[scalanative] (private[scalanative] val underlying: Int)
    * //            00011111 11111111 11111111 11111101
    * }}}
    */
-  @inline final def >>>(x: Long): UInt = new UInt(underlying >>> x)
+  @inline final def >>>(x: Long): UInt = new UInt(underlying >>> x.toInt)
 
   /**
    * Returns this value bit-shifted left by the specified number of bits,
@@ -95,7 +95,7 @@ final class UInt private[scalanative] (private[scalanative] val underlying: Int)
    * //            11111111 11111111 11111111 11111101
    * }}}
    */
-  @inline final def >>(x: Long): UInt = new UInt(underlying >> x)
+  @inline final def >>(x: Long): UInt = new UInt(underlying >> x.toInt)
 
   @inline final override def compareTo(x: UInt): Int =
     JInteger.compareUnsigned(underlying, x.underlying)

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -32,7 +32,7 @@ object Attr {
   final case object Abstract          extends Attr
 }
 
-final case class Attrs(inline: Inline = MayInline,
+final case class Attrs(doInline: Inline = MayInline,
                        specialize: Specialize = MaySpecialize,
                        opt: Opt = UnOpt,
                        isExtern: Boolean = false,
@@ -43,7 +43,7 @@ final case class Attrs(inline: Inline = MayInline,
   def toSeq: Seq[Attr] = {
     val out = mutable.UnrolledBuffer.empty[Attr]
 
-    if (inline != MayInline) out += inline
+    if (doInline != MayInline) out += doInline
     if (specialize != MaySpecialize) out += specialize
     if (opt != UnOpt) out += opt
     if (isExtern) out += Extern
@@ -58,8 +58,8 @@ final case class Attrs(inline: Inline = MayInline,
 object Attrs {
   val None = new Attrs()
 
-  def fromSeq(attrs: Seq[Attr]) = {
-    var inline     = None.inline
+  def fromSeq(attrs: Seq[Attr]): Attrs = {
+    var inline     = None.doInline
     var specialize = None.specialize
     var opt        = None.opt
     var isExtern   = false

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -32,7 +32,7 @@ object Attr {
   final case object Abstract          extends Attr
 }
 
-final case class Attrs(doInline: Inline = MayInline,
+final case class Attrs(inlineHint: Inline = MayInline,
                        specialize: Specialize = MaySpecialize,
                        opt: Opt = UnOpt,
                        isExtern: Boolean = false,
@@ -43,7 +43,7 @@ final case class Attrs(doInline: Inline = MayInline,
   def toSeq: Seq[Attr] = {
     val out = mutable.UnrolledBuffer.empty[Attr]
 
-    if (doInline != MayInline) out += doInline
+    if (inlineHint != MayInline) out += inlineHint
     if (specialize != MaySpecialize) out += specialize
     if (opt != UnOpt) out += opt
     if (isExtern) out += Extern
@@ -59,7 +59,7 @@ object Attrs {
   val None = new Attrs()
 
   def fromSeq(attrs: Seq[Attr]): Attrs = {
-    var inline     = None.doInline
+    var inline     = None.inlineHint
     var specialize = None.specialize
     var opt        = None.opt
     var isExtern   = false

--- a/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
@@ -89,7 +89,7 @@ object ControlFlow {
 
             val block = new Block(n, params, body, isEntry = k == 0)
             blocks(local) = block
-            todo :+= block
+            todo ::= block
             block
           }
         )
@@ -130,8 +130,8 @@ object ControlFlow {
       val visited = mutable.Set.empty[Local]
 
       while (todo.nonEmpty) {
-        val block = todo.last
-        todo = todo.init
+        val block = todo.head
+        todo = todo.tail
         val name = block.name
         if (!visited(name)) {
           visited += name

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -125,11 +125,6 @@ object Type {
       false
   }
 
-  def isPtr(ty: Type): Boolean = ty match {
-    case Type.Ptr => true
-    case _        => false
-  }
-
   val typeToArray = Map[Type, Global](
     Type.Bool    -> Global.Top("scala.scalanative.runtime.BooleanArray"),
     Type.Char    -> Global.Top("scala.scalanative.runtime.CharArray"),

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -125,6 +125,11 @@ object Type {
       false
   }
 
+  def isPtr(ty: Type): Boolean = ty match {
+    case Type.Ptr => true
+    case _        => false
+  }
+
   val typeToArray = Map[Type, Global](
     Type.Bool    -> Global.Top("scala.scalanative.runtime.BooleanArray"),
     Type.Char    -> Global.Top("scala.scalanative.runtime.CharArray"),

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirCompat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirCompat.scala
@@ -11,6 +11,8 @@ trait NirCompat { self: NirGenPhase =>
 
   import global._
 
+  // SAMFunction was introduced in 2.12 for LMF-capable SAM type
+
   object SAMFunctionAttachCompatDef {
     case class SAMFunction(samTp: Type, sam: Symbol, synthCls: Symbol)
         extends PlainAttachment
@@ -23,13 +25,12 @@ trait NirCompat { self: NirGenPhase =>
       import global._
 
       type SAMFunctionAlias = SAMFunction
-      val SAMFunctionAlias: global.SAMFunction.type = SAMFunction
+      val SAMFunctionAlias = SAMFunction
     }
   }
 
   type SAMFunctionCompat = SAMFunctionAttachCompat.Inner.SAMFunctionAlias
-  lazy val SAMFunctionCompat: global.SAMFunction.type =
-    SAMFunctionAttachCompat.Inner.SAMFunctionAlias
+  lazy val SAMFunctionCompat = SAMFunctionAttachCompat.Inner.SAMFunctionAlias
 
   implicit final class SAMFunctionCompatOps(self: SAMFunctionCompat) {
     // Introduced in 2.12.5 to synthesize bridges in LMF classes

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirCompat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirCompat.scala
@@ -23,12 +23,13 @@ trait NirCompat { self: NirGenPhase =>
       import global._
 
       type SAMFunctionAlias = SAMFunction
-      val SAMFunctionAlias = SAMFunction
+      val SAMFunctionAlias: global.SAMFunction.type = SAMFunction
     }
   }
 
   type SAMFunctionCompat = SAMFunctionAttachCompat.Inner.SAMFunctionAlias
-  lazy val SAMFunctionCompat = SAMFunctionAttachCompat.Inner.SAMFunctionAlias
+  lazy val SAMFunctionCompat: global.SAMFunction.type =
+    SAMFunctionAttachCompat.Inner.SAMFunctionAlias
 
   implicit final class SAMFunctionCompatOps(self: SAMFunctionCompat) {
     // Introduced in 2.12.5 to synthesize bridges in LMF classes
@@ -60,6 +61,18 @@ trait NirCompat { self: NirGenPhase =>
 
   def isImplClass(sym: Symbol): Boolean =
     scalaUsesImplClasses && sym.hasFlag(Flags.IMPLCLASS)
+
+  implicit final class StdTermNamesCompat(self: global.nme.type) {
+    def IMPL_CLASS_SUFFIX: String = noImplClasses()
+
+    def isImplClassName(name: Name): Boolean = false
+  }
+
+  implicit final class StdTypeNamesCompat(self: global.tpnme.type) {
+    def IMPL_CLASS_SUFFIX: String = noImplClasses()
+
+    def interfaceName(implname: Name): TypeName = noImplClasses()
+  }
 
 }
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -97,7 +97,7 @@ trait NirDefinitions { self: NirGlobalAddons =>
 
     lazy val StructClass = getRequiredClass("scala.scalanative.runtime.struct")
 
-    lazy val RuntimePackage = getPackage(TermName("scala.scalanative.runtime"))
+    lazy val RuntimePackage = getPackage("scala.scalanative.runtime")
 
     lazy val RuntimeMonitorClass = getRequiredClass(
       "scala.scalanative.runtime.Monitor")

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -287,6 +287,14 @@ trait NirDefinitions { self: NirGlobalAddons =>
       ULongClass  -> getDecl(RuntimeBoxesModule, TermName("boxToULong"))
     )
 
+    lazy val HashMethods = Seq(
+      getDecl(BoxesRunTimeModule, TermName("hashFromObject")),
+      getDecl(BoxesRunTimeModule, TermName("hashFromNumber")),
+      getDecl(BoxesRunTimeModule, TermName("hashFromFloat")),
+      getDecl(BoxesRunTimeModule, TermName("hashFromDouble")),
+      getDecl(BoxesRunTimeModule, TermName("hashFromLong"))
+    ) ++ getMember(ScalaRunTimeModule, TermName("hash")).alternatives
+
     lazy val UnboxMethod = Map[Char, Symbol](
       'B' -> getDecl(BoxesRunTimeModule, TermName("unboxToBoolean")),
       'C' -> getDecl(BoxesRunTimeModule, TermName("unboxToChar")),

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -97,7 +97,7 @@ trait NirDefinitions { self: NirGlobalAddons =>
 
     lazy val StructClass = getRequiredClass("scala.scalanative.runtime.struct")
 
-    lazy val RuntimePackage = getPackage("scala.scalanative.runtime")
+    lazy val RuntimePackage = getPackageObject("scala.scalanative.runtime")
 
     lazy val RuntimeMonitorClass = getRequiredClass(
       "scala.scalanative.runtime.Monitor")

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -703,7 +703,7 @@ trait NirGenExpr { self: NirGenPhase =>
           paramSyms.zip(functionArgs.takeRight(sigTypes.length)).zip(params).foreach {
             case ((sym, arg), value) =>
               val unboxedOrCast = {
-                val unboxed = buf.unboxValue(sym.tpe, partial = false, value)
+                val unboxed = buf.unboxValue(sym.tpe, partial = true, value)
                 if (unboxed == value) // no need to or cannot unbox, we should cast
                   buf.genCastOp(genType(sym.tpe), genType(arg.tpe), value)
                 else
@@ -725,7 +725,7 @@ trait NirGenExpr { self: NirGenPhase =>
           val res      = buf.call(sig, method, values, Next.None)
           val boxedRes = {
             val expectedResTy = genType(funSym.tpe.resultType)
-            if (res.ty != expectedResTy) {
+            if (!res.ty.isInstanceOf[Type.RefKind] && res.ty != expectedResTy) {
               buf.boxValue(callTree.tpe, res)
             } else {
               res

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2,6 +2,7 @@ package scala.scalanative
 package nscplugin
 
 import scala.collection.mutable
+import scala.scalanative.nir.Type.isPtr
 import scalanative.nir._
 import scalanative.util.{Platform, StringUtils, unsupported}
 import scalanative.util.ScopedVar.scoped
@@ -1850,7 +1851,7 @@ trait NirGenExpr { self: NirGenPhase =>
         }
       val args = genMethodArgs(sym, argsp)
       val method =
-        if (isImplClass(owner) || statically || owner.isStruct || owner.isExternModule || self.ty == nir.Type.Ptr) {
+        if (isImplClass(owner) || statically || owner.isStruct || owner.isExternModule || isPtr(self.ty)) {
           Val.Global(name, nir.Type.Ptr)
         } else {
           val Global.Member(_, sig) = name

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -546,19 +546,10 @@ trait NirGenExpr { self: NirGenPhase =>
     }
 
     def genAssign(tree: Assign): Val = {
-      // println("genAssign: ")
-      // println("- " + showRaw(tree))
-      // println("- " + showCode(tree))
       val Assign(lhsp, rhsp) = tree
 
       lhsp match {
         case sel @ Select(qualp, _) =>
-          // println("@ sel.tpe " + sel.tpe)
-          // println("@ sel.sym " + sel.symbol)
-          // println("@ sel.sym.tpe " + sel.symbol.tpe)
-          // println("@ qualp.tpe " + qualp.tpe)
-          // println("@ qualp.sym " + qualp.symbol)
-          // println("@ rhs.tpe " + rhsp.tpe)
           val qual = genExpr(qualp)
           val rhs  = genExpr(rhsp)
           val name = genFieldName(sel.symbol)

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -4,7 +4,7 @@ package nscplugin
 import scala.collection.mutable
 import scala.scalanative.nir.Type.isPtr
 import scalanative.nir._
-import scalanative.util.{Platform, StringUtils, unsupported}
+import scalanative.util.{StringUtils, unsupported}
 import scalanative.util.ScopedVar.scoped
 import scalanative.nscplugin.NirPrimitives._
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -15,8 +15,8 @@ trait NirGenExpr { self: NirGenPhase =>
   import nirDefinitions._
   import SimpleType.{fromType, fromSymbol}
 
-  final case class ValTree(value: nir.Val)    extends Tree
-  final case class ContTree(f: () => nir.Val) extends Tree
+  case class ValTree(value: nir.Val)    extends Tree
+  case class ContTree(f: () => nir.Val) extends Tree
 
   class FixupBuffer(implicit fresh: Fresh) extends nir.Buffer {
     private var labeled = false
@@ -1822,7 +1822,7 @@ trait NirGenExpr { self: NirGenPhase =>
           buf.method(self, sig, unwind)
         }
       val values =
-        if (owner.isExternModule || owner.isImplClass)
+        if (owner.isExternModule || isImplClass(owner))
           args
         else
           self +: args

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -15,6 +15,8 @@ trait NirGenExpr { self: NirGenPhase =>
   import nirDefinitions._
   import SimpleType.{fromType, fromSymbol}
 
+  // TODO: These classes should be final - however, it results in the following error:
+  // TODO: > The outer reference in this type test cannot be checked at run time.
   case class ValTree(value: nir.Val)    extends Tree
   case class ContTree(f: () => nir.Val) extends Tree
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -615,11 +615,11 @@ trait NirGenExpr { self: NirGenPhase =>
 
       // Generate an anonymous class definition.
 
-      val suffix   = "$$Lambda$" + curClassFresh.get.apply().id
-      val anonName = nir.Global.Top(genName(curClassSym).top.id + suffix)
-      val trtName  = genName(funSym)
+      val suffix    = "$$Lambda$" + curClassFresh.get.apply().id
+      val anonName  = nir.Global.Top(genName(curClassSym).top.id + suffix)
+      val traitName = genName(funSym)
 
-      statBuf += nir.Defn.Class(Attrs.None, anonName, Some(nir.Rt.Object.name), Seq(trtName))
+      statBuf += nir.Defn.Class(Attrs.None, anonName, Some(nir.Rt.Object.name), Seq(traitName))
 
       // Generate fields to store the captures.
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1827,7 +1827,7 @@ trait NirGenExpr { self: NirGenPhase =>
         }
       val args = genMethodArgs(sym, argsp)
       val method =
-        if (isImplClass(owner) || statically || owner.isStruct || owner.isExternModule) {
+        if (isImplClass(owner) || statically || owner.isStruct || owner.isExternModule || self.ty == nir.Type.Ptr) {
           Val.Global(name, nir.Type.Ptr)
         } else {
           val Global.Member(_, sig) = name

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -775,9 +775,6 @@ trait NirGenExpr { self: NirGenPhase =>
         val samsBuilder    = List.newBuilder[Symbol]
         val seenSignatures = mutable.Set.empty[Sig]
 
-        // On Scala < 2.12.5, `synthCls` is polyfilled to `NoSymbol` and hence
-        // `samBridges` will always be empty. This causes our compiler to be
-        // bug-compatible on these versions.
         val synthCls = samInfo.synthCls
         // On Scala < 2.12.5, `synthCls` is polyfilled to `NoSymbol`
         // and hence `samBridges` will always be empty (scala/bug#10512).

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -16,10 +16,8 @@ trait NirGenExpr { self: NirGenPhase =>
   import nirDefinitions._
   import SimpleType.{fromType, fromSymbol}
 
-  // TODO: These classes should be final - however, it results in the following error:
-  // TODO: > The outer reference in this type test cannot be checked at run time.
-  case class ValTree(value: nir.Val)    extends Tree
-  case class ContTree(f: () => nir.Val) extends Tree
+  sealed case class ValTree(value: nir.Val)    extends Tree
+  sealed case class ContTree(f: () => nir.Val) extends Tree
 
   class FixupBuffer(implicit fresh: Fresh) extends nir.Buffer {
     private var labeled = false

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -641,16 +641,16 @@ trait NirGenExpr { self: NirGenPhase =>
       val ctorName = anonName.member(Sig.Ctor(captureTypes))
       val ctorTy   = nir.Type.Function(Type.Ref(anonName) +: captureTypes, Type.Unit)
       val ctorBody = {
-        val fresh    = Fresh()
-        val buf      = new nir.Buffer()(fresh)
-        val self     = Val.Local(fresh(), Type.Ref(anonName))
-        val captures = captureTypes.map { ty => Val.Local(fresh(), ty) }
-        buf.label(fresh(), self +: captures)
+        val fresh          = Fresh()
+        val buf            = new nir.Buffer()(fresh)
+        val self           = Val.Local(fresh(), Type.Ref(anonName))
+        val captureFormals = captureTypes.map { ty => Val.Local(fresh(), ty) }
+        buf.label(fresh(), self +: captureFormals)
         val superTy   = nir.Type.Function(Seq(Rt.Object), Type.Unit)
         val superName = Rt.Object.name.member(Sig.Ctor(Seq()))
         val superCtor = Val.Global(superName, Type.Ptr)
         buf.call(superTy, superCtor, Seq(self), Next.None)
-        captureNames.zip(captures).foreach {
+        captureNames.zip(captureFormals).foreach {
           case (name, capture) =>
             buf.fieldstore(capture.ty, self, name, capture, Next.None)
         }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -667,7 +667,7 @@ trait NirGenExpr { self: NirGenPhase =>
         val funName = anonName.member(funSig)
 
         val selfType = Type.Ref(anonName)
-        val nir.Sig.Method(_, sigTypes :+ retType) = funSig.unmangled
+        val Sig.Method(_, sigTypes :+ retType, _) = funSig.unmangled
         val paramTypes = selfType +: sigTypes
 
         val bodyFresh = Fresh()

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenFile.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenFile.scala
@@ -21,7 +21,7 @@ trait NirGenFile { self: NirGenPhase =>
       settings.outputDirs.outputDirFor(cunit.source.file)
 
     val pathParts = id.split("[./]")
-    val dir = pathParts.init.foldLeft(baseDir)(_.subdirectoryNamed(_))
+    val dir       = pathParts.init.foldLeft(baseDir)(_.subdirectoryNamed(_))
 
     val filename = pathParts.last
     val file     = dir fileNamed (filename + ".nir")

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenFile.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenFile.scala
@@ -21,7 +21,7 @@ trait NirGenFile { self: NirGenPhase =>
       settings.outputDirs.outputDirFor(cunit.source.file)
 
     val pathParts = id.split("[./]")
-    val dir       = (baseDir /: pathParts.init)(_.subdirectoryNamed(_))
+    val dir = pathParts.init.foldLeft(baseDir)(_.subdirectoryNamed(_))
 
     val filename = pathParts.last
     val file     = dir fileNamed (filename + ".nir")

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
@@ -39,7 +39,7 @@ trait NirGenName { self: NirGenPhase =>
         genTypeName(sym.moduleClass)
       case _ =>
         val idWithSuffix =
-          if (sym.isModuleClass) {
+          if (sym.isModuleClass && !isImplClass(sym)) {
             id + "$"
           } else {
             id

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -20,7 +20,7 @@ trait NirGenStat { self: NirGenPhase =>
     mutable.UnrolledBuffer.empty[ReflectiveInstantiationBuffer]
 
   def isStaticModule(sym: Symbol): Boolean =
-    sym.isModuleClass && !sym.isImplClass && !sym.isLifted
+    sym.isModuleClass && !isImplClass(sym) && !sym.isLifted
 
   class MethodEnv(val fresh: Fresh) {
     private val env = mutable.Map.empty[Symbol, Val]
@@ -593,7 +593,7 @@ trait NirGenStat { self: NirGenPhase =>
         val attrs    = genMethodAttrs(sym)
         val name     = genMethodName(sym)
         val sig      = genMethodSig(sym)
-        val isStatic = owner.isExternModule || owner.isImplClass
+        val isStatic = owner.isExternModule || isImplClass(owner)
 
         dd.rhs match {
           case EmptyTree =>

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -68,7 +68,7 @@ trait NirGenStat { self: NirGenPhase =>
   }
 
   class StatBuffer {
-    val buf                  = mutable.UnrolledBuffer.empty[nir.Defn]
+    private val buf          = mutable.UnrolledBuffer.empty[nir.Defn]
     def toSeq: Seq[nir.Defn] = buf
 
     def +=(defn: nir.Defn): Unit = {

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -68,7 +68,7 @@ trait NirGenStat { self: NirGenPhase =>
   }
 
   class StatBuffer {
-    val buf          = mutable.UnrolledBuffer.empty[nir.Defn]
+    val buf                  = mutable.UnrolledBuffer.empty[nir.Defn]
     def toSeq: Seq[nir.Defn] = buf
 
     def +=(defn: nir.Defn): Unit = {
@@ -225,10 +225,8 @@ trait NirGenStat { self: NirGenPhase =>
     def genClassFields(sym: Symbol): Unit = {
       val attrs = nir.Attrs(isExtern = sym.isExternModule)
 
-      for (
-        f <- sym.info.decls
-        if !f.isMethod && f.isTerm && !f.isModule
-      ) {
+      for (f <- sym.info.decls
+           if !f.isMethod && f.isTerm && !f.isModule) {
         val ty   = genType(f.tpe)
         val name = genFieldName(f)
 
@@ -582,10 +580,10 @@ trait NirGenStat { self: NirGenPhase =>
       val env   = new MethodEnv(fresh)
 
       scoped(
-        curMethodSym     := dd.symbol,
-        curMethodEnv     := env,
-        curMethodInfo    := (new CollectMethodInfo).collect(dd.rhs),
-        curFresh         := fresh,
+        curMethodSym := dd.symbol,
+        curMethodEnv := env,
+        curMethodInfo := (new CollectMethodInfo).collect(dd.rhs),
+        curFresh := fresh,
         curUnwindHandler := None
       ) {
         val sym      = dd.symbol

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenType.scala
@@ -14,7 +14,7 @@ trait NirGenType { self: NirGenPhase =>
       sym.isInterface
 
     def isScalaModule: Boolean =
-      sym.isModuleClass && !sym.isImplClass && !sym.isLifted
+      sym.isModuleClass && !isImplClass(sym) && !sym.isLifted
 
     def isExternModule: Boolean =
       isScalaModule && sym.annotations.exists(_.symbol == ExternClass)
@@ -163,7 +163,7 @@ trait NirGenType { self: NirGenPhase =>
     val owner    = sym.owner
     val paramtys = genMethodSigParamsImpl(sym, isExtern)
     val selfty =
-      if (isExtern || owner.isExternModule || owner.isImplClass) None
+      if (isExtern || owner.isExternModule || isImplClass(owner)) None
       else Some(genType(owner.tpe))
     val retty =
       if (sym.isClassConstructor) nir.Type.Unit

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirPrimitives.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirPrimitives.scala
@@ -128,6 +128,16 @@ abstract class NirPrimitives {
     addPrimitive(ULongToFloatMethod, ULONG_TO_FLOAT)
     addPrimitive(UIntToDoubleMethod, UINT_TO_DOUBLE)
     addPrimitive(ULongToDoubleMethod, ULONG_TO_DOUBLE)
+
+    {
+      import scala.tools.nsc.settings._
+      ScalaVersion.current match {
+        case SpecificScalaVersion(2, 11, _, _) =>
+          HashMethods.foreach(addPrimitive(_, HASH))
+        case _ =>
+      }
+    }
+
     addPrimitive(LoadBoolMethod, LOAD_BOOL)
     addPrimitive(LoadCharMethod, LOAD_CHAR)
     addPrimitive(LoadByteMethod, LOAD_BYTE)

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -100,7 +100,7 @@ abstract class PrepNativeInterop
         //
         // or so it seems, at least.
         case TypeApply(classOfTree @ Select(predef, nme.classOf), List(tpeArg))
-          if predef.symbol == PredefModule =>
+            if predef.symbol == PredefModule =>
           // Replace call by literal constant containing type
           if (typer.checkClassType(tpeArg)) {
             val widenedTpe = tpeArg.tpe.dealias.widen

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -195,10 +195,6 @@ abstract class PrepNativeInterop
           )
           super.transform(tree)
 
-        // case TypeApply(_, _) if tree.toString.contains("classOf") =>
-        //   println("type apply: " + tree)
-        //   super.transform(tree)
-
         case _ =>
           super.transform(tree)
       }

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -10,7 +10,6 @@ object MyScalaNativePlugin extends AutoPlugin {
   override def requires: Plugins = ScalaNativePlugin
 
   override def projectSettings: Seq[Setting[_]] = Def.settings(
-    crossScalaVersions := ScalaVersions.libCrossScalaVersions,
     /* Remove libraryDependencies on ourselves; we use .dependsOn() instead
      * inside this build.
      */

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -10,6 +10,7 @@ object MyScalaNativePlugin extends AutoPlugin {
   override def requires: Plugins = ScalaNativePlugin
 
   override def projectSettings: Seq[Setting[_]] = Def.settings(
+    crossScalaVersions := ScalaVersions.libCrossScalaVersions,
     /* Remove libraryDependencies on ourselves; we use .dependsOn() instead
      * inside this build.
      */

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -7,6 +7,5 @@ object ScalaVersions {
 
   val sbt10Version: String               = "1.1.6" // minimum version
   val sbt10ScalaVersion: String          = scala212
-  val libScalaVersion: String            = scala212
   val libCrossScalaVersions: Seq[String] = Seq(scala211, scala212)
 }

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -1,0 +1,12 @@
+package build
+
+object ScalaVersions {
+  val scala211: String = "2.11.12"
+  val scala212: String = "2.12.12"
+  //val scala213: String = "2.13.3"
+
+  val sbt10Version: String               = "1.1.6" // minimum version
+  val sbt10ScalaVersion: String          = scala212
+  val libScalaVersion: String            = scala212
+  val libCrossScalaVersions: Seq[String] = Seq(scala211, scala212)
+}

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -15,6 +15,7 @@ addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
 addSbtPlugin("org.foundweekends"  % "sbt-bintray"       % "0.5.4")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"           % "2.0.0")
 addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"   % "0.6.1")
+addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"     % "0.9.0")
 
 // scalacOptions used to bootstrap to sbt prompt.
 // In particular, no "-Xfatal-warnings"

--- a/sandbox/Test.scala
+++ b/sandbox/Test.scala
@@ -1,5 +1,5 @@
 object Test {
   def main(args: Array[String]): Unit = {
-    println("Hello, world!")
+    println("Hello, World!")
   }
 }

--- a/scalalib/overrides-2.11/scala/runtime/ScalaRunTime.scala
+++ b/scalalib/overrides-2.11/scala/runtime/ScalaRunTime.scala
@@ -174,6 +174,7 @@ object ScalaRunTime {
 
   def hash(x: Any): Int =
     if (x == null) 0
+    else if (x.isInstanceOf[java.lang.Number]) BoxesRunTime.hashFromNumber(x.asInstanceOf[java.lang.Number])
     else x.hashCode
 
   def hash(dv: Double): Int = {
@@ -200,7 +201,7 @@ object ScalaRunTime {
     val high = (lv >>> 32).toInt
     low ^ (high + lowSign)
   }
-  def hash(x: Number): Int = x.hashCode
+  def hash(x: Number): Int  = runtime.BoxesRunTime.hashFromNumber(x)
 
   // The remaining overloads are here for completeness, but the compiler
   // inlines these definitions directly so they're not generally used.

--- a/scalalib/overrides-2.11/scala/runtime/ScalaRunTime.scala
+++ b/scalalib/overrides-2.11/scala/runtime/ScalaRunTime.scala
@@ -174,7 +174,6 @@ object ScalaRunTime {
 
   def hash(x: Any): Int =
     if (x == null) 0
-    else if (x.isInstanceOf[java.lang.Number]) BoxesRunTime.hashFromNumber(x.asInstanceOf[java.lang.Number])
     else x.hashCode
 
   def hash(dv: Double): Int = {
@@ -201,7 +200,7 @@ object ScalaRunTime {
     val high = (lv >>> 32).toInt
     low ^ (high + lowSign)
   }
-  def hash(x: Number): Int  = runtime.BoxesRunTime.hashFromNumber(x)
+  def hash(x: Number): Int = x.hashCode
 
   // The remaining overloads are here for completeness, but the compiler
   // inlines these definitions directly so they're not generally used.

--- a/scalalib/overrides-2.12/scala/App.scala
+++ b/scalalib/overrides-2.12/scala/App.scala
@@ -1,0 +1,77 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import scala.compat.Platform.currentTime
+import scala.collection.mutable.ListBuffer
+
+/** The `App` trait can be used to quickly turn objects
+ *  into executable programs. Here is an example:
+ *  {{{
+ *  object Main extends App {
+ *    Console.println("Hello World: " + (args mkString ", "))
+ *  }
+ *  }}}
+ *  Here, object `Main` inherits the `main` method of `App`.
+ *
+ *  `args` returns the current command line arguments as an array.
+ *
+ *  ==Caveats==
+ *
+ *  '''''It should be noted that this trait is implemented using the [[DelayedInit]]
+ *  functionality, which means that fields of the object will not have been initialized
+ *  before the main method has been executed.'''''
+ *
+ *  It should also be noted that the `main` method should not be overridden:
+ *  the whole class body becomes the "main method".
+ *
+ *  Future versions of this trait will no longer extend `DelayedInit`.
+ *
+ *  @author  Martin Odersky
+ *  @since   2.1
+ */
+trait App extends DelayedInit {
+
+  /** The command line arguments passed to the application's `main` method.
+   */
+  @deprecatedOverriding("args should not be overridden", "2.11.0")
+  protected def args: Array[String] = _args
+
+  private var _args: Array[String] = _
+
+  private val initCode = new ListBuffer[() => Unit]
+
+  /** The init hook. This saves all initialization code for execution within `main`.
+   *  This method is normally never called directly from user code.
+   *  Instead it is called as compiler-generated code for those classes and objects
+   *  (but not traits) that inherit from the `DelayedInit` trait and that do not
+   *  themselves define a `delayedInit` method.
+   *  @param body the initialization code to be stored for later execution
+   */
+  @deprecated("the delayedInit mechanism will disappear", "2.11.0")
+  override def delayedInit(body: => Unit) {
+    initCode += (() => body)
+  }
+
+  /** The main method.
+   *  This stores all arguments so that they can be retrieved with `args`
+   *  and then executes all initialization code segments in the order in which
+   *  they were passed to `delayedInit`.
+   *  @param args the arguments passed to the main method
+   */
+  @deprecatedOverriding("main should not be overridden", "2.11.0")
+  def main(args: Array[String]) = {
+    this._args = args
+    for (proc <- initCode) proc()
+  }
+}

--- a/scalalib/overrides-2.12/scala/Array.scala
+++ b/scalalib/overrides-2.12/scala/Array.scala
@@ -1,0 +1,714 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import scala.collection.generic._
+import scala.collection.{ mutable, immutable }
+import mutable.{ ArrayBuilder, ArraySeq }
+import scala.reflect.ClassTag
+import scala.runtime.ScalaRunTime.{ array_apply, array_update }
+import scala.collection.mutable.WrappedArray
+
+/** Contains a fallback builder for arrays when the element type
+ *  does not have a class tag. In that case a generic array is built.
+ */
+class FallbackArrayBuilding {
+
+  /** A builder factory that generates a generic array.
+   *  Called instead of `Array.newBuilder` if the element type of an array
+   *  does not have a class tag. Note that fallbackBuilder factory
+   *  needs an implicit parameter (otherwise it would not be dominated in
+   *  implicit search by `Array.canBuildFrom`). We make sure that
+   *  implicit search is always successful.
+   */
+  implicit def fallbackCanBuildFrom[T](implicit m: DummyImplicit): CanBuildFrom[Array[_], T, ArraySeq[T]] =
+    new CanBuildFrom[Array[_], T, ArraySeq[T]] {
+      def apply(from: Array[_]) = ArraySeq.newBuilder[T]
+      def apply() = ArraySeq.newBuilder[T]
+    }
+}
+
+/** Utility methods for operating on arrays.
+ *  For example:
+ *  {{{
+ *  val a = Array(1, 2)
+ *  val b = Array.ofDim[Int](2)
+ *  val c = Array.concat(a, b)
+ *  }}}
+ *  where the array objects `a`, `b` and `c` have respectively the values
+ *  `Array(1, 2)`, `Array(0, 0)` and `Array(1, 2, 0, 0)`.
+ *
+ *  @author Martin Odersky
+ *  @since  1.0
+ */
+object Array extends FallbackArrayBuilding {
+  @inline def emptyBooleanArray = new Array[Boolean](0)
+  @inline def emptyByteArray    = new Array[Byte](0)
+  @inline def emptyCharArray    = new Array[Char](0)
+  @inline def emptyDoubleArray  = new Array[Double](0)
+  @inline def emptyFloatArray   = new Array[Float](0)
+  @inline def emptyIntArray     = new Array[Int](0)
+  @inline def emptyLongArray    = new Array[Long](0)
+  @inline def emptyShortArray   = new Array[Short](0)
+  @inline def emptyObjectArray  = new Array[Object](0)
+
+  implicit def canBuildFrom[T](implicit tag: ClassTag[T]): CanBuildFrom[Array[_], T, Array[T]] = {
+    val cls = tag.runtimeClass
+    (if (cls.isPrimitive) {
+      cls match {
+        case java.lang.Integer.TYPE   => cbfIntArray
+        case java.lang.Double.TYPE    => cbfDoubleArray
+        case java.lang.Long.TYPE      => cbfLongArray
+        case java.lang.Float.TYPE     => cbfFloatArray
+        case java.lang.Character.TYPE => cbfCharArray
+        case java.lang.Byte.TYPE      => cbfByteArray
+        case java.lang.Short.TYPE     => cbfShortArray
+        case java.lang.Boolean.TYPE   => cbfBooleanArray
+        case java.lang.Void.TYPE      => cbfUnitArray
+      }
+    } else if (cls == ObjectClass) {
+      cbfObjectArray
+    } else {
+      refCBF[T with AnyRef](tag.asInstanceOf[ClassTag[T with AnyRef]])
+    }).asInstanceOf[CanBuildFrom[Array[_], T, Array[T]]]
+  }
+  private[this] val ObjectClass = classOf[Object]
+
+  private[this] val cbfBooleanArray = new CanBuildFrom[Array[_], Boolean, Array[Boolean]] {
+    def apply(from: Array[_]) = new ArrayBuilder.ofBoolean()
+    def apply() = new ArrayBuilder.ofBoolean()
+  }
+
+  private[this] val cbfByteArray    = new CanBuildFrom[Array[_], Byte, Array[Byte]] {
+    def apply(from: Array[_]) = new ArrayBuilder.ofByte()
+    def apply() = new ArrayBuilder.ofByte()
+  }
+
+  private[this] val cbfCharArray    = new CanBuildFrom[Array[_], Char, Array[Char]] {
+    def apply(from: Array[_]) = new ArrayBuilder.ofChar()
+    def apply() = new ArrayBuilder.ofChar()
+  }
+
+  private[this] val cbfDoubleArray  = new CanBuildFrom[Array[_], Double, Array[Double]] {
+    def apply(from: Array[_]) = new ArrayBuilder.ofDouble()
+    def apply() = new ArrayBuilder.ofDouble()
+  }
+
+  private[this] val cbfFloatArray   = new CanBuildFrom[Array[_], Float, Array[Float]] {
+    def apply(from: Array[_]) = new ArrayBuilder.ofFloat()
+    def apply() = new ArrayBuilder.ofFloat()
+  }
+
+  private[this] val cbfIntArray     = new CanBuildFrom[Array[_], Int, Array[Int]] {
+    def apply(from: Array[_]) = new ArrayBuilder.ofInt()
+    def apply() = new ArrayBuilder.ofInt()
+  }
+
+  private[this] val cbfLongArray    = new CanBuildFrom[Array[_], Long, Array[Long]] {
+    def apply(from: Array[_]) = new ArrayBuilder.ofLong()
+    def apply() = new ArrayBuilder.ofLong()
+  }
+
+  private[this] val cbfShortArray   = new CanBuildFrom[Array[_], Short, Array[Short]] {
+    def apply(from: Array[_]) = new ArrayBuilder.ofShort()
+    def apply() = new ArrayBuilder.ofShort()
+  }
+
+  private[this] val cbfUnitArray    = new CanBuildFrom[Array[_], Unit, Array[Unit]] {
+    def apply(from: Array[_]) = new ArrayBuilder.ofUnit()
+    def apply() = new ArrayBuilder.ofUnit()
+  }
+
+  private[this] val cbfObjectArray  = refCBF[Object]
+  private[this] def refCBF[T <: AnyRef](implicit t: ClassTag[T]): CanBuildFrom[Array[_], T, Array[T]] =
+    new CanBuildFrom[Array[_], T, Array[T]] {
+      def apply(from: Array[_]) = new ArrayBuilder.ofRef[T]()(t)
+      def apply() = new ArrayBuilder.ofRef[T]()(t)
+    }
+
+  /**
+   * Returns a new [[scala.collection.mutable.ArrayBuilder]].
+   */
+  def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T]()(t)
+
+  private def slowcopy(src : AnyRef,
+                       srcPos : Int,
+                       dest : AnyRef,
+                       destPos : Int,
+                       length : Int) {
+    var i = srcPos
+    var j = destPos
+    val srcUntil = srcPos + length
+    while (i < srcUntil) {
+      array_update(dest, j, array_apply(src, i))
+      i += 1
+      j += 1
+    }
+  }
+
+  /** Copy one array to another.
+   *  Equivalent to Java's
+   *    `System.arraycopy(src, srcPos, dest, destPos, length)`,
+   *  except that this also works for polymorphic and boxed arrays.
+   *
+   *  Note that the passed-in `dest` array will be modified by this call.
+   *
+   *  @param src the source array.
+   *  @param srcPos  starting position in the source array.
+   *  @param dest destination array.
+   *  @param destPos starting position in the destination array.
+   *  @param length the number of array elements to be copied.
+   *
+   *  @see `java.lang.System#arraycopy`
+   */
+  def copy(src: AnyRef, srcPos: Int, dest: AnyRef, destPos: Int, length: Int) {
+    val srcClass = src.getClass
+    if (srcClass.isArray && dest.getClass.isAssignableFrom(srcClass))
+      java.lang.System.arraycopy(src, srcPos, dest, destPos, length)
+    else
+      slowcopy(src, srcPos, dest, destPos, length)
+  }
+
+  /** Returns an array of length 0 */
+  def empty[T: ClassTag]: Array[T] = new Array[T](0)
+
+  /** Creates an array with given elements.
+   *
+   *  @param xs the elements to put in the array
+   *  @return an array containing all elements from xs.
+   */
+  // Subject to a compiler optimization in Cleanup.
+  // Array(e0, ..., en) is translated to { val a = new Array(3); a(i) = ei; a }
+  def apply[T: ClassTag](xs: T*): Array[T] = xs match {
+    case xs: WrappedArray.ofBoolean =>
+      val from = xs.array
+      val array = new Array[Boolean](from.length)
+      System.arraycopy(from, 0, array, 0, from.length)
+      array.asInstanceOf[Array[T]]
+    case xs: WrappedArray.ofByte =>
+      val from = xs.array
+      val array = new Array[Byte](from.length)
+      System.arraycopy(from, 0, array, 0, from.length)
+      array.asInstanceOf[Array[T]]
+    case xs: WrappedArray.ofShort =>
+      val from = xs.array
+      val array = new Array[Short](from.length)
+      System.arraycopy(from, 0, array, 0, from.length)
+      array.asInstanceOf[Array[T]]
+    case xs: WrappedArray.ofChar =>
+      val from = xs.array
+      val array = new Array[Char](from.length)
+      System.arraycopy(from, 0, array, 0, from.length)
+      array.asInstanceOf[Array[T]]
+    case xs: WrappedArray.ofInt =>
+      val from = xs.array
+      val array = new Array[Int](from.length)
+      System.arraycopy(from, 0, array, 0, from.length)
+      array.asInstanceOf[Array[T]]
+    case xs: WrappedArray.ofLong =>
+      val from = xs.array
+      val array = new Array[Long](from.length)
+      System.arraycopy(from, 0, array, 0, from.length)
+      array.asInstanceOf[Array[T]]
+    case xs: WrappedArray.ofFloat =>
+      val from = xs.array
+      val array = new Array[Float](from.length)
+      System.arraycopy(from, 0, array, 0, from.length)
+      array.asInstanceOf[Array[T]]
+    case xs: WrappedArray.ofDouble =>
+      val from = xs.array
+      val array = new Array[Double](from.length)
+      System.arraycopy(from, 0, array, 0, from.length)
+      array.asInstanceOf[Array[T]]
+    case xs =>
+      val array = new Array[T](xs.length)
+      var i = 0
+      for (x <- xs.iterator) { array(i) = x; i += 1 }
+      array
+  }
+
+  /** Creates an array of `Boolean` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
+    val array = new Array[Boolean](xs.length + 1)
+    array(0) = x
+    xs match {
+      case xs: WrappedArray.ofBoolean =>
+        System.arraycopy(xs.array, 0, array, 1, xs.array.length)
+      case xs =>
+        var i = 1
+        for (x <- xs.iterator) { array(i) = x; i += 1 }
+    }
+    array
+  }
+
+  /** Creates an array of `Byte` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Byte, xs: Byte*): Array[Byte] = {
+    val array = new Array[Byte](xs.length + 1)
+    array(0) = x
+    xs match {
+      case xs: WrappedArray.ofByte =>
+        System.arraycopy(xs.array, 0, array, 1, xs.array.length)
+      case xs =>
+        var i = 1
+        for (x <- xs.iterator) { array(i) = x; i += 1 }
+    }
+    array
+  }
+
+  /** Creates an array of `Short` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Short, xs: Short*): Array[Short] = {
+    val array = new Array[Short](xs.length + 1)
+    array(0) = x
+    xs match {
+      case xs: WrappedArray.ofShort =>
+        System.arraycopy(xs.array, 0, array, 1, xs.array.length)
+      case xs =>
+        var i = 1
+        for (x <- xs.iterator) { array(i) = x; i += 1 }
+    }
+    array
+  }
+
+  /** Creates an array of `Char` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Char, xs: Char*): Array[Char] = {
+    val array = new Array[Char](xs.length + 1)
+    array(0) = x
+    xs match {
+      case xs: WrappedArray.ofChar =>
+        System.arraycopy(xs.array, 0, array, 1, xs.array.length)
+      case xs =>
+        var i = 1
+        for (x <- xs.iterator) { array(i) = x; i += 1 }
+    }
+    array
+  }
+
+  /** Creates an array of `Int` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Int, xs: Int*): Array[Int] = {
+    val array = new Array[Int](xs.length + 1)
+    array(0) = x
+    xs match {
+      case xs: WrappedArray.ofInt =>
+        System.arraycopy(xs.array, 0, array, 1, xs.array.length)
+      case xs =>
+        var i = 1
+        for (x <- xs.iterator) { array(i) = x; i += 1 }
+    }
+    array
+  }
+
+  /** Creates an array of `Long` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Long, xs: Long*): Array[Long] = {
+    val array = new Array[Long](xs.length + 1)
+    array(0) = x
+    xs match {
+      case xs: WrappedArray.ofLong =>
+        System.arraycopy(xs.array, 0, array, 1, xs.array.length)
+      case xs =>
+        var i = 1
+        for (x <- xs.iterator) { array(i) = x; i += 1 }
+    }
+    array
+  }
+
+  /** Creates an array of `Float` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Float, xs: Float*): Array[Float] = {
+    val array = new Array[Float](xs.length + 1)
+    array(0) = x
+    xs match {
+      case xs: WrappedArray.ofFloat =>
+        System.arraycopy(xs.array, 0, array, 1, xs.array.length)
+      case xs =>
+        var i = 1
+        for (x <- xs.iterator) { array(i) = x; i += 1 }
+    }
+    array
+  }
+
+  /** Creates an array of `Double` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Double, xs: Double*): Array[Double] = {
+    val array = new Array[Double](xs.length + 1)
+    array(0) = x
+    xs match {
+      case xs: WrappedArray.ofDouble =>
+        System.arraycopy(xs.array, 0, array, 1, xs.array.length)
+      case xs =>
+        var i = 1
+        for (x <- xs.iterator) { array(i) = x; i += 1 }
+    }
+    array
+  }
+
+  /** Creates an array of `Unit` objects */
+  def apply(x: Unit, xs: Unit*): Array[Unit] = {
+    val array = new Array[Unit](xs.length + 1)
+    array(0) = x
+    xs match {
+      case xs: WrappedArray.ofUnit =>
+        System.arraycopy(xs.array, 0, array, 1, xs.array.length)
+      case xs =>
+        var i = 1
+        for (x <- xs.iterator) { array(i) = x; i += 1 }
+    }
+    array
+  }
+
+  /** Creates array with given dimensions */
+  def ofDim[T: ClassTag](n1: Int): Array[T] =
+    new Array[T](n1)
+  /** Creates a 2-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
+    val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
+    for (i <- 0 until n1) arr(i) = new Array[T](n2)
+    arr
+    // tabulate(n1)(_ => ofDim[T](n2))
+  }
+  /** Creates a 3-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
+    tabulate(n1)(_ => ofDim[T](n2, n3))
+  /** Creates a 4-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
+    tabulate(n1)(_ => ofDim[T](n2, n3, n4))
+  /** Creates a 5-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
+    tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
+
+  /** Concatenates all arrays into a single array.
+   *
+   *  @param xss the given arrays
+   *  @return   the array created from concatenating `xss`
+   */
+  def concat[T: ClassTag](xss: Array[T]*): Array[T] = {
+    val b = newBuilder[T]
+    b.sizeHint(xss.map(_.length).sum)
+    for (xs <- xss) b ++= xs
+    b.result()
+  }
+
+  /** Returns an array that contains the results of some element computation a number
+   *  of times.
+   *
+   *  Note that this means that `elem` is computed a total of n times:
+   *  {{{
+   * scala> Array.fill(3){ math.random }
+   * res3: Array[Double] = Array(0.365461167592537, 1.550395944913685E-4, 0.7907242137333306)
+   *  }}}
+   *
+   *  @param   n  the number of elements desired
+   *  @param   elem the element computation
+   *  @return an Array of size n, where each element contains the result of computing
+   *  `elem`.
+   */
+  def fill[T: ClassTag](n: Int)(elem: => T): Array[T] = {
+    val b = newBuilder[T]
+    b.sizeHint(n)
+    var i = 0
+    while (i < n) {
+      b += elem
+      i += 1
+    }
+    b.result()
+  }
+
+  /** Returns a two-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int)(elem: => T): Array[Array[T]] =
+    tabulate(n1)(_ => fill(n2)(elem))
+
+  /** Returns a three-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int, n3: Int)(elem: => T): Array[Array[Array[T]]] =
+    tabulate(n1)(_ => fill(n2, n3)(elem))
+
+  /** Returns a four-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => T): Array[Array[Array[Array[T]]]] =
+    tabulate(n1)(_ => fill(n2, n3, n4)(elem))
+
+  /** Returns a five-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => T): Array[Array[Array[Array[Array[T]]]]] =
+    tabulate(n1)(_ => fill(n2, n3, n4, n5)(elem))
+
+  /** Returns an array containing values of a given function over a range of integer
+   *  values starting from 0.
+   *
+   *  @param  n   The number of elements in the array
+   *  @param  f   The function computing element values
+   *  @return A traversable consisting of elements `f(0),f(1), ..., f(n - 1)`
+   */
+  def tabulate[T: ClassTag](n: Int)(f: Int => T): Array[T] = {
+    val b = newBuilder[T]
+    b.sizeHint(n)
+    var i = 0
+    while (i < n) {
+      b += f(i)
+      i += 1
+    }
+    b.result()
+  }
+
+  /** Returns a two-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int)(f: (Int, Int) => T): Array[Array[T]] =
+    tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
+
+  /** Returns a three-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => T): Array[Array[Array[T]]] =
+    tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
+
+  /** Returns a four-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => T): Array[Array[Array[Array[T]]]] =
+    tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
+
+  /** Returns a five-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => T): Array[Array[Array[Array[Array[T]]]]] =
+    tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
+
+  /** Returns an array containing a sequence of increasing integers in a range.
+   *
+   *  @param start  the start value of the array
+   *  @param end    the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @return  the array with values in range `start, start + 1, ..., end - 1`
+   *  up to, but excluding, `end`.
+   */
+  def range(start: Int, end: Int): Array[Int] = range(start, end, 1)
+
+  /** Returns an array containing equally spaced values in some integer interval.
+   *
+   *  @param start the start value of the array
+   *  @param end   the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @param step  the increment value of the array (may not be zero)
+   *  @return      the array with values in `start, start + step, ...` up to, but excluding `end`
+   */
+  def range(start: Int, end: Int, step: Int): Array[Int] = {
+    if (step == 0) throw new IllegalArgumentException("zero step")
+    val b = newBuilder[Int]
+    b.sizeHint(immutable.Range.count(start, end, step, isInclusive = false))
+
+    var i = start
+    while (if (step < 0) end < i else i < end) {
+      b += i
+      i += step
+    }
+    b.result()
+  }
+
+  /** Returns an array containing repeated applications of a function to a start value.
+   *
+   *  @param start the start value of the array
+   *  @param len   the number of elements returned by the array
+   *  @param f     the function that is repeatedly applied
+   *  @return      the array returning `len` values in the sequence `start, f(start), f(f(start)), ...`
+   */
+  def iterate[T: ClassTag](start: T, len: Int)(f: T => T): Array[T] = {
+    val b = newBuilder[T]
+
+    if (len > 0) {
+      b.sizeHint(len)
+      var acc = start
+      var i = 1
+      b += acc
+
+      while (i < len) {
+        acc = f(acc)
+        i += 1
+        b += acc
+      }
+    }
+    b.result()
+  }
+
+  /** Called in a pattern match like `{ case Array(x,y,z) => println('3 elements')}`.
+   *
+   *  @param x the selector value
+   *  @return  sequence wrapped in a [[scala.Some]], if `x` is a Seq, otherwise `None`
+   */
+  def unapplySeq[T](x: Array[T]): Option[IndexedSeq[T]] =
+    if (x == null) None else Some(x.toIndexedSeq)
+    // !!! the null check should to be necessary, but without it 2241 fails. Seems to be a bug
+    // in pattern matcher.  @PP: I noted in #4364 I think the behavior is correct.
+}
+
+/** Arrays are mutable, indexed collections of values. `Array[T]` is Scala's representation
+ *  for Java's `T[]`.
+ *
+ *  {{{
+ *  val numbers = Array(1, 2, 3, 4)
+ *  val first = numbers(0) // read the first element
+ *  numbers(3) = 100 // replace the 4th array element with 100
+ *  val biggerNumbers = numbers.map(_ * 2) // multiply all numbers by two
+ *  }}}
+ *
+ *  Arrays make use of two common pieces of Scala syntactic sugar, shown on lines 2 and 3 of the above
+ *  example code.
+ *  Line 2 is translated into a call to `apply(Int)`, while line 3 is translated into a call to
+ *  `update(Int, T)`.
+ *
+ *  Two implicit conversions exist in [[scala.Predef]] that are frequently applied to arrays: a conversion
+ *  to [[scala.collection.mutable.ArrayOps]] (shown on line 4 of the example above) and a conversion
+ *  to [[scala.collection.mutable.WrappedArray]] (a subtype of [[scala.collection.Seq]]).
+ *  Both types make available many of the standard operations found in the Scala collections API.
+ *  The conversion to `ArrayOps` is temporary, as all operations defined on `ArrayOps` return an `Array`,
+ *  while the conversion to `WrappedArray` is permanent as all operations return a `WrappedArray`.
+ *
+ *  The conversion to `ArrayOps` takes priority over the conversion to `WrappedArray`. For instance,
+ *  consider the following code:
+ *
+ *  {{{
+ *  val arr = Array(1, 2, 3)
+ *  val arrReversed = arr.reverse
+ *  val seqReversed : Seq[Int] = arr.reverse
+ *  }}}
+ *
+ *  Value `arrReversed` will be of type `Array[Int]`, with an implicit conversion to `ArrayOps` occurring
+ *  to perform the `reverse` operation. The value of `seqReversed`, on the other hand, will be computed
+ *  by converting to `WrappedArray` first and invoking the variant of `reverse` that returns another
+ *  `WrappedArray`.
+ *
+ *  @author Martin Odersky
+ *  @since  1.0
+ *  @see [[http://www.scala-lang.org/files/archive/spec/2.12/ Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
+ *  @see [[http://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.
+ *  @see [[http://docs.scala-lang.org/overviews/collections/arrays.html "The Scala 2.8 Collections' API"]] section on `Array` by Martin Odersky for more information.
+ *  @hideImplicitConversion scala.Predef.booleanArrayOps
+ *  @hideImplicitConversion scala.Predef.byteArrayOps
+ *  @hideImplicitConversion scala.Predef.charArrayOps
+ *  @hideImplicitConversion scala.Predef.doubleArrayOps
+ *  @hideImplicitConversion scala.Predef.floatArrayOps
+ *  @hideImplicitConversion scala.Predef.intArrayOps
+ *  @hideImplicitConversion scala.Predef.longArrayOps
+ *  @hideImplicitConversion scala.Predef.refArrayOps
+ *  @hideImplicitConversion scala.Predef.shortArrayOps
+ *  @hideImplicitConversion scala.Predef.unitArrayOps
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapRefArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapIntArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapDoubleArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapLongArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapFloatArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapCharArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapByteArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapShortArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapBooleanArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapUnitArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.genericWrapArray
+ *  @define coll array
+ *  @define Coll `Array`
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ *  @define collectExample
+ *  @define undefinedorder
+ *  @define thatinfo the class of the returned collection. In the standard library configuration,
+ *    `That` is either `Array[B]` if an ClassTag is available for B or `ArraySeq[B]` otherwise.
+ *  @define zipthatinfo $thatinfo
+ *  @define bfinfo an implicit value of class `CanBuildFrom` which determines the result class `That` from the current
+ *    representation type `Repr` and the new element type `B`.
+ */
+final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable {
+
+  /** The length of the array */
+  def length: Int = throw new Error()
+
+  /** The element at given index.
+   *
+   *  Indices start at `0`; `xs.apply(0)` is the first element of array `xs`.
+   *  Note the indexing syntax `xs(i)` is a shorthand for `xs.apply(i)`.
+   *
+   *  @param    i   the index
+   *  @return       the element at the given index
+   *  @throws       ArrayIndexOutOfBoundsException if `i < 0` or `length <= i`
+   */
+  def apply(i: Int): T = throw new Error()
+
+  /** Update the element at given index.
+   *
+   *  Indices start at `0`; `xs.update(i, x)` replaces the i^th^ element in the array.
+   *  Note the syntax `xs(i) = x` is a shorthand for `xs.update(i, x)`.
+   *
+   *  @param    i   the index
+   *  @param    x   the value to be written at index `i`
+   *  @throws       ArrayIndexOutOfBoundsException if `i < 0` or `length <= i`
+   */
+  def update(i: Int, x: T) { throw new Error() }
+
+  /** Clone the Array.
+   *
+   *  @return A clone of the Array.
+   */
+  override def clone(): Array[T] = throw new Error()
+}

--- a/scalalib/overrides-2.12/scala/Symbol.scala
+++ b/scalalib/overrides-2.12/scala/Symbol.scala
@@ -1,0 +1,31 @@
+package scala
+
+// Ported from Scala.js.
+// Modified to use collection.mutable.Map instead of java.util.WeakHashMap.
+
+final class Symbol private (val name: String) extends Serializable {
+  override def toString(): String = "'" + name
+
+  @throws(classOf[java.io.ObjectStreamException])
+  private def readResolve(): Any = Symbol.apply(name)
+  override def hashCode = name.hashCode()
+  override def equals(other: Any) = this eq other.asInstanceOf[AnyRef]
+}
+
+object Symbol extends UniquenessCache[Symbol] {
+  override def apply(name: String): Symbol = super.apply(name)
+  protected def valueFromKey(name: String): Symbol = new Symbol(name)
+  protected def keyFromValue(sym: Symbol): Option[String] = Some(sym.name)
+}
+
+private[scala] abstract class UniquenessCache[V] {
+  private val cache = collection.mutable.Map.empty[String, V]
+
+  protected def valueFromKey(k: String): V
+  protected def keyFromValue(v: V): Option[String]
+
+  def apply(name: String): V =
+    cache.getOrElseUpdate(name, valueFromKey(name))
+
+  def unapply(other: V): Option[String] = keyFromValue(other)
+}

--- a/scalalib/overrides-2.12/scala/collection/GenIterable.scala
+++ b/scalalib/overrides-2.12/scala/collection/GenIterable.scala
@@ -1,0 +1,46 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+
+
+import generic._
+
+
+/** A trait for all iterable collections which may possibly
+ *  have their operations implemented in parallel.
+ *
+ *  @author Martin Odersky
+ *  @author Aleksandar Prokopec
+ *  @since 2.9
+ */
+trait GenIterable[+A]
+extends GenIterableLike[A, GenIterable[A]]
+   with GenTraversable[A]
+   with GenericTraversableTemplate[A, GenIterable]
+{
+  def seq: Iterable[A]
+  override def companion: GenericCompanion[GenIterable] = GenIterable
+}
+
+
+object GenIterable extends GenTraversableFactory[GenIterable] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A] = Iterable.newBuilder
+}
+

--- a/scalalib/overrides-2.12/scala/collection/GenSeq.scala
+++ b/scalalib/overrides-2.12/scala/collection/GenSeq.scala
@@ -1,0 +1,46 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+
+
+import generic._
+
+
+/** A trait for all sequences which may possibly
+ *  have their operations implemented in parallel.
+ *
+ *  @author Martin Odersky
+ *  @author Aleksandar Prokopec
+ *  @since 2.9
+ */
+trait GenSeq[+A]
+extends GenSeqLike[A, GenSeq[A]]
+   with GenIterable[A]
+   with Equals
+   with GenericTraversableTemplate[A, GenSeq]
+{
+  def seq: Seq[A]
+  override def companion: GenericCompanion[GenSeq] = GenSeq
+}
+
+
+object GenSeq extends GenTraversableFactory[GenSeq] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A] = Seq.newBuilder
+}

--- a/scalalib/overrides-2.12/scala/collection/GenSet.scala
+++ b/scalalib/overrides-2.12/scala/collection/GenSet.scala
@@ -1,0 +1,46 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+
+
+import generic._
+
+
+/** A trait for sets which may possibly
+ *  have their operations implemented in parallel.
+ *
+ *  @author Martin Odersky
+ *  @author Aleksandar Prokopec
+ *  @since 2.9
+ */
+trait GenSet[A]
+extends GenSetLike[A, GenSet[A]]
+   with GenIterable[A]
+   with GenericSetTemplate[A, GenSet]
+{
+  override def companion: GenericCompanion[GenSet] = GenSet
+  def seq: Set[A]
+}
+
+
+object GenSet extends GenTraversableFactory[GenSet] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A] = Set.newBuilder
+}
+

--- a/scalalib/overrides-2.12/scala/collection/GenTraversable.scala
+++ b/scalalib/overrides-2.12/scala/collection/GenTraversable.scala
@@ -1,0 +1,42 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+
+import generic._
+
+/** A trait for all traversable collections which may possibly
+ *  have their operations implemented in parallel.
+ *
+ *  @author Martin Odersky
+ *  @author Aleksandar Prokopec
+ *  @since 2.9
+ */
+trait GenTraversable[+A]
+extends GenTraversableLike[A, GenTraversable[A]]
+   with GenTraversableOnce[A]
+   with GenericTraversableTemplate[A, GenTraversable]
+{
+  def seq: Traversable[A]
+  def companion: GenericCompanion[GenTraversable] = GenTraversable
+}
+
+object GenTraversable extends GenTraversableFactory[GenTraversable] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A] = Traversable.newBuilder
+}

--- a/scalalib/overrides-2.12/scala/collection/IndexedSeq.scala
+++ b/scalalib/overrides-2.12/scala/collection/IndexedSeq.scala
@@ -1,0 +1,45 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+
+import generic._
+import mutable.Builder
+
+/** A base trait for indexed sequences.
+ *  $indexedSeqInfo
+ */
+trait IndexedSeq[+A] extends Seq[A]
+                    with GenericTraversableTemplate[A, IndexedSeq]
+                    with IndexedSeqLike[A, IndexedSeq[A]] {
+  override def companion: GenericCompanion[IndexedSeq] = IndexedSeq
+  override def seq: IndexedSeq[A] = this
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is a `Vector`.
+ *  @define coll indexed sequence
+ *  @define Coll `IndexedSeq`
+ */
+object IndexedSeq extends IndexedSeqFactory[IndexedSeq] {
+  // A single CBF which can be checked against to identify
+  // an indexed collection type.
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline def newBuilder[A]: Builder[A, IndexedSeq[A]] = immutable.IndexedSeq.newBuilder[A]
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, IndexedSeq[A]] =
+    ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+}

--- a/scalalib/overrides-2.12/scala/collection/Iterable.scala
+++ b/scalalib/overrides-2.12/scala/collection/Iterable.scala
@@ -1,0 +1,59 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+
+import generic._
+import mutable.Builder
+
+/** A base trait for iterable collections.
+ *  $iterableInfo
+ */
+trait Iterable[+A] extends Traversable[A]
+                      with GenIterable[A]
+                      with GenericTraversableTemplate[A, Iterable]
+                      with IterableLike[A, Iterable[A]] {
+  override def companion: GenericCompanion[Iterable] = Iterable
+
+  override def seq = this
+
+  /* The following methods are inherited from trait IterableLike
+   *
+  override def iterator: Iterator[A]
+  override def takeRight(n: Int): Iterable[A]
+  override def dropRight(n: Int): Iterable[A]
+  override def sameElements[B >: A](that: GenIterable[B]): Boolean
+  override def view
+  override def view(from: Int, until: Int)
+  */
+
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is a `List`.
+ *  @define coll iterable collection
+ *  @define Coll `Iterable`
+ */
+object Iterable extends TraversableFactory[Iterable] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  /** $genericCanBuildFromInfo */
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Iterable[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, Iterable[A]] = immutable.Iterable.newBuilder[A]
+}
+
+/** Explicit instantiation of the `Iterable` trait to reduce class file size in subclasses. */
+abstract class AbstractIterable[+A] extends AbstractTraversable[A] with Iterable[A]

--- a/scalalib/overrides-2.12/scala/collection/LinearSeq.scala
+++ b/scalalib/overrides-2.12/scala/collection/LinearSeq.scala
@@ -1,0 +1,49 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+
+import generic._
+import mutable.Builder
+
+/** A base trait for linear sequences.
+ *
+ *  $linearSeqInfo
+ *
+ *  @define  linearSeqInfo
+ *  Linear sequences have reasonably efficient `head`, `tail`, and `isEmpty` methods.
+ *  If these methods provide the fastest way to traverse the collection, a 
+ *  collection `Coll` that extends this trait should also extend
+ *  `LinearSeqOptimized[A, Coll[A]]`.
+ */
+trait LinearSeq[+A] extends Seq[A]
+                            with GenericTraversableTemplate[A, LinearSeq]
+                            with LinearSeqLike[A, LinearSeq[A]] {
+  override def companion: GenericCompanion[LinearSeq] = LinearSeq
+  override def seq: LinearSeq[A] = this
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is a `List`.
+ *  @define coll linear sequence
+ *  @define Coll `LinearSeq`
+ */
+object LinearSeq extends SeqFactory[LinearSeq] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, LinearSeq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, LinearSeq[A]] = immutable.LinearSeq.newBuilder[A]
+}

--- a/scalalib/overrides-2.12/scala/collection/Seq.scala
+++ b/scalalib/overrides-2.12/scala/collection/Seq.scala
@@ -1,0 +1,49 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+
+import generic._
+import mutable.Builder
+
+/** A base trait for sequences.
+ *  $seqInfo
+ */
+trait Seq[+A] extends PartialFunction[Int, A]
+                      with Iterable[A]
+                      with GenSeq[A]
+                      with GenericTraversableTemplate[A, Seq]
+                      with SeqLike[A, Seq[A]] {
+  override def companion: GenericCompanion[Seq] = Seq
+
+  override def seq: Seq[A] = this
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is a `List`.
+ *  @define coll sequence
+ *  @define Coll `Seq`
+ */
+object Seq extends SeqFactory[Seq] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  /** $genericCanBuildFromInfo */
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Seq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, Seq[A]] = immutable.Seq.newBuilder[A]
+}
+
+/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses. */
+abstract class AbstractSeq[+A] extends AbstractIterable[A] with Seq[A]

--- a/scalalib/overrides-2.12/scala/collection/Traversable.scala
+++ b/scalalib/overrides-2.12/scala/collection/Traversable.scala
@@ -1,0 +1,111 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+
+import generic._
+import mutable.Builder
+import scala.util.control.Breaks
+
+/** A trait for traversable collections.
+ *  All operations are guaranteed to be performed in a single-threaded manner.
+ *
+ *  $traversableInfo
+ */
+trait Traversable[+A] extends TraversableLike[A, Traversable[A]]
+                         with GenTraversable[A]
+                         with TraversableOnce[A]
+                         with GenericTraversableTemplate[A, Traversable] {
+  override def companion: GenericCompanion[Traversable] = Traversable
+
+  override def seq: Traversable[A] = this
+
+  /* The following methods are inherited from TraversableLike
+   *
+  override def isEmpty: Boolean
+  override def size: Int
+  override def hasDefiniteSize
+  override def ++[B >: A, That](xs: GenTraversableOnce[B])(implicit bf: CanBuildFrom[Traversable[A], B, That]): That
+  override def map[B, That](f: A => B)(implicit bf: CanBuildFrom[Traversable[A], B, That]): That
+  override def flatMap[B, That](f: A => GenTraversableOnce[B])(implicit bf: CanBuildFrom[Traversable[A], B, That]): That
+  override def filter(p: A => Boolean): Traversable[A]
+  override def remove(p: A => Boolean): Traversable[A]
+  override def partition(p: A => Boolean): (Traversable[A], Traversable[A])
+  override def groupBy[K](f: A => K): Map[K, Traversable[A]]
+  override def foreach[U](f: A => U): Unit
+  override def forall(p: A => Boolean): Boolean
+  override def exists(p: A => Boolean): Boolean
+  override def count(p: A => Boolean): Int
+  override def find(p: A => Boolean): Option[A]
+  override def foldLeft[B](z: B)(op: (B, A) => B): B
+  override def /: [B](z: B)(op: (B, A) => B): B
+  override def foldRight[B](z: B)(op: (A, B) => B): B
+  override def :\ [B](z: B)(op: (A, B) => B): B
+  override def reduceLeft[B >: A](op: (B, A) => B): B
+  override def reduceLeftOption[B >: A](op: (B, A) => B): Option[B]
+  override def reduceRight[B >: A](op: (A, B) => B): B
+  override def reduceRightOption[B >: A](op: (A, B) => B): Option[B]
+  override def head: A
+  override def headOption: Option[A]
+  override def tail: Traversable[A]
+  override def last: A
+  override def lastOption: Option[A]
+  override def init: Traversable[A]
+  override def take(n: Int): Traversable[A]
+  override def drop(n: Int): Traversable[A]
+  override def slice(from: Int, until: Int): Traversable[A]
+  override def takeWhile(p: A => Boolean): Traversable[A]
+  override def dropWhile(p: A => Boolean): Traversable[A]
+  override def span(p: A => Boolean): (Traversable[A], Traversable[A])
+  override def splitAt(n: Int): (Traversable[A], Traversable[A])
+  override def copyToBuffer[B >: A](dest: Buffer[B])
+  override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int)
+  override def copyToArray[B >: A](xs: Array[B], start: Int)
+  override def toArray[B >: A : ClassTag]: Array[B]
+  override def toList: List[A]
+  override def toIterable: Iterable[A]
+  override def toSeq: Seq[A]
+  override def toStream: Stream[A]
+  override def sortWith(lt : (A,A) => Boolean): Traversable[A]
+  override def mkString(start: String, sep: String, end: String): String
+  override def mkString(sep: String): String
+  override def mkString: String
+  override def addString(b: StringBuilder, start: String, sep: String, end: String): StringBuilder
+  override def addString(b: StringBuilder, sep: String): StringBuilder
+  override def addString(b: StringBuilder): StringBuilder
+  override def toString
+  override def stringPrefix : String
+  override def view
+  override def view(from: Int, until: Int): TraversableView[A, Traversable[A]]
+  */
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is a `List`.
+ */
+object Traversable extends TraversableFactory[Traversable] { self =>
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  /** Provides break functionality separate from client code */
+  private[collection] val breaks: Breaks = new Breaks
+
+  /** $genericCanBuildFromInfo */
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Traversable[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, Traversable[A]] = immutable.Traversable.newBuilder[A]
+}
+
+/** Explicit instantiation of the `Traversable` trait to reduce class file size in subclasses. */
+abstract class AbstractTraversable[+A] extends Traversable[A]

--- a/scalalib/overrides-2.12/scala/collection/generic/GenTraversableFactory.scala
+++ b/scalalib/overrides-2.12/scala/collection/generic/GenTraversableFactory.scala
@@ -1,0 +1,255 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package generic
+
+import scala.language.higherKinds
+
+/** A template for companion objects of `Traversable` and subclasses thereof.
+ *  This class provides a set of operations to create `$Coll` objects.
+ *  It is typically inherited by companion objects of subclasses of `Traversable`.
+ *
+ *  @since 2.8
+ *
+ *  @define coll collection
+ *  @define Coll `Traversable`
+ *  @define factoryInfo
+ *    This object provides a set of operations to create `$Coll` values.
+ *    @author Martin Odersky
+ *  @define canBuildFromInfo
+ *    The standard `CanBuildFrom` instance for $Coll objects.
+ *    @see CanBuildFrom
+ *  @define genericCanBuildFromInfo
+ *    The standard `CanBuildFrom` instance for $Coll objects.
+ *    The created value is an instance of class `GenericCanBuildFrom`,
+ *    which forwards calls to create a new builder to the
+ *    `genericBuilder` method of the requesting collection.
+ *    @see CanBuildFrom
+ *    @see GenericCanBuildFrom
+ */
+abstract class GenTraversableFactory[CC[X] <: GenTraversable[X] with GenericTraversableTemplate[X, CC]]
+extends GenericCompanion[CC] {
+
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+
+  /** A generic implementation of the `CanBuildFrom` trait, which forwards
+   *  all calls to `apply(from)` to the `genericBuilder` method of
+   *  $coll `from`, and which forwards all calls of `apply()` to the
+   *  `newBuilder` method of this factory.
+   */
+  class GenericCanBuildFrom[A] extends CanBuildFrom[CC[_], A, CC[A]] {
+    /** Creates a new builder on request of a collection.
+     *  @param from  the collection requesting the builder to be created.
+     *  @return the result of invoking the `genericBuilder` method on `from`.
+     */
+    def apply(from: Coll) = from.genericBuilder[A]
+
+    /** Creates a new builder from scratch
+     *  @return the result of invoking the `newBuilder` method of this factory.
+     */
+    def apply() = newBuilder[A]
+  }
+
+  /** Concatenates all argument collections into a single $coll.
+   *
+   *  @param xss the collections that are to be concatenated.
+   *  @return the concatenation of all the collections.
+   */
+  def concat[A](xss: Traversable[A]*): CC[A] = {
+    val b = newBuilder[A]
+    // At present we're using IndexedSeq as a proxy for "has a cheap size method".
+    if (xss forall (_.isInstanceOf[IndexedSeq[_]]))
+      b.sizeHint(xss.map(_.size).sum)
+
+    for (xs <- xss.seq) b ++= xs
+    b.result()
+  }
+
+  /** Produces a $coll containing the results of some element computation a number of times.
+   *  @param   n  the number of elements contained in the $coll.
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n` evaluations of `elem`.
+   */
+  def fill[A](n: Int)(elem: => A): CC[A] = {
+    val b = newBuilder[A]
+    b.sizeHint(n)
+    var i = 0
+    while (i < n) {
+      b += elem
+      i += 1
+    }
+    b.result()
+  }
+
+  /** Produces a two-dimensional $coll containing the results of some element computation a number of times.
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2` evaluations of `elem`.
+   */
+  def fill[A](n1: Int, n2: Int)(elem: => A): CC[CC[A]] =
+    tabulate(n1)(_ => fill(n2)(elem))
+
+  /** Produces a three-dimensional $coll containing the results of some element computation a number of times.
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2 x n3` evaluations of `elem`.
+   */
+  def fill[A](n1: Int, n2: Int, n3: Int)(elem: => A): CC[CC[CC[A]]] =
+    tabulate(n1)(_ => fill(n2, n3)(elem))
+
+  /** Produces a four-dimensional $coll containing the results of some element computation a number of times.
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4` evaluations of `elem`.
+   */
+  def fill[A](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A): CC[CC[CC[CC[A]]]] =
+    tabulate(n1)(_ => fill(n2, n3, n4)(elem))
+
+  /** Produces a five-dimensional $coll containing the results of some element computation a number of times.
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4 x n5` evaluations of `elem`.
+   */
+  def fill[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A): CC[CC[CC[CC[CC[A]]]]] =
+    tabulate(n1)(_ => fill(n2, n3, n4, n5)(elem))
+
+  /** Produces a $coll containing values of a given function over a range of integer values starting from 0.
+   *  @param  n   The number of elements in the $coll
+   *  @param  f   The function computing element values
+   *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
+   */
+  def tabulate[A](n: Int)(f: Int => A): CC[A] = {
+    val b = newBuilder[A]
+    b.sizeHint(n)
+    var i = 0
+    while (i < n) {
+      b += f(i)
+      i += 1
+    }
+    b.result()
+  }
+
+  /** Produces a two-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2)`
+   *          for `0 <= i1 < n1` and `0 <= i2 < n2`.
+   */
+  def tabulate[A](n1: Int, n2: Int)(f: (Int, Int) => A): CC[CC[A]] =
+    tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
+
+  /** Produces a three-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2, i3)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, and `0 <= i3 < n3`.
+   */
+  def tabulate[A](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A): CC[CC[CC[A]]] =
+    tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
+
+  /** Produces a four-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2, i3, i4)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, and `0 <= i4 < n4`.
+   */
+  def tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): CC[CC[CC[CC[A]]]] =
+    tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
+
+  /** Produces a five-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2, i3, i4, i5)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, `0 <= i4 < n4`, and `0 <= i5 < n5`.
+   */
+  def tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): CC[CC[CC[CC[CC[A]]]]] =
+    tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
+
+  /** Produces a $coll containing a sequence of increasing of integers.
+   *
+   *  @param start the first element of the $coll
+   *  @param end   the end value of the $coll (the first value NOT contained)
+   *  @return  a $coll with values `start, start + 1, ..., end - 1`
+   */
+  def range[T: Integral](start: T, end: T): CC[T] = range(start, end, implicitly[Integral[T]].one)
+
+  /** Produces a $coll containing equally spaced values in some integer interval.
+   *  @param start the start value of the $coll
+   *  @param end   the end value of the $coll (the first value NOT contained)
+   *  @param step  the difference between successive elements of the $coll (must be positive or negative)
+   *  @return      a $coll with values `start, start + step, ...` up to, but excluding `end`
+   */
+  def range[T: Integral](start: T, end: T, step: T): CC[T] = {
+    val num = implicitly[Integral[T]]
+    import num._
+
+    if (step == zero) throw new IllegalArgumentException("zero step")
+    val b = newBuilder[T]
+    b sizeHint immutable.NumericRange.count(start, end, step, isInclusive = false)
+    var i = start
+    while (if (step < zero) end < i else i < end) {
+      b += i
+      i += step
+    }
+    b.result()
+  }
+
+  /** Produces a $coll containing repeated applications of a function to a start value.
+   *
+   *  @param start the start value of the $coll
+   *  @param len   the number of elements contained in the $coll
+   *  @param f     the function that's repeatedly applied
+   *  @return      a $coll with `len` values in the sequence `start, f(start), f(f(start)), ...`
+   */
+  def iterate[A](start: A, len: Int)(f: A => A): CC[A] = {
+    val b = newBuilder[A]
+    if (len > 0) {
+      b.sizeHint(len)
+      var acc = start
+      var i = 1
+      b += acc
+
+      while (i < len) {
+        acc = f(acc)
+        i += 1
+        b += acc
+      }
+    }
+    b.result()
+  }
+}

--- a/scalalib/overrides-2.12/scala/collection/immutable/Iterable.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/Iterable.scala
@@ -1,0 +1,55 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package immutable
+
+import generic._
+import mutable.Builder
+import parallel.immutable.ParIterable
+
+/** A base trait for iterable collections that are guaranteed immutable.
+ *  $iterableInfo
+ *
+ *  @define Coll `immutable.Iterable`
+ *  @define coll immutable iterable collection
+ */
+trait Iterable[+A] extends Traversable[A]
+//                      with GenIterable[A]
+                      with scala.collection.Iterable[A]
+                      with GenericTraversableTemplate[A, Iterable]
+                      with IterableLike[A, Iterable[A]]
+                      with Parallelizable[A, ParIterable[A]]
+{
+  override def companion: GenericCompanion[Iterable] = Iterable
+  protected[this] override def parCombiner = ParIterable.newCombiner[A] // if `immutable.IterableLike` gets introduced, please move this there!
+  override def seq: Iterable[A] = this
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is a `List`.
+ *  @define Coll `immutable.Iterable`
+ *  @define coll immutable iterable collection
+ */
+object Iterable extends TraversableFactory[Iterable] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Iterable[A]] =
+    ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+
+  @inline def newBuilder[A]: Builder[A, Iterable[A]] =
+    new mutable.ListBuffer
+}

--- a/scalalib/overrides-2.12/scala/collection/immutable/LinearSeq.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/LinearSeq.scala
@@ -1,0 +1,48 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package immutable
+
+import generic._
+import mutable.Builder
+
+/** A subtrait of `collection.LinearSeq` which represents sequences that
+ *  are guaranteed immutable.
+ *  $linearSeqInfo
+ */
+trait LinearSeq[+A] extends Seq[A]
+                            with scala.collection.LinearSeq[A]
+                            with GenericTraversableTemplate[A, LinearSeq]
+                            with LinearSeqLike[A, LinearSeq[A]] {
+  override def companion: GenericCompanion[LinearSeq] = LinearSeq
+  override def seq: LinearSeq[A] = this
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is a `List`.
+ *  @define coll immutable linear sequence
+ *  @define Coll `immutable.LinearSeq`
+ */
+object LinearSeq extends SeqFactory[LinearSeq] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, LinearSeq[A]] =
+    ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+
+  @inline def newBuilder[A]: Builder[A, LinearSeq[A]] =
+    new mutable.ListBuffer
+}

--- a/scalalib/overrides-2.12/scala/collection/immutable/List.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/List.scala
@@ -1,0 +1,549 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package immutable
+
+import generic._
+import mutable.{Builder, ListBuffer}
+import scala.annotation.tailrec
+import java.io.{ObjectInputStream, ObjectOutputStream}
+
+import scala.runtime.AbstractFunction1
+
+/** A class for immutable linked lists representing ordered collections
+ *  of elements of type `A`.
+ *
+ *  This class comes with two implementing case classes `scala.Nil`
+ *  and `scala.::` that implement the abstract members `isEmpty`,
+ *  `head` and `tail`.
+ *
+ *  This class is optimal for last-in-first-out (LIFO), stack-like access patterns. If you need another access
+ *  pattern, for example, random access or FIFO, consider using a collection more suited to this than `List`.
+ *
+ *  $usesMutableState
+ *
+ *  ==Performance==
+ *  '''Time:''' `List` has `O(1)` prepend and head/tail access. Most other operations are `O(n)` on the number of elements in the list.
+ *  This includes the index-based lookup of elements, `length`, `append` and `reverse`.
+ *
+ *  '''Space:''' `List` implements '''structural sharing''' of the tail list. This means that many operations are either
+ *  zero- or constant-memory cost.
+ *  {{{
+ *  val mainList = List(3, 2, 1)
+ *  val with4 =    4 :: mainList  // re-uses mainList, costs one :: instance
+ *  val with42 =   42 :: mainList // also re-uses mainList, cost one :: instance
+ *  val shorter =  mainList.tail  // costs nothing as it uses the same 2::1::Nil instances as mainList
+ *  }}}
+ *
+ *  @example {{{
+ *  // Make a list via the companion object factory
+ *  val days = List("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+ *
+ *  // Make a list element-by-element
+ *  val when = "AM" :: "PM" :: List()
+ *
+ *  // Pattern match
+ *  days match {
+ *    case firstDay :: otherDays =>
+ *      println("The first day of the week is: " + firstDay)
+ *    case List() =>
+ *      println("There don't seem to be any week days.")
+ *  }
+ *  }}}
+ *
+ *  @note The functional list is characterized by persistence and structural sharing, thus offering considerable
+ *        performance and space consumption benefits in some scenarios if used correctly.
+ *        However, note that objects having multiple references into the same functional list (that is,
+ *        objects that rely on structural sharing), will be serialized and deserialized with multiple lists, one for
+ *        each reference to it. I.e. structural sharing is lost after serialization/deserialization.
+ *
+ *  @author  Martin Odersky and others
+ *  @since   1.0
+ *  @see  [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#lists "Scala's Collection Library overview"]]
+ *  section on `Lists` for more information.
+ *
+ *  @define coll list
+ *  @define Coll `List`
+ *  @define thatinfo the class of the returned collection. In the standard library configuration,
+ *    `That` is always `List[B]` because an implicit of type `CanBuildFrom[List, B, That]`
+ *    is defined in object `List`.
+ *  @define bfinfo an implicit value of class `CanBuildFrom` which determines the
+ *    result class `That` from the current representation type `Repr`
+ *    and the new element type `B`. This is usually the `canBuildFrom` value
+ *    defined in object `List`.
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+@SerialVersionUID(-6084104484083858598L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
+sealed abstract class List[+A] extends AbstractSeq[A]
+                                  with LinearSeq[A]
+                                  with Product
+                                  with GenericTraversableTemplate[A, List]
+                                  with LinearSeqOptimized[A, List[A]]
+                                  with scala.Serializable {
+  override def companion: GenericCompanion[List] = List
+
+  def isEmpty: Boolean
+  def head: A
+  def tail: List[A]
+
+  // New methods in List
+
+  /** Adds an element at the beginning of this list.
+   *  @param x the element to prepend.
+   *  @return  a list which contains `x` as first element and
+   *           which continues with this list.
+   *
+   *  @usecase def ::(x: A): List[A]
+   *    @inheritdoc
+   *
+   *    Example:
+   *    {{{1 :: List(2, 3) = List(2, 3).::(1) = List(1, 2, 3)}}}
+   */
+  def ::[B >: A] (x: B): List[B] =
+    new scala.collection.immutable.::(x, this)
+
+  /** Adds the elements of a given list in front of this list.
+   *  @param prefix  The list elements to prepend.
+   *  @return a list resulting from the concatenation of the given
+   *    list `prefix` and this list.
+   *
+   *  @usecase def :::(prefix: List[A]): List[A]
+   *    @inheritdoc
+   *
+   *    Example:
+   *    {{{List(1, 2) ::: List(3, 4) = List(3, 4).:::(List(1, 2)) = List(1, 2, 3, 4)}}}
+   */
+  def :::[B >: A](prefix: List[B]): List[B] =
+    if (isEmpty) prefix
+    else if (prefix.isEmpty) this
+    else (new ListBuffer[B] ++= prefix).prependToList(this)
+
+  /** Adds the elements of a given list in reverse order in front of this list.
+   *  `xs reverse_::: ys` is equivalent to
+   *  `xs.reverse ::: ys` but is more efficient.
+   *
+   *  @param prefix the prefix to reverse and then prepend
+   *  @return       the concatenation of the reversed prefix and the current list.
+   *
+   *  @usecase def reverse_:::(prefix: List[A]): List[A]
+   *    @inheritdoc
+   */
+  def reverse_:::[B >: A](prefix: List[B]): List[B] = {
+    var these: List[B] = this
+    var pres = prefix
+    while (!pres.isEmpty) {
+      these = pres.head :: these
+      pres = pres.tail
+    }
+    these
+  }
+
+  /** Builds a new list by applying a function to all elements of this list.
+   *  Like `xs map f`, but returns `xs` unchanged if function
+   *  `f` maps all elements to themselves (as determined by `eq`).
+   *
+   *  @param f      the function to apply to each element.
+   *  @tparam B     the element type of the returned collection.
+   *  @return       a list resulting from applying the given function
+   *                `f` to each element of this list and collecting the results.
+   *
+   *  @usecase def mapConserve(f: A => A): List[A]
+   *    @inheritdoc
+   */
+  @inline final def mapConserve[B >: A <: AnyRef](f: A => B): List[B] = {
+    // Note to developers: there exists a duplication between this function and `reflect.internal.util.Collections#map2Conserve`.
+    // If any successful optimization attempts or other changes are made, please rehash them there too.
+    @tailrec
+    def loop(mappedHead: List[B] = Nil, mappedLast: ::[B], unchanged: List[A], pending: List[A]): List[B] =
+    if (pending.isEmpty) {
+      if (mappedHead eq null) unchanged
+      else {
+        mappedLast.tl = unchanged
+        mappedHead
+      }
+    }
+    else {
+      val head0 = pending.head
+      val head1 = f(head0)
+
+      if (head1 eq head0.asInstanceOf[AnyRef])
+        loop(mappedHead, mappedLast, unchanged, pending.tail)
+      else {
+        var xc = unchanged
+        var mappedHead1: List[B] = mappedHead
+        var mappedLast1: ::[B] = mappedLast
+        while (xc ne pending) {
+          val next = new ::[B](xc.head, Nil)
+          if (mappedHead1 eq null) mappedHead1 = next
+          if (mappedLast1 ne null) mappedLast1.tl = next
+          mappedLast1 = next
+          xc = xc.tail
+        }
+        val next = new ::(head1, Nil)
+        if (mappedHead1 eq null) mappedHead1 = next
+        if (mappedLast1 ne null) mappedLast1.tl = next
+        mappedLast1 = next
+        val tail0 = pending.tail
+        loop(mappedHead1, mappedLast1, tail0, tail0)
+
+      }
+    }
+    loop(null, null, this, this)
+  }
+
+  private def isLikeListReusableCBF( bf: CanBuildFrom[_,_,_]): Boolean = {
+    (bf eq List.ReusableCBF) ||
+      (bf eq immutable.LinearSeq.ReusableCBF) || (bf eq collection.LinearSeq.ReusableCBF) ||
+      (bf eq immutable.Seq.ReusableCBF) ||(bf eq collection.Seq.ReusableCBF)
+  }
+  // Overridden methods from IterableLike and SeqLike or overloaded variants of such methods
+
+  override def ++[B >: A, That](that: GenTraversableOnce[B])(implicit bf: CanBuildFrom[List[A], B, That]): That =
+    if (isLikeListReusableCBF(bf)) (this ::: that.seq.toList).asInstanceOf[That]
+    else super.++(that)
+
+  override def +:[B >: A, That](elem: B)(implicit bf: CanBuildFrom[List[A], B, That]): That = bf match {
+    case _: List.GenericCanBuildFrom[_] => (elem :: this).asInstanceOf[That]
+    case _ => super.+:(elem)(bf)
+  }
+
+  override def toList: List[A] = this
+
+  override def take(n: Int): List[A] = if (isEmpty || n <= 0) Nil else {
+    val h = new ::(head, Nil)
+    var t = h
+    var rest = tail
+    var i = 1
+    while ({if (rest.isEmpty) return this; i < n}) {
+      i += 1
+      val nx = new ::(rest.head, Nil)
+      t.tl = nx
+      t = nx
+      rest = rest.tail
+    }
+    h
+  }
+
+  override def drop(n: Int): List[A] = {
+    var these = this
+    var count = n
+    while (!these.isEmpty && count > 0) {
+      these = these.tail
+      count -= 1
+    }
+    these
+  }
+
+  /**
+   *  @example {{{
+   *  // Given a list
+   *  val letters = List('a','b','c','d','e')
+   *
+   *  // `slice` returns all elements beginning at index `from` and afterwards,
+   *  // up until index `until` (excluding index `until`.)
+   *  letters.slice(1,3) // Returns List('b','c')
+   *  }}}
+   */
+  override def slice(from: Int, until: Int): List[A] = {
+    val lo = scala.math.max(from, 0)
+    if (until <= lo || isEmpty) Nil
+    else this drop lo take (until - lo)
+  }
+
+  override def takeRight(n: Int): List[A] = {
+    @tailrec
+    def loop(lead: List[A], lag: List[A]): List[A] = lead match {
+      case Nil => lag
+      case _ :: tail => loop(tail, lag.tail)
+    }
+    loop(drop(n), this)
+  }
+
+  // dropRight is inherited from LinearSeq
+
+  override def splitAt(n: Int): (List[A], List[A]) = {
+    val b = new ListBuffer[A]
+    var i = 0
+    var these = this
+    while (!these.isEmpty && i < n) {
+      i += 1
+      b += these.head
+      these = these.tail
+    }
+    (b.toList, these)
+  }
+
+  final override def map[B, That](f: A => B)(implicit bf: CanBuildFrom[List[A], B, That]): That = {
+    if (isLikeListReusableCBF(bf)) {
+      if (this eq Nil) Nil.asInstanceOf[That] else {
+        val h = new ::[B](f(head), Nil)
+        var t: ::[B] = h
+        var rest = tail
+        while (rest ne Nil) {
+          val nx = new ::(f(rest.head), Nil)
+          t.tl = nx
+          t = nx
+          rest = rest.tail
+        }
+        h.asInstanceOf[That]
+      }
+    }
+    else super.map(f)
+  }
+
+  final override def collect[B, That](pf: PartialFunction[A, B])(implicit bf: CanBuildFrom[List[A], B, That]): That = {
+    if (isLikeListReusableCBF(bf)) {
+      if (this eq Nil) Nil.asInstanceOf[That] else {
+        var rest = this
+        var h: ::[B] = null
+        // Special case for first element
+        do {
+          val x: Any = pf.applyOrElse(rest.head, List.partialNotApplied)
+          if (x.asInstanceOf[AnyRef] ne List.partialNotApplied) h = new ::(x.asInstanceOf[B], Nil)
+          rest = rest.tail
+          if (rest eq Nil) return (if (h eq null ) Nil else h).asInstanceOf[That]
+        } while (h eq null)
+        var t = h
+        // Remaining elements
+        do {
+          val x: Any = pf.applyOrElse(rest.head, List.partialNotApplied)
+          if (x.asInstanceOf[AnyRef] ne List.partialNotApplied) {
+            val nx = new ::(x.asInstanceOf[B], Nil)
+            t.tl = nx
+            t = nx
+          }
+          rest = rest.tail
+        } while (rest ne Nil)
+        h.asInstanceOf[That]
+      }
+    }
+    else super.collect(pf)
+  }
+
+  final override def flatMap[B, That](f: A => GenTraversableOnce[B])(implicit bf: CanBuildFrom[List[A], B, That]): That = {
+    if (isLikeListReusableCBF(bf)) {
+      if (this eq Nil) Nil.asInstanceOf[That] else {
+        var rest = this
+        class Appender extends AbstractFunction1[B, Unit] {
+          var h: ::[B] = null
+          var t: ::[B] = null
+          override def apply(b: B): Unit = {
+            if (h eq null) {
+              h = new ::(b, Nil)
+              t = h
+            }
+            else {
+              val nx = new ::(b, Nil)
+              t.tl = nx
+              t = nx
+            }
+          }
+          //where flatMap generates a List, we can reuse the last non-empty one
+          def appendLast(last: ::[B]): Unit = {
+            if (h eq null) h = last
+            else t.tl = last
+          }
+        }
+        // we only build an appender if we have to, to reduce allocations. It's a commom case that we have
+        // short lists to map over and often flatMap may provide only zero or one segment that is non empty
+        var appender: Appender = null
+        var lastList: ::[B] = null
+        while (rest ne Nil) {
+          val c = f(rest.head).seq
+          rest = rest.tail
+          if (c.asInstanceOf[AnyRef] ne Nil) {
+            if (lastList ne null) {
+              if (appender eq null)
+                appender = new Appender
+              lastList foreach appender
+              lastList = null
+            }
+            if (c.isInstanceOf[::[B]])
+              lastList = c.asInstanceOf[::[B]]
+            else {
+              if (appender eq null)
+                appender = new Appender
+              c foreach appender
+            }
+          }
+        }
+        val result = if ((appender eq null) || (appender.h eq null))
+          if (lastList eq null) Nil else lastList
+        else {
+          if (lastList ne null)
+            appender.appendLast(lastList)
+          appender.h
+        }
+        result.asInstanceOf[That]
+      }
+    }
+    else super.flatMap(f)
+  }
+
+  @inline final override def takeWhile(p: A => Boolean): List[A] = {
+    val b = new ListBuffer[A]
+    var these = this
+    while (!these.isEmpty && p(these.head)) {
+      b += these.head
+      these = these.tail
+    }
+    b.toList
+  }
+
+  @inline final override def dropWhile(p: A => Boolean): List[A] = {
+    @tailrec
+    def loop(xs: List[A]): List[A] =
+      if (xs.isEmpty || !p(xs.head)) xs
+      else loop(xs.tail)
+
+    loop(this)
+  }
+
+  @inline final override def span(p: A => Boolean): (List[A], List[A]) = {
+    val b = new ListBuffer[A]
+    var these = this
+    while (!these.isEmpty && p(these.head)) {
+      b += these.head
+      these = these.tail
+    }
+    (b.toList, these)
+  }
+
+  // Overridden with an implementation identical to the inherited one (at this time)
+  // solely so it can be finalized and thus inlinable.
+  @inline final override def foreach[U](f: A => U) {
+    var these = this
+    while (!these.isEmpty) {
+      f(these.head)
+      these = these.tail
+    }
+  }
+
+  override def reverse: List[A] = {
+    var result: List[A] = Nil
+    var these = this
+    while (!these.isEmpty) {
+      result = these.head :: result
+      these = these.tail
+    }
+    result
+  }
+
+  override def foldRight[B](z: B)(op: (A, B) => B): B =
+    reverse.foldLeft(z)((right, left) => op(left, right))
+
+  override def stringPrefix = "List"
+
+  override def toStream : Stream[A] =
+    if (isEmpty) Stream.Empty
+    else new Stream.Cons(head, tail.toStream)
+
+  // Create a proxy for Java serialization that allows us to avoid mutation
+  // during deserialization.  This is the Serialization Proxy Pattern.
+  protected final def writeReplace(): AnyRef = new List.SerializationProxy(this)
+}
+
+/** The empty list.
+ *
+ *  @author  Martin Odersky
+ *  @since   2.8
+ */
+@SerialVersionUID(0 - 8256821097970055419L)
+case object Nil extends List[Nothing] {
+  override def isEmpty = true
+  override def head: Nothing =
+    throw new NoSuchElementException("head of empty list")
+  override def tail: List[Nothing] =
+    throw new UnsupportedOperationException("tail of empty list")
+  // Removal of equals method here might lead to an infinite recursion similar to IntMap.equals.
+  override def equals(that: Any) = that match {
+    case that1: scala.collection.GenSeq[_] => that1.isEmpty
+    case _ => false
+  }
+}
+
+/** A non empty list characterized by a head and a tail.
+ *  @param head the first element of the list
+ *  @param tl   the list containing the remaining elements of this list after the first one.
+ *  @tparam B   the type of the list elements.
+ *  @author  Martin Odersky
+ *  @since   2.8
+ */
+@SerialVersionUID(509929039250432923L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
+final case class ::[B](override val head: B, private[scala] var tl: List[B]) extends List[B] {
+  override def tail : List[B] = tl
+  override def isEmpty: Boolean = false
+}
+
+/** $factoryInfo
+ *  @define coll list
+ *  @define Coll `List`
+ */
+object List extends SeqFactory[List] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  /** $genericCanBuildFromInfo */
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, List[A]] =
+    ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+
+  @inline def newBuilder[A]: Builder[A, List[A]] =
+    new ListBuffer[A]
+
+  @inline override def empty[A]: List[A] = Nil
+
+  @inline override def apply[A](xs: A*): List[A] = xs.toList
+
+  private[collection] val partialNotApplied = new Function1[Any, Any] { def apply(x: Any): Any = this }
+
+  @SerialVersionUID(1L)
+  private class SerializationProxy[A](@transient private var orig: List[A]) extends Serializable {
+
+    private def writeObject(out: ObjectOutputStream) {
+      out.defaultWriteObject()
+      var xs: List[A] = orig
+      while (!xs.isEmpty) {
+        out.writeObject(xs.head)
+        xs = xs.tail
+      }
+      out.writeObject(ListSerializeEnd)
+    }
+
+    // Java serialization calls this before readResolve during deserialization.
+    // Read the whole list and store it in `orig`.
+    private def readObject(in: ObjectInputStream) {
+      in.defaultReadObject()
+      val builder = List.newBuilder[A]
+      while (true) in.readObject match {
+        case ListSerializeEnd =>
+          orig = builder.result()
+          return
+        case a =>
+          builder += a.asInstanceOf[A]
+      }
+    }
+
+    // Provide the result stored in `orig` for Java serialization
+    private def readResolve(): AnyRef = orig
+  }
+}
+
+/** Only used for list serialization */
+@SerialVersionUID(0L - 8476791151975527571L)
+private[scala] case object ListSerializeEnd

--- a/scalalib/overrides-2.12/scala/collection/immutable/Queue.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/Queue.scala
@@ -1,0 +1,198 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package immutable
+
+import generic._
+import mutable.{ Builder, ListBuffer }
+
+/** `Queue` objects implement data structures that allow to
+ *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
+ *
+ *  `Queue` is implemented as a pair of `List`s, one containing the ''in'' elements and the other the ''out'' elements.
+ *  Elements are added to the ''in'' list and removed from the ''out'' list. When the ''out'' list runs dry, the
+ *  queue is pivoted by replacing the ''out'' list by ''in.reverse'', and ''in'' by ''Nil''.
+ *
+ *  Adding items to the queue always has cost `O(1)`. Removing items has cost `O(1)`, except in the case
+ *  where a pivot is required, in which case, a cost of `O(n)` is incurred, where `n` is the number of elements in the queue. When this happens,
+ *  `n` remove operations with `O(1)` cost are guaranteed. Removing an item is on average `O(1)`.
+ *
+ *  @author  Erik Stenman
+ *  @since   1
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-queues "Scala's Collection Library overview"]]
+ *  section on `Immutable Queues` for more information.
+ *
+ *  @define Coll `immutable.Queue`
+ *  @define coll immutable queue
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+
+@SerialVersionUID(-7622936493364270175L)
+sealed class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
+         extends AbstractSeq[A]
+            with LinearSeq[A]
+            with GenericTraversableTemplate[A, Queue]
+            with LinearSeqLike[A, Queue[A]]
+            with Serializable {
+
+  override def companion: GenericCompanion[Queue] = Queue
+
+  /** Returns the `n`-th element of this queue.
+   *  The first element is at position `0`.
+   *
+   *  @param  n index of the element to return
+   *  @return   the element at position `n` in this queue.
+   *  @throws java.util.NoSuchElementException if the queue is too short.
+   */
+  override def apply(n: Int): A = {
+    val olen = out.length
+    if (n < olen) out.apply(n)
+    else {
+      val m = n - olen
+      val ilen = in.length
+      if (m < ilen) in.apply(ilen - m - 1)
+      else throw new NoSuchElementException("index out of range")
+    }
+  }
+
+  /** Returns the elements in the list as an iterator
+   */
+  override def iterator: Iterator[A] = (out ::: in.reverse).iterator
+
+  /** Checks if the queue is empty.
+   *
+   *  @return true, iff there is no element in the queue.
+   */
+  override def isEmpty: Boolean = in.isEmpty && out.isEmpty
+
+  override def head: A =
+    if (out.nonEmpty) out.head
+    else if (in.nonEmpty) in.last
+    else throw new NoSuchElementException("head on empty queue")
+
+  override def tail: Queue[A] =
+    if (out.nonEmpty) new Queue(in, out.tail)
+    else if (in.nonEmpty) new Queue(Nil, in.reverse.tail)
+    else throw new NoSuchElementException("tail on empty queue")
+
+  /* This is made to avoid inefficient implementation of iterator. */
+  override def forall(p: A => Boolean): Boolean =
+    in.forall(p) && out.forall(p)
+
+  /* This is made to avoid inefficient implementation of iterator. */
+  override def exists(p: A => Boolean): Boolean =
+    in.exists(p) || out.exists(p)
+
+  override def stringPrefix = "Queue"
+
+  /** Returns the length of the queue.
+   */
+  override def length = in.length + out.length
+
+  override def +:[B >: A, That](elem: B)(implicit bf: CanBuildFrom[Queue[A], B, That]): That = bf match {
+    case _: Queue.GenericCanBuildFrom[_] => new Queue(in, elem :: out).asInstanceOf[That]
+    case _                               => super.+:(elem)(bf)
+  }
+
+  override def :+[B >: A, That](elem: B)(implicit bf: CanBuildFrom[Queue[A], B, That]): That = bf match {
+    case _: Queue.GenericCanBuildFrom[_] => enqueue(elem).asInstanceOf[That]
+    case _                               => super.:+(elem)(bf)
+  }
+
+  override def ++[B >: A, That](that: GenTraversableOnce[B])(implicit bf: CanBuildFrom[Queue[A], B, That]): That = {
+    if (bf eq Queue.ReusableCBF) {
+      val newIn =
+        if (that.isInstanceOf[Queue[_]]) {
+          val thatQueue: Queue[B] = that.asInstanceOf[Queue[B]]
+          thatQueue.in ++ (thatQueue.out reverse_::: this.in)
+        } else {
+          val lb = new ListBuffer[B]
+          that.seq.foreach(_ +=: lb)
+          lb.prependToList(this.in)
+        }
+      new Queue[B](newIn, this.out).asInstanceOf[That]
+    } else {
+      super.++(that)(bf)
+    }
+  }
+
+  /** Creates a new queue with element added at the end
+   *  of the old queue.
+   *
+   *  @param  elem        the element to insert
+   */
+  def enqueue[B >: A](elem: B) = new Queue(elem :: in, out)
+
+  /** Returns a new queue with all elements provided by an `Iterable` object
+   *  added at the end of the queue.
+   *
+   *  The elements are appended in the order they are given out by the
+   *  iterator.
+   *
+   *  @param  iter        an iterable object
+   */
+  def enqueue[B >: A](iter: Iterable[B]) =
+    new Queue(iter.toList reverse_::: in, out)
+
+  /** Returns a tuple with the first element in the queue,
+   *  and a new queue with this element removed.
+   *
+   *  @throws java.util.NoSuchElementException
+   *  @return the first element of the queue.
+   */
+  def dequeue: (A, Queue[A]) = out match {
+    case Nil if !in.isEmpty => val rev = in.reverse ; (rev.head, new Queue(Nil, rev.tail))
+    case x :: xs            => (x, new Queue(in, xs))
+    case _                  => throw new NoSuchElementException("dequeue on empty queue")
+  }
+
+  /** Optionally retrieves the first element and a queue of the remaining elements.
+   *
+   * @return A tuple of the first element of the queue, and a new queue with this element removed.
+   *         If the queue is empty, `None` is returned.
+   */
+  def dequeueOption: Option[(A, Queue[A])] = if(isEmpty) None else Some(dequeue)
+
+  /** Returns the first element in the queue, or throws an error if there
+   *  is no element contained in the queue.
+   *
+   *  @throws java.util.NoSuchElementException
+   *  @return the first element.
+   */
+  def front: A = head
+
+  /** Returns a string representation of this queue.
+   */
+  override def toString() = mkString("Queue(", ", ", ")")
+}
+
+/** $factoryInfo
+ *  @define Coll `immutable.Queue`
+ *  @define coll immutable queue
+ */
+object Queue extends SeqFactory[Queue] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  /** $genericCanBuildFromInfo */
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Queue[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, Queue[A]] = new ListBuffer[A] mapResult (x => new Queue[A](Nil, x.toList))
+  @inline override def empty[A]: Queue[A] = EmptyQueue.asInstanceOf[Queue[A]]
+  @inline override def apply[A](xs: A*): Queue[A] = new Queue[A](Nil, xs.toList)
+
+  private object EmptyQueue extends Queue[Nothing](Nil, Nil) { }
+}

--- a/scalalib/overrides-2.12/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/Range.scala
@@ -1,0 +1,526 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection.immutable
+
+import scala.collection.parallel.immutable.ParRange
+
+/** The `Range` class represents integer values in range
+ *  ''[start;end)'' with non-zero step value `step`.
+ *  It's a special case of an indexed sequence.
+ *  For example:
+ *
+ *  {{{
+ *     val r1 = 0 until 10
+ *     val r2 = r1.start until r1.end by r1.step + 1
+ *     println(r2.length) // = 5
+ *  }}}
+ *
+ *  Ranges that contain more than `Int.MaxValue` elements can be created, but
+ *  these overfull ranges have only limited capabilities.  Any method that
+ *  could require a collection of over `Int.MaxValue` length to be created, or
+ *  could be asked to index beyond `Int.MaxValue` elements will throw an
+ *  exception.  Overfull ranges can safely be reduced in size by changing
+ *  the step size (e.g. `by 3`) or taking/dropping elements.  `contains`,
+ *  `equals`, and access to the ends of the range (`head`, `last`, `tail`,
+ *  `init`) are also permitted on overfull ranges.
+ *
+ *  @param start      the start of this range.
+ *  @param end        the end of the range.  For exclusive ranges, e.g.
+ *                    `Range(0,3)` or `(0 until 3)`, this is one
+ *                    step past the last one in the range.  For inclusive
+ *                    ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
+ *                    it may be in the range if it is not skipped by the step size.
+ *                    To find the last element inside a non-empty range,
+                      use `last` instead.
+ *  @param step       the step for the range.
+ *
+ *  @author Martin Odersky
+ *  @author Paul Phillips
+ *  @since   2.5
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#ranges "Scala's Collection Library overview"]]
+ *  section on `Ranges` for more information.
+ *
+ *  @define coll range
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ *  @define doesNotUseBuilders
+ *    '''Note:''' this method does not use builders to construct a new range,
+ *         and its complexity is O(1).
+ */
+@SerialVersionUID(7618862778670199309L)
+sealed class Range(val start: Int, val end: Int, val step: Int)
+extends scala.collection.AbstractSeq[Int]
+   with IndexedSeq[Int]
+   with scala.collection.CustomParallelizable[Int, ParRange]
+   with Serializable
+{
+  override def par = new ParRange(this)
+
+  private def gap           = end.toLong - start.toLong
+  private def isExact       = gap % step == 0
+  private def hasStub       = isInclusive || !isExact
+  private def longLength    = gap / step + ( if (hasStub) 1 else 0 )
+
+  // Check cannot be evaluated eagerly because we have a pattern where
+  // ranges are constructed like: "x to y by z" The "x to y" piece
+  // should not trigger an exception. So the calculation is delayed,
+  // which means it will not fail fast for those cases where failing was
+  // correct.
+  override final val isEmpty = (
+       (start > end && step > 0)
+    || (start < end && step < 0)
+    || (start == end && !isInclusive)
+  )
+
+  private val numRangeElements: Int = {
+    if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
+    else if (isEmpty) 0
+    else {
+      val len = longLength
+      if (len > scala.Int.MaxValue) -1
+      else len.toInt
+    }
+  }
+
+  // This field has a sensible value only for non-empty ranges
+  private val lastElement = step match {
+    case 1  => if (isInclusive) end else end-1
+    case -1 => if (isInclusive) end else end+1
+    case _  =>
+      val remainder = (gap % step).toInt
+      if (remainder != 0) end - remainder
+      else if (isInclusive) end
+      else end - step
+  }
+
+  /** The last element of this range.  This method will return the correct value
+   *  even if there are too many elements to iterate over.
+   */
+  override def last = if (isEmpty) Nil.last else lastElement
+  override def head = if (isEmpty) Nil.head else start
+
+  override def min[A1 >: Int](implicit ord: Ordering[A1]): Int =
+    if (ord eq Ordering.Int) {
+      if (step > 0) head
+      else last
+    } else super.min(ord)
+
+  override def max[A1 >: Int](implicit ord: Ordering[A1]): Int =
+    if (ord eq Ordering.Int) {
+      if (step > 0) last
+      else head
+    } else super.max(ord)
+
+  protected def copy(start: Int, end: Int, step: Int): Range = new Range(start, end, step)
+
+  /** Create a new range with the `start` and `end` values of this range and
+   *  a new `step`.
+   *
+   *  @return a new range with a different step
+   */
+  def by(step: Int): Range = copy(start, end, step)
+
+  def isInclusive = false
+
+  override def size = length
+  override def length = if (numRangeElements < 0) fail() else numRangeElements
+
+  private def description = "%d %s %d by %s".format(start, if (isInclusive) "to" else "until", end, step)
+  private def fail() = throw new IllegalArgumentException(description + ": seqs cannot contain more than Int.MaxValue elements.")
+  private def validateMaxLength() {
+    if (numRangeElements < 0)
+      fail()
+  }
+
+  final def apply(idx: Int): Int = {
+    validateMaxLength()
+    if (idx < 0 || idx >= numRangeElements) throw new IndexOutOfBoundsException(idx.toString)
+    else start + (step * idx)
+  }
+
+  @inline final override def foreach[@specialized(Unit) U](f: Int => U) {
+    // Implementation chosen on the basis of favorable microbenchmarks
+    // Note--initialization catches step == 0 so we don't need to here
+    if (!isEmpty) {
+      var i = start
+      while (true) {
+        f(i)
+        if (i == lastElement) return
+        i += step
+      }
+    }
+  }
+
+  /** Creates a new range containing the first `n` elements of this range.
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @param n  the number of elements to take.
+   *  @return   a new range consisting of `n` first elements.
+   */
+  final override def take(n: Int): Range = (
+    if (n <= 0 || isEmpty) newEmptyRange(start)
+    else if (n >= numRangeElements && numRangeElements >= 0) this
+    else {
+      // May have more than Int.MaxValue elements in range (numRangeElements < 0)
+      // but the logic is the same either way: take the first n
+      new Range.Inclusive(start, locationAfterN(n - 1), step)
+    }
+  )
+
+  /** Creates a new range containing all the elements of this range except the first `n` elements.
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @param n  the number of elements to drop.
+   *  @return   a new range consisting of all the elements of this range except `n` first elements.
+   */
+  final override def drop(n: Int): Range = (
+    if (n <= 0 || isEmpty) this
+    else if (n >= numRangeElements && numRangeElements >= 0) newEmptyRange(end)
+    else {
+      // May have more than Int.MaxValue elements (numRangeElements < 0)
+      // but the logic is the same either way: go forwards n steps, keep the rest
+      copy(locationAfterN(n), end, step)
+    }
+  )
+
+  /** Creates a new range containing the elements starting at `from` up to but not including `until`.
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @param from  the element at which to start
+   *  @param until  the element at which to end (not included in the range)
+   *  @return   a new range consisting of a contiguous interval of values in the old range
+   */
+  override def slice(from: Int, until: Int): Range =
+    if (from <= 0) take(until)
+    else if (until >= numRangeElements && numRangeElements >= 0) drop(from)
+    else {
+      val fromValue = locationAfterN(from)
+      if (from >= until) newEmptyRange(fromValue)
+      else new Range.Inclusive(fromValue, locationAfterN(until-1), step)
+    }
+
+  /** Creates a new range containing all the elements of this range except the last one.
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @return  a new range consisting of all the elements of this range except the last one.
+   */
+  final override def init: Range = {
+    if (isEmpty)
+      Nil.init
+
+    dropRight(1)
+  }
+
+  /** Creates a new range containing all the elements of this range except the first one.
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @return  a new range consisting of all the elements of this range except the first one.
+   */
+  final override def tail: Range = {
+    if (isEmpty)
+      Nil.tail
+
+    drop(1)
+  }
+
+  // Advance from the start while we meet the given test
+  private def argTakeWhile(p: Int => Boolean): Long = {
+    if (isEmpty) start
+    else {
+      var current = start
+      val stop = last
+      while (current != stop && p(current)) current += step
+      if (current != stop || !p(current)) current
+      else current.toLong + step
+    }
+  }
+  // Methods like apply throw exceptions on invalid n, but methods like take/drop
+  // are forgiving: therefore the checks are with the methods.
+  private def locationAfterN(n: Int) = start + (step * n)
+
+  // When one drops everything.  Can't ever have unchecked operations
+  // like "end + 1" or "end - 1" because ranges involving Int.{ MinValue, MaxValue }
+  // will overflow.  This creates an exclusive range where start == end
+  // based on the given value.
+  private def newEmptyRange(value: Int) = new Range(value, value, step)
+
+  final override def takeWhile(p: Int => Boolean): Range = {
+    val stop = argTakeWhile(p)
+    if (stop==start) newEmptyRange(start)
+    else {
+      val x = (stop - step).toInt
+      if (x == last) this
+      else new Range.Inclusive(start, x, step)
+    }
+  }
+  final override def dropWhile(p: Int => Boolean): Range = {
+    val stop = argTakeWhile(p)
+    if (stop == start) this
+    else {
+      val x = (stop - step).toInt
+      if (x == last) newEmptyRange(last)
+      else new Range.Inclusive(x + step, last, step)
+    }
+  }
+  final override def span(p: Int => Boolean): (Range, Range) = {
+    val border = argTakeWhile(p)
+    if (border == start) (newEmptyRange(start), this)
+    else {
+      val x = (border - step).toInt
+      if (x == last) (this, newEmptyRange(last))
+      else (new Range.Inclusive(start, x, step), new Range.Inclusive(x+step, last, step))
+    }
+  }
+
+  /** Creates a pair of new ranges, first consisting of elements before `n`, and the second
+   *  of elements after `n`.
+   *
+   *  $doesNotUseBuilders
+   */
+  final override def splitAt(n: Int) = (take(n), drop(n))
+
+  /** Creates a new range consisting of the last `n` elements of the range.
+   *
+   *  $doesNotUseBuilders
+   */
+  final override def takeRight(n: Int): Range = {
+    if (n <= 0) newEmptyRange(start)
+    else if (numRangeElements >= 0) drop(numRangeElements - n)
+    else {
+    // Need to handle over-full range separately
+      val y = last
+      val x = y - step.toLong*(n-1)
+      if ((step > 0 && x < start) || (step < 0 && x > start)) this
+      else new Range.Inclusive(x.toInt, y, step)
+    }
+  }
+
+  /** Creates a new range consisting of the initial `length - n` elements of the range.
+   *
+   *  $doesNotUseBuilders
+   */
+  final override def dropRight(n: Int): Range = {
+    if (n <= 0) this
+    else if (numRangeElements >= 0) take(numRangeElements - n)
+    else {
+    // Need to handle over-full range separately
+      val y = last - step.toInt*n
+      if ((step > 0 && y < start) || (step < 0 && y > start)) newEmptyRange(start)
+      else new Range.Inclusive(start, y.toInt, step)
+    }
+  }
+
+  /** Returns the reverse of this range.
+   *
+   *  $doesNotUseBuilders
+   */
+  final override def reverse: Range =
+    if (isEmpty) this
+    else new Range.Inclusive(last, start, -step)
+
+  /** Make range inclusive.
+   */
+  def inclusive =
+    if (isInclusive) this
+    else new Range.Inclusive(start, end, step)
+
+  final def contains(x: Int) = {
+    if (x==end && !isInclusive) false
+    else if (step > 0) {
+      if (x < start || x > end) false
+      else (step == 1) || (((x - start) % step) == 0)
+    }
+    else {
+      if (x < end || x > start) false
+      else (step == -1) || (((x - start) % step) == 0)
+    }
+  }
+
+  final override def sum[B >: Int](implicit num: Numeric[B]): Int = {
+    if (num eq scala.math.Numeric.IntIsIntegral) {
+      // this is normal integer range with usual addition. arithmetic series formula can be used
+      if (isEmpty) 0
+      else if (numRangeElements == 1) head
+      else ((numRangeElements * (head.toLong + last)) / 2).toInt
+    } else {
+      // user provided custom Numeric, we cannot rely on arithmetic series formula
+      if (isEmpty) num.toInt(num.zero)
+      else {
+        var acc = num.zero
+        var i = head
+        while (true) {
+          acc = num.plus(acc, i)
+          if (i == lastElement) return num.toInt(acc)
+          i = i + step
+        }
+        0 // Never hit this--just to satisfy compiler since it doesn't know while(true) has type Nothing
+      }
+    }
+  }
+
+  override def toIterable = this
+
+  override def toSeq = this
+
+  override def equals(other: Any) = other match {
+    case x: Range =>
+      // Note: this must succeed for overfull ranges (length > Int.MaxValue)
+      (x canEqual this) && {
+        if (isEmpty) x.isEmpty                  // empty sequences are equal
+        else                                    // this is non-empty...
+          x.nonEmpty && start == x.start && {   // ...so other must contain something and have same start
+            val l0 = last
+            (l0 == x.last && (                    // And same end
+              start == l0 || step == x.step       // And either the same step, or not take any steps
+            ))
+          }
+      }
+    case _ =>
+      super.equals(other)
+  }
+
+  /* Note: hashCode can't be overridden without breaking Seq's equals contract. */
+
+  override def toString = {
+    val preposition = if (isInclusive) "to" else "until"
+    val stepped = if (step == 1) "" else s" by $step"
+    val prefix = if (isEmpty) "empty " else if (!isExact) "inexact " else ""
+    s"${prefix}Range $start $preposition $end$stepped"
+  }
+}
+
+/** A companion object for the `Range` class.
+ */
+object Range {
+  /** Counts the number of range elements.
+   *  @pre  step != 0
+   *  If the size of the range exceeds Int.MaxValue, the
+   *  result will be negative.
+   */
+  def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
+    if (step == 0)
+      throw new IllegalArgumentException("step cannot be 0.")
+
+    val isEmpty = (
+      if (start == end) !isInclusive
+      else if (start < end) step < 0
+      else step > 0
+    )
+    if (isEmpty) 0
+    else {
+      // Counts with Longs so we can recognize too-large ranges.
+      val gap: Long    = end.toLong - start.toLong
+      val jumps: Long  = gap / step
+      // Whether the size of this range is one larger than the
+      // number of full-sized jumps.
+      val hasStub      = isInclusive || (gap % step != 0)
+      val result: Long = jumps + ( if (hasStub) 1 else 0 )
+
+      if (result > scala.Int.MaxValue) -1
+      else result.toInt
+    }
+  }
+  def count(start: Int, end: Int, step: Int): Int =
+    count(start, end, step, isInclusive = false)
+
+  final class Inclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
+//    override def par = new ParRange(this)
+    override def isInclusive = true
+    override protected def copy(start: Int, end: Int, step: Int): Range = new Inclusive(start, end, step)
+  }
+
+  /** Make a range from `start` until `end` (exclusive) with given step value.
+   * @note step != 0
+   */
+  def apply(start: Int, end: Int, step: Int): Range = new Range(start, end, step)
+
+  /** Make a range from `start` until `end` (exclusive) with step value 1.
+   */
+  def apply(start: Int, end: Int): Range = new Range(start, end, 1)
+
+  /** Make an inclusive range from `start` to `end` with given step value.
+   * @note step != 0
+   */
+  def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Inclusive(start, end, step)
+
+  /** Make an inclusive range from `start` to `end` with step value 1.
+   */
+  def inclusive(start: Int, end: Int): Range.Inclusive = new Inclusive(start, end, 1)
+
+  // BigInt and Long are straightforward generic ranges.
+  object BigInt {
+    def apply(start: BigInt, end: BigInt, step: BigInt) = NumericRange(start, end, step)
+    def inclusive(start: BigInt, end: BigInt, step: BigInt) = NumericRange.inclusive(start, end, step)
+  }
+
+  object Long {
+    def apply(start: Long, end: Long, step: Long) = NumericRange(start, end, step)
+    def inclusive(start: Long, end: Long, step: Long) = NumericRange.inclusive(start, end, step)
+  }
+
+  // BigDecimal uses an alternative implementation of Numeric in which
+  // it pretends to be Integral[T] instead of Fractional[T].  See Numeric for
+  // details.  The intention is for it to throw an exception anytime
+  // imprecision or surprises might result from anything, although this may
+  // not yet be fully implemented.
+  object BigDecimal {
+    implicit val bigDecAsIntegral = scala.math.Numeric.BigDecimalAsIfIntegral
+
+    def apply(start: BigDecimal, end: BigDecimal, step: BigDecimal) =
+      NumericRange(start, end, step)
+    def inclusive(start: BigDecimal, end: BigDecimal, step: BigDecimal) =
+      NumericRange.inclusive(start, end, step)
+  }
+
+  // Double works by using a BigDecimal under the hood for precise
+  // stepping, but mapping the sequence values back to doubles with
+  // .doubleValue.  This constructs the BigDecimals by way of the
+  // String constructor (valueOf) instead of the Double one, which
+  // is necessary to keep 0.3d at 0.3 as opposed to
+  // 0.299999999999999988897769753748434595763683319091796875 or so.
+  object Double {
+    implicit val bigDecAsIntegral = scala.math.Numeric.BigDecimalAsIfIntegral
+    implicit val doubleAsIntegral = scala.math.Numeric.DoubleAsIfIntegral
+    def toBD(x: Double): BigDecimal = scala.math.BigDecimal valueOf x
+
+    @deprecated("use Range.BigDecimal instead", "2.12.6")
+    def apply(start: Double, end: Double, step: Double) =
+      BigDecimal(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
+
+    @deprecated("use Range.BigDecimal.inclusive instead", "2.12.6")
+    def inclusive(start: Double, end: Double, step: Double) =
+      BigDecimal.inclusive(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
+  }
+
+  // As there is no appealing default step size for not-really-integral ranges,
+  // we offer a partially constructed object.
+  class Partial[T, U](private val f: T => U) extends AnyVal {
+    def by(x: T): U = f(x)
+    override def toString = "Range requires step"
+  }
+
+  // Illustrating genericity with Int Range, which should have the same behavior
+  // as the original Range class.  However we leave the original Range
+  // indefinitely, for performance and because the compiler seems to bootstrap
+  // off it and won't do so with our parameterized version without modifications.
+  object Int {
+    def apply(start: Int, end: Int, step: Int) = NumericRange(start, end, step)
+    def inclusive(start: Int, end: Int, step: Int) = NumericRange.inclusive(start, end, step)
+  }
+}

--- a/scalalib/overrides-2.12/scala/collection/immutable/Seq.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/Seq.scala
@@ -1,0 +1,54 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package immutable
+
+import generic._
+import mutable.Builder
+import parallel.immutable.ParSeq
+
+/** A subtrait of `collection.Seq` which represents sequences
+ *  that are guaranteed immutable.
+ *
+ *  $seqInfo
+ *  @define Coll `immutable.Seq`
+ *  @define coll immutable sequence
+ */
+trait Seq[+A] extends Iterable[A]
+//                      with GenSeq[A]
+                      with scala.collection.Seq[A]
+                      with GenericTraversableTemplate[A, Seq]
+                      with SeqLike[A, Seq[A]]
+                      with Parallelizable[A, ParSeq[A]]
+{
+  override def companion: GenericCompanion[Seq] = Seq
+  override def toSeq: Seq[A] = this
+  override def seq: Seq[A] = this
+  protected[this] override def parCombiner = ParSeq.newCombiner[A] // if `immutable.SeqLike` gets introduced, please move this there!
+}
+
+/** $factoryInfo
+ *  @define Coll `immutable.Seq`
+ *  @define coll immutable sequence
+ */
+object Seq extends SeqFactory[Seq] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  /** genericCanBuildFromInfo */
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Seq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, Seq[A]] = new mutable.ListBuffer
+}

--- a/scalalib/overrides-2.12/scala/collection/immutable/Stack.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/Stack.scala
@@ -1,0 +1,140 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package immutable
+
+import generic._
+import mutable.{ ArrayBuffer, Builder }
+
+/** $factoryInfo
+ *  @define Coll `immutable.Stack`
+ *  @define coll immutable stack
+ */
+object Stack extends SeqFactory[Stack] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  /** $genericCanBuildFromInfo */
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Stack[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, Stack[A]] = new ArrayBuffer[A] mapResult (buf => new Stack(buf.toList))
+}
+
+/** This class implements immutable stacks using a list-based data
+ *  structure.
+ *
+ *  '''Note:''' This class exists only for historical reason and as an
+ *           analogue of mutable stacks.
+ *           Instead of an immutable stack you can just use a list.
+ *
+ *  @tparam A    the type of the elements contained in this stack.
+ *
+ *  @author  Matthias Zenger
+ *  @since   1
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-stacks "Scala's Collection Library overview"]]
+ *  section on `Immutable stacks` for more information.
+ *
+ *  @define Coll `immutable.Stack`
+ *  @define coll immutable stack
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+@SerialVersionUID(1976480595012942526L)
+@deprecated("Stack is an inelegant and potentially poorly-performing wrapper around List. Use List instead: stack push x becomes x :: list; stack.pop is list.tail.", "2.11.0")
+class Stack[+A] protected (protected val elems: List[A])
+                 extends AbstractSeq[A]
+                    with LinearSeq[A]
+                    with GenericTraversableTemplate[A, Stack]
+                    with LinearSeqOptimized[A, Stack[A]]
+                    with Serializable {
+  override def companion: GenericCompanion[Stack] = Stack
+
+  def this() = this(Nil)
+
+  /** Checks if this stack is empty.
+   *
+   *  @return true, iff there is no element on the stack.
+   */
+  override def isEmpty: Boolean = elems.isEmpty
+
+  override def head = elems.head
+  override def tail = new Stack(elems.tail)
+
+  /** Push an element on the stack.
+   *
+   *  @param   elem       the element to push on the stack.
+   *  @return the stack with the new element on top.
+   */
+  def push[B >: A](elem: B): Stack[B] = new Stack(elem :: elems)
+
+  /** Push a sequence of elements onto the stack. The last element
+   *  of the sequence will be on top of the new stack.
+   *
+   *  @param   elems      the element sequence.
+   *  @return the stack with the new elements on top.
+   */
+  def push[B >: A](elem1: B, elem2: B, elems: B*): Stack[B] =
+    this.push(elem1).push(elem2).pushAll(elems)
+
+  /** Push all elements provided by the given traversable object onto
+   *  the stack. The last element returned by the traversable object
+   *  will be on top of the new stack.
+   *
+   *  @param   xs      the iterator object.
+   *  @return the stack with the new elements on top.
+   */
+  def pushAll[B >: A](xs: TraversableOnce[B]): Stack[B] =
+    ((this: Stack[B]) /: xs.toIterator)(_ push _)
+
+  /** Returns the top element of the stack. An error is signaled if
+   *  there is no element on the stack.
+   *
+   *  @throws java.util.NoSuchElementException
+   *  @return the top element.
+   */
+  def top: A =
+    if (!isEmpty) elems.head
+    else throw new NoSuchElementException("top of empty stack")
+
+  /** Removes the top element from the stack.
+   *  Note: should return `(A, Stack[A])` as for queues (mics)
+   *
+   *  @throws java.util.NoSuchElementException
+   *  @return the new stack without the former top element.
+   */
+  def pop: Stack[A] =
+    if (!isEmpty) new Stack(elems.tail)
+    else throw new NoSuchElementException("pop of empty stack")
+
+  def pop2: (A, Stack[A]) =
+    if (!isEmpty) (elems.head, new Stack(elems.tail))
+    else throw new NoSuchElementException("pop of empty stack")
+
+  override def reverse: Stack[A] = new Stack(elems.reverse)
+
+  /** Returns an iterator over all elements on the stack. The iterator
+   *  issues elements in the reversed order they were inserted into the
+   *  stack (LIFO order).
+   *
+   *  @return an iterator over all stack elements.
+   */
+  override def iterator: Iterator[A] = elems.iterator
+
+  /** Returns a string representation of this stack.
+   */
+  override def toString() = elems.mkString("Stack(", ", ", ")")
+}

--- a/scalalib/overrides-2.12/scala/collection/immutable/Stream.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/Stream.scala
@@ -1,0 +1,1295 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package immutable
+
+import generic._
+import mutable.{Builder, StringBuilder, LazyBuilder}
+import scala.annotation.tailrec
+import Stream.cons
+import scala.language.implicitConversions
+
+/** The class `Stream` implements lazy lists where elements
+ *  are only evaluated when they are needed. Here is an example:
+ *
+ *  {{{
+ *  import scala.math.BigInt
+ *  object Main extends App {
+ *
+ *    lazy val fibs: Stream[BigInt] = BigInt(0) #:: BigInt(1) #:: fibs.zip(fibs.tail).map { n => n._1 + n._2 }
+ *
+ *    fibs take 5 foreach println
+ *  }
+ *
+ *  // prints
+ *  //
+ *  // 0
+ *  // 1
+ *  // 1
+ *  // 2
+ *  // 3
+ *  }}}
+ *
+ *  The `Stream` class also employs memoization such that previously computed
+ *  values are converted from `Stream` elements to concrete values of type `A`.
+ *  To illustrate, we will alter body of the `fibs` value above and take some
+ *  more values:
+ *
+ *  {{{
+ *  import scala.math.BigInt
+ *  object Main extends App {
+ *
+ *    lazy val fibs: Stream[BigInt] = BigInt(0) #:: BigInt(1) #:: fibs.zip(
+ *      fibs.tail).map(n => {
+ *        println("Adding %d and %d".format(n._1, n._2))
+ *        n._1 + n._2
+ *      })
+ *
+ *    fibs take 5 foreach println
+ *    fibs take 6 foreach println
+ *  }
+ *
+ *  // prints
+ *  //
+ *  // 0
+ *  // 1
+ *  // Adding 0 and 1
+ *  // 1
+ *  // Adding 1 and 1
+ *  // 2
+ *  // Adding 1 and 2
+ *  // 3
+ *
+ *  // And then prints
+ *  //
+ *  // 0
+ *  // 1
+ *  // 1
+ *  // 2
+ *  // 3
+ *  // Adding 2 and 3
+ *  // 5
+ *  }}}
+ *
+ *  There are a number of subtle points to the above example.
+ *
+ *  - The definition of `fibs` is a `val` not a method.  The memoization of the
+ *  `Stream` requires us to have somewhere to store the information and a `val`
+ *  allows us to do that.
+ *
+ *  - While the `Stream` is actually being modified during access, this does not
+ *  change the notion of its immutability.  Once the values are memoized they do
+ *  not change and values that have yet to be memoized still "exist", they
+ *  simply haven't been realized yet.
+ *
+ *  - One must be cautious of memoization; you can very quickly eat up large
+ *  amounts of memory if you're not careful.  The reason for this is that the
+ *  memoization of the `Stream` creates a structure much like
+ *  [[scala.collection.immutable.List]].  So long as something is holding on to
+ *  the head, the head holds on to the tail, and so it continues recursively.
+ *  If, on the other hand, there is nothing holding on to the head (e.g. we used
+ *  `def` to define the `Stream`) then once it is no longer being used directly,
+ *  it disappears.
+ *
+ *  - Note that some operations, including [[drop]], [[dropWhile]],
+ *  [[flatMap]] or [[collect]] may process a large number of intermediate
+ *  elements before returning.  These necessarily hold onto the head, since
+ *  they are methods on `Stream`, and a stream holds its own head.  For
+ *  computations of this sort where memoization is not desired, use
+ *  `Iterator` when possible.
+ *
+ *  {{{
+ *  // For example, let's build the natural numbers and do some silly iteration
+ *  // over them.
+ *
+ *  // We'll start with a silly iteration
+ *  def loop(s: String, i: Int, iter: Iterator[Int]): Unit = {
+ *    // Stop after 200,000
+ *    if (i < 200001) {
+ *      if (i % 50000 == 0) println(s + i)
+ *      loop(s, iter.next, iter)
+ *    }
+ *  }
+ *
+ *  // Our first Stream definition will be a val definition
+ *  val stream1: Stream[Int] = {
+ *    def loop(v: Int): Stream[Int] = v #:: loop(v + 1)
+ *    loop(0)
+ *  }
+ *
+ *  // Because stream1 is a val, everything that the iterator produces is held
+ *  // by virtue of the fact that the head of the Stream is held in stream1
+ *  val it1 = stream1.iterator
+ *  loop("Iterator1: ", it1.next, it1)
+ *
+ *  // We can redefine this Stream such that all we have is the Iterator left
+ *  // and allow the Stream to be garbage collected as required.  Using a def
+ *  // to provide the Stream ensures that no val is holding onto the head as
+ *  // is the case with stream1
+ *  def stream2: Stream[Int] = {
+ *    def loop(v: Int): Stream[Int] = v #:: loop(v + 1)
+ *    loop(0)
+ *  }
+ *  val it2 = stream2.iterator
+ *  loop("Iterator2: ", it2.next, it2)
+ *
+ *  // And, of course, we don't actually need a Stream at all for such a simple
+ *  // problem.  There's no reason to use a Stream if you don't actually need
+ *  // one.
+ *  val it3 = new Iterator[Int] {
+ *    var i = -1
+ *    def hasNext = true
+ *    def next(): Int = { i += 1; i }
+ *  }
+ *  loop("Iterator3: ", it3.next, it3)
+ *  }}}
+ *
+ *  - The fact that `tail` works at all is of interest.  In the definition of
+ *  `fibs` we have an initial `(0, 1, Stream(...))` so `tail` is deterministic.
+ *  If we defined `fibs` such that only `0` were concretely known then the act
+ *  of determining `tail` would require the evaluation of `tail` which would
+ *  cause an infinite recursion and stack overflow.  If we define a definition
+ *  where the tail is not initially computable then we're going to have an
+ *  infinite recursion:
+ *  {{{
+ *  // The first time we try to access the tail we're going to need more
+ *  // information which will require us to recurse, which will require us to
+ *  // recurse, which...
+ *  lazy val sov: Stream[Vector[Int]] = Vector(0) #:: sov.zip(sov.tail).map { n => n._1 ++ n._2 }
+ *  }}}
+ *
+ *  The definition of `fibs` above creates a larger number of objects than
+ *  necessary depending on how you might want to implement it.  The following
+ *  implementation provides a more "cost effective" implementation due to the
+ *  fact that it has a more direct route to the numbers themselves:
+ *
+ *  {{{
+ *  lazy val fib: Stream[Int] = {
+ *    def loop(h: Int, n: Int): Stream[Int] = h #:: loop(n, h + n)
+ *    loop(1, 1)
+ *  }
+ *  }}}
+ *
+ *  Note that `mkString` forces evaluation of a `Stream`, but `addString` does
+ *  not.  In both cases, a `Stream` that is or ends in a cycle
+ *  (e.g. `lazy val s: Stream[Int] = 0 #:: s`) will convert additional trips
+ *  through the cycle to `...`.  Additionally, `addString` will display an
+ *  un-memoized tail as `?`.
+ *
+ *  @tparam A    the type of the elements contained in this stream.
+ *
+ *  @author Martin Odersky, Matthias Zenger
+ *  @since   2.8
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#streams "Scala's Collection Library overview"]]
+ *  section on `Streams` for more information.
+
+ *  @define naturalsEx def naturalsFrom(i: Int): Stream[Int] = i #:: naturalsFrom(i + 1)
+ *  @define Coll `Stream`
+ *  @define coll stream
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define willTerminateInf Note: lazily evaluated; will terminate for infinite-sized collections.
+ */
+sealed abstract class Stream[+A] extends AbstractSeq[A]
+                             with LinearSeq[A]
+                             with GenericTraversableTemplate[A, Stream]
+                             with LinearSeqOptimized[A, Stream[A]]
+                             with Serializable { self =>
+
+  override def companion: GenericCompanion[Stream] = Stream
+
+  /** Indicates whether or not the `Stream` is empty.
+   *
+   * @return `true` if the `Stream` is empty and `false` otherwise.
+   */
+  def isEmpty: Boolean
+
+  /** Gives constant time access to the first element of this `Stream`.  Using
+   * the `fibs` example from earlier:
+   *
+   * {{{
+   * println(fibs head)
+   * // prints
+   * // 0
+   * }}}
+   *
+   *  @return The first element of the `Stream`.
+   *  @throws java.util.NoSuchElementException if the stream is empty.
+   */
+  def head: A
+
+  /** A stream consisting of the remaining elements of this stream after the
+   *  first one.
+   *
+   *  Note that this method does not force evaluation of the `Stream` but merely
+   *  returns the lazy result.
+   *
+   *  @return The tail of the `Stream`.
+   *  @throws UnsupportedOperationException if the stream is empty.
+   */
+  def tail: Stream[A]
+
+  /** Is the tail of this stream defined? */
+  protected def tailDefined: Boolean
+
+  // Implementation of abstract method in Traversable
+
+  // New methods in Stream
+
+  /** The stream resulting from the concatenation of this stream with the argument stream.
+   *  @param rest   The stream that gets appended to this stream
+   *  @return       The stream containing elements of this stream and the traversable object.
+   */
+  def append[B >: A](rest: => TraversableOnce[B]): Stream[B] =
+    if (isEmpty) rest.toStream else cons(head, tail append rest)
+
+  /** Forces evaluation of the whole stream and returns it.
+   *
+   * @note Often we use `Stream`s to represent an infinite set or series.  If
+   * that's the case for your particular `Stream` then this function will never
+   * return and will probably crash the VM with an `OutOfMemory` exception.
+   * This function will not hang on a finite cycle, however.
+   *
+   *  @return The fully realized `Stream`.
+   */
+  def force: Stream[A] = {
+    // Use standard 2x 1x iterator trick for cycle detection ("those" is slow one)
+    var these, those = this
+    if (!these.isEmpty) these = these.tail
+    while (those ne these) {
+      if (these.isEmpty) return this
+      these = these.tail
+      if (these.isEmpty) return this
+      these = these.tail
+      if (these eq those) return this
+      those = those.tail
+    }
+    this
+  }
+
+  /** Prints elements of this stream one by one, separated by commas. */
+  def print() { print(", ") }
+
+  /** Prints elements of this stream one by one, separated by `sep`.
+   *  @param sep   The separator string printed between consecutive elements.
+   */
+  def print(sep: String) {
+    def loop(these: Stream[A], start: String) {
+      Console.print(start)
+      if (these.isEmpty) Console.print("empty")
+      else {
+        Console.print(these.head)
+        loop(these.tail, sep)
+      }
+    }
+    loop(this, "")
+  }
+
+  /** Returns the length of this `Stream`.
+   *
+   * @note In order to compute the length of the `Stream`, it must first be
+   * fully realized, which could cause the complete evaluation of an infinite
+   * series, assuming that's what your `Stream` represents.
+   *
+   * @return The length of this `Stream`.
+   */
+  override def length: Int = {
+    var len = 0
+    var left = this
+    while (!left.isEmpty) {
+      len += 1
+      left = left.tail
+    }
+    len
+  }
+
+  // It's an imperfect world, but at least we can bottle up the
+  // imperfection in a capsule.
+  @inline private def asThat[That](x: AnyRef): That     = x.asInstanceOf[That]
+  @inline private def asStream[B](x: AnyRef): Stream[B] = x.asInstanceOf[Stream[B]]
+  @inline private def isStreamBuilder[B, That](bf: CanBuildFrom[Stream[A], B, That]) =
+    bf(repr).isInstanceOf[Stream.StreamBuilder[_]]
+
+  // Overridden methods from Traversable
+
+  override def toStream: Stream[A] = this
+
+  override def hasDefiniteSize: Boolean = isEmpty || {
+    if (!tailDefined) false
+    else {
+      // Two-iterator trick (2x & 1x speed) for cycle detection.
+      var those = this
+      var these = tail
+      while (those ne these) {
+        if (these.isEmpty) return true
+        if (!these.tailDefined) return false
+        these = these.tail
+        if (these.isEmpty) return true
+        if (!these.tailDefined) return false
+        these = these.tail
+        if (those eq these) return false
+        those = those.tail
+      }
+      false  // Cycle detected
+    }
+  }
+
+  /** Create a new stream which contains all elements of this stream followed by
+   * all elements of Traversable `that`.
+   *
+   * @note It's subtle why this works. We know that if the target type of the
+   * [[scala.collection.mutable.Builder]] `That` is either a `Stream`, or one of
+   * its supertypes, or undefined, then `StreamBuilder` will be chosen for the
+   * implicit.  We recognize that fact and optimize to get more laziness.
+   *
+   * @note This method doesn't cause the `Stream` to be fully realized but it
+   * should be noted that using the `++` operator from another collection type
+   * could cause infinite realization of a `Stream`.  For example, referring to
+   * the definition of `fibs` in the preamble, the following would never return:
+   * `List(BigInt(12)) ++ fibs`.
+   *
+   * @tparam B The element type of the returned collection.'''That'''
+   * @param that The [[scala.collection.GenTraversableOnce]] to be concatenated
+   * to this `Stream`.
+   * @return A new collection containing the result of concatenating `this` with
+   * `that`.
+   */
+  override def ++[B >: A, That](that: GenTraversableOnce[B])(implicit bf: CanBuildFrom[Stream[A], B, That]): That =
+    // we assume there is no other builder factory on streams and therefore know that That = Stream[A]
+    if (isStreamBuilder(bf)) asThat(
+      if (isEmpty) that.toStream
+      else cons(head, asStream[A](tail ++ that))
+    )
+    else super.++(that)(bf)
+
+  override def +:[B >: A, That](elem: B)(implicit bf: CanBuildFrom[Stream[A], B, That]): That =
+    if (isStreamBuilder(bf)) asThat(cons(elem, this))
+    else super.+:(elem)(bf)
+
+  /**
+   * Create a new stream which contains all intermediate results of applying the
+   * operator to subsequent elements left to right.  `scanLeft` is analogous to
+   * `foldLeft`.
+   *
+   * @note This works because the target type of the
+   * [[scala.collection.mutable.Builder]] `That` is a `Stream`.
+   *
+   * @param z The initial value for the scan.
+   * @param op A function that will apply operations to successive values in the
+   * `Stream` against previous accumulated results.
+   * @return A new collection containing the modifications from the application
+   * of `op`.
+   */
+  override final def scanLeft[B, That](z: B)(op: (B, A) => B)(implicit bf: CanBuildFrom[Stream[A], B, That]): That =
+    if (isStreamBuilder(bf)) asThat(
+      if (isEmpty) Stream(z)
+      else cons(z, asStream[B](tail.scanLeft(op(z, head))(op)))
+    )
+    else super.scanLeft(z)(op)(bf)
+
+  /** Returns the stream resulting from applying the given function `f` to each
+   * element of this stream.  This returns a lazy `Stream` such that it does not
+   * need to be fully realized.
+   *
+   * @example {{{
+   * $naturalsEx
+   * naturalsFrom(1).map(_ + 10) take 5 mkString(", ")
+   * // produces: "11, 12, 13, 14, 15"
+   * }}}
+   *
+   * @tparam B The element type of the returned collection '''That'''.
+   * @param f function to apply to each element.
+   * @return  `f(a,,0,,), ..., f(a,,n,,)` if this sequence is `a,,0,,, ..., a,,n,,`.
+   */
+  override final def map[B, That](f: A => B)(implicit bf: CanBuildFrom[Stream[A], B, That]): That = {
+    if (isStreamBuilder(bf)) asThat(
+      if (isEmpty) Stream.Empty
+      else cons(f(head), asStream[B](tail map f))
+    )
+    else super.map(f)(bf)
+  }
+
+  override final def collect[B, That](pf: PartialFunction[A, B])(implicit bf: CanBuildFrom[Stream[A], B, That]): That = {
+    if (!isStreamBuilder(bf)) super.collect(pf)(bf)
+    else {
+      // this implementation avoids:
+      // 1) stackoverflows (could be achieved with tailrec, too)
+      // 2) out of memory errors for big streams (`this` reference can be eliminated from the stack)
+      var rest: Stream[A] = this
+
+      // Avoids calling both `pf.isDefined` and `pf.apply`.
+      var newHead: B = null.asInstanceOf[B]
+      val runWith = pf.runWith((b: B) => newHead = b)
+
+      while (rest.nonEmpty && !runWith(rest.head)) rest = rest.tail
+
+      //  without the call to the companion object, a thunk is created for the tail of the new stream,
+      //  and the closure of the thunk will reference `this`
+      if (rest.isEmpty) Stream.Empty.asInstanceOf[That]
+      else Stream.collectedTail(newHead, rest, pf, bf).asInstanceOf[That]
+    }
+  }
+
+  /** Applies the given function `f` to each element of this stream, then
+   * concatenates the results.  As with `map` this function does not need to
+   * realize the entire `Stream` but continues to keep it as a lazy `Stream`.
+   *
+   * @example {{{
+   * // Let's create a Stream of Vectors, each of which contains the
+   * // collection of Fibonacci numbers up to the current value.  We
+   * // can then 'flatMap' that Stream.
+   *
+   * val fibVec: Stream[Vector[Int]] = Vector(0) #:: Vector(0, 1) #:: fibVec.zip(fibVec.tail).map(n => {
+   *   n._2 ++ Vector(n._1.last + n._2.last)
+   * })
+   *
+   * fibVec take 5 foreach println
+   * // prints
+   * // Vector(0)
+   * // Vector(0, 1)
+   * // Vector(0, 1, 1)
+   * // Vector(0, 1, 1, 2)
+   * // Vector(0, 1, 1, 2, 3)
+   *
+   * // If we now want to `flatMap` across that stream by adding 10
+   * // we can see what the series turns into:
+   *
+   * fibVec.flatMap(_.map(_ + 10)) take 15 mkString(", ")
+   * // produces: 10, 10, 11, 10, 11, 11, 10, 11, 11, 12, 10, 11, 11, 12, 13
+   * }}}
+   *
+   * ''Note:''  Currently `flatMap` will evaluate as much of the Stream as needed
+   * until it finds a non-empty element for the head, which is non-lazy.
+   *
+   * @tparam B The element type of the returned collection '''That'''.
+   * @param f  the function to apply on each element.
+   * @return  `f(a,,0,,) ::: ... ::: f(a,,n,,)` if
+   *           this stream is `[a,,0,,, ..., a,,n,,]`.
+   */
+  override final def flatMap[B, That](f: A => GenTraversableOnce[B])(implicit bf: CanBuildFrom[Stream[A], B, That]): That =
+    // we assume there is no other builder factory on streams and therefore know that That = Stream[B]
+    // optimisations are not for speed, but for functionality
+    // see tickets #153, #498, #2147, and corresponding tests in run/ (as well as run/stream_flatmap_odds.scala)
+    if (isStreamBuilder(bf)) asThat(
+      if (isEmpty) Stream.Empty
+      else {
+        // establish !prefix.isEmpty || nonEmptyPrefix.isEmpty
+        var nonEmptyPrefix = this
+        var prefix = f(nonEmptyPrefix.head).toStream
+        while (!nonEmptyPrefix.isEmpty && prefix.isEmpty) {
+          nonEmptyPrefix = nonEmptyPrefix.tail
+          if(!nonEmptyPrefix.isEmpty)
+            prefix = f(nonEmptyPrefix.head).toStream
+        }
+
+        if (nonEmptyPrefix.isEmpty) Stream.empty
+        else prefix append asStream[B](nonEmptyPrefix.tail flatMap f)
+      }
+    )
+    else super.flatMap(f)(bf)
+
+  override private[scala] def filterImpl(p: A => Boolean, isFlipped: Boolean): Stream[A] = {
+    // optimization: drop leading prefix of elems for which f returns false
+    // var rest = this dropWhile (!p(_)) - forget DRY principle - GC can't collect otherwise
+    var rest = this
+    while (!rest.isEmpty && p(rest.head) == isFlipped) rest = rest.tail
+    // private utility func to avoid `this` on stack (would be needed for the lazy arg)
+    if (rest.nonEmpty) Stream.filteredTail(rest, p, isFlipped)
+    else Stream.Empty
+  }
+
+  /** A FilterMonadic which allows GC of the head of stream during processing */
+  @noinline // Workaround scala/bug#9137, see https://github.com/scala/scala/pull/4284#issuecomment-73180791
+  override final def withFilter(p: A => Boolean): FilterMonadic[A, Stream[A]] = new Stream.StreamWithFilter(this, p)
+
+  /** A lazier Iterator than LinearSeqLike's. */
+  override def iterator: Iterator[A] = new StreamIterator(self)
+
+  /** Apply the given function `f` to each element of this linear sequence
+   * (while respecting the order of the elements).
+   *
+   *  @param f The treatment to apply to each element.
+   *  @note  Overridden here as final to trigger tail-call optimization, which
+   *  replaces 'this' with 'tail' at each iteration. This is absolutely
+   *  necessary for allowing the GC to collect the underlying stream as elements
+   *  are consumed.
+   *  @note  This function will force the realization of the entire stream
+   *  unless the `f` throws an exception.
+   */
+  @tailrec
+  override final def foreach[U](f: A => U) {
+    if (!this.isEmpty) {
+      f(head)
+      tail.foreach(f)
+    }
+  }
+
+  /** Stream specialization of foldLeft which allows GC to collect along the
+   * way.
+   *
+   * @tparam B The type of value being accumulated.
+   * @param z The initial value seeded into the function `op`.
+   * @param op The operation to perform on successive elements of the `Stream`.
+   * @return The accumulated value from successive applications of `op`.
+   */
+  @tailrec
+  override final def foldLeft[B](z: B)(op: (B, A) => B): B = {
+    if (this.isEmpty) z
+    else tail.foldLeft(op(z, head))(op)
+  }
+
+  /** Stream specialization of reduceLeft which allows GC to collect
+   *  along the way.
+   *
+   * @tparam B The type of value being accumulated.
+   * @param f The operation to perform on successive elements of the `Stream`.
+   * @return The accumulated value from successive applications of `f`.
+   */
+  override final def reduceLeft[B >: A](f: (B, A) => B): B = {
+    if (this.isEmpty) throw new UnsupportedOperationException("empty.reduceLeft")
+    else {
+      var reducedRes: B = this.head
+      var left = this.tail
+      while (!left.isEmpty) {
+        reducedRes = f(reducedRes, left.head)
+        left = left.tail
+      }
+      reducedRes
+    }
+  }
+
+  /** Returns all the elements of this stream that satisfy the predicate `p`
+   * returning of [[scala.Tuple2]] of `Stream`s obeying the partition predicate
+   * `p`. The order of the elements is preserved.
+   *
+   * @param p the predicate used to filter the stream.
+   * @return the elements of this stream satisfying `p`.
+   *
+   * @example {{{
+   * $naturalsEx
+   * val parts = naturalsFrom(1) partition { _ % 2 == 0 }
+   * parts._1 take 10 mkString ", "
+   * // produces: "2, 4, 6, 8, 10, 12, 14, 16, 18, 20"
+   * parts._2 take 10 mkString ", "
+   * // produces: "1, 3, 5, 7, 9, 11, 13, 15, 17, 19"
+   * }}}
+   *
+   */
+  override def partition(p: A => Boolean): (Stream[A], Stream[A]) = (filter(p(_)), filterNot(p(_)))
+
+  /** Returns a stream formed from this stream and the specified stream `that`
+   * by associating each element of the former with the element at the same
+   * position in the latter.
+   *
+   * If one of the two streams is longer than the other, its remaining elements
+   * are ignored.
+   *
+   * The return type of this function may not be obvious.  The lazy aspect of
+   * the returned value is different than that of `partition`.  In `partition`
+   * we get back a [[scala.Tuple2]] of two lazy `Stream`s whereas here we get
+   * back a single lazy `Stream` of [[scala.Tuple2]]s where the
+   * [[scala.Tuple2]]'s type signature is `(A1, B)`.
+   *
+   * @tparam A1 The type of the first parameter of the zipped tuple
+   * @tparam B The type of the second parameter of the zipped tuple
+   * @tparam That The type of the returned `Stream`.
+   * @return `Stream({a,,0,,,b,,0,,}, ...,
+   *         {a,,min(m,n),,,b,,min(m,n),,)}` when
+   *         `Stream(a,,0,,, ..., a,,m,,)
+   *         zip Stream(b,,0,,, ..., b,,n,,)` is invoked.
+   *
+   * @example {{{
+   * $naturalsEx
+   * naturalsFrom(1) zip naturalsFrom(2) take 5 foreach println
+   * // prints
+   * // (1,2)
+   * // (2,3)
+   * // (3,4)
+   * // (4,5)
+   * // (5,6)
+   * }}}
+   */
+  override final def zip[A1 >: A, B, That](that: scala.collection.GenIterable[B])(implicit bf: CanBuildFrom[Stream[A], (A1, B), That]): That =
+    // we assume there is no other builder factory on streams and therefore know that That = Stream[(A1, B)]
+    if (isStreamBuilder(bf)) asThat(
+      if (this.isEmpty || that.isEmpty) Stream.Empty
+      else cons((this.head, that.head), asStream[(A1, B)](this.tail zip that.tail))
+    )
+    else super.zip(that)(bf)
+
+  /** Zips this iterable with its indices. `s.zipWithIndex` is equivalent to `s
+   * zip s.indices`.
+   *
+   * This method is much like `zip` in that it returns a single lazy `Stream` of
+   * [[scala.Tuple2]].
+   *
+   * @tparam A1 The type of the first element of the [[scala.Tuple2]] in the
+   * resulting stream.
+   * @tparam That The type of the resulting `Stream`.
+   * @return `Stream({a,,0,,,0}, ..., {a,,n,,,n)}`
+   *
+   * @example {{{
+   * $naturalsEx
+   * (naturalsFrom(1) zipWithIndex) take 5 foreach println
+   * // prints
+   * // (1,0)
+   * // (2,1)
+   * // (3,2)
+   * // (4,3)
+   * // (5,4)
+   * }}}
+   */
+  override def zipWithIndex[A1 >: A, That](implicit bf: CanBuildFrom[Stream[A], (A1, Int), That]): That =
+    this.zip[A1, Int, That](Stream.from(0))
+
+  /** Write all defined elements of this iterable into given string builder.
+   *  The written text begins with the string `start` and is finished by the string
+   *  `end`. Inside, the string representations of defined elements (w.r.t.
+   *  the method `toString()`) are separated by the string `sep`. The method will
+   *  not force evaluation of undefined elements. A tail of such elements will be
+   * represented by a `"?"` instead.  A cyclic stream is represented by a `"..."`
+   * at the point where the cycle repeats.
+   *
+   * @param b The [[collection.mutable.StringBuilder]] factory to which we need
+   * to add the string elements.
+   * @param start The prefix of the resulting string (e.g. "Stream(")
+   * @param sep The separator between elements of the resulting string (e.g. ",")
+   * @param end The end of the resulting string (e.g. ")")
+   * @return The original [[collection.mutable.StringBuilder]] containing the
+   * resulting string.
+   */
+  override def addString(b: StringBuilder, start: String, sep: String, end: String): StringBuilder = {
+    b append start
+    if (!isEmpty) {
+      b append head
+      var cursor = this
+      var n = 1
+      if (cursor.tailDefined) {  // If tailDefined, also !isEmpty
+        var scout = tail
+        if (scout.isEmpty) {
+          // Single element.  Bail out early.
+          b append end
+          return b
+        }
+        if (cursor ne scout) {
+          cursor = scout
+          if (scout.tailDefined) {
+            scout = scout.tail
+            // Use 2x 1x iterator trick for cycle detection; slow iterator can add strings
+            while ((cursor ne scout) && scout.tailDefined) {
+              b append sep append cursor.head
+              n += 1
+              cursor = cursor.tail
+              scout = scout.tail
+              if (scout.tailDefined) scout = scout.tail
+            }
+          }
+        }
+        if (!scout.tailDefined) {  // Not a cycle, scout hit an end
+          while (cursor ne scout) {
+            b append sep append cursor.head
+            n += 1
+            cursor = cursor.tail
+          }
+          if (cursor.nonEmpty) {
+            b append sep append cursor.head
+          }
+        }
+        else {
+          // Cycle.
+          // If we have a prefix of length P followed by a cycle of length C,
+          // the scout will be at position (P%C) in the cycle when the cursor
+          // enters it at P.  They'll then collide when the scout advances another
+          // C - (P%C) ahead of the cursor.
+          // If we run the scout P farther, then it will be at the start of
+          // the cycle: (C - (P%C) + (P%C)) == C == 0.  So if another runner
+          // starts at the beginning of the prefix, they'll collide exactly at
+          // the start of the loop.
+          var runner = this
+          var k = 0
+          while (runner ne scout) {
+            runner = runner.tail
+            scout = scout.tail
+            k += 1
+          }
+          // Now runner and scout are at the beginning of the cycle.  Advance
+          // cursor, adding to string, until it hits; then we'll have covered
+          // everything once.  If cursor is already at beginning, we'd better
+          // advance one first unless runner didn't go anywhere (in which case
+          // we've already looped once).
+          if ((cursor eq scout) && (k > 0)) {
+            b append sep append cursor.head
+            n += 1
+            cursor = cursor.tail
+          }
+          while (cursor ne scout) {
+            b append sep append cursor.head
+            n += 1
+            cursor = cursor.tail
+          }
+          // Subtract prefix length from total length for cycle reporting.
+          // (Not currently used, but probably a good idea for the future.)
+          n -= k
+        }
+      }
+      if (!cursor.isEmpty) {
+        // Either undefined or cyclic; we can check with tailDefined
+        if (!cursor.tailDefined) b append sep append "?"
+        else b append sep append "..."
+      }
+    }
+    b append end
+    b
+  }
+
+  override def mkString(sep: String): String = mkString("", sep, "")
+  override def mkString: String = mkString("")
+  override def mkString(start: String, sep: String, end: String): String = {
+    this.force
+    super.mkString(start, sep, end)
+  }
+  override def toString = super.mkString(stringPrefix + "(", ", ", ")")
+
+  override def splitAt(n: Int): (Stream[A], Stream[A]) = (take(n), drop(n))
+
+  /** Returns the `n` first elements of this `Stream` as another `Stream`, or
+   * else the whole `Stream`, if it has less than `n` elements.
+   *
+   * The result of `take` is, again, a `Stream` meaning that it also does not
+   * make any needless evaluations of the `Stream` itself, delaying that until
+   * the usage of the resulting `Stream`.
+   *
+   * @param n the number of elements to take.
+   * @return the `n` first elements of this stream.
+   *
+   * @example {{{
+   * $naturalsEx
+   * scala> naturalsFrom(5) take 5
+   * res1: scala.collection.immutable.Stream[Int] = Stream(5, ?)
+   *
+   * scala> naturalsFrom(5) take 5 mkString ", "
+   * // produces: "5, 6, 7, 8, 9"
+   * }}}
+   */
+  override def take(n: Int): Stream[A] = (
+    // Note that the n == 1 condition appears redundant but is not.
+    // It prevents "tail" from being referenced (and its head being evaluated)
+    // when obtaining the last element of the result. Such are the challenges
+    // of working with a lazy-but-not-really sequence.
+    if (n <= 0 || isEmpty) Stream.empty
+    else if (n == 1) cons(head, Stream.empty)
+    else cons(head, tail take n-1)
+  )
+
+  @tailrec final override def drop(n: Int): Stream[A] =
+    if (n <= 0 || isEmpty) this
+    else tail drop n-1
+
+  /** A substream starting at index `from` and extending up to (but not including)
+   *  index `until`.  This returns a `Stream` that is lazily evaluated.
+   *
+   * @param from    The index of the first element of the returned subsequence
+   * @param until   The index of the element following the returned subsequence
+   * @return A new string containing the elements requested from `start` until
+   * `end`.
+   *
+   * @example {{{
+   * naturalsFrom(0) slice(50, 60) mkString ", "
+   * // produces: "50, 51, 52, 53, 54, 55, 56, 57, 58, 59"
+   * }}}
+   */
+  override def slice(from: Int, until: Int): Stream[A] = {
+    val lo = from max 0
+    if (until <= lo || isEmpty) Stream.empty
+    else this drop lo take (until - lo)
+  }
+
+  /** The stream without its last element.
+   *
+   * @return A new `Stream` containing everything but the last element.  If your
+   * `Stream` represents an infinite series, this method will not return.
+   *
+   *  @throws UnsupportedOperationException if the stream is empty.
+   */
+  override def init: Stream[A] =
+    if (isEmpty) super.init
+    else if (tail.isEmpty) Stream.Empty
+    else cons(head, tail.init)
+
+  /** Returns the rightmost `n` elements from this iterable.
+   *
+   * @note Take serious caution here.  If the `Stream` represents an infinite
+   * series then this function ''will not return''.  The right most elements of
+   * an infinite series takes an infinite amount of time to produce.
+   *
+   *  @param n the number of elements to take
+   *  @return The last `n` elements from this `Stream`.
+   */
+  override def takeRight(n: Int): Stream[A] = {
+    var these: Stream[A] = this
+    var lead = this drop n
+    while (!lead.isEmpty) {
+      these = these.tail
+      lead = lead.tail
+    }
+    these
+  }
+
+  /**
+   * @inheritdoc
+   * $willTerminateInf
+   */
+  override def dropRight(n: Int): Stream[A] = {
+    // We make dropRight work for possibly infinite streams by carrying
+    // a buffer of the dropped size. As long as the buffer is full and the
+    // rest is non-empty, we can feed elements off the buffer head.  When
+    // the rest becomes empty, the full buffer is the dropped elements.
+    def advance(stub0: List[A], stub1: List[A], rest: Stream[A]): Stream[A] = {
+      if (rest.isEmpty) Stream.empty
+      else if (stub0.isEmpty) advance(stub1.reverse, Nil, rest)
+      else cons(stub0.head, advance(stub0.tail, rest.head :: stub1, rest.tail))
+    }
+    if (n <= 0) this
+    else advance((this take n).toList, Nil, this drop n)
+  }
+
+  /** Returns the longest prefix of this `Stream` whose elements satisfy the
+   * predicate `p`.
+   *
+   * @param p the test predicate.
+   * @return A new `Stream` representing the values that satisfy the predicate
+   * `p`.
+   *
+   * @example {{{
+   + naturalsFrom(0) takeWhile { _ < 5 } mkString ", "
+   * produces: "0, 1, 2, 3, 4"
+   * }}}
+   */
+  override def takeWhile(p: A => Boolean): Stream[A] =
+    if (!isEmpty && p(head)) cons(head, tail takeWhile p)
+    else Stream.Empty
+
+  /** Returns the a `Stream` representing the longest suffix of this iterable
+   * whose first element does not satisfy the predicate `p`.
+   *
+   * @note This method realizes the entire `Stream` beyond the truth value of
+   * the predicate `p`.
+   *
+   * @param p the test predicate.
+   * @return A new `Stream` representing the results of applying `p` to the
+   * original `Stream`.
+   *
+   * @example {{{
+   * // Assume we have a Stream that takes the first 20 natural numbers
+   * def naturalsLt50(i: Int): Stream[Int] = i #:: { if (i < 20) naturalsLt50(i * + 1) else Stream.Empty }
+   * naturalsLt50(0) dropWhile { _ < 10 }
+   * // produces: "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
+   * }}}
+   */
+  override def dropWhile(p: A => Boolean): Stream[A] = {
+    var these: Stream[A] = this
+    while (!these.isEmpty && p(these.head)) these = these.tail
+    these
+  }
+
+  /** Builds a new stream from this stream in which any duplicates (as
+   * determined by `==`) have been removed. Among duplicate elements, only the
+   * first one is retained in the resulting `Stream`.
+   *
+   * @return A new `Stream` representing the result of applying distinctness to
+   * the original `Stream`.
+   * @example {{{
+   * // Creates a Stream where every element is duplicated
+   * def naturalsFrom(i: Int): Stream[Int] = i #:: { i #:: naturalsFrom(i + 1) }
+   * naturalsFrom(1) take 6 mkString ", "
+   * // produces: "1, 1, 2, 2, 3, 3"
+   * (naturalsFrom(1) distinct) take 6 mkString ", "
+   * // produces: "1, 2, 3, 4, 5, 6"
+   * }}}
+   */
+  override def distinct: Stream[A] = {
+    // This should use max memory proportional to N, whereas
+    // recursively calling distinct on the tail is N^2.
+    def loop(seen: Set[A], rest: Stream[A]): Stream[A] = {
+      if (rest.isEmpty) rest
+      else if (seen(rest.head)) loop(seen, rest.tail)
+      else cons(rest.head, loop(seen + rest.head, rest.tail))
+    }
+    loop(Set(), this)
+  }
+
+  /** Returns a new sequence of given length containing the elements of this
+   * sequence followed by zero or more occurrences of given elements.
+   *
+   * @tparam B The type of the value to pad with.
+   * @tparam That The type contained within the resulting `Stream`.
+   * @param len The number of elements to pad into the `Stream`.
+   * @param elem The value of the type `B` to use for padding.
+   * @return A new `Stream` representing the collection with values padding off
+   * to the end. If your `Stream` represents an infinite series, this method will
+   * not return.
+   * @example {{{
+   * def naturalsFrom(i: Int): Stream[Int] = i #:: { if (i < 5) naturalsFrom(i + 1) else Stream.Empty }
+   * naturalsFrom(1) padTo(10, 0) foreach println
+   * // prints
+   * // 1
+   * // 2
+   * // 3
+   * // 4
+   * // 5
+   * // 0
+   * // 0
+   * // 0
+   * // 0
+   * // 0
+   * }}}
+   */
+  override def padTo[B >: A, That](len: Int, elem: B)(implicit bf: CanBuildFrom[Stream[A], B, That]): That = {
+    def loop(len: Int, these: Stream[A]): Stream[B] =
+      if (these.isEmpty) Stream.fill(len)(elem)
+      else cons(these.head, loop(len - 1, these.tail))
+
+    if (isStreamBuilder(bf)) asThat(loop(len, this))
+    else super.padTo(len, elem)(bf)
+  }
+
+  /** A list consisting of all elements of this list in reverse order.
+   *
+   * @note This function must realize the entire `Stream` in order to perform
+   * this operation so if your `Stream` represents an infinite sequence then
+   * this function will never return.
+   *
+   * @return A new `Stream` containing the representing of the original `Stream`
+   * in reverse order.
+   *
+   * @example {{{
+   * def naturalsFrom(i: Int): Stream[Int] = i #:: { if (i < 5) naturalsFrom(i + 1) else Stream.Empty }
+   * (naturalsFrom(1) reverse) foreach println
+   * // prints
+   * // 5
+   * // 4
+   * // 3
+   * // 2
+   * // 1
+   * }}}
+   */
+  override def reverse: Stream[A] = {
+    var result: Stream[A] = Stream.Empty
+    var these = this
+    while (!these.isEmpty) {
+      val r = Stream.consWrapper(result).#::(these.head)
+      r.tail // force it!
+      result = r
+      these = these.tail
+    }
+    result
+  }
+
+  /** Evaluates and concatenates all elements within the `Stream` into a new
+   * flattened `Stream`.
+   *
+   * @tparam B The type of the elements of the resulting `Stream`.
+   * @return A new `Stream` of type `B` of the flattened elements of `this`
+   * `Stream`.
+   * @example {{{
+   * val sov: Stream[Vector[Int]] = Vector(0) #:: Vector(0, 0) #:: sov.zip(sov.tail).map { n => n._1 ++ n._2 }
+   * sov.flatten take 10 mkString ", "
+   * // produces: "0, 0, 0, 0, 0, 0, 0, 0, 0, 0"
+   * }}}
+   */
+  override def flatten[B](implicit asTraversable: A => /*<:<!!!*/ GenTraversableOnce[B]): Stream[B] = {
+    var st: Stream[A] = this
+    while (st.nonEmpty) {
+      val h = asTraversable(st.head)
+      if (h.isEmpty) {
+        st = st.tail
+      } else {
+        return h.toStream #::: st.tail.flatten
+      }
+    }
+    Stream.empty
+  }
+
+  override def view = new StreamView[A, Stream[A]] {
+    protected lazy val underlying = self.repr
+    override def iterator = self.iterator
+    override def length = self.length
+    override def apply(idx: Int) = self.apply(idx)
+  }
+
+  /** Defines the prefix of this object's `toString` representation as `Stream`.
+   */
+  override def stringPrefix = "Stream"
+
+  override def equals(that: Any): Boolean =
+    if (this eq that.asInstanceOf[AnyRef]) true else super.equals(that)
+}
+
+/** A specialized, extra-lazy implementation of a stream iterator, so it can
+ *  iterate as lazily as it traverses the tail.
+ */
+final class StreamIterator[+A] private() extends AbstractIterator[A] with Iterator[A] {
+  def this(self: Stream[A]) {
+    this()
+    these = new LazyCell(self)
+  }
+
+  // A call-by-need cell.
+  class LazyCell(st: => Stream[A]) {
+    lazy val v = st
+  }
+
+  private var these: LazyCell = _
+
+  def hasNext: Boolean = these.v.nonEmpty
+  def next(): A =
+    if (isEmpty) Iterator.empty.next()
+    else {
+      val cur    = these.v
+      val result = cur.head
+      these = new LazyCell(cur.tail)
+      result
+    }
+  override def toStream = {
+    val result = these.v
+    these = new LazyCell(Stream.empty)
+    result
+  }
+  override def toList   = toStream.toList
+}
+
+/**
+ * The object `Stream` provides helper functions to manipulate streams.
+ *
+ * @author Martin Odersky, Matthias Zenger
+ * @since   2.8
+ */
+object Stream extends SeqFactory[Stream] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  /** The factory for streams.
+   *  @note Methods such as map/flatMap will not invoke the `Builder` factory,
+   *        but will return a new stream directly, to preserve laziness.
+   *        The new stream is then cast to the factory's result type.
+   *        This means that every CanBuildFrom that takes a
+   *        Stream as its From type parameter must yield a stream as its result parameter.
+   *        If that assumption is broken, cast errors might result.
+   */
+  class StreamCanBuildFrom[A] extends GenericCanBuildFrom[A]
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Stream[A]] = new StreamCanBuildFrom[A]
+
+  /** Creates a new builder for a stream */
+  @inline def newBuilder[A]: Builder[A, Stream[A]] = new StreamBuilder[A]
+
+  import scala.collection.{Iterable, Seq, IndexedSeq}
+
+  /** A builder for streams
+   *  @note This builder is lazy only in the sense that it does not go downs the spine
+   *        of traversables that are added as a whole. If more laziness can be achieved,
+   *        this builder should be bypassed.
+   */
+  class StreamBuilder[A] extends LazyBuilder[A, Stream[A]] {
+    def result: Stream[A] = parts.toStream flatMap (_.toStream)
+  }
+
+  object Empty extends Stream[Nothing] {
+    override def isEmpty = true
+    override def head = throw new NoSuchElementException("head of empty stream")
+    override def tail = throw new UnsupportedOperationException("tail of empty stream")
+    def tailDefined = false
+  }
+
+  /** The empty stream */
+  @inline override def empty[A]: Stream[A] = Empty
+
+  /** A stream consisting of given elements */
+  @inline override def apply[A](xs: A*): Stream[A] = xs.toStream
+
+  /** A wrapper class that adds `#::` for cons and `#:::` for concat as operations
+   *  to streams.
+   */
+  class ConsWrapper[A](tl: => Stream[A]) {
+    /** Construct a stream consisting of a given first element followed by elements
+     *  from a lazily evaluated Stream.
+     */
+    def #::[B >: A](hd: B): Stream[B] = cons(hd, tl)
+    /** Construct a stream consisting of the concatenation of the given stream and
+     *  a lazily evaluated Stream.
+     */
+    def #:::[B >: A](prefix: Stream[B]): Stream[B] = prefix append tl
+  }
+
+  /** A wrapper method that adds `#::` for cons and `#:::` for concat as operations
+   *  to streams.
+   */
+  implicit def consWrapper[A](stream: => Stream[A]): ConsWrapper[A] =
+    new ConsWrapper[A](stream)
+
+  /** An extractor that allows to pattern match streams with `#::`.
+   */
+  object #:: {
+    def unapply[A](xs: Stream[A]): Option[(A, Stream[A])] =
+      if (xs.isEmpty) None
+      else Some((xs.head, xs.tail))
+  }
+
+  /** An alternative way of building and matching Streams using Stream.cons(hd, tl).
+   */
+  object cons {
+
+    /** A stream consisting of a given first element and remaining elements
+     *  @param hd   The first element of the result stream
+     *  @param tl   The remaining elements of the result stream
+     */
+    def apply[A](hd: A, tl: => Stream[A]) = new Cons(hd, tl)
+
+    /** Maps a stream to its head and tail */
+    def unapply[A](xs: Stream[A]): Option[(A, Stream[A])] = #::.unapply(xs)
+  }
+
+  /** A lazy cons cell, from which streams are built. */
+  @SerialVersionUID(-602202424901551803L)
+  final class Cons[+A](hd: A, tl: => Stream[A]) extends Stream[A] {
+    override def isEmpty = false
+    override def head = hd
+    @volatile private[this] var tlVal: Stream[A] = _
+    @volatile private[this] var tlGen = tl _
+    def tailDefined: Boolean = tlGen eq null
+    override def tail: Stream[A] = {
+      if (!tailDefined)
+        synchronized {
+          if (!tailDefined) {
+            tlVal = tlGen()
+            tlGen = null
+          }
+        }
+
+      tlVal
+    }
+
+    override /*LinearSeqOptimized*/
+    def sameElements[B >: A](that: GenIterable[B]): Boolean = {
+      @tailrec def consEq(a: Cons[_], b: Cons[_]): Boolean = {
+        if (a.head != b.head) false
+        else {
+          a.tail match {
+            case at: Cons[_] =>
+              b.tail match {
+                case bt: Cons[_] => (at eq bt) || consEq(at, bt)
+                case _ => false
+              }
+            case _ => b.tail.isEmpty
+          }
+        }
+      }
+      that match {
+        case that: Cons[_] => consEq(this, that)
+        case _ =>             super.sameElements(that)
+      }
+    }
+  }
+
+  /** An infinite stream that repeatedly applies a given function to a start value.
+   *
+   *  @param start the start value of the stream
+   *  @param f     the function that's repeatedly applied
+   *  @return      the stream returning the infinite sequence of values `start, f(start), f(f(start)), ...`
+   */
+  def iterate[A](start: A)(f: A => A): Stream[A] = cons(start, iterate(f(start))(f))
+
+  override def iterate[A](start: A, len: Int)(f: A => A): Stream[A] =
+    iterate(start)(f) take len
+
+  /**
+   * Create an infinite stream starting at `start` and incrementing by
+   * step `step`.
+   *
+   * @param start the start value of the stream
+   * @param step the increment value of the stream
+   * @return the stream starting at value `start`.
+   */
+  def from(start: Int, step: Int): Stream[Int] =
+    cons(start, from(start+step, step))
+
+  /**
+   * Create an infinite stream starting at `start` and incrementing by `1`.
+   *
+   * @param start the start value of the stream
+   * @return the stream starting at value `start`.
+   */
+  def from(start: Int): Stream[Int] = from(start, 1)
+
+  /**
+   * Create an infinite stream containing the given element expression (which
+   * is computed for each occurrence).
+   *
+   * @param elem the element composing the resulting stream
+   * @return the stream containing an infinite number of elem
+   */
+  def continually[A](elem: => A): Stream[A] = cons(elem, continually(elem))
+
+  override def fill[A](n: Int)(elem: => A): Stream[A] =
+    if (n <= 0) Empty else cons(elem, fill(n-1)(elem))
+
+  override def tabulate[A](n: Int)(f: Int => A): Stream[A] = {
+    def loop(i: Int): Stream[A] =
+      if (i >= n) Empty else cons(f(i), loop(i+1))
+    loop(0)
+  }
+
+  override def range[T: Integral](start: T, end: T, step: T): Stream[T] = {
+    val num = implicitly[Integral[T]]
+    import num._
+
+    if (if (step < zero) start <= end else end <= start) Empty
+    else cons(start, range(start + step, end, step))
+  }
+
+  private[immutable] def filteredTail[A](stream: Stream[A], p: A => Boolean, isFlipped: Boolean) = {
+    cons(stream.head, stream.tail.filterImpl(p, isFlipped))
+  }
+
+  private[immutable] def collectedTail[A, B, That](head: B, stream: Stream[A], pf: PartialFunction[A, B], bf: CanBuildFrom[Stream[A], B, That]) = {
+    cons(head, stream.tail.collect(pf)(bf).asInstanceOf[Stream[B]])
+  }
+
+  /** An implementation of `FilterMonadic` allowing GC of the filtered-out elements of
+    * the `Stream` as it is processed.
+    *
+    * Because this is not an inner class of `Stream` with a reference to the original
+    * head, it is now possible for GC to collect any leading and filtered-out elements
+    * which do not satisfy the filter, while the tail is still processing (see scala/bug#8990).
+    */
+  private[immutable] final class StreamWithFilter[A](sl: => Stream[A], p: A => Boolean) extends FilterMonadic[A, Stream[A]] {
+    private var s = sl                                              // set to null to allow GC after filtered
+    private lazy val filtered = { val f = s filter p; s = null; f } // don't set to null if throw during filter
+
+    def map[B, That](f: A => B)(implicit bf: CanBuildFrom[Stream[A], B, That]): That =
+      filtered map f
+
+    def flatMap[B, That](f: A => scala.collection.GenTraversableOnce[B])(implicit bf: CanBuildFrom[Stream[A], B, That]): That =
+      filtered flatMap f
+
+    def foreach[U](f: A => U): Unit =
+      filtered foreach f
+
+    def withFilter(q: A => Boolean): FilterMonadic[A, Stream[A]] =
+      new StreamWithFilter[A](filtered, q)
+  }
+
+}

--- a/scalalib/overrides-2.12/scala/collection/immutable/Traversable.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/Traversable.scala
@@ -1,0 +1,57 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package immutable
+
+import generic._
+import mutable.Builder
+
+/** A trait for traversable collections that are guaranteed immutable.
+ *  $traversableInfo
+ *  @define mutability immutable
+ *
+ *  @define usesMutableState
+ *
+ *    Note: Despite being an immutable collection, the implementation uses mutable state internally during
+ *    construction. These state changes are invisible in single-threaded code but can lead to race conditions
+ *    in some multi-threaded scenarios. The state of a new collection instance may not have been "published"
+ *    (in the sense of the Java Memory Model specification), so that an unsynchronized non-volatile read from
+ *    another thread may observe the object in an invalid state (see
+ *    [[https://github.com/scala/bug/issues/7838 scala/bug#7838]] for details). Note that such a read is not
+ *    guaranteed to ''ever'' see the written object at all, and should therefore not be used, regardless
+ *    of this issue. The easiest workaround is to exchange values between threads through a volatile var.
+ */
+trait Traversable[+A] extends scala.collection.Traversable[A]
+//                         with GenTraversable[A]
+                         with GenericTraversableTemplate[A, Traversable]
+                         with TraversableLike[A, Traversable[A]]
+                         with Immutable {
+  override def companion: GenericCompanion[Traversable] = Traversable
+  override def seq: Traversable[A] = this
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is a `List`.
+ *  @define coll immutable traversable collection
+ *  @define Coll `immutable.Traversable`
+ */
+object Traversable extends TraversableFactory[Traversable] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Traversable[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, Traversable[A]] = new mutable.ListBuffer
+}

--- a/scalalib/overrides-2.12/scala/collection/immutable/VM.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/VM.scala
@@ -1,0 +1,7 @@
+package scala.collection.immutable
+
+// Backport from scala.runtime moved into s.c.immutable and made package
+// private to avoid the need for MiMa whitelisting.
+/* private[immutable] */ object VM {
+  def releaseFence(): Unit = ()
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/ArrayBuffer.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/ArrayBuffer.scala
@@ -1,0 +1,202 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+import parallel.mutable.ParArray
+
+/** An implementation of the `Buffer` class using an array to
+ *  represent the assembled sequence internally. Append, update and random
+ *  access take constant time (amortized time). Prepends and removes are
+ *  linear in the buffer size.
+ *
+ *  @author  Matthias Zenger
+ *  @author  Martin Odersky
+ *  @since   1
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
+ *  section on `Array Buffers` for more information.
+
+ *
+ *  @tparam A    the type of this arraybuffer's elements.
+ *
+ *  @define Coll `mutable.ArrayBuffer`
+ *  @define coll array buffer
+ *  @define thatinfo the class of the returned collection. In the standard library configuration,
+ *    `That` is always `ArrayBuffer[B]` because an implicit of type `CanBuildFrom[ArrayBuffer, B, ArrayBuffer[B]]`
+ *    is defined in object `ArrayBuffer`.
+ *  @define bfinfo an implicit value of class `CanBuildFrom` which determines the
+ *    result class `That` from the current representation type `Repr`
+ *    and the new element type `B`. This is usually the `canBuildFrom` value
+ *    defined in object `ArrayBuffer`.
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+@SerialVersionUID(1529165946227428979L)
+class ArrayBuffer[A](override protected val initialSize: Int)
+  extends AbstractBuffer[A]
+     with Buffer[A]
+     with GenericTraversableTemplate[A, ArrayBuffer]
+     with BufferLike[A, ArrayBuffer[A]]
+     with IndexedSeqOptimized[A, ArrayBuffer[A]]
+     with Builder[A, ArrayBuffer[A]]
+     with ResizableArray[A]
+     with CustomParallelizable[A, ParArray[A]]
+     with Serializable {
+
+  override def companion: GenericCompanion[ArrayBuffer] = ArrayBuffer
+
+  import scala.collection.Traversable
+
+  def this() = this(16)
+
+  def clear() { reduceToSize(0) }
+
+  override def sizeHint(len: Int) {
+    if (len > size && len >= 1) {
+      val newarray = new Array[AnyRef](len)
+      java.lang.System.arraycopy(array, 0, newarray, 0, size0)
+      array = newarray
+    }
+  }
+
+  override def par = ParArray.handoff[A](array.asInstanceOf[Array[A]], size)
+
+  /** Appends a single element to this buffer and returns
+   *  the identity of the buffer. It takes constant amortized time.
+   *
+   *  @param elem  the element to append.
+   *  @return      the updated buffer.
+   */
+  def +=(elem: A): this.type = {
+    ensureSize(size0 + 1)
+    array(size0) = elem.asInstanceOf[AnyRef]
+    size0 += 1
+    this
+  }
+
+  /** Appends a number of elements provided by a traversable object.
+   *  The identity of the buffer is returned.
+   *
+   *  @param xs    the traversable object.
+   *  @return      the updated buffer.
+   */
+  override def ++=(xs: TraversableOnce[A]): this.type = xs match {
+    case v: scala.collection.IndexedSeqLike[_, _] =>
+      val n = v.length
+      ensureSize(size0 + n)
+      v.copyToArray(array.asInstanceOf[scala.Array[Any]], size0, n)
+      size0 += n
+      this
+    case _ =>
+      super.++=(xs)
+  }
+
+  /** Prepends a single element to this buffer and returns
+   *  the identity of the buffer. It takes time linear in
+   *  the buffer size.
+   *
+   *  @param elem  the element to prepend.
+   *  @return      the updated buffer.
+   */
+  def +=:(elem: A): this.type = {
+    ensureSize(size0 + 1)
+    copy(0, 1, size0)
+    array(0) = elem.asInstanceOf[AnyRef]
+    size0 += 1
+    this
+  }
+
+  /** Prepends a number of elements provided by a traversable object.
+   *  The identity of the buffer is returned.
+   *
+   *  @param xs    the traversable object.
+   *  @return      the updated buffer.
+   */
+  override def ++=:(xs: TraversableOnce[A]): this.type = { insertAll(0, xs.toTraversable); this }
+
+  /** Inserts new elements at the index `n`. Opposed to method
+   *  `update`, this method will not replace an element with a new
+   *  one. Instead, it will insert a new element at index `n`.
+   *
+   *  @param n     the index where a new element will be inserted.
+   *  @param seq   the traversable object providing all elements to insert.
+   *  @throws IndexOutOfBoundsException if `n` is out of bounds.
+   */
+  def insertAll(n: Int, seq: Traversable[A]) {
+    if (n < 0 || n > size0) throw new IndexOutOfBoundsException(n.toString)
+    val len = seq.size
+    val newSize = size0 + len
+    ensureSize(newSize)
+
+    copy(n, n + len, size0 - n)
+    seq.copyToArray(array.asInstanceOf[Array[Any]], n)
+    size0 = newSize
+  }
+
+  /** Removes the element on a given index position. It takes time linear in
+   *  the buffer size.
+   *
+   *  @param n       the index which refers to the first element to remove.
+   *  @param count   the number of elements to remove.
+   *  @throws   IndexOutOfBoundsException if the index `n` is not in the valid range
+   *            `0 <= n <= length - count` (with `count > 0`).
+   *  @throws   IllegalArgumentException if `count < 0`.
+   */
+  override def remove(n: Int, count: Int) {
+    if (count < 0) throw new IllegalArgumentException("removing negative number of elements: " + count.toString)
+    else if (count == 0) return  // Did nothing
+    if (n < 0 || n > size0 - count) throw new IndexOutOfBoundsException("at " + n.toString + " deleting " + count.toString)
+    copy(n + count, n, size0 - (n + count))
+    reduceToSize(size0 - count)
+  }
+
+  /** Removes the element at a given index position.
+   *
+   *  @param n  the index which refers to the element to delete.
+   *  @return   the element that was formerly at position `n`.
+   */
+  def remove(n: Int): A = {
+    val result = apply(n)
+    remove(n, 1)
+    result
+  }
+
+  def result: ArrayBuffer[A] = this
+
+  /** Defines the prefix of the string representation.
+   */
+  override def stringPrefix: String = "ArrayBuffer"
+
+}
+
+/** Factory object for the `ArrayBuffer` class.
+ *
+ *  $factoryInfo
+ *  @define coll array buffer
+ *  @define Coll `ArrayBuffer`
+ */
+object ArrayBuffer extends SeqFactory[ArrayBuffer] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  /** $genericCanBuildFromInfo */
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, ArrayBuffer[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new ArrayBuffer[A]
+}
+

--- a/scalalib/overrides-2.12/scala/collection/mutable/ArraySeq.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/ArraySeq.scala
@@ -1,0 +1,121 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+import parallel.mutable.ParArray
+
+/** A class for polymorphic arrays of elements that's represented
+ *  internally by an array of objects. This means that elements of
+ *  primitive types are boxed.
+ *
+ *  @author Martin Odersky
+ *  @since   2.8
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-sequences "Scala's Collection Library overview"]]
+ *  section on `Array Sequences` for more information.
+ *
+ *  @tparam A      type of the elements contained in this array sequence.
+ *  @param length  the length of the underlying array.
+ *
+ *  @define Coll `ArraySeq`
+ *  @define coll array sequence
+ *  @define thatinfo the class of the returned collection. In the standard library configuration,
+ *    `That` is always `ArraySeq[B]` because an implicit of type `CanBuildFrom[ArraySeq, B, ArraySeq[B]]`
+ *    is defined in object `ArraySeq`.
+ *  @define bfinfo an implicit value of class `CanBuildFrom` which determines the
+ *    result class `That` from the current representation type `Repr`
+ *    and the new element type `B`. This is usually the `canBuildFrom` value
+ *    defined in object `ArraySeq`.
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+@SerialVersionUID(1530165946227428979L)
+class ArraySeq[A](override val length: Int)
+extends AbstractSeq[A]
+   with IndexedSeq[A]
+   with GenericTraversableTemplate[A, ArraySeq]
+   with IndexedSeqOptimized[A, ArraySeq[A]]
+   with CustomParallelizable[A, ParArray[A]]
+   with Serializable
+{
+
+  override def companion: GenericCompanion[ArraySeq] = ArraySeq
+
+  val array: Array[AnyRef] = new Array[AnyRef](length)
+
+  override def par = ParArray.handoff(array.asInstanceOf[Array[A]], length)
+
+  def apply(idx: Int): A = {
+    if (idx >= length) throw new IndexOutOfBoundsException(idx.toString)
+    array(idx).asInstanceOf[A]
+  }
+
+  def update(idx: Int, elem: A) {
+    if (idx >= length) throw new IndexOutOfBoundsException(idx.toString)
+    array(idx) = elem.asInstanceOf[AnyRef]
+  }
+
+  override def foreach[U](f: A => U) {
+    var i = 0
+    while (i < length) {
+      f(array(i).asInstanceOf[A])
+      i += 1
+    }
+  }
+
+  /** Fills the given array `xs` with at most `len` elements of
+   *  this traversable starting at position `start`.
+   *  Copying will stop once either the end of the current traversable is reached or
+   *  `len` elements have been copied or the end of the array is reached.
+   *
+   *  @param  xs the array to fill.
+   *  @param  start starting index.
+   *  @param  len number of elements to copy
+   */
+  override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int) {
+    val len1 = len min (xs.length - start) min length
+    if (len1 > 0) Array.copy(array, 0, xs, start, len1)
+  }
+
+  override def clone(): ArraySeq[A] = {
+    val cloned = array.clone().asInstanceOf[Array[AnyRef]]
+    new ArraySeq[A](length) {
+      override val array = cloned
+    }
+  }
+
+}
+
+/** $factoryInfo
+ *  @define coll array sequence
+ *  @define Coll `ArraySeq`
+ */
+object ArraySeq extends SeqFactory[ArraySeq] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  /** $genericCanBuildFromInfo */
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, ArraySeq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, ArraySeq[A]] =
+    new ArrayBuffer[A] mapResult { buf =>
+      val result = new ArraySeq[A](buf.length)
+      buf.copyToArray(result.array.asInstanceOf[Array[Any]], 0)
+      result
+    }
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/ArrayStack.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/ArrayStack.scala
@@ -1,0 +1,256 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+import scala.reflect.ClassTag
+
+/** Factory object for the `ArrayStack` class.
+ *
+ *  $factoryInfo
+ *  @define coll array stack
+ *  @define Coll `ArrayStack`
+ */
+object ArrayStack extends SeqFactory[ArrayStack] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, ArrayStack[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, ArrayStack[A]] = new ArrayStack[A]
+
+  @inline def empty: ArrayStack[Nothing] = new ArrayStack()
+  def apply[A: ClassTag](elems: A*): ArrayStack[A] = {
+    val els: Array[AnyRef] = elems.reverseMap(_.asInstanceOf[AnyRef])(breakOut)
+    if (els.length == 0) new ArrayStack()
+    else new ArrayStack[A](els, els.length)
+  }
+
+  private[mutable] def growArray(x: Array[AnyRef]) = {
+    val y = new Array[AnyRef](math.max(x.length * 2, 1))
+    Array.copy(x, 0, y, 0, x.length)
+    y
+  }
+
+  private[mutable] def clone(x: Array[AnyRef]) = {
+    val y = new Array[AnyRef](x.length)
+    Array.copy(x, 0, y, 0, x.length)
+    y
+  }
+}
+
+
+/** Simple stack class backed by an array. Should be significantly faster
+ *  than the standard mutable stack.
+ *
+ *  @author David MacIver
+ *  @since  2.7
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-stacks "Scala's Collection Library overview"]]
+ *  section on `Array Stacks` for more information.
+ *
+ *  @tparam T    type of the elements contained in this array stack.
+ *
+ *  @define Coll `ArrayStack`
+ *  @define coll array stack
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+@SerialVersionUID(8565219180626620510L)
+class ArrayStack[T] private(private var table : Array[AnyRef],
+                            private var index : Int)
+extends AbstractSeq[T]
+   with IndexedSeq[T]
+   with IndexedSeqLike[T, ArrayStack[T]]
+   with GenericTraversableTemplate[T, ArrayStack]
+   with IndexedSeqOptimized[T, ArrayStack[T]]
+   with Cloneable[ArrayStack[T]]
+   with Builder[T, ArrayStack[T]]
+   with Serializable
+{
+  def this() = this(new Array[AnyRef](1), 0)
+
+  /** Retrieve n'th element from stack, where top of stack has index 0.
+   *
+   *  This is a constant time operation.
+   *
+   *  @param n     the index of the element to return
+   *  @return      the element at the specified index
+   *  @throws IndexOutOfBoundsException if the index is out of bounds
+   */
+  def apply(n: Int): T =
+    table(index - 1 - n).asInstanceOf[T]
+
+  /** The number of elements in the stack */
+  def length = index
+
+  override def companion = ArrayStack
+
+  /** Replace element at index `n` with the new element `newelem`.
+   *
+   *  This is a constant time operation.
+   *
+   *  @param n       the index of the element to replace.
+   *  @param newelem the new element.
+   *  @throws   IndexOutOfBoundsException if the index is not valid
+   */
+  def update(n: Int, newelem: T) =
+    table(index - 1 - n) = newelem.asInstanceOf[AnyRef]
+
+  /** Push an element onto the stack.
+   *
+   *  @param x The element to push
+   */
+  def push(x: T) {
+    if (index == table.length) table = ArrayStack.growArray(table)
+    table(index) = x.asInstanceOf[AnyRef]
+    index += 1
+  }
+
+  /** Pop the top element off the stack.
+   *
+   *  @return the element on top of the stack
+   */
+  def pop(): T = {
+    if (index == 0) sys.error("Stack empty")
+    index -= 1
+    val x = table(index).asInstanceOf[T]
+    table(index) = null
+    x
+  }
+
+  /** View the top element of the stack.
+   *
+   *  Does not remove the element on the top. If the stack is empty,
+   *  an exception is thrown.
+   *
+   *  @return the element on top of the stack.
+   */
+  def top: T = table(index - 1).asInstanceOf[T]
+
+  /** Duplicate the top element of the stack.
+   *
+   *  After calling this method, the stack will have an additional element at
+   *  the top equal to the element that was previously at the top.
+   *  If the stack is empty, an exception is thrown.
+   */
+  def dup() = push(top)
+
+  /** Empties the stack. */
+  def clear() {
+    index = 0
+    table = new Array(1)
+  }
+
+  /** Empties the stack, passing all elements on it in LIFO order to the
+   *  provided function.
+   *
+   *  @param f The function to drain to.
+   */
+  def drain(f: T => Unit) = while (!isEmpty) f(pop())
+
+  /** Pushes all the provided elements in the traversable object onto the stack.
+   *
+   *  @param xs The source of elements to push.
+   *  @return   A reference to this stack.
+   */
+  override def ++=(xs: TraversableOnce[T]): this.type = { xs foreach += ; this }
+
+  /** Does the same as `push`, but returns the updated stack.
+   *
+   *  @param x  The element to push.
+   *  @return   A reference to this stack.
+   */
+  def +=(x: T): this.type = { push(x); this }
+
+  def result = {
+    reverseTable()
+    this
+  }
+
+  private def reverseTable() {
+    var i = 0
+    val until = index / 2
+    while (i < until) {
+      val revi = index - i - 1
+      val tmp = table(i)
+      table(i) = table(revi)
+      table(revi) = tmp
+      i += 1
+    }
+  }
+
+  /** Pop the top two elements off the stack, apply `f` to them and push the result
+   *  back on to the stack.
+   *
+   *  This function will throw an exception if stack contains fewer than 2 elements.
+   *
+   *  @param f   The function to apply to the top two elements.
+   */
+  def combine(f: (T, T) => T): Unit = push(f(pop(), pop()))
+
+  /** Repeatedly combine the top elements of the stack until the stack contains only
+   *  one element.
+   *
+   *  @param f   The function to apply repeatedly to topmost elements.
+   */
+  def reduceWith(f: (T, T) => T): Unit = while(size > 1) combine(f)
+
+  override def size = index
+
+  /** Evaluates the expression, preserving the contents of the stack so that
+   *  any changes the evaluation makes to the stack contents will be undone after
+   *  it completes.
+   *
+   *  @param action The action to run.
+   */
+  def preserving[T](action: => T) = {
+    val oldIndex = index
+    val oldTable = ArrayStack.clone(table)
+
+    try {
+      action
+    } finally {
+      index = oldIndex
+      table = oldTable
+    }
+  }
+
+  override def isEmpty: Boolean = index == 0
+
+  /** Creates and iterator over the stack in LIFO order.
+   *  @return an iterator over the elements of the stack.
+   */
+  override def iterator: Iterator[T] = new AbstractIterator[T] {
+    var currentIndex = index
+    def hasNext = currentIndex > 0
+    def next() = {
+      currentIndex -= 1
+      table(currentIndex).asInstanceOf[T]
+    }
+  }
+
+  override def foreach[U](f: T => U) {
+    var currentIndex = index
+    while (currentIndex > 0) {
+      currentIndex -= 1
+      f(table(currentIndex).asInstanceOf[T])
+    }
+  }
+
+  override def clone() = new ArrayStack[T](ArrayStack.clone(table), index)
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/Buffer.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/Buffer.scala
@@ -1,0 +1,55 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+
+/** Buffers are used to create sequences of elements incrementally by
+ *  appending, prepending, or inserting new elements. It is also
+ *  possible to access and modify elements in a random access fashion
+ *  via the index of the element in the current sequence.
+ *
+ *  @author Matthias Zenger
+ *  @author Martin Odersky
+ *  @since   1
+ *
+ *  @tparam A    type of the elements contained in this buffer.
+ *
+ *  @define Coll `Buffer`
+ *  @define coll buffer
+ */
+trait Buffer[A] extends Seq[A]
+                   with GenericTraversableTemplate[A, Buffer]
+                   with BufferLike[A, Buffer[A]]
+                   with scala.Cloneable {
+  override def companion: GenericCompanion[Buffer] = Buffer
+}
+
+/** $factoryInfo
+ *  @define coll buffer
+ *  @define Coll `Buffer`
+ */
+object Buffer extends SeqFactory[Buffer] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Buffer[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, Buffer[A]] = new ArrayBuffer
+}
+
+/** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses. */
+abstract class AbstractBuffer[A] extends AbstractSeq[A] with Buffer[A]

--- a/scalalib/overrides-2.12/scala/collection/mutable/DoubleLinkedList.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/DoubleLinkedList.scala
@@ -1,0 +1,104 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+
+/** This class implements double linked lists where both the head (`elem`),
+ *  the tail (`next`) and a reference to the previous node (`prev`) are mutable.
+ *
+ *  @author Matthias Zenger
+ *  @author Martin Odersky
+ *  @since   1
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#double-linked-lists "Scala's Collection Library overview"]]
+ *  section on `Double Linked Lists` for more information.
+
+ *
+ *  @tparam A     the type of the elements contained in this double linked list.
+ *
+ *  @define Coll `DoubleLinkedList`
+ *  @define coll double linked list
+ *  @define thatinfo the class of the returned collection. In the standard library configuration,
+ *    `That` is always `DoubleLinkedList[B]` because an implicit of type `CanBuildFrom[DoubleLinkedList, B, DoubleLinkedList[B]]`
+ *    is defined in object `DoubleLinkedList`.
+ *  @define bfinfo an implicit value of class `CanBuildFrom` which determines the
+ *    result class `That` from the current representation type `Repr`
+ *    and the new element type `B`. This is usually the `canBuildFrom` value
+ *    defined in object `DoubleLinkedList`.
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+@deprecated("low-level linked lists are deprecated due to idiosyncrasies in interface and incomplete features", "2.11.0")
+@SerialVersionUID(-8144992287952814767L)
+class DoubleLinkedList[A]() extends AbstractSeq[A]
+                            with LinearSeq[A]
+                            with GenericTraversableTemplate[A, DoubleLinkedList]
+                            with DoubleLinkedListLike[A, DoubleLinkedList[A]]
+                            with Serializable {
+  next = this
+
+  /** Creates a node for the double linked list.
+   *
+   *  @param elem    the element this node contains.
+   *  @param next    the next node in the double linked list.
+   */
+  def this(elem: A, next: DoubleLinkedList[A]) {
+    this()
+    if (next != null) {
+      this.elem = elem
+      this.next = next
+      this.next.prev = this
+    }
+  }
+
+  override def companion: GenericCompanion[DoubleLinkedList] = DoubleLinkedList
+
+  // Accurately clone this collection.  See scala/bug#6296
+  override def clone(): DoubleLinkedList[A] = {
+    val builder = newBuilder
+    builder ++= this
+    builder.result()
+  }
+}
+
+/** $factoryInfo
+ *  @define coll double linked list
+ *  @define Coll `DoubleLinkedList`
+ */
+@deprecated("low-level linked lists are deprecated", "2.11.0")
+object DoubleLinkedList extends SeqFactory[DoubleLinkedList] {
+  /** $genericCanBuildFromInfo */
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, DoubleLinkedList[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+
+  @inline def newBuilder[A]: Builder[A, DoubleLinkedList[A]] =
+    new Builder[A, DoubleLinkedList[A]] {
+      def emptyList() = new DoubleLinkedList[A]()
+      var current = emptyList()
+
+      def +=(elem: A): this.type = {
+        if (current.isEmpty)
+          current = new DoubleLinkedList(elem, emptyList())
+        else
+          current append new DoubleLinkedList(elem, emptyList())
+
+        this
+      }
+
+      def clear(): Unit = current = emptyList()
+      def result() = current
+    }
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/IndexedSeq.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/IndexedSeq.scala
@@ -1,0 +1,45 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+
+/** A subtrait of `collection.IndexedSeq` which represents sequences
+ *  that can be mutated.
+ *
+ *  $indexedSeqInfo
+ */
+trait IndexedSeq[A] extends Seq[A]
+                   with scala.collection.IndexedSeq[A]
+                   with GenericTraversableTemplate[A, IndexedSeq]
+                   with IndexedSeqLike[A, IndexedSeq[A]] {
+  override def companion: GenericCompanion[IndexedSeq]  = IndexedSeq
+  override def seq: IndexedSeq[A] = this
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is an `ArrayBuffer`.
+ *  @define coll mutable indexed sequence
+ *  @define Coll `mutable.IndexedSeq`
+ */
+object IndexedSeq extends SeqFactory[IndexedSeq] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, IndexedSeq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, IndexedSeq[A]] = new ArrayBuffer[A]
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/Iterable.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/Iterable.scala
@@ -1,0 +1,51 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+import parallel.mutable.ParIterable
+
+/** A base trait for iterable collections that can be mutated.
+ *  $iterableInfo
+ */
+trait Iterable[A] extends Traversable[A]
+//                     with GenIterable[A]
+                     with scala.collection.Iterable[A]
+                     with GenericTraversableTemplate[A, Iterable]
+                     with IterableLike[A, Iterable[A]]
+                     with Parallelizable[A, ParIterable[A]]
+{
+  override def companion: GenericCompanion[Iterable] = Iterable
+  protected[this] override def parCombiner = ParIterable.newCombiner[A] // if `mutable.IterableLike` gets introduced, please move this there!
+  override def seq: Iterable[A] = this
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is an `ArrayBuffer`.
+ *  @define coll mutable iterable collection
+ *  @define Coll `mutable.Iterable`
+ */
+object Iterable extends TraversableFactory[Iterable] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Iterable[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, Iterable[A]] = new ArrayBuffer
+}
+
+/** Explicit instantiation of the `Iterable` trait to reduce class file size in subclasses. */
+abstract class AbstractIterable[A] extends scala.collection.AbstractIterable[A] with Iterable[A]

--- a/scalalib/overrides-2.12/scala/collection/mutable/LinearSeq.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/LinearSeq.scala
@@ -1,0 +1,49 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+
+/** A subtrait of `collection.LinearSeq` which represents sequences
+ *  that can be mutated.
+ *  $linearSeqInfo
+ *
+ *  @define Coll `LinearSeq`
+ *  @define coll linear sequence
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable-lists "Scala's Collection Library overview"]]
+ *  section on `Mutable Lists` for more information.
+ */
+trait LinearSeq[A] extends Seq[A]
+                           with scala.collection.LinearSeq[A]
+                           with GenericTraversableTemplate[A, LinearSeq]
+                           with LinearSeqLike[A, LinearSeq[A]] {
+  override def companion: GenericCompanion[LinearSeq] = LinearSeq
+  override def seq: LinearSeq[A] = this
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is a `MutableList`.
+ *  @define coll mutable linear sequence
+ *  @define Coll `mutable.LinearSeq`
+ */
+object LinearSeq extends SeqFactory[LinearSeq] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, LinearSeq[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, LinearSeq[A]] = new MutableList[A]
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/LinkedList.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/LinkedList.scala
@@ -1,0 +1,132 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+
+/** A more traditional/primitive style of linked list where the "list" is also the "head" link. Links can be manually
+  * created and manipulated, though the use of the API, when possible, is recommended.
+  *
+  * The danger of directly manipulating next:
+  * {{{
+  *     scala> val b = LinkedList(1)
+  *     b: scala.collection.mutable.LinkedList[Int] = LinkedList(1)
+  *
+  *     scala> b.next = null
+  *
+  *     scala> println(b)
+  *     java.lang.NullPointerException
+  * }}}
+  *
+  *  $singleLinkedListExample
+  *
+  *  @author Matthias Zenger
+  *  @author Martin Odersky
+  *  @since   1
+  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#linked-lists "Scala's Collection Library overview"]]
+  *  section on `Linked Lists` for more information.
+  *
+  *  @tparam A     the type of the elements contained in this linked list.
+  *
+  *  @constructor Creates an "empty" list, defined as a single node with no data element and next pointing to itself.
+
+  *  @define Coll `LinkedList`
+  *  @define coll linked list
+  *  @define thatinfo the class of the returned collection. In the standard library configuration,
+  *    `That` is always `LinkedList[B]` because an implicit of type `CanBuildFrom[LinkedList, B, LinkedList[B]]`
+  *    is defined in object `LinkedList`.
+  *  @define bfinfo an implicit value of class `CanBuildFrom` which determines the
+  *    result class `That` from the current representation type `Repr`
+  *    and the new element type `B`. This is usually the `canBuildFrom` value
+  *    defined in object `LinkedList`.
+  *  @define orderDependent
+  *  @define orderDependentFold
+  *  @define mayNotTerminateInf
+  *  @define willNotTerminateInf
+  *  @define collectExample Example:
+  *  {{{
+  *    scala>     val a = LinkedList(1, 2, 3)
+  *    a: scala.collection.mutable.LinkedList[Int] = LinkedList(1, 2, 3)
+  *
+  *    scala>     val addOne: PartialFunction[Any, Float] = {case i: Int => i + 1.0f}
+  *    addOne: PartialFunction[Any,Float] = <function1>
+  *
+  *    scala>     val b = a.collect(addOne)
+  *    b: scala.collection.mutable.LinkedList[Float] = LinkedList(2.0, 3.0, 4.0)
+  *
+  *    scala> val c = LinkedList('a')
+  *    c: scala.collection.mutable.LinkedList[Char] = LinkedList(a)
+  *
+  *    scala> val d = a ++ c
+  *    d: scala.collection.mutable.LinkedList[AnyVal] = LinkedList(1, 2, 3, a)
+  *
+  *    scala> val e = d.collect(addOne)
+  *    e: scala.collection.mutable.LinkedList[Float] = LinkedList(2.0, 3.0, 4.0)
+  *  }}}
+  */
+@SerialVersionUID(-7308240733518833071L)
+@deprecated("low-level linked lists are deprecated due to idiosyncrasies in interface and incomplete features", "2.11.0")
+class LinkedList[A]() extends AbstractSeq[A]
+                         with LinearSeq[A]
+                         with GenericTraversableTemplate[A, LinkedList]
+                         with LinkedListLike[A, LinkedList[A]]
+                         with Serializable {
+  next = this
+
+  /** Creates a new list. If the parameter next is null, the result is an empty list. Otherwise, the result is
+   * a list with elem at the head, followed by the contents of next.
+   *
+   * Note that next is part of the new list, as opposed to the +: operator,
+   * which makes a new copy of the original list.
+   *
+   * @example
+   * {{{
+   *     scala> val m = LinkedList(1)
+   *     m: scala.collection.mutable.LinkedList[Int] = LinkedList(1)
+   *
+   *     scala> val n = new LinkedList[Int](2, m)
+   *     n: scala.collection.mutable.LinkedList[Int] = LinkedList(2, 1)
+   * }}}
+   */
+  def this(elem: A, next: LinkedList[A]) {
+    this()
+    if (next != null) {
+      this.elem = elem
+      this.next = next
+    }
+  }
+
+  override def companion: GenericCompanion[LinkedList] = LinkedList
+}
+
+/** $factoryInfo
+ *  @define Coll `LinkedList`
+ *  @define coll linked list
+ */
+@deprecated("low-level linked lists are deprecated", "2.11.0")
+object LinkedList extends SeqFactory[LinkedList] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline override def empty[A]: LinkedList[A] =
+    new LinkedList[A]
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, LinkedList[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+
+  @inline def newBuilder[A]: Builder[A, LinkedList[A]] =
+    (new MutableList) mapResult ((l: MutableList[A]) => l.toLinkedList)
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/ListBuffer.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/ListBuffer.scala
@@ -1,0 +1,491 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+import immutable.{List, Nil, ::}
+import java.io.{ObjectOutputStream, ObjectInputStream}
+
+/** A `Buffer` implementation backed by a list. It provides constant time
+ *  prepend and append. Most other operations are linear.
+ *
+ *  @author  Matthias Zenger
+ *  @author  Martin Odersky
+ *  @since   1
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#list-buffers "Scala's Collection Library overview"]]
+ *  section on `List Buffers` for more information.
+ *
+ *  @tparam A    the type of this list buffer's elements.
+ *
+ *  @define Coll `ListBuffer`
+ *  @define coll list buffer
+ *  @define thatinfo the class of the returned collection. In the standard library configuration,
+ *    `That` is always `ListBuffer[B]` because an implicit of type `CanBuildFrom[ListBuffer, B, ListBuffer[B]]`
+ *    is defined in object `ListBuffer`.
+ *  @define bfinfo an implicit value of class `CanBuildFrom` which determines the
+ *    result class `That` from the current representation type `Repr`
+ *    and the new element type `B`. This is usually the `canBuildFrom` value
+ *    defined in object `ListBuffer`.
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+@SerialVersionUID(3419063961353022662L)
+final class ListBuffer[A]
+      extends AbstractBuffer[A]
+         with Buffer[A]
+         with GenericTraversableTemplate[A, ListBuffer]
+         with BufferLike[A, ListBuffer[A]]
+         with ReusableBuilder[A, List[A]]
+         with SeqForwarder[A]
+         with Serializable
+{
+  override def companion: GenericCompanion[ListBuffer] = ListBuffer
+
+  import scala.collection.Traversable
+  import scala.collection.immutable.ListSerializeEnd
+
+  /** Expected invariants:
+   *  If start.isEmpty, last0 == null
+   *  If start.nonEmpty, last0 != null
+   *  If len == 0, start.isEmpty
+   *  If len > 0, start.nonEmpty
+   */
+  private var start: List[A] = Nil
+  private var last0: ::[A] = _
+  private[this] var exported: Boolean = false
+  private[this] var len = 0
+
+  protected def underlying: List[A] = start
+
+  private def writeObject(out: ObjectOutputStream) {
+    // write start
+    var xs: List[A] = start
+    while (!xs.isEmpty) { out.writeObject(xs.head); xs = xs.tail }
+    out.writeObject(ListSerializeEnd)
+
+    // no need to write last0
+
+    // write if exported
+    out.writeBoolean(exported)
+
+    // write the length
+    out.writeInt(len)
+  }
+
+  private def readObject(in: ObjectInputStream) {
+    // read start, set last0 appropriately
+    var elem: A = in.readObject.asInstanceOf[A]
+    if (elem == ListSerializeEnd) {
+      start = Nil
+      last0 = null
+    } else {
+      var current = new ::(elem, Nil)
+      start = current
+      elem = in.readObject.asInstanceOf[A]
+      while (elem != ListSerializeEnd) {
+        val list = new ::(elem, Nil)
+        current.tl = list
+        current = list
+        elem = in.readObject.asInstanceOf[A]
+      }
+      last0 = current
+      start
+    }
+
+    // read if exported
+    exported = in.readBoolean()
+
+    // read the length
+    len = in.readInt()
+  }
+
+  /** The current length of the buffer.
+   *
+   *  This operation takes constant time.
+   */
+  override def length = len
+
+  // Don't use the inherited size, which forwards to a List and is O(n).
+  override def size = length
+
+  // Override with efficient implementations using the extra size information available to ListBuffer.
+  override def isEmpty: Boolean = len == 0
+  override def nonEmpty: Boolean = len > 0
+
+  // Implementations of abstract methods in Buffer
+
+  override def apply(n: Int): A =
+    if (n < 0 || n >= len) throw new IndexOutOfBoundsException(n.toString())
+    else super.apply(n)
+
+  /** Replaces element at index `n` with the new element
+   *  `newelem`. Takes time linear in the buffer size. (except the
+   *  first element, which is updated in constant time).
+   *
+   *  @param n  the index of the element to replace.
+   *  @param x  the new element.
+   *  @throws IndexOutOfBoundsException if `n` is out of bounds.
+   */
+  def update(n: Int, x: A) {
+    // We check the bounds early, so that we don't trigger copying.
+    if (n < 0 || n >= len) throw new IndexOutOfBoundsException(n.toString)
+    ensureUnaliased()
+    if (n == 0) {
+      val newElem = new :: (x, start.tail)
+      if (last0 eq start) {
+        last0 = newElem
+      }
+      start = newElem
+    } else {
+      var cursor = start
+      var i = 1
+      while (i < n) {
+        cursor = cursor.tail
+        i += 1
+      }
+      val newElem = new :: (x, cursor.tail.tail)
+      if (last0 eq cursor.tail) {
+        last0 = newElem
+      }
+      cursor.asInstanceOf[::[A]].tl = newElem
+    }
+  }
+
+  /** Appends a single element to this buffer. This operation takes constant time.
+   *
+   *  @param x  the element to append.
+   *  @return   this $coll.
+   */
+  def += (x: A): this.type = {
+    ensureUnaliased()
+    val last1 = new ::[A](x, Nil)
+    if (len == 0) start = last1 else last0.tl = last1
+    last0 = last1
+    len += 1
+    this
+  }
+
+  override def ++=(xs: TraversableOnce[A]): this.type = xs match {
+    case x: AnyRef if x eq this      => this ++= (this take size)
+    case _                           => super.++=(xs)
+
+  }
+
+  override def ++=:(xs: TraversableOnce[A]): this.type =
+    if (xs.asInstanceOf[AnyRef] eq this) ++=: (this take size) else super.++=:(xs)
+
+  /** Clears the buffer contents.
+   */
+  def clear() {
+    start = Nil
+    last0 = null
+    exported = false
+    len = 0
+  }
+
+  /** Prepends a single element to this buffer. This operation takes constant
+   *  time.
+   *
+   *  @param x  the element to prepend.
+   *  @return   this $coll.
+   */
+  def +=: (x: A): this.type = {
+    ensureUnaliased()
+    val newElem = new :: (x, start)
+    if (isEmpty) last0 = newElem
+    start = newElem
+    len += 1
+    this
+  }
+
+  /** Inserts new elements at the index `n`. Opposed to method
+   *  `update`, this method will not replace an element with a new
+   *  one. Instead, it will insert a new element at index `n`.
+   *
+   *  @param  n     the index where a new element will be inserted.
+   *  @param  seq   the iterable object providing all elements to insert.
+   *  @throws IndexOutOfBoundsException if `n` is out of bounds.
+   */
+  def insertAll(n: Int, seq: Traversable[A]) {
+    // We check the bounds early, so that we don't trigger copying.
+    if (n < 0 || n > len) throw new IndexOutOfBoundsException(n.toString)
+    ensureUnaliased()
+    var elems = seq.toList.reverse
+    len += elems.length
+    if (n == 0) {
+      while (!elems.isEmpty) {
+        val newElem = new :: (elems.head, start)
+        if (start.isEmpty) last0 = newElem
+        start = newElem
+        elems = elems.tail
+      }
+    } else {
+      var cursor = start
+      var i = 1
+      while (i < n) {
+        cursor = cursor.tail
+        i += 1
+      }
+      while (!elems.isEmpty) {
+        val newElem = new :: (elems.head, cursor.tail)
+        if (cursor.tail.isEmpty) last0 = newElem
+        cursor.asInstanceOf[::[A]].tl = newElem
+        elems = elems.tail
+      }
+    }
+  }
+
+  /** Reduce the length of the buffer, and null out last0
+   *  if this reduces the length to 0.
+   */
+  private def reduceLengthBy(num: Int) {
+    len -= num
+    if (len <= 0)   // obviously shouldn't be < 0, but still better not to leak
+      last0 = null
+  }
+
+  /** Removes a given number of elements on a given index position. May take
+   *  time linear in the buffer size.
+   *
+   *  @param n         the index which refers to the first element to remove.
+   *  @param count     the number of elements to remove.
+   *  @throws   IndexOutOfBoundsException if the index `n` is not in the valid range
+   *            `0 <= n <= length - count` (with `count > 0`).
+   *  @throws   IllegalArgumentException if `count < 0`.
+   */
+  override def remove(n: Int, count: Int) {
+    if (count < 0) throw new IllegalArgumentException("removing negative number of elements: " + count.toString)
+    else if (count == 0) return  // Nothing to do
+    if (n < 0 || n > len - count) throw new IndexOutOfBoundsException("at " + n.toString + " deleting " + count.toString)
+    ensureUnaliased()
+    val n1 = n max 0
+    val count1 = count min (len - n1)
+    if (n1 == 0) {
+      var c = count1
+      while (c > 0) {
+        start = start.tail
+        c -= 1
+      }
+    } else {
+      var cursor = start
+      var i = 1
+      while (i < n1) {
+        cursor = cursor.tail
+        i += 1
+      }
+      var c = count1
+      while (c > 0) {
+        if (last0 eq cursor.tail) last0 = cursor.asInstanceOf[::[A]]
+        cursor.asInstanceOf[::[A]].tl = cursor.tail.tail
+        c -= 1
+      }
+    }
+    reduceLengthBy(count1)
+  }
+
+// Implementation of abstract method in Builder
+
+  /** Returns the accumulated `List`.
+   *
+   *  This method may be called multiple times to obtain snapshots of the list in different stages of construction.
+   */
+  def result: List[A] = toList
+
+  /** Converts this buffer to a list. Takes constant time. The buffer is
+   *  copied lazily the first time it is mutated.
+   */
+  override def toList: List[A] = {
+    exported = !isEmpty
+    start
+  }
+
+  // scala/bug#11869
+  override def toSeq: collection.Seq[A] = toList
+  override def toIterable: collection.Iterable[A] = toList
+  override def toStream: immutable.Stream[A] = toList.toStream // mind the laziness
+
+// New methods in ListBuffer
+
+  /** Prepends the elements of this buffer to a given list
+   *
+   *  @param xs   the list to which elements are prepended
+   */
+  def prependToList(xs: List[A]): List[A] = {
+    if (isEmpty) xs
+    else {
+      ensureUnaliased()
+      last0.tl = xs
+      toList
+    }
+  }
+
+// Overrides of methods in Buffer
+
+  /** Removes the element on a given index position. May take time linear in
+   *  the buffer size.
+   *
+   *  @param  n  the index which refers to the element to delete.
+   *  @return n  the element that was formerly at position `n`.
+   *  @note      an element must exists at position `n`.
+   *  @throws IndexOutOfBoundsException if `n` is out of bounds.
+   */
+  def remove(n: Int): A = {
+    if (n < 0 || n >= len) throw new IndexOutOfBoundsException(n.toString())
+    ensureUnaliased()
+    var old = start.head
+    if (n == 0) {
+      start = start.tail
+    } else {
+      var cursor = start
+      var i = 1
+      while (i < n) {
+        cursor = cursor.tail
+        i += 1
+      }
+      old = cursor.tail.head
+      if (last0 eq cursor.tail) last0 = cursor.asInstanceOf[::[A]]
+      cursor.asInstanceOf[::[A]].tl = cursor.tail.tail
+    }
+    reduceLengthBy(1)
+    old
+  }
+
+  /** Remove a single element from this buffer. May take time linear in the
+   *  buffer size.
+   *
+   *  @param elem  the element to remove.
+   *  @return      this $coll.
+   */
+  override def -= (elem: A): this.type = {
+    ensureUnaliased()
+    if (isEmpty) {}
+    else if (start.head == elem) {
+      start = start.tail
+      reduceLengthBy(1)
+    }
+    else {
+      var cursor = start
+      while (!cursor.tail.isEmpty && cursor.tail.head != elem) {
+        cursor = cursor.tail
+      }
+      if (!cursor.tail.isEmpty) {
+        val z = cursor.asInstanceOf[::[A]]
+        if (z.tl == last0)
+          last0 = z
+        z.tl = cursor.tail.tail
+        reduceLengthBy(1)
+      }
+    }
+    this
+  }
+
+  /** Selects the last element.
+   *
+   *  Runs in constant time.
+   *
+   *  @return the last element of this buffer.
+   *  @throws NoSuchElementException if this buffer is empty.
+   */
+  override def last: A =
+    if (last0 eq null) throw new NoSuchElementException("last of empty ListBuffer")
+    else last0.head
+
+  /** Optionally selects the last element.
+   *
+   *  Runs in constant time.
+   *
+   *  @return `Some` of the last element of this buffer if the buffer is nonempty, `None` if it is empty.
+   */
+  override def lastOption: Option[A] = if (last0 eq null) None else Some(last0.head)
+
+  /** Returns an iterator over this `ListBuffer`.  The iterator will reflect
+   *  changes made to the underlying `ListBuffer` beyond the next element;
+   *  the next element's value is cached so that `hasNext` and `next` are
+   *  guaranteed to be consistent.  In particular, an empty `ListBuffer`
+   *  will give an empty iterator even if the `ListBuffer` is later filled.
+   */
+  override def iterator: Iterator[A] = new AbstractIterator[A] {
+    // Have to be careful iterating over mutable structures.
+    // This used to have "(cursor ne last0)" as part of its hasNext
+    // condition, which means it can return true even when the iterator
+    // is exhausted.  Inconsistent results are acceptable when one mutates
+    // a structure while iterating, but we should never return hasNext == true
+    // on exhausted iterators (thus creating exceptions) merely because
+    // values were changed in-place.
+    var cursor: List[A] = if (ListBuffer.this.isEmpty) Nil else start
+
+    def hasNext: Boolean = cursor ne Nil
+    def next(): A =
+      if (!hasNext) throw new NoSuchElementException("next on empty Iterator")
+      else {
+        val ans = cursor.head
+        cursor = cursor.tail
+        ans
+      }
+  }
+
+  // Private methods
+  private def ensureUnaliased() = {
+    if (exported) copy()
+  }
+
+  /** Copy contents of this buffer */
+  private def copy() {
+    if (isEmpty) return
+    var cursor = start
+    val limit = last0.tail
+    clear()
+    while (cursor ne limit) {
+      this += cursor.head
+      cursor = cursor.tail
+    }
+  }
+
+  override def equals(that: Any): Boolean = that match {
+    case that: ListBuffer[_] => this.start equals that.start
+    case _                   => super.equals(that)
+  }
+
+  /** Returns a clone of this buffer.
+   *
+   *  @return a `ListBuffer` with the same elements.
+   */
+  override def clone(): ListBuffer[A] = (new ListBuffer[A]) ++= this
+
+  /** Defines the prefix of the string representation.
+   *
+   *  @return the string representation of this buffer.
+   */
+  override def stringPrefix: String = "ListBuffer"
+}
+
+/** $factoryInfo
+ *  @define Coll `ListBuffer`
+ *  @define coll list buffer
+ */
+object ListBuffer extends SeqFactory[ListBuffer] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, ListBuffer[A]] =
+    ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+
+  @inline def newBuilder[A]: Builder[A, ListBuffer[A]] =
+    new GrowingBuilder(new ListBuffer[A])
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/MutableList.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/MutableList.scala
@@ -1,0 +1,181 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+import immutable.List
+
+/**
+ *  This class is used internally to represent mutable lists. It is the
+ *  basis for the implementation of the class `Queue`.
+ *
+ *  @author  Matthias Zenger
+ *  @author  Martin Odersky
+ *  @since   1
+ *  @define Coll `mutable.MutableList`
+ *  @define coll mutable list
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable-lists "Scala's Collection Library overview"]]
+ *  section on `Mutable Lists` for more information.
+ */
+@SerialVersionUID(5938451523372603072L)
+class MutableList[A]
+extends AbstractSeq[A]
+   with LinearSeq[A]
+   with LinearSeqOptimized[A, MutableList[A]]
+   with GenericTraversableTemplate[A, MutableList]
+   with Builder[A, MutableList[A]]
+   with Serializable
+{
+  override def companion: GenericCompanion[MutableList] = MutableList
+
+  override protected[this] def newBuilder: Builder[A, MutableList[A]] = new MutableList[A]
+
+  protected var first0: LinkedList[A] = new LinkedList[A]
+  protected var last0: LinkedList[A] = first0
+  protected var len: Int = 0
+
+  def toQueue = new Queue(first0, last0, len)
+
+  /** Is the list empty?
+   */
+  override def isEmpty = len == 0
+
+  /** Returns the first element in this list
+   */
+  override def head: A = if (nonEmpty) first0.head else throw new NoSuchElementException
+
+  /** Returns the rest of this list
+   */
+  override def tail: MutableList[A] = {
+    val tl = new MutableList[A]
+    tailImpl(tl)
+    tl
+  }
+
+  protected final def tailImpl(tl: MutableList[A]) {
+    require(nonEmpty, "tail of empty list")
+    tl.first0 = first0.tail
+    tl.len = len - 1
+    tl.last0 = if (tl.len == 0) tl.first0 else last0
+  }
+
+  /** Prepends a single element to this list. This operation takes constant
+   *  time.
+   *  @param elem  the element to prepend.
+   *  @return   this $coll.
+   */
+  def +=: (elem: A): this.type = { prependElem(elem); this }
+
+  /** Returns the length of this list.
+   */
+  override def length: Int = len
+
+  /** Returns the `n`-th element of this list.
+   *  @throws IndexOutOfBoundsException if index does not exist.
+   */
+  override def apply(n: Int): A = first0.apply(n)
+
+  /** Updates the `n`-th element of this list to a new value.
+   *  @throws IndexOutOfBoundsException if index does not exist.
+   */
+  def update(n: Int, x: A): Unit = first0.update(n, x)
+
+  /** Returns the `n`-th element of this list or `None`
+   *  if index does not exist.
+   */
+  def get(n: Int): Option[A] = first0.get(n)
+
+  protected def prependElem(elem: A) {
+    first0 = new LinkedList[A](elem, first0)
+    if (len == 0) last0 = first0
+    len = len + 1
+  }
+
+  protected def appendElem(elem: A) {
+    if (len == 0) {
+      prependElem(elem)
+    } else {
+      last0.next = new LinkedList[A]
+      last0 = last0.next
+      last0.elem = elem
+      last0.next = new LinkedList[A] // for performance, use sentinel `object` instead?
+      len = len + 1
+    }
+  }
+
+  /** Returns an iterator over up to `length` elements of this list.
+   */
+  override def iterator: Iterator[A] = if (isEmpty) Iterator.empty else
+    new AbstractIterator[A] {
+      var elems   = first0
+      var count   = len
+      def hasNext = count > 0 && elems.nonEmpty
+      def next()  = {
+        if (!hasNext) throw new NoSuchElementException
+        count = count - 1
+        val e = elems.elem
+        elems = if (count == 0) null else elems.next
+        e
+      }
+    }
+
+  override def last = {
+    if (isEmpty) throw new NoSuchElementException("MutableList.empty.last")
+    last0.elem
+  }
+
+  /** Returns an instance of [[scala.List]] containing the same
+   *  sequence of elements.
+   */
+  override def toList: List[A] = first0.toList
+
+  /** Returns the current list of elements as a linked List
+   *  sequence of elements.
+   */
+  private[mutable] def toLinkedList: LinkedList[A] = first0
+
+  /** Appends a single element to this buffer. This takes constant time.
+   *
+   *  @param elem  the element to append.
+   */
+  def +=(elem: A): this.type = { appendElem(elem); this }
+
+  def clear() {
+    first0 = new LinkedList[A]
+    last0 = first0
+    len = 0
+  }
+
+  def result = this
+
+  override def clone(): MutableList[A]  = {
+    val bf = newBuilder
+    bf ++= seq
+    bf.result()
+  }
+}
+
+object MutableList extends SeqFactory[MutableList] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, MutableList[A]] =
+    ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+
+  @inline def newBuilder[A]: Builder[A, MutableList[A]] =
+    new MutableList[A]
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/Queue.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/Queue.scala
@@ -1,0 +1,203 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+
+/** `Queue` objects implement data structures that allow to
+ *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
+ *
+ *  @author  Matthias Zenger
+ *  @author  Martin Odersky
+ *  @since   1
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#queues "Scala's Collection Library overview"]]
+ *  section on `Queues` for more information.
+ *
+ *  @define Coll `mutable.Queue`
+ *  @define coll mutable queue
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+class Queue[A]
+extends MutableList[A]
+   with LinearSeqOptimized[A, Queue[A]]
+   with GenericTraversableTemplate[A, Queue]
+   with Cloneable[Queue[A]]
+   with Serializable
+{
+  override def companion: GenericCompanion[Queue] = Queue
+
+  override protected[this] def newBuilder = companion.newBuilder[A]
+
+  private[mutable] def this(fst: LinkedList[A], lst: LinkedList[A], lng: Int) {
+    this()
+    first0 = fst
+    last0 = lst
+    len = lng
+  }
+
+  /** Adds all elements to the queue.
+   *
+   *  @param  elems       the elements to add.
+   */
+  def enqueue(elems: A*): Unit = this ++= elems
+
+  /** Returns the first element in the queue, and removes this element
+   *  from the queue.
+   *
+   *  @throws java.util.NoSuchElementException
+   *  @return the first element of the queue.
+   */
+  def dequeue(): A =
+    if (isEmpty)
+      throw new NoSuchElementException("queue empty")
+    else {
+      val res = first0.elem
+      first0 = first0.next
+      decrementLength()
+      res
+    }
+
+  /** Returns the first element in the queue which satisfies the
+   *  given predicate, and removes this element from the queue.
+   *
+   *  @param p   the predicate used for choosing the first element
+   *  @return the first element of the queue for which p yields true
+   */
+  def dequeueFirst(p: A => Boolean): Option[A] =
+    if (isEmpty)
+      None
+    else if (p(first0.elem)) {
+      val res: Option[A] = Some(first0.elem)
+      first0 = first0.next
+      decrementLength()
+      res
+    } else {
+      val optElem = removeFromList(p)
+      if (optElem != None) decrementLength()
+      optElem
+    }
+
+  private def removeFromList(p: A => Boolean): Option[A] = {
+    var leftlst = first0
+    var res: Option[A] = None
+    while (leftlst.next.nonEmpty && !p(leftlst.next.elem)) {
+      leftlst = leftlst.next
+    }
+    if (leftlst.next.nonEmpty) {
+      res = Some(leftlst.next.elem)
+      if (leftlst.next eq last0) last0 = leftlst
+      leftlst.next = leftlst.next.next
+    }
+    res
+  }
+
+  /** Returns all elements in the queue which satisfy the
+   *  given predicate, and removes those elements from the queue.
+   *
+   *  @param p   the predicate used for choosing elements
+   *  @return    a sequence of all elements in the queue for which
+   *             p yields true.
+   */
+  def dequeueAll(p: A => Boolean): Seq[A] = {
+    if (first0.isEmpty)
+      Seq.empty
+    else {
+      val res = new ArrayBuffer[A]
+      while ((first0.nonEmpty) && p(first0.elem)) {
+        res += first0.elem
+        first0 = first0.next
+        decrementLength()
+      }
+      if (first0.isEmpty) res
+      else removeAllFromList(p, res)
+    }
+  }
+
+  private def removeAllFromList(p: A => Boolean, res: ArrayBuffer[A]): ArrayBuffer[A] = {
+    var leftlst = first0
+    while (leftlst.next.nonEmpty) {
+      if (p(leftlst.next.elem)) {
+        res += leftlst.next.elem
+        if (leftlst.next eq last0) last0 = leftlst
+        leftlst.next = leftlst.next.next
+        decrementLength()
+      } else leftlst = leftlst.next
+    }
+    res
+  }
+
+  /** Return the proper suffix of this list which starts with the first element that satisfies `p`.
+   *  That element is unlinked from the list. If no element satisfies `p`, return None.
+   */
+  @deprecated("extractFirst inappropriately exposes implementation details. Use dequeue or dequeueAll.", "2.11.0")
+  def extractFirst(start: LinkedList[A], p: A => Boolean): Option[LinkedList[A]] = {
+    if (isEmpty) None
+    else {
+      var cell = start
+      while ((cell.next.nonEmpty) && !p(cell.next.elem)) {
+        cell = cell.next
+      }
+      if (cell.next.isEmpty)
+        None
+      else {
+        val res: Option[LinkedList[A]] = Some(cell.next)
+        cell.next = cell.next.next
+        decrementLength()
+        res
+      }
+    }
+  }
+
+  /** Returns the first element in the queue, or throws an error if there
+   *  is no element contained in the queue.
+   *
+   *  @return the first element.
+   */
+  def front: A = head
+
+
+  // TODO - Don't override this just for new to create appropriate type....
+  override def tail: Queue[A] = {
+    val tl = new Queue[A]
+    tailImpl(tl)
+    tl
+  }
+
+  override def clone(): Queue[A] = {
+    val bf = newBuilder
+    bf ++= seq
+    bf.result()
+  }
+
+  private[this] def decrementLength() {
+    len -= 1
+    if (len == 0) last0 = first0
+  }
+}
+
+
+object Queue extends SeqFactory[Queue] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Queue[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+
+  @inline def newBuilder[A]: Builder[A, Queue[A]] = new MutableList[A] mapResult { _.toQueue }
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/ResizableArray.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/ResizableArray.scala
@@ -1,0 +1,137 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+
+/** This class is used internally to implement data structures that
+ *  are based on resizable arrays.
+ *
+ *  @tparam A    type of the elements contained in this resizable array.
+ *
+ *  @author  Matthias Zenger, Burak Emir
+ *  @author Martin Odersky
+ *  @since   1
+ */
+trait ResizableArray[A] extends IndexedSeq[A]
+                           with GenericTraversableTemplate[A, ResizableArray]
+                           with IndexedSeqOptimized[A, ResizableArray[A]] {
+
+  override def companion: GenericCompanion[ResizableArray] = ResizableArray
+
+  protected def initialSize: Int = 16
+  protected var array: Array[AnyRef] = new Array[AnyRef](math.max(initialSize, 1))
+  protected var size0: Int = 0
+
+  //##########################################################################
+  // implement/override methods of IndexedSeq[A]
+
+  /** Returns the length of this resizable array.
+   */
+  def length: Int = size0
+
+  def apply(idx: Int) = {
+    if (idx >= size0) throw new IndexOutOfBoundsException(idx.toString)
+    array(idx).asInstanceOf[A]
+  }
+
+  def update(idx: Int, elem: A) {
+    if (idx >= size0) throw new IndexOutOfBoundsException(idx.toString)
+    array(idx) = elem.asInstanceOf[AnyRef]
+  }
+
+  override def foreach[U](f: A => U) {
+    var i = 0
+    // size is cached here because profiling reports a lot of time spent calling
+    // it on every iteration.  I think it's likely a profiler ghost but it doesn't
+    // hurt to lift it into a local.
+    val top = size
+    while (i < top) {
+      f(array(i).asInstanceOf[A])
+      i += 1
+    }
+  }
+
+  /** Fills the given array `xs` with at most `len` elements of this
+   *  traversable starting at position `start`.
+   *
+   *  Copying will stop once either the end of the current traversable is
+   *  reached or `len` elements have been copied or the end of the array
+   *  is reached.
+   *
+   *  @param  xs the array to fill.
+   *  @param  start starting index.
+   *  @param  len number of elements to copy
+   */
+   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int) {
+     val len1 = len min (xs.length - start) min length
+     if (len1 > 0) Array.copy(array, 0, xs, start, len1)
+   }
+
+  //##########################################################################
+
+  /** Remove elements of this array at indices after `sz`.
+   */
+  def reduceToSize(sz: Int) {
+    require(sz <= size0)
+    while (size0 > sz) {
+      size0 -= 1
+      array(size0) = null
+    }
+  }
+
+  /** Ensure that the internal array has at least `n` cells. */
+  protected def ensureSize(n: Int) {
+    // Use a Long to prevent overflows
+    val arrayLength: Long = array.length
+    if (n > arrayLength) {
+      var newSize: Long = arrayLength * 2
+      while (n > newSize)
+        newSize = newSize * 2
+      // Clamp newSize to Int.MaxValue
+      if (newSize > Int.MaxValue) newSize = Int.MaxValue
+
+      val newArray: Array[AnyRef] = new Array(newSize.toInt)
+      java.lang.System.arraycopy(array, 0, newArray, 0, size0)
+      array = newArray
+    }
+  }
+
+  /** Swap two elements of this array.
+   */
+  protected def swap(a: Int, b: Int) {
+    val h = array(a)
+    array(a) = array(b)
+    array(b) = h
+  }
+
+  /** Move parts of the array.
+   */
+  protected def copy(m: Int, n: Int, len: Int) {
+    scala.compat.Platform.arraycopy(array, m, array, n, len)
+  }
+}
+
+object ResizableArray extends SeqFactory[ResizableArray] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, ResizableArray[A]] =
+    ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+
+  @inline def newBuilder[A]: Builder[A, ResizableArray[A]] = new ArrayBuffer[A]
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/Seq.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/Seq.scala
@@ -1,0 +1,58 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+
+
+/** A subtrait of `collection.Seq` which represents sequences
+ *  that can be mutated.
+ *
+ *  $seqInfo
+ *
+ *  The class adds an `update` method to `collection.Seq`.
+ *
+ *  @define Coll `mutable.Seq`
+ *  @define coll mutable sequence
+ */
+trait Seq[A] extends Iterable[A]
+//                with GenSeq[A]
+                with scala.collection.Seq[A]
+                with GenericTraversableTemplate[A, Seq]
+                with SeqLike[A, Seq[A]] {
+  override def companion: GenericCompanion[Seq] = Seq
+  override def seq: Seq[A] = this
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is an `ArrayBuffer`.
+ *  @define coll mutable sequence
+ *  @define Coll `mutable.Seq`
+ */
+object Seq extends SeqFactory[Seq] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Seq[A]] =
+    ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+
+  @inline def newBuilder[A]: Builder[A, Seq[A]] =
+    new ArrayBuffer
+}
+
+/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses. */
+abstract class AbstractSeq[A] extends scala.collection.AbstractSeq[A] with Seq[A]

--- a/scalalib/overrides-2.12/scala/collection/mutable/Stack.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/Stack.scala
@@ -1,0 +1,184 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+import scala.collection.immutable.{List, Nil}
+import scala.collection.Iterator
+import scala.annotation.migration
+
+/** Factory object for the `mutable.Stack` class.
+ *
+ *  $factoryInfo
+ *  @define coll mutable stack
+ *  @define Coll `mutable.Stack`
+ */
+object Stack extends SeqFactory[Stack] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  class StackBuilder[A] extends Builder[A, Stack[A]] {
+    val lbuff = new ListBuffer[A]
+    def +=(elem: A) = { lbuff += elem; this }
+    def clear() = lbuff.clear()
+    def result = new Stack(lbuff.result)
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Stack[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  @inline def newBuilder[A]: Builder[A, Stack[A]] = new StackBuilder[A]
+  @inline val empty: Stack[Nothing] = new Stack(Nil)
+}
+
+/** A stack implements a data structure which allows to store and retrieve
+ *  objects in a last-in-first-out (LIFO) fashion.
+ *
+ *  @tparam A    type of the elements contained in this stack.
+ *
+ *  @author  Matthias Zenger
+ *  @author  Martin Odersky
+ *  @since   1
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stacks "Scala's Collection Library overview"]]
+ *  section on `Stacks` for more information.
+ *  @define Coll `Stack`
+ *  @define coll stack
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+@deprecated("Stack is an inelegant and potentially poorly-performing wrapper around List. Use a List assigned to a var instead.", "2.12.0")
+class Stack[A] private (var elems: List[A])
+extends AbstractSeq[A]
+   with Seq[A]
+   with SeqLike[A, Stack[A]]
+   with GenericTraversableTemplate[A, Stack]
+   with Cloneable[Stack[A]]
+   with Serializable
+{
+  def this() = this(Nil)
+
+  override def companion = Stack
+
+  /** Checks if the stack is empty.
+   *
+   *  @return true, iff there is no element on the stack
+   */
+  override def isEmpty: Boolean = elems.isEmpty
+
+  /** The number of elements in the stack */
+  override def length = elems.length
+
+  /** Retrieve `n`-th element from stack, where top of stack has index `0`.
+   *
+   *  This is a linear time operation.
+   *
+   *  @param index     the index of the element to return
+   *  @return          the element at the specified index
+   *  @throws IndexOutOfBoundsException if the index is out of bounds
+   */
+  override def apply(index: Int) = elems(index)
+
+  /** Replace element at index `n` with the new element `newelem`.
+   *
+   *  This is a linear time operation.
+   *
+   *  @param n       the index of the element to replace.
+   *  @param newelem the new element.
+   *  @throws   IndexOutOfBoundsException if the index is not valid
+   */
+  def update(n: Int, newelem: A) =
+    if(n < 0 || n >= length) throw new IndexOutOfBoundsException(n.toString)
+    else elems = elems.take(n) ++ (newelem :: elems.drop(n+1))
+
+  /** Push an element on the stack.
+   *
+   *  @param   elem       the element to push on the stack.
+   *  @return the stack with the new element on top.
+   */
+  def push(elem: A): this.type = { elems = elem :: elems; this }
+
+  /** Push two or more elements onto the stack. The last element
+   *  of the sequence will be on top of the new stack.
+   *
+   *  @param   elems      the element sequence.
+   *  @return the stack with the new elements on top.
+   */
+  def push(elem1: A, elem2: A, elems: A*): this.type =
+    this.push(elem1).push(elem2).pushAll(elems)
+
+  /** Push all elements in the given traversable object onto the stack. The
+   *  last element in the traversable object will be on top of the new stack.
+   *
+   *  @param xs the traversable object.
+   *  @return the stack with the new elements on top.
+   */
+  def pushAll(xs: TraversableOnce[A]): this.type = { xs foreach push ; this }
+
+  /** Returns the top element of the stack. This method will not remove
+   *  the element from the stack. An error is signaled if there is no
+   *  element on the stack.
+   *
+   *  @throws java.util.NoSuchElementException
+   *  @return the top element
+   */
+  def top: A =
+    elems.head
+
+  /** Removes the top element from the stack.
+   *
+   *  @throws java.util.NoSuchElementException
+   *  @return the top element
+   */
+  def pop(): A = {
+    val res = elems.head
+    elems = elems.tail
+    res
+  }
+
+  /**
+   * Removes all elements from the stack. After this operation completed,
+   * the stack will be empty.
+   */
+  def clear(): Unit = elems = Nil
+
+  /** Returns an iterator over all elements on the stack. This iterator
+   *  is stable with respect to state changes in the stack object; i.e.
+   *  such changes will not be reflected in the iterator. The iterator
+   *  issues elements in the reversed order they were inserted into the
+   *  stack (LIFO order).
+   *
+   *  @return an iterator over all stack elements.
+   */
+  @migration("`iterator` traverses in FIFO order.", "2.8.0")
+  override def iterator: Iterator[A] = elems.iterator
+
+  /** Creates a list of all stack elements in LIFO order.
+   *
+   *  @return the created list.
+   */
+  @migration("`toList` traverses in FIFO order.", "2.8.0")
+  override def toList: List[A] = elems
+
+  @migration("`foreach` traverses in FIFO order.", "2.8.0")
+  override def foreach[U](f: A => U): Unit = super.foreach(f)
+
+  /** This method clones the stack.
+   *
+   *  @return  a stack with the same elements.
+   */
+  override def clone(): Stack[A] = new Stack[A](elems)
+}

--- a/scalalib/overrides-2.12/scala/collection/mutable/Traversable.scala
+++ b/scalalib/overrides-2.12/scala/collection/mutable/Traversable.scala
@@ -1,0 +1,50 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+import generic._
+
+/** A trait for traversable collections that can be mutated.
+ *  $traversableInfo
+ *  @define mutability mutable
+ */
+trait Traversable[A] extends scala.collection.Traversable[A]
+//                        with GenTraversable[A]
+                        with GenericTraversableTemplate[A, Traversable]
+                        with TraversableLike[A, Traversable[A]]
+                        with Mutable {
+  override def companion: GenericCompanion[Traversable] = Traversable
+  override def seq: Traversable[A] = this
+}
+
+/** $factoryInfo
+ *  The current default implementation of a $Coll is an `ArrayBuffer`.
+ *  @define coll mutable traversable collection
+ *  @define Coll `mutable.Traversable`
+ */
+object Traversable extends TraversableFactory[Traversable] {
+  @inline override def ReusableCBF: GenericCanBuildFrom[Nothing] = ReusableCBFInstance
+  private object ReusableCBFInstance extends GenericCanBuildFrom[Nothing] {
+    @inline override def apply() = newBuilder[Nothing]
+  }
+
+  @inline implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Traversable[A]] =
+    ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+
+  @inline def newBuilder[A]: Builder[A, Traversable[A]] =
+    new ArrayBuffer
+}
+
+

--- a/scalalib/overrides-2.12/scala/compat/Platform.scala
+++ b/scalalib/overrides-2.12/scala/compat/Platform.scala
@@ -1,0 +1,136 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package compat
+
+import java.lang.System
+
+object Platform {
+
+  /** Thrown when a stack overflow occurs because a method or function recurses too deeply.
+    *
+    * On the JVM, this is a type alias for `java.lang.StackOverflowError`, which itself extends `java.lang.Error`.
+    * The same rules apply to catching a `java.lang.Error` as for Java, that it indicates a serious problem that a reasonable application should not try and catch.
+    */
+  type StackOverflowError = java.lang.StackOverflowError
+
+  /** This is a type alias for `java.util.ConcurrentModificationException`,
+    * which may be thrown by methods that detect an invalid modification of an object.
+    * For example, many common collection types do not allow modifying a collection
+    * while it is being iterated over.
+    */
+  type ConcurrentModificationException = java.util.ConcurrentModificationException
+
+  /** Copies `length` elements of array `src` starting at position `srcPos` to the
+    * array `dest` starting at position `destPos`. If `src`==`dest`, the copying will
+    * behave as if the elements copied from `src` were first copied to a temporary
+    * array before being copied back into the array at the destination positions.
+    *
+    * @param src     A non-null array as source for the copy.
+    * @param srcPos  The starting index in the source array.
+    * @param dest    A non-null array as destination for the copy.
+    * @param destPos The starting index in the destination array.
+    * @param length  The number of elements to be copied.
+    * @throws java.lang.NullPointerException If either `src` or `dest` are `null`.
+    * @throws java.lang.ArrayStoreException If either `src` or `dest` are not of type
+    *                [java.lang.Array]; or if the element type of `src` is not
+    *                compatible with that of `dest`.
+    * @throws java.lang.IndexOutOfBoundsException If either `srcPos` or `destPos` are
+    *                outside of the bounds of their respective arrays; or if `length`
+    *                is negative; or if there are less than `length` elements available
+    *                after `srcPos` or `destPos` in `src` and `dest` respectively.
+    */
+  @inline
+  def arraycopy(src: AnyRef, srcPos: Int, dest: AnyRef, destPos: Int, length: Int) {
+    System.arraycopy(src, srcPos, dest, destPos, length)
+  }
+
+  /** Creates a new array of the specified type and given length.
+   *
+   *  Note that if `elemClass` is a subclass of [[scala.AnyVal]] then the returned value is an Array of the corresponding java primitive type.
+   *  For example, the following code `scala.compat.Platform.createArray(classOf[Int], 4)` returns an array of the java primitive type `int`.
+   *
+   *  For a [[scala.AnyVal]] array, the values of the array are set to 0 for ''numeric value types'' ([[scala.Double]], [[scala.Float]], [[scala.Long]], [[scala.Int]], [[scala.Char]],
+   *  [[scala.Short]], and [[scala.Byte]]), and `false` for [[scala.Boolean]]. Creation of an array of type [[scala.Unit]] is not possible.
+   *
+   *  For subclasses of [[scala.AnyRef]], the values of the array are set to `null`.
+   *
+   *  The caller must cast the returned value to the correct type.
+   *
+   *  @example {{{
+   *  val a = scala.compat.Platform.createArray(classOf[Int], 4).asInstanceOf[Array[Int]] // returns Array[Int](0, 0, 0, 0)
+   *  }}}
+   *
+   *  @param elemClass the `Class` object of the component type of the array
+   *  @param length    the length of the new array.
+   *  @return          an array of the given component type as an `AnyRef`.
+   *  @throws java.lang.NullPointerException If `elemClass` is `null`.
+   *  @throws java.lang.IllegalArgumentException if componentType is [[scala.Unit]] or `java.lang.Void.TYPE`
+   *  @throws java.lang.NegativeArraySizeException if the specified length is negative
+   */
+  @inline
+  def createArray(elemClass: Class[_], length: Int): AnyRef =
+    java.lang.reflect.Array.newInstance(elemClass, length)
+
+  /** Assigns the value of 0 to each element in the array.
+    * @param arr     A non-null Array[Int].
+    * @throws java.lang.NullPointerException If `arr` is `null`.
+    */
+  @inline
+  def arrayclear(arr: Array[Int]) { java.util.Arrays.fill(arr, 0) }
+
+  /** Returns the `Class` object associated with the class or interface with the given string name using the current `ClassLoader`.
+   *  On the JVM, invoking this method is equivalent to: `java.lang.Class.forName(name)`
+   *
+   *  For more information, please see the Java documentation for [[java.lang.Class]].
+   *
+   * @param    name the fully qualified name of the desired class.
+   * @return   the `Class` object for the class with the specified name.
+   * @throws java.lang.LinkageError if the linkage fails
+   * @throws java.lang.ExceptionInInitializerError if the initialization provoked by this method fails
+   * @throws java.lang.ClassNotFoundException if the class cannot be located
+   *  @example {{{
+   *  val a = scala.compat.Platform.getClassForName("java.lang.Integer")  // returns the Class[_] for java.lang.Integer
+   *  }}}
+   */
+  @inline
+  def getClassForName(name: String): Class[_] = java.lang.Class.forName(name)
+
+  /** The default line separator.
+   *
+   * On the Native backend, this is always "\n".
+   */
+  val EOL = "\n"
+
+  /** The current time in milliseconds. The time is counted since 1 January 1970
+    * UTC.
+    *
+    * Note that the operating system timer used to obtain this value may be less
+    * precise than a millisecond.
+    */
+  @inline
+  def currentTime: Long = System.currentTimeMillis()
+
+  /** Runs the garbage collector.
+   *
+   * This is a request that the underlying JVM runs the garbage collector.
+   * The results of this call depends heavily on the JVM used.
+   * The underlying JVM is free to ignore this request.
+   */
+  @inline
+  def collectGarbage(): Unit = System.gc()
+
+  /** The name of the default character set encoding as a string */
+  @inline
+  def defaultCharsetName: String = java.nio.charset.Charset.defaultCharset.name
+}

--- a/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala
+++ b/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala
@@ -1,0 +1,202 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.concurrent
+
+
+import java.util.concurrent.{ ExecutorService, Executor }
+import scala.annotation.implicitNotFound
+
+/**
+ * An `ExecutionContext` can execute program logic asynchronously,
+ * typically but not necessarily on a thread pool.
+ *
+ * A general purpose `ExecutionContext` must be asynchronous in executing
+ * any `Runnable` that is passed into its `execute`-method. A special purpose
+ * `ExecutionContext` may be synchronous but must only be passed to code that
+ * is explicitly safe to be run using a synchronously executing `ExecutionContext`.
+ *
+ * APIs such as `Future.onComplete` require you to provide a callback
+ * and an implicit `ExecutionContext`. The implicit `ExecutionContext`
+ * will be used to execute the callback.
+ *
+ * While it is possible to simply import
+ * `scala.concurrent.ExecutionContext.Implicits.global` to obtain an
+ * implicit `ExecutionContext`, application developers should carefully
+ * consider where they want to set execution policy;
+ * ideally, one place per application—or per logically related section of code—
+ * will make a decision about which `ExecutionContext` to use.
+ * That is, you will mostly want to avoid hardcoding, especially via an import,
+ * `scala.concurrent.ExecutionContext.Implicits.global`.
+ * The recommended approach is to add `(implicit ec: ExecutionContext)` to methods,
+ * or class constructor parameters, which need an `ExecutionContext`.
+ * 
+ * Then locally import a specific `ExecutionContext` in one place for the entire
+ * application or module, passing it implicitly to individual methods.
+ * Alternatively define a local implicit val with the required `ExecutionContext`.
+ *
+ * A custom `ExecutionContext` may be appropriate to execute code
+ * which blocks on IO or performs long-running computations.
+ * `ExecutionContext.fromExecutorService` and `ExecutionContext.fromExecutor`
+ * are good ways to create a custom `ExecutionContext`.
+ *
+ * The intent of `ExecutionContext` is to lexically scope code execution.
+ * That is, each method, class, file, package, or application determines
+ * how to run its own code. This avoids issues such as running
+ * application callbacks on a thread pool belonging to a networking library.
+ * The size of a networking library's thread pool can be safely configured,
+ * knowing that only that library's network operations will be affected.
+ * Application callback execution can be configured separately.
+ */
+@implicitNotFound("""Cannot find an implicit ExecutionContext. You might pass
+an (implicit ec: ExecutionContext) parameter to your method.
+
+The ExecutionContext is used to configure how and on which
+thread pools Futures will run, so the specific ExecutionContext
+that is selected is important.
+
+If your application does not define an ExecutionContext elsewhere,
+consider using Scala's global ExecutionContext by defining
+the following:
+
+implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global""")
+trait ExecutionContext {
+
+  /** Runs a block of code on this execution context.
+   *
+   *  @param runnable  the task to execute
+   */
+  def execute(runnable: Runnable): Unit
+
+  /** Reports that an asynchronous computation failed.
+   *
+   *  @param cause  the cause of the failure
+   */
+  def reportFailure(@deprecatedName('t) cause: Throwable): Unit
+
+  /** Prepares for the execution of a task. Returns the prepared
+     *  execution context. The recommended implementation of
+     *  `prepare` is to return `this`.
+     *
+     *  This method should no longer be overridden or called. It was
+     *  originally expected that `prepare` would be called by
+     *  all libraries that consume ExecutionContexts, in order to
+     *  capture thread local context. However, this usage has proven
+     *  difficult to implement in practice and instead it is
+     *  now better to avoid using `prepare` entirely.
+     *
+     *  Instead, if an `ExecutionContext` needs to capture thread
+     *  local context, it should capture that context when it is
+     *  constructed, so that it doesn't need any additional
+     *  preparation later.
+     */
+  @deprecated("preparation of ExecutionContexts will be removed", "2.12.0")
+  def prepare(): ExecutionContext = this
+}
+
+/**
+ * An [[ExecutionContext]] that is also a
+ * Java [[http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executor.html Executor]].
+ */
+trait ExecutionContextExecutor extends ExecutionContext with Executor
+
+/**
+ * An [[ExecutionContext]] that is also a
+ * Java [[http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html ExecutorService]].
+ */
+trait ExecutionContextExecutorService extends ExecutionContextExecutor with ExecutorService
+
+
+/** Contains factory methods for creating execution contexts.
+ */
+object ExecutionContext {
+  /**
+   * The explicit global `ExecutionContext`. Invoke `global` when you want to provide the global
+   * `ExecutionContext` explicitly.
+   *
+   * The default `ExecutionContext` implementation is backed by a work-stealing thread pool.
+   * It can be configured via the following [[scala.sys.SystemProperties]]:
+   *
+   * `scala.concurrent.context.minThreads` = defaults to "1"
+   * `scala.concurrent.context.numThreads` = defaults to "x1" (i.e. the current number of available processors * 1)
+   * `scala.concurrent.context.maxThreads` = defaults to "x1" (i.e. the current number of available processors * 1)
+   * `scala.concurrent.context.maxExtraThreads` = defaults to "256"
+   *
+   * The pool size of threads is then `numThreads` bounded by `minThreads` on the lower end and `maxThreads` on the high end.
+   *
+   * The `maxExtraThreads` is the maximum number of extra threads to have at any given time to evade deadlock,
+   * see [[scala.concurrent.BlockContext]].
+   *
+   * @return the global `ExecutionContext`
+   */
+  def global: ExecutionContextExecutor = Implicits.global.asInstanceOf[ExecutionContextExecutor]
+
+  object Implicits {
+    /**
+     * The implicit global `ExecutionContext`. Import `global` when you want to provide the global
+     * `ExecutionContext` implicitly.
+     *
+     * The default `ExecutionContext` implementation is backed by a work-stealing thread pool. By default,
+     * the thread pool uses a target number of worker threads equal to the number of
+     * [[https://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#availableProcessors-- available processors]].
+     */
+    implicit lazy val global: ExecutionContext = impl.ExecutionContextImpl.fromExecutor(null: Executor)
+  }
+
+  /** Creates an `ExecutionContext` from the given `ExecutorService`.
+   *
+   *  @param e         the `ExecutorService` to use. If `null`, a new `ExecutorService` is created with [[scala.concurrent.ExecutionContext$.global default configuration]].
+   *  @param reporter  a function for error reporting
+   *  @return          the `ExecutionContext` using the given `ExecutorService`
+   */
+  def fromExecutorService(e: ExecutorService, reporter: Throwable => Unit): ExecutionContextExecutorService =
+    impl.ExecutionContextImpl.fromExecutorService(e, reporter)
+
+  /** Creates an `ExecutionContext` from the given `ExecutorService` with the [[scala.concurrent.ExecutionContext$.defaultReporter default reporter]].
+   *
+   *  If it is guaranteed that none of the executed tasks are blocking, a single-threaded `ExecutorService`
+   *  can be used to create an `ExecutionContext` as follows:
+   *
+   *  {{{
+   *  import java.util.concurrent.Executors
+   *  val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+   *  }}}
+   *
+   *  @param e the `ExecutorService` to use. If `null`, a new `ExecutorService` is created with [[scala.concurrent.ExecutionContext$.global default configuration]].
+   *  @return  the `ExecutionContext` using the given `ExecutorService`
+   */
+  def fromExecutorService(e: ExecutorService): ExecutionContextExecutorService = fromExecutorService(e, defaultReporter)
+
+  /** Creates an `ExecutionContext` from the given `Executor`.
+   *
+   *  @param e         the `Executor` to use. If `null`, a new `Executor` is created with [[scala.concurrent.ExecutionContext$.global default configuration]].
+   *  @param reporter  a function for error reporting
+   *  @return          the `ExecutionContext` using the given `Executor`
+   */
+  def fromExecutor(e: Executor, reporter: Throwable => Unit): ExecutionContextExecutor =
+    impl.ExecutionContextImpl.fromExecutor(e, reporter)
+
+  /** Creates an `ExecutionContext` from the given `Executor` with the [[scala.concurrent.ExecutionContext$.defaultReporter default reporter]].
+   *
+   *  @param e the `Executor` to use. If `null`, a new `Executor` is created with [[scala.concurrent.ExecutionContext$.global default configuration]].
+   *  @return  the `ExecutionContext` using the given `Executor`
+   */
+  def fromExecutor(e: Executor): ExecutionContextExecutor = fromExecutor(e, defaultReporter)
+
+  /** The default reporter simply prints the stack trace of the `Throwable` to [[http://docs.oracle.com/javase/8/docs/api/java/lang/System.html#err System.err]].
+   *
+   *  @return the function for error reporting
+   */
+  def defaultReporter: Throwable => Unit = _.printStackTrace()
+}
+
+

--- a/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala
+++ b/scalalib/overrides-2.12/scala/concurrent/ExecutionContext.scala
@@ -138,7 +138,7 @@ object ExecutionContext {
    *
    * @return the global `ExecutionContext`
    */
-  def global: ExecutionContextExecutor = Implicits.global.asInstanceOf[ExecutionContextExecutor]
+  def global: ExecutionContext = Implicits.global
 
   object Implicits {
     /**
@@ -149,7 +149,8 @@ object ExecutionContext {
      * the thread pool uses a target number of worker threads equal to the number of
      * [[https://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#availableProcessors-- available processors]].
      */
-    implicit lazy val global: ExecutionContext = impl.ExecutionContextImpl.fromExecutor(null: Executor)
+    implicit lazy val global: ExecutionContext =
+      scala.scalanative.runtime.ExecutionContext.global
   }
 
   /** Creates an `ExecutionContext` from the given `ExecutorService`.

--- a/scalalib/overrides-2.12/scala/package.scala
+++ b/scalalib/overrides-2.12/scala/package.scala
@@ -1,0 +1,136 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+/**
+ * Core Scala types. They are always available without an explicit import.
+ * @contentDiagram hideNodes "scala.Serializable"
+ */
+package object scala {
+  type Throwable = java.lang.Throwable
+  type Exception = java.lang.Exception
+  type Error     = java.lang.Error
+
+  type RuntimeException                = java.lang.RuntimeException
+  type NullPointerException            = java.lang.NullPointerException
+  type ClassCastException              = java.lang.ClassCastException
+  type IndexOutOfBoundsException       = java.lang.IndexOutOfBoundsException
+  type ArrayIndexOutOfBoundsException  = java.lang.ArrayIndexOutOfBoundsException
+  type StringIndexOutOfBoundsException = java.lang.StringIndexOutOfBoundsException
+  type UnsupportedOperationException   = java.lang.UnsupportedOperationException
+  type IllegalArgumentException        = java.lang.IllegalArgumentException
+  type NoSuchElementException          = java.util.NoSuchElementException
+  type NumberFormatException           = java.lang.NumberFormatException
+  type AbstractMethodError             = java.lang.AbstractMethodError
+  type InterruptedException            = java.lang.InterruptedException
+
+  // A dummy used by the specialization annotation.
+  lazy val AnyRef = new Specializable {
+    override def toString = "object AnyRef"
+  }
+
+  type TraversableOnce[+A] = scala.collection.TraversableOnce[A]
+
+  type Traversable[+A] = scala.collection.Traversable[A]
+  lazy val Traversable = scala.collection.Traversable
+
+  type Iterable[+A] = scala.collection.Iterable[A]
+  lazy val Iterable = scala.collection.Iterable
+
+  type Seq[+A] = scala.collection.Seq[A]
+  lazy val Seq = scala.collection.Seq
+
+  type IndexedSeq[+A] = scala.collection.IndexedSeq[A]
+  lazy val IndexedSeq = scala.collection.IndexedSeq
+
+  type Iterator[+A] = scala.collection.Iterator[A]
+  lazy val Iterator = scala.collection.Iterator
+
+  type BufferedIterator[+A] = scala.collection.BufferedIterator[A]
+
+  type List[+A] = scala.collection.immutable.List[A]
+  lazy val List = scala.collection.immutable.List
+
+  lazy val Nil = scala.collection.immutable.Nil
+
+  type ::[A] = scala.collection.immutable.::[A]
+  lazy val :: = scala.collection.immutable.::
+
+  lazy val +: = scala.collection.+:
+  lazy val :+ = scala.collection.:+
+
+  type Stream[+A] = scala.collection.immutable.Stream[A]
+  lazy val Stream = scala.collection.immutable.Stream
+  lazy val #:: = scala.collection.immutable.Stream.#::
+
+  type Vector[+A] = scala.collection.immutable.Vector[A]
+  lazy val Vector = scala.collection.immutable.Vector
+
+  type StringBuilder = scala.collection.mutable.StringBuilder
+  lazy val StringBuilder = scala.collection.mutable.StringBuilder
+
+  type Range = scala.collection.immutable.Range
+  lazy val Range = scala.collection.immutable.Range
+
+  // Numeric types which were moved into scala.math.*
+
+  type BigDecimal = scala.math.BigDecimal
+  lazy val BigDecimal = scala.math.BigDecimal
+
+  type BigInt = scala.math.BigInt
+  lazy val BigInt = scala.math.BigInt
+
+  type Equiv[T] = scala.math.Equiv[T]
+  lazy val Equiv = scala.math.Equiv
+
+  type Fractional[T] = scala.math.Fractional[T]
+  lazy val Fractional = scala.math.Fractional
+
+  type Integral[T] = scala.math.Integral[T]
+  lazy val Integral = scala.math.Integral
+
+  type Numeric[T] = scala.math.Numeric[T]
+  lazy val Numeric = scala.math.Numeric
+
+  type Ordered[T] = scala.math.Ordered[T]
+  lazy val Ordered = scala.math.Ordered
+
+  type Ordering[T] = scala.math.Ordering[T]
+  lazy val Ordering = scala.math.Ordering
+
+  type PartialOrdering[T] = scala.math.PartialOrdering[T]
+  type PartiallyOrdered[T] = scala.math.PartiallyOrdered[T]
+
+  type Either[+A, +B] = scala.util.Either[A, B]
+  lazy val Either = scala.util.Either
+
+  type Left[+A, +B] = scala.util.Left[A, B]
+  lazy val Left = scala.util.Left
+
+  type Right[+A, +B] = scala.util.Right[A, B]
+  lazy val Right = scala.util.Right
+
+  // Annotations which we might move to annotation.*
+/*
+  type SerialVersionUID = annotation.SerialVersionUID
+  type deprecated = annotation.deprecated
+  type deprecatedName = annotation.deprecatedName
+  type inline = annotation.inline
+  type native = annotation.native
+  type noinline = annotation.noinline
+  type remote = annotation.remote
+  type specialized = annotation.specialized
+  type transient = annotation.transient
+  type throws  = annotation.throws
+  type unchecked = annotation.unchecked.unchecked
+  type volatile = annotation.volatile
+  */
+}

--- a/scalalib/overrides-2.12/scala/reflect/Manifest.scala
+++ b/scalalib/overrides-2.12/scala/reflect/Manifest.scala
@@ -1,0 +1,381 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package reflect
+
+import scala.collection.mutable.{ArrayBuilder, WrappedArray}
+
+/** A `Manifest[T]` is an opaque descriptor for type T.  Its supported use
+ *  is to give access to the erasure of the type as a `Class` instance, as
+ *  is necessary for the creation of native `Arrays` if the class is not
+ *  known at compile time.
+ *
+ *  The type-relation operators `<:<` and `=:=` should be considered
+ *  approximations only, as there are numerous aspects of type conformance
+ *  which are not yet adequately represented in manifests.
+ *
+ *  Example usages:
+ *  {{{
+ *    def arr[T] = new Array[T](0)                          // does not compile
+ *    def arr[T](implicit m: Manifest[T]) = new Array[T](0) // compiles
+ *    def arr[T: Manifest] = new Array[T](0)                // shorthand for the preceding
+ *
+ *    // Methods manifest, classManifest, and optManifest are in [[scala.Predef]].
+ *    def isApproxSubType[T: Manifest, U: Manifest] = manifest[T] <:< manifest[U]
+ *    isApproxSubType[List[String], List[AnyRef]] // true
+ *    isApproxSubType[List[String], List[Int]]    // false
+ *
+ *    def methods[T: ClassManifest] = classManifest[T].erasure.getMethods
+ *    def retType[T: ClassManifest](name: String) =
+ *      methods[T] find (_.getName == name) map (_.getGenericReturnType)
+ *
+ *    retType[Map[_, _]]("values")  // Some(scala.collection.Iterable<B>)
+ *  }}}
+ */
+@scala.annotation.implicitNotFound(msg = "No Manifest available for ${T}.")
+// TODO undeprecated until Scala reflection becomes non-experimental
+// @deprecated("use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
+trait Manifest[T] extends ClassManifest[T] with Equals {
+  override def typeArguments: List[Manifest[_]] = Nil
+
+  override def arrayManifest: Manifest[Array[T]] =
+    Manifest.classType[Array[T]](arrayClass[T](runtimeClass), this)
+
+  override def canEqual(that: Any): Boolean = that match {
+    case _: Manifest[_]   => true
+    case _                => false
+  }
+  /** Note: testing for erasure here is important, as it is many times
+   *  faster than <:< and rules out most comparisons.
+   */
+  override def equals(that: Any): Boolean = that match {
+    case m: Manifest[_] => (m canEqual this) && (this.runtimeClass == m.runtimeClass) && (this <:< m) && (m <:< this)
+    case _              => false
+  }
+  override def hashCode = this.runtimeClass.##
+}
+
+// TODO undeprecated until Scala reflection becomes non-experimental
+// @deprecated("use type tags and manually check the corresponding class or type instead", "2.10.0")
+@SerialVersionUID(1L)
+abstract class AnyValManifest[T <: AnyVal](override val toString: String) extends Manifest[T] with Equals {
+  override def <:<(that: ClassManifest[_]): Boolean =
+    (that eq this) || (that eq Manifest.Any) || (that eq Manifest.AnyVal)
+  override def canEqual(other: Any) = other match {
+    case _: AnyValManifest[_] => true
+    case _                    => false
+  }
+  override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
+  @transient
+  override val hashCode = System.identityHashCode(this)
+}
+
+/** `ManifestFactory` defines factory methods for manifests.
+ *  It is intended for use by the compiler and should not be used in client code.
+ *
+ *  Unlike `Manifest`, this factory isn't annotated with a deprecation warning.
+ *  This is done to prevent avalanches of deprecation warnings in the code that calls methods with manifests.
+ *  Why so complicated? Read up the comments for `ClassManifestFactory`.
+ */
+object ManifestFactory {
+  def valueManifests: List[AnyValManifest[_]] =
+    List(Byte, Short, Char, Int, Long, Float, Double, Boolean, Unit)
+
+  @SerialVersionUID(1L)
+  private class ByteManifest extends AnyValManifest[scala.Byte]("Byte") {
+    def runtimeClass = java.lang.Byte.TYPE
+    override def newArray(len: Int): Array[Byte] = new Array[Byte](len)
+    override def newWrappedArray(len: Int): WrappedArray[Byte] = new WrappedArray.ofByte(new Array[Byte](len))
+    override def newArrayBuilder(): ArrayBuilder[Byte] = new ArrayBuilder.ofByte()
+    override def unapply(x: Any): Option[Byte] = {
+      x match {
+        case d: Byte => Some(d)
+        case _ => None
+      }
+    }
+    private def readResolve(): Any = Manifest.Byte
+  }
+  @inline def Byte: AnyValManifest[Byte] = new ByteManifest
+
+  @SerialVersionUID(1L)
+  private class ShortManifest extends AnyValManifest[scala.Short]("Short") {
+    def runtimeClass = java.lang.Short.TYPE
+    override def newArray(len: Int): Array[Short] = new Array[Short](len)
+    override def newWrappedArray(len: Int): WrappedArray[Short] = new WrappedArray.ofShort(new Array[Short](len))
+    override def newArrayBuilder(): ArrayBuilder[Short] = new ArrayBuilder.ofShort()
+    override def unapply(x: Any): Option[Short] = {
+      x match {
+        case d: Short => Some(d)
+        case _ => None
+      }
+    }
+    private def readResolve(): Any = Manifest.Short
+  }
+  @inline def Short: AnyValManifest[Short] = new ShortManifest
+
+  @SerialVersionUID(1L)
+  private class CharManifest extends AnyValManifest[scala.Char]("Char") {
+    def runtimeClass = java.lang.Character.TYPE
+    override def newArray(len: Int): Array[Char] = new Array[Char](len)
+    override def newWrappedArray(len: Int): WrappedArray[Char] = new WrappedArray.ofChar(new Array[Char](len))
+    override def newArrayBuilder(): ArrayBuilder[Char] = new ArrayBuilder.ofChar()
+    override def unapply(x: Any): Option[Char] = {
+      x match {
+        case d: Char => Some(d)
+        case _ => None
+      }
+    }
+    private def readResolve(): Any = Manifest.Char
+  }
+  @inline def Char: AnyValManifest[Char] = new CharManifest
+
+  @SerialVersionUID(1L)
+  private class IntManifest extends AnyValManifest[scala.Int]("Int") {
+    def runtimeClass = java.lang.Integer.TYPE
+    override def newArray(len: Int): Array[Int] = new Array[Int](len)
+    override def newWrappedArray(len: Int): WrappedArray[Int] = new WrappedArray.ofInt(new Array[Int](len))
+    override def newArrayBuilder(): ArrayBuilder[Int] = new ArrayBuilder.ofInt()
+    override def unapply(x: Any): Option[Int] = {
+      x match {
+        case d: Int => Some(d)
+        case _ => None
+      }
+    }
+    private def readResolve(): Any = Manifest.Int
+  }
+  @inline def Int: AnyValManifest[Int] = new IntManifest
+
+  @SerialVersionUID(1L)
+  private class LongManifest extends AnyValManifest[scala.Long]("Long") {
+    def runtimeClass = java.lang.Long.TYPE
+    override def newArray(len: Int): Array[Long] = new Array[Long](len)
+    override def newWrappedArray(len: Int): WrappedArray[Long] = new WrappedArray.ofLong(new Array[Long](len))
+    override def newArrayBuilder(): ArrayBuilder[Long] = new ArrayBuilder.ofLong()
+    override def unapply(x: Any): Option[Long] = {
+      x match {
+        case d: Long => Some(d)
+        case _ => None
+      }
+    }
+    private def readResolve(): Any = Manifest.Long
+  }
+  @inline def Long: AnyValManifest[Long] = new LongManifest
+
+  @SerialVersionUID(1L)
+  private class FloatManifest extends AnyValManifest[scala.Float]("Float") {
+    def runtimeClass = java.lang.Float.TYPE
+    override def newArray(len: Int): Array[Float] = new Array[Float](len)
+    override def newWrappedArray(len: Int): WrappedArray[Float] = new WrappedArray.ofFloat(new Array[Float](len))
+    override def newArrayBuilder(): ArrayBuilder[Float] = new ArrayBuilder.ofFloat()
+    override def unapply(x: Any): Option[Float] = {
+      x match {
+        case d: Float => Some(d)
+        case _ => None
+      }
+    }
+    private def readResolve(): Any = Manifest.Float
+  }
+  @inline def Float: AnyValManifest[Float] = new FloatManifest
+
+  @SerialVersionUID(1L)
+  private class DoubleManifest extends AnyValManifest[scala.Double]("Double") {
+    def runtimeClass = java.lang.Double.TYPE
+    override def newArray(len: Int): Array[Double] = {
+      new Array[Double](len)
+    }
+    override def newWrappedArray(len: Int): WrappedArray[Double] = new WrappedArray.ofDouble(new Array[Double](len))
+    override def newArrayBuilder(): ArrayBuilder[Double] = new ArrayBuilder.ofDouble()
+
+    override def unapply(x: Any): Option[Double] = {
+      x match {
+        case d: Double => Some(d)
+        case _ => None
+      }
+    }
+    private def readResolve(): Any = Manifest.Double
+  }
+  @inline def Double: AnyValManifest[Double] = new DoubleManifest
+
+  @SerialVersionUID(1L)
+  private class BooleanManifest extends AnyValManifest[scala.Boolean]("Boolean") {
+    def runtimeClass = java.lang.Boolean.TYPE
+    override def newArray(len: Int): Array[Boolean] = new Array[Boolean](len)
+    override def newWrappedArray(len: Int): WrappedArray[Boolean] = new WrappedArray.ofBoolean(new Array[Boolean](len))
+    override def newArrayBuilder(): ArrayBuilder[Boolean] = new ArrayBuilder.ofBoolean()
+    override def unapply(x: Any): Option[Boolean] = {
+      x match {
+        case d: Boolean => Some(d)
+        case _ => None
+      }
+    }
+    private def readResolve(): Any = Manifest.Boolean
+  }
+  @inline def Boolean: AnyValManifest[Boolean] = new BooleanManifest
+
+  @SerialVersionUID(1L)
+  private class UnitManifest extends AnyValManifest[scala.Unit]("Unit") {
+    def runtimeClass = java.lang.Void.TYPE
+    override def newArray(len: Int): Array[Unit] = new Array[Unit](len)
+    override def newWrappedArray(len: Int): WrappedArray[Unit] = new WrappedArray.ofUnit(new Array[Unit](len))
+    override def newArrayBuilder(): ArrayBuilder[Unit] = new ArrayBuilder.ofUnit()
+    override protected def arrayClass[T](tp: Class[_]): Class[Array[T]] =
+      if (tp eq runtimeClass) classOf[Array[scala.runtime.BoxedUnit]].asInstanceOf[Class[Array[T]]]
+      else super.arrayClass(tp)
+    override def unapply(x: Any): Option[Unit] = {
+      x match {
+        case d: Unit => Some(d)
+        case _ => None
+      }
+    }
+    private def readResolve(): Any = Manifest.Unit
+  }
+  @inline def Unit: AnyValManifest[Unit] = new UnitManifest
+
+  private val ObjectTYPE = classOf[java.lang.Object]
+  private val NothingTYPE = classOf[scala.runtime.Nothing$]
+  private val NullTYPE = classOf[scala.runtime.Null$]
+
+  @SerialVersionUID(1L)
+  private class AnyManifest extends PhantomManifest[scala.Any](ObjectTYPE, "Any") {
+    override def newArray(len: Int) = new Array[scala.Any](len)
+    override def <:<(that: ClassManifest[_]): Boolean = (that eq this)
+    private def readResolve(): Any = Manifest.Any
+  }
+  @inline def Any: Manifest[scala.Any] = new AnyManifest
+
+  @SerialVersionUID(1L)
+  private class ObjectManifest extends PhantomManifest[java.lang.Object](ObjectTYPE, "Object") {
+    override def newArray(len: Int) = new Array[java.lang.Object](len)
+    override def <:<(that: ClassManifest[_]): Boolean = (that eq this) || (that eq Any)
+    private def readResolve(): Any = Manifest.Object
+  }
+  @inline def Object: Manifest[java.lang.Object] = new ObjectManifest
+
+  @inline def AnyRef: Manifest[scala.AnyRef] = Object.asInstanceOf[Manifest[scala.AnyRef]]
+
+  @SerialVersionUID(1L)
+  private class AnyValPhantomManifest extends PhantomManifest[scala.AnyVal](ObjectTYPE, "AnyVal") {
+    override def newArray(len: Int) = new Array[scala.AnyVal](len)
+    override def <:<(that: ClassManifest[_]): Boolean = (that eq this) || (that eq Any)
+    private def readResolve(): Any = Manifest.AnyVal
+  }
+  @inline def AnyVal: Manifest[scala.AnyVal] = new AnyValPhantomManifest
+
+  @SerialVersionUID(1L)
+  private class NullManifest extends PhantomManifest[scala.Null](NullTYPE, "Null") {
+    override def newArray(len: Int) = new Array[scala.Null](len)
+    override def <:<(that: ClassManifest[_]): Boolean =
+      (that ne null) && (that ne Nothing) && !(that <:< AnyVal)
+    private def readResolve(): Any = Manifest.Null
+  }
+  @inline def Null: Manifest[scala.Null] = new NullManifest
+
+  @SerialVersionUID(1L)
+  private class NothingManifest extends PhantomManifest[scala.Nothing](NothingTYPE, "Nothing") {
+    override def newArray(len: Int) = new Array[scala.Nothing](len)
+    override def <:<(that: ClassManifest[_]): Boolean = (that ne null)
+    private def readResolve(): Any = Manifest.Nothing
+  }
+  @inline def Nothing: Manifest[scala.Nothing] = new NothingManifest
+
+  @SerialVersionUID(1L)
+  private class SingletonTypeManifest[T <: AnyRef](value: AnyRef) extends Manifest[T] {
+    lazy val runtimeClass = value.getClass
+    override lazy val toString = value.toString + ".type"
+  }
+
+  /** Manifest for the singleton type `value.type`. */
+  def singleType[T <: AnyRef](value: AnyRef): Manifest[T] =
+    new SingletonTypeManifest[T](value)
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a top-level or static class.
+    * @note This no-prefix, no-arguments case is separate because we
+    *       it's called from ScalaRunTime.boxArray itself. If we
+    *       pass varargs as arrays into this, we get an infinitely recursive call
+    *       to boxArray. (Besides, having a separate case is more efficient)
+    */
+  def classType[T](clazz: Predef.Class[_]): Manifest[T] =
+    new ClassTypeManifest[T](None, clazz, Nil)
+
+  /** Manifest for the class type `clazz`, where `clazz` is
+    * a top-level or static class and args are its type arguments. */
+  def classType[T](clazz: Predef.Class[T], arg1: Manifest[_], args: Manifest[_]*): Manifest[T] =
+    new ClassTypeManifest[T](None, clazz, arg1 :: args.toList)
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a class with non-package prefix type `prefix` and type arguments `args`.
+    */
+  def classType[T](prefix: Manifest[_], clazz: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
+    new ClassTypeManifest[T](Some(prefix), clazz, args.toList)
+
+  @SerialVersionUID(1L)
+  private abstract class PhantomManifest[T](_runtimeClass: Predef.Class[_],
+                                            override val toString: String) extends ClassTypeManifest[T](None, _runtimeClass, Nil) {
+    override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
+    @transient
+    override val hashCode = System.identityHashCode(this)
+  }
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a top-level or static class. */
+  @SerialVersionUID(1L)
+  private class ClassTypeManifest[T](prefix: Option[Manifest[_]],
+                                     val runtimeClass: Predef.Class[_],
+                                     override val typeArguments: List[Manifest[_]]) extends Manifest[T] {
+    override def toString =
+      (if (prefix.isEmpty) "" else prefix.get.toString+"#") +
+      (if (runtimeClass.isArray) "Array" else runtimeClass.getName) +
+      argString
+   }
+
+  def arrayType[T](arg: Manifest[_]): Manifest[Array[T]] =
+    arg.asInstanceOf[Manifest[T]].arrayManifest
+
+  @SerialVersionUID(1L)
+  private class AbstractTypeManifest[T](prefix: Manifest[_], name: String, upperBound: Predef.Class[_], args: Seq[Manifest[_]]) extends Manifest[T] {
+    def runtimeClass = upperBound
+    override val typeArguments = args.toList
+    override def toString = prefix.toString+"#"+name+argString
+  }
+
+  /** Manifest for the abstract type `prefix # name`. `upperBound` is not
+    * strictly necessary as it could be obtained by reflection. It was
+    * added so that erasure can be calculated without reflection. */
+  def abstractType[T](prefix: Manifest[_], name: String, upperBound: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
+    new AbstractTypeManifest[T](prefix, name, upperBound, args)
+
+  @SerialVersionUID(1L)
+  private class WildcardManifest[T](lowerBound: Manifest[_], upperBound: Manifest[_]) extends Manifest[T] {
+    def runtimeClass = upperBound.runtimeClass
+    override def toString =
+      "_" +
+        (if (lowerBound eq Nothing) "" else " >: "+lowerBound) +
+        (if (upperBound eq Nothing) "" else " <: "+upperBound)
+  }
+
+  /** Manifest for the unknown type `_ >: L <: U` in an existential.
+    */
+  def wildcardType[T](lowerBound: Manifest[_], upperBound: Manifest[_]): Manifest[T] =
+    new WildcardManifest[T](lowerBound, upperBound)
+
+  @SerialVersionUID(1L)
+  private class IntersectionTypeManifest[T](parents: Seq[Manifest[_]]) extends Manifest[T] {
+    def runtimeClass = parents.head.runtimeClass
+    override def toString = parents.mkString(" with ")
+  }
+
+  /** Manifest for the intersection type `parents_0 with ... with parents_n`. */
+  def intersectionType[T](parents: Manifest[_]*): Manifest[T] =
+    new IntersectionTypeManifest[T](parents)
+}

--- a/scalalib/overrides-2.12/scala/reflect/ScalaLongSignature.scala
+++ b/scalalib/overrides-2.12/scala/reflect/ScalaLongSignature.scala
@@ -1,0 +1,3 @@
+package scala.reflect
+
+class ScalaLongSignature

--- a/scalalib/overrides-2.12/scala/reflect/ScalaSignature.scala
+++ b/scalalib/overrides-2.12/scala/reflect/ScalaSignature.scala
@@ -1,0 +1,3 @@
+package scala.reflect
+
+class ScalaSignature

--- a/scalalib/overrides-2.12/scala/runtime/ScalaRunTime.scala
+++ b/scalalib/overrides-2.12/scala/runtime/ScalaRunTime.scala
@@ -1,0 +1,267 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package runtime
+
+import scala.collection.{ TraversableView, AbstractIterator, GenIterable }
+import scala.collection.mutable.WrappedArray
+import scala.collection.immutable.{ StringLike, NumericRange }
+import scala.collection.generic.{ Sorted, IsTraversableLike }
+import scala.reflect.{ ClassTag, classTag }
+import java.lang.{ Class => jClass }
+
+import java.lang.reflect.{ Method => JMethod }
+
+/** The object ScalaRunTime provides support methods required by
+ *  the scala runtime.  All these methods should be considered
+ *  outside the API and subject to change or removal without notice.
+ */
+object ScalaRunTime {
+  def isArray(x: Any, atLevel: Int = 1): Boolean =
+    x != null && isArrayClass(x.getClass, atLevel)
+
+  private def isArrayClass(clazz: jClass[_], atLevel: Int): Boolean =
+    clazz.isArray && (atLevel == 1 || isArrayClass(clazz.getComponentType, atLevel - 1))
+
+  // A helper method to make my life in the pattern matcher a lot easier.
+  def drop[Repr](coll: Repr, num: Int)(implicit traversable: IsTraversableLike[Repr]): Repr =
+    traversable conversion coll drop num
+
+  /** Return the class object representing an array with element class `clazz`.
+   */
+  def arrayClass(clazz: jClass[_]): jClass[_] = {
+    // newInstance throws an exception if the erasure is Void.TYPE. see scala/bug#5680
+    if (clazz == java.lang.Void.TYPE) classOf[Array[Unit]]
+    else java.lang.reflect.Array.newInstance(clazz, 0).getClass
+  }
+
+  /** Return the class object representing an unboxed value type,
+   *  e.g., classOf[int], not classOf[java.lang.Integer].  The compiler
+   *  rewrites expressions like 5.getClass to come here.
+   */
+  def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
+    classTag[T].runtimeClass.asInstanceOf[jClass[T]]
+
+  /** Retrieve generic array element */
+  @inline def array_apply(xs: AnyRef, idx: Int): Any = {
+    if (xs == null) {
+      throw new NullPointerException
+    } else {
+      xs.asInstanceOf[scala.scalanative.runtime.Array[Any]].apply(idx)
+    }
+  }
+
+  /** update generic array element */
+  @inline def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
+    if (xs == null) {
+      throw new NullPointerException
+    } else {
+      xs.asInstanceOf[scala.scalanative.runtime.Array[Any]].update(idx, value)
+    }
+  }
+
+  /** Get generic array length */
+  def array_length(xs: AnyRef): Int = {
+    if (xs == null) {
+      throw new NullPointerException
+    } else {
+      xs.asInstanceOf[scala.scalanative.runtime.Array[Any]].length
+    }
+  }
+
+  def array_clone(xs: AnyRef): AnyRef = {
+    if (xs == null) {
+      throw new NullPointerException
+    } else {
+      xs.asInstanceOf[scala.scalanative.runtime.Array[Any]].clone()
+    }
+  }
+
+  /** Convert an array to an object array.
+   *  Needed to deal with vararg arguments of primitive types that are passed
+   *  to a generic Java vararg parameter T ...
+   */
+  def toObjectArray(src: AnyRef): Array[Object] = {
+    def copy[@specialized T <: AnyVal](src: Array[T]): Array[Object] = {
+      val length = src.length
+      if (length == 0) Array.emptyObjectArray
+      else {
+        val dest = new Array[Object](length)
+        var i = 0
+        while (i < length) {
+          dest(i) = src(i).asInstanceOf[AnyRef]
+          i += 1
+        }
+        dest
+      }
+    }
+    src match {
+      case x: Array[AnyRef]  => x
+      case x: Array[Int]     => copy(x)
+      case x: Array[Double]  => copy(x)
+      case x: Array[Long]    => copy(x)
+      case x: Array[Float]   => copy(x)
+      case x: Array[Char]    => copy(x)
+      case x: Array[Byte]    => copy(x)
+      case x: Array[Short]   => copy(x)
+      case x: Array[Boolean] => copy(x)
+      case x: Array[Unit]    => copy(x)
+      case null => throw new NullPointerException
+    }
+  }
+
+  def toArray[T](xs: scala.collection.Seq[T]) = {
+    if (xs.isEmpty) Array.emptyObjectArray
+    else {
+      val arr = new Array[AnyRef](xs.length)
+      val it = xs.iterator
+      var i = 0
+      while (it.hasNext) {
+        arr(i) = it.next().asInstanceOf[AnyRef]
+        i += 1
+      }
+      arr
+    }
+  }
+
+  // Java bug: https://bugs.java.com/view_bug.do?bug_id=4071957
+  // More background at ticket #2318.
+  def ensureAccessible(m: JMethod): JMethod = scala.reflect.ensureAccessible(m)
+
+  def _toString(x: Product): String =
+    x.productIterator.mkString(x.productPrefix + "(", ",", ")")
+
+  def _hashCode(x: Product): Int = scala.util.hashing.MurmurHash3.productHash(x)
+
+  /** A helper for case classes. */
+  def typedProductIterator[T](x: Product): Iterator[T] = {
+    new AbstractIterator[T] {
+      private var c: Int = 0
+      private val cmax = x.productArity
+      def hasNext = c < cmax
+      def next() = {
+        val result = x.productElement(c)
+        c += 1
+        result.asInstanceOf[T]
+      }
+    }
+  }
+
+  /** Old implementation of `##`. */
+  @deprecated("Use scala.runtime.Statics.anyHash instead.", "2.12.0")
+  def hash(x: Any): Int = Statics.anyHash(x.asInstanceOf[Object])
+
+  /** Given any Scala value, convert it to a String.
+   *
+   * The primary motivation for this method is to provide a means for
+   * correctly obtaining a String representation of a value, while
+   * avoiding the pitfalls of naively calling toString on said value.
+   * In particular, it addresses the fact that (a) toString cannot be
+   * called on null and (b) depending on the apparent type of an
+   * array, toString may or may not print it in a human-readable form.
+   *
+   * @param   arg   the value to stringify
+   * @return        a string representation of arg.
+   */
+  def stringOf(arg: Any): String = stringOf(arg, scala.Int.MaxValue)
+  def stringOf(arg: Any, maxElements: Int): String = {
+    def packageOf(x: AnyRef) = x.getClass.getPackage match {
+      case null   => ""
+      case p      => p.getName
+    }
+    def isScalaClass(x: AnyRef)         = packageOf(x) startsWith "scala."
+    def isScalaCompilerClass(x: AnyRef) = packageOf(x) startsWith "scala.tools.nsc."
+
+    // includes specialized subclasses and future proofed against hypothetical TupleN (for N > 22)
+    def isTuple(x: Any) = x != null && x.getClass.getName.startsWith("scala.Tuple")
+
+    // We use reflection because the scala.xml package might not be available
+    def isSubClassOf(potentialSubClass: Class[_], ofClass: String) =
+      try {
+        val classLoader = potentialSubClass.getClassLoader
+        val clazz = Class.forName(ofClass, /*initialize =*/ false, classLoader)
+        clazz.isAssignableFrom(potentialSubClass)
+      } catch {
+        case cnfe: ClassNotFoundException => false
+      }
+    def isXmlNode(potentialSubClass: Class[_])     = isSubClassOf(potentialSubClass, "scala.xml.Node")
+    def isXmlMetaData(potentialSubClass: Class[_]) = isSubClassOf(potentialSubClass, "scala.xml.MetaData")
+
+    // When doing our own iteration is dangerous
+    def useOwnToString(x: Any) = x match {
+      // Range/NumericRange have a custom toString to avoid walking a gazillion elements
+      case _: Range | _: NumericRange[_] => true
+      // Sorted collections to the wrong thing (for us) on iteration - ticket #3493
+      case _: Sorted[_, _]  => true
+      // StringBuilder(a, b, c) and similar not so attractive
+      case _: StringLike[_] => true
+      // Don't want to evaluate any elements in a view
+      case _: TraversableView[_, _] => true
+      // Node extends NodeSeq extends Seq[Node] and MetaData extends Iterable[MetaData]
+      // -> catch those by isXmlNode and isXmlMetaData.
+      // Don't want to a) traverse infinity or b) be overly helpful with peoples' custom
+      // collections which may have useful toString methods - ticket #3710
+      // or c) print AbstractFiles which are somehow also Iterable[AbstractFile]s.
+      case x: Traversable[_] => !x.hasDefiniteSize || !isScalaClass(x) || isScalaCompilerClass(x) || isXmlNode(x.getClass) || isXmlMetaData(x.getClass)
+      // Otherwise, nothing could possibly go wrong
+      case _ => false
+    }
+
+    // A variation on inner for maps so they print -> instead of bare tuples
+    def mapInner(arg: Any): String = arg match {
+      case (k, v)   => inner(k) + " -> " + inner(v)
+      case _        => inner(arg)
+    }
+
+    // Special casing Unit arrays, the value class which uses a reference array type.
+    def arrayToString(x: AnyRef) = {
+      if (x.getClass.getComponentType == classOf[BoxedUnit])
+        0 until (array_length(x) min maxElements) map (_ => "()") mkString ("Array(", ", ", ")")
+      else
+        WrappedArray make x take maxElements map inner mkString ("Array(", ", ", ")")
+    }
+
+    // The recursively applied attempt to prettify Array printing.
+    // Note that iterator is used if possible and foreach is used as a
+    // last resort, because the parallel collections "foreach" in a
+    // random order even on sequences.
+    def inner(arg: Any): String = arg match {
+      case null                         => "null"
+      case ""                           => "\"\""
+      case x: String                    => if (x.head.isWhitespace || x.last.isWhitespace) "\"" + x + "\"" else x
+      case x if useOwnToString(x)       => x.toString
+      case x: AnyRef if isArray(x)      => arrayToString(x)
+      case x: scala.collection.Map[_, _]      => x.iterator take maxElements map mapInner mkString (x.stringPrefix + "(", ", ", ")")
+      case x: GenIterable[_]            => x.iterator take maxElements map inner mkString (x.stringPrefix + "(", ", ", ")")
+      case x: Traversable[_]            => x take maxElements map inner mkString (x.stringPrefix + "(", ", ", ")")
+      case x: Product1[_] if isTuple(x) => "(" + inner(x._1) + ",)" // that special trailing comma
+      case x: Product if isTuple(x)     => x.productIterator map inner mkString ("(", ",", ")")
+      case x                            => x.toString
+    }
+
+    // The try/catch is defense against iterables which aren't actually designed
+    // to be iterated, such as some scala.tools.nsc.io.AbstractFile derived classes.
+    try inner(arg)
+    catch {
+      case _: UnsupportedOperationException | _: AssertionError => "" + arg
+    }
+  }
+
+  /** stringOf formatted for use in a repl result. */
+  def replStringOf(arg: Any, maxElements: Int): String = {
+    val s  = stringOf(arg, maxElements)
+    val nl = if (s contains "\n") "\n" else ""
+
+    nl + s + "\n"
+  }
+}

--- a/scripted-tests/run/C_argc_argv-to-java_args/build.sbt
+++ b/scripted-tests/run/C_argc_argv-to-java_args/build.sbt
@@ -1,3 +1,10 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}

--- a/scripted-tests/run/C_argc_argv-to-java_args/build.sbt
+++ b/scripted-tests/run/C_argc_argv-to-java_args/build.sbt
@@ -1,3 +1,3 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"

--- a/scripted-tests/run/errors-reported/build.sbt
+++ b/scripted-tests/run/errors-reported/build.sbt
@@ -1,3 +1,10 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}

--- a/scripted-tests/run/errors-reported/build.sbt
+++ b/scripted-tests/run/errors-reported/build.sbt
@@ -1,3 +1,3 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"

--- a/scripted-tests/run/execution-context/build.sbt
+++ b/scripted-tests/run/execution-context/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"
 
 lazy val runAndCheck = taskKey[Unit]("...")
 

--- a/scripted-tests/run/execution-context/build.sbt
+++ b/scripted-tests/run/execution-context/build.sbt
@@ -1,6 +1,13 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}
 
 lazy val runAndCheck = taskKey[Unit]("...")
 
@@ -8,7 +15,7 @@ runAndCheck := {
   import scala.sys.process._
 
   val bin = (Compile / nativeLink).value
-  val out = Process(bin.getAbsolutePath).lines_!.toList
+  val out = Process(bin.getAbsolutePath).lineStream_!.toList
   assert(
     out == List(
       "start main",

--- a/scripted-tests/run/hello-scala-app/build.sbt
+++ b/scripted-tests/run/hello-scala-app/build.sbt
@@ -1,3 +1,10 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}

--- a/scripted-tests/run/hello-scala-app/build.sbt
+++ b/scripted-tests/run/hello-scala-app/build.sbt
@@ -1,3 +1,3 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"

--- a/scripted-tests/run/hello-world/build.sbt
+++ b/scripted-tests/run/hello-world/build.sbt
@@ -1,3 +1,10 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}

--- a/scripted-tests/run/hello-world/build.sbt
+++ b/scripted-tests/run/hello-world/build.sbt
@@ -1,3 +1,3 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"

--- a/scripted-tests/run/java-io-file-1/build.sbt
+++ b/scripted-tests/run/java-io-file-1/build.sbt
@@ -3,7 +3,14 @@ import java.nio.file.{Files => NioFiles}
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}
 
 lazy val setupTests = taskKey[Unit]("")
 

--- a/scripted-tests/run/java-io-file-1/build.sbt
+++ b/scripted-tests/run/java-io-file-1/build.sbt
@@ -3,7 +3,7 @@ import java.nio.file.{Files => NioFiles}
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"
 
 lazy val setupTests = taskKey[Unit]("")
 

--- a/scripted-tests/run/java-io-file-2/build.sbt
+++ b/scripted-tests/run/java-io-file-2/build.sbt
@@ -3,7 +3,7 @@ import java.nio.file.{Files => NioFiles}
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"
 
 nativeLinkStubs := true // DateFormatSymbols
 

--- a/scripted-tests/run/java-io-file-2/build.sbt
+++ b/scripted-tests/run/java-io-file-2/build.sbt
@@ -3,7 +3,14 @@ import java.nio.file.{Files => NioFiles}
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}
 
 nativeLinkStubs := true // DateFormatSymbols
 

--- a/scripted-tests/run/java-io-file-input-stream/build.sbt
+++ b/scripted-tests/run/java-io-file-input-stream/build.sbt
@@ -1,10 +1,16 @@
 import java.io.File
 import java.io.FileOutputStream
-import java.io.FileInputStream
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}
 
 lazy val createFileWithAlreadyWrittenText =
   taskKey[Unit]("Creating a file with some text on it")

--- a/scripted-tests/run/java-io-file-input-stream/build.sbt
+++ b/scripted-tests/run/java-io-file-input-stream/build.sbt
@@ -4,7 +4,7 @@ import java.io.FileInputStream
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"
 
 lazy val createFileWithAlreadyWrittenText =
   taskKey[Unit]("Creating a file with some text on it")

--- a/scripted-tests/run/java-io-file-output-stream/build.sbt
+++ b/scripted-tests/run/java-io-file-output-stream/build.sbt
@@ -4,7 +4,14 @@ import java.io.FileInputStream
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}
 
 lazy val createFileWithAlreadyWrittenText =
   taskKey[Unit]("Creating a file with some text on it")

--- a/scripted-tests/run/java-io-file-output-stream/build.sbt
+++ b/scripted-tests/run/java-io-file-output-stream/build.sbt
@@ -4,7 +4,7 @@ import java.io.FileInputStream
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"
 
 lazy val createFileWithAlreadyWrittenText =
   taskKey[Unit]("Creating a file with some text on it")

--- a/scripted-tests/run/java-net-server-socket/build.sbt
+++ b/scripted-tests/run/java-net-server-socket/build.sbt
@@ -1,10 +1,17 @@
 import java.net.{Socket, InetSocketAddress}
-import java.io.{PrintWriter, BufferedReader, InputStreamReader, File}
+import java.io.{PrintWriter, BufferedReader, InputStreamReader}
 import java.nio.file.{Files, Paths}
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}
 
 lazy val launchClient = taskKey[Unit]("Launching a client for tests")
 

--- a/scripted-tests/run/java-net-server-socket/build.sbt
+++ b/scripted-tests/run/java-net-server-socket/build.sbt
@@ -4,7 +4,7 @@ import java.nio.file.{Files, Paths}
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"
 
 lazy val launchClient = taskKey[Unit]("Launching a client for tests")
 

--- a/scripted-tests/run/java-net-socket/build.sbt
+++ b/scripted-tests/run/java-net-socket/build.sbt
@@ -7,7 +7,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"
 
 lazy val launchServer = taskKey[Unit]("Setting up a server for tests")
 lazy val launchTcpEchoServer =

--- a/scripted-tests/run/java-net-socket/build.sbt
+++ b/scripted-tests/run/java-net-socket/build.sbt
@@ -1,4 +1,4 @@
-import java.net.{ServerSocket}
+import java.net.ServerSocket
 import java.io.{PrintWriter, BufferedReader, InputStreamReader, File}
 import java.nio.file.{Files, Paths}
 
@@ -7,7 +7,14 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}
 
 lazy val launchServer = taskKey[Unit]("Setting up a server for tests")
 lazy val launchTcpEchoServer =

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -2,7 +2,7 @@ enablePlugins(ScalaNativePlugin)
 
 import scala.sys.process._
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"
 
 Compile / nativeLinkingOptions += s"-L${target.value.getAbsoluteFile}"
 

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -2,7 +2,14 @@ enablePlugins(ScalaNativePlugin)
 
 import scala.sys.process._
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}
 
 Compile / nativeLinkingOptions += s"-L${target.value.getAbsoluteFile}"
 

--- a/scripted-tests/run/link-stubs/build.sbt
+++ b/scripted-tests/run/link-stubs/build.sbt
@@ -1,3 +1,10 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}

--- a/scripted-tests/run/link-stubs/build.sbt
+++ b/scripted-tests/run/link-stubs/build.sbt
@@ -1,3 +1,3 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"

--- a/scripted-tests/run/native-code-include/build.sbt
+++ b/scripted-tests/run/native-code-include/build.sbt
@@ -1,3 +1,10 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}

--- a/scripted-tests/run/native-code-include/build.sbt
+++ b/scripted-tests/run/native-code-include/build.sbt
@@ -1,3 +1,3 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"

--- a/scripted-tests/run/shutdown/build.sbt
+++ b/scripted-tests/run/shutdown/build.sbt
@@ -2,7 +2,7 @@ import java.util.concurrent.TimeUnit
 import java.lang.ProcessBuilder
 import java.nio.file.Files
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"
 
 val runTest = taskKey[Unit]("run test")
 

--- a/scripted-tests/run/shutdown/build.sbt
+++ b/scripted-tests/run/shutdown/build.sbt
@@ -1,8 +1,14 @@
 import java.util.concurrent.TimeUnit
-import java.lang.ProcessBuilder
 import java.nio.file.Files
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}
 
 val runTest = taskKey[Unit]("run test")
 

--- a/scripted-tests/run/system-exit/build.sbt
+++ b/scripted-tests/run/system-exit/build.sbt
@@ -1,3 +1,10 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.12.12"
+scalaVersion := {
+  val scalaVersion = System.getProperty("scala.version")
+  if (scalaVersion == null)
+    throw new RuntimeException(
+      """|The system property 'scala.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else scalaVersion
+}

--- a/scripted-tests/run/system-exit/build.sbt
+++ b/scripted-tests/run/system-exit/build.sbt
@@ -1,3 +1,3 @@
 enablePlugins(ScalaNativePlugin)
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.12"

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -249,9 +249,9 @@ object CodeGen {
       if (attrs.opt eq Attr.NoOpt) {
         str(" optnone noinline")
       } else {
-        if (attrs.inline ne Attr.MayInline) {
+        if (attrs.doInline ne Attr.MayInline) {
           str(" ")
-          genAttr(attrs.inline)
+          genAttr(attrs.doInline)
         }
       }
       if (!attrs.isExtern && !isDecl) {

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -249,9 +249,9 @@ object CodeGen {
       if (attrs.opt eq Attr.NoOpt) {
         str(" optnone noinline")
       } else {
-        if (attrs.doInline ne Attr.MayInline) {
+        if (attrs.inlineHint ne Attr.MayInline) {
           str(" ")
-          genAttr(attrs.doInline)
+          genAttr(attrs.inlineHint)
         }
       }
       if (!attrs.isExtern && !isDecl) {

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -68,7 +68,7 @@ object Generate {
       val result           = Val.Local(fresh(), Type.Bool)
 
       buf += Defn.Define(
-        Attrs(doInline = Attr.AlwaysInline),
+        Attrs(inlineHint = Attr.AlwaysInline),
         ClassHasTraitName,
         ClassHasTraitSig,
         Seq(
@@ -99,7 +99,7 @@ object Generate {
       val result          = Val.Local(fresh(), Type.Bool)
 
       buf += Defn.Define(
-        Attrs(doInline = Attr.AlwaysInline),
+        Attrs(inlineHint = Attr.AlwaysInline),
         TraitHasTraitName,
         TraitHasTraitSig,
         Seq(
@@ -223,7 +223,7 @@ object Generate {
             val loadName = name.member(Sig.Generated("load"))
             val loadSig  = Type.Function(Seq(), clsTy)
             val loadDefn = Defn.Define(
-              Attrs(doInline = Attr.NoInline),
+              Attrs(inlineHint = Attr.NoInline),
               loadName,
               loadSig,
               Seq(

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -68,7 +68,7 @@ object Generate {
       val result           = Val.Local(fresh(), Type.Bool)
 
       buf += Defn.Define(
-        Attrs(inline = Attr.AlwaysInline),
+        Attrs(doInline = Attr.AlwaysInline),
         ClassHasTraitName,
         ClassHasTraitSig,
         Seq(
@@ -99,7 +99,7 @@ object Generate {
       val result          = Val.Local(fresh(), Type.Bool)
 
       buf += Defn.Define(
-        Attrs(inline = Attr.AlwaysInline),
+        Attrs(doInline = Attr.AlwaysInline),
         TraitHasTraitName,
         TraitHasTraitSig,
         Seq(
@@ -223,7 +223,7 @@ object Generate {
             val loadName = name.member(Sig.Generated("load"))
             val loadSig  = Type.Function(Seq(), clsTy)
             val loadDefn = Defn.Define(
-              Attrs(inline = Attr.NoInline),
+              Attrs(doInline = Attr.NoInline),
               loadName,
               loadSig,
               Seq(

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -35,11 +35,11 @@ trait Inline { self: Interflow =>
         val noOpt =
           defn.attrs.opt == Attr.NoOpt
         val noInline =
-          defn.attrs.doInline == Attr.NoInline
+          defn.attrs.inlineHint == Attr.NoInline
         val alwaysInline =
-          defn.attrs.doInline == Attr.AlwaysInline
+          defn.attrs.inlineHint == Attr.AlwaysInline
         val hintInline =
-          defn.attrs.doInline == Attr.InlineHint
+          defn.attrs.inlineHint == Attr.InlineHint
         val isRecursive =
           hasContext(s"inlining ${name.show}")
         val isBlacklisted =

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -35,11 +35,11 @@ trait Inline { self: Interflow =>
         val noOpt =
           defn.attrs.opt == Attr.NoOpt
         val noInline =
-          defn.attrs.inline == Attr.NoInline
+          defn.attrs.doInline == Attr.NoInline
         val alwaysInline =
-          defn.attrs.inline == Attr.AlwaysInline
+          defn.attrs.doInline == Attr.AlwaysInline
         val hintInline =
-          defn.attrs.inline == Attr.InlineHint
+          defn.attrs.doInline == Attr.InlineHint
         val isRecursive =
           hasContext(s"inlining ${name.show}")
         val isBlacklisted =
@@ -140,7 +140,7 @@ trait Inline { self: Interflow =>
 
       val inlineArgs  = adapt(args, defn.ty)
       val inlineInsts = defn.insts.toArray
-      val blocks      = process(inlineInsts, inlineArgs, state, inline = true)
+      val blocks      = process(inlineInsts, inlineArgs, state, doInline = true)
 
       val emit = new nir.Buffer()(state.fresh)
 

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -410,6 +410,10 @@ final class MergeProcessor(insts: Array[Inst],
           case _               => v.ty
         }
       }
+      // !!! CAUTION: j.l.Object is provided here as the most generic upper bound type.
+      // !!! In case `tys` have more than one common super-type and a type which is more
+      // !!! specific than j.l.Object is expected as the return type, then Sub.lub may
+      // !!! calculate the wrong type.
       val retTy = Sub.lub(tys, Type.Ref(Global.Top("java.lang.Object")))
 
       // Create synthetic label and block where all returning blocks

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -85,8 +85,8 @@ final class MergeProcessor(insts: Array[Inst],
             }
             val name = mergeFresh()
             val bound = params.headOption match {
-              case Some(local) => local.ty
-              case None        => Type.Ref(Global.Top("java.lang.Object"))
+              case Some(Val.Local(_, ty: Type.RefKind)) => ty
+              case _                                    => Type.Ref(Global.Top("java.lang.Object"))
             }
             val paramty = Sub.lub(materialized.map(_.ty), bound)
             val param   = Val.Local(name, paramty)

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -89,21 +89,10 @@ trait Opt { self: Interflow =>
       case tys     => Sub.lub(tys, Type.Ref(Global.Top("java.lang.Object")))
     }
 
-    // Interflow usually infers better types on our erased type system
-    // than scalac, yet we live it a benefit of the doubt and make sure
-    // that if original return type is more specific, we keep it as is.
-    val origRetty = {
+    val resRetty = {
       val Type.Function(_, ty) = origdefn.ty
       ty
     }
-    val resRetty =
-      if (!Sub.is(retty, origRetty)) {
-        log(
-          s"inferred type ${retty.show} is less precise than ${origRetty.show}")
-        origRetty
-      } else {
-        retty
-      }
 
     result(resRetty, insts)
   }

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -62,7 +62,7 @@ trait Opt { self: Interflow =>
     val blocks =
       try {
         pushBlockFresh(fresh)
-        process(origdefn.insts.toArray, args, state, inline = false)
+        process(origdefn.insts.toArray, args, state, doInline = false)
       } finally {
         popBlockFresh()
       }
@@ -111,9 +111,9 @@ trait Opt { self: Interflow =>
   def process(insts: Array[Inst],
               args: Seq[Val],
               state: State,
-              inline: Boolean): Seq[MergeBlock] = {
+              doInline: Boolean): Seq[MergeBlock] = {
     val processor =
-      MergeProcessor.fromEntry(insts, args, state, inline, blockFresh, this)
+      MergeProcessor.fromEntry(insts, args, state, doInline, blockFresh, this)
 
     try {
       pushMergeProcessor(processor)
@@ -125,6 +125,6 @@ trait Opt { self: Interflow =>
       popMergeProcessor()
     }
 
-    processor.toSeq()
+    processor.toSeq
   }
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -86,7 +86,7 @@ trait Opt { self: Interflow =>
     val retty = rets match {
       case Seq()   => Type.Nothing
       case Seq(ty) => ty
-      case tys     => Sub.lub(tys)
+      case tys     => Sub.lub(tys, Type.Ref(Global.Top("java.lang.Object")))
     }
 
     // Interflow usually infers better types on our erased type system

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -115,7 +115,9 @@ trait PolyInline { self: Interflow =>
         emit.jump(Next.Label(mergeLabel, Seq(res)))
     }
 
-    val result = Val.Local(fresh(), Sub.lub(rettys))
+    val result = Val.Local(
+      fresh(),
+      Sub.lub(rettys, Type.Ref(Global.Top("java.lang.Object"))))
     emit.label(mergeLabel, Seq(result))
 
     result

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -115,6 +115,10 @@ trait PolyInline { self: Interflow =>
         emit.jump(Next.Label(mergeLabel, Seq(res)))
     }
 
+    // !!! CAUTION: j.l.Object is provided here as the most generic upper bound type.
+    // !!! In case `tys` have more than one common super-type and a type which is more
+    // !!! specific than j.l.Object is expected as the return type, then Sub.lub may
+    // !!! calculate the wrong type.
     val result = Val.Local(
       fresh(),
       Sub.lub(rettys, Type.Ref(Global.Top("java.lang.Object"))))

--- a/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
@@ -21,9 +21,8 @@ object ClassLoader {
     new FromDisk(classpath)
   }
 
-  def fromMemory(defns: Seq[Defn]): ClassLoader = {
+  def fromMemory(defns: Seq[Defn]): ClassLoader =
     new FromMemory(defns)
-  }
 
   final class FromDisk(classpath: Seq[ClassPath]) extends ClassLoader {
     lazy val classesWithEntryPoints: Iterable[Global] = {

--- a/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
@@ -22,8 +22,6 @@ object ClassLoader {
   }
 
   def fromMemory(defns: Seq[Defn]): ClassLoader = {
-    assert(defns != null)
-    assert(defns.forall(_ != null))
     new FromMemory(defns)
   }
 

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -143,12 +143,7 @@ final class Class(val attrs: Attrs,
     isModule && (isWhitelisted || attrs.isExtern || (hasEmptyOrNoCtor && hasNoFields))
   }
   def resolve(sig: Sig): Option[Global] = {
-    responds.get(sig) match {
-      case None =>
-        defaultResponds.get(sig)
-      case someImpl =>
-        someImpl
-    }
+    responds.get(sig).orElse(defaultResponds.get(sig))
   }
   def targets(sig: Sig): mutable.Set[Global] = {
     val out = mutable.Set.empty[Global]

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -27,7 +27,10 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
     cleanup()
 
     val defns = mutable.UnrolledBuffer.empty[Defn]
-    defns ++= done.valuesIterator
+
+    // drop the null values that have been introduced
+    // in reachUnavailable
+    defns ++= done.valuesIterator.filter(_ != null)
 
     new Result(infos,
                entries,

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -48,18 +48,22 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
     // past what's known now, so it's safe to do this.
     infos.values.foreach {
       case cls: Class =>
-        cls.responds.foreach {
+        val responds = cls.responds.toArray
+        responds.foreach {
           case (sig, name) =>
             if (!done.contains(name)) {
               cls.responds -= sig
             }
         }
-        cls.defaultResponds.foreach {
+
+        val defaultResponds = cls.defaultResponds.toArray
+        defaultResponds.foreach {
           case (sig, name) =>
             if (!done.contains(name)) {
               cls.defaultResponds -= sig
             }
         }
+
       case _ =>
         ()
     }
@@ -212,9 +216,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
         loaded(info.name).foreach {
           case (_, defn: Defn.Define) =>
             val Global.Member(_, sig) = defn.name
-
             info.responds(sig) = defn.name
-
           case _ =>
             ()
         }

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -83,15 +83,15 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def process(): Unit =
     while (todo.nonEmpty) {
-      val name = todo.last
-      todo = todo.init
+      val name = todo.head
+      todo = todo.tail
       if (!done.contains(name)) {
         reachDefn(name)
       }
     }
 
   def reachDefn(name: Global): Unit = {
-    stack :+= name
+    stack ::= name
     lookup(name).fold[Unit] {
       reachUnavailable(name)
     } { defn =>
@@ -101,7 +101,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
         reachDefn(defn)
       }
     }
-    stack = stack.init
+    stack = stack.tail
   }
 
   def reachDefn(defn: Defn): Unit = {
@@ -164,7 +164,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
     if (!enqueued.contains(name) && name.ne(Global.None)) {
       enqueued += name
       from(name) = if (stack.isEmpty) Global.None else stack.head
-      todo :+= name
+      todo ::= name
     }
 
   def reachGlobalNow(name: Global): Unit =

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -698,8 +698,8 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
       case Rt.ScalaHashCodeSig =>
         val scalaImpl = lookupSig(cls, Rt.ScalaHashCodeSig).get
         val javaImpl  = lookupSig(cls, Rt.JavaHashCodeSig).get
-        if (javaImpl.top != Some(Rt.Object.name) &&
-            scalaImpl.top == Some(Rt.Object.name)) {
+        if (javaImpl.top != Rt.Object.name &&
+            scalaImpl.top == Rt.Object.name) {
           Some(javaImpl)
         } else {
           Some(scalaImpl)

--- a/tools/src/test/scala/scala/scalanative/NativePlatform.scala
+++ b/tools/src/test/scala/scala/scalanative/NativePlatform.scala
@@ -1,0 +1,7 @@
+package scala.scalanative
+
+import scala.scalanative.buildinfo.ScalaNativeBuildInfo._
+
+private[scalanative] object NativePlatform {
+  def scalaUsesImplClasses: Boolean = nativeScalaVersion.startsWith("2.11.")
+}

--- a/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
@@ -27,14 +27,7 @@ class StubSpec extends LinkerSpec {
   "Stub methods" should "be ignored by the linker when `linkStubs = false`" in {
     link(entry, stubMethodSource, linkStubs = false) { (cfg, result) =>
       assert(!cfg.linkStubs)
-      if (scalaVersion.startsWith("2.11")) {
-        assert(result.unavailable.length == 1)
-      } else {
-        // In Scala 2.12.x, the reachability analysis discards a few extra symbols:
-        // - java.util.Properties.load
-        // - java.lang.Class.getResourceAsStream
-        assert(result.unavailable.length == 3)
-      }
+      assert(result.unavailable.length == 1)
       assert(
         result.unavailable.head == Global
           .Top("Main$")
@@ -52,14 +45,7 @@ class StubSpec extends LinkerSpec {
   "Stub classes" should "be ignored by the linker when `linkStubs = false`" in {
     link(entry, stubClassSource, linkStubs = false) { (cfg, result) =>
       assert(!cfg.linkStubs)
-      if (scalaVersion.startsWith("2.11")) {
-        assert(result.unavailable.length == 1)
-      } else {
-        // In Scala 2.12.x, the reachability analysis discards a few extra symbols:
-        // - java.util.Properties.load
-        // - java.lang.Class.getResourceAsStream
-        assert(result.unavailable.length == 3)
-      }
+      assert(result.unavailable.length == 1)
       assert(result.unavailable.head == Global.Top("StubClass"))
     }
   }
@@ -74,14 +60,7 @@ class StubSpec extends LinkerSpec {
   "Stub modules" should "be ignored by the linker when `linkStubs = false`" in {
     link(entry, stubModuleSource, linkStubs = false) { (cfg, result) =>
       assert(!cfg.linkStubs)
-      if (scalaVersion.startsWith("2.11")) {
-        assert(result.unavailable.length == 1)
-      } else {
-        // In Scala 2.12.x, the reachability analysis discards a few extra symbols:
-        // - java.util.Properties.load
-        // - java.lang.Class.getResourceAsStream
-        assert(result.unavailable.length == 3)
-      }
+      assert(result.unavailable.length == 1)
       assert(result.unavailable.head == Global.Top("StubModule$"))
     }
   }

--- a/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
@@ -1,6 +1,7 @@
 package scala.scalanative
 package linker
 
+import scala.scalanative.util.Platform.scalaVersion
 import nir.{Sig, Type, Global}
 
 class StubSpec extends LinkerSpec {
@@ -26,7 +27,14 @@ class StubSpec extends LinkerSpec {
   "Stub methods" should "be ignored by the linker when `linkStubs = false`" in {
     link(entry, stubMethodSource, linkStubs = false) { (cfg, result) =>
       assert(!cfg.linkStubs)
-      assert(result.unavailable.length == 1)
+      if (scalaVersion.startsWith("2.11")) {
+        assert(result.unavailable.length == 1)
+      } else {
+        // In Scala 2.12.x, the reachability analysis discards a few extra symbols:
+        // - java.util.Properties.load
+        // - java.lang.Class.getResourceAsStream
+        assert(result.unavailable.length == 3)
+      }
       assert(
         result.unavailable.head == Global
           .Top("Main$")
@@ -44,7 +52,14 @@ class StubSpec extends LinkerSpec {
   "Stub classes" should "be ignored by the linker when `linkStubs = false`" in {
     link(entry, stubClassSource, linkStubs = false) { (cfg, result) =>
       assert(!cfg.linkStubs)
-      assert(result.unavailable.length == 1)
+      if (scalaVersion.startsWith("2.11")) {
+        assert(result.unavailable.length == 1)
+      } else {
+        // In Scala 2.12.x, the reachability analysis discards a few extra symbols:
+        // - java.util.Properties.load
+        // - java.lang.Class.getResourceAsStream
+        assert(result.unavailable.length == 3)
+      }
       assert(result.unavailable.head == Global.Top("StubClass"))
     }
   }
@@ -59,7 +74,14 @@ class StubSpec extends LinkerSpec {
   "Stub modules" should "be ignored by the linker when `linkStubs = false`" in {
     link(entry, stubModuleSource, linkStubs = false) { (cfg, result) =>
       assert(!cfg.linkStubs)
-      assert(result.unavailable.length == 1)
+      if (scalaVersion.startsWith("2.11")) {
+        assert(result.unavailable.length == 1)
+      } else {
+        // In Scala 2.12.x, the reachability analysis discards a few extra symbols:
+        // - java.util.Properties.load
+        // - java.lang.Class.getResourceAsStream
+        assert(result.unavailable.length == 3)
+      }
       assert(result.unavailable.head == Global.Top("StubModule$"))
     }
   }

--- a/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
@@ -1,7 +1,6 @@
 package scala.scalanative
 package linker
 
-import scala.scalanative.util.Platform.scalaVersion
 import nir.{Sig, Type, Global}
 
 class StubSpec extends LinkerSpec {

--- a/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
@@ -1,14 +1,25 @@
 package scala.scalanative.linker
 
 import org.scalatest._
+import scalanative.util.Platform.scalaVersion
 import scalanative.nir.{Type, Sig, Global}
 
 class TraitReachabilitySuite extends ReachabilitySuite {
   val Parent = g("Parent")
+
+  // Scala 2.11.x
+  val ParentClass = g("Parent$class")
+  val ParentClassInit =
+    g("Parent$class", Sig.Method("$init$", Seq(Type.Ref(Parent), Type.Unit)))
+  val ParentClassFoo =
+    g("Parent$class", Sig.Method("foo", Seq(Type.Ref(Parent), Type.Unit)))
+
+  // Scala 2.12.x
   val ParentInit =
     g("Parent", Sig.Method("$init$", Seq(Type.Unit)))
   val ParentFoo =
     g("Parent", Sig.Method("foo", Seq(Type.Unit)))
+
   val Child          = g("Child")
   val ChildInit      = g("Child", Sig.Ctor(Seq.empty))
   val ChildFoo       = g("Child", Sig.Method("foo", Seq(Type.Unit)))
@@ -164,12 +175,24 @@ class TraitReachabilitySuite extends ReachabilitySuite {
       Child,
       ChildInit,
       ChildFoo,
-      Parent,
-      ParentInit,
-      ParentFoo,
       Object,
       ObjectInit
-    )
+    ) ++ {
+      if (scalaVersion.startsWith("2.11")) {
+        Seq(
+          Parent,
+          ParentClass,
+          ParentClassInit,
+          ParentClassFoo
+        )
+      } else {
+        Seq(
+          Parent,
+          ParentInit,
+          ParentFoo
+        )
+      }
+    }
     (source, entry, reachable)
   }
 
@@ -199,11 +222,22 @@ class TraitReachabilitySuite extends ReachabilitySuite {
       Child,
       ChildInit,
       ChildFoo,
-      Parent,
-      ParentInit,
       Object,
       ObjectInit
-    )
+    ) ++ {
+      if (scalaVersion.startsWith("2.11")) {
+        Seq(
+          Parent,
+          ParentClass,
+          ParentClassInit
+        )
+      } else {
+        Seq(
+          Parent,
+          ParentInit
+        )
+      }
+    }
     (source, entry, reachable)
   }
 }

--- a/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
@@ -4,15 +4,17 @@ import org.scalatest._
 import scalanative.util.Platform.scalaVersion
 import scalanative.nir.{Type, Sig, Global}
 
+// import scala.scalanative.buildinfo.ScalaNativeBuildInfo.scalaVersion
+
 class TraitReachabilitySuite extends ReachabilitySuite {
   val Parent = g("Parent")
 
   // Scala 2.11.x
-  val ParentClass = g("Parent$class$")
+  val ParentClass = g("Parent$class")
   val ParentClassInit =
-    g("Parent$class$", Sig.Method("$init$", Seq(Type.Ref(Parent), Type.Unit)))
+    g("Parent$class", Sig.Method("$init$", Seq(Type.Ref(Parent), Type.Unit)))
   val ParentClassFoo =
-    g("Parent$class$", Sig.Method("foo", Seq(Type.Ref(Parent), Type.Unit)))
+    g("Parent$class", Sig.Method("foo", Seq(Type.Ref(Parent), Type.Unit)))
 
   // Scala 2.12.x
   val ParentInit =

--- a/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
@@ -8,11 +8,11 @@ class TraitReachabilitySuite extends ReachabilitySuite {
   val Parent = g("Parent")
 
   // Scala 2.11.x
-  val ParentClass = g("Parent$class")
+  val ParentClass = g("Parent$class$")
   val ParentClassInit =
-    g("Parent$class", Sig.Method("$init$", Seq(Type.Ref(Parent), Type.Unit)))
+    g("Parent$class$", Sig.Method("$init$", Seq(Type.Ref(Parent), Type.Unit)))
   val ParentClassFoo =
-    g("Parent$class", Sig.Method("foo", Seq(Type.Ref(Parent), Type.Unit)))
+    g("Parent$class$", Sig.Method("foo", Seq(Type.Ref(Parent), Type.Unit)))
 
   // Scala 2.12.x
   val ParentInit =

--- a/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
@@ -1,39 +1,36 @@
 package scala.scalanative.linker
 
-import org.scalatest._
-import scalanative.util.Platform.scalaVersion
-import scalanative.nir.{Type, Sig, Global}
-
-// import scala.scalanative.buildinfo.ScalaNativeBuildInfo.scalaVersion
+import scala.scalanative.NativePlatform
+import scala.scalanative.nir.{Global, Sig, Type}
 
 class TraitReachabilitySuite extends ReachabilitySuite {
-  val Parent = g("Parent")
+  val Parent: Global = g("Parent")
 
   // Scala 2.11.x
-  val ParentClass = g("Parent$class")
-  val ParentClassInit =
+  val ParentClass: Global = g("Parent$class")
+  val ParentClassInit: Global =
     g("Parent$class", Sig.Method("$init$", Seq(Type.Ref(Parent), Type.Unit)))
-  val ParentClassFoo =
+  val ParentClassFoo: Global =
     g("Parent$class", Sig.Method("foo", Seq(Type.Ref(Parent), Type.Unit)))
 
   // Scala 2.12.x
-  val ParentInit =
+  val ParentInit: Global =
     g("Parent", Sig.Method("$init$", Seq(Type.Unit)))
-  val ParentFoo =
+  val ParentFoo: Global =
     g("Parent", Sig.Method("foo", Seq(Type.Unit)))
 
-  val Child          = g("Child")
-  val ChildInit      = g("Child", Sig.Ctor(Seq.empty))
-  val ChildFoo       = g("Child", Sig.Method("foo", Seq(Type.Unit)))
-  val GrandChild     = g("GrandChild")
-  val GrandChildInit = g("GrandChild", Sig.Ctor(Seq.empty))
-  val GrandChildFoo  = g("GrandChild", Sig.Method("foo", Seq(Type.Unit)))
-  val Object         = g("java.lang.Object")
-  val ObjectInit     = g("java.lang.Object", Sig.Ctor(Seq.empty))
-  val Test           = g("Test$")
-  val TestInit       = g("Test$", Sig.Ctor(Seq.empty))
-  val TestMain       = g("Test$", Sig.Method("main", Seq(Type.Unit)))
-  val TestCallFoo =
+  val Child: Global          = g("Child")
+  val ChildInit: Global      = g("Child", Sig.Ctor(Seq.empty))
+  val ChildFoo: Global       = g("Child", Sig.Method("foo", Seq(Type.Unit)))
+  val GrandChild: Global     = g("GrandChild")
+  val GrandChildInit: Global = g("GrandChild", Sig.Ctor(Seq.empty))
+  val GrandChildFoo: Global  = g("GrandChild", Sig.Method("foo", Seq(Type.Unit)))
+  val Object: Global         = g("java.lang.Object")
+  val ObjectInit: Global     = g("java.lang.Object", Sig.Ctor(Seq.empty))
+  val Test: Global           = g("Test$")
+  val TestInit: Global       = g("Test$", Sig.Ctor(Seq.empty))
+  val TestMain: Global       = g("Test$", Sig.Method("main", Seq(Type.Unit)))
+  val TestCallFoo: Global =
     g("Test$", Sig.Method("callFoo", Seq(Type.Ref(Parent), Type.Unit)))
 
   testReachable("unused traits are discarded") {
@@ -180,7 +177,7 @@ class TraitReachabilitySuite extends ReachabilitySuite {
       Object,
       ObjectInit
     ) ++ {
-      if (scalaVersion.startsWith("2.11")) {
+      if (NativePlatform.scalaUsesImplClasses) {
         Seq(
           Parent,
           ParentClass,
@@ -227,7 +224,7 @@ class TraitReachabilitySuite extends ReachabilitySuite {
       Object,
       ObjectInit
     ) ++ {
-      if (scalaVersion.startsWith("2.11")) {
+      if (NativePlatform.scalaUsesImplClasses) {
         Seq(
           Parent,
           ParentClass,

--- a/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.linker
+package scala.scalanative
+package linker
 
 import scala.scalanative.NativePlatform
 import scala.scalanative.nir.{Global, Sig, Type}

--- a/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/TraitReachabilitySuite.scala
@@ -4,12 +4,11 @@ import org.scalatest._
 import scalanative.nir.{Type, Sig, Global}
 
 class TraitReachabilitySuite extends ReachabilitySuite {
-  val Parent      = g("Parent")
-  val ParentClass = g("Parent$class")
-  val ParentClassInit =
-    g("Parent$class", Sig.Method("$init$", Seq(Type.Ref(Parent), Type.Unit)))
-  val ParentClassFoo =
-    g("Parent$class", Sig.Method("foo", Seq(Type.Ref(Parent), Type.Unit)))
+  val Parent = g("Parent")
+  val ParentInit =
+    g("Parent", Sig.Method("$init$", Seq(Type.Unit)))
+  val ParentFoo =
+    g("Parent", Sig.Method("foo", Seq(Type.Unit)))
   val Child          = g("Child")
   val ChildInit      = g("Child", Sig.Ctor(Seq.empty))
   val ChildFoo       = g("Child", Sig.Method("foo", Seq(Type.Unit)))
@@ -142,7 +141,7 @@ class TraitReachabilitySuite extends ReachabilitySuite {
   }
 
   testReachable(
-    "calling a method on a trait with default implemention includes impl class") {
+    "calling a method on a trait with default implementation includes impl class") {
     val source = """
       trait Parent {
         def foo: Unit = ()
@@ -166,9 +165,8 @@ class TraitReachabilitySuite extends ReachabilitySuite {
       ChildInit,
       ChildFoo,
       Parent,
-      ParentClass,
-      ParentClassInit,
-      ParentClassFoo,
+      ParentInit,
+      ParentFoo,
       Object,
       ObjectInit
     )
@@ -176,7 +174,7 @@ class TraitReachabilitySuite extends ReachabilitySuite {
   }
 
   testReachable(
-    "calling a method on a trait with default implemention discards impl class") {
+    "calling a method on a trait with default implementation discards impl class") {
     val source = """
       trait Parent {
         def foo: Unit = ()
@@ -201,9 +199,8 @@ class TraitReachabilitySuite extends ReachabilitySuite {
       Child,
       ChildInit,
       ChildFoo,
-      ParentClass,
-      ParentClassInit,
       Parent,
+      ParentInit,
       Object,
       ObjectInit
     )

--- a/unit-tests/src/test/scala/java/util/ArrayDequeSuite.scala
+++ b/unit-tests/src/test/scala/java/util/ArrayDequeSuite.scala
@@ -1,7 +1,5 @@
 package java.util
 
-import java.util
-
 import scala.collection.JavaConverters._
 
 object ArrayDequeSuite extends tests.Suite {

--- a/unit-tests/src/test/scala/java/util/ArrayDequeSuite.scala
+++ b/unit-tests/src/test/scala/java/util/ArrayDequeSuite.scala
@@ -1,5 +1,7 @@
 package java.util
 
+import java.util
+
 import scala.collection.JavaConverters._
 
 object ArrayDequeSuite extends tests.Suite {
@@ -109,7 +111,7 @@ object ArrayDequeSuite extends tests.Suite {
 
   test(s"addFirst(e)") {
     locally {
-      type E = Float
+      type E = AnyRef
       val ad = new ArrayDeque[E]()
 
       assertThrows[NullPointerException] {
@@ -135,7 +137,7 @@ object ArrayDequeSuite extends tests.Suite {
 
   test(s"addLast(e)") {
     locally {
-      type E = Long
+      type E = AnyRef
       val ad = new ArrayDeque[E]()
 
       assertThrows[NullPointerException] {
@@ -300,7 +302,7 @@ object ArrayDequeSuite extends tests.Suite {
 
   test(s"offer(e: E)") {
     locally {
-      type E = Long
+      type E = AnyRef
       val ad = new ArrayDeque[E]()
 
       assertThrows[NullPointerException] {
@@ -325,7 +327,7 @@ object ArrayDequeSuite extends tests.Suite {
 
   test(s"offerFirst(e: E)") {
     locally {
-      type E = Float
+      type E = AnyRef
       val ad = new ArrayDeque[E]()
 
       assertThrows[NullPointerException] {
@@ -351,7 +353,7 @@ object ArrayDequeSuite extends tests.Suite {
 
   test(s"offerLast(e: E)") {
     locally {
-      type E = Long
+      type E = AnyRef
       val ad = new ArrayDeque[E]()
 
       assertThrows[NullPointerException] {
@@ -551,7 +553,7 @@ object ArrayDequeSuite extends tests.Suite {
 
   test(s"push(e: E)") {
     locally {
-      type E = Double
+      type E = AnyRef
       val ad = new ArrayDeque[E]()
 
       assertThrows[NullPointerException] {

--- a/unit-tests/src/test/scala/scala/AsInstanceOfSuite.scala
+++ b/unit-tests/src/test/scala/scala/AsInstanceOfSuite.scala
@@ -33,7 +33,7 @@ object AsInstanceOfSuite extends tests.Suite {
     assert(anyNull.asInstanceOf[Unit] == anyNull)
   }
 
-  test("null.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12.")) {
+  test("null.asInstanceOf[Unit]", cond = !scalaVersion.startsWith("2.11.")) {
     assert(anyNull.asInstanceOf[Unit] != anyNull)
   }
 
@@ -61,7 +61,7 @@ object AsInstanceOfSuite extends tests.Suite {
     assertThrows[ClassCastException](any42.asInstanceOf[Unit])
   }
 
-  test("42.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12.")) {
+  test("42.asInstanceOf[Unit]", cond = !scalaVersion.startsWith("2.11.")) {
     assertNotNull(any42.asInstanceOf[Unit])
   }
 
@@ -89,7 +89,7 @@ object AsInstanceOfSuite extends tests.Suite {
     assertThrows[ClassCastException](anyC.asInstanceOf[Unit])
   }
 
-  test("c.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12.")) {
+  test("c.asInstanceOf[Unit]", cond = !scalaVersion.startsWith("2.11.")) {
     assertNotNull(c.asInstanceOf[Unit])
   }
 }

--- a/unit-tests/src/test/scala/scala/AsInstanceOfSuite.scala
+++ b/unit-tests/src/test/scala/scala/AsInstanceOfSuite.scala
@@ -1,4 +1,6 @@
-package scala.scalanative.unsafe
+package scala
+
+import scala.scalanative.buildinfo.ScalaNativeBuildInfo.scalaVersion
 
 object AsInstanceOfSuite extends tests.Suite {
   class C
@@ -27,8 +29,12 @@ object AsInstanceOfSuite extends tests.Suite {
     assertThrows[NullPointerException](anyNull.asInstanceOf[Nothing])
   }
 
-  test("null.asInstanceOf[Unit]") {
+  test("null.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.11")) {
     assert(anyNull.asInstanceOf[Unit] == anyNull)
+  }
+
+  test("null.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12")) {
+    assert(anyNull.asInstanceOf[Unit] != anyNull)
   }
 
   test("42.asInstanceOf[Object]") {
@@ -51,8 +57,12 @@ object AsInstanceOfSuite extends tests.Suite {
     assertThrows[ClassCastException](any42.asInstanceOf[Nothing])
   }
 
-  test("42.asInstanceOf[Unit]") {
+  test("42.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.11")) {
     assertThrows[ClassCastException](any42.asInstanceOf[Unit])
+  }
+
+  test("42.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12")) {
+    assertNotNull(any42.asInstanceOf[Unit])
   }
 
   test("c.asInstanceOf[Object]") {
@@ -75,7 +85,11 @@ object AsInstanceOfSuite extends tests.Suite {
     assertThrows[ClassCastException](anyC.asInstanceOf[Nothing])
   }
 
-  test("c.asInstanceOf[Unit]") {
+  test("c.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.11")) {
     assertThrows[ClassCastException](anyC.asInstanceOf[Unit])
+  }
+
+  test("c.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12")) {
+    assertNotNull(c.asInstanceOf[Unit])
   }
 }

--- a/unit-tests/src/test/scala/scala/AsInstanceOfSuite.scala
+++ b/unit-tests/src/test/scala/scala/AsInstanceOfSuite.scala
@@ -29,11 +29,11 @@ object AsInstanceOfSuite extends tests.Suite {
     assertThrows[NullPointerException](anyNull.asInstanceOf[Nothing])
   }
 
-  test("null.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.11")) {
+  test("null.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.11.")) {
     assert(anyNull.asInstanceOf[Unit] == anyNull)
   }
 
-  test("null.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12")) {
+  test("null.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12.")) {
     assert(anyNull.asInstanceOf[Unit] != anyNull)
   }
 
@@ -57,11 +57,11 @@ object AsInstanceOfSuite extends tests.Suite {
     assertThrows[ClassCastException](any42.asInstanceOf[Nothing])
   }
 
-  test("42.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.11")) {
+  test("42.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.11.")) {
     assertThrows[ClassCastException](any42.asInstanceOf[Unit])
   }
 
-  test("42.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12")) {
+  test("42.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12.")) {
     assertNotNull(any42.asInstanceOf[Unit])
   }
 
@@ -85,11 +85,11 @@ object AsInstanceOfSuite extends tests.Suite {
     assertThrows[ClassCastException](anyC.asInstanceOf[Nothing])
   }
 
-  test("c.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.11")) {
+  test("c.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.11.")) {
     assertThrows[ClassCastException](anyC.asInstanceOf[Unit])
   }
 
-  test("c.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12")) {
+  test("c.asInstanceOf[Unit]", cond = scalaVersion.startsWith("2.12.")) {
     assertNotNull(c.asInstanceOf[Unit])
   }
 }

--- a/unit-tests/src/test/scala/tests/SuiteSuite.scala
+++ b/unit-tests/src/test/scala/tests/SuiteSuite.scala
@@ -66,12 +66,12 @@ object SuiteSuite extends Suite {
         }
 
       case exc: Throwable =>
-        if (exc.isInstanceOf[
-              AssertionFailed
-            ]) // got case object, expected case class
-          throw AssertionFailed("expected message yet none found")
-        else
-          throw exc
+        exc match {
+          case _: AssertionFailed =>
+            // got case object, expected case class
+            throw AssertionFailed("expected message yet none found")
+          case _ => throw exc
+        }
     }
   }
 

--- a/unit-tests/src/test/scala/tests/SuiteSuite.scala
+++ b/unit-tests/src/test/scala/tests/SuiteSuite.scala
@@ -68,7 +68,7 @@ object SuiteSuite extends Suite {
       case exc: Throwable =>
         exc match {
           case _: AssertionFailed =>
-            // got case object, expected case class
+            // got class instance, expected case object
             throw AssertionFailed("expected message yet none found")
           case _ => throw exc
         }

--- a/unit-tests/src/test/scala/tests/SuiteSuite.scala
+++ b/unit-tests/src/test/scala/tests/SuiteSuite.scala
@@ -66,7 +66,9 @@ object SuiteSuite extends Suite {
         }
 
       case exc: Throwable =>
-        if (exc.isInstanceOf[AssertionFailed]) // got case object, expected case class
+        if (exc.isInstanceOf[
+              AssertionFailed
+            ]) // got case object, expected case class
           throw AssertionFailed("expected message yet none found")
         else
           throw exc

--- a/unit-tests/src/test/scala/tests/SuiteSuite.scala
+++ b/unit-tests/src/test/scala/tests/SuiteSuite.scala
@@ -66,7 +66,7 @@ object SuiteSuite extends Suite {
         }
 
       case exc: Throwable =>
-        if (exc == AssertionFailed) // got case object, expected case class
+        if (exc.isInstanceOf[AssertionFailed]) // got case object, expected case class
           throw AssertionFailed("expected message yet none found")
         else
           throw exc

--- a/util/src/main/scala/scala/scalanative/util/Platform.scala
+++ b/util/src/main/scala/scala/scalanative/util/Platform.scala
@@ -1,0 +1,5 @@
+package scala.scalanative.util
+
+object Platform {
+  def scalaVersion: String = scala.util.Properties.versionNumberString
+}

--- a/util/src/main/scala/scala/scalanative/util/Platform.scala
+++ b/util/src/main/scala/scala/scalanative/util/Platform.scala
@@ -1,5 +1,0 @@
-package scala.scalanative.util
-
-object Platform {
-  def scalaVersion: String = scala.util.Properties.versionNumberString
-}


### PR DESCRIPTION
### Summary
Add Scala 2.12 support for Scala Native. You can consult the Scala 2.12 changelog [here](https://www.scala-lang.org/news/2.12.0/). This PR takes into account all the changes and adapts them for Scala Native.

### Lambdas
In order to keep the NIR changes to a minimum, we continue generating a `FunctionN` class with an `apply` method for each lambda. All the lambda captures are stored inside the class instance and initialised via its constructor. The `apply` method calls the generated `$anonfun` method, also extracting and forwarding the captures.

### NIR compatibility
Scala 2.12 now compiles trait methods as default methods in Java interfaces. This means that the NIR compiled with 2.12 is not compatible with that compiled with 2.11.

### Scala 2.11 cross-compilation
In order to keep the project compilable with Scala 2.11, a `scala.scalanative.nscplugin.NirCompat` component is introduced in `nscplugin`. This allows the compiler plugin to function with both Scala 2.11 and 2.12.

In addition, some tests need to know under which Scala version they are running. We use `sbt-buildinfo` to provide Scala version information to the projects that need them (mainly for `unit-tests` and `tools` tests).