### PR TITLE
Fix BufferedInputStream.read() for values bigger than 0x7f

### DIFF
--- a/javalib/src/main/scala/java/io/BufferedInputStream.scala
+++ b/javalib/src/main/scala/java/io/BufferedInputStream.scala
@@ -61,7 +61,7 @@ class BufferedInputStream(_in: InputStream, size: Int)
     ensureOpen()
 
     if (prepareRead()) {
-      val res = buf(pos).toInt
+      val res = buf(pos).toInt & 0xff
       pos += 1
       res
     } else -1

--- a/unit-tests/src/test/scala/java/io/BufferedInputStreamSuite.scala
+++ b/unit-tests/src/test/scala/java/io/BufferedInputStreamSuite.scala
@@ -38,6 +38,17 @@ object BufferedInputStreamSuite extends tests.Suite {
 
   }
 
+  test("read value bigger than 0x7f") {
+    val inputArray = Array[Byte](0x85.toByte)
+
+    val arrayIn = new ByteArrayInputStream(inputArray)
+
+    val in = new BufferedInputStream(arrayIn)
+
+    assert(in.read() == 0x85)
+    assert(in.read() == -1)
+  }
+
   test("read to closed buffer throws IOException") {
 
     val inputArray =


### PR DESCRIPTION
`read()` should return a value between `-1` and `255` and `-1` means `EOF`.

When `buf(pos)` contains value bigger than `0x7f` for example `171.toByte` and makes `.toInt`, it converts this value to `-85` that can be regarded by enduser as `EOF` if he uses `< 0` condition.

Unfortunately this bug hasn't got workaround on user side because when stream contains `0xff`, the `read()` returns `-1` and it is impossibly to distinguish the `EOF` and `0xff`.