### PR TITLE
Port Scala.js j.u.Objects parameter widening & later changes.

### DIFF
--- a/javalib/src/main/scala/java/util/Objects.scala
+++ b/javalib/src/main/scala/java/util/Objects.scala
@@ -1,3 +1,9 @@
+/*
+ * Ported from Scala.js
+ *   commit SHA1: e07d99d
+ *   dated: 2019-07-31
+ */
+
 package java.util
 
 import scala.reflect.ClassTag
@@ -5,18 +11,17 @@ import scala.reflect.ClassTag
 object Objects {
 
   @inline
-  def equals(a: AnyRef, b: AnyRef): Boolean =
+  def equals(a: Any, b: Any): Boolean =
     if (a == null) b == null
     else a.equals(b)
 
   @inline
-  def deepEquals(a: AnyRef, b: AnyRef): Boolean = {
-    if (a eq b) true
+  def deepEquals(a: Any, b: Any): Boolean = {
+    if (a.asInstanceOf[AnyRef] eq b.asInstanceOf[AnyRef]) true
     else if (a == null || b == null) false
     else {
       (a, b) match {
-        case (a1: Array[AnyRef], a2: Array[AnyRef]) =>
-          Arrays.deepEquals(a1, a2)
+        case (a1: Array[AnyRef], a2: Array[AnyRef])   => Arrays.deepEquals(a1, a2)
         case (a1: Array[Long], a2: Array[Long])       => Arrays.equals(a1, a2)
         case (a1: Array[Int], a2: Array[Int])         => Arrays.equals(a1, a2)
         case (a1: Array[Short], a2: Array[Short])     => Arrays.equals(a1, a2)
@@ -25,13 +30,13 @@ object Objects {
         case (a1: Array[Boolean], a2: Array[Boolean]) => Arrays.equals(a1, a2)
         case (a1: Array[Float], a2: Array[Float])     => Arrays.equals(a1, a2)
         case (a1: Array[Double], a2: Array[Double])   => Arrays.equals(a1, a2)
-        case _                                        => a === b
+        case _                                        => Objects.equals(a, b)
       }
     }
   }
 
   @inline
-  def hashCode(o: AnyRef): Int =
+  def hashCode(o: Any): Int =
     if (o == null) 0
     else o.hashCode()
 
@@ -40,11 +45,11 @@ object Objects {
     Arrays.hashCode(values)
 
   @inline
-  def toString(o: AnyRef): String =
+  def toString(o: Any): String =
     String.valueOf(o)
 
   @inline
-  def toString(o: AnyRef, nullDefault: String): String =
+  def toString(o: Any, nullDefault: String): String =
     if (o == null) nullDefault
     else o.toString
 
@@ -64,11 +69,11 @@ object Objects {
     else obj
 
   @inline
-  def isNull(obj: AnyRef): Boolean =
+  def isNull(obj: Any): Boolean =
     obj == null
 
   @inline
-  def nonNull(obj: AnyRef): Boolean =
+  def nonNull(obj: Any): Boolean =
     obj != null
 
   // Requires the implementation of java.util.function

--- a/unit-tests/src/test/scala/java/util/ObjectsTest.scala
+++ b/unit-tests/src/test/scala/java/util/ObjectsTest.scala
@@ -1,0 +1,104 @@
+/*
+ * Ported from Scala.js
+ *   commit SHA1:  d94325e
+ *   dated: Oct 8, 2020
+ */
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+import org.junit.Test
+import org.junit.Assert._
+// import org.scalanative.testsuite.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows._
+
+class ObjectsTest {
+
+  @Test def testEquals(): Unit = {
+    val obj = new Object
+    assertTrue(ju.Objects.equals(null, null))
+    assertFalse(ju.Objects.equals(null, obj))
+    assertFalse(ju.Objects.equals(obj, null))
+    assertTrue(ju.Objects.equals(obj, obj))
+    assertFalse(ju.Objects.equals(new Object, new Object))
+    assertTrue(ju.Objects.equals(1, 1))
+    assertFalse(ju.Objects.equals(1, 2))
+    assertTrue(ju.Objects.equals("abc", "abc"))
+    assertFalse(ju.Objects.equals("abc", "abd"))
+  }
+
+  @Test def testDeepEquals(): Unit = {
+    val obj = new Object
+    assertTrue(ju.Objects.deepEquals(null, null))
+    assertFalse(ju.Objects.deepEquals(null, obj))
+    assertFalse(ju.Objects.deepEquals(obj, null))
+    assertTrue(ju.Objects.deepEquals(obj, obj))
+    assertFalse(ju.Objects.deepEquals(new Object, new Object))
+    assertTrue(ju.Objects.deepEquals(1, 1))
+    assertFalse(ju.Objects.deepEquals(1, 2))
+    assertTrue(ju.Objects.deepEquals("abc", "abc"))
+    assertFalse(ju.Objects.deepEquals("abc", "abd"))
+    assertFalse(ju.Objects.deepEquals(0.0, -0.0))
+    assertTrue(ju.Objects.deepEquals(0.0, 0.0))
+    assertTrue(ju.Objects.deepEquals(Double.NaN, Double.NaN))
+    assertTrue(ju.Objects.deepEquals(Array(Array(1)), Array(Array(1))))
+  }
+
+  @Test def testHashCode(): Unit = {
+    val obj = new Object
+    assertEquals(0, ju.Objects.hashCode(null))
+    assertEquals(obj.hashCode, ju.Objects.hashCode(obj))
+    assertEquals(1.hashCode, ju.Objects.hashCode(1))
+  }
+
+  @Test def hash(): Unit = {
+    assertEquals(ju.Arrays.hashCode(Array.empty[AnyRef]), ju.Objects.hash())
+    assertEquals(ju.Arrays.hashCode(Array[AnyRef](null)), ju.Objects.hash(null))
+    assertEquals(ju.Arrays.hashCode(Array[AnyRef]("1")), ju.Objects.hash("1"))
+    assertEquals(ju.Arrays.hashCode(Array[AnyRef]("1", "2")),
+                 ju.Objects.hash("1", "2"))
+    assertEquals(ju.Arrays.hashCode(Array[AnyRef]("1", null)),
+                 ju.Objects.hash("1", null))
+  }
+
+  @Test def testToString(): Unit = {
+    val obj = new Object
+    assertEquals("null", ju.Objects.toString(null))
+    assertEquals("abc", ju.Objects.toString(null, "abc"))
+    assertEquals(obj.toString, ju.Objects.toString(obj))
+    assertEquals(obj.toString, ju.Objects.toString(obj, "abc"))
+    assertEquals(1.toString, ju.Objects.toString(1))
+    assertEquals(1.toString, ju.Objects.toString(1, "abc"))
+  }
+
+  @Test def compare(): Unit = {
+    val cmp1: ju.Comparator[Int] = Ordering[Int]
+    val cmp2: ju.Comparator[AnyRef] = new Ordering[AnyRef] {
+      def compare(x: AnyRef, y: AnyRef): Int =
+        x.hashCode.compareTo(y.hashCode)
+    }
+    assertEquals(0, ju.Objects.compare(null, null, cmp2))
+    assertEquals(0, ju.Objects.compare(1, 1, cmp1))
+    assertTrue(ju.Objects.compare(2, 1, cmp1) > 0)
+    assertTrue(ju.Objects.compare(1, 2, cmp1) < 0)
+  }
+
+  @Test def requireNonNull(): Unit = {
+    assertThrows(classOf[NullPointerException], ju.Objects.requireNonNull(null))
+    assertThrows(classOf[NullPointerException],
+                 ju.Objects.requireNonNull(null, "message"))
+    assertEquals("abc", ju.Objects.requireNonNull("abc"))
+    assertEquals("abc", ju.Objects.requireNonNull("abc", ""))
+  }
+
+  @Test def isNull(): Unit = {
+    assertTrue(ju.Objects.isNull(null))
+    assertFalse(ju.Objects.isNull(new Object))
+  }
+
+  @Test def nonNull(): Unit = {
+    assertFalse(ju.Objects.nonNull(null))
+    assertTrue(ju.Objects.nonNull(new Object))
+  }
+}


### PR DESCRIPTION
  * This PR was motivated by my attempts to use an automated
    script to port Scala.js j.u.Map. Scala.js appears to
    pay considerable attention to using Objects.equals().
    Before this PR, The Scala Native compiler would fail
    because it was looking to apply implicit conversions
    and found two, in Predef.

    After this PR, the freshly ported j.u.Map code compiles
    and executes its extensive test code without introducing
    failures elsewhere in the ensemble.

    This PR should ease future porting either way.

  * This PR is pretty much an automated, but curated, port of the
    Scala.js code. As per past guidance, the Scals.js license is
    stripped. A Scala Native header is prepended, with information
    allowing future developers to synchronize this port with
    Scala.js original. The new header multi-line comment style follows
    the Scala.js original.

    The new ObjectsTests.scala contains some scalafmt differences from
    the Scala.js original. Once content has been substantially aligned
    between the two projects, perhaps there is an opportunity to reduce
    porting & review loads by aligning the automated formatting tools and/or
    rules.

  * Previously, there was no j.u.Objects{Test | Suite}.
    ObjectsTests.scala was ported via script.

Documentation:

  * The standard changelog entry is requested.

Testing:

  Safety -

  + Built and tested ("test-all") in debug mode using sbt 1.3.13 on
      X86_64 only. All tests pass.

  Efficacy -

  + An automated port of a private j.u.Map.scala now compiles & passes
      unit-tests without having to manually edit the file for Objects.equals().