### PR TITLE
Update NIR version to 5.8

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Prelude.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Prelude.scala
@@ -24,12 +24,7 @@ object Prelude {
     // and thus should be made reachable, no matter
     // what the reachability algorithm does
     // example: reflectively instantiatable classes
-    // since: compat = 4, revision = 7
-    val hasEntryPoints =
-      if (revision < 7)
-        false
-      else
-        buffer.get() != 0
+    val hasEntryPoints = buffer.get() != 0
 
     Prelude(magic, compat, revision, hasEntryPoints)
   }

--- a/nir/src/main/scala/scala/scalanative/nir/Versions.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Versions.scala
@@ -21,8 +21,8 @@ object Versions {
    * when 2.3-based release happens all of the code needs to recompiled with
    * new version of the toolchain.
    */
-  final val compat: Int   = 4 // a.k.a. MAJOR version
-  final val revision: Int = 7 // a.k.a. MINOR version
+  final val compat: Int   = 5 // a.k.a. MAJOR version
+  final val revision: Int = 8 // a.k.a. MINOR version
 
   /* Current public release version of Scala Native. */
   final val current: String = "0.4.0-SNAPSHOT"

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -269,24 +269,16 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
     case T.DoubleVal      => Val.Double(getDouble)
     case T.StructValueVal => Val.StructValue(getVals)
     case T.ArrayValueVal  => Val.ArrayValue(getType, getVals)
-    case T.CharsVal =>
-      Val.Chars {
-        if (prelude.revision < 7)
-          StringUtils.processEscapes(getUTF8String)
-        else getBytes()
-      }
-    case T.LocalVal  => Val.Local(getLocal, getType)
-    case T.GlobalVal => Val.Global(getGlobal, getType)
+    case T.CharsVal       => Val.Chars(getBytes())
+    case T.LocalVal       => Val.Local(getLocal, getType)
+    case T.GlobalVal      => Val.Global(getGlobal, getType)
 
     case T.UnitVal  => Val.Unit
     case T.ConstVal => Val.Const(getVal)
     case T.StringVal =>
       Val.String {
-        if (prelude.revision < 7) getUTF8String()
-        else {
-          val chars = Array.fill(getInt)(getChar)
-          new String(chars)
-        }
+        val chars = Array.fill(getInt)(getChar)
+        new String(chars)
       }
     case T.VirtualVal => Val.Virtual(getLong)
   }


### PR DESCRIPTION
This PR updates NIR version to 5.8. It removes back-compatibility hacks in NIR deserializer. 
Version 5.8 is not backward-compatible with previous releases. 

This PR should be merged before introducing breaking changes: #1877 #1878 #1894 #1898   