### PR TITLE
Fix #1943: Support JUnit's @Ignore on test class

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -582,7 +582,6 @@ lazy val tests =
     )
     .settings(noPublishSettings)
     .settings(
-      nativeConfig ~= (_.withMode(scalanative.build.Mode.releaseFast)),
       // nativeOptimizerReporter := OptimizerReporter.toDirectory(
       //   crossTarget.value),
       // nativeLinkerReporter := LinkerReporter.toFile(
@@ -617,8 +616,6 @@ lazy val sandbox =
     .settings(scalacOptions -= "-Xfatal-warnings")
     .settings(noPublishSettings)
     .settings(
-      nativeConfig ~= (_.withMode(scalanative.build.Mode.releaseFast))
-
       // nativeOptimizerReporter := OptimizerReporter.toDirectory(
       //   crossTarget.value),
     )

--- a/build.sbt
+++ b/build.sbt
@@ -582,6 +582,7 @@ lazy val tests =
     )
     .settings(noPublishSettings)
     .settings(
+      nativeConfig ~= (_.withMode(scalanative.build.Mode.releaseFast)),
       // nativeOptimizerReporter := OptimizerReporter.toDirectory(
       //   crossTarget.value),
       // nativeLinkerReporter := LinkerReporter.toFile(
@@ -616,6 +617,8 @@ lazy val sandbox =
     .settings(scalacOptions -= "-Xfatal-warnings")
     .settings(noPublishSettings)
     .settings(
+      nativeConfig ~= (_.withMode(scalanative.build.Mode.releaseFast))
+
       // nativeOptimizerReporter := OptimizerReporter.toDirectory(
       //   crossTarget.value),
     )

--- a/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
@@ -218,16 +218,7 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
           val ignored     = testIgnored.orElse(testClassIgnored)
           val isIgnored   = Literal(Constant(ignored.isDefined))
 
-          // We're not using `ignored` in order to get reason message of
-          // either `testIgnored` or, if it's missing, `testClassIgnored`
-          val ignoreReason: Tree = List(testIgnored, testClassIgnored)
-            .flatMap(_.flatMap(_.args.headOption))
-            .headOption match {
-            case Some(reason) => Apply(SomeModule, reason)
-            case None         => Ident(NoneModule)
-          }
-
-          New(TestMetadataClass, name, isIgnored, ignoreReason, reifiedAnnot)
+          New(TestMetadataClass, name, isIgnored, reifiedAnnot)
         }
 
         val rhs = ArrayValue(TypeTree(TestMetadataClass.tpe), metadata.toList)

