### PR TITLE
Implement j.u.Map default methods

### DIFF
--- a/javalib/src/main/scala/java/util/Map.scala
+++ b/javalib/src/main/scala/java/util/Map.scala
@@ -26,10 +26,13 @@ trait Map[K, V] {
 
   def getOrDefault(key: Any, default: V): V = {
     val v = this.get(key)
-    if ((v == null.asInstanceOf[V]) && this.containsKey(key))
+    if (v != null.asInstanceOf[V]) {
+      v
+    } else if (this.containsKey(key)) {
       null.asInstanceOf[V]
-    else
+    } else {
       default
+    }
   }
 
   def forEach(action: BiConsumer[_ >: K, _ >: V]): Unit = {

--- a/javalib/src/main/scala/java/util/Map.scala
+++ b/javalib/src/main/scala/java/util/Map.scala
@@ -1,5 +1,11 @@
 package java.util
 
+import java.util.function.{BiConsumer, BiFunction, Function}
+
+// These declarations follow the Scala.js standard of listing
+// methods in the order of their full, not summary,
+// description in the Java 8 documentation.
+
 trait Map[K, V] {
   def size(): Int
   def isEmpty(): Boolean
@@ -15,10 +21,159 @@ trait Map[K, V] {
   def entrySet(): Set[Map.Entry[K, V]]
   def equals(o: Any): Boolean
   def hashCode(): Int
+
+  // Java 8 default methods
+
+  def getOrDefault(key: Any, default: V): V = {
+    val v = this.get(key)
+    if ((v == null.asInstanceOf[V]) && this.containsKey(key))
+      null.asInstanceOf[V]
+    else
+      default
+  }
+
+  def forEach(action: BiConsumer[_ >: K, _ >: V]): Unit = {
+    if (action == null)
+      throw new NullPointerException
+
+    val it = this.entrySet.iterator
+    while (it.hasNext) {
+      val entry = it.next()
+      action.accept(entry.getKey(), entry.getValue())
+    }
+  }
+
+  def replaceAll(function: BiFunction[_ >: K, _ >: V, _ <: V]): Unit = {
+    if (function == null)
+      throw new NullPointerException
+
+    val it = this.entrySet.iterator
+    while (it.hasNext) {
+      val entry = it.next()
+      entry.setValue(function.apply(entry.getKey(), entry.getValue()))
+    }
+  }
+
+  def putIfAbsent(key: K, value: V): V = {
+    val v = this.get(key)
+    if ((v != null.asInstanceOf[V]) || this.containsKey(key))
+      v
+    else
+      this.put(key, value)
+  }
+
+  def remove(key: Any, value: Any): Boolean = {
+    if (!((this.containsKey(key)) && (this.get(key) == value))) {
+      false
+    } else {
+      this.remove(key)
+      true
+    }
+  }
+
+  def replace(key: K, oldValue: V, newValue: V): Boolean = {
+    if (!((this.containsKey(key)) && (this.get(key) == oldValue))) {
+      false
+    } else {
+      this.put(key, newValue)
+      true
+    }
+  }
+
+  def replace(key: K, value: V): V = {
+    if (!this.containsKey(key))
+      null.asInstanceOf[V]
+    else
+      this.put(key, value)
+  }
+
+  def computeIfAbsent(key: K, mappingFunction: Function[_ >: K, _ <: V]): V = {
+    if (mappingFunction == null)
+      throw new NullPointerException
+
+    val oldValue = this.get(key)
+
+    if (oldValue != null.asInstanceOf[V]) {
+      oldValue
+    } else {
+      val newValue = mappingFunction.apply(key)
+      if (newValue != null.asInstanceOf[V]) {
+        this.put(key, newValue)
+      }
+      newValue
+    }
+  }
+
+  def computeIfPresent(
+      key: K,
+      remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]): V = {
+    if (remappingFunction == null)
+      throw new NullPointerException
+
+    val oldValue = this.get(key)
+
+    if (oldValue == null.asInstanceOf[V]) {
+      null.asInstanceOf[V]
+    } else {
+      val newValue = remappingFunction.apply(key, oldValue)
+      if (newValue == null.asInstanceOf[V]) {
+        this.remove(key)
+        null.asInstanceOf[V]
+      } else {
+        this.put(key, newValue)
+        newValue
+      }
+    }
+  }
+
+  def compute(key: K,
+              remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]): V = {
+    if (remappingFunction == null)
+      throw new NullPointerException
+
+    val oldValue = this.get(key)
+    val newValue = remappingFunction.apply(key, oldValue)
+
+    if (oldValue != null.asInstanceOf[V]) {
+      if (newValue != null.asInstanceOf[V]) {
+        this.put(key, newValue)
+      } else {
+        this.remove(key)
+      }
+    } else {
+      if (newValue == null.asInstanceOf[V])
+        null.asInstanceOf[V]
+      else
+        this.put(key, newValue)
+    }
+  }
+
+  def merge(key: K,
+            value: V,
+            remappingFunction: BiFunction[_ >: V, _ >: V, _ <: V]): V = {
+    if ((value == null.asInstanceOf[V]) || (remappingFunction == null))
+      throw new NullPointerException
+
+    val oldValue = this.get(key)
+
+    if (oldValue == null.asInstanceOf[V]) {
+      this.put(key, value)
+      value
+    } else {
+      val newValue = remappingFunction.apply(oldValue, value)
+
+      if (newValue == null.asInstanceOf[V]) {
+        this.remove(key)
+        null.asInstanceOf[V]
+      } else {
+        this.put(key, newValue)
+        newValue
+      }
+    }
+  }
 }
 
 object Map {
-
   trait Entry[K, V] {
     def getKey(): K
     def getValue(): V

--- a/javalib/src/main/scala/java/util/Map.scala
+++ b/javalib/src/main/scala/java/util/Map.scala
@@ -37,7 +37,7 @@ trait Map[K, V] {
       throw new NullPointerException
 
     val it = this.entrySet.iterator
-    while (it.hasNext) {
+    while (it.hasNext()) {
       val entry = it.next()
       action.accept(entry.getKey(), entry.getValue())
     }
@@ -48,7 +48,7 @@ trait Map[K, V] {
       throw new NullPointerException
 
     val it = this.entrySet.iterator
-    while (it.hasNext) {
+    while (it.hasNext()) {
       val entry = it.next()
       entry.setValue(function.apply(entry.getKey(), entry.getValue()))
     }

--- a/unit-tests/src/test/scala/java/util/MapSuite.scala
+++ b/unit-tests/src/test/scala/java/util/MapSuite.scala
@@ -571,13 +571,14 @@ trait MapSuite extends tests.Suite {
 
     val presentKey   = 400
     val presentValue = 876234
+    val defaultValue = 9999
 
     mp.put(100, 12345)
     mp.put(300, 98765)
     mp.put(presentKey, presentValue)
     assertEquals(3, mp.size())
 
-    assertEquals(presentValue, mp.getOrDefault(presentKey, presentValue))
+    assertEquals(presentValue, mp.getOrDefault(presentKey, defaultValue))
   }
 
   test("getOrDefault(key, d) should return default when key is absent") {


### PR DESCRIPTION
  * This PR implements and tests the methods in the Java 8 description
    of the Map class which are described as default.

    For Scala Native, this means that these methods are available and
    tested in j.u.HashMap, j.u.IdentityHashMap, and j.u.LinkedHashMap.
    They will also become available for future classes which extend
    Map.scala.

    scala.collection.JavaConversions._ exists for general users and
    j.u.ScalaOps exists for Scala Native developers. This PR makes
    the SN implementation correspond to its reference documentation,
    aiding porting and supporting people's established coding styles.

  * This PR provides features which enable my work in progress j.u.TreeMap
    which can provide a better performing Map implementation to be used in
    scala-java-time.

  * Previously Map.scala was exercised by the corresponding MapSuite.scala.
    When I touched MapSuite.scala I considered converting it to
    JUnit. An actual trial implementation convinced me that porting
    the Scala.js collection framework to Scala Native should be done in
    its own PR, as a dedicated and focused effort, and not tomorrow but
    soon (last is a not to self, not suggesting that anybody else do work).

    So, I backed off and extended prior art.

  * Because Scala Native supports Scala 2.11, MapSuite.scala
    uses correct but ugly full code for j.u.function.Function,
    BiFunction, & Consumer arguments.

    With Scala 2.12 and above these can be simplified to something like:

    mp.forEach((k, v) -> printf(s"key: ${key} value: ${value}\n")

  * At least three areas for improvement remain:

      1) I tried to conform to the documented Scala.js coding style.
          I am new to that style, it is not my natural style, and it
          is too complex for scalafmt.  There are probable multiple
          deviations from that style; I beg kindness from reviewers and
          do not mean to annoy anyone.

      2) MapSuite.scala contains a lot of duplication and test setup &
          final check boilerplate.  Some of this is due to a desire to
          make each test independent but some could be simplified and
          removed.

      3) The added tests make heavy use of Map[String, String]. In a better
          world, the full, or a fuller, matrix of key types versus key types
          would be used to give better coverage.

         String is used heavily as a value type rather than Int, Double, or
         Float, because null.asInstanceOf[X], where X is one of those is
         indistinguishable from a value of 0 which is actually in the map.
         java.math.BigInteger and probably j.m.BigDecimal do not have this
         issue.

    In my assessment it did not make sense spending time heavily optimizing
    the Suit when it ia about to be ported to JUnit. The time is better
    spent porting the Scala.js Collections testing framework.

    Certainly the Suite needs to be correct and should give warranted belief in the code
    under test. I believe the Suite in this PR offers "adequate to the task" but not perfection.

    When a more complete Scala.js Collections Testing environment becomes
    available in SN it might be easier to vary the key, value types and do
    more combinations. Similarly, it will be easier to factor out
    boilerplate.

Documentation:

  * The standard changelog entry is requested.

  * No change to javalib.rst is necessary.

Testing:

  Safety -

  + Built and tested ("test-all") in debug mode using sbt 1.3.13 on
     X86_64 only . All tests pass.

  Efficacy -

  * The changes of this PR are exercised and all tests pass in the
      following Suites:

      HashMapSuite
      IdentityHashMapSuite
      LinkedHashMapInsertionOrderLimitedSuite
      LinkedHashMapInsertionOrderSuite$