### PR TITLE
Partial fix #1023 : implement j.t.ParsePosition

### DIFF
--- a/javalib/src/main/scala/java/text/ParsePosition.scala
+++ b/javalib/src/main/scala/java/text/ParsePosition.scala
@@ -1,0 +1,37 @@
+package java.text
+
+// Hand ported from Apache Harmony, URL:
+//   https://github.com/apache/harmony/blob/trunk/classlib/modules/text/src/\
+//         main/java/java/text/ParsePosition.java
+//
+// The port is close enough to the original that it inherits the
+// Apache Harmony license through the Scala Native license.
+
+class ParsePosition(private[this] var _index: Int) {
+  private[this] var errorIndex = -1
+
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case that: ParsePosition =>
+        (this.getIndex() == that.getIndex()) &&
+          (this.getErrorIndex() == that.getErrorIndex())
+
+      case _ => false
+    }
+
+  override def hashCode(): Int = _index + errorIndex
+
+  def getErrorIndex(): Int = errorIndex
+
+  def getIndex(): Int = _index
+
+  def setErrorIndex(index: Int): Unit = { errorIndex = index }
+
+  def setIndex(index: Int): Unit = { _index = index }
+
+  override def toString(): String = {
+    val idx      = getIndex()
+    val errorIdx = getErrorIndex()
+    s"java.text.ParsePosition[index=${idx},errorIndex=${errorIdx}]"
+  }
+}

--- a/unit-tests/src/test/scala/java/text/ParsePositionTest.scala
+++ b/unit-tests/src/test/scala/java/text/ParsePositionTest.scala
@@ -1,0 +1,143 @@
+package java.text
+
+// This file is original content, covered by the Scala Native license.
+
+// The order in which tests are run is not defined, so there is no
+// concept of "test a method before using it in another test".
+// Because any given test can not assume the existence & passing of
+// any other test, there may be checks which would be redundant in a
+// more ordered world.
+
+import org.junit.Assert._
+import org.junit.Test
+
+class ParsePositionTest {
+  @Test def constructorTest(): Unit = {
+    val expectedIndex      = 2
+    val expectedErrorIndex = -1
+
+    val pp = new ParsePosition(expectedIndex)
+
+    assertEquals("index| ", expectedIndex, pp.getIndex())
+    assertEquals("errorIndex| ", expectedErrorIndex, pp.getErrorIndex())
+  }
+
+  @Test def equalsTest(): Unit = {
+    val idx = 11
+
+    val pp1 = new ParsePosition(idx)
+    val pp2 = new ParsePosition(idx)
+    val pp3 = new ParsePosition(idx + 1)
+
+    assertFalse("Similar ParsePositions should not be reference equal",
+                pp1.eq(pp2))
+
+    assertEquals("Similar ParsePositions should be content equal", pp1, pp2)
+
+    // Detect hidden caching which might mess up content equality setting.
+    assertFalse("Different ParsePositions should not be reference equal",
+                pp1.eq(pp3))
+
+    assertFalse("Different ParsePositions should not be content equal",
+                pp1.equals(pp3))
+
+    val errorIdx = -7
+    pp1.setErrorIndex(errorIdx)
+
+    assertFalse("Changed ParsePositions should not be content equal",
+                pp1.equals(pp2))
+
+    pp2.setErrorIndex(errorIdx)
+    assertEquals("Newly similar ParsePositions should be content equal",
+                 pp1,
+                 pp2)
+  }
+
+  @Test def hashCodeTest(): Unit = {
+    val idx = 22
+
+    val pp1 = new ParsePosition(idx)
+    val pp2 = new ParsePosition(idx * 2)
+
+    assertFalse("Different ParsePositions should not be reference equal",
+                pp1.eq(pp2))
+
+    val firstHash = pp1.hashCode
+
+    // Uses knowledge of underlying implementation having no hash collisions.
+    assertFalse("Different ParsePositions should not have same hashCode",
+                firstHash == pp2.hashCode)
+
+    pp2.setIndex(idx)
+
+    assertEquals("Similar ParsePositions should have same hashCode",
+                 firstHash,
+                 pp2.hashCode)
+
+    val errorIdx = -5
+    pp1.setErrorIndex(errorIdx)
+    pp2.setErrorIndex(errorIdx)
+
+    val secondHash = pp1.hashCode
+    assertEquals("Parallel changes should maintain hashCode equality",
+                 secondHash,
+                 pp2.hashCode)
+
+    assertFalse("Changing ParsePosition should change hashCode",
+                secondHash == firstHash)
+  }
+
+  @Test def setGetErrorIndexTest(): Unit = {
+    val expectedIndex                 = 7
+    val expectedConstructorErrorIndex = -1
+
+    val expectedSetErrorIndex = -7
+
+    val pp = new ParsePosition(expectedIndex)
+
+    assertEquals("Constructor errorIndex| ",
+                 expectedConstructorErrorIndex,
+                 pp.getErrorIndex())
+
+    pp.setErrorIndex(expectedSetErrorIndex)
+
+    assertEquals("Set errorIndex| ", expectedSetErrorIndex, pp.getErrorIndex())
+
+    assertEquals("Set errorIndex should not change index| ",
+                 expectedIndex,
+                 pp.getIndex())
+  }
+
+  @Test def setGetIndexTest(): Unit = {
+    val expectedIndex      = 6
+    val expectedErrorIndex = -1
+
+    val expectedSetIndex = -8
+
+    val pp = new ParsePosition(expectedIndex)
+
+    assertEquals("Constructor index| ", expectedIndex, pp.getIndex())
+
+    pp.setIndex(expectedSetIndex)
+
+    assertEquals("Set method Index| ", expectedSetIndex, pp.getIndex())
+
+    assertEquals("Set index should not change errorIndex| ",
+                 expectedErrorIndex,
+                 pp.getErrorIndex())
+  }
+
+  @Test def toStringTest(): Unit = {
+    val idx      = 99
+    val errorIdx = -2
+
+    val pp = new ParsePosition(idx)
+
+    pp.setErrorIndex(errorIdx)
+
+    val expected =
+      s"java.text.ParsePosition[index=${idx},errorIndex=${errorIdx}]"
+
+    assertEquals(expected, pp.toString())
+  }
+}


### PR DESCRIPTION
  * This PR was motivated by Issue #1023 "Missing methods to support
    scala-java-time". The actual missing methods have changed over the past
    three years, but the goal remains valid.

  * This PR implements the missing method java.text.ParsePosition and
    provides JUnit tests.

  * Having j.t.ParsePosition allows a private version of scala-java-time
    to build its core project and execute its demo project without
    failures.  This gives Scala Native one credible third-party way to provide
    java.time methods but does not require the use of scala-java-time.
    
    Having competent java.time methods available allows me to 
    get on with my Zio fibers-in-ScalaNative work.

  * The next step is to port ScalaTest to the Summer 2020 SN test framework
    and see if there are missing methods in the scala-java-time test
    environment proper. scala-java-time is well exercised on the JVM and
    with Scala.js. Having its demo project execute on Scala Native is a
    step in the right direction.

  * I could not find a ParsePosition class for Scala.js. I did not
    explore why Scala Native requires the class in order to link
    scala-java-time's demo project when Scala.js does not.

    This PR could be ported to Scala.js if it would be useful to
    Scala.js. Please advise.

  * unit-tests/.../ParsePositionTest.scala was created as a JUnit
    class to test the new class and its methods, as described in the
    Java 8 documentation.

Documentation:

  * The standard changelog entry is requested.

Testing:

  * Built and tested ("test-all") in debug mode using sbt 1.3.13 on
    X86_64 only . All tests pass.