--- a/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
@@ -200,8 +200,9 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
       private def genTests(owner: ClassSymbol,
                            testClass: ClassSymbol,
                            tests: Scope): DefDef = {
-        val sym              = owner.newMethodSymbol(Names.tests)
-        val testClassIgnored = testClass.getAnnotation(JUnitAnnots.Ignore)
+        val sym                = owner.newMethodSymbol(Names.tests)
+        val testClassIgnored   = testClass.getAnnotation(JUnitAnnots.Ignore)
+        val isTestClassIgnored = Literal(Constant(testClassIgnored.isDefined))
 
         sym.setInfoAndEnter(
           MethodType(Nil,
@@ -218,7 +219,11 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
           val ignored     = testIgnored.orElse(testClassIgnored)
           val isIgnored   = Literal(Constant(ignored.isDefined))
 
-          New(TestMetadataClass, name, isIgnored, reifiedAnnot)
+          New(TestMetadataClass,
+              name,
+              isTestClassIgnored,
+              isIgnored,
+              reifiedAnnot)
         }
 
         val rhs = ArrayValue(TypeTree(TestMetadataClass.tpe), metadata.toList)

--- a/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
@@ -218,7 +218,16 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
           val ignored     = testIgnored.orElse(testClassIgnored)
           val isIgnored   = Literal(Constant(ignored.isDefined))
 
-          New(TestMetadataClass, name, isIgnored, reifiedAnnot)
+          // We're not using `ignored` in order to get reason message of
+          // either `testIgnored` or, if it's missing, `testClassIgnored`
+          val ignoreReason: Tree = List(testIgnored, testClassIgnored)
+            .flatMap(_.flatMap(_.args.headOption))
+            .headOption match {
+            case Some(reason) => Apply(SomeModule, reason)
+            case None         => Ident(NoneModule)
+          }
+
+          New(TestMetadataClass, name, isIgnored, ignoreReason, reifiedAnnot)
         }
 
         val rhs = ArrayValue(TypeTree(TestMetadataClass.tpe), metadata.toList)

--- a/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
@@ -53,14 +53,14 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
     }
 
     private object Names {
-      val beforeClass: TermName  = newTermName("beforeClass")
-      val afterClass: TermName   = newTermName("afterClass")
-      val before: TermName       = newTermName("before")
-      val after: TermName        = newTermName("after")
-      val testMetadata: TermName = newTermName("testMetadata")
-      val tests: TermName        = newTermName("tests")
-      val invokeTest: TermName   = newTermName("invokeTest")
-      val newInstance: TermName  = newTermName("newInstance")
+      val beforeClass: TermName       = newTermName("beforeClass")
+      val afterClass: TermName        = newTermName("afterClass")
+      val before: TermName            = newTermName("before")
+      val after: TermName             = newTermName("after")
+      val testClassMetadata: TermName = newTermName("testClassMetadata")
+      val tests: TermName             = newTermName("tests")
+      val invokeTest: TermName        = newTermName("invokeTest")
+      val newInstance: TermName       = newTermName("newInstance")
 
       val instance: TermName = newTermName("instance")
       val name: TermName     = newTermName("name")
@@ -204,7 +204,7 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
 
       private def genTestMetadata(owner: ClassSymbol,
                                   testClass: ClassSymbol): DefDef = {
-        val sym = owner.newMethodSymbol(Names.testMetadata)
+        val sym = owner.newMethodSymbol(Names.testClassMetadata)
 
         sym.setInfoAndEnter(
           MethodType(Nil, typeRef(NoType, TestClassMetadataClass, Nil))

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
@@ -36,6 +36,7 @@ trait Bootstrapper {
  */
 final class TestMetadata(
     val name: String,
-    val ignored: Boolean,
+    val testClassIgnored: Boolean,
+    val testIgnored: Boolean,
     val annotation: org.junit.Test
 )

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
@@ -21,6 +21,7 @@ trait Bootstrapper {
   def before(instance: AnyRef): Unit
   def after(instance: AnyRef): Unit
 
+  def testMetadata(): TestClassMetadata
   def tests(): Array[TestMetadata]
   def invokeTest(instance: AnyRef, name: String): Future[Try[Unit]]
 
@@ -36,7 +37,17 @@ trait Bootstrapper {
  */
 final class TestMetadata(
     val name: String,
-    val testClassIgnored: Boolean,
-    val testIgnored: Boolean,
+    val ignored: Boolean,
     val annotation: org.junit.Test
+)
+
+/** Scala Native interal JUnit test class metadata
+ *
+ *  This class is public due to implementation details. Only the junit compiler
+ *  plugin may create instances of it.
+ *
+ *  Relying on this class directly is unspecified behavior.
+ *  */
+final class TestClassMetadata(
+    val ignored: Boolean
 )

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
@@ -37,5 +37,6 @@ trait Bootstrapper {
 final class TestMetadata(
     val name: String,
     val ignored: Boolean,
+    val ignoreReason: Option[String],
     val annotation: org.junit.Test
 )

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
@@ -47,7 +47,7 @@ final class TestMetadata(
  *  plugin may create instances of it.
  *
  *  Relying on this class directly is unspecified behavior.
- *  */
+ */
 final class TestClassMetadata(
     val ignored: Boolean
 )

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
@@ -37,6 +37,5 @@ trait Bootstrapper {
 final class TestMetadata(
     val name: String,
     val ignored: Boolean,
-    val ignoreReason: Option[String],
     val annotation: org.junit.Test
 )

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Bootstrapper.scala
@@ -21,7 +21,7 @@ trait Bootstrapper {
   def before(instance: AnyRef): Unit
   def after(instance: AnyRef): Unit
 
-  def testMetadata(): TestClassMetadata
+  def testClassMetadata(): TestClassMetadata
   def tests(): Array[TestMetadata]
   def invokeTest(instance: AnyRef, name: String): Future[Try[Unit]]
 

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
@@ -34,10 +34,14 @@ private[junit] final class JUnitTask(val taskDef: TaskDef,
 
     @tailrec
     def runTests(tests: List[TestMetadata]): Try[Unit] = {
-      val (nextIgnored, other) = tests.span(_.ignored)
-
-      nextIgnored.foreach(t => reporter.reportIgnored(Some(t.name)))
-      ignored += nextIgnored.size
+      val (nextIgnored, other) = tests.span(_.testIgnored)
+      if (tests.exists(_.testClassIgnored)) {
+        reporter.reportIgnored(None)
+        ignored += 1
+      } else {
+        nextIgnored.foreach(t => reporter.reportIgnored(Some(t.name)))
+        ignored += nextIgnored.size
+      }
 
       other match {
         case t :: ts =>

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
@@ -33,33 +33,36 @@ private[junit] final class JUnitTask(val taskDef: TaskDef,
     var total   = 0
 
     @tailrec
-    def runTests(tests: List[TestMetadata]): Try[Unit] = {
-      val (nextIgnored, other) = tests.span(_.testIgnored)
-      if (tests.exists(_.testClassIgnored)) {
+    def runTests(tests: List[TestMetadata],
+                 testClass: TestClassMetadata): Try[Unit] = {
+      val (nextIgnored, other) = tests.span(_.ignored)
+
+      if (testClass.ignored) {
         reporter.reportIgnored(None)
         ignored += 1
+        Success(())
       } else {
         nextIgnored.foreach(t => reporter.reportIgnored(Some(t.name)))
         ignored += nextIgnored.size
-      }
 
-      other match {
-        case t :: ts =>
-          total += 1
+        other match {
+          case t :: ts =>
+            total += 1
 
-          val fc = executeTestMethod(bootstrapper, t, reporter)
-          failed += fc
-          runTests(ts)
+            val fc = executeTestMethod(bootstrapper, t, reporter)
+            failed += fc
+            runTests(ts, testClass)
 
-        case Nil =>
-          Success(())
+          case Nil =>
+            Success(())
+        }
       }
     }
 
     val result = runTestLifecycle {
       Success(())
     } { _ => catchAll(bootstrapper.beforeClass()) } { _ =>
-      runTests(bootstrapper.tests().toList)
+      runTests(bootstrapper.tests().toList, bootstrapper.testMetadata())
     } { _ => catchAll(bootstrapper.afterClass()) }
 
     val (errors, timeInSeconds) = result

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
@@ -62,7 +62,7 @@ private[junit] final class JUnitTask(val taskDef: TaskDef,
     val result = runTestLifecycle {
       Success(())
     } { _ => catchAll(bootstrapper.beforeClass()) } { _ =>
-      runTests(bootstrapper.tests().toList, bootstrapper.testMetadata())
+      runTests(bootstrapper.tests().toList, bootstrapper.testClassMetadata())
     } { _ => catchAll(bootstrapper.afterClass()) }
 
     val (errors, timeInSeconds) = result

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
@@ -36,8 +36,7 @@ private[junit] final class JUnitTask(val taskDef: TaskDef,
     def runTests(tests: List[TestMetadata]): Try[Unit] = {
       val (nextIgnored, other) = tests.span(_.ignored)
 
-      nextIgnored.foreach(t =>
-        reporter.reportIgnored(Some(t.name), t.ignoreReason))
+      nextIgnored.foreach(t => reporter.reportIgnored(Some(t.name)))
       ignored += nextIgnored.size
 
       other match {
@@ -63,8 +62,7 @@ private[junit] final class JUnitTask(val taskDef: TaskDef,
 
     errors match {
       case e :: Nil if isAssumptionViolation(e) =>
-        reporter.reportIgnored(None,
-                               Some(s"assumption violated: ${e.getMessage}"))
+        reporter.reportIgnored(None)
         ignored += 1
 
       case es =>

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/JUnitTask.scala
@@ -36,7 +36,8 @@ private[junit] final class JUnitTask(val taskDef: TaskDef,
     def runTests(tests: List[TestMetadata]): Try[Unit] = {
       val (nextIgnored, other) = tests.span(_.ignored)
 
-      nextIgnored.foreach(t => reporter.reportIgnored(Some(t.name)))
+      nextIgnored.foreach(t =>
+        reporter.reportIgnored(Some(t.name), t.ignoreReason))
       ignored += nextIgnored.size
 
       other match {
@@ -62,7 +63,8 @@ private[junit] final class JUnitTask(val taskDef: TaskDef,
 
     errors match {
       case e :: Nil if isAssumptionViolation(e) =>
-        reporter.reportIgnored(None)
+        reporter.reportIgnored(None,
+                               Some(s"assumption violated: ${e.getMessage}"))
         ignored += 1
 
       case es =>

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
@@ -30,8 +30,8 @@ private[junit] final class Reporter(eventHandler: EventHandler,
     log(infoOrDebug, msg)
   }
 
-  def reportIgnored(method: Option[String], reason: Option[String]): Unit = {
-    logTestInfo(_.info, method, s"ignored ${reason.getOrElse("")}")
+  def reportIgnored(method: Option[String]): Unit = {
+    logTestInfo(_.info, method, "ignored")
     emitEvent(method, Status.Skipped)
   }
 

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
@@ -30,8 +30,8 @@ private[junit] final class Reporter(eventHandler: EventHandler,
     log(infoOrDebug, msg)
   }
 
-  def reportIgnored(method: Option[String]): Unit = {
-    logTestInfo(_.info, method, "ignored")
+  def reportIgnored(method: Option[String], reason: Option[String]): Unit = {
+    logTestInfo(_.info, method, s"ignored ${reason.getOrElse("")}")
     emitEvent(method, Status.Skipped)
   }
 

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_.txt
@@ -1,0 +1,5 @@
+ld[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
+e3scala.scalanative.junit.IgnoreAllTest
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_a.txt
@@ -1,0 +1,5 @@
+ld[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
+e3scala.scalanative.junit.IgnoreAllTest
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_n.txt
@@ -1,0 +1,5 @@
+ldTest run started
+liTest scala.scalanative.junit.IgnoreAllTest ignored
+e3scala.scalanative.junit.IgnoreAllTest
+ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_na.txt
@@ -1,0 +1,5 @@
+ldTest run started
+liTest scala.scalanative.junit.IgnoreAllTest ignored
+e3scala.scalanative.junit.IgnoreAllTest
+ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nv.txt
@@ -1,0 +1,5 @@
+liTest run started
+liTest scala.scalanative.junit.IgnoreAllTest ignored
+e3scala.scalanative.junit.IgnoreAllTest
+liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nva.txt
@@ -1,0 +1,5 @@
+liTest run started
+liTest scala.scalanative.junit.IgnoreAllTest ignored
+e3scala.scalanative.junit.IgnoreAllTest
+liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvc.txt
@@ -1,0 +1,5 @@
+liTest run started
+liTest scala.scalanative.junit.IgnoreAllTest ignored
+e3scala.scalanative.junit.IgnoreAllTest
+liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_nvca.txt
@@ -1,0 +1,5 @@
+liTest run started
+liTest scala.scalanative.junit.IgnoreAllTest ignored
+e3scala.scalanative.junit.IgnoreAllTest
+liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_v.txt
@@ -1,0 +1,5 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
+e3scala.scalanative.junit.IgnoreAllTest
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_va.txt
@@ -1,0 +1,5 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
+e3scala.scalanative.junit.IgnoreAllTest
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vc.txt
@@ -1,0 +1,5 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
+e3scala.scalanative.junit.IgnoreAllTest
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vs.txt
@@ -1,0 +1,5 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTest[0m ignored
+e3scala.scalanative.junit.IgnoreAllTest
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestAssertions_vsn.txt
@@ -1,0 +1,5 @@
+liTest run started
+liTest scala.scalanative.junit.IgnoreAllTest ignored
+e3scala.scalanative.junit.IgnoreAllTest
+liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_.txt
@@ -1,0 +1,5 @@
+ld[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_a.txt
@@ -1,0 +1,5 @@
+ld[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_n.txt
@@ -1,0 +1,5 @@
+ldTest run started
+liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_na.txt
@@ -1,0 +1,5 @@
+ldTest run started
+liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nv.txt
@@ -1,0 +1,5 @@
+liTest run started
+liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nva.txt
@@ -1,0 +1,5 @@
+liTest run started
+liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvc.txt
@@ -1,0 +1,5 @@
+liTest run started
+liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_nvca.txt
@@ -1,0 +1,5 @@
+liTest run started
+liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_v.txt
@@ -1,0 +1,5 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_va.txt
@@ -1,0 +1,5 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vc.txt
@@ -1,0 +1,5 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vs.txt
@@ -1,0 +1,5 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mIgnoreAllTestWithReason[0m ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/IgnoreAllTestWithReasonAssertions_vsn.txt
@@ -1,0 +1,5 @@
+liTest run started
+liTest scala.scalanative.junit.IgnoreAllTestWithReason ignored
+e3scala.scalanative.junit.IgnoreAllTestWithReason
+liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+d

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/IgnoreAllTest.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/IgnoreAllTest.scala
@@ -6,6 +6,8 @@ import scala.scalanative.junit.utils.JUnitTest
 
 @Ignore
 class IgnoreAllTest {
+  throw new Error("unreachable")
+
   @Test def multiTest1(): Unit = ()
   @Test def multiTest2(): Unit = ()
   @Test def multiTest3(): Unit = ()

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/IgnoreAllTest.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/IgnoreAllTest.scala
@@ -1,0 +1,14 @@
+package scala.scalanative.junit
+
+import org.junit._
+
+import scala.scalanative.junit.utils.JUnitTest
+
+@Ignore
+class IgnoreAllTest {
+  @Test def multiTest1(): Unit = ()
+  @Test def multiTest2(): Unit = ()
+  @Test def multiTest3(): Unit = ()
+}
+
+class IgnoreAllTestAssertions extends JUnitTest

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/IgnoreAllTestWithReason.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/IgnoreAllTestWithReason.scala
@@ -8,6 +8,9 @@ class IgnoreAllTestWithReason {
   @Ignore("reason override") @Test def multiTest1(): Unit = ()
   @Ignore @Test def multiTest2(): Unit                    = ()
   @Test def multiTest3(): Unit                            = ()
+
+  throw new Error("unreachable")
+
 }
 
 class IgnoreAllTestWithReasonAssertions extends JUnitTest

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/IgnoreAllTestWithReason.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/IgnoreAllTestWithReason.scala
@@ -1,0 +1,13 @@
+package scala.scalanative.junit
+
+import org.junit._
+import scala.scalanative.junit.utils.JUnitTest
+
+@Ignore("ignore reason")
+class IgnoreAllTestWithReason {
+  @Ignore("reason override") @Test def multiTest1(): Unit = ()
+  @Ignore @Test def multiTest2(): Unit                    = ()
+  @Test def multiTest3(): Unit                            = ()
+}
+
+class IgnoreAllTestWithReasonAssertions extends JUnitTest

--- a/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicReferenceTest.scala
+++ b/unit-tests/src/test/scala/java/util/concurrent/atomic/AtomicReferenceTest.scala
@@ -8,7 +8,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
 
-@Ignore("tests disabled but ignore on class doesn't work")
+@Ignore
 class AtomicReferenceTest {
 
   // This test suite is INCOMPLETE (obviously!).
@@ -21,7 +21,6 @@ class AtomicReferenceTest {
   // how to test concurrent and contended access patterns within
   // the scope of unit-tests.
 
-  @Ignore
   @Test def get(): Unit = {
 
     val expected = -1
@@ -33,7 +32,6 @@ class AtomicReferenceTest {
                result == expected)
   }
 
-  @Ignore
   @Test def getAndUpdateUpdateFunction(): Unit = {
 
     val expectedValue    = 100
@@ -58,7 +56,6 @@ class AtomicReferenceTest {
                newValue == expectedNewValue)
   }
 
-  @Ignore
   @Test def updateAndGetUpdateFunction(): Unit = {
 
     val initialValue = 100


### PR DESCRIPTION
Resolves #1943 

This PR fixes behaviour of Native JUnit by allowing to annotate whole test class with `Ignore`. In such a scenario all tests within that class should be ignored. 

Proposal to include ignore reason was discarded - it's technically possible, but it violates Native/JVM JUnit outputs compatibility. In JVM version ignore reason is never included in the output