### PR TITLE
Fix #1944: Compile error for non-public methods with JUnit annotations

### DIFF
--- a/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
@@ -171,6 +171,7 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
         sym.setInfoAndEnter(MethodType(Nil, definitions.UnitTpe))
 
         val calls = annotatedMethods(module, annot)
+          .map(_.makePublic)
           .map(gen.mkMethodCall(Ident(module), _, Nil, Nil))
           .toList
 
@@ -191,6 +192,7 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
 
         val instance = castParam(instanceParam, testClass)
         val calls = annotatedMethods(testClass, annot)
+          .map(_.makePublic)
           .map(gen.mkMethodCall(instance, _, Nil, Nil))
           .toList
 

--- a/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
@@ -171,9 +171,16 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
         sym.setInfoAndEnter(MethodType(Nil, definitions.UnitTpe))
 
         val calls = annotatedMethods(module, annot)
-          .map(_.makePublic)
           .map(gen.mkMethodCall(Ident(module), _, Nil, Nil))
           .toList
+
+        val nonPublicCalls = calls.filterNot(_.symbol.isPublic)
+        if (nonPublicCalls.nonEmpty) {
+          globalError(
+            pos = module.pos,
+            s"Methods marked with ${annot.nameString} annotation in $module must be public"
+          )
+        }
 
         typer.typedDefDef(newDefDef(sym, Block(calls: _*))())
       }
@@ -192,9 +199,16 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
 
         val instance = castParam(instanceParam, testClass)
         val calls = annotatedMethods(testClass, annot)
-          .map(_.makePublic)
           .map(gen.mkMethodCall(instance, _, Nil, Nil))
           .toList
+
+        val nonPublicCalls = calls.filterNot(_.symbol.isPublic)
+        if (nonPublicCalls.nonEmpty) {
+          globalError(
+            pos = testClass.pos,
+            s"Methods marked with ${annot.nameString} annotation in $testClass must be public"
+          )
+        }
 
         typer.typedDefDef(newDefDef(sym, Block(calls: _*))())
       }


### PR DESCRIPTION
Resolves #1944 

This PR fixes problem with compiler crashing in the `inject-junit` phase when the method annotated with `Before` is declared with a `private` modifier. The problem did not occur with other access modifiers.  

Although this change fixes the issue it also makes it less compatible with [JUnit API](https://junit.org/junit4/javadoc/latest/org/junit/Before.html) which states:
_Annotating a **public void** method with @Before causes that method to be run before the Test method_
Even though I would opt-in merging this PR as it's not breaking, but it's widening the JUnit features set.