### PR TITLE
Fix #1669: Put private methods in a separate scope through mangling.

### DIFF
--- a/docs/contrib/mangling.rst
+++ b/docs/contrib/mangling.rst
@@ -15,13 +15,13 @@ that uses a notation inspired by
         M <name> <sig-name>            // member name
 
     <sig-name> ::=
-        F <name>                       // field name
-        R <type-name>+ E               // constructor name
-        D <name> <type-name>+ E        // method name
-        P <name> <type-name>+ E        // proxy name
-        C <name>                       // c extern name
-        G <name>                       // generated name
-        K <sig-name> <type-name>+ E    // duplicate name
+        F <name> <scope>                    // field name
+        R <type-name>+ E                    // constructor name
+        D <name> <type-name>+ E <scope>     // method name
+        P <name> <type-name>+ E             // proxy name
+        C <name>                            // c extern name
+        G <name>                            // generated name
+        K <sig-name> <type-name>+ E         // duplicate name
 
     <type-name> ::=
         v                              // c vararg
@@ -52,6 +52,10 @@ that uses a notation inspired by
         s                              // scala.Short
         i                              // scala.Int
         j                              // scala.Long
+    
+    <scope> ::=
+        P <defn-name>                  // private to defn-name
+        O                              // public
 
     <name> ::=
         <length number> [-] <chars>    // raw identifier of given length; `-` separator is only used when <chars> starts with digit or `-` itself

--- a/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
@@ -1,5 +1,6 @@
 package scala.scalanative
 package nir
