### PR TITLE
Add explicit conversions required on JDK13+

### DIFF
--- a/unit-tests/src/test/scala/java/nio/ByteBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/ByteBufferTest.scala
@@ -143,7 +143,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
 
         buf.order(ByteOrder.BIG_ENDIAN)
         val charBuf1 = buf.asCharBuffer()
-        charBuf1.put(1, 0x7e7f)
+        charBuf1.put(1, 0x7e7f.toChar)
         assertEquals(0x7e, buf.get(3))
         assertEquals(0x7f, buf.get(4))
         assertEquals(0, charBuf1.position())
@@ -154,7 +154,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
 
         buf.order(ByteOrder.LITTLE_ENDIAN)
         val charBuf2 = buf.asCharBuffer()
-        charBuf2.put(1, 0x7e7f)
+        charBuf2.put(1, 0x7e7f.toChar)
         assertEquals(0x7f, buf.get(3))
         assertEquals(0x7e, buf.get(4))
         assertEquals(0, charBuf2.position())
@@ -167,7 +167,9 @@ abstract class ByteBufferTest extends BaseBufferTest {
         buf.limit(8).position(1)
 
         val charBuf1 = buf.asReadOnlyBuffer().asCharBuffer()
-        assertThrows[ReadOnlyBufferException] { charBuf1.put(1, 0x7e7f) }
+        assertThrows[ReadOnlyBufferException] {
+          charBuf1.put(1, 0x7e7f.toChar)
+        }
       }
     }
 
@@ -297,7 +299,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
 
         buf.order(ByteOrder.BIG_ENDIAN)
         val shortBuf1 = buf.asShortBuffer()
-        shortBuf1.put(1, 0x7e7f)
+        shortBuf1.put(1, 0x7e7f.toShort)
         assertEquals(0x7e, buf.get(3))
         assertEquals(0x7f, buf.get(4))
         assertEquals(0, shortBuf1.position())
@@ -308,7 +310,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
 
         buf.order(ByteOrder.LITTLE_ENDIAN)
         val shortBuf2 = buf.asShortBuffer()
-        shortBuf2.put(1, 0x7e7f)
+        shortBuf2.put(1, 0x7e7f.toShort)
         assertEquals(0x7f, buf.get(3))
         assertEquals(0x7e, buf.get(4))
         assertEquals(0, shortBuf2.position())
@@ -321,7 +323,9 @@ abstract class ByteBufferTest extends BaseBufferTest {
         buf.limit(8).position(1)
 
         val shortBuf1 = buf.asReadOnlyBuffer().asShortBuffer()
-        assertThrows[ReadOnlyBufferException] { shortBuf1.put(1, 0x7e7f) }
+        assertThrows[ReadOnlyBufferException] {
+          shortBuf1.put(1, 0x7e7f.toShort)
+        }
       }
     }
 


### PR DESCRIPTION
jdk13 introduced a new methods for `CharBuffer` and `ShortBuffer` that brokes building with errors like:
```
[error] unit-tests/src/test/scala/java/nio/ByteBufferTest.scala:146:18: overloaded method value put with alternatives:
[error]   (x$1: Int,x$2: Array[Char])java.nio.CharBuffer <and>
[error]   (x$1: Int,x$2: Char)java.nio.CharBuffer
[error]  cannot be applied to (Int, Int)
[error]         charBuf1.put(1, 0x7e7f)
```
and
```
[error] unit-tests/src/test/scala/java/nio/ByteBufferTest.scala:300:19: overloaded method value put with alternatives:
[error]   (x$1: Int,x$2: Array[Short])java.nio.ShortBuffer <and>
[error]   (x$1: Int,x$2: Short)java.nio.ShortBuffer
[error]  cannot be applied to (Int, Int)
[error]         shortBuf1.put(1, 0x7e7f)
```

anyway, a few lines bellow the same tests are doint the same trick with `.toChar` and `.toShort` to same value.

Let make it here to allow build scala-native by jdk13+