### PR TITLE
Partial fix #1023: Port j.u.NavigableMap

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -538,6 +538,7 @@ Here is the list of currently available classes:
 * ``java.util.MissingFormatArgumentException``
 * ``java.util.MissingFormatWidthException``
 * ``java.util.MissingResourceException``
+* ``java.util.NavigableMap``
 * ``java.util.NavigableSet``
 * ``java.util.NavigableView``
 * ``java.util.NoSuchElementException``

--- a/javalib/src/main/scala/java/util/NavigableMap.scala
+++ b/javalib/src/main/scala/java/util/NavigableMap.scala
@@ -1,0 +1,46 @@
+// Ported, with thanks & gratitude, from Scala.js.
+//   commit: 9dc4d5b36ff2b2a3dfe2e91d5c6b1ef6d10d3e51 dated: Oct 12, 2018
+//
+//   Minor scalafmt change to subMap() declaraton in order to pass current
+//   Scala Native Travis CI scalafmt check stage.
+
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util
+
+trait NavigableMap[K, V] extends SortedMap[K, V] {
+  def lowerEntry(key: K): Map.Entry[K, V]
+  def lowerKey(key: K): K
+  def floorEntry(key: K): Map.Entry[K, V]
+  def floorKey(key: K): K
+  def ceilingEntry(key: K): Map.Entry[K, V]
+  def ceilingKey(key: K): K
+  def higherEntry(key: K): Map.Entry[K, V]
+  def higherKey(key: K): K
+  def firstEntry(): Map.Entry[K, V]
+  def lastEntry(): Map.Entry[K, V]
+  def pollFirstEntry(): Map.Entry[K, V]
+  def pollLastEntry(): Map.Entry[K, V]
+  def descendingMap(): NavigableMap[K, V]
+  def navigableKeySet(): NavigableSet[K]
+  def descendingKeySet(): NavigableSet[K]
+  def subMap(fromKey: K,
+             fromInclusive: Boolean,
+             toKey: K,
+             toInclusive: Boolean): NavigableMap[K, V]
+  def headMap(toKey: K, inclusive: Boolean): NavigableMap[K, V]
+  def tailMap(toKey: K, inclusive: Boolean): NavigableMap[K, V]
+  def subMap(fromKey: K, toKey: K): SortedMap[K, V]
+  def headMap(toKey: K): SortedMap[K, V]
+  def tailMap(fromKey: K): SortedMap[K, V]
+}

--- a/javalib/src/main/scala/java/util/NavigableMap.scala
+++ b/javalib/src/main/scala/java/util/NavigableMap.scala
@@ -4,18 +4,6 @@
 //   Minor scalafmt change to subMap() declaraton in order to pass current
 //   Scala Native Travis CI scalafmt check stage.
 
-/*
- * Scala.js (https://www.scala-js.org/)
- *
- * Copyright EPFL.
- *
- * Licensed under Apache License 2.0
- * (https://www.apache.org/licenses/LICENSE-2.0).
- *
- * See the NOTICE file distributed with this work for
- * additional information regarding copyright ownership.
- */
-
 package java.util
 
 trait NavigableMap[K, V] extends SortedMap[K, V] {

--- a/javalib/src/main/scala/java/util/NavigableMap.scala
+++ b/javalib/src/main/scala/java/util/NavigableMap.scala
@@ -1,7 +1,7 @@
 // Ported, with thanks & gratitude, from Scala.js.
 //   commit: 9dc4d5b36ff2b2a3dfe2e91d5c6b1ef6d10d3e51 dated: Oct 12, 2018
 //
-//   Minor scalafmt change to subMap() declaraton in order to pass current
+//   Minor scalafmt change to subMap() declaration in order to pass current
 //   Scala Native Travis CI scalafmt check stage.
 
 package java.util


### PR DESCRIPTION
 * This PR was motivated by Issue #1023 "Missing methods to support
    scala-java-time". It provides one of the methods missing on
    2020-09-13, java.util.NavigableMap.

    That method was used in TzdbZoneRulesProvider.scala.  Tread carefully
    when tracing because that file is generated by the separate
    scala-java-time-tzdb plugin and not in the obvious but wrong
    git repository.

  * No tests are provided because j.u.NavigableMap is an abstract
    trait with no default (concrete) methods. Implementations of the
    trait (interface) will provide their own tests.

Documentation:

  * The standard changelog entry is requested.

  * An entry for j.u.NavigableMap was added to docs/lib/javalib.rst.

Testing:

  * Built and tested ("test-all") in debug mode using sbt 1.3.13 on
    X86_64 only . All tests pass.

  * Local copies of the  docs were manually regenerated to verify that
    they build after the change of this PR to javalib.rst.

    The build succeeds with no new errors due to this PR. I believe there
    are PRs awaiting merge which fix the errors unrelated to this PR.

    The expected entry shows up in a browser.  As expected, the link is
    broken, because its target does not exist until after this PR is
    merged: circularity.