### PR TITLE
Update gitignore for new Metals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ bin/
 # metals
 /.bloop/
 /.metals/
-metals.sbt
+/project/**/metals.sbt
 
 # vscode
 /.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ bin/
 # metals
 /.bloop/
 /.metals/
-/project/metals.sbt
+metals.sbt
 
 # vscode
 /.vscode/


### PR DESCRIPTION
The newest Metals supports `sbt` build files and generates a `metals.sbt` in `project` and in `project/project`. This now ignores both cases.