### PR TITLE
Fix #1496: Encode Strings in NIR as char code units instead of UTF-8

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -50,7 +50,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
   }
 
   private def getASCIIString(): String = {
-    new String(getBytes(), StandardCharsets.ISO_8859_1)
+    new String(getBytes(), StandardCharsets.UTF_8)
   }
 
   private def getBytes(): Array[Byte] = {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -17,7 +17,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
     val prelude = Prelude.readFrom(buffer)
 
     val pairs = getSeq((getGlobal, getInt))
-    val map = pairs.toMap
+    val map   = pairs.toMap
     prelude -> map
   }
 
@@ -176,7 +176,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
       Defn.Module(getAttrs, getGlobal, getGlobalOpt, getGlobals)
   }
 
-  private def getGlobals(): Seq[Global] = getSeq(getGlobal)
+  private def getGlobals(): Seq[Global]      = getSeq(getGlobal)
   private def getGlobalOpt(): Option[Global] = getOpt(getGlobal)
   private def getGlobal(): Global = getInt match {
     case T.NoneGlobal =>
@@ -235,7 +235,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
   }
 
   private def getParams(): Seq[Val.Local] = getSeq(getParam)
-  private def getParam(): Val.Local = Val.Local(getLocal, getType)
+  private def getParam(): Val.Local       = Val.Local(getLocal, getType)
 
   private def getTypes(): Seq[Type] = getSeq(getType)
   private def getType(): Type = getInt match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -11,7 +11,7 @@ final class BinarySerializer(buffer: ByteBuffer) {
   import buffer._
 
   final def serialize(defns: Seq[Defn]): Unit = {
-    val names = defns.map(_.name)
+    val names     = defns.map(_.name)
     val positions = mutable.UnrolledBuffer.empty[Int]
 
     Prelude.writeTo(buffer,

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -53,13 +53,10 @@ final class BinarySerializer(buffer: ByteBuffer) {
 
   private def putInts(ints: Seq[Int]) = putSeq[Int](ints)(putInt(_))
 
-  private def putASCIIString(v: String) = putBytes {
+  private def putUTF8tring(v: String) = putBytes {
     v.getBytes(StandardCharsets.UTF_8)
   }
-  private def putString(v: String) = {
-    putInt(v.length)
-    v.foreach(putChar)
-  }
+
   private def putBytes(bytes: Array[Byte]) = {
     putInt(bytes.length); put(bytes)
   }
@@ -79,12 +76,12 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Attr.UnOpt        => putInt(T.UnOptAttr)
     case Attr.NoOpt        => putInt(T.NoOptAttr)
     case Attr.DidOpt       => putInt(T.DidOptAttr)
-    case Attr.BailOpt(msg) => putInt(T.BailOptAttr); putASCIIString(msg)
+    case Attr.BailOpt(msg) => putInt(T.BailOptAttr); putUTF8tring(msg)
 
     case Attr.Dyn      => putInt(T.DynAttr)
     case Attr.Stub     => putInt(T.StubAttr)
     case Attr.Extern   => putInt(T.ExternAttr)
-    case Attr.Link(s)  => putInt(T.LinkAttr); putASCIIString(s)
+    case Attr.Link(s)  => putInt(T.LinkAttr); putUTF8tring(s)
     case Attr.Abstract => putInt(T.AbstractAttr)
   }
 
@@ -250,17 +247,17 @@ final class BinarySerializer(buffer: ByteBuffer) {
       putInt(T.NoneGlobal)
     case Global.Top(id) =>
       putInt(T.TopGlobal)
-      putASCIIString(id)
+      putUTF8tring(id)
     case Global.Member(Global.Top(owner), sig) =>
       putInt(T.MemberGlobal)
-      putASCIIString(owner)
+      putUTF8tring(owner)
       putSig(sig)
     case _ =>
       util.unreachable
   }
 
   private def putSig(sig: Sig): Unit =
-    putASCIIString(sig.mangle)
+    putUTF8tring(sig.mangle)
 
   private def putLocal(local: Local): Unit =
     putLong(local.id)
@@ -489,9 +486,12 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Val.Local(n, ty)  => putInt(T.LocalVal); putLocal(n); putType(ty)
     case Val.Global(n, ty) => putInt(T.GlobalVal); putGlobal(n); putType(ty)
 
-    case Val.Unit       => putInt(T.UnitVal)
-    case Val.Const(v)   => putInt(T.ConstVal); putVal(v)
-    case Val.String(v)  => putInt(T.StringVal); putString(v)
+    case Val.Unit     => putInt(T.UnitVal)
+    case Val.Const(v) => putInt(T.ConstVal); putVal(v)
+    case Val.String(v) =>
+      putInt(T.StringVal)
+      putInt(v.length)
+      v.foreach(putChar)
     case Val.Virtual(v) => putInt(T.VirtualVal); putLong(v)
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -54,7 +54,7 @@ final class BinarySerializer(buffer: ByteBuffer) {
   private def putInts(ints: Seq[Int]) = putSeq[Int](ints)(putInt(_))
 
   private def putASCIIString(v: String) = putBytes {
-    v.getBytes(StandardCharsets.ISO_8859_1)
+    v.getBytes(StandardCharsets.UTF_8)
   }
   private def putString(v: String) = {
     putInt(v.length)

--- a/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
@@ -75,6 +75,17 @@ object CharacterSuite extends tests.Suite {
     assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
   }
 
+  test("codePointAt - low surrogate at beginning of line") {
+    val str1     = "\uDC00eol" // Character.MIN_LOW_SURROGATE
+    val index    = 0
+    val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
+    val resultCS = Character.codePointAt(str1, index)
+    val expected = 0xDC00 // Character.MIN_LOW_SURROGATE, 56320 decimal
+
+    assert(resultCA == resultCS, s"resultCA: $resultCA != resultCS: $resultCS")
+    assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
+  }
+
   test("codePointAt - high surrogate at end of line") {
     val str1  = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
     val index = str1.length - 1
@@ -98,6 +109,36 @@ object CharacterSuite extends tests.Suite {
 
     assert(resultCA == resultCS, s"resultCA: $resultCA != resultCS: $resultCS")
     assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
+  }
+
+  test("codePointAt - high-non-high surrogate") {
+    val str1    = "a\uDBFFb\uDBFFc"
+    val indexes = Seq(1, 3)
+    indexes.foreach { index =>
+      val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
+      val resultCS = Character.codePointAt(str1, index)
+      val expected = 0xDBFF
+
+      assert(resultCA == resultCS,
+             s"resultCA: $resultCA != resultCS: $resultCS")
+      assert(resultCA == expected,
+             s"resultCA: $resultCA != expected: $expected")
+    }
+  }
+
+  test("codePointAt - low-non-low surrogate") {
+    val str1    = "a\uDC00b\uDC00c"
+    val indexes = Seq(1, 3)
+    indexes.foreach { index =>
+      val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
+      val resultCS = Character.codePointAt(str1, index)
+      val expected = 0xDC00
+
+      assert(resultCA == resultCS,
+             s"resultCA: $resultCA != resultCS: $resultCS")
+      assert(resultCA == expected,
+             s"resultCA: $resultCA != expected: $expected")
+    }
   }
 
   // codePointBefore tests
@@ -164,6 +205,17 @@ object CharacterSuite extends tests.Suite {
     assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
   }
 
+  test("codePointBefore - low surrogate at beginning of line") {
+    val str1     = "\uDC00eol" // Character.MIN_LOW_SURROGATE
+    val index    = 1
+    val resultCA = Character.codePointBefore(str1.toArray, index)
+    val resultCS = Character.codePointBefore(str1, index)
+    val expected = 0xDC00 // Character.MIN_LOW_SURROGATE, 56320 decimal
+
+    assert(resultCA == resultCS, s"resultCA: $resultCA != resultCS: $resultCS")
+    assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
+  }
+
   test("codePointBefore - high surrogate at end of line") {
     val str1  = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
     val index = str1.length
@@ -187,6 +239,36 @@ object CharacterSuite extends tests.Suite {
 
     assert(resultCA == resultCS, s"resultCA: $resultCA != resultCS: $resultCS")
     assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
+  }
+
+  test("codePointBefore - high-non-high surrogate") {
+    val str1    = "a\uDBFFb\uDBFFc"
+    val indexes = Seq(2, 4)
+    indexes.foreach { index =>
+      val resultCA = Character.codePointBefore(str1.toArray, index)
+      val resultCS = Character.codePointBefore(str1, index)
+      val expected = 0xDBFF
+
+      assert(resultCA == resultCS,
+             s"resultCA: $resultCA != resultCS: $resultCS")
+      assert(resultCA == expected,
+             s"resultCA: $resultCA != expected: $expected")
+    }
+  }
+
+  test("codePointBefore - low-non-low surrogate") {
+    val str1    = "a\uDC00b\uDC00c"
+    val indexes = Seq(2, 4)
+    indexes.foreach { index =>
+      val resultCA = Character.codePointBefore(str1.toArray, index)
+      val resultCS = Character.codePointBefore(str1, index)
+      val expected = 0xDC00
+
+      assert(resultCA == resultCS,
+             s"resultCA: $resultCA != resultCS: $resultCS")
+      assert(resultCA == expected,
+             s"resultCA: $resultCA != expected: $expected")
+    }
   }
 
   test("codePointCount") {

--- a/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
@@ -1,15 +1,15 @@
 package java.lang
 
 /** Test suite for [[java.lang.Character]]
-  *
-  * To be consistent the implementations should be based on
-  * Unicode 7.0.
-  * @see [[http://www.unicode.org/Public/7.0.0 Unicode 7.0]]
-  *
-  * Overall code point range U+0000 - U+D7FF and U+E000 - U+10FFF.
-  * Surrogate code points are in the gap and U+FFFF
-  * is the max value for [[scala.Char]].
-  */
+ *
+ * To be consistent the implementations should be based on
+ * Unicode 7.0.
+ * @see [[http://www.unicode.org/Public/7.0.0 Unicode 7.0]]
+ *
+ * Overall code point range U+0000 - U+D7FF and U+E000 - U+10FFF.
+ * Surrogate code points are in the gap and U+FFFF
+ * is the max value for [[scala.Char]].
+ */
 object CharacterSuite extends tests.Suite {
   import java.lang.Character._
 
@@ -50,7 +50,7 @@ object CharacterSuite extends tests.Suite {
   test("codePointAt - Array[Char]") {
     val arr1 = "abcdEfghIjklMnoPqrsTuvwXyz".toArray
 
-    val result = Character.codePointAt(arr1, 3, arr1.length)
+    val result   = Character.codePointAt(arr1, 3, arr1.length)
     val expected = 100 // 'd'
     assert(result == expected, s"result: $result != expected: $expected")
   }
@@ -58,13 +58,13 @@ object CharacterSuite extends tests.Suite {
   test("codePointAt - CharSeq") {
     val charSeq1: CharSequence = "abcdEfghIjklMnoPqrsTuvwXyz"
 
-    val result = Character.codePointAt(charSeq1, 8)
+    val result   = Character.codePointAt(charSeq1, 8)
     val expected = 73 // 'I'
     assert(result == expected, s"result: $result != expected: $expected")
   }
 
   test("codePointAt - Array[Char],CharSeq return same non-ASCII value") {
-    val str1 = "30\u20ac" // 'euro-character'
+    val str1  = "30\u20ac" // 'euro-character'
     val index = str1.length - 1
 
     val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
@@ -76,7 +76,7 @@ object CharacterSuite extends tests.Suite {
   }
 
   test("codePointAt - high surrogate at end of line") {
-    val str1 = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
+    val str1  = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
     val index = str1.length - 1
 
     val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
@@ -89,7 +89,7 @@ object CharacterSuite extends tests.Suite {
 
   test("codePointAt - surrogate pair") {
     // Character.MIN_HIGH_SURROGATE followed by Character.MAX_LOW_SURROGATE
-    val str1 = "before \uD800\uDFFF after"
+    val str1  = "before \uD800\uDFFF after"
     val index = 7
 
     val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
@@ -133,27 +133,27 @@ object CharacterSuite extends tests.Suite {
   }
 
   test("codePointBefore - Array[Char]") {
-    val arr1 = "abcdEfghIjklMnopQrstUvwxYz".toArray
+    val arr1  = "abcdEfghIjklMnopQrstUvwxYz".toArray
     val index = 10
 
-    val result = Character.codePointBefore(arr1, index)
+    val result   = Character.codePointBefore(arr1, index)
     val expected = 106 // 'j'
 
     assert(result == expected, s"result: $result != expected: $expected")
   }
 
   test("codePointBefore - CharSeq") {
-    val str1 = "abcdEfghIjklMnoPqrsTuvwXyz"
+    val str1  = "abcdEfghIjklMnoPqrsTuvwXyz"
     val index = str1.length - 1
 
-    val result = Character.codePointBefore(str1, index)
+    val result   = Character.codePointBefore(str1, index)
     val expected = 121 // 'y'
 
     assert(result == expected, s"result: $result != expected: $expected")
   }
 
   test("codePointBefore - Array[Char], CharSeq return same non-ASCII value") {
-    val str1 = "bugsabound\u03bb" // Greek small letter lambda
+    val str1  = "bugsabound\u03bb" // Greek small letter lambda
     val index = str1.length
 
     val resultCA = Character.codePointBefore(str1.toArray, index)
@@ -165,7 +165,7 @@ object CharacterSuite extends tests.Suite {
   }
 
   test("codePointBefore - high surrogate at end of line") {
-    val str1 = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
+    val str1  = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
     val index = str1.length
 
     val resultCA = Character.codePointBefore(str1.toArray, index)
@@ -178,7 +178,7 @@ object CharacterSuite extends tests.Suite {
 
   test("codePointBefore - surrogate pair") {
     // Character.MIN_HIGH_SURROGATE followed by Character.MAX_LOW_SURROGATE
-    val str1 = "Denali\uD800\uDFFF"
+    val str1  = "Denali\uD800\uDFFF"
     val index = str1.length
 
     val resultCA = Character.codePointBefore(str1.toArray, index, str1.length)
@@ -190,10 +190,10 @@ object CharacterSuite extends tests.Suite {
   }
 
   test("codePointCount") {
-    val data = "Mt. Whitney".toArray[scala.Char]
-    val offset = 1
+    val data     = "Mt. Whitney".toArray[scala.Char]
+    val offset   = 1
     val expected = data.size - offset
-    val result = Character.codePointCount(data, offset, expected)
+    val result   = Character.codePointCount(data, offset, expected)
 
     assert(result == expected, s"result: $result != expected: $expected")
   }
@@ -267,7 +267,7 @@ object CharacterSuite extends tests.Suite {
 // format: on
 
     for {
-      zero <- All0s
+      zero   <- All0s
       offset <- 0 to 9
     } {
       assay(offset, zero + offset)
@@ -276,7 +276,7 @@ object CharacterSuite extends tests.Suite {
     val AllAs = Array[Int]('A', 'a', 0xff21, 0xff41)
 
     for {
-      a <- AllAs
+      a      <- AllAs
       offset <- 0 to 25
     } {
       assay(10 + offset, a + offset)

--- a/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
+++ b/unit-tests/src/test/scala/java/lang/CharacterSuite.scala
@@ -1,15 +1,15 @@
 package java.lang
 
 /** Test suite for [[java.lang.Character]]
- *
- * To be consistent the implementations should be based on
- * Unicode 7.0.
- * @see [[http://www.unicode.org/Public/7.0.0 Unicode 7.0]]
- *
- * Overall code point range U+0000 - U+D7FF and U+E000 - U+10FFF.
- * Surrogate code points are in the gap and U+FFFF
- * is the max value for [[scala.Char]].
- */
+  *
+  * To be consistent the implementations should be based on
+  * Unicode 7.0.
+  * @see [[http://www.unicode.org/Public/7.0.0 Unicode 7.0]]
+  *
+  * Overall code point range U+0000 - U+D7FF and U+E000 - U+10FFF.
+  * Surrogate code points are in the gap and U+FFFF
+  * is the max value for [[scala.Char]].
+  */
 object CharacterSuite extends tests.Suite {
   import java.lang.Character._
 
@@ -50,7 +50,7 @@ object CharacterSuite extends tests.Suite {
   test("codePointAt - Array[Char]") {
     val arr1 = "abcdEfghIjklMnoPqrsTuvwXyz".toArray
 
-    val result   = Character.codePointAt(arr1, 3, arr1.length)
+    val result = Character.codePointAt(arr1, 3, arr1.length)
     val expected = 100 // 'd'
     assert(result == expected, s"result: $result != expected: $expected")
   }
@@ -58,13 +58,13 @@ object CharacterSuite extends tests.Suite {
   test("codePointAt - CharSeq") {
     val charSeq1: CharSequence = "abcdEfghIjklMnoPqrsTuvwXyz"
 
-    val result   = Character.codePointAt(charSeq1, 8)
+    val result = Character.codePointAt(charSeq1, 8)
     val expected = 73 // 'I'
     assert(result == expected, s"result: $result != expected: $expected")
   }
 
   test("codePointAt - Array[Char],CharSeq return same non-ASCII value") {
-    val str1  = "30\u20ac" // 'euro-character'
+    val str1 = "30\u20ac" // 'euro-character'
     val index = str1.length - 1
 
     val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
@@ -75,8 +75,8 @@ object CharacterSuite extends tests.Suite {
     assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
   }
 
-  testFails("codePointAt - high surrogate at end of line", issue = 1496) {
-    val str1  = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
+  test("codePointAt - high surrogate at end of line") {
+    val str1 = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
     val index = str1.length - 1
 
     val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
@@ -89,7 +89,7 @@ object CharacterSuite extends tests.Suite {
 
   test("codePointAt - surrogate pair") {
     // Character.MIN_HIGH_SURROGATE followed by Character.MAX_LOW_SURROGATE
-    val str1  = "before \uD800\uDFFF after"
+    val str1 = "before \uD800\uDFFF after"
     val index = 7
 
     val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
@@ -133,27 +133,27 @@ object CharacterSuite extends tests.Suite {
   }
 
   test("codePointBefore - Array[Char]") {
-    val arr1  = "abcdEfghIjklMnopQrstUvwxYz".toArray
+    val arr1 = "abcdEfghIjklMnopQrstUvwxYz".toArray
     val index = 10
 
-    val result   = Character.codePointBefore(arr1, index)
+    val result = Character.codePointBefore(arr1, index)
     val expected = 106 // 'j'
 
     assert(result == expected, s"result: $result != expected: $expected")
   }
 
   test("codePointBefore - CharSeq") {
-    val str1  = "abcdEfghIjklMnoPqrsTuvwXyz"
+    val str1 = "abcdEfghIjklMnoPqrsTuvwXyz"
     val index = str1.length - 1
 
-    val result   = Character.codePointBefore(str1, index)
+    val result = Character.codePointBefore(str1, index)
     val expected = 121 // 'y'
 
     assert(result == expected, s"result: $result != expected: $expected")
   }
 
   test("codePointBefore - Array[Char], CharSeq return same non-ASCII value") {
-    val str1  = "bugsabound\u03bb" // Greek small letter lambda
+    val str1 = "bugsabound\u03bb" // Greek small letter lambda
     val index = str1.length
 
     val resultCA = Character.codePointBefore(str1.toArray, index)
@@ -164,12 +164,12 @@ object CharacterSuite extends tests.Suite {
     assert(resultCA == expected, s"resultCA: $resultCA != expected: $expected")
   }
 
-  testFails("codePointBefore - high surrogate at end of line", issue = 1496) {
-    val str1  = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
+  test("codePointBefore - high surrogate at end of line") {
+    val str1 = "eol\uDBFF" // Character.MAX_HIGH_SURROGATE
     val index = str1.length
 
-    val resultCA = Character.codePointAt(str1.toArray, index, str1.length)
-    val resultCS = Character.codePointAt(str1, index)
+    val resultCA = Character.codePointBefore(str1.toArray, index)
+    val resultCS = Character.codePointBefore(str1, index)
     val expected = 0xDBFF // Character.MAX_HIGH_SURROGATE, 56319 decimal
 
     assert(resultCA == resultCS, s"resultCA: $resultCA != resultCS: $resultCS")
@@ -178,7 +178,7 @@ object CharacterSuite extends tests.Suite {
 
   test("codePointBefore - surrogate pair") {
     // Character.MIN_HIGH_SURROGATE followed by Character.MAX_LOW_SURROGATE
-    val str1  = "Denali\uD800\uDFFF"
+    val str1 = "Denali\uD800\uDFFF"
     val index = str1.length
 
     val resultCA = Character.codePointBefore(str1.toArray, index, str1.length)
@@ -190,10 +190,10 @@ object CharacterSuite extends tests.Suite {
   }
 
   test("codePointCount") {
-    val data     = "Mt. Whitney".toArray[scala.Char]
-    val offset   = 1
+    val data = "Mt. Whitney".toArray[scala.Char]
+    val offset = 1
     val expected = data.size - offset
-    val result   = Character.codePointCount(data, offset, expected)
+    val result = Character.codePointCount(data, offset, expected)
 
     assert(result == expected, s"result: $result != expected: $expected")
   }
@@ -267,7 +267,7 @@ object CharacterSuite extends tests.Suite {
 // format: on
 
     for {
-      zero   <- All0s
+      zero <- All0s
       offset <- 0 to 9
     } {
       assay(offset, zero + offset)
@@ -276,7 +276,7 @@ object CharacterSuite extends tests.Suite {
     val AllAs = Array[Int]('A', 'a', 0xff21, 0xff41)
 
     for {
-      a      <- AllAs
+      a <- AllAs
       offset <- 0 to 25
     } {
       assay(10 + offset, a + offset)


### PR DESCRIPTION
Resolves #1496 
This PR fixes encoding of string in NIR files. Each `Val.String` is encoded as `List[Char]` which is equal to list of code points of chars. 
Previous implementation encoded `Val.String` as UTF-8 string which resulted in data loss e.q in case of Unicode surrogate pairs.
Legacy encoding/decoding methods `putString`/`getString` where replaced with `putASCIIString`/`getASCIIString`. They're still used while encoding names (`Sig`, `Global` etc.) which are always ASCII strings. Thanks to that size of NIR files should not change. 