+import scala.scalanative.nir.Sig.Scope.{Private, Public}
 
 object Mangle {
   def apply(ty: Type): String = {
@@ -43,10 +44,16 @@ object Mangle {
     def mangleSig(sig: Sig): Unit =
       str(sig.mangle)
 
+    def mangleSigScope(scope: Sig.Scope): Unit = scope match {
+      case Public      => str("O")
+      case Private(in) => str("P"); mangleGlobal(in)
+    }
+
     def mangleUnmangledSig(sig: Sig.Unmangled): Unit = sig match {
-      case Sig.Field(id) =>
+      case Sig.Field(id, scope) =>
         str("F")
         mangleIdent(id)
+        mangleSigScope(scope)
       case Sig.Ctor(types) =>
         str("R")
         types.foreach(mangleType)
@@ -54,11 +61,12 @@ object Mangle {
       case Sig.Clinit() =>
         str("I")
         str("E")
-      case Sig.Method(id, types) =>
+      case Sig.Method(id, types, scope) =>
         str("D")
         mangleIdent(id)
         types.foreach(mangleType)
         str("E")
+        mangleSigScope(scope)
       case Sig.Proxy(id, types) =>
         str("P")
         mangleIdent(id)

--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -1,12 +1,13 @@
 package scala.scalanative
 package nir
 
+import scala.annotation.tailrec
 import scala.language.implicitConversions
 
 final class Sig(val mangle: String) {
   final def toProxy: Sig =
     if (isMethod) {
-      val Sig.Method(id, types) = this.unmangled
+      val Sig.Method(id, types, _) = this.unmangled
       Sig.Proxy(id, types.init).mangled
     } else {
       util.unsupported(
@@ -34,15 +35,42 @@ final class Sig(val mangle: String) {
   final def isExtern: Boolean    = mangle(0) == 'C'
   final def isGenerated: Boolean = mangle(0) == 'G'
   final def isDuplicate: Boolean = mangle(0) == 'K'
+
+  final def isPrivate: Boolean = privateIn.isDefined
+  final lazy val privateIn: Option[Global.Top] = {
+    unmangled.sigScope match {
+      case Sig.Scope.Private(in: Global.Top) => Some(in)
+      case _                                 => None
+    }
+  }
 }
 object Sig {
+  sealed trait Scope
+  object Scope {
+    case object Public             extends Scope
+    case class Private(in: Global) extends Scope
+  }
+
   sealed abstract class Unmangled {
     final def mangled: Sig = new Sig(Mangle(this))
+    def sigScope: Scope = this match {
+      case Field(_, scope)     => scope
+      case Method(_, _, scope) => scope
+      case Duplicate(of, _)    => of.unmangled.sigScope
+      case _                   => Scope.Public
+    }
   }
-  final case class Field(id: String)                    extends Unmangled
+
+  final case class Field(id: String, scope: Scope = Scope.Public)
+      extends Unmangled
+
+  final case class Method(id: String,
+                          types: Seq[Type],
+                          scope: Scope = Scope.Public)
+      extends Unmangled
+
   final case class Ctor(types: Seq[Type])               extends Unmangled
   final case class Clinit()                             extends Unmangled
-  final case class Method(id: String, types: Seq[Type]) extends Unmangled
   final case class Proxy(id: String, types: Seq[Type])  extends Unmangled
   final case class Extern(id: String)                   extends Unmangled
   final case class Generated(id: String)                extends Unmangled

--- a/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
@@ -19,15 +19,20 @@ object Unmangle {
         error(s"expected global, but got $ch")
     }
 
+    def readSigScope(): Sig.Scope = read() match {
+      case 'O' => Sig.Scope.Public
+      case 'P' => Sig.Scope.Private(readGlobal())
+    }
+
     def readUnmangledSig(): Sig.Unmangled = read() match {
       case 'F' =>
-        Sig.Field(readIdent())
+        Sig.Field(readIdent(), readSigScope())
       case 'R' =>
         Sig.Ctor(readTypes())
       case 'I' =>
         Sig.Clinit()
       case 'D' =>
-        Sig.Method(readIdent(), readTypes())
+        Sig.Method(readIdent(), readTypes(), readSigScope())
       case 'P' =>
         Sig.Proxy(readIdent(), readTypes())
       case 'C' =>

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
@@ -54,7 +54,8 @@ trait NirGenName { self: NirGenPhase =>
     val id    = nativeIdOf(sym)
     val scope = {
       /* Variables are internally private, but with public setter/getter.
-       Removing this check would cause problems with reachability  */
+       * Removing this check would cause problems with reachability
+       */
       if (sym.isPrivate && !sym.isVariable) nir.Sig.Scope.Private(owner)
       else nir.Sig.Scope.Public
     }

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/NativeRPC.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/NativeRPC.scala
@@ -16,7 +16,7 @@ private[testinterface] class NativeRPC(clientSocket: Socket) extends RPCCore {
 
   override def send(msg: String): Unit = {
     outStream.writeInt(msg.length)
-    outStream.write(msg.getBytes(StandardCharsets.UTF_16))
+    outStream.write(msg.getBytes(StandardCharsets.UTF_16BE))
   }
 
   @tailrec

--- a/tools/src/test/scala/scala/scalanative/nir/GlobalManglingSuite.scala
+++ b/tools/src/test/scala/scala/scalanative/nir/GlobalManglingSuite.scala
@@ -3,6 +3,7 @@ package nir
 
 import org.scalatest._
 import org.scalatest.funsuite.AnyFunSuite
+import Sig.Scope.Private
 
 class GlobalManglingSuite extends AnyFunSuite {
   Seq(
@@ -13,9 +14,17 @@ class GlobalManglingSuite extends AnyFunSuite {
     Global.Member(Global.Top("1"), Sig.Field("2")),
     Global.Member(Global.Top("-1bar"), Sig.Field("-2foo")),
     Global.Member(Global.Top("foo"), Sig.Field("field")),
+    Global.Member(Global.Top("foo"),
+                  Sig.Field("field", Private(Global.Top("foo")))),
     Global.Member(Global.Top("foo"), Sig.Ctor(Seq.empty)),
     Global.Member(Global.Top("foo"), Sig.Ctor(Seq(Type.Int))),
     Global.Member(Global.Top("foo"), Sig.Method("bar", Seq(Type.Unit))),
+    Global.Member(
+      Global.Top("foo"),
+      Sig.Method("bar", Seq(Type.Unit), Private(Global.Top("foo")))),
+    Global.Member(
+      Global.Top("foo"),
+      Sig.Method("bar", Seq(Type.Int, Type.Unit), Private(Global.Top("foo")))),
     Global.Member(Global.Top("foo"),
                   Sig.Method("bar", Seq(Type.Int, Type.Unit))),
     Global.Member(Global.Top("foo"), Sig.Proxy("bar", Seq(Type.Int))),

--- a/tools/src/test/scala/scala/scalanative/nir/PrivateMethodsManglingSuite.scala
+++ b/tools/src/test/scala/scala/scalanative/nir/PrivateMethodsManglingSuite.scala
@@ -77,19 +77,19 @@ class PrivateMethodsManglingSuite extends LinkerSpec with Matchers {
         val loopType = Seq(Type.Int, Rt.String, Type.Bool, Rt.String)
         val fooType  = Seq(Type.Int, Type.Int)
 
-        def privateDef(method: String, in: String) = {
-          s"P_${in}_$method"
+        def privateMethodSig(method: String, tpe: Seq[Type], in: String) = {
+          Sig.Method(method, tpe, Sig.Scope.Private(Global.Top(in)))
         }
 
-        val expected = Set(
+        val expected = Seq(
           Sig.Method("encode", Seq(Type.Int, Rt.String, Type.Bool, Rt.String)),
           Sig.Method("encodeLoop", Seq(Type.Int, Rt.String, Rt.String)),
-          Sig.Method(privateDef("loop$1", "xyz.A"), loopType),
-          Sig.Method(privateDef("loop$1", "xyz.B$"), loopType),
-          Sig.Method(privateDef("loop$1", "foo.B$"), loopType),
-          Sig.Method(privateDef("foo", "xyz.A"), fooType),
-          Sig.Method(privateDef("foo", "xyz.B$"), fooType),
-          Sig.Method(privateDef("foo", "foo.B$"), fooType)
+          privateMethodSig("loop$1", loopType, "xyz.B$"),
+          privateMethodSig("loop$1", loopType, "xyz.A"),
+          privateMethodSig("loop$1", loopType, "foo.B$"),
+          privateMethodSig("foo", fooType, "xyz.A"),
+          privateMethodSig("foo", fooType, "xyz.B$"),
+          privateMethodSig("foo", fooType, "foo.B$")
         ).map(_.mangle)
 
         expected.foreach { sig => assert(testedDefns.contains(sig)) }

--- a/tools/src/test/scala/scala/scalanative/nir/PrivateMethodsManglingSuite.scala
+++ b/tools/src/test/scala/scala/scalanative/nir/PrivateMethodsManglingSuite.scala
@@ -1,0 +1,99 @@
+package scala.scalanative.nir
+import org.scalatest.matchers.should.Matchers
+import scala.scalanative.LinkerSpec
+
+class PrivateMethodsManglingSuite extends LinkerSpec with Matchers {
+  "Nested mangling" should "distinguish private methods from different classes" in {
+    val sources = Map(
+      "A.scala" ->
+        """package xyz
+		  |abstract class A{
+		  | protected def encodeLoop(arg1: Int, arg2: String): String
+		  | final def encode(arg1: Int, arg2: String, arg3: Boolean): String = {
+		  | 	def loop(): String = {
+		  |  		if(arg3) "hello"
+		  |    		else encodeLoop(arg1, arg2)
+		  |  	}
+		  | 	loop()	
+		  | }
+		  | private def foo(x: Int): Int = x + 1
+		  | def bar(x: Int): Int = foo(x)
+		  |}
+		  |
+		  |""".stripMargin,
+      "B.scala" ->
+        """
+		|package xyz
+		|object B extends A {
+	    |	def encodeLoop(arg1: Int, arg2: String): String = {
+	    | 		println("init_logic")
+	    |   	val bool: Boolean = false
+	    |  		def loop(): String = {
+	    |   		if(bool) "asd" else arg2 * arg1
+	    |   	}
+	    |   	loop()
+	    |  }
+		|  private def foo(x: Int): Int = x * 2
+		|  def baz(x: Int): Int = foo(x)
+	    |}
+		|""".stripMargin,
+      "C.scala" ->
+        """package foo
+		|object B extends xyz.A {
+		|	def encodeLoop(arg1: Int, arg2: String): String = {
+		| 		println("init_logic")
+		|   	val bool: Boolean = false
+		|  		def loop(): String = {
+		|   		if(bool) "asd" else arg2 * arg1
+		|   	}
+		|   	loop()
+		|  }
+		|  private def foo(x: Int): Int = x * 2
+		|  def fooBar(x: Int): Int = foo(x)
+		|}
+		|""".stripMargin,
+      "Main.scala" -> """object Main {
+					 |  def main(args: Array[String]): Unit = {
+					 |  	xyz.B.encode(1,"asd", true)
+					 |   	xyz.B.baz(1)
+					 |  	foo.B.encode(1,"asd", true)
+					 |   	foo.B.fooBar(1)
+					 |    	xyz.B.bar(1)
+					 |  }
+					 |}""".stripMargin
+    )
+
+    val tops = Seq("xyz.B$", "xyz.A", "foo.B$").map(Global.Top)
+
+    link("Main$", sources) {
+      case (_, result) =>
+        val testedDefns = result.defns.collect {
+          case Defn.Define(_, Global.Member(owner, sig), _, _)
+              if tops.contains(owner) &&
+                !sig.isCtor =>
+            sig.mangle
+        }.toSet
+
+        val loopType = Seq(Type.Int, Rt.String, Type.Bool, Rt.String)
+        val fooType  = Seq(Type.Int, Type.Int)
+
+        def privateDef(method: String, in: String) = {
+          s"P_${in}_$method"
+        }
+
+        val expected = Set(
+          Sig.Method("encode", Seq(Type.Int, Rt.String, Type.Bool, Rt.String)),
+          Sig.Method("encodeLoop", Seq(Type.Int, Rt.String, Rt.String)),
+          Sig.Method(privateDef("loop$1", "xyz.A"), loopType),
+          Sig.Method(privateDef("loop$1", "xyz.B$"), loopType),
+          Sig.Method(privateDef("loop$1", "foo.B$"), loopType),
+          Sig.Method(privateDef("foo", "xyz.A"), fooType),
+          Sig.Method(privateDef("foo", "xyz.B$"), fooType),
+          Sig.Method(privateDef("foo", "foo.B$"), fooType)
+        ).map(_.mangle)
+
+        expected.foreach { sig => assert(testedDefns.contains(sig)) }
+    }
+
+  }
+}

--- a/tools/src/test/scala/scala/scalanative/nir/PrivateMethodsManglingSuite.scala
+++ b/tools/src/test/scala/scala/scalanative/nir/PrivateMethodsManglingSuite.scala
@@ -5,62 +5,62 @@ import scala.scalanative.LinkerSpec
 class PrivateMethodsManglingSuite extends LinkerSpec with Matchers {
   "Nested mangling" should "distinguish private methods from different classes" in {
     val sources = Map(
-      "A.scala" ->
-        """package xyz
-		  |abstract class A{
-		  | protected def encodeLoop(arg1: Int, arg2: String): String
-		  | final def encode(arg1: Int, arg2: String, arg3: Boolean): String = {
-		  | 	def loop(): String = {
-		  |  		if(arg3) "hello"
-		  |    		else encodeLoop(arg1, arg2)
-		  |  	}
-		  | 	loop()	
-		  | }
-		  | private def foo(x: Int): Int = x + 1
-		  | def bar(x: Int): Int = foo(x)
-		  |}
-		  |
-		  |""".stripMargin,
-      "B.scala" ->
-        """
+      "A.scala"    -> """
 		|package xyz
-		|object B extends A {
-	    |	def encodeLoop(arg1: Int, arg2: String): String = {
-	    | 		println("init_logic")
-	    |   	val bool: Boolean = false
-	    |  		def loop(): String = {
-	    |   		if(bool) "asd" else arg2 * arg1
-	    |   	}
-	    |   	loop()
-	    |  }
-		|  private def foo(x: Int): Int = x * 2
-		|  def baz(x: Int): Int = foo(x)
-	    |}
-		|""".stripMargin,
-      "C.scala" ->
-        """package foo
-		|object B extends xyz.A {
-		|	def encodeLoop(arg1: Int, arg2: String): String = {
-		| 		println("init_logic")
-		|   	val bool: Boolean = false
-		|  		def loop(): String = {
-		|   		if(bool) "asd" else arg2 * arg1
-		|   	}
-		|   	loop()
+		|abstract class A {
+		|  protected def encodeLoop(arg1: Int, arg2: String): String
+		|  final def encode(arg1: Int, arg2: String, arg3: Boolean): String = {
+		|    def loop(): String = {
+		|      if (arg3) "hello"
+		|      else encodeLoop(arg1, arg2)
+		|    }
+		|    loop()
 		|  }
-		|  private def foo(x: Int): Int = x * 2
-		|  def fooBar(x: Int): Int = foo(x)
+		|  private def foo(x: Int): Int = x + 1
+		|  def bar(x: Int): Int         = foo(x)
 		|}
 		|""".stripMargin,
-      "Main.scala" -> """object Main {
-					 |  def main(args: Array[String]): Unit = {
-					 |  	xyz.B.encode(1,"asd", true)
-					 |   	xyz.B.baz(1)
-					 |  	foo.B.encode(1,"asd", true)
-					 |   	foo.B.fooBar(1)
-					 |    	xyz.B.bar(1)
-					 |  }
-					 |}""".stripMargin
+      "B.scala"    -> """
+  		|package xyz
+  		|object B extends A {
+  		|  def encodeLoop(arg1: Int, arg2: String): String = {
+  		|    println("init_logic")
+  		|    val bool: Boolean = false
+  		|    def loop(): String = {
+  		|      if (bool) "asd" else arg2 * arg1
+  		|    }
+  		|    loop()
+  		|  }
+  		|  private def foo(x: Int): Int = x * 2
+  		|  def baz(x: Int): Int         = foo(x)
+  		|}
+		|""".stripMargin,
+      "C.scala"    -> """
+  		|package foo
+  		|object B extends xyz.A {
+  		|  def encodeLoop(arg1: Int, arg2: String): String = {
+  		|    println("init_logic")
+  		|    val bool: Boolean = false
+  		|    def loop(): String = {
+  		|      if (bool) "asd" else arg2 * arg1
+  		|    }
+  		|    loop()
+  		|  }
+  		|  private def foo(x: Int): Int = x * 2
+  		|  def fooBar(x: Int): Int      = foo(x)
+  		|}
+		|""".stripMargin,
+      "Main.scala" -> """
+  		|object Main {
+  		|  def main(args: Array[String]): Unit = {
+  		|    xyz.B.encode(1, "asd", true)
+  		|    xyz.B.baz(1)
+  		|    foo.B.encode(1, "asd", true)
+  		|    foo.B.fooBar(1)
+  		|    xyz.B.bar(1)
+  		|  }
+  		|}
+		|""".stripMargin
     )
 
     val tops = Seq("xyz.B$", "xyz.A", "foo.B$").map(Global.Top)

--- a/tools/src/test/scala/scala/scalanative/nir/SigManglingSuite.scala
+++ b/tools/src/test/scala/scala/scalanative/nir/SigManglingSuite.scala
@@ -3,33 +3,49 @@ package nir
 
 import org.scalatest._
 import org.scalatest.funsuite.AnyFunSuite
-
+import Sig.Scope._
 class SigManglingSuite extends AnyFunSuite {
-  Seq(
-    Sig.Field("f"),
-    Sig.Field("len"),
-    Sig.Field("field"),
-    Sig.Field("-field"),
-    Sig.Field("2"),
-    Sig.Field("-"),
-    Sig.Field("-2field"),
-    Sig.Field("2-field"),
-    Sig.Ctor(Seq.empty),
-    Sig.Ctor(Seq(Type.Int)),
-    Sig.Ctor(Seq(Rt.Object, Type.Int)),
-    Sig.Method("bar", Seq()),
-    Sig.Method("bar", Seq(Type.Unit)),
-    Sig.Method("bar", Seq(Type.Int, Type.Unit)),
-    Sig.Proxy("bar", Seq()),
-    Sig.Proxy("bar", Seq(Type.Int)),
-    Sig.Proxy("bar", Seq(Type.Int, Type.Int)),
-    Sig.Extern("read"),
-    Sig.Extern("malloc"),
-    Sig.Generated("layout"),
-    Sig.Generated("type"),
-    Sig.Duplicate(Sig.Method("bar", Seq()), Seq()),
-    Sig.Duplicate(Sig.Method("bar", Seq(Type.Unit)), Seq(Type.Unit))
-  ).foreach { sig =>
+  val fieldNames =
+    Seq("f", "len", "field", "-field", "2", "-", "-2field", "2-field")
+  val scopes = Seq(
+    Sig.Scope.Public,
+    Sig.Scope.Private(Global.Top("foo"))
+  )
+
+  val methodArgs = Seq(
+    Seq(),
+    Seq(Type.Unit),
+    Seq(Type.Int, Type.Unit)
+  )
+
+  val fields = for {
+    scope <- scopes
+    field <- fieldNames
+  } yield Sig.Field(field, scope)
+
+  val methods = for {
+    scope <- scopes
+    args  <- methodArgs
+  } yield Sig.Method("bar", args, scope)
+
+  val proxies = methodArgs.map(Sig.Proxy("bar", _))
+
+  {
+    fields ++
+      methods ++
+      proxies ++
+      Seq(
+        Sig.Ctor(Seq.empty),
+        Sig.Ctor(Seq(Type.Int)),
+        Sig.Ctor(Seq(Rt.Object, Type.Int)),
+        Sig.Extern("read"),
+        Sig.Extern("malloc"),
+        Sig.Generated("layout"),
+        Sig.Generated("type"),
+        Sig.Duplicate(Sig.Method("bar", Seq()), Seq()),
+        Sig.Duplicate(Sig.Method("bar", Seq(Type.Unit)), Seq(Type.Unit))
+      )
+  }.foreach { sig =>
     test(s"mangle/unmangle sig `${sig.toString}`") {
       val mangled = sig.mangle
       assert(mangled.nonEmpty, "empty mangle")


### PR DESCRIPTION
Resolves #1669 

As described in resolved issue private methods with same arguments and return types may have duplicate mangled names. This causes undefined behavior and executing wrong method (private in other class). 
Proposed fix introduces Scope to mangled signature of `Method` and `Field`. It can take values of of `Scope.Public`, and `Scope.Private(in: Global)`. With appropriate changes to mangling this allows get rid of duplicate names. 
 
 