### PR TITLE
WIP: Port Scala.js j.u.Map default methods

### DIFF
--- a/javalib/src/main/scala/java/util/Map.scala
+++ b/javalib/src/main/scala/java/util/Map.scala
@@ -147,7 +147,6 @@ trait Map[K, V] {
 }
 
 object Map {
-
   trait Entry[K, V] {
     def getKey(): K
     def getValue(): V
@@ -155,5 +154,4 @@ object Map {
     def equals(o: Any): Boolean
     def hashCode(): Int
   }
-
 }

--- a/javalib/src/main/scala/java/util/Map.scala
+++ b/javalib/src/main/scala/java/util/Map.scala
@@ -1,4 +1,14 @@
+/*
+ * Ported from Scala.js
+ *   commit SHA1: f7be410
+ *   dated:  2020-10-12
+ */
+
 package java.util
+
+import java.util.function.{BiConsumer, BiFunction, Function}
+
+import ScalaOps._
 
 trait Map[K, V] {
   def size(): Int
@@ -15,6 +25,116 @@ trait Map[K, V] {
   def entrySet(): Set[Map.Entry[K, V]]
   def equals(o: Any): Boolean
   def hashCode(): Int
+
+  def getOrDefault(key: Any, defaultValue: V): V =
+    if (containsKey(key)) get(key)
+    else defaultValue
+
+  def forEach(action: BiConsumer[_ >: K, _ >: V]): Unit = {
+    for (entry <- entrySet().scalaOps)
+      action.accept(entry.getKey(), entry.getValue())
+  }
+
+  def replaceAll(function: BiFunction[_ >: K, _ >: V, _ <: V]): Unit = {
+    for (entry <- entrySet().scalaOps)
+      entry.setValue(function.apply(entry.getKey(), entry.getValue()))
+  }
+
+  def putIfAbsent(key: K, value: V): V = {
+    val prevValue = get(key)
+    if (prevValue == null)
+      put(key, value) // will return null
+    else
+      prevValue
+  }
+
+  def remove(key: Any, value: Any): Boolean = {
+    if (containsKey(key) && Objects.equals(get(key), value)) {
+      remove(key)
+      true
+    } else {
+      false
+    }
+  }
+
+  def replace(key: K, oldValue: V, newValue: V): Boolean = {
+    if (containsKey(key) && Objects.equals(get(key), oldValue)) {
+      put(key, newValue)
+      true
+    } else {
+      false
+    }
+  }
+
+  def replace(key: K, value: V): V =
+    if (containsKey(key)) put(key, value)
+    else null.asInstanceOf[V]
+
+  def computeIfAbsent(key: K, mappingFunction: Function[_ >: K, _ <: V]): V = {
+    val oldValue = get(key)
+    if (oldValue != null) {
+      oldValue
+    } else {
+      val newValue = mappingFunction.apply(key)
+      if (newValue != null)
+        put(key, newValue)
+      newValue
+    }
+  }
+
+  def computeIfPresent(
+      key: K,
+      remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]): V = {
+    val oldValue = get(key)
+    if (oldValue == null) {
+      oldValue
+    } else {
+      val newValue = remappingFunction.apply(key, oldValue)
+      putOrRemove(key, newValue)
+      newValue
+    }
+  }
+
+  def compute(key: K,
+              remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]): V = {
+    val oldValue = get(key)
+    val newValue = remappingFunction.apply(key, oldValue)
+
+    /* The "Implementation Requirements" section of the JavaDoc for this method
+     * does not correspond to the textual specification in the case where both
+     * a) there was a null mapping, and
+     * b) the remapping function returned null.
+     *
+     * The Implementation Requirements would leave the null mapping, whereas
+     * the specification says to remove it.
+     *
+     * We implement the specification, as it appears that the actual Map
+     * implementations on the JVM behave like the spec.
+     */
+    putOrRemove(key, newValue)
+
+    newValue
+  }
+
+  def merge(key: K,
+            value: V,
+            remappingFunction: BiFunction[_ >: V, _ >: V, _ <: V]): V = {
+    Objects.requireNonNull(value)
+
+    val oldValue = get(key)
+    val newValue =
+      if (oldValue == null) value
+      else remappingFunction.apply(oldValue, value)
+    putOrRemove(key, newValue)
+    newValue
+  }
+
+  private def putOrRemove(key: K, value: V): Unit = {
+    if (value != null)
+      put(key, value)
+    else
+      remove(key)
+  }
 }
 
 object Map {
@@ -26,4 +146,5 @@ object Map {
     def equals(o: Any): Boolean
     def hashCode(): Int
   }
+
 }

