### PR TITLE
Provide more useful j.l.Thread#getStackTrace stub

### DIFF
--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -24,8 +24,9 @@ class Thread private (runnable: Runnable) extends Runnable {
   final def getName(): String =
     this.name
 
-  @stub
-  def getStackTrace(): Array[StackTraceElement] = ???
+  // Stub implementation which is more useful than '???'.
+  def getStackTrace(): Array[StackTraceElement] =
+    new Array[StackTraceElement](0) // Do not use scala collections.
 
   def getId(): scala.Long = 1
 

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -24,7 +24,7 @@ class Thread private (runnable: Runnable) extends Runnable {
   final def getName(): String =
     this.name
 
-  // Stub implementation which is more useful than '???'.
+  // Stub implementation
   def getStackTrace(): Array[StackTraceElement] =
     new Array[StackTraceElement](0) // Do not use scala collections.
 

--- a/unit-tests/src/test/scala/java/lang/ThreadTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ThreadTest.scala
@@ -1,0 +1,64 @@
+// Ported, with thanks & gratitude, from Scala.js
+// 2020-09-20
+// Scala.js Repository Info
+//   commit: 9dc4d5b36ff2b2a3dfe2e91d5c6b1ef6d10d3e51
+//   commit date: 2018-10-11
+//
+// Slightly modified for Scala Native.
+
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.lang
+
+import org.junit.Test
+import org.junit.Assert._
+
+class ThreadTest {
+
+  val executingInJVM = false
+
+  @Test def getName_and_setName(): Unit = {
+    if (!executingInJVM) {
+      val t = Thread.currentThread()
+      assertEquals("main", t.getName) // default name of the main thread
+      t.setName("foo")
+      try {
+        assertEquals("foo", t.getName)
+      } finally {
+        t.setName("main") // don't pollute the rest of the world with this test
+      }
+      assertEquals("main", t.getName)
+    }
+  }
+
+  @Test def currentThread_getStackTrace(): Unit = {
+    val trace = Thread.currentThread().getStackTrace()
+    assertEquals(trace.length, 0)
+  }
+
+  @Test def getId(): Unit = {
+    assertTrue(Thread.currentThread().getId > 0)
+  }
+
+  @Test def interrupt_exist_and_the_status_is_properly_reflected(): Unit = {
+    val t = Thread.currentThread()
+    assertFalse(t.isInterrupted())
+    assertFalse(Thread.interrupted())
+    assertFalse(t.isInterrupted())
+    t.interrupt()
+    assertTrue(t.isInterrupted())
+    assertTrue(Thread.interrupted())
+    assertFalse(t.isInterrupted())
+    assertFalse(Thread.interrupted())
+  }
+}

--- a/unit-tests/src/test/scala/java/lang/ThreadTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ThreadTest.scala
@@ -6,18 +6,6 @@
 //
 // Slightly modified for Scala Native.
 
-/*
- * Scala.js (https://www.scala-js.org/)
- *
- * Copyright EPFL.
- *
- * Licensed under Apache License 2.0
- * (https://www.apache.org/licenses/LICENSE-2.0).
- *
- * See the NOTICE file distributed with this work for
- * additional information regarding copyright ownership.
- */
-
 package java.lang
 
 import org.junit.Test
@@ -26,6 +14,7 @@ import org.junit.Assert._
 class ThreadTest {
 
   val executingInJVM = false
+  val executingInScalaNative = true
 
   @Test def getName_and_setName(): Unit = {
     if (!executingInJVM) {
@@ -43,7 +32,9 @@ class ThreadTest {
 
   @Test def currentThread_getStackTrace(): Unit = {
     val trace = Thread.currentThread().getStackTrace()
-    assertEquals(trace.length, 0)
+    if (executingInScalaNative) {
+      assertEquals(trace.length, 0)
+    }
   }
 
   @Test def getId(): Unit = {

--- a/unit-tests/src/test/scala/java/lang/ThreadTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ThreadTest.scala
@@ -13,7 +13,7 @@ import org.junit.Assert._
 
 class ThreadTest {
 
-  val executingInJVM = false
+  val executingInJVM         = false
   val executingInScalaNative = true
 
   @Test def getName_and_setName(): Unit = {


### PR DESCRIPTION
  * This PR was motivated by my current exploratory work to enable
    ScalaTest to be used with Scala Native snapshots circa Fall, 2020.

    I was/am triggering some ScalaTest error paths. The prior "???"
    implementation was less than useful.  The "empty trace" implementation
    of this PR is not as useful as a proper, full implementation but
    allows me to get on with solving the issues preventing ScalaTest
    from running on current (Fall, 2020) Scala Native.

 * ThreadTest.scala (JUnit) was ported from Scala.js, with thanks &
   appreciation, to both the original authors and to the SN developers
   who implemented JUnit support.

   That file was lightly edited to be applicable to current Scala Native.
   It exercises the change introduced in this PR to verify that it
   is effective.

Documentation:

  * Issue considered, but no user documentation needed.

Testing:

  Safety & Efficacy

    + Built and tested ("test-all") in debug mode using sbt 1.3.13 on
      X86_64 only . All tests pass, including the newly ported
      ThreadTest.scala.