### PR TITLE
Ignore .bsp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ scripts/.coursier
 scripts/.scalafmt*
 sbt-crossproject/
 local.sbt
+.bsp/
 
 CMakeLists.txt
 cmake-build-debug/


### PR DESCRIPTION
sbt since 1.4.0 created `.bsp/` folder inside root. Let ignore it.