### PR TITLE
Fix #1435: Cache instances of j.l.Class

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/commix/headers/ObjectHeader.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/headers/ObjectHeader.h
@@ -19,6 +19,7 @@ typedef struct {
         int32_t id;
         int32_t tid;
         word_t *name;
+        word_t *cls;
     } rt;
     int32_t size;
     int32_t idRangeUntil;

--- a/nativelib/src/main/resources/scala-native/gc/immix/headers/ObjectHeader.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/headers/ObjectHeader.h
@@ -19,6 +19,7 @@ typedef struct {
         int32_t id;
         int32_t tid;
         word_t *name;
+        word_t *cls;
     } rt;
     int32_t size;
     int32_t idRangeUntil;

--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -19,6 +19,7 @@ object rtti {
 }
 import rtti._
 
+/** @param rawty - Pointer with underlying Rt.Type info */
 final class _Class[A](val rawty: RawPtr) {
   @alwaysinline private def ty: Ptr[Type] =
     fromRawPtr[Type](rawty)

--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -62,9 +62,8 @@ final class _Class[A](val rawty: RawPtr) {
   def isInstance(obj: Object): scala.Boolean =
     is(obj.getClass.asInstanceOf[_Class[_]].ty, ty)
 
-  @alwaysinline private def is(cls: Class[_]): Boolean = {
-    rawty == toRawType(cls)
-  }
+  @alwaysinline private def is(cls: Class[_]): Boolean =
+    this eq cls.asInstanceOf[_Class[A]]
 
   private def is(left: Ptr[Type], right: Ptr[Type]): Boolean =
     // This replicates the logic of the compiler-generated instance check

--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -28,14 +28,14 @@ final class _Class[A](val rawty: RawPtr) {
     obj.asInstanceOf[A]
 
   def getComponentType(): _Class[_] = {
-    if (rawty == toRawType(classOf[BooleanArray])) classOf[scala.Boolean]
-    else if (rawty == toRawType(classOf[CharArray])) classOf[scala.Char]
-    else if (rawty == toRawType(classOf[ByteArray])) classOf[scala.Byte]
-    else if (rawty == toRawType(classOf[ShortArray])) classOf[scala.Short]
-    else if (rawty == toRawType(classOf[IntArray])) classOf[scala.Int]
-    else if (rawty == toRawType(classOf[LongArray])) classOf[scala.Long]
-    else if (rawty == toRawType(classOf[FloatArray])) classOf[scala.Float]
-    else if (rawty == toRawType(classOf[DoubleArray])) classOf[scala.Double]
+    if (is(classOf[BooleanArray])) classOf[scala.Boolean]
+    else if (is(classOf[CharArray])) classOf[scala.Char]
+    else if (is(classOf[ByteArray])) classOf[scala.Byte]
+    else if (is(classOf[ShortArray])) classOf[scala.Short]
+    else if (is(classOf[IntArray])) classOf[scala.Int]
+    else if (is(classOf[LongArray])) classOf[scala.Long]
+    else if (is(classOf[FloatArray])) classOf[scala.Float]
+    else if (is(classOf[DoubleArray])) classOf[scala.Double]
     else classOf[java.lang.Object]
   }
 
@@ -46,20 +46,25 @@ final class _Class[A](val rawty: RawPtr) {
     getName().split('.').last.split('$').last
 
   def isArray(): scala.Boolean =
-    (rawty == toRawType(classOf[BooleanArray]) ||
-      rawty == toRawType(classOf[CharArray]) ||
-      rawty == toRawType(classOf[ByteArray]) ||
-      rawty == toRawType(classOf[ShortArray]) ||
-      rawty == toRawType(classOf[IntArray]) ||
-      rawty == toRawType(classOf[LongArray]) ||
-      rawty == toRawType(classOf[FloatArray]) ||
-      rawty == toRawType(classOf[DoubleArray]) ||
-      rawty == toRawType(classOf[ObjectArray]))
+    is(classOf[BooleanArray]) ||
+      is(classOf[CharArray]) ||
+      is(classOf[ByteArray]) ||
+      is(classOf[ShortArray]) ||
+      is(classOf[IntArray]) ||
+      is(classOf[LongArray]) ||
+      is(classOf[FloatArray]) ||
+      is(classOf[DoubleArray]) ||
+      is(classOf[ObjectArray])
+
   def isAssignableFrom(that: Class[_]): scala.Boolean =
     is(that.asInstanceOf[_Class[_]].ty, ty)
 
   def isInstance(obj: Object): scala.Boolean =
     is(obj.getClass.asInstanceOf[_Class[_]].ty, ty)
+
+  @alwaysinline private def is(cls: Class[_]): Boolean = {
+    Intrinsics.castObjectToRawPtr(this) == Intrinsics.castObjectToRawPtr(cls)
+  }
 
   private def is(left: Ptr[Type], right: Ptr[Type]): Boolean =
     // This replicates the logic of the compiler-generated instance check
@@ -87,15 +92,15 @@ final class _Class[A](val rawty: RawPtr) {
     !ty.isClass
 
   def isPrimitive(): scala.Boolean =
-    (rawty == toRawType(classOf[PrimitiveBoolean]) ||
-      rawty == toRawType(classOf[PrimitiveChar]) ||
-      rawty == toRawType(classOf[PrimitiveByte]) ||
-      rawty == toRawType(classOf[PrimitiveShort]) ||
-      rawty == toRawType(classOf[PrimitiveInt]) ||
-      rawty == toRawType(classOf[PrimitiveLong]) ||
-      rawty == toRawType(classOf[PrimitiveFloat]) ||
-      rawty == toRawType(classOf[PrimitiveDouble]) ||
-      rawty == toRawType(classOf[PrimitiveUnit]))
+    is(classOf[PrimitiveBoolean]) ||
+      is(classOf[PrimitiveChar]) ||
+      is(classOf[PrimitiveByte]) ||
+      is(classOf[PrimitiveShort]) ||
+      is(classOf[PrimitiveInt]) ||
+      is(classOf[PrimitiveLong]) ||
+      is(classOf[PrimitiveFloat]) ||
+      is(classOf[PrimitiveDouble]) ||
+      is(classOf[PrimitiveUnit])
 
   @inline override def equals(other: Any): scala.Boolean =
     other match {

--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -63,7 +63,7 @@ final class _Class[A](val rawty: RawPtr) {
     is(obj.getClass.asInstanceOf[_Class[_]].ty, ty)
 
   @alwaysinline private def is(cls: Class[_]): Boolean = {
-    Intrinsics.castObjectToRawPtr(this) == Intrinsics.castObjectToRawPtr(cls)
+    rawty == toRawType(cls)
   }
 
   private def is(left: Ptr[Type], right: Ptr[Type]): Boolean =

--- a/nativelib/src/main/scala/java/lang/ClassInstancesRegistry.scala
+++ b/nativelib/src/main/scala/java/lang/ClassInstancesRegistry.scala
@@ -1,20 +1,19 @@
 package java.lang
 
 /** Registry for created instances of java.lang.Class
- * It's only purpose is to prevent GC from collecting instances of java.lang.Class
+ * Its only purpose is to prevent the GC from collecting instances of java.lang.Class
  **/
-object ClassInstancesRegistry {
-  type Arr[T] = scala.Array[T]
-  type Bucket = Arr[_Class[_]]
+private[lang] object ClassInstancesRegistry {
+  type Bucket = Array[_Class[_]]
 
-  final val BucketSize = 256
-  private var buckets  = new Arr[Bucket](2)
-  private var lastId   = -1
-  private var bucketId = -1
-  private var itemId   = -1
+  private final val BucketSize = 256
+  private var buckets          = new Array[Bucket](2)
+  private var lastId           = -1
+  private var bucketId         = -1
+  private var itemId           = -1
 
   @inline def nextIds(): Unit = {
-    lastId += 1;
+    lastId += 1
     bucketId = lastId / BucketSize
     itemId = lastId % BucketSize
   }
@@ -23,8 +22,8 @@ object ClassInstancesRegistry {
     nextIds()
     if (bucketId >= buckets.length) {
       val newSize: Int = buckets.length * 2
-      val newArr       = new Arr[Bucket](newSize)
-      Array.copy(buckets, 0, newArr, 0, buckets.length)
+      val newArr       = new Array[Bucket](newSize)
+      System.arraycopy(buckets, 0, newArr, 0, buckets.length)
       buckets = newArr
     }
     if (buckets(bucketId) == null) {

--- a/nativelib/src/main/scala/java/lang/ClassInstancesRegistry.scala
+++ b/nativelib/src/main/scala/java/lang/ClassInstancesRegistry.scala
@@ -1,0 +1,36 @@
+package java.lang
+
+/** Registry for created instances of java.lang.Class
+ * It's only purpose is to prevent GC from collecting instances of java.lang.Class
+ **/
+object ClassInstancesRegistry {
+  type Arr[T] = scala.Array[T]
+  type Bucket = Arr[_Class[_]]
+
+  final val BucketSize = 256
+  private var buckets  = new Arr[Bucket](2)
+  private var lastId   = -1
+  private var bucketId = -1
+  private var itemId   = -1
+
+  @inline def nextIds(): Unit = {
+    lastId += 1;
+    bucketId = lastId / BucketSize
+    itemId = lastId % BucketSize
+  }
+
+  def add(cls: _Class[_]): _Class[_] = {
+    nextIds()
+    if (bucketId >= buckets.length) {
+      val newSize: Int = buckets.length * 2
+      val newArr       = new Arr[Bucket](newSize)
+      Array.copy(buckets, 0, newArr, 0, buckets.length)
+      buckets = newArr
+    }
+    if (buckets(bucketId) == null) {
+      buckets(bucketId) = new Bucket(BucketSize)
+    }
+    buckets(bucketId)(itemId) = cls
+    cls
+  }
+}

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -16,18 +16,7 @@ class _Object {
   @inline def __toString(): String =
     getClass.getName + "@" + Integer.toHexString(hashCode)
 
-  @inline def __getClass(): _Class[_] = {
-    val rtti   = getRawType(this)
-    val clsPtr = elemRawPtr(rtti, 16)
-
-    if (loadRawPtr(clsPtr) == null) {
-      val newClass = new _Class[Any](rtti)
-      storeObject(clsPtr, newClass)
-      ClassInstancesRegistry.add(newClass)
-    } else {
-      loadObject(clsPtr).asInstanceOf[_Class[_]]
-    }
-  }
+  @inline def __getClass(): _Class[_] = runtime.toClass(getRawType(this))
 
   @inline def __notify(): Unit =
     getMonitor(this)._notify()

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -16,7 +16,7 @@ class _Object {
   @inline def __toString(): String =
     getClass.getName + "@" + Integer.toHexString(hashCode)
 
-  @inline def __getClass(): _Class[_] = runtime.toClass(getRawType(this))
+  @inline def __getClass(): _Class[_] = toClass(getRawType(this))
 
   @inline def __notify(): Unit =
     getMonitor(this)._notify()

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -75,11 +75,19 @@ class _Object {
  * It's only purpose is to prevent GC from collecting instances of java.lang.Class
  **/
 object ClassInstancesRegistry {
-  import scala.collection.mutable.UnrolledBuffer
-  private lazy val instances = UnrolledBuffer.empty[_Class[_]]
+  private var instances     = new scala.Array[_Class[_]](512)
+  private var lastId        = -1
+  @inline def nextId(): Int = { lastId += 1; lastId }
 
   def add(cls: _Class[_]): _Class[_] = {
-    instances += cls
+    val id = nextId()
+    if (instances.length <= id) {
+      val newSize: Int = (instances.length * 1.1).toInt
+      val newArr       = new scala.Array[_Class[_]](newSize)
+      Array.copy(instances, 0, newArr, 0, instances.length)
+      instances = newArr
+    }
+    instances(id) = cls
     cls
   }
 }

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -70,24 +70,3 @@ class _Object {
 
   protected def __finalize(): Unit = ()
 }
-
-/** Registry for created instances of java.lang.Class
- * It's only purpose is to prevent GC from collecting instances of java.lang.Class
- **/
-object ClassInstancesRegistry {
-  private var instances     = new scala.Array[_Class[_]](512)
-  private var lastId        = -1
-  @inline def nextId(): Int = { lastId += 1; lastId }
-
-  def add(cls: _Class[_]): _Class[_] = {
-    val id = nextId()
-    if (instances.length <= id) {
-      val newSize: Int = (instances.length * 1.1).toInt
-      val newArr       = new scala.Array[_Class[_]](newSize)
-      Array.copy(instances, 0, newArr, 0, instances.length)
-      instances = newArr
-    }
-    instances(id) = cls
-    cls
-  }
-}

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -22,8 +22,18 @@ class _Object {
     if (loadRawPtr(clsPtr) == null) {
       val newClass = new _Class[Any](self)
       storeObject(clsPtr, newClass)
+      newClass
+    } else {
+      loadObject(clsPtr) match {
+        case cls: _Class[_] => cls
+        case _              =>
+          // There are some cases when clsPtr does not contain instance of j.l.Class
+          // Until this issue is resolved we're overriding it's value with new instance of Class
+          storeObject(clsPtr, null)
+          __getClass()
+
+      }
     }
-    loadObject(clsPtr).asInstanceOf[_Class[_]]
   }
 
   @inline def __notify(): Unit =

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -16,8 +16,16 @@ class _Object {
   @inline def __toString(): String =
     getClass.getName + "@" + Integer.toHexString(hashCode)
 
-  @inline def __getClass(): _Class[_] =
-    new _Class(getRawType(this))
+  @inline def __getClass(): _Class[_] = {
+    val self       = getRawType(this)
+    val clsPtr     = elemRawPtr(self, 16)
+    val maybeClass = loadRawPtr(clsPtr)
+    if (maybeClass == null) {
+      val newClass = new _Class[Any](self)
+      storeObject(clsPtr, newClass)
+      newClass
+    } else castRawPtrToObject(maybeClass).asInstanceOf[_Class[Any]]
+  }
 
   @inline def __notify(): Unit =
     getMonitor(this)._notify()

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -75,19 +75,11 @@ class _Object {
  * It's only purpose is to prevent GC from collecting instances of java.lang.Class
  **/
 object ClassInstancesRegistry {
-  private var instances     = new scala.Array[_Class[_]](512)
-  private var lastId        = -1
-  @inline def nextId(): Int = { lastId += 1; lastId }
+  import scala.collection.mutable.UnrolledBuffer
+  private lazy val instances = UnrolledBuffer.empty[_Class[_]]
 
   def add(cls: _Class[_]): _Class[_] = {
-    val id = nextId()
-    if (instances.length <= id) {
-      val newSize: Int = (instances.length * 1.1).toInt
-      val newArr       = new scala.Array[_Class[_]](newSize)
-      Array.copy(instances, 0, newArr, 0, instances.length)
-      instances = newArr
-    }
-    instances(id) = cls
+    instances += cls
     cls
   }
 }

--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -17,14 +17,13 @@ class _Object {
     getClass.getName + "@" + Integer.toHexString(hashCode)
 
   @inline def __getClass(): _Class[_] = {
-    val self       = getRawType(this)
-    val clsPtr     = elemRawPtr(self, 16)
-    val maybeClass = loadRawPtr(clsPtr)
-    if (maybeClass == null) {
+    val self   = getRawType(this)
+    val clsPtr = elemRawPtr(self, 16)
+    if (loadRawPtr(clsPtr) == null) {
       val newClass = new _Class[Any](self)
       storeObject(clsPtr, newClass)
-      newClass
-    } else castRawPtrToObject(maybeClass).asInstanceOf[_Class[Any]]
+    }
+    loadObject(clsPtr).asInstanceOf[_Class[_]]
   }
 
   @inline def __notify(): Unit =

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ClassInstancesRegistry.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ClassInstancesRegistry.scala
@@ -1,13 +1,13 @@
-package java.lang
+package scala.scalanative.runtime
 
 /** Registry for created instances of java.lang.Class
  * Its only purpose is to prevent the GC from collecting instances of java.lang.Class
  **/
-private[lang] object ClassInstancesRegistry {
-  type Bucket = Array[_Class[_]]
+private[runtime] object ClassInstancesRegistry {
+  type Bucket = scala.Array[_Class[_]]
 
   private final val BucketSize = 256
-  private var buckets          = new Array[Bucket](2)
+  private var buckets          = new scala.Array[Bucket](2)
   private var lastId           = -1
   private var bucketId         = -1
   private var itemId           = -1
@@ -22,7 +22,7 @@ private[lang] object ClassInstancesRegistry {
     nextIds()
     if (bucketId >= buckets.length) {
       val newSize: Int = buckets.length * 2
-      val newArr       = new Array[Bucket](newSize)
+      val newArr       = new scala.Array[Bucket](newSize)
       System.arraycopy(buckets, 0, newArr, 0, buckets.length)
       buckets = newArr
     }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ClassInstancesRegistry.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ClassInstancesRegistry.scala
@@ -1,7 +1,7 @@
 package scala.scalanative.runtime
 
-/* Registry for created instances of java.lang.Class
- * Its only purpose is to prevent the GC from collecting instances of java.lang.Class
+/** Registry for created instances of java.lang.Class
+ *  Its only purpose is to prevent the GC from collecting instances of java.lang.Class
  */
 private[runtime] object ClassInstancesRegistry {
   type Bucket = scala.Array[_Class[_]]

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ClassInstancesRegistry.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ClassInstancesRegistry.scala
@@ -1,8 +1,8 @@
 package scala.scalanative.runtime
 
-/** Registry for created instances of java.lang.Class
+/* Registry for created instances of java.lang.Class
  * Its only purpose is to prevent the GC from collecting instances of java.lang.Class
- **/
+ */
 private[runtime] object ClassInstancesRegistry {
   type Bucket = scala.Array[_Class[_]]
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -1,10 +1,8 @@
 package scala.scalanative
 
-import scala.reflect.ClassTag
 import scalanative.annotation.alwaysinline
 import scalanative.unsafe._
 import scalanative.runtime.Intrinsics._
-import scalanative.runtime.LLVMIntrinsics._
 
 package object runtime {
 
@@ -29,6 +27,18 @@ package object runtime {
 
   /** Used as a stub right hand of intrinsified methods. */
   def intrinsic: Nothing = throwUndefined()
+
+  def toClass(rtti: RawPtr): _Class[_] = {
+    val clsPtr = elemRawPtr(rtti, 16)
+
+    if (loadRawPtr(clsPtr) == null) {
+      val newClass = new _Class[Any](rtti)
+      storeObject(clsPtr, newClass)
+      ClassInstancesRegistry.add(newClass)
+    } else {
+      loadObject(clsPtr).asInstanceOf[_Class[_]]
+    }
+  }
 
   @alwaysinline def toRawType(cls: Class[_]): RawPtr =
     cls.asInstanceOf[java.lang._Class[_]].rawty

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -9,7 +9,7 @@ import scalanative.runtime.LLVMIntrinsics._
 package object runtime {
 
   /** Runtime Type Information. */
-  type Type = CStruct2[Int, String]
+  type Type = CStruct3[Int, String, Class[Any]]
 
   implicit class TypeOps(val self: Ptr[Type]) extends AnyVal {
     @alwaysinline def id: Int          = self._1

--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -16,7 +16,6 @@ object Rt {
   val BoxedUnitModule = Ref(Global.Top("scala.scalanative.runtime.BoxedUnit$"))
 
   val GetRawTypeSig    = Sig.Method("getRawType", Seq(Rt.Object, Ptr)).mangled
-  val ToClassSig       = Sig.Method("toClass", Seq(Ptr, Class)).mangled
   val JavaEqualsSig    = Sig.Method("equals", Seq(Object, Bool)).mangled
   val JavaHashCodeSig  = Sig.Method("hashCode", Seq(Int)).mangled
   val ScalaEqualsSig   = Sig.Method("scala_==", Seq(Object, Bool)).mangled

--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -7,7 +7,7 @@ object Rt {
   val Object  = Ref(Global.Top("java.lang.Object"))
   val Class   = Ref(Global.Top("java.lang.Class"))
   val String  = Ref(Global.Top("java.lang.String"))
-  val Type    = StructValue(Seq(Int, Int, Ptr))
+  val Type    = StructValue(Seq(Int, Int, Ptr, Ptr))
   val Runtime = Ref(Global.Top("scala.scalanative.runtime.package$"))
 
   val BoxedPtr        = Ref(Global.Top("scala.scalanative.unsafe.Ptr"))
@@ -17,6 +17,7 @@ object Rt {
 
   val GetRawTypeSig    = Sig.Method("getRawType", Seq(Rt.Object, Ptr)).mangled
   val JavaEqualsSig    = Sig.Method("equals", Seq(Object, Bool)).mangled
+  val JavaGetClassSig  = Sig.Method("getClass", Seq(Class)).mangled
   val JavaHashCodeSig  = Sig.Method("hashCode", Seq(Int)).mangled
   val ScalaEqualsSig   = Sig.Method("scala_==", Seq(Object, Bool)).mangled
   val ScalaHashCodeSig = Sig.Method("scala_##", Seq(Int)).mangled

--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -16,8 +16,8 @@ object Rt {
   val BoxedUnitModule = Ref(Global.Top("scala.scalanative.runtime.BoxedUnit$"))
 
   val GetRawTypeSig    = Sig.Method("getRawType", Seq(Rt.Object, Ptr)).mangled
+  val ToClassSig       = Sig.Method("toClass", Seq(Ptr, Class)).mangled
   val JavaEqualsSig    = Sig.Method("equals", Seq(Object, Bool)).mangled
-  val JavaGetClassSig  = Sig.Method("getClass", Seq(Class)).mangled
   val JavaHashCodeSig  = Sig.Method("hashCode", Seq(Int)).mangled
   val ScalaEqualsSig   = Sig.Method("scala_==", Seq(Object, Bool)).mangled
   val ScalaHashCodeSig = Sig.Method("scala_##", Seq(Int)).mangled

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -479,6 +479,10 @@ object Show {
       case Val.Virtual(key) =>
         str("virtual ")
         str(key)
+      case Val.ClassOf(cls) =>
+        str("classOf[")
+        global_(cls)
+        str("]")
     }
 
     def defns_(defns: Seq[Defn]): Unit =

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -27,6 +27,7 @@ sealed abstract class Val {
     case Val.String(_) =>
       Type.Ref(Rt.String.name, exact = true, nullable = false)
     case Val.Virtual(_) => Type.Virtual
+    case Val.ClassOf(n) => Rt.Class
   }
 
   final def show: String = nir.Show(this)
@@ -185,4 +186,5 @@ object Val {
   final case class Const(value: Val)               extends Val
   final case class String(value: java.lang.String) extends Val
   final case class Virtual(key: scala.Long)        extends Val
+  final case class ClassOf(name: nir.Global)       extends Val
 }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -292,6 +292,7 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
         new String(chars)
       }
     case T.VirtualVal => Val.Virtual(getLong)
+    case T.ClassOfVal => Val.ClassOf(getGlobal())
   }
 
   // Ported from Scala.js

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -520,7 +520,8 @@ final class BinarySerializer {
       putInt(T.StringVal)
       putInt(v.length)
       v.foreach(putChar(_))
-    case Val.Virtual(v) => putInt(T.VirtualVal); putLong(v)
+    case Val.Virtual(v)   => putInt(T.VirtualVal); putLong(v)
+    case Val.ClassOf(cls) => putInt(T.ClassOfVal); putGlobal(cls)
   }
 
   // Ported from Scala.js

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -228,4 +228,5 @@ object Tags {
   final val ConstVal       = 1 + UnitVal
   final val StringVal      = 1 + ConstVal
   final val VirtualVal     = 1 + StringVal
+  final val ClassOfVal     = 1 + VirtualVal
 }

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Val.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Val.scala
@@ -41,8 +41,11 @@ object Val extends Base[nir.Val] {
   val Unit   = P("unit".! map (_ => nir.Val.Unit))
   val Const  = P("const" ~ Val.parser map (nir.Val.Const(_)))
   val String = P(stringLit map (nir.Val.String(_)))
+  val ClassOf = P(
+    "classOf" ~ "[" ~ nir.parser.Global.parser ~ "]"
+  ) map (nir.Val.ClassOf(_))
 
   override val parser: P[nir.Val] =
-    Char | True | False | Null | Zero | Long | Int | Short | Byte | Double | Float | StructValue | ArrayValue | Chars | Local | Global | Unit | Const | String
+    Char | True | False | Null | Zero | Long | Int | Short | Byte | Double | Float | StructValue | ArrayValue | Chars | Local | Global | Unit | Const | String | ClassOf
 
 }

--- a/nirparser/src/test/scala/scala/scalanative/nir/ValParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/ValParserTest.scala
@@ -32,7 +32,8 @@ class ValParserTest extends AnyFunSuite {
     Val.Const(Val.Int(0)),
     Val.String("foobar"),
     Val.String("foo bar"),
-    Val.String("foo \"bar\" baz")
+    Val.String("foo \"bar\" baz"),
+    Val.ClassOf(global)
   ).foreach { ty =>
     test(s"parse value `${ty.show}`") {
       val Parsed.Success(result, _) = parser.Val.parser.parse(ty.show)

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -474,7 +474,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           genLiteralValue(lit)
 
         case ClazzTag =>
-          genBoxClass(genTypeValue(value.typeValue))
+          genTypeValue(value.typeValue)
 
         case EnumTag =>
           genStaticMember(value.symbolValue)
@@ -1035,19 +1035,6 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           "Unknown primitive operation: " + sym.fullName + "(" +
             fun.symbol.simpleName + ") " + " at: " + (app.pos))
       }
-    }
-
-    lazy val jlClassName     = nir.Global.Top("java.lang.Class")
-    lazy val jlClass         = nir.Type.Ref(jlClassName)
-    lazy val jlClassCtorName = jlClassName.member(nir.Sig.Ctor(Seq(nir.Type.Ptr)))
-    lazy val jlClassCtorSig =
-      nir.Type.Function(Seq(jlClass, Type.Ptr), nir.Type.Unit)
-    lazy val jlClassCtor = nir.Val.Global(jlClassCtorName, nir.Type.Ptr)
-
-    def genBoxClass(typeVal: Val)(implicit pos: nir.Position): Val = {
-      val alloc = buf.classalloc(jlClassName, unwind)
-      buf.call(jlClassCtorSig, jlClassCtor, Seq(alloc, typeVal), unwind)
-      alloc
     }
 
     def numOfType(num: Int, ty: nir.Type): Val = ty match {

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -396,9 +396,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       withFreshExprBuffer { exprBuf =>
         exprBuf.label(curFresh(), Seq())
 
-        val fqcnArg = Val.String(fqSymId)
-        val runtimeClassArg =
-          exprBuf.genBoxClass(Val.Global(Global.Top(fqSymId), Type.Ptr))
+        val fqcnArg          = Val.String(fqSymId)
+        val runtimeClassArg  = Val.ClassOf(fqSymName)
         val loadModuleFunArg = genModuleLoaderAnonFun(exprBuf)
 
         exprBuf.genApplyModuleMethod(
@@ -523,12 +522,14 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                                              unwind(curFresh))
           for ((arg, argIdx) <- ctorSig.args.tail.zipWithIndex) {
             // Allocate and instantiate a java.lang.Class object for the arg.
-            val co = allocAndConstruct(
-              exprBuf,
-              jlClass,
-              Seq(Type.Ptr),
-              Seq(Val.Global(Type.typeToName(arg), Type.Ptr))
-            )
+            val co = Val.ClassOf(Type.typeToName(arg))
+
+//            allocAndConstruct(
+//              exprBuf,
+//              jlClass,
+//              Seq(Type.Ptr),
+//              Seq(Val.Global(Type.typeToName(arg), Type.Ptr))
+//            )
             // Store the runtime class in the array.
             exprBuf.arraystore(jlClassRef,
                                rtClasses,
@@ -566,9 +567,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         withFreshExprBuffer { exprBuf =>
           exprBuf.label(curFresh(), Seq())
 
-          val fqcnArg = Val.String(fqSymId)
-          val runtimeClassArg =
-            exprBuf.genBoxClass(Val.Global(fqSymName, Type.Ptr))
+          val fqcnArg         = Val.String(fqSymId)
+          val runtimeClassArg = Val.ClassOf(fqSymName)
+
           val instantiateClassFunArg =
             genClassConstructorsInfo(exprBuf, ctors)
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -521,20 +521,11 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                                              Val.Int(ctorSig.args.tail.length),
                                              unwind(curFresh))
           for ((arg, argIdx) <- ctorSig.args.tail.zipWithIndex) {
-            // Allocate and instantiate a java.lang.Class object for the arg.
-            val co = Val.ClassOf(Type.typeToName(arg))
-
-//            allocAndConstruct(
-//              exprBuf,
-//              jlClass,
-//              Seq(Type.Ptr),
-//              Seq(Val.Global(Type.typeToName(arg), Type.Ptr))
-//            )
             // Store the runtime class in the array.
             exprBuf.arraystore(jlClassRef,
                                rtClasses,
                                Val.Int(argIdx),
-                               co,
+                               Val.ClassOf(Type.typeToName(arg)),
                                unwind(curFresh))
           }
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenType.scala
@@ -119,7 +119,7 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
       case _ if st.sym == ArrayClass =>
         genTypeValue(RuntimeArrayClass(genPrimCode(st.targs.head)))
       case 'O' =>
-        nir.Val.Global(genTypeName(st.sym), nir.Type.Ptr)
+        nir.Val.ClassOf(genTypeName(st.sym))
       case code =>
         genTypeValue(RuntimePrimitive(code))
     }

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -55,11 +55,9 @@ object Generate {
 
     def genClassMetadata(): Unit = {
       meta.classes.foreach { cls =>
-        val struct = meta.layout(cls).struct
-        val rtti   = meta.rtti(cls)
-
-        buf += Defn.Const(Attrs.None, rtti.name, rtti.struct, rtti.value)(
-          cls.position)
+        val rtti = meta.rtti(cls)
+        val pos  = cls.position
+        buf += Defn.Var(Attrs.None, rtti.name, rtti.struct, rtti.value)(pos)
       }
     }
 
@@ -89,9 +87,8 @@ object Generate {
     def genTraitMetadata(): Unit = {
       meta.traits.foreach { trt =>
         val rtti = meta.rtti(trt)
-
-        buf += Defn.Const(Attrs.None, rtti.name, rtti.struct, rtti.value)(
-          trt.position)
+        val pos  = trt.position
+        buf += Defn.Var(Attrs.None, rtti.name, rtti.struct, rtti.value)(pos)
       }
     }
 
@@ -155,30 +152,28 @@ object Generate {
                             stackBottom),
                    unwind),
           Inst.Let(Op.Call(InitSig, Init, Seq()), unwind)
+        ) ++ // generate the class initialisers
+          defns.collect {
+            case Defn.Define(_, name: Global.Member, _, _)
+                if name.sig.isClinit =>
+              Inst.Let(Op.Call(Type.Function(Seq(), Type.Unit),
+                               Val.Global(name, Type.Ref(name)),
+                               Seq()),
+                       unwind)
+          } ++ Seq(
+          Inst.Let(rt.name, Op.Module(Runtime.name), unwind),
+          Inst.Let(arr.name,
+                   Op.Call(RuntimeInitSig, RuntimeInit, Seq(rt, argc, argv)),
+                   unwind),
+          Inst.Let(module.name, Op.Module(entry.top), unwind),
+          Inst.Let(Op.Call(entryMainTy, entryMain, Seq(module, arr)), unwind),
+          Inst.Let(Op.Call(RuntimeLoopSig, RuntimeLoop, Seq(module)), unwind),
+          Inst.Ret(Val.Int(0)),
+          Inst.Label(handler, Seq(exc)),
+          Inst.Let(Op.Call(PrintStackTraceSig, PrintStackTrace, Seq(exc)),
+                   Next.None),
+          Inst.Ret(Val.Int(1))
         )
-          ++ // generate the class initialisers
-            defns.collect {
-              case Defn.Define(_, name: Global.Member, _, _)
-                  if name.sig.isClinit =>
-                Inst.Let(Op.Call(Type.Function(Seq(), Type.Unit),
-                                 Val.Global(name, Type.Ref(name)),
-                                 Seq()),
-                         unwind)
-            }
-          ++ Seq(
-            Inst.Let(rt.name, Op.Module(Runtime.name), unwind),
-            Inst.Let(arr.name,
-                     Op.Call(RuntimeInitSig, RuntimeInit, Seq(rt, argc, argv)),
-                     unwind),
-            Inst.Let(module.name, Op.Module(entry.top), unwind),
-            Inst.Let(Op.Call(entryMainTy, entryMain, Seq(module, arr)), unwind),
-            Inst.Let(Op.Call(RuntimeLoopSig, RuntimeLoop, Seq(module)), unwind),
-            Inst.Ret(Val.Int(0)),
-            Inst.Label(handler, Seq(exc)),
-            Inst.Let(Op.Call(PrintStackTraceSig, PrintStackTrace, Seq(exc)),
-                     Next.None),
-            Inst.Ret(Val.Int(1))
-          )
       )
     }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -1291,6 +1291,7 @@ object Lower {
     buf += throwNoSuchMethod
     buf += RuntimeNull.name
     buf += RuntimeNothing.name
+    buf += JavaGetClass.name
     buf
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -189,8 +189,7 @@ object Lower {
     def genClassOf(buf: Buffer, node: ScopeInfo)(
         implicit pos: Position): Val = {
       val tpePtr = rtti(node).const
-      val recv   = Val.Global(Rt.Runtime.name, Rt.Runtime)
-      buf.call(toClassSig, toClass, Seq(recv, tpePtr), Next.None)
+      buf.call(toClassTy, toClassVal, Seq(Val.Null, tpePtr), Next.None)
     }
 
     def genVal(buf: Buffer, value: Val)(implicit pos: Position): Val =
@@ -1143,10 +1142,6 @@ object Lower {
   val throwSig  = Type.Function(Seq(Type.Ptr), Type.Nothing)
   val throw_    = Val.Global(throwName, Type.Ptr)
 
-  val toClassName = Rt.Runtime.name.member(Rt.ToClassSig)
-  val toClassSig  = Type.Function(Seq(Rt.Runtime, Type.Ptr), Rt.Class)
-  val toClass     = Val.Global(toClassName, Type.Ptr)
-
   val arrayAlloc = Type.typeToArray.map {
     case (ty, arrname) =>
       val Global.Top(id) = arrname
@@ -1259,6 +1254,11 @@ object Lower {
   val throwNoSuchMethodVal =
     Val.Global(throwNoSuchMethod, Type.Ptr)
 
+  val toClassTy = Type.Function(Seq(Type.Ptr, Type.Ptr), Rt.Class)
+  val toClass = Global.Member(Rt.Runtime.name,
+                              Sig.Method("toClass", Seq(Type.Ptr, Rt.Class)))
+  val toClassVal = Val.Global(toClass, Type.Ptr)
+
   val RuntimeNull    = Type.Ref(Global.Top("scala.runtime.Null$"))
   val RuntimeNothing = Type.Ref(Global.Top("scala.runtime.Nothing$"))
 
@@ -1300,7 +1300,7 @@ object Lower {
     buf += throwNoSuchMethod
     buf += RuntimeNull.name
     buf += RuntimeNothing.name
-    buf += toClass.name
+    buf += toClassVal.name
     buf
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -496,7 +496,9 @@ object Lower {
       }
 
       def genMethodLookup(): Unit = {
-        val targets = obj.ty match {
+        // We check type of original value, because it may change inside `genVal` transformation
+        // Eg. Val.String is transformed to Const(StructValue) which changes type from Ref to Ptr
+        val targets = v.ty match {
           case ClassRef(cls) if !sig.isVirtual =>
             cls.resolve(sig).toSeq
           case ScopeRef(scope) =>

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -185,8 +185,9 @@ object Lower {
     }
 
     def genClassOf(buf: Buffer, node: ScopeInfo): Val = {
-      val tpePtr = Val.Const(rtti(node).const)
-      buf.call(JavaGetClassSig, JavaGetClass, Seq(tpePtr), Next.None)
+      val tpePtr = rtti(node).const
+      val recv   = Val.Global(Rt.Runtime.name, Rt.Runtime)
+      buf.call(toClassSig, toClass, Seq(recv, tpePtr), Next.None)
     }
 
     def genVal(buf: Buffer, value: Val): Val = value match {
@@ -1134,9 +1135,9 @@ object Lower {
   val throwSig  = Type.Function(Seq(Type.Ptr), Type.Nothing)
   val throw_    = Val.Global(throwName, Type.Ptr)
 
-  val JavaGetClassName = Rt.Object.name.member(Rt.JavaGetClassSig)
-  val JavaGetClassSig  = Type.Function(Seq(Type.Ptr), Rt.Class)
-  val JavaGetClass     = Val.Global(JavaGetClassName, Type.Ptr)
+  val toClassName = Rt.Runtime.name.member(Rt.ToClassSig)
+  val toClassSig  = Type.Function(Seq(Rt.Runtime, Type.Ptr), Rt.Class)
+  val toClass     = Val.Global(toClassName, Type.Ptr)
 
   val arrayAlloc = Type.typeToArray.map {
     case (ty, arrname) =>
@@ -1291,7 +1292,7 @@ object Lower {
     buf += throwNoSuchMethod
     buf += RuntimeNull.name
     buf += RuntimeNothing.name
-    buf += JavaGetClass.name
+    buf += toClass.name
     buf
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/RuntimeTypeInformation.scala
@@ -41,8 +41,9 @@ class RuntimeTypeInformation(meta: Metadata, info: ScopeInfo) {
       case _ =>
         -1
     })
-    val base =
-      Val.StructValue(Seq(typeId, traitId, typeStr))
+    val base = Val.StructValue(
+      Seq(typeId, traitId, typeStr, Val.Null)
+    )
     info match {
       case cls: Class =>
         val dynmap =

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -523,6 +523,8 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
       reachGlobal(n); reachType(ty)
     case Val.Const(v) =>
       reachVal(v)
+    case Val.ClassOf(cls) =>
+      reachGlobal(cls)
     case _ =>
       ()
   }

--- a/unit-tests/src/test/scala/java/lang/ClassTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ClassTest.scala
@@ -1,6 +1,6 @@
 package java.lang
 
-import org.junit.Test
+import org.junit.{Ignore, Test}
 import org.junit.Assert._
 
 class ClassTest {
@@ -138,5 +138,60 @@ class ClassTest {
   @Test def isInterface(): Unit = {
     assertFalse(classOf[java.lang.Class[_]].isInterface)
     assertTrue(classOf[java.lang.Runnable].isInterface)
+  }
+
+  private def assertDiffClass(l: java.lang.Class[_],
+                              r: java.lang.Class[_]): Unit = {
+    assertTrue(s"$l eq $r", l ne r)
+  }
+
+  private def assertEqualClass(l: java.lang.Class[_],
+                               r: java.lang.Class[_]): Unit = {
+    assertTrue(s"$l ne $r", l eq r)
+  }
+
+  @Test def classInstancesAreCache(): Unit = {
+
+    val cls1 = "asd".getClass
+    val cls2 = "xyz".getClass
+
+    assertEqualClass(classOf[String], cls1)
+    assertEqualClass(cls1, cls2)
+    assertEqualClass(classOf[String], classOf[String])
+
+    assertTrue(123L.getClass != 42.getClass)
+  }
+
+  @Test def distinguishableClassInstancesForPrimitiveArrays(): Unit = {
+    val cls1 = Array.empty[Int].getClass
+    val cls2 = Array.empty[Array[Int]].getClass
+
+    assertEqualClass(cls1, cls1)
+    assertEqualClass(cls1, classOf[Array[Int]])
+    assertEqualClass(cls2, classOf[Array[Array[Int]]])
+    assertDiffClass(cls1, cls2)
+
+    assertDiffClass(cls1, classOf[Array[scala.Long]])
+    assertDiffClass(cls1, classOf[Array[scala.Boolean]])
+    assertDiffClass(cls1, classOf[Array[scala.Float]])
+    assertDiffClass(cls1, classOf[Array[scala.Double]])
+    assertDiffClass(cls1, classOf[Array[scala.Short]])
+    assertDiffClass(cls1, classOf[Array[scala.Byte]])
+    assertDiffClass(cls1, classOf[Array[Object]])
+  }
+
+  @Ignore("#1435, nested arrays are stored as ObjectArray")
+  @Test def distinguishableClassInstancesForNestedPrimitiveArrays(): Unit = {
+    val cls1 = classOf[Array[Array[Int]]]
+    val cls2 = classOf[Array[Array[Array[Int]]]]
+    assertDiffClass(cls1, cls2)
+  }
+
+  @Ignore("#1435, all object arrays are classOf[ObjectArray]")
+  @Test def distinguishableClassInstancesForNestedObjectArrays(): Unit = {
+    val cls1 = Array.empty[String].getClass
+    val cls2 = Array.empty[Array[String]].getClass
+
+    assertDiffClass(cls1, cls2)
   }
 }


### PR DESCRIPTION
Resolves #1435 

This PR moves allocation of java.lang.Class instances to linker phase and introduces caching of them.
In previous implementation Class instances were created by compiler backend, which lead to multiple instances of this type in runtime and made impossible to cache them.
Current implementation introduces new Val literal type `Val.ClassOf(n: Global)` which replaces allocations from previous implementation. At lowering phase this literals are transformed into `Object.getClass` calls with argument of RTTI object (as previous).  RTTI type was also extended to store reference of associated with it java.lang.Class. Inside `Object.getClass` it's checked whether RTTI class pointer is not empty and  instantiated in otherwise. Newly created instance of j.l.Class is added to registry in order to prevent GC from collecting it. 

Immix/Commix implementation was fixed to handle new RTTI layout.