### PR TITLE
Fix Build crashes in releaseFull mode

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -138,10 +138,12 @@ trait Inline { self: Interflow =>
         case _: build.Mode.Release =>
           getDone(name)
       }
+      val Type.Function(_, origRetTy) = defn.ty
 
       val inlineArgs  = adapt(args, defn.ty)
       val inlineInsts = defn.insts.toArray
-      val blocks      = process(inlineInsts, inlineArgs, state, doInline = true)
+      val blocks =
+        process(inlineInsts, inlineArgs, state, doInline = true, origRetTy)
 
       val emit = new nir.Buffer()(state.fresh)
 

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -75,7 +75,7 @@ final class MergeProcessor(insts: Array[Inst],
         val mergeEmitted = mutable.Map.empty[Op, Val]
         val newEscapes   = mutable.Set.empty[Addr]
 
-        def mergePhi(values: Seq[Val], bound: Option[Type] = None): Val = {
+        def mergePhi(values: Seq[Val], bound: Option[Type]): Val = {
           if (values.distinct.size == 1) {
             values.head
           } else {
@@ -130,7 +130,7 @@ final class MergeProcessor(insts: Array[Inst],
                       case _                      => Val.Virtual(addr)
                     }
                   }
-                  mergeHeap(addr) = EscapedInstance(mergePhi(values))
+                  mergeHeap(addr) = EscapedInstance(mergePhi(values, None))
                 case VirtualInstance(headKind, headCls, headValues) =>
                   val mergeValues = headValues.zipWithIndex.map {
                     case (_, idx) =>

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -383,7 +383,8 @@ final class MergeProcessor(insts: Array[Inst],
     }
   }
 
-  def toSeq()(implicit originDefnPos: nir.Position): Seq[MergeBlock] = {
+  def toSeq(retTy: Type)(
+      implicit originDefnPos: nir.Position): Seq[MergeBlock] = {
     val sortedBlocks = blocks.values.toSeq
       .filter(_.cf != null)
       .sortBy { block => offsets(block.label.name) }
@@ -413,17 +414,13 @@ final class MergeProcessor(insts: Array[Inst],
           case _               => v.ty
         }
       }
-      // !!! CAUTION: j.l.Object is provided here as the most generic upper bound type.
-      // !!! In case `tys` have more than one common super-type and a type which is more
-      // !!! specific than j.l.Object is expected as the return type, then Sub.lub may
-      // !!! calculate the wrong type.
-      val retTy = Sub.lub(tys, Type.Ref(Global.Top("java.lang.Object")))
 
       // Create synthetic label and block where all returning blocks
       // are going tojump to. Synthetics names must be fresh relative
       // to the source instructions, not relative to generated ones.
       val syntheticFresh = Fresh(insts)
-      val syntheticParam = Val.Local(syntheticFresh(), retTy)
+      val syntheticParam =
+        Val.Local(syntheticFresh(), Sub.lub(tys, Some(retTy)))
       val syntheticLabel =
         Inst.Label(syntheticFresh(), Seq(syntheticParam))
       val resultMergeBlock =

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -39,7 +39,7 @@ trait Opt { self: Interflow =>
     val state = new State(Local(0))
 
     // Interflow usually infers better types on our erased type system
-    // than scalac, yet we live it a benefit of the doubt and make sure
+    // than scalac, yet we live it as a benefit of the doubt and make sure
     // that if original return type is more specific, we keep it as is.
     val Type.Function(_, origRetTy) = origdefn.ty
 

--- a/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Opt.scala
@@ -38,6 +38,11 @@ trait Opt { self: Interflow =>
     val fresh = Fresh(0)
     val state = new State(Local(0))
 
+    // Interflow usually infers better types on our erased type system
+    // than scalac, yet we live it a benefit of the doubt and make sure
+    // that if original return type is more specific, we keep it as is.
+    val Type.Function(_, origRetTy) = origdefn.ty
+
     // Compute opaque fresh locals for the arguments. Argument types
     // are always a subtype of the original declared type, but in
     // some cases they might not be obviously related, despite
@@ -65,7 +70,11 @@ trait Opt { self: Interflow =>
     val blocks =
       try {
         pushBlockFresh(fresh)
-        process(origdefn.insts.toArray, args, state, doInline = false)
+        process(origdefn.insts.toArray,
+                args,
+                state,
+                doInline = false,
+                origRetTy)
       } finally {
         popBlockFresh()
       }
@@ -87,18 +96,10 @@ trait Opt { self: Interflow =>
       case Inst.Ret(v) => v.ty
     }
 
-    // Interflow usually infers better types on our erased type system
-    // than scalac, yet we live it a benefit of the doubt and make sure
-    // that if original return type is more specific, we keep it as is.
-    val origRetty = {
-      val Type.Function(_, ty) = origdefn.ty
-      ty
-    }
-
     val retty = rets match {
       case Seq()   => Type.Nothing
       case Seq(ty) => ty
-      case tys     => Sub.lub(tys, origRetty)
+      case tys     => Sub.lub(tys, Some(origRetTy))
     }
 
     result(retty, insts)
@@ -107,7 +108,8 @@ trait Opt { self: Interflow =>
   def process(insts: Array[Inst],
               args: Seq[Val],
               state: State,
-              doInline: Boolean)(
+              doInline: Boolean,
+              retTy: Type)(
       implicit originDefnPos: nir.Position
   ): Seq[MergeBlock] = {
     val processor =
@@ -123,6 +125,6 @@ trait Opt { self: Interflow =>
       popMergeProcessor()
     }
 
-    processor.toSeq()
+    processor.toSeq(retTy)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -118,13 +118,7 @@ trait PolyInline { self: Interflow =>
         emit.jump(Next.Label(mergeLabel, Seq(res)))
     }
 
-    // !!! CAUTION: j.l.Object is provided here as the most generic upper bound type.
-    // !!! In case `tys` have more than one common super-type and a type which is more
-    // !!! specific than j.l.Object is expected as the return type, then Sub.lub may
-    // !!! calculate the wrong type.
-    val result = Val.Local(
-      fresh(),
-      Sub.lub(rettys, Type.Ref(Global.Top("java.lang.Object"))))
+    val result = Val.Local(fresh(), Sub.lub(rettys, Some(op.resty)))
     emit.label(mergeLabel, Seq(result))
 
     result

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -88,7 +88,7 @@ final class Trait(val attrs: Attrs, val name: Global, val traits: Seq[Trait])(
         case info: Trait =>
           info.subtraits.contains(this)
         case _ =>
-          false
+          info.name == Rt.Object.name
       }
     }
   }

--- a/tools/src/main/scala/scala/scalanative/linker/Sub.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Sub.scala
@@ -61,7 +61,8 @@ object Sub {
     }
   }
 
-  def lub(tys: Seq[Type], bound: Type)(implicit linked: linker.Result): Type = {
+  def lub(tys: Seq[Type], bound: Option[Type] = None)(
+      implicit linked: linker.Result): Type = {
     tys match {
       case Seq() =>
         unreachable
@@ -70,7 +71,7 @@ object Sub {
     }
   }
 
-  def lub(lty: Type, rty: Type, bound: Type)(
+  def lub(lty: Type, rty: Type, bound: Option[Type])(
       implicit linked: linker.Result): Type = {
     (lty, rty) match {
       case _ if lty == rty =>
@@ -90,7 +91,7 @@ object Sub {
       case (lty: Type.RefKind, rty: Type.RefKind) =>
         val ScopeRef(linfo) = lty
         val ScopeRef(rinfo) = rty
-        val ScopeRef(binfo) = bound
+        val binfo           = bound.flatMap(ScopeRef.unapply)
         val lubinfo         = lub(linfo, rinfo, binfo)
         val exact =
           lubinfo.name == rinfo.name && rty.isExact &&
@@ -103,7 +104,7 @@ object Sub {
     }
   }
 
-  def lub(linfo: ScopeInfo, rinfo: ScopeInfo, boundInfo: ScopeInfo)(
+  def lub(linfo: ScopeInfo, rinfo: ScopeInfo, boundInfo: Option[ScopeInfo])(
       implicit linked: linker.Result): ScopeInfo = {
     if (linfo == rinfo) {
       linfo
@@ -113,7 +114,7 @@ object Sub {
       linfo
     } else {
       val candidates =
-        linfo.linearized.filter(i => rinfo.is(i) && i.is(boundInfo))
+        linfo.linearized.filter { i => rinfo.is(i) && boundInfo.forall(i.is) }
 
       candidates match {
         case Seq() =>

--- a/tools/src/main/scala/scala/scalanative/linker/Sub.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Sub.scala
@@ -61,7 +61,7 @@ object Sub {
     }
   }
 
-  def lub(tys: Seq[Type], bound: Option[Type] = None)(
+  def lub(tys: Seq[Type], bound: Option[Type])(
       implicit linked: linker.Result): Type = {
     tys match {
       case Seq() =>


### PR DESCRIPTION
Resolves #1976 
As described in the linked issue SN was crashing in tests when releaseFull mode was used. 
The combination of this PR and #1979 allows fixing this problem.
One of the root problems was the wrong calculation of the expected type when using Sub.lub methods. This PR allows passing bound as an optional argument to the mentioned method. Also in most of the usages of this method, we make sure to pass bound type basing on the current context. 

To be noted, in one of the recent tests I've discovered that the current Xmx setting of 5G is not sufficient in release full mode - it throws OutOfMemoryError when dumping lowered Defns (the content of all methods is stored in memory, sorted, and then written to file). It's recommended to disable the default nativeDump setting in `MyScalaNativePlugin` or increase Xmx (build passed with Xmx 15G, not tested with the lower value). This problem <del>should be addressed in later PR.</del> was fixed in #1982 

Interflow optimization in release full mode took for unit-tests took 51 minutes. Additional ~30 minutes are needed for compilation using clang. 
