### PR TITLE
Allow setting target triple and show when compiling

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -54,6 +54,9 @@ object ScalaNativePlugin extends AutoPlugin {
     val nativeDump =
       taskKey[Boolean](
         "Shall native toolchain dump intermediate NIR to disk during linking?")
+
+    val nativeTarget =
+      taskKey[String]("The LLVM target triple for cross compiling.")
   }
 
   @deprecated("use autoImport instead", "0.3.7")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -21,9 +21,6 @@ object ScalaNativePluginInternal {
   val nativeWarnOldJVM =
     taskKey[Unit]("Warn if JVM 7 or older is used.")
 
-  val nativeTarget =
-    taskKey[String]("Target triple.")
-
   val nativeWorkdir =
     taskKey[File]("Working directory for intermediate build files.")
 
@@ -51,7 +48,8 @@ object ScalaNativePluginInternal {
     nativeLTO := nativeConfig.value.lto.name,
     nativeLinkStubs := nativeConfig.value.linkStubs,
     nativeCheck := nativeConfig.value.check,
-    nativeDump := nativeConfig.value.dump
+    nativeDump := nativeConfig.value.dump,
+    nativeTarget := ""
   )
 
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
@@ -84,9 +82,14 @@ object ScalaNativePluginInternal {
 
   lazy val scalaNativeConfigSettings: Seq[Setting[_]] = Seq(
     nativeTarget := interceptBuildException {
-      val cwd   = nativeWorkdir.value.toPath
-      val clang = nativeClang.value.toPath
-      Discover.targetTriple(clang, cwd)
+      val cwd          = nativeWorkdir.value.toPath
+      val clang        = nativeClang.value.toPath
+      val targetTriple = nativeTarget.value
+      if (targetTriple.isEmpty()) {
+        Discover.targetTriple(clang, cwd)
+      } else {
+        targetTriple
+      }
     },
     artifactPath in nativeLink := {
       crossTarget.value / (moduleName.value + "-out")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -91,7 +91,7 @@ object ScalaNativePluginInternal {
         targetTriple
       }
     },
-    artifactPath in nativeLink := {
+    nativeLink / artifactPath := {
       crossTarget.value / (moduleName.value + "-out")
     },
     nativeWorkdir := {
@@ -115,7 +115,7 @@ object ScalaNativePluginInternal {
         .withDump(nativeDump.value)
     },
     nativeLink := {
-      val outpath = (artifactPath in nativeLink).value
+      val outpath = (nativeLink / artifactPath).value
       val config = {
         val mainClass = selectMainClass.value.getOrElse {
           throw new MessageOnlyException("No main class detected.")
@@ -141,7 +141,7 @@ object ScalaNativePluginInternal {
       outpath
     },
     run := {
-      val env    = (envVars in run).value.toSeq
+      val env    = (run / envVars).value.toSeq
       val logger = streams.value.log
       val binary = nativeLink.value.getAbsolutePath
       val args   = spaceDelimited("<arg>").parsed

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -66,7 +66,8 @@ object Build {
     val nativelib    = NativeLib.findNativeLib(nativelibs)
     val unpackedLibs = nativelibs.map(LLVM.unpackNativeCode(_))
 
-    val objectFiles = config.logger.time("Compiling to native code") {
+    val msg = s"Compiling to native code (${config.targetTriple})"
+    val objectFiles = config.logger.time(msg) {
       val nativelibConfig =
         config.withCompilerConfig(
           _.withCompileOptions("-O2" +: config.compileOptions))

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -210,9 +210,9 @@ private[scalanative] object LLVM {
       // * libpthread for process APIs and parallel garbage collection.
       "pthread" +: "dl" +: srclinks ++: gclinks
     }
-    val linkopts    = config.linkingOptions ++ links.map("-l" + _)
-    val targetopt   = target(config)
-    val flags       = flto(config) ++ Seq("-rdynamic", "-o", outpath.abs) ++ targetopt
+    val linkopts = config.linkingOptions ++ links.map("-l" + _)
+    val flags = flto(config) ++ Seq("-rdynamic", "-o", outpath.abs) ++
+      target(config)
     val objPatterns = NativeLib.destObjPatterns(workdir, nativelibs)
     val opaths      = IO.getAll(workdir, objPatterns).map(_.abs)
     val paths       = llPaths.map(_.abs) ++ opaths


### PR DESCRIPTION
This is nice to have confirmation to have while compiling.
```
[info] Linking (1346 ms)
[info] Checking intermediate code (278 ms)
[info] Dumping intermediate code (linked) (306 ms)
[info] Discovered 592 classes and 3545 methods
[info] Optimizing (debug mode) (1426 ms)
[info] Checking intermediate code (56 ms)
[info] Dumping intermediate code (optimized) (139 ms)
[info] Dumping intermediate code (lowered) (213 ms)
[info] Generating intermediate code (1135 ms)
[info] Produced 8 files
[info] Compiling to native code (x86_64-apple-macosx10.14.0) (3453 ms)
[info] Linking native code (immix gc, none lto) (147 ms)
```
This would have been nice to have for my recent Raspberry Pi demo to show the target triple for 64bit armv8.