### PR TITLE
Work around limitation for JDK12+ about j.l.constant.Constable

### DIFF
--- a/unit-tests/src/test/scala/java/util/DefaultFormatterTest.scala
+++ b/unit-tests/src/test/scala/java/util/DefaultFormatterTest.scala
@@ -830,7 +830,7 @@ class DefaultFormatterTest {
   }
 
   @Test def formatForGeneralConversionType_bB(): Unit = {
-    val triple = Array(
+    val triple: Array[Array[Object]] = Array(
       Array(Boolean.box(false), "%3.2b", " fa"),
       Array(Boolean.box(false), "%-4.6b", "false"),
       Array(Boolean.box(false), "%.2b", "fa"),
@@ -891,7 +891,7 @@ class DefaultFormatterTest {
   }
 
   @Test def formatForGeneralConversionType_sS(): Unit = {
-    val triple = Array(
+    val triple: Array[Array[Object]] = Array(
       Array(Boolean.box(false), "%2.3s", "fal"),
       Array(Boolean.box(false), "%-6.4s", "fals  "),
       Array(Boolean.box(false), "%.5s", "false"),

--- a/unit-tests/src/test/scala/java/util/FormatterUSTest.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterUSTest.scala
@@ -829,7 +829,7 @@ class FormatterUSTest {
   }
 
   @Test def formatForGeneralConversionType_bB(): Unit = {
-    val triple = Array(
+    val triple: Array[Array[Object]] = Array(
       Array(Boolean.box(false), "%3.2b", " fa"),
       Array(Boolean.box(false), "%-4.6b", "false"),
       Array(Boolean.box(false), "%.2b", "fa"),
@@ -921,7 +921,7 @@ class FormatterUSTest {
   }
 
   @Test def formatForGeneralConversionType_sS(): Unit = {
-    val triple = Array(
+    val triple: Array[Array[Object]] = Array(
       Array(Boolean.box(false), "%2.3s", "fal"),
       Array(Boolean.box(false), "%-6.4s", "fals  "),
       Array(Boolean.box(false), "%.5s", "false"),


### PR DESCRIPTION
java.lang.Constable was introduced at JDK12 and it requires to link an application by scala-native via JDK12+.

It oversteps https://github.com/scala-native/scala-native/issues/1938