### PR TITLE
Fix #1796: Nativelib toCString() & fromCString() now return nulls.

### DIFF
--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -369,6 +369,9 @@ It's worth to remember that ``unsafe.toCString`` and `c"..."` interpreter cannot
 Helper methods ``unsafe.fromCString` and ``unsafe.toCString`` are charset aware.
 They will always assume `String` is UTF-16, and take a `Charset` parameter to know what encoding to assume for the byte string (`CString`) - if not present it is UTF-8.
 
+If passed a null as an argument, they will return a null of the appropriate
+type instead of throwing a NullPointerException.
+
 
 Platform-specific types
 -----------------------

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -140,8 +140,8 @@ package object unsafe {
   /** Convert a CString to a String using given charset. */
   def fromCString(cstr: CString,
                   charset: Charset = Charset.defaultCharset()): String = {
-    if (cstr == null.asInstanceOf[CString]) {
-      null.asInstanceOf[String]
+    if (cstr == null) {
+      null
     } else {
       val len   = libc.strlen(cstr).toInt
       val bytes = new Array[Byte](len)
@@ -165,8 +165,8 @@ package object unsafe {
   /** Convert a java.lang.String to a CString using given charset and allocator.
    */
   def toCString(str: String, charset: Charset)(implicit z: Zone): CString = {
-    if (str == null.asInstanceOf[String]) {
-      null.asInstanceOf[CString]
+    if (str == null) {
+      null
     } else {
       val bytes = str.getBytes(charset)
       val cstr  = z.alloc(bytes.length + 1)

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -140,16 +140,20 @@ package object unsafe {
   /** Convert a CString to a String using given charset. */
   def fromCString(cstr: CString,
                   charset: Charset = Charset.defaultCharset()): String = {
-    val len   = libc.strlen(cstr).toInt
-    val bytes = new Array[Byte](len)
+    if (cstr == null.asInstanceOf[CString]) {
+      null.asInstanceOf[String]
+    } else {
+      val len   = libc.strlen(cstr).toInt
+      val bytes = new Array[Byte](len)
 
-    var c = 0
-    while (c < len) {
-      bytes(c) = !(cstr + c)
-      c += 1
+      var c = 0
+      while (c < len) {
+        bytes(c) = !(cstr + c)
+        c += 1
+      }
+
+      new String(bytes, charset)
     }
-
-    new String(bytes, charset)
   }
 
   /** Convert a java.lang.String to a CString using default charset and
@@ -161,18 +165,22 @@ package object unsafe {
   /** Convert a java.lang.String to a CString using given charset and allocator.
    */
   def toCString(str: String, charset: Charset)(implicit z: Zone): CString = {
-    val bytes = str.getBytes(charset)
-    val cstr  = z.alloc(bytes.length + 1)
+    if (str == null.asInstanceOf[String]) {
+      null.asInstanceOf[CString]
+    } else {
+      val bytes = str.getBytes(charset)
+      val cstr  = z.alloc(bytes.length + 1)
 
-    var c = 0
-    while (c < bytes.length) {
-      !(cstr + c) = bytes(c)
-      c += 1
+      var c = 0
+      while (c < bytes.length) {
+        !(cstr + c) = bytes(c)
+        c += 1
+      }
+
+      !(cstr + c) = 0.toByte
+
+      cstr
     }
-
-    !(cstr + c) = 0.toByte
-
-    cstr
   }
 
   /** Create an empty CVarArgList. */

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
@@ -64,7 +64,7 @@ object CStringSuite extends tests.Suite {
 
   // Issue 1796
   test("fromCString(null) returns null") {
-    assertNull(fromCString(null.asInstanceOf[CString]))
+    assertNull(fromCString(null))
   }
 
   test("fromCString") {
@@ -80,7 +80,7 @@ object CStringSuite extends tests.Suite {
 
   // Issue 1796
   test("toCString(null) return null") {
-    Zone { implicit z => assertNull(toCString(null.asInstanceOf[String])) }
+    Zone { implicit z => assertNull(toCString(null)) }
   }
 
   test("toCString") {

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CStringSuite.scala
@@ -62,6 +62,11 @@ object CStringSuite extends tests.Suite {
     assertEquals("\\'", fromCString(c"\\'"))
   }
 
+  // Issue 1796
+  test("fromCString(null) returns null") {
+    assertNull(fromCString(null.asInstanceOf[CString]))
+  }
+
   test("fromCString") {
     val cstrFrom = c"1234"
     val szTo     = fromCString(cstrFrom)
@@ -71,6 +76,11 @@ object CStringSuite extends tests.Suite {
     assert(szTo.charAt(1) == '2')
     assert(szTo.charAt(2) == '3')
     assert(szTo.charAt(3) == '4')
+  }
+
+  // Issue 1796
+  test("toCString(null) return null") {
+    Zone { implicit z => assertNull(toCString(null.asInstanceOf[String])) }
   }
 
   test("toCString") {


### PR DESCRIPTION
>    In the sweat of thy face shalt thou eat bread, till thou return unto
>   the ground; for out of it wast thou taken: for null thou art, and
>   unto null shalt thou return. [1]

  * This PR was motivated by Issue #1796.  There is extensive discussion
    of design alternatives in that Issue. This PR implements the
    final decision; toCString() & fromCString are to
    return null when given a null.

  * Two test cases for exercising null handling were added to
    were added to CStringSuite.scala.

    To isolate the changes of this PR, I left CStringSuite.scala
    as the old-style Scala Native test Suite it was before I touched
    it this time.  If/when the core changes of this PR are found
    acceptable, I can sweep through and convert that file to JUnit,
    under the guidance of: You touch it, you own it.

Documentation:

  * The standard changelog entry is requested.

  * I added a one sentence paragraph to `docs/user/interop.rst`
    to make the newly defined behavior accessible to users of Scala Native.

    `interop.rst` had a number (7 or 8) warnings before I touched it.
    I left it with the same warnings.  That is, I did not introduce
    any warning, but, to keep this PR reviewable on-sight, I did
    not fix any.  I think I have a PR in the queue which fixes some
    of those warnings and others; yielding, at that time, a clean build.

Testing:

  Safety -

  + Built and tested ("test-all") in debug mode using sbt 1.3.13 on
      X86_64 only . All tests pass.

  Efficacy -

  + The two newly cases in CStringSuite.scala to exercise the changes
      of this both passed.

  Documentation -

  + I did a successful manual html build of the `doc` directory.

[1]:  Adapted from [original](https://www.phrases.org.uk/meanings/ashes-to-ashes.html)