### PR TITLE
Update gitignore for sbt build server protocol files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,8 @@ bin/
 /.metals/
 /project/**/metals.sbt
 
+# Build Server Protocol, used by sbt
+/.bsp/
+
 # vscode
 /.vscode/


### PR DESCRIPTION
sbt 1.4.x now uses build server protocol files in .bsp directory.
There is no utility in tracking these.