### PR TITLE
Add the default methods of j.u.Iterator default methods

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractList.scala
+++ b/javalib/src/main/scala/java/util/AbstractList.scala
@@ -21,7 +21,7 @@ abstract class AbstractList[E] protected ()
   def add(index: Int, element: E): Unit =
     throw new UnsupportedOperationException
 
-  def remove(index: Int): E =
+  override def remove(index: Int): E =
     throw new UnsupportedOperationException
 
   def indexOf(o: Any): Int = {
@@ -237,7 +237,7 @@ private class BackedUpListIterator[E](innerIterator: ListIterator[E],
 
   def previousIndex(): Int = i - 1
 
-  def remove(): Unit = {
+  override def remove(): Unit = {
     innerIterator.remove()
     changeSize(-1)
   }

--- a/javalib/src/main/scala/java/util/AbstractMap.scala
+++ b/javalib/src/main/scala/java/util/AbstractMap.scala
@@ -100,7 +100,7 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
   def put(key: K, value: V): V =
     throw new UnsupportedOperationException()
 
-  def remove(key: Any): V = {
+  override def remove(key: Any): V = {
     @tailrec
     def findAndRemove(iter: Iterator[Map.Entry[K, V]]): V = {
       if (iter.hasNext) {
@@ -134,7 +134,7 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
 
           def next(): K = iter.next().getKey()
 
-          def remove(): Unit = iter.remove()
+          override def remove(): Unit = iter.remove()
         }
       }
     }
@@ -152,7 +152,7 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
 
           def next(): V = iter.next().getValue()
 
-          def remove(): Unit = iter.remove()
+          override def remove(): Unit = iter.remove()
         }
       }
     }

--- a/javalib/src/main/scala/java/util/AbstractRandomAccessListIterator.scala
+++ b/javalib/src/main/scala/java/util/AbstractRandomAccessListIterator.scala
@@ -31,7 +31,7 @@ abstract private[util] class AbstractRandomAccessListIterator[E](
 
   def previousIndex(): Int = i - 1
 
-  def remove(): Unit = {
+  override def remove(): Unit = {
     checkThatHasLast()
     remove(last)
     if (last < i)

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -159,7 +159,7 @@ class ArrayDeque[E] private (private val inner: ArrayList[E])
 
   def offer(e: E): Boolean = offerLast(e)
 
-  def remove(): E = removeFirst()
+  override def remove(): E = removeFirst()
 
   def poll(): E = pollFirst()
 
@@ -196,7 +196,7 @@ class ArrayDeque[E] private (private val inner: ArrayList[E])
         inner.get(index)
       }
 
-      def remove(): Unit = {
+      override def remove(): Unit = {
         checkStatus()
         if (index < 0 || index >= inner.size) {
           throw new IllegalStateException()

--- a/javalib/src/main/scala/java/util/Collections.scala
+++ b/javalib/src/main/scala/java/util/Collections.scala
@@ -471,7 +471,7 @@ object Collections {
             o
           }
 
-          def remove(): Unit =
+          override def remove(): Unit =
             throw new UnsupportedOperationException
         }
       }
@@ -788,7 +788,7 @@ object Collections {
     def next(): E =
       inner.next()
 
-    def remove(): Unit =
+    override def remove(): Unit =
       inner.remove()
   }
 
@@ -1146,7 +1146,7 @@ object Collections {
     def next(): Any =
       throw new NoSuchElementException
 
-    def remove(): Unit =
+    override def remove(): Unit =
       throw new IllegalStateException
   }
 

--- a/javalib/src/main/scala/java/util/HashSet.scala
+++ b/javalib/src/main/scala/java/util/HashSet.scala
@@ -75,7 +75,7 @@ class HashSet[E]
         last.get
       }
 
-      def remove(): Unit = {
+      override def remove(): Unit = {
         if (last.isEmpty) {
           throw new IllegalStateException()
         } else {

--- a/javalib/src/main/scala/java/util/Iterator.scala
+++ b/javalib/src/main/scala/java/util/Iterator.scala
@@ -1,7 +1,18 @@
+// Influenced by and corresponds to Scala.js commit SHA: f86ed65
+
 package java.util
+
+import java.util.function.Consumer
 
 trait Iterator[E] {
   def hasNext(): Boolean
   def next(): E
-  def remove(): Unit
+
+  def remove(): Unit =
+    throw new UnsupportedOperationException("remove")
+
+  def forEachRemaining(action: Consumer[_ >: E]): Unit = {
+    while (hasNext())
+      action.accept(next())
+  }
 }

--- a/javalib/src/main/scala/java/util/LinkedList.scala
+++ b/javalib/src/main/scala/java/util/LinkedList.scala
@@ -41,7 +41,7 @@ class LinkedList[E]()
       peekLast()
   }
 
-  override def removeFirst(): E = {
+  def removeFirst(): E = {
     if (isEmpty())
       throw new NoSuchElementException()
 

--- a/javalib/src/main/scala/java/util/LinkedList.scala
+++ b/javalib/src/main/scala/java/util/LinkedList.scala
@@ -41,7 +41,7 @@ class LinkedList[E]()
       peekLast()
   }
 
-  def removeFirst(): E = {
+  override def removeFirst(): E = {
     if (isEmpty())
       throw new NoSuchElementException()
 
@@ -313,7 +313,7 @@ class LinkedList[E]()
 
       def previousIndex(): Int = (i - 1).toInt
 
-      def remove(): Unit = {
+      override def remove(): Unit = {
         checkThatHasLast()
 
         if (currentNode eq null) {
@@ -373,7 +373,7 @@ class LinkedList[E]()
         ret.value
       }
 
-      def remove(): Unit = {
+      override def remove(): Unit = {
         if (!removeEnabled)
           throw new IllegalStateException()
 

--- a/javalib/src/main/scala/java/util/NavigableView.scala
+++ b/javalib/src/main/scala/java/util/NavigableView.scala
@@ -49,7 +49,7 @@ private[util] class NavigableView[E](original: NavigableSet[E],
         last.get
       }
 
-      def remove(): Unit = {
+      override def remove(): Unit = {
         if (last.isEmpty) {
           throw new IllegalStateException()
         } else {

--- a/javalib/src/main/scala/java/util/PriorityQueue.scala
+++ b/javalib/src/main/scala/java/util/PriorityQueue.scala
@@ -103,7 +103,7 @@ class PriorityQueue[E] protected (ordering: Ordering[_ >: E],
         last.get
       }
 
-      def remove(): Unit = {
+      override def remove(): Unit = {
         if (last.isEmpty) {
           throw new IllegalStateException()
         } else {

--- a/javalib/src/main/scala/java/util/TreeSet.scala
+++ b/javalib/src/main/scala/java/util/TreeSet.scala
@@ -50,7 +50,7 @@ class TreeSet[E](_comparator: Comparator[_ >: E])
         last.get
       }
 
-      def remove(): Unit = {
+      override def remove(): Unit = {
         if (last.isEmpty) {
           throw new IllegalStateException()
         } else {
@@ -75,7 +75,7 @@ class TreeSet[E](_comparator: Comparator[_ >: E])
         nxt
       }
 
-      def remove(): Unit = {
+      override def remove(): Unit = {
         if (last.isEmpty) {
           throw new IllegalStateException()
         } else {


### PR DESCRIPTION
  * This PR provides the missing remove() default method. This method is used
    by the Scala.js TestMainBase hierarchy.  Having this method,
    along with previous PR #1934 allows JUnit CollectionsTest.scala
    and others to link and execute, with the expected zero tests run.

  * For completeness, this PR also provides the forEachRemaining()
    default method.  It is not used by the TestMainBase hierarchy
    and could be deferred to a separate PR.  The overall project cost of
    including it here seemed to be less than the cost of a separate PR.

  * The effective change is in Iterator.scala. Because it now provides
    a default message, a number of other files need overrides.  There
    should be no functional change.

  * There is no direct corresponding JUnit test for remove() because
    of circularity. This method is used by the environment which would test any
    standalone file. These changes will be extensively exercised
    by that test environment and defects will become obvious.

  * forEachRemaining() has a test in Scala.js IteratorTest.scala.  That
    change in this PR Will become publicly tested when the current work to port
    the TestMainBase environment finishes. Until then, it is being heavily
    exercised in my porting environment.

Documentation:

 * None required

Testing:

  Safety -

   + Built and tested ("test-all") in debug mode using sbt 1.3.13 on
      X86_64 only . All tests pass.

  Efficacy -

   + Will be shown when the port of the Scala.js TestMainBase environment
     to Scala Native has been accomplished.