### PR TITLE
Fix #1909, #1843: Statically resolve constructors, not as virtual methods

### DIFF
--- a/junit-runtime/src/main/scala/org/junit/AssumptionViolatedException.scala
+++ b/junit-runtime/src/main/scala/org/junit/AssumptionViolatedException.scala
@@ -29,10 +29,8 @@ class AssumptionViolatedException protected (fAssumption: String,
   def this(message: String) =
     this(message, false, null, null)
 
-//  Commented out, as this constructor triggers an unknown runtime error in Scala Native.
-//  See: https://github.com/scala-native/scala-native/issues/1843
-//  def this(assumption: String, t: Throwable) = {
-//    this(assumption, false, null, null)
-//    initCause(t)
-//  }
+  def this(assumption: String, t: Throwable) = {
+    this(assumption, false, null, null)
+    initCause(t)
+  }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -36,6 +36,7 @@ final class Sig(val mangle: String) {
   final def isGenerated: Boolean = mangle(0) == 'G'
   final def isDuplicate: Boolean = mangle(0) == 'K'
 
+  final def isVirtual          = !(isCtor || isClinit || isImplCtor || isExtern)
   final def isPrivate: Boolean = privateIn.isDefined
   final lazy val privateIn: Option[Global.Top] = {
     unmangled.sigScope match {

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -200,17 +200,22 @@ final class Check(implicit linked: linker.Result) {
         case _ =>
           error(s"method must take a method signature, not ${sig.show}")
       }
+
+      def checkCallable(cls: Class): Unit = {
+        if (cls.allocated) {
+          if (cls.resolve(sig).isEmpty) {
+            error(s"can't call ${sig.show} on ${cls.name.show}")
+          }
+        }
+      }
+
       obj.ty match {
         case Type.Null =>
           ok
-        case ScopeRef(info) =>
-          info.implementors.foreach { cls =>
-            if (cls.allocated) {
-              if (cls.resolve(sig).isEmpty) {
-                error(s"can't call ${sig.show} on ${cls.name.show}")
-              }
-            }
-          }
+        case ScopeRef(info) if sig.isVirtual =>
+          info.implementors.foreach(checkCallable)
+        case ClassRef(info) =>
+          checkCallable(info)
         case ty =>
           error(s"can't resolve method on ${ty.show}")
       }

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -438,6 +438,8 @@ object Lower {
 
       def genMethodLookup(): Unit = {
         val targets = obj.ty match {
+          case ScopeRef(scope) if sig.isCtor =>
+            scope.targets(sig).find(_.top == scope.name).toSeq
           case ScopeRef(scope) =>
             scope.targets(sig).toSeq
           case _ =>

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -438,8 +438,6 @@ object Lower {
 
       def genMethodLookup(): Unit = {
         val targets = obj.ty match {
-          case ScopeRef(scope) if sig.isCtor =>
-            scope.targets(sig).find(_.top == scope.name).toSeq
           case ScopeRef(scope) =>
             scope.targets(sig).toSeq
           case _ =>

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -438,6 +438,8 @@ object Lower {
 
       def genMethodLookup(): Unit = {
         val targets = obj.ty match {
+          case ClassRef(cls) if !sig.isVirtual =>
+            cls.resolve(sig).toSeq
           case ScopeRef(scope) =>
             scope.targets(sig).toSeq
           case _ =>

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -232,22 +232,23 @@ trait Eval { self: Interflow =>
         }
       case Op.Method(rawObj, sig) =>
         val obj = eval(rawObj)
-        val objty = obj match {
-          case InstanceRef(ty) =>
-            ty
-          case _ =>
-            /* If method is not virtual (eg. constructor) we need to ensure that
-             * we would fetch for expected type targets (rawObj) instead of real (evaluated) type
-             * It might result in calling wrong method and lead to infinite loops, eg. issue #1909
-             */
-            val realType     = obj.ty
-            val expectedType = rawObj.ty
-            val shallUseExpectedType = !sig.isVirtual &&
-              Sub.is(realType, expectedType) && !Sub.is(expectedType, realType)
+        val objty = {
+          /* If method is not virtual (eg. constructor) we need to ensure that
+           * we would fetch for expected type targets (rawObj) instead of real (evaluated) type
+           * It might result in calling wrong method and lead to infinite loops, eg. issue #1909
+           */
+          val realType = obj match {
+            case InstanceRef(ty) => ty
+            case _               => obj.ty
+          }
+          val expectedType = rawObj.ty
+          val shallUseExpectedType = !sig.isVirtual &&
+            Sub.is(realType, expectedType) && !Sub.is(expectedType, realType)
 
-            if (shallUseExpectedType) expectedType
-            else realType
+          if (shallUseExpectedType) expectedType
+          else realType
         }
+
         val targets = objty match {
           case Type.Null =>
             Seq.empty

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -243,6 +243,8 @@ trait Eval { self: Interflow =>
             Seq.empty
           case ExactClassRef(cls, _) =>
             cls.resolve(sig).toSeq
+          case ClassRef(cls) if !sig.isVirtual =>
+            cls.resolve(sig).toSeq
           case ScopeRef(scope) =>
             scope.targets(sig)
           case _ =>

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -63,9 +63,6 @@ trait PolyInline { self: Interflow =>
     val obj     = materialize(op.obj)
     val margs   = args.map(materialize(_))
     val targets = polyTargets(op)
-    if (op.toString.contains("Random") && !op.sig.isVirtual) {
-      println(s"polyinline: $op ($args) - $targets")
-    }
     val classes = targets.map(_._1)
     val impls   = targets.map(_._2).distinct
 

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -20,6 +20,8 @@ trait PolyInline { self: Interflow =>
     val res = objty match {
       case ExactClassRef(cls, _) =>
         cls.resolve(sig).map(g => (cls, g)).toSeq
+      case ClassRef(cls) if !sig.isVirtual =>
+        cls.resolve(sig).map(g => (cls, g)).toSeq
       case ScopeRef(scope) =>
         val targets = mutable.UnrolledBuffer.empty[(Class, Global)]
         scope.implementors.foreach { cls =>
@@ -61,6 +63,9 @@ trait PolyInline { self: Interflow =>
     val obj     = materialize(op.obj)
     val margs   = args.map(materialize(_))
     val targets = polyTargets(op)
+    if (op.toString.contains("Random") && !op.sig.isVirtual) {
+      println(s"polyinline: $op ($args) - $targets")
+    }
     val classes = targets.map(_._1)
     val impls   = targets.map(_._2).distinct
 

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -159,7 +159,9 @@ final class Class(val attrs: Attrs,
       }
 
     add(this)
-    subclasses.foreach(add)
+    if (sig.isVirtual || out.isEmpty) {
+      subclasses.foreach(add)
+    }
 
     out
   }

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -159,9 +159,7 @@ final class Class(val attrs: Attrs,
       }
 
     add(this)
-    if (sig.isVirtual || out.isEmpty) {
-      subclasses.foreach(add)
-    }
+    subclasses.foreach(add)
 
     out
   }

--- a/unit-tests/src/test/scala/scala/scalanative/IssuesSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/IssuesSuite.scala
@@ -408,6 +408,11 @@ object IssuesSuite extends tests.Suite {
       assert(data(0).toString == "64")
     }
   }
+
+  test("#1909") {
+    import issue1909._
+    assertNotNull(new RandomWrapper().nextInt())
+  }
 }
 
 package issue1090 {
@@ -442,5 +447,14 @@ package issue1359 {
     def f2[T](a: => T) = ()
 
     def main(args: Array[String]): Unit = f2(f)
+  }
+}
+
+package issue1909 {
+  import java.util.Random
+  class RandomWrapper(impl: Random = new Random()) extends Random {
+    def this(seed: Long) = {
+      this()
+    }
   }
 }


### PR DESCRIPTION
Resolves #1909 
Resolves #1843 

This PR fixes issue described in the linked issue. 
<del>After a few tries, the most naive fix of this problem was considered to be the most effective and non-breaking.</del>
 Original fix for this issue did not worked when `release` mode was used. New implementation generates targets based on condition with `sig` can be virtual.
