### PR TITLE
Store source code positions in NIR

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -17,92 +17,104 @@ class Buffer(implicit fresh: Fresh) {
     buffer.size
 
   // Control-flow ops
-  def label(name: Local): Unit =
+  def label(name: Local)(implicit pos: Position): Unit =
     this += Inst.Label(name, Seq.empty)
-  def label(name: Local, params: Seq[Val.Local]): Unit =
+  def label(name: Local, params: Seq[Val.Local])(implicit pos: Position): Unit =
     this += Inst.Label(name, params)
-  def unreachable(unwind: Next): Unit =
+  def unreachable(unwind: Next)(implicit pos: Position): Unit =
     this += Inst.Unreachable(unwind)
-  def ret(value: Val): Unit =
+  def ret(value: Val)(implicit pos: Position): Unit =
     this += Inst.Ret(value)
-  def jump(next: Next): Unit =
+  def jump(next: Next)(implicit pos: Position): Unit =
     this += Inst.Jump(next)
-  def jump(to: Local, args: Seq[Val]): Unit =
+  def jump(to: Local, args: Seq[Val])(implicit pos: Position): Unit =
     this += Inst.Jump(Next.Label(to, args))
-  def branch(value: Val, thenp: Next, elsep: Next): Unit =
+  def branch(value: Val, thenp: Next, elsep: Next)(
+      implicit pos: Position): Unit =
     this += Inst.If(value, thenp, elsep)
-  def switch(value: Val, default: Next, cases: Seq[Next]): Unit =
+  def switch(value: Val, default: Next, cases: Seq[Next])(
+      implicit pos: Position): Unit =
     this += Inst.Switch(value, default, cases)
-  def raise(value: Val, unwind: Next): Unit =
+  def raise(value: Val, unwind: Next)(implicit pos: Position): Unit =
     this += Inst.Throw(value, unwind)
 
   // Compute ops
-  def let(name: Local, op: Op, unwind: Next): Val = {
+  def let(name: Local, op: Op, unwind: Next)(implicit pos: Position): Val = {
     this += Inst.Let(name, op, unwind)
     Val.Local(name, op.resty)
   }
-  def let(op: Op, unwind: Next): Val =
+  def let(op: Op, unwind: Next)(implicit pos: Position): Val =
     let(fresh(), op, unwind)
-  def call(ty: Type, ptr: Val, args: Seq[Val], unwind: Next): Val =
+  def call(ty: Type, ptr: Val, args: Seq[Val], unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Call(ty, ptr, args), unwind)
-  def load(ty: Type, ptr: Val, unwind: Next): Val =
+  def load(ty: Type, ptr: Val, unwind: Next)(implicit pos: Position): Val =
     let(Op.Load(ty, ptr), unwind)
-  def store(ty: Type, ptr: Val, value: Val, unwind: Next): Val =
+  def store(ty: Type, ptr: Val, value: Val, unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Store(ty, ptr, value), unwind)
-  def elem(ty: Type, ptr: Val, indexes: Seq[Val], unwind: Next): Val =
+  def elem(ty: Type, ptr: Val, indexes: Seq[Val], unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Elem(ty, ptr, indexes), unwind)
-  def extract(aggr: Val, indexes: Seq[Int], unwind: Next): Val =
+  def extract(aggr: Val, indexes: Seq[Int], unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Extract(aggr, indexes), unwind)
-  def insert(aggr: Val, value: Val, indexes: Seq[Int], unwind: Next): Val =
+  def insert(aggr: Val, value: Val, indexes: Seq[Int], unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Insert(aggr, value, indexes), unwind)
-  def stackalloc(ty: Type, n: Val, unwind: Next): Val =
+  def stackalloc(ty: Type, n: Val, unwind: Next)(implicit pos: Position): Val =
     let(Op.Stackalloc(ty, n), unwind)
-  def bin(bin: nir.Bin, ty: Type, l: Val, r: Val, unwind: Next): Val =
+  def bin(bin: nir.Bin, ty: Type, l: Val, r: Val, unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Bin(bin, ty, l, r), unwind)
-  def comp(comp: nir.Comp, ty: Type, l: Val, r: Val, unwind: Next): Val =
+  def comp(comp: nir.Comp, ty: Type, l: Val, r: Val, unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Comp(comp, ty, l, r), unwind)
-  def conv(conv: nir.Conv, ty: Type, value: Val, unwind: Next): Val =
+  def conv(conv: nir.Conv, ty: Type, value: Val, unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Conv(conv, ty, value), unwind)
-  def classalloc(name: Global, unwind: Next): Val =
+  def classalloc(name: Global, unwind: Next)(implicit pos: Position): Val =
     let(Op.Classalloc(name), unwind)
-  def fieldload(ty: Type, obj: Val, name: Global, unwind: Next): Val =
+  def fieldload(ty: Type, obj: Val, name: Global, unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Fieldload(ty, obj, name), unwind)
-  def fieldstore(ty: Type,
-                 obj: Val,
-                 name: Global,
-                 value: Val,
-                 unwind: Next): Val =
+  def fieldstore(ty: Type, obj: Val, name: Global, value: Val, unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Fieldstore(ty, obj, name, value), unwind)
-  def method(obj: Val, sig: Sig, unwind: Next): Val =
+  def method(obj: Val, sig: Sig, unwind: Next)(implicit pos: Position): Val =
     let(Op.Method(obj, sig), unwind)
-  def dynmethod(obj: Val, sig: Sig, unwind: Next): Val =
+  def dynmethod(obj: Val, sig: Sig, unwind: Next)(implicit pos: Position): Val =
     let(Op.Dynmethod(obj, sig), unwind)
-  def module(name: Global, unwind: Next): Val =
+  def module(name: Global, unwind: Next)(implicit pos: Position): Val =
     let(Op.Module(name), unwind)
-  def as(ty: Type, obj: Val, unwind: Next): Val =
+  def as(ty: Type, obj: Val, unwind: Next)(implicit pos: Position): Val =
     let(Op.As(ty, obj), unwind)
-  def is(ty: Type, obj: Val, unwind: Next): Val =
+  def is(ty: Type, obj: Val, unwind: Next)(implicit pos: Position): Val =
     let(Op.Is(ty, obj), unwind)
-  def copy(value: Val, unwind: Next): Val =
+  def copy(value: Val, unwind: Next)(implicit pos: Position): Val =
     let(Op.Copy(value), unwind)
-  def sizeof(ty: Type, unwind: Next): Val =
+  def sizeof(ty: Type, unwind: Next)(implicit pos: Position): Val =
     let(Op.Sizeof(ty), unwind)
-  def box(ty: Type, obj: Val, unwind: Next): Val =
+  def box(ty: Type, obj: Val, unwind: Next)(implicit pos: Position): Val =
     let(Op.Box(ty, obj), unwind)
-  def unbox(ty: Type, obj: Val, unwind: Next): Val =
+  def unbox(ty: Type, obj: Val, unwind: Next)(implicit pos: Position): Val =
     let(Op.Unbox(ty, obj), unwind)
-  def var_(ty: Type, unwind: Next): Val =
+  def var_(ty: Type, unwind: Next)(implicit pos: Position): Val =
     let(Op.Var(ty), unwind)
-  def varload(slot: Val, unwind: Next): Val =
+  def varload(slot: Val, unwind: Next)(implicit pos: Position): Val =
     let(Op.Varload(slot), unwind)
-  def varstore(slot: Val, value: Val, unwind: Next): Val =
+  def varstore(slot: Val, value: Val, unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Varstore(slot, value), unwind)
-  def arrayalloc(ty: Type, init: Val, unwind: Next): Val =
+  def arrayalloc(ty: Type, init: Val, unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Arrayalloc(ty, init), unwind)
-  def arrayload(ty: Type, arr: Val, idx: Val, unwind: Next): Val =
+  def arrayload(ty: Type, arr: Val, idx: Val, unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Arrayload(ty, arr, idx), unwind)
-  def arraystore(ty: Type, arr: Val, idx: Val, value: Val, unwind: Next): Val =
+  def arraystore(ty: Type, arr: Val, idx: Val, value: Val, unwind: Next)(
+      implicit pos: Position): Val =
     let(Op.Arraystore(ty, arr, idx, value), unwind)
-  def arraylength(arr: Val, unwind: Next): Val =
+  def arraylength(arr: Val, unwind: Next)(implicit pos: Position): Val =
     let(Op.Arraylength(arr), unwind)
 }

--- a/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
@@ -17,7 +17,7 @@ object ControlFlow {
   final case class Block(name: Local,
                          params: Seq[Val.Local],
                          insts: Seq[Inst],
-                         isEntry: Boolean)(implicit val pos: nir.Position) {
+                         isEntry: Boolean)(implicit val pos: Position) {
     val inEdges  = mutable.UnrolledBuffer.empty[Edge]
     val outEdges = mutable.UnrolledBuffer.empty[Edge]
 
@@ -72,7 +72,7 @@ object ControlFlow {
         to.inEdges += e
       }
 
-      def block(local: Local)(implicit pos: nir.Position): Block =
+      def block(local: Local)(implicit pos: Position): Block =
         blocks.getOrElse(
           local, {
             val k                     = locations(local)
@@ -128,10 +128,9 @@ object ControlFlow {
         }
       }
 
-      val entry = block {
-        insts.head.asInstanceOf[Inst.Label].name
-      }(insts.head.pos)
-      val visited = mutable.Set.empty[Local]
+      val entryInst = insts.head.asInstanceOf[Inst.Label]
+      val entry     = block(entryInst.name)(entryInst.pos)
+      val visited   = mutable.Set.empty[Local]
 
       while (todo.nonEmpty) {
         val block = todo.head

--- a/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
@@ -34,7 +34,7 @@ object ControlFlow {
 
     def pred  = inEdges.map(_.from)
     def succ  = outEdges.map(_.to)
-    def label = Inst.Label(name, params)
+    def label = Inst.Label(name, params)(Position.generated)
     def show  = name.show
   }
 

--- a/nir/src/main/scala/scala/scalanative/nir/Defns.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Defns.scala
@@ -4,35 +4,40 @@ package nir
 sealed abstract class Defn {
   def name: Global
   def attrs: Attrs
-
+  def pos: Position
   final def show: String = nir.Show(this)
 }
 
 object Defn {
   // low-level
-  final case class Var(attrs: Attrs, name: Global, ty: Type, rhs: Val)
+  final case class Var(attrs: Attrs, name: Global, ty: Type, rhs: Val)(
+      implicit val pos: Position)
       extends Defn
-  final case class Const(attrs: Attrs, name: Global, ty: Type, rhs: Val)
+  final case class Const(attrs: Attrs, name: Global, ty: Type, rhs: Val)(
+      implicit val pos: Position)
       extends Defn
-  final case class Declare(attrs: Attrs, name: Global, ty: Type) extends Defn
+  final case class Declare(attrs: Attrs, name: Global, ty: Type)(
+      implicit val pos: Position)
+      extends Defn
   final case class Define(attrs: Attrs,
                           name: Global,
                           ty: Type,
-                          insts: Seq[Inst])
+                          insts: Seq[Inst])(implicit val pos: Position)
       extends Defn
 
   // high-level
-  final case class Trait(attrs: Attrs, name: Global, traits: Seq[Global])
+  final case class Trait(attrs: Attrs, name: Global, traits: Seq[Global])(
+      implicit val pos: Position)
       extends Defn
   final case class Class(attrs: Attrs,
                          name: Global,
                          parent: Option[Global],
-                         traits: Seq[Global])
+                         traits: Seq[Global])(implicit val pos: Position)
       extends Defn
   final case class Module(attrs: Attrs,
                           name: Global,
                           parent: Option[Global],
-                          traits: Seq[Global])
+                          traits: Seq[Global])(implicit val pos: Position)
       extends Defn
 
   def existsEntryPoint(defns: Seq[Defn]): Boolean = {

--- a/nir/src/main/scala/scala/scalanative/nir/Insts.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Insts.scala
@@ -3,22 +3,32 @@ package nir
 
 sealed abstract class Inst {
   final def show: String = nir.Show(this)
+  def pos: Position
 }
 
 object Inst {
-  final case class Label(name: Local, params: Seq[Val.Local]) extends Inst
-  final case class Let(name: Local, op: Op, unwind: Next)     extends Inst
+  final case class Label(name: Local, params: Seq[Val.Local])(
+      implicit val pos: Position)
+      extends Inst
+  final case class Let(name: Local, op: Op, unwind: Next)(
+      implicit val pos: Position)
+      extends Inst
   object Let {
-    def apply(op: Op, unwind: Next)(implicit fresh: Fresh): Let =
+    def apply(op: Op, unwind: Next)(implicit fresh: Fresh, pos: Position): Let =
       Let(fresh(), op, unwind)
   }
 
-  sealed abstract class Cf                                  extends Inst
-  final case class Ret(value: Val)                          extends Cf
-  final case class Jump(next: Next)                         extends Cf
-  final case class If(value: Val, thenp: Next, elsep: Next) extends Cf
-  final case class Switch(value: Val, default: Next, cases: Seq[Next])
+  sealed abstract class Cf                                      extends Inst
+  final case class Ret(value: Val)(implicit val pos: Position)  extends Cf
+  final case class Jump(next: Next)(implicit val pos: Position) extends Cf
+  final case class If(value: Val, thenp: Next, elsep: Next)(
+      implicit val pos: Position)
       extends Cf
-  final case class Throw(value: Val, unwind: Next) extends Cf
-  final case class Unreachable(unwind: Next)       extends Cf
+  final case class Switch(value: Val, default: Next, cases: Seq[Next])(
+      implicit val pos: Position)
+      extends Cf
+  final case class Throw(value: Val, unwind: Next)(implicit val pos: Position)
+      extends Cf
+  final case class Unreachable(unwind: Next)(implicit val pos: Position)
+      extends Cf
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Position.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Position.scala
@@ -31,5 +31,4 @@ object Position {
     def apply(f: String): SourceFile       = new java.net.URI(f)
   }
   val NoPosition = Position(SourceFile(""), 0, 0)
-  val generated  = NoPosition
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Position.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Position.scala
@@ -1,0 +1,35 @@
+package scala.scalanative.nir
+
+final case class Position(
+    /** Source file. */
+    source: Position.SourceFile,
+    /** Zero-based line number. */
+    line: Int,
+    /** Zero-based column number. */
+    column: Int
+) {
+  def show: String = s"$line:$column"
+
+  def isEmpty: Boolean = {
+    def isEmptySlowPath(): Boolean = {
+      source.getScheme == null && source.getRawAuthority == null &&
+      source.getRawQuery == null && source.getRawFragment == null
+    }
+    source.getRawPath == "" && isEmptySlowPath()
+  }
+
+  def isDefined: Boolean = !isEmpty
+
+  def orElse(that: => Position): Position = if (isDefined) this else that
+}
+
+object Position {
+  type SourceFile = java.net.URI
+
+  object SourceFile {
+    def apply(f: java.io.File): SourceFile = f.toURI
+    def apply(f: String): SourceFile       = new java.net.URI(f)
+  }
+  val NoPosition = Position(SourceFile(""), 0, 0)
+  val generated  = NoPosition
+}

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -5,47 +5,53 @@ trait Transform {
   def onDefns(assembly: Seq[Defn]): Seq[Defn] =
     assembly.map(onDefn)
 
-  def onDefn(defn: Defn): Defn = defn match {
-    case defn @ Defn.Var(_, _, ty, value) =>
-      defn.copy(ty = onType(ty), rhs = onVal(value))
-    case defn @ Defn.Const(_, _, ty, value) =>
-      defn.copy(ty = onType(ty), rhs = onVal(value))
-    case defn @ Defn.Declare(_, _, ty) =>
-      defn.copy(ty = onType(ty))
-    case defn @ Defn.Define(_, _, ty, insts) =>
-      defn.copy(ty = onType(ty), insts = onInsts(insts))
-    case defn @ Defn.Trait(_, _, _) =>
-      defn
-    case defn @ Defn.Class(_, _, _, _) =>
-      defn
-    case defn @ Defn.Module(_, _, _, _) =>
-      defn
+  def onDefn(defn: Defn): Defn = {
+    implicit val rootPos: Position = defn.pos
+    defn match {
+      case defn @ Defn.Var(_, _, ty, value) =>
+        defn.copy(ty = onType(ty), rhs = onVal(value))
+      case defn @ Defn.Const(_, _, ty, value) =>
+        defn.copy(ty = onType(ty), rhs = onVal(value))
+      case defn @ Defn.Declare(_, _, ty) =>
+        defn.copy(ty = onType(ty))
+      case defn @ Defn.Define(_, _, ty, insts) =>
+        defn.copy(ty = onType(ty), insts = onInsts(insts))
+      case defn @ Defn.Trait(_, _, _) =>
+        defn
+      case defn @ Defn.Class(_, _, _, _) =>
+        defn
+      case defn @ Defn.Module(_, _, _, _) =>
+        defn
+    }
   }
 
   def onInsts(insts: Seq[Inst]): Seq[Inst] =
     insts.map(onInst)
 
-  def onInst(inst: Inst): Inst = inst match {
-    case Inst.Label(n, params) =>
-      val newparams = params.map { param =>
-        Val.Local(param.name, onType(param.ty))
-      }
-      Inst.Label(n, newparams)
-    case Inst.Let(n, op, unwind) =>
-      Inst.Let(n, onOp(op), onNext(unwind))
+  def onInst(inst: Inst): Inst = {
+    implicit val pos = inst.pos
+    inst match {
+      case Inst.Label(n, params) =>
+        val newparams = params.map { param =>
+          Val.Local(param.name, onType(param.ty))
+        }
+        Inst.Label(n, newparams)
+      case Inst.Let(n, op, unwind) =>
+        Inst.Let(n, onOp(op), onNext(unwind))
 
-    case Inst.Ret(v) =>
-      Inst.Ret(onVal(v))
-    case Inst.Jump(next) =>
-      Inst.Jump(onNext(next))
-    case Inst.If(v, thenp, elsep) =>
-      Inst.If(onVal(v), onNext(thenp), onNext(elsep))
-    case Inst.Switch(v, default, cases) =>
-      Inst.Switch(onVal(v), onNext(default), cases.map(onNext))
-    case Inst.Throw(v, unwind) =>
-      Inst.Throw(onVal(v), onNext(unwind))
-    case Inst.Unreachable(unwind) =>
-      Inst.Unreachable(onNext(unwind))
+      case Inst.Ret(v) =>
+        Inst.Ret(onVal(v))
+      case Inst.Jump(next) =>
+        Inst.Jump(onNext(next))
+      case Inst.If(v, thenp, elsep) =>
+        Inst.If(onVal(v), onNext(thenp), onNext(elsep))
+      case Inst.Switch(v, default, cases) =>
+        Inst.Switch(onVal(v), onNext(default), cases.map(onNext))
+      case Inst.Throw(v, unwind) =>
+        Inst.Throw(onVal(v), onNext(unwind))
+      case Inst.Unreachable(unwind) =>
+        Inst.Unreachable(onNext(unwind))
+    }
   }
 
   def onOp(op: Op): Op = op match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -23,7 +23,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
 
     val files =
       if (prelude.revision < 7) Array.empty[java.net.URI]
-      else Array.fill(getInt())(new URI(getString()))
+      else Array.fill(getInt())(new URI(getUTF8String()))
 
     val pairs = getSeq((getGlobal, getInt))
     (prelude, pairs, files)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -21,9 +21,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
 
     val prelude = Prelude.readFrom(buffer)
 
-    val files =
-      if (prelude.revision < 7) Array.empty[java.net.URI]
-      else Array.fill(getInt())(new URI(getUTF8String()))
+    val files = Array.fill(getInt())(new URI(getUTF8String()))
 
     val pairs = getSeq((getGlobal, getInt))
     (prelude, pairs, files)
@@ -335,7 +333,6 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
       }
     }
 
-    if (prelude.revision < 7) Position.NoPosition
-    else readPosition()
+    readPosition()
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -180,7 +180,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
     }
   }
 
-  private def getGlobals(): Seq[Global] = getSeq(getGlobal)
+  private def getGlobals(): Seq[Global]      = getSeq(getGlobal)
   private def getGlobalOpt(): Option[Global] = getOpt(getGlobal)
   private def getGlobal(): Global = getInt match {
     case T.NoneGlobal =>
@@ -239,7 +239,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
   }
 
   private def getParams(): Seq[Val.Local] = getSeq(getParam)
-  private def getParam(): Val.Local = Val.Local(getLocal, getType)
+  private def getParam(): Val.Local       = Val.Local(getLocal, getType)
 
   private def getTypes(): Seq[Type] = getSeq(getType)
   private def getType(): Type = getInt match {
@@ -305,8 +305,8 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
         Position.NoPosition
       } else {
         val result = if ((first & FormatFullMask) == FormatFullMaskValue) {
-          val file = files(getInt())
-          val line = getInt()
+          val file   = files(getInt())
+          val line   = getInt()
           val column = getInt()
           Position(file, line, column)
         } else {
@@ -319,14 +319,14 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
                      lastPosition.column + columnDiff)
           } else if ((first & Format2Mask) == Format2MaskValue) {
             val lineDiff = first >> Format2Shift
-            val column = get() & 0xff // unsigned
+            val column   = get() & 0xff // unsigned
             Position(lastPosition.source, lastPosition.line + lineDiff, column)
           } else {
             assert(
               (first & Format3Mask) == Format3MaskValue,
               s"Position format error: first byte $first does not match any format")
             val lineDiff = getShort()
-            val column = get() & 0xff // unsigned
+            val column   = get() & 0xff // unsigned
             Position(lastPosition.source, lastPosition.line + lineDiff, column)
           }
         }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -21,7 +21,9 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
 
     val prelude = Prelude.readFrom(buffer)
 
-    val files = Array.fill(getInt())(new URI(getString()))
+    val files =
+      if (prelude.revision < 7) Array.empty[java.net.URI]
+      else Array.fill(getInt())(new URI(getString()))
 
     val pairs = getSeq((getGlobal, getInt))
     (prelude, pairs, files)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -30,7 +30,7 @@ final class BinarySerializer(buffer: ByteBuffer) {
     putSeq {
       fileIndexMap.toVector.sortBy(_._2)
     } {
-      case (file, _) => putString(file.toString)
+      case (file, _) => putUTF8tring(file.toString)
     }
 
     putSeq(names) { n =>

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -14,13 +14,13 @@ final class BinarySerializer(buffer: ByteBuffer) {
 
   private[this] var lastPosition: Position = Position.NoPosition
 
-  private[this] val files = mutable.ListBuffer.empty[URI]
+  private[this] val files        = mutable.ListBuffer.empty[URI]
   private[this] val fileIndexMap = mutable.Map.empty[URI, Int]
   private def fileToIndex(file: URI): Int =
     fileIndexMap.getOrElseUpdate(file, (files += file).size - 1)
 
   final def serialize(defns: Seq[Defn]): Unit = {
-    val names = defns.map(_.name)
+    val names     = defns.map(_.name)
     val positions = mutable.UnrolledBuffer.empty[Int]
 
     // Init map with all possible filenames as they must be serialized before other definitions
@@ -541,10 +541,10 @@ final class BinarySerializer(buffer: ByteBuffer) {
       writeFull()
       lastPosition = pos
     } else {
-      val line = pos.line
-      val column = pos.column
-      val lineDiff = line - lastPosition.line
-      val columnDiff = column - lastPosition.column
+      val line         = pos.line
+      val column       = pos.column
+      val lineDiff     = line - lastPosition.line
+      val columnDiff   = column - lastPosition.column
       val columnIsByte = column >= 0 && column < 256
 
       if (lineDiff == 0 && columnDiff >= -64 && columnDiff < 64) {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/PositionFormat.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/PositionFormat.scala
@@ -1,0 +1,36 @@
+package scala.scalanative.nir.serialization
+
+// Ported from Scala.js
+
+private[serialization] object PositionFormat {
+  /* Positions are serialized incrementally as diffs wrt the last position.
+   *
+   * Formats are (the first byte is decomposed in bits):
+   *
+   *   1st byte | next bytes |  description
+   *  -----------------------------------------
+   *   ccccccc0 |            | Column diff (7-bit signed)
+   *   llllll01 | CC         | Line diff (6-bit signed), column (8-bit unsigned)
+   *   ____0011 | LL LL CC   | Line diff (16-bit signed), column (8-bit unsigned)
+   *   ____0111 | 12 bytes   | File index, line, column (all 32-bit signed)
+   *   11111111 |            | NoPosition (is not compared/stored in last position)
+   *
+   * Underscores are irrelevant and must be set to 0.
+   */
+
+  final val Format1Mask      = 0x01
+  final val Format1MaskValue = 0x00
+  final val Format1Shift     = 1
+
+  final val Format2Mask      = 0x03
+  final val Format2MaskValue = 0x01
+  final val Format2Shift     = 2
+
+  final val Format3Mask      = 0x0f
+  final val Format3MaskValue = 0x03
+
+  final val FormatFullMask      = 0x0f
+  final val FormatFullMaskValue = 0x7
+
+  final val FormatNoPositionValue = -1
+}

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Defn.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Defn.scala
@@ -7,7 +7,7 @@ import fastparse.all._
 object Defn extends Base[nir.Defn] {
 
   import Base.IgnoreWhitespace._
-  implicit val pos = Position.generated
+  implicit val pos = Position.NoPosition
 
   val Var =
     P(Attrs.parser ~ "var" ~ Global.parser ~ ":" ~ Type.parser ~ "=" ~ Val.parser map {

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Defn.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Defn.scala
@@ -7,6 +7,7 @@ import fastparse.all._
 object Defn extends Base[nir.Defn] {
 
   import Base.IgnoreWhitespace._
+  implicit val pos = Position.generated
 
   val Var =
     P(Attrs.parser ~ "var" ~ Global.parser ~ ":" ~ Type.parser ~ "=" ~ Val.parser map {

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Inst.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Inst.scala
@@ -6,7 +6,7 @@ import fastparse.all._
 
 object Inst extends Base[nir.Inst] {
   import Base.IgnoreWhitespace._
-  implicit val pos = Position.generated
+  implicit val pos = Position.NoPosition
 
   private val unwind: P[Next] =
     P(Next.parser.?).map(_.getOrElse(nir.Next.None))

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Inst.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Inst.scala
@@ -6,6 +6,7 @@ import fastparse.all._
 
 object Inst extends Base[nir.Inst] {
   import Base.IgnoreWhitespace._
+  implicit val pos = Position.generated
 
   private val unwind: P[Next] =
     P(Next.parser.?).map(_.getOrElse(nir.Next.None))

--- a/nirparser/src/test/scala/scala/scalanative/nir/DefnParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/DefnParserTest.scala
@@ -6,8 +6,8 @@ import org.scalatest._
 import org.scalatest.funsuite.AnyFunSuite
 
 class DefnParserTest extends AnyFunSuite {
-  val ty = Type.Int
-  val global = Global.Top("global")
+  val ty           = Type.Int
+  val global       = Global.Top("global")
   implicit val pos = Position.generated
   Seq[Defn](
     Defn.Var(Attrs.None, global, ty, Val.Zero(ty)),

--- a/nirparser/src/test/scala/scala/scalanative/nir/DefnParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/DefnParserTest.scala
@@ -6,9 +6,9 @@ import org.scalatest._
 import org.scalatest.funsuite.AnyFunSuite
 
 class DefnParserTest extends AnyFunSuite {
-  val ty     = Type.Int
+  val ty = Type.Int
   val global = Global.Top("global")
-
+  implicit val pos = Position.generated
   Seq[Defn](
     Defn.Var(Attrs.None, global, ty, Val.Zero(ty)),
     Defn.Const(Attrs.None, global, ty, Val.Zero(ty)),

--- a/nirparser/src/test/scala/scala/scalanative/nir/DefnParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/DefnParserTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.funsuite.AnyFunSuite
 class DefnParserTest extends AnyFunSuite {
   val ty           = Type.Int
   val global       = Global.Top("global")
-  implicit val pos = Position.generated
+  implicit val pos = Position.NoPosition
   Seq[Defn](
     Defn.Var(Attrs.None, global, ty, Val.Zero(ty)),
     Defn.Const(Attrs.None, global, ty, Val.Zero(ty)),

--- a/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
@@ -6,11 +6,11 @@ import org.scalatest._
 import org.scalatest.funsuite.AnyFunSuite
 
 class InstParserTest extends AnyFunSuite {
-  val local = Local(1)
-  val next = Next(local)
-  val noTpe = Type.Unit
-  val value = Val.Int(42)
-  val unwind = Next.Unwind(Val.Local(local, nir.Rt.Object), next)
+  val local        = Local(1)
+  val next         = Next(local)
+  val noTpe        = Type.Unit
+  val value        = Val.Int(42)
+  val unwind       = Next.Unwind(Val.Local(local, nir.Rt.Object), next)
   implicit val pos = Position.generated
   Seq[Inst](
     Inst.Label(local, Seq.empty),

--- a/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
@@ -6,12 +6,12 @@ import org.scalatest._
 import org.scalatest.funsuite.AnyFunSuite
 
 class InstParserTest extends AnyFunSuite {
-  val local  = Local(1)
-  val next   = Next(local)
-  val noTpe  = Type.Unit
-  val value  = Val.Int(42)
+  val local = Local(1)
+  val next = Next(local)
+  val noTpe = Type.Unit
+  val value = Val.Int(42)
   val unwind = Next.Unwind(Val.Local(local, nir.Rt.Object), next)
-
+  implicit val pos = Position.generated
   Seq[Inst](
     Inst.Label(local, Seq.empty),
     Inst.Let(local, Op.As(noTpe, value), Next.None),

--- a/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/InstParserTest.scala
@@ -11,7 +11,7 @@ class InstParserTest extends AnyFunSuite {
   val noTpe        = Type.Unit
   val value        = Val.Int(42)
   val unwind       = Next.Unwind(Val.Local(local, nir.Rt.Object), next)
-  implicit val pos = Position.generated
+  implicit val pos = Position.NoPosition
   Seq[Inst](
     Inst.Label(local, Seq.empty),
     Inst.Let(local, Op.As(noTpe, value), Next.None),

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -2,8 +2,8 @@ package scala.scalanative
 package nscplugin
 
 import java.nio.file.Path
-
 import scala.collection.mutable
+import scala.language.implicitConversions
 import scala.scalanative.nir._
 import scala.scalanative.util.ScopedVar.scoped
 import scala.tools.nsc.plugins._
@@ -97,6 +97,43 @@ abstract class NirGenPhase
       (files ++ reflectiveInstFiles).par.foreach {
         case (path, stats) =>
           genIRFile(path, stats)
+      }
+    }
+  }
+
+  protected implicit def toNirPosition(pos: Position): nir.Position = {
+    if (!pos.isDefined) nir.Position.NoPosition
+    else
+      nir.Position(
+        source = nirPositionCachedConverter.toNIRSource(pos.source),
+        line = pos.line - 1,
+        column = pos.column - 1
+      )
+  }
+
+  private[this] object nirPositionCachedConverter {
+    import scala.reflect.internal.util._
+    private[this] var lastNscSource: SourceFile              = _
+    private[this] var lastNIRSource: nir.Position.SourceFile = _
+
+    def toNIRSource(nscSource: SourceFile): nir.Position.SourceFile = {
+      if (nscSource != lastNscSource) {
+        lastNIRSource = convert(nscSource)
+        lastNscSource = nscSource
+      }
+      lastNIRSource
+    }
+
+    private[this] def convert(
+        nscSource: SourceFile): nir.Position.SourceFile = {
+      nscSource.file.file match {
+        case null =>
+          new java.net.URI(
+            "virtualfile",       // Pseudo-Scheme
+            nscSource.file.path, // Scheme specific part
+            null                 // Fragment
+          )
+        case file => file.toURI
       }
     }
   }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -109,7 +109,7 @@ trait NirGenStat { self: NirGenPhase =>
       val body =
         Seq(Inst.Label(Local(0), Seq.empty), Inst.Unreachable(Next.None))
 
-      Defn.Define(attrs, name, sig, body)
+      Defn.Define(attrs, name, sig, body)(cd.pos)
     }
 
     def genFuncPtrExternForwarder(cd: ClassDef): Defn = {

--- a/sandbox/Test.scala
+++ b/sandbox/Test.scala
@@ -1,5 +1,11 @@
 object Test {
+  def foo(x: Int): Unit = {
+    val y = x
+    println("hello native")
+  }
+
   def main(args: Array[String]): Unit = {
     println("Hello, World!")
+    foo(1)
   }
 }

--- a/sandbox/Test.scala
+++ b/sandbox/Test.scala
@@ -1,11 +1,5 @@
 object Test {
-  def foo(x: Int): Unit = {
-    val y = x
-    println("hello native")
-  }
-
   def main(args: Array[String]): Unit = {
     println("Hello, World!")
-    foo(1)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -113,7 +113,9 @@ object CodeGen {
       if (!generated.contains(mn)) {
         newline()
         genDefn {
-          env(n) match {
+          val defn             = env(n)
+          implicit val rootPos = defn.pos
+          defn match {
             case defn @ Defn.Var(attrs, _, _, _) =>
               defn.copy(attrs.copy(isExtern = true))
             case defn @ Defn.Const(attrs, _, ty, _) =>
@@ -438,7 +440,7 @@ object CodeGen {
       line(s"$w2 = getelementptr i8*, i8** $w1, i32 1")
       line(s"$exc = load i8*, i8** $w2")
       line(s"call void @__cxa_end_catch()")
-      genInst(Inst.Jump(next))
+      genInst(Inst.Jump(next)(Position.generated))
       unindent()
 
       line(s"$excfail:")
@@ -614,7 +616,7 @@ object CodeGen {
                    elseNext @ Next.Label(elseName, elseArgs))
           if thenName == elseName =>
         if (thenArgs == elseArgs) {
-          genInst(Inst.Jump(thenNext))
+          genInst(Inst.Jump(thenNext)(inst.pos))
         } else {
           val args = thenArgs.zip(elseArgs).map {
             case (thenV, elseV) =>
@@ -630,7 +632,7 @@ object CodeGen {
               genVal(elseV)
               Val.Local(name, thenV.ty)
           }
-          genInst(Inst.Jump(Next.Label(thenName, args)))
+          genInst(Inst.Jump(Next.Label(thenName, args))(inst.pos))
         }
 
       case Inst.If(cond, thenp, elsep) =>

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -58,7 +58,8 @@ object Generate {
         val struct = meta.layout(cls).struct
         val rtti   = meta.rtti(cls)
 
-        buf += Defn.Const(Attrs.None, rtti.name, rtti.struct, rtti.value)
+        buf += Defn.Const(Attrs.None, rtti.name, rtti.struct, rtti.value)(
+          cls.position)
       }
     }
 
@@ -89,7 +90,8 @@ object Generate {
       meta.traits.foreach { trt =>
         val rtti = meta.rtti(trt)
 
-        buf += Defn.Const(Attrs.None, rtti.name, rtti.struct, rtti.value)
+        buf += Defn.Const(Attrs.None, rtti.name, rtti.struct, rtti.value)(
+          trt.position)
       }
     }
 
@@ -190,6 +192,7 @@ object Generate {
           val clsTy = cls.ty
 
           implicit val fresh = Fresh()
+          implicit val pos   = cls.position
 
           val entry      = fresh()
           val existing   = fresh()

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -14,7 +14,7 @@ object Generate {
 
   implicit def linked(implicit meta: Metadata): linker.Result =
     meta.linked
-  private implicit val pos: Position = Position.generated
+  private implicit val pos: Position = Position.NoPosition
 
   private class Impl(entry: Global.Top, defns: Seq[Defn])(
       implicit meta: Metadata) {

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -14,6 +14,7 @@ object Generate {
 
   implicit def linked(implicit meta: Metadata): linker.Result =
     meta.linked
+  private implicit val pos: Position = Position.generated
 
   private class Impl(entry: Global.Top, defns: Seq[Defn])(
       implicit meta: Metadata) {

--- a/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
@@ -8,7 +8,8 @@ import scala.collection.mutable
  * Created by lukaskellenberger on 17.12.16.
  */
 object GenerateReflectiveProxies {
-  implicit val fresh = Fresh()
+  implicit val fresh                 = Fresh()
+  private implicit val pos: Position = Position.generated
 
   private def genReflProxy(defn: Defn.Define): Defn.Define = {
     val Global.Member(owner, sig) = defn.name

--- a/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
@@ -8,12 +8,12 @@ import scala.collection.mutable
  * Created by lukaskellenberger on 17.12.16.
  */
 object GenerateReflectiveProxies {
-  implicit val fresh                 = Fresh()
-  private implicit val pos: Position = Position.generated
+  implicit val fresh = Fresh()
 
   private def genReflProxy(defn: Defn.Define): Defn.Define = {
     val Global.Member(owner, sig) = defn.name
     val defnType                  = defn.ty.asInstanceOf[Type.Function]
+    implicit val pos: Position    = defn.pos
 
     val proxyArgs = genProxyArgs(defnType)
     val proxyTy   = genProxyTy(defnType, proxyArgs)
@@ -46,25 +46,28 @@ object GenerateReflectiveProxies {
       case _         => Type.Ref(Global.Top("java.lang.Object"))
     })
 
-  private def genProxyLabel(args: Seq[Type]) = {
+  private def genProxyLabel(args: Seq[Type])(implicit pos: nir.Position) = {
     val argLabels = Val.Local(fresh(), args.head) ::
       args.tail.map(argty => Val.Local(fresh(), argty)).toList
 
     Inst.Label(fresh(), argLabels)
   }
 
-  private def genArgUnboxes(label: Inst.Label) =
+  private def genArgUnboxes(label: Inst.Label) = {
+    import label.pos
     label.params.tail.map {
       case local: Val.Local if Type.unbox.contains(local.ty) =>
         Inst.Let(Op.Unbox(local.ty, local), Next.None)
       case local: Val.Local =>
         Inst.Let(Op.Copy(local), Next.None)
     }
+  }
 
   private def genCall(defnTy: Type.Function,
                       method: Inst.Let,
                       params: Seq[Val.Local],
                       unboxes: Seq[Inst.Let]) = {
+    import method.pos
     val callParams =
       params.head ::
         unboxes
@@ -79,7 +82,8 @@ object GenerateReflectiveProxies {
              Next.None)
   }
 
-  private def genRetValBox(callName: Local, defnRetTy: Type, proxyRetTy: Type) =
+  private def genRetValBox(callName: Local, defnRetTy: Type, proxyRetTy: Type)(
+      implicit pos: nir.Position) =
     Type.box.get(defnRetTy) match {
       case Some(boxTy) =>
         Inst.Let(Op.Box(boxTy, Val.Local(callName, defnRetTy)), Next.None)
@@ -87,7 +91,8 @@ object GenerateReflectiveProxies {
         Inst.Let(Op.Copy(Val.Local(callName, defnRetTy)), Next.None)
     }
 
-  private def genRet(retValBoxName: Local, proxyRetTy: Type) =
+  private def genRet(retValBoxName: Local, proxyRetTy: Type)(
+      implicit pos: nir.Position) =
     proxyRetTy match {
       case Type.Unit => Inst.Ret(Val.Unit)
       case _         => Inst.Ret(Val.Local(retValBoxName, proxyRetTy))

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -5,6 +5,8 @@ import scalanative.nir._
 import scalanative.linker.{Trait, Class}
 
 class HasTraitTables(meta: Metadata) {
+  private implicit val pos: Position = Position.generated
+
   val classHasTraitName       = Global.Top("__class_has_trait")
   val classHasTraitVal        = Val.Global(classHasTraitName, Type.Ptr)
   var classHasTraitTy: Type   = _

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -5,7 +5,7 @@ import scalanative.nir._
 import scalanative.linker.{Trait, Class}
 
 class HasTraitTables(meta: Metadata) {
-  private implicit val pos: Position = Position.generated
+  private implicit val pos: Position = Position.NoPosition
 
   val classHasTraitName       = Global.Top("__class_has_trait")
   val classHasTraitVal        = Val.Global(classHasTraitName, Type.Ptr)

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -138,7 +138,7 @@ object Lower {
           buf += inst
       }
 
-      implicit val pos: Position = Position.generated
+      implicit val pos: Position = Position.NoPosition
       genNullPointerSlowPath(buf)
       genDivisionByZeroSlowPath(buf)
       genClassCastSlowPath(buf)
@@ -1177,7 +1177,7 @@ object Lower {
   val RuntimeNothing = Type.Ref(Global.Top("scala.runtime.Nothing$"))
 
   val injects: Seq[Defn] = {
-    implicit val pos = Position.generated
+    implicit val pos = Position.NoPosition
     val buf          = mutable.UnrolledBuffer.empty[Defn]
     buf += Defn.Declare(Attrs.None, allocSmallName, allocSig)
     buf += Defn.Declare(Attrs.None, largeAllocName, allocSig)

--- a/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
@@ -92,7 +92,8 @@ class TraitDispatchTable(meta: Metadata) {
 
     dispatchOffset = offsets
     dispatchTy = Type.Ptr
-    dispatchDefn = Defn.Const(Attrs.None, dispatchName, value.ty, value)
+    dispatchDefn =
+      Defn.Const(Attrs.None, dispatchName, value.ty, value)(Position.generated)
   }
 
   // Generate a compressed representation of the dispatch table

--- a/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
@@ -93,7 +93,7 @@ class TraitDispatchTable(meta: Metadata) {
     dispatchOffset = offsets
     dispatchTy = Type.Ptr
     dispatchDefn =
-      Defn.Const(Attrs.None, dispatchName, value.ty, value)(Position.generated)
+      Defn.Const(Attrs.None, dispatchName, value.ty, value)(Position.NoPosition)
   }
 
   // Generate a compressed representation of the dispatch table

--- a/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
@@ -11,8 +11,8 @@ import nir.Conv._
 
 trait Combine { self: Interflow =>
 
-  def combine(bin: Bin, ty: Type, l: Val, r: Val)(
-      implicit state: State): Val = {
+  def combine(bin: Bin, ty: Type, l: Val, r: Val)(implicit state: State,
+                                                  origPos: Position): Val = {
     import state.{materialize, delay, emit}
 
     def fallback = {

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -99,7 +99,9 @@ trait Eval { self: Interflow =>
     unreachable
   }
 
-  def eval(op: Op)(implicit state: State, linked: linker.Result): Val = {
+  def eval(op: Op)(implicit state: State,
+                   linked: linker.Result,
+                   origPos: Position): Val = {
     import state.{emit, materialize, delay}
     def bailOut =
       throw BailOut("can't eval op: " + op.show)
@@ -411,7 +413,8 @@ trait Eval { self: Interflow =>
     }
   }
 
-  def eval(bin: Bin, ty: Type, l: Val, r: Val)(implicit state: State): Val = {
+  def eval(bin: Bin, ty: Type, l: Val, r: Val)(implicit state: State,
+                                               origPos: Position): Val = {
     import state.{emit, materialize}
     def fallback =
       emit(Op.Bin(bin, ty, materialize(l), materialize(r)))
@@ -821,7 +824,7 @@ trait Eval { self: Interflow =>
     }
   }
 
-  def eval(value: Val)(implicit state: State): Val = {
+  def eval(value: Val)(implicit state: State, origPos: Position): Val = {
     value match {
       case Val.Local(local, _) if local.id >= 0 =>
         state.loadLocal(local) match {

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -15,7 +15,7 @@ trait Eval { self: Interflow =>
     var pc = offsets(from) + 1
 
     while (true) {
-      val inst = insts(pc)
+      val inst                   = insts(pc)
       implicit val pos: Position = inst.pos
       def bailOut =
         throw BailOut("can't eval inst: " + inst.show)

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -16,6 +16,7 @@ trait Eval { self: Interflow =>
 
     while (true) {
       val inst = insts(pc)
+      implicit val pos: Position = inst.pos
       def bailOut =
         throw BailOut("can't eval inst: " + inst.show)
       inst match {
@@ -27,7 +28,7 @@ trait Eval { self: Interflow =>
           }
           val value = eval(op)
           if (value.ty == Type.Nothing) {
-            return Inst.Unreachable(unwind)
+            return Inst.Unreachable(unwind)(inst.pos)
           } else {
             val ty = value match {
               case InstanceRef(ty) => ty

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -145,7 +145,7 @@ trait Inline { self: Interflow =>
       val emit = new nir.Buffer()(state.fresh)
 
       def nothing = {
-        emit.label(state.fresh(), Seq.empty)
+        emit.label(state.fresh(), Seq.empty)(defn.pos)
         Val.Zero(Type.Nothing)
       }
 
@@ -154,6 +154,7 @@ trait Inline { self: Interflow =>
           util.unreachable
 
         case Seq(block) =>
+          implicit val pos = block.cf.pos
           block.cf match {
             case Inst.Ret(value) =>
               emit ++= block.end.emit
@@ -181,7 +182,7 @@ trait Inline { self: Interflow =>
               case Inst.Throw(value, unwind) =>
                 val excv = block.end.materialize(value)
                 emit ++= block.toInsts.init
-                emit.raise(excv, unwind)
+                emit.raise(excv, unwind)(block.cf.pos)
               case _ =>
                 emit ++= block.toInsts
             }

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -129,7 +129,8 @@ trait Inline { self: Interflow =>
   }
 
   def inline(name: Global, args: Seq[Val])(implicit state: State,
-                                           linked: linker.Result): Val =
+                                           linked: linker.Result,
+                                           origPos: Position): Val =
     in(s"inlining ${name.show}") {
       val defn = mode match {
         case build.Mode.Debug =>
@@ -137,8 +138,6 @@ trait Inline { self: Interflow =>
         case _: build.Mode.Release =>
           getDone(name)
       }
-
-      implicit val pos: Position = defn.pos
 
       val inlineArgs  = adapt(args, defn.ty)
       val inlineInsts = defn.insts.toArray
@@ -156,7 +155,6 @@ trait Inline { self: Interflow =>
           util.unreachable
 
         case Seq(block) =>
-          implicit val pos = Option(block.cf.pos).getOrElse(defn.pos)
           block.cf match {
             case Inst.Ret(value) =>
               emit ++= block.end.emit

--- a/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Intrinsics.scala
@@ -32,7 +32,8 @@ trait Intrinsics { self: Interflow =>
   ) ++ arrayIntrinsics
 
   def intrinsic(ty: Type, name: Global, rawArgs: Seq[Val])(
-      implicit state: State): Option[Val] = {
+      implicit state: State,
+      origPos: Position): Option[Val] = {
     val Global.Member(_, sig) = name
 
     val args = rawArgs.map(eval)
@@ -78,7 +79,7 @@ trait Intrinsics { self: Interflow =>
       case Rt.GetNameSig =>
         args match {
           case Seq(VirtualRef(_, _, Array(Val.Global(name: Global.Top, _)))) =>
-            Some(eval(Val.String(name.id))(state))
+            Some(eval(Val.String(name.id)))
           case _ =>
             None
         }

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
@@ -12,11 +12,14 @@ final class MergeBlock(val label: Inst.Label, val name: Local) {
   var end: State          = _
   var cf: Inst.Cf         = _
   var invalidations: Int  = 0
+  implicit def cfPos: Position = {
+    if (cf != null) cf.pos
+    else label.pos
+  }
 
   def toInsts(): Seq[Inst] = {
-    implicit def pos: Position = cf.pos
-    val block                  = this
-    val result                 = new nir.Buffer()(Fresh(0))
+    val block  = this
+    val result = new nir.Buffer()(Fresh(0))
     def mergeNext(next: Next.Label): Next.Label = {
       val nextBlock = outgoing(next.name)
       val mergeValues = nextBlock.phis.flatMap {

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
@@ -14,10 +14,9 @@ final class MergeBlock(val label: Inst.Label, val name: Local) {
   var invalidations: Int  = 0
 
   def toInsts(): Seq[Inst] = {
-    implicit def pos: Position =
-      if (cf.pos != null) cf.pos else Position.generated
-    val block  = this
-    val result = new nir.Buffer()(Fresh(0))
+    implicit def pos: Position = cf.pos
+    val block                  = this
+    val result                 = new nir.Buffer()(Fresh(0))
     def mergeNext(next: Next.Label): Next.Label = {
       val nextBlock = outgoing(next.name)
       val mergeValues = nextBlock.phis.flatMap {

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeBlock.scala
@@ -5,18 +5,18 @@ import scala.collection.mutable
 import scalanative.nir._
 
 final class MergeBlock(val label: Inst.Label, val name: Local) {
-  var incoming = mutable.Map.empty[Local, (Seq[Val], State)]
-  var outgoing = mutable.Map.empty[Local, MergeBlock]
+  var incoming            = mutable.Map.empty[Local, (Seq[Val], State)]
+  var outgoing            = mutable.Map.empty[Local, MergeBlock]
   var phis: Seq[MergePhi] = _
-  var start: State = _
-  var end: State = _
-  var cf: Inst.Cf = _
-  var invalidations: Int = 0
+  var start: State        = _
+  var end: State          = _
+  var cf: Inst.Cf         = _
+  var invalidations: Int  = 0
 
   def toInsts(): Seq[Inst] = {
     implicit def pos: Position =
       if (cf.pos != null) cf.pos else Position.generated
-    val block = this
+    val block  = this
     val result = new nir.Buffer()(Fresh(0))
     def mergeNext(next: Next.Label): Next.Label = {
       val nextBlock = outgoing(next.name)

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -380,7 +380,7 @@ final class MergeProcessor(insts: Array[Inst],
     }
   }
 
-  def toSeq: Seq[MergeBlock] = {
+  def toSeq()(implicit originDefnPos: nir.Position): Seq[MergeBlock] = {
     val sortedBlocks = blocks.values.toSeq
       .filter(_.cf != null)
       .sortBy { block => offsets(block.label.name) }
@@ -422,7 +422,7 @@ final class MergeProcessor(insts: Array[Inst],
       val syntheticFresh = Fresh(insts)
       val syntheticParam = Val.Local(syntheticFresh(), retTy)
       val syntheticLabel =
-        Inst.Label(syntheticFresh(), Seq(syntheticParam))(Position.generated)
+        Inst.Label(syntheticFresh(), Seq(syntheticParam))
       val resultMergeBlock =
         new MergeBlock(syntheticLabel, Local(blockFresh().id * 10000))
       blocks(syntheticLabel.name) = resultMergeBlock
@@ -446,8 +446,7 @@ final class MergeProcessor(insts: Array[Inst],
       resultMergeBlock.phis = phis
       resultMergeBlock.start = state
       resultMergeBlock.end = state
-      resultMergeBlock.cf =
-        Inst.Ret(eval.eval(syntheticParam)(state))(Position.generated)
+      resultMergeBlock.cf = Inst.Ret(eval.eval(syntheticParam)(state))
     }
 
     orderedBlocks ++= sortedBlocks.filter(isExceptional)

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -421,7 +421,8 @@ final class MergeProcessor(insts: Array[Inst],
       // to the source instructions, not relative to generated ones.
       val syntheticFresh = Fresh(insts)
       val syntheticParam = Val.Local(syntheticFresh(), retTy)
-      val syntheticLabel = Inst.Label(syntheticFresh(), Seq(syntheticParam))(Position.generated)
+      val syntheticLabel =
+        Inst.Label(syntheticFresh(), Seq(syntheticParam))(Position.generated)
       val resultMergeBlock =
         new MergeBlock(syntheticLabel, Local(blockFresh().id * 10000))
       blocks(syntheticLabel.name) = resultMergeBlock
@@ -431,7 +432,8 @@ final class MergeProcessor(insts: Array[Inst],
       // and update incoming/outgoing edges to include result block.
       retMergeBlocks.foreach { block =>
         val Inst.Ret(v) = block.cf
-        block.cf = Inst.Jump(Next.Label(syntheticLabel.name, Seq(v)))(block.cf.pos)
+        block.cf =
+          Inst.Jump(Next.Label(syntheticLabel.name, Seq(v)))(block.cf.pos)
         block.outgoing(syntheticLabel.name) = resultMergeBlock
         resultMergeBlock.incoming(block.label.name) = (Seq(v), block.end)
       }
@@ -444,7 +446,8 @@ final class MergeProcessor(insts: Array[Inst],
       resultMergeBlock.phis = phis
       resultMergeBlock.start = state
       resultMergeBlock.end = state
-      resultMergeBlock.cf = Inst.Ret(eval.eval(syntheticParam)(state))(Position.generated)
+      resultMergeBlock.cf =
+        Inst.Ret(eval.eval(syntheticParam)(state))(Position.generated)
     }
 
     orderedBlocks ++= sortedBlocks.filter(isExceptional)

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -421,7 +421,7 @@ final class MergeProcessor(insts: Array[Inst],
       // to the source instructions, not relative to generated ones.
       val syntheticFresh = Fresh(insts)
       val syntheticParam = Val.Local(syntheticFresh(), retTy)
-      val syntheticLabel = Inst.Label(syntheticFresh(), Seq(syntheticParam))
+      val syntheticLabel = Inst.Label(syntheticFresh(), Seq(syntheticParam))(Position.generated)
       val resultMergeBlock =
         new MergeBlock(syntheticLabel, Local(blockFresh().id * 10000))
       blocks(syntheticLabel.name) = resultMergeBlock
@@ -431,7 +431,7 @@ final class MergeProcessor(insts: Array[Inst],
       // and update incoming/outgoing edges to include result block.
       retMergeBlocks.foreach { block =>
         val Inst.Ret(v) = block.cf
-        block.cf = Inst.Jump(Next.Label(syntheticLabel.name, Seq(v)))
+        block.cf = Inst.Jump(Next.Label(syntheticLabel.name, Seq(v)))(block.cf.pos)
         block.outgoing(syntheticLabel.name) = resultMergeBlock
         resultMergeBlock.incoming(block.label.name) = (Seq(v), block.end)
       }
@@ -444,7 +444,7 @@ final class MergeProcessor(insts: Array[Inst],
       resultMergeBlock.phis = phis
       resultMergeBlock.start = state
       resultMergeBlock.end = state
-      resultMergeBlock.cf = Inst.Ret(eval.eval(syntheticParam)(state))
+      resultMergeBlock.cf = Inst.Ret(eval.eval(syntheticParam)(state))(Position.generated)
     }
 
     orderedBlocks ++= sortedBlocks.filter(isExceptional)

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -20,10 +20,10 @@ trait Opt { self: Interflow =>
   }
 
   def opt(name: Global): Defn.Define = in(s"visit ${name.show}") {
-    val orig = originalName(name)
-    val origtys = argumentTypes(orig)
-    val origdefn = getOriginal(orig)
-    val argtys = argumentTypes(name)
+    val orig         = originalName(name)
+    val origtys      = argumentTypes(orig)
+    val origdefn     = getOriginal(orig)
+    val argtys       = argumentTypes(name)
     implicit val pos = origdefn.pos
     // Wrap up the result.
     def result(retty: Type, rawInsts: Seq[Inst]) =

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -27,10 +27,12 @@ trait Opt { self: Interflow =>
     implicit val pos = origdefn.pos
     // Wrap up the result.
     def result(retty: Type, rawInsts: Seq[Inst]) =
-      origdefn.copy(name = name,
-                    attrs = origdefn.attrs.copy(opt = Attr.DidOpt),
-                    ty = Type.Function(argtys, retty),
-                    insts = ControlFlow.removeDeadBlocks(rawInsts))
+      origdefn.copy(
+        name = name,
+        attrs = origdefn.attrs.copy(opt = Attr.DidOpt),
+        ty = Type.Function(argtys, retty),
+        insts = ControlFlow.removeDeadBlocks(rawInsts)
+      )(origdefn.pos)
 
     // Create new fresh and state for the first basic block.
     val fresh = Fresh(0)
@@ -72,10 +74,10 @@ trait Opt { self: Interflow =>
     // and compute the result type.
     val insts = blocks.flatMap { block =>
       block.cf = block.cf match {
-        case Inst.Ret(retv) =>
-          Inst.Ret(block.end.materialize(retv))
-        case Inst.Throw(excv, unwind) =>
-          Inst.Throw(block.end.materialize(excv), unwind)
+        case inst @ Inst.Ret(retv) =>
+          Inst.Ret(block.end.materialize(retv))(inst.pos)
+        case inst @ Inst.Throw(excv, unwind) =>
+          Inst.Throw(block.end.materialize(excv), unwind)(inst.pos)
         case cf =>
           cf
       }
@@ -105,7 +107,9 @@ trait Opt { self: Interflow =>
   def process(insts: Array[Inst],
               args: Seq[Val],
               state: State,
-              doInline: Boolean): Seq[MergeBlock] = {
+              doInline: Boolean)(
+      implicit originDefnPos: nir.Position
+  ): Seq[MergeBlock] = {
     val processor =
       MergeProcessor.fromEntry(insts, args, state, doInline, blockFresh, this)
 
@@ -119,6 +123,6 @@ trait Opt { self: Interflow =>
       popMergeProcessor()
     }
 
-    processor.toSeq
+    processor.toSeq()
   }
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -5,6 +5,7 @@ import scalanative.nir._
 import scalanative.linker._
 
 trait Opt { self: Interflow =>
+
   def shallOpt(name: Global): Boolean = {
     val defn =
       getOriginal(originalName(name))
@@ -19,11 +20,11 @@ trait Opt { self: Interflow =>
   }
 
   def opt(name: Global): Defn.Define = in(s"visit ${name.show}") {
-    val orig     = originalName(name)
-    val origtys  = argumentTypes(orig)
+    val orig = originalName(name)
+    val origtys = argumentTypes(orig)
     val origdefn = getOriginal(orig)
-    val argtys   = argumentTypes(name)
-
+    val argtys = argumentTypes(name)
+    implicit val pos = origdefn.pos
     // Wrap up the result.
     def result(retty: Type, rawInsts: Seq[Inst]) =
       origdefn.copy(name = name,

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -6,7 +6,7 @@ import scalanative.nir._
 import scalanative.linker._
 
 trait PolyInline { self: Interflow =>
-  private implicit val pos = Position.generated
+//  private implicit val pos = Position.generated
 
   private def polyTargets(op: Op.Method)(
       implicit state: State): Seq[(Class, Global)] = {
@@ -56,7 +56,8 @@ trait PolyInline { self: Interflow =>
   }
 
   def polyInline(op: Op.Method, args: Seq[Val])(implicit state: State,
-                                                linked: linker.Result): Val = {
+                                                linked: linker.Result,
+                                                origPos: Position): Val = {
     import state.{emit, fresh, materialize}
 
     val obj     = materialize(op.obj)

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -6,8 +6,6 @@ import scalanative.nir._
 import scalanative.linker._
 
 trait PolyInline { self: Interflow =>
-//  private implicit val pos = Position.generated
-
   private def polyTargets(op: Op.Method)(
       implicit state: State): Seq[(Class, Global)] = {
     val Op.Method(obj, sig) = op

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -26,9 +26,7 @@ trait PolyInline { self: Interflow =>
         val targets = mutable.UnrolledBuffer.empty[(Class, Global)]
         scope.implementors.foreach { cls =>
           if (cls.allocated) {
-            cls.resolve(sig).foreach { g =>
-              targets += ((cls, g))
-            }
+            cls.resolve(sig).foreach { g => targets += ((cls, g)) }
           }
         }
         targets
@@ -46,9 +44,9 @@ trait PolyInline { self: Interflow =>
       false
 
     case _: build.Mode.Release =>
-      val targets = polyTargets(op)
+      val targets    = polyTargets(op)
       val classCount = targets.map(_._1).size
-      val implCount = targets.map(_._2).distinct.size
+      val implCount  = targets.map(_._2).distinct.size
 
       if (mode == build.Mode.ReleaseFast) {
         classCount <= 8 && implCount == 2
@@ -61,14 +59,14 @@ trait PolyInline { self: Interflow =>
                                                 linked: linker.Result): Val = {
     import state.{emit, fresh, materialize}
 
-    val obj = materialize(op.obj)
-    val margs = args.map(materialize(_))
+    val obj     = materialize(op.obj)
+    val margs   = args.map(materialize(_))
     val targets = polyTargets(op)
     val classes = targets.map(_._1)
-    val impls = targets.map(_._2).distinct
+    val impls   = targets.map(_._2).distinct
 
     val checkLabels = (1 until targets.size).map(_ => fresh()).toSeq
-    val callLabels = (1 to impls.size).map(_ => fresh()).toSeq
+    val callLabels  = (1 to impls.size).map(_ => fresh()).toSeq
     val callLabelIndex =
       (0 until targets.size).map(i => impls.indexOf(targets(i)._2))
     val mergeLabel = fresh()
@@ -103,7 +101,7 @@ trait PolyInline { self: Interflow =>
     callLabels.zip(impls).foreach {
       case (callLabel, m) =>
         emit.label(callLabel, Seq.empty)
-        val ty = originalFunctionType(m)
+        val ty                           = originalFunctionType(m)
         val Type.Function(argtys, retty) = ty
         rettys += retty
 

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -68,12 +68,12 @@ final class State(block: Local) {
       if (emitted.contains(op)) {
         emitted(op)
       } else {
-        val value = emit.let(op, Next.None)
+        val value = emit.let(op, Next.None)(Position.generated)
         emitted(op) = value
         value
       }
     } else {
-      emit.let(op, Next.None)
+      emit.let(op, Next.None)(Position.generated)
     }
   }
   def deref(addr: Addr): Instance = {
@@ -245,7 +245,7 @@ final class State(block: Local) {
           } else {
             Val.Int(values.length)
           }
-        emit.arrayalloc(elemty, init, Next.None)
+        emit.arrayalloc(elemty, init, Next.None)(Position.generated)
       case VirtualInstance(BoxKind, cls, Array(value)) =>
         reachVal(value)
         emit(Op.Box(Type.Ref(cls.name), escapedVal(value)))
@@ -262,7 +262,7 @@ final class State(block: Local) {
           .toArray[Char]
         Val.String(new java.lang.String(chars))
       case VirtualInstance(_, cls, values) =>
-        emit.classalloc(cls.name, Next.None)
+        emit.classalloc(cls.name, Next.None)(Position.generated)
       case DelayedInstance(op) =>
         reachOp(op)
         emit(escapedOp(op), idempotent = true)
@@ -287,7 +287,7 @@ final class State(block: Local) {
                                 local,
                                 Val.Int(idx),
                                 escapedVal(value),
-                                Next.None)
+                                Next.None)(Position.generated)
               }
           }
         }
@@ -305,7 +305,7 @@ final class State(block: Local) {
                               local,
                               fld.name,
                               escapedVal(value),
-                              Next.None)
+                              Next.None)(Position.generated)
             }
         }
       case DelayedInstance(op) =>

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -131,7 +131,8 @@ trait Visit { self: Interflow =>
         case BailOut(msg) =>
           log(s"failed to expand ${name.show}: $msg")
           val baildefn =
-            origdefn.copy(attrs = origdefn.attrs.copy(opt = Attr.BailOpt(msg)))
+            origdefn.copy(attrs = origdefn.attrs.copy(opt = Attr.BailOpt(msg)))(
+              origdefn.pos)
           noOpt(origdefn)
           setDone(name, baildefn)
           setDone(origname, baildefn)

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -7,7 +7,7 @@ import scalanative.nir._
 sealed abstract class Info {
   def attrs: Attrs
   def name: Global
-  implicit def position: Position
+  def position: Position
 }
 
 sealed abstract class ScopeInfo extends Info {

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -7,6 +7,7 @@ import scalanative.nir._
 sealed abstract class Info {
   def attrs: Attrs
   def name: Global
+  implicit def position: Position
 }
 
 sealed abstract class ScopeInfo extends Info {
@@ -56,9 +57,13 @@ sealed abstract class MemberInfo extends Info {
 final class Unavailable(val name: Global) extends Info {
   def attrs: Attrs =
     util.unsupported(s"unavailable ${name.show} has no attrs")
+
+  def position: Position =
+    util.unsupported(s"unavailable ${name.show} has no position")
 }
 
-final class Trait(val attrs: Attrs, val name: Global, val traits: Seq[Trait])
+final class Trait(val attrs: Attrs, val name: Global, val traits: Seq[Trait])(
+    implicit val position: Position)
     extends ScopeInfo {
   val implementors = mutable.Set.empty[Class]
   val subtraits    = mutable.Set.empty[Trait]
@@ -93,7 +98,7 @@ final class Class(val attrs: Attrs,
                   val name: Global,
                   val parent: Option[Class],
                   val traits: Seq[Trait],
-                  val isModule: Boolean)
+                  val isModule: Boolean)(implicit val position: Position)
     extends ScopeInfo {
   val implementors    = mutable.Set[Class](this)
   val subclasses      = mutable.Set.empty[Class]
@@ -176,7 +181,7 @@ final class Method(val attrs: Attrs,
                    val owner: Info,
                    val name: Global,
                    val ty: Type,
-                   val insts: Array[Inst])
+                   val insts: Array[Inst])(implicit val position: Position)
     extends MemberInfo {
   val value: Val =
     if (isConcrete) {
@@ -193,7 +198,7 @@ final class Field(val attrs: Attrs,
                   val name: Global,
                   val isConst: Boolean,
                   val ty: nir.Type,
-                  val init: Val)
+                  val init: Val)(implicit val position: Position)
     extends MemberInfo {
   lazy val index: Int =
     owner.asInstanceOf[Class].fields.indexOf(this)

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -400,6 +400,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachVar(defn: Defn.Var): Unit = {
     val Defn.Var(attrs, name, ty, rhs) = defn
+    import defn.pos
     newInfo(
       new Field(attrs,
                 scopeInfoOrUnavailable(name.top),
@@ -414,6 +415,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachConst(defn: Defn.Const): Unit = {
     val Defn.Const(attrs, name, ty, rhs) = defn
+    import defn.pos
     newInfo(
       new Field(attrs,
                 scopeInfoOrUnavailable(name.top),
@@ -428,6 +430,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachDeclare(defn: Defn.Declare): Unit = {
     val Defn.Declare(attrs, name, ty) = defn
+    import defn.pos
     newInfo(
       new Method(attrs, scopeInfoOrUnavailable(name.top), name, ty, Array()))
     reachAttrs(attrs)
@@ -436,6 +439,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachDefine(defn: Defn.Define): Unit = {
     val Defn.Define(attrs, name, ty, insts) = defn
+    import defn.pos
     newInfo(
       new Method(attrs,
                  scopeInfoOrUnavailable(name.top),
@@ -449,12 +453,14 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachTrait(defn: Defn.Trait): Unit = {
     val Defn.Trait(attrs, name, traits) = defn
+    import defn.pos
     newInfo(new Trait(attrs, name, traits.flatMap(traitInfo)))
     reachAttrs(attrs)
   }
 
   def reachClass(defn: Defn.Class): Unit = {
     val Defn.Class(attrs, name, parent, traits) = defn
+    import defn.pos
     newInfo(
       new Class(attrs,
                 name,
@@ -466,6 +472,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachModule(defn: Defn.Module): Unit = {
     val Defn.Module(attrs, name, parent, traits) = defn
+    import defn.pos
     newInfo(
       new Class(attrs,
                 name,

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -400,7 +400,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachVar(defn: Defn.Var): Unit = {
     val Defn.Var(attrs, name, ty, rhs) = defn
-    import defn.pos
+    implicit val pos: nir.Position     = defn.pos
     newInfo(
       new Field(attrs,
                 scopeInfoOrUnavailable(name.top),
@@ -415,7 +415,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachConst(defn: Defn.Const): Unit = {
     val Defn.Const(attrs, name, ty, rhs) = defn
-    import defn.pos
+    implicit val pos: nir.Position       = defn.pos
     newInfo(
       new Field(attrs,
                 scopeInfoOrUnavailable(name.top),
@@ -430,7 +430,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachDeclare(defn: Defn.Declare): Unit = {
     val Defn.Declare(attrs, name, ty) = defn
-    import defn.pos
+    implicit val pos: nir.Position    = defn.pos
     newInfo(
       new Method(attrs, scopeInfoOrUnavailable(name.top), name, ty, Array()))
     reachAttrs(attrs)
@@ -439,7 +439,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachDefine(defn: Defn.Define): Unit = {
     val Defn.Define(attrs, name, ty, insts) = defn
-    import defn.pos
+    implicit val pos: nir.Position          = defn.pos
     newInfo(
       new Method(attrs,
                  scopeInfoOrUnavailable(name.top),
@@ -453,14 +453,14 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachTrait(defn: Defn.Trait): Unit = {
     val Defn.Trait(attrs, name, traits) = defn
-    import defn.pos
+    implicit val pos: nir.Position      = defn.pos
     newInfo(new Trait(attrs, name, traits.flatMap(traitInfo)))
     reachAttrs(attrs)
   }
 
   def reachClass(defn: Defn.Class): Unit = {
     val Defn.Class(attrs, name, parent, traits) = defn
-    import defn.pos
+    implicit val pos: nir.Position              = defn.pos
     newInfo(
       new Class(attrs,
                 name,
@@ -472,7 +472,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
 
   def reachModule(defn: Defn.Module): Unit = {
     val Defn.Module(attrs, name, parent, traits) = defn
-    import defn.pos
+    implicit val pos: nir.Position               = defn.pos
     newInfo(
       new Class(attrs,
                 name,


### PR DESCRIPTION
This PR adds basic support for embedding source code positions inside NIR format, which is first step in enabling debugging in Scala Native.

Positions metadata was added to `Defn` and `Inst` NIR objects via implicit parameters. Within generated code/transformations positions may be preserved if it's possible. In multiple cases code generated via Scala Native plugin contains mocked up Position. 
Serialization of Positions was ported from Scala.js