--- a/javalib/src/main/scala/java/util/Map.scala
+++ b/javalib/src/main/scala/java/util/Map.scala
@@ -1,7 +1,7 @@
 /*
  * Ported from Scala.js
  *   commit SHA1: f7be410
- *   dated:  2020-10-12
+ *   dated: 2020-10-12
  */
 
 package java.util

--- a/javalib/src/main/scala/java/util/Map.scala
+++ b/javalib/src/main/scala/java/util/Map.scala
@@ -1,12 +1,10 @@
-/*
- * Ported from Scala.js
- *   commit SHA1: f7be410
- *   dated: 2020-10-12
- */
+// Ported from Scala.js  commit f7be410 dated: 2020-10-07
 
 package java.util
 
 import java.util.function.{BiConsumer, BiFunction, Function}
+
+import scala.scalanative.annotation.JavaDefaultMethod
 
 import ScalaOps._
 
@@ -26,20 +24,24 @@ trait Map[K, V] {
   def equals(o: Any): Boolean
   def hashCode(): Int
 
+  @JavaDefaultMethod
   def getOrDefault(key: Any, defaultValue: V): V =
     if (containsKey(key)) get(key)
     else defaultValue
 
+  @JavaDefaultMethod
   def forEach(action: BiConsumer[_ >: K, _ >: V]): Unit = {
     for (entry <- entrySet().scalaOps)
       action.accept(entry.getKey(), entry.getValue())
   }
 
+  @JavaDefaultMethod
   def replaceAll(function: BiFunction[_ >: K, _ >: V, _ <: V]): Unit = {
     for (entry <- entrySet().scalaOps)
       entry.setValue(function.apply(entry.getKey(), entry.getValue()))
   }
 
+  @JavaDefaultMethod
   def putIfAbsent(key: K, value: V): V = {
     val prevValue = get(key)
     if (prevValue == null)
@@ -48,6 +50,7 @@ trait Map[K, V] {
       prevValue
   }
 
+  @JavaDefaultMethod
   def remove(key: Any, value: Any): Boolean = {
     if (containsKey(key) && Objects.equals(get(key), value)) {
       remove(key)
@@ -57,6 +60,7 @@ trait Map[K, V] {
     }
   }
 
+  @JavaDefaultMethod
   def replace(key: K, oldValue: V, newValue: V): Boolean = {
     if (containsKey(key) && Objects.equals(get(key), oldValue)) {
       put(key, newValue)
@@ -66,10 +70,12 @@ trait Map[K, V] {
     }
   }
 
+  @JavaDefaultMethod
   def replace(key: K, value: V): V =
     if (containsKey(key)) put(key, value)
     else null.asInstanceOf[V]
 
+  @JavaDefaultMethod
   def computeIfAbsent(key: K, mappingFunction: Function[_ >: K, _ <: V]): V = {
     val oldValue = get(key)
     if (oldValue != null) {
@@ -82,6 +88,7 @@ trait Map[K, V] {
     }
   }
 
+  @JavaDefaultMethod
   def computeIfPresent(
       key: K,
       remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]): V = {
@@ -95,6 +102,7 @@ trait Map[K, V] {
     }
   }
 
+  @JavaDefaultMethod
   def compute(key: K,
               remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]): V = {
     val oldValue = get(key)
@@ -116,6 +124,7 @@ trait Map[K, V] {
     newValue
   }
 
+  @JavaDefaultMethod
   def merge(key: K,
             value: V,
             remappingFunction: BiFunction[_ >: V, _ >: V, _ <: V]): V = {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
 sbt.version = 1.4.2
-


### PR DESCRIPTION
This PR is an _almost_ straight port from Scala.js original.
I ran my automated script to do a preliminary port.
The required scalafmt introduced some textual, but not content, changes.

* See ScalaNative Issue #1972 for a discussion of Scala.js annotations,
  which were elided, especially `@JavaDefaultMethod`.

* See ScalaNative Issue #1993 for a full discussion of why MapTest.scala was
  not ported or changed.

  The existing MapTest will exercise the methods which existed before this PR.
  A future port of Scala.js MapTest will exercise the default methods
  introduced in this PR.