### PR TITLE
Upgrade build to Sbt 1.4.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,14 @@ lazy val mimaSettings: Seq[Setting[_]] = Seq(
   }
 )
 
+// Sbt 1.4.0 introduced mandatory key linting.
+// The val crossSbtVersions is used in toolsSettings below.
+// toolsSettings are used by nir, test-runner, util, etc.
+// but Sbt 1.4.0 still complained about crossSbtVersions.
+// Disable the linting for it, rather than upsetting the apple cart by
+// deleting the probably essential crossSbeVersions. Minimal change.
+Global / excludeLintKeys += crossSbtVersions
+
 // Common start but individual sub-projects may add or remove scalacOptions.
 // project/build.sbt uses a less stringent set to bootstrap.
 inThisBuild(

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -20,7 +20,7 @@ This generates the following files:
 
 * ``project/build.properties`` to specify the sbt version::
 
-    sbt.version = 1.3.13
+    sbt.version = 1.4.1
 
 * ``build.sbt`` to enable the plugin and specify Scala version::
 
@@ -234,9 +234,9 @@ support Scala/JVM or Scala.js if the Native portions have replacement
 code on the respective platforms.
 
 The primary purpose of this feature is to allow libraries to support
-Scala Native that need native `glue` code to operate. The current
+Scala Native that need native "glue" code to operate. The current
 C interopt does not allow direct access to macro defined constants and
-functions or allow passing `struct`s from the stack to C functions.
+functions or allow passing "struct"s from the stack to C functions.
 Future versions of Scala Native may relax these restrictions making
 this feature obsolete.
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.13
+sbt.version = 1.4.1


### PR DESCRIPTION
  * This PR upgrades the Scala Native build to use Sbt 1.4.1.

  * Sbt 1.4.0 introduces mandatory checking for apparently unused
    keys.  It uses an algorithm which may or may not be accurate.
    Sbt 1.4.0 complains about the key 'crossSbtVersions' in several
    sub-projects.  Sbt says that it is unused; lore suggests that it
    is used in a subtle but critical way.  I did not have time to
    verify the lore, so I turned linting off for that key.  The situation
    is no worse than before. Yes, perhaps I missed an opportunity to
    get rid of a truly unseen key, but I did not want to inflict
    breakage on others. Not a way to win friends.

Documentation:

  * No changelog entry necessary; internal build details.

  * The build.properties version in docs/user/sbt.rst was updated
     and manually rebuilt. A pre-existing warning was eliminated.

Testing:

  Safety -

   + Built and tested ("test-all") in debug mode using sbt 1.3.13 on
      X86_64 only . All tests pass.

  Efficacy -

   +  Interactive "sbt sbtVersion" in the project root shows 1.4.1.