### PR TITLE
Revert to normal artifact names in the jar manifest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,8 @@ def projectName(project: sbt.ResolvedProject): String = {
 
 // Provide consistent project name pattern.
 lazy val nameSettings: Seq[Setting[_]] = Seq(
-  normalizedName := projectName(thisProject.value),         // Maven <artifactId>
-  name := s"Scala Native ${projectName(thisProject.value)}" // Maven <name>
+  normalizedName := projectName(thisProject.value), // Maven <artifactId>
+  name := projectName(thisProject.value)            // Maven <name>
 )
 
 // The previous releases of Scala Native with which this version is binary compatible.

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,7 @@ def projectName(project: sbt.ResolvedProject): String = {
 
 // Provide consistent project name pattern.
 lazy val nameSettings: Seq[Setting[_]] = Seq(
-  normalizedName := projectName(thisProject.value), // Maven <artifactId>
-  name := projectName(thisProject.value)            // Maven <name>
+  name := projectName(thisProject.value) // Maven <name>
 )
 
 // The previous releases of Scala Native with which this version is binary compatible.


### PR DESCRIPTION
This reverts a portion of the a previous issue/change (https://github.com/scala-native/scala-native/issues/1193). The change prepended "Scala Native" to the artifact like `nativelib`. This was to allow all the Scala Native projects to be next to each other in an Eclipse workspace where you have other projects. 

This PR changes the behavior back, making the artifact name (Implementation-Title and Specification-Title) standard in the MANIFEST.MF in the Scala Native published jars. 

Here is a before and after look at this change.

Before:
```
-- listing properties --
Manifest-Version=1.0
Implementation-Title=Scala Native nativelib
Implementation-Vendor=org.scala-native
Specification-Version=0.4.0-SNAPSHOT
Specification-Title=Scala Native nativelib
Implementation-Vendor-Id=org.scala-native
Specification-Vendor=org.scala-native
Implementation-Version=0.4.0-SNAPSHOT
Implementation-URL=http://www.scala-native.org
```

After:
```
-- listing properties --
Manifest-Version=1.0
Implementation-Title=nativelib
Implementation-Vendor=org.scala-native
Specification-Version=0.4.0-SNAPSHOT
Specification-Title=nativelib
Implementation-Vendor-Id=org.scala-native
Specification-Vendor=org.scala-native
Implementation-Version=0.4.0-SNAPSHOT
Implementation-URL=http://www.scala-native.org
```