### PR TITLE
Avoid importing `runtime` in the java.lang package

### DIFF
--- a/nativelib/src/main/scala/java/lang/Object.scala
+++ b/nativelib/src/main/scala/java/lang/Object.scala
@@ -1,9 +1,7 @@
 package java.lang
 
 import scala.scalanative.unsafe._
-import scala.scalanative.runtime, runtime.ClassTypeOps
-import scala.scalanative.runtime
-import scala.scalanative.runtime.libc
+import scala.scalanative.runtime._
 import scala.scalanative.runtime.Intrinsics._
 
 class _Object {
@@ -19,22 +17,22 @@ class _Object {
     getClass.getName + "@" + Integer.toHexString(hashCode)
 
   @inline def __getClass(): _Class[_] =
-    new _Class(runtime.getRawType(this))
+    new _Class(getRawType(this))
 
   @inline def __notify(): Unit =
-    runtime.getMonitor(this)._notify
+    getMonitor(this)._notify
 
   @inline def __notifyAll(): Unit =
-    runtime.getMonitor(this)._notifyAll
+    getMonitor(this)._notifyAll
 
   @inline def __wait(): Unit =
-    runtime.getMonitor(this)._wait
+    getMonitor(this)._wait
 
   @inline def __wait(timeout: scala.Long): Unit =
-    runtime.getMonitor(this)._wait(timeout)
+    getMonitor(this)._wait(timeout)
 
   @inline def __wait(timeout: scala.Long, nanos: Int): Unit =
-    runtime.getMonitor(this)._wait(timeout, nanos)
+    getMonitor(this)._wait(timeout, nanos)
 
   @inline def __scala_==(that: _Object): scala.Boolean = {
     // This implementation is only called for classes that don't override
@@ -52,9 +50,9 @@ class _Object {
   }
 
   protected def __clone(): _Object = {
-    val rawty = runtime.getRawType(this)
-    val size  = loadInt(elemRawPtr(rawty, sizeof[runtime.Type]))
-    val clone = runtime.GC.alloc(rawty, size)
+    val rawty = getRawType(this)
+    val size  = loadInt(elemRawPtr(rawty, sizeof[Type]))
+    val clone = GC.alloc(rawty, size)
     val src   = castObjectToRawPtr(this)
     libc.memcpy(clone, src, size)
     castRawPtrToObject(clone).asInstanceOf[_Object]


### PR DESCRIPTION
Right now it is impossible to build `scala-native` on jdk14+ and it crashed with error:
```
imported `runtime' is permanently hidden by definition of package runtime in package lang
```

Fixed this issue.