### PR TITLE
Increase sbt Xmx setting to 5G

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,2 @@
--J-Xmx4092M
+-J-Xmx5G
 -J-Xms1024M

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,2 @@
--J-Xmx3072M
+-J-Xmx4092M
 -J-Xms1024M

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -47,4 +47,4 @@ USER scala-native
 
 WORKDIR /home/scala-native/scala-native
 
-CMD sbt "++ $TRAVIS_SCALA_VERSION -v" -no-colors -J-Xmx3G "set scriptedBufferLog in sbtScalaNative := false" "$TEST_COMMAND"
+CMD sbt "++ $TRAVIS_SCALA_VERSION -v" -no-colors -J-Xmx5G "set scriptedBufferLog in sbtScalaNative := false" "$TEST_COMMAND"


### PR DESCRIPTION
In recent PR's I've observed increased usage of memory resulting in `OutOfMemory` fatal error while generating `.ll` file using `release-fast` mode

As temporary solution I suggest increasing `Xmx` setting in `.sbtops` by 1GB.
In future this issue should be properly addressed and handled in order to minimize plugin memory usage

Such behaviour was observed in:
- #1894 [CI failure](https://travis-ci.org/github/scala-native/scala-native/jobs/734252821)
- #1845 [CI failure](https://travis-ci.org/github/scala-native/scala-native/jobs/735366450)