### PR TITLE
Add j.l.Iterable.forEach

### DIFF
--- a/javalib/src/main/scala/java/lang/Iterable.scala
+++ b/javalib/src/main/scala/java/lang/Iterable.scala
@@ -1,7 +1,16 @@
+// Influenced by and corresponds to Scala.js commit SHA: f9fc1ae
+
 package java.lang
 
 import java.util.Iterator
+import java.util.function.Consumer
 
 trait Iterable[T] {
   def iterator(): Iterator[T]
+
+  def forEach(action: Consumer[_ >: T]): Unit = {
+    val iter = iterator()
+    while (iter.hasNext())
+      action.accept(iter.next())
+  }
 }


### PR DESCRIPTION
  * This PR provides a missing default method. This method is used
    by the Scala.js TestMainBase hierarchy.  Having this method
    allows JUnit CollectionsTest.scala and others to link with
    one less missing symbol.

  * There is no direct corresponding JUnit test because of circularity.
    This method is used by the environment which would test any
    standalone file. These changes will be extensively exercised
    by that test environment and defects will become obvious.

  * I wrote the code based on my recent work providing similar default
    methods in Map.scala. After some "back-brain consolidation time", I
    realized that Scala.js had already implemented the method;
    obvious after the fact. I brought the code into correspondence with
    the Scala.js file and documented the SHA1 of the reference commit.
    Hence the  "Influenced by" credit line.

Documentation:

  * None required

Testing:

  Safety -

    + Built and tested ("test-all") in debug mode using sbt 1.3.13 on
      X86_64 only . All tests pass.

  Efficacy -

   + Will be shown when the port of the Scala.js TestMainBase environment
     to Scala Native has been accomplished.