### PR TITLE
Lower memory usage in dump stage

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -54,7 +54,7 @@ object Show {
     def dumpChunk(range: Range, chunkId: Int) = Future {
       write(Paths.get(s"$id-$chunkId.hnir")) { writer =>
         new NirShowBuilder(new FileShowBuilder(writer))
-          .defns_(sortedDefnsView.slice(range.start, range.last))
+          .defns_(sortedDefnsView.slice(range.start, range.last + 1))
       }.toAbsolutePath
     }
 

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -11,30 +11,29 @@ import scala.scalanative.util.{ShowBuilder, splitRange, unreachable}
 
 object Show {
   def newBuilder: NirShowBuilder = new NirShowBuilder(new InMemoryShowBuilder)
+  private def withInMemoryBuilder(fn: NirShowBuilder => Unit): String = {
+    val b = newBuilder; fn(b); b.toString
+  }
   def debug[T](msg: String)(f: => T): T = {
     val value = f
     println("$msg: " + value)
     value
   }
 
-  def apply(v: Attr): String  = { val b = newBuilder; b.attr_(v); b.toString }
-  def apply(v: Attrs): String = { val b = newBuilder; b.attrs_(v); b.toString }
-  def apply(v: Bin): String   = { val b = newBuilder; b.bin_(v); b.toString }
-  def apply(v: Comp): String  = { val b = newBuilder; b.comp_(v); b.toString }
-  def apply(v: Conv): String  = { val b = newBuilder; b.conv_(v); b.toString }
-  def apply(v: Defn): String  = { val b = newBuilder; b.defn_(v); b.toString }
-  def apply(v: Global): String = {
-    val b = newBuilder; b.global_(v); b.toString
-  }
-  def apply(v: Sig): String = {
-    val b = newBuilder; b.sig_(v); b.toString
-  }
-  def apply(v: Inst): String  = { val b = newBuilder; b.inst_(v); b.toString }
-  def apply(v: Local): String = { val b = newBuilder; b.local_(v); b.toString }
-  def apply(v: Next): String  = { val b = newBuilder; b.next_(v); b.toString }
-  def apply(v: Op): String    = { val b = newBuilder; b.op_(v); b.toString }
-  def apply(v: Type): String  = { val b = newBuilder; b.type_(v); b.toString }
-  def apply(v: Val): String   = { val b = newBuilder; b.val_(v); b.toString }
+  def apply(v: Attr): String   = withInMemoryBuilder(_.attr_(v))
+  def apply(v: Attrs): String  = withInMemoryBuilder(_.attrs_(v))
+  def apply(v: Bin): String    = withInMemoryBuilder(_.bin_(v))
+  def apply(v: Comp): String   = withInMemoryBuilder(_.comp_(v))
+  def apply(v: Conv): String   = withInMemoryBuilder(_.conv_(v))
+  def apply(v: Defn): String   = withInMemoryBuilder(_.defn_(v))
+  def apply(v: Global): String = withInMemoryBuilder(_.global_(v))
+  def apply(v: Sig): String    = withInMemoryBuilder(_.sig_(v))
+  def apply(v: Inst): String   = withInMemoryBuilder(_.inst_(v))
+  def apply(v: Local): String  = withInMemoryBuilder(_.local_(v))
+  def apply(v: Next): String   = withInMemoryBuilder(_.next_(v))
+  def apply(v: Op): String     = withInMemoryBuilder(_.op_(v))
+  def apply(v: Type): String   = withInMemoryBuilder(_.type_(v))
+  def apply(v: Val): String    = withInMemoryBuilder(_.val_(v))
 
   def dump(defns: Seq[Defn], id: String, dir: VirtualDirectory): Unit = {
     import ExecutionContext.Implicits.global

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -35,7 +35,9 @@ object Show {
   def apply(v: Type): String   = withInMemoryBuilder(_.type_(v))
   def apply(v: Val): String    = withInMemoryBuilder(_.val_(v))
 
-  def dump(defns: Seq[Defn], id: String, dir: VirtualDirectory): Unit = {
+  def dumpAsync(defns: Seq[Defn],
+                id: String,
+                dir: VirtualDirectory): Future[Unit] = {
     import ExecutionContext.Implicits.global
     import dir.{merge, write}
 

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -48,9 +48,10 @@ object Show {
     import ExecutionContext.Implicits.global
     import dir.{merge, write}
 
-    val sortedDefnsView = defns.view
+    val sortedDefnsView = defns
       .filter(_ != null)
       .sortBy(_.name)
+      .view
 
     def dumpChunk(range: Range, chunkId: Int) = Future {
       write(Paths.get(s"$id-$chunkId.hnir")) { writer =>

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -35,6 +35,12 @@ object Show {
   def apply(v: Type): String   = withInMemoryBuilder(_.type_(v))
   def apply(v: Val): String    = withInMemoryBuilder(_.val_(v))
 
+  def dump(defns: Seq[Defn], id: String, dir: VirtualDirectory): Unit = {
+    import scala.concurrent.Await
+    import scala.concurrent.duration._
+    Await.ready(dumpAsync(defns, id, dir), 5.minutes)
+  }
+
   def dumpAsync(defns: Seq[Defn],
                 id: String,
                 dir: VirtualDirectory): Future[Unit] = {

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -153,7 +153,7 @@ private[scalanative] object ScalaNative {
   def dumpDefns(config: Config, phase: String, defns: Seq[Defn]): Unit = {
     if (config.dump) {
       config.logger.time(s"Dumping intermediate code ($phase)") {
-        nir.Show.dump(defns, phase, VirtualDirectory.local(config.workdir))
+        nir.Show.dumpAsync(defns, phase, VirtualDirectory.local(config.workdir))
       }
     }
   }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -153,7 +153,7 @@ private[scalanative] object ScalaNative {
   def dumpDefns(config: Config, phase: String, defns: Seq[Defn]): Unit = {
     if (config.dump) {
       config.logger.time(s"Dumping intermediate code ($phase)") {
-        nir.Show.dumpAsync(defns, phase, VirtualDirectory.local(config.workdir))
+        nir.Show.dump(defns, phase, VirtualDirectory.local(config.workdir))
       }
     }
   }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -8,6 +8,7 @@ import scala.scalanative.codegen.CodeGen
 import scala.scalanative.linker.Link
 import scala.scalanative.nir._
 import scala.scalanative.util.Scope
+import scala.scalanative.io.VirtualDirectory
 
 /** Internal utilities to instrument Scala Native linker, optimizer and codegen. */
 private[scalanative] object ScalaNative {
@@ -152,8 +153,7 @@ private[scalanative] object ScalaNative {
   def dumpDefns(config: Config, phase: String, defns: Seq[Defn]): Unit = {
     if (config.dump) {
       config.logger.time(s"Dumping intermediate code ($phase)") {
-        val path = config.workdir.resolve(phase + ".hnir")
-        nir.Show.dump(defns, path.toFile.getAbsolutePath)
+        nir.Show.dump(defns, phase, VirtualDirectory.local(config.workdir))
       }
     }
   }

--- a/util/src/main/scala/scala/scalanative/util/ShowBuilder.scala
+++ b/util/src/main/scala/scala/scalanative/util/ShowBuilder.scala
@@ -44,5 +44,17 @@ object ShowBuilder {
   }
 
   final class FileShowBuilder(protected val out: java.io.Writer)
-      extends ShowBuilder
+      extends ShowBuilder {
+    override def str(value: Any): Unit = {
+      val body = value.toString
+      out.append {
+        /* Writer may have problems with strings containing surrogate pairs and throw exception,
+         * but such cases may be observed only when dumping linked and optimized defns.
+         * In lowered code strings are already transformed into array[byte] and effectively into safe string
+         */
+        if (!body.exists(_.isSurrogate)) body
+        else body.filterNot(_.isSurrogate)
+      }
+    }
+  }
 }

--- a/util/src/main/scala/scala/scalanative/util/ShowBuilder.scala
+++ b/util/src/main/scala/scala/scalanative/util/ShowBuilder.scala
@@ -45,16 +45,6 @@ object ShowBuilder {
 
   final class FileShowBuilder(protected val out: java.io.Writer)
       extends ShowBuilder {
-    override def str(value: Any): Unit = {
-      val body = value.toString
-      out.append {
-        /* Writer may have problems with strings containing surrogate pairs and throw exception,
-         * but such cases may be observed only when dumping linked and optimized defns.
-         * In lowered code strings are already transformed into array[byte] and effectively into safe string
-         */
-        if (!body.exists(_.isSurrogate)) body
-        else body.filterNot(_.isSurrogate)
-      }
-    }
+    override def str(value: Any): Unit = out.append(value.toString)
   }
 }

--- a/util/src/main/scala/scala/scalanative/util/package.scala
+++ b/util/src/main/scala/scala/scalanative/util/package.scala
@@ -52,4 +52,15 @@ package object util {
   def partitionBy[T](elems: Seq[T], batches: Int)(
       f: T => Any): Map[Int, Seq[T]] =
     elems.groupBy { elem => Math.abs(f(elem).##) % batches }
+
+  def splitRange(r: Range, chunks: Int): Seq[Range] = {
+    val nchunks   = chunks max 1
+    val chunkSize = (r.length / nchunks) max 1
+    val starts    = r.by(chunkSize).take(nchunks)
+    val ends      = starts.map(_ - 1).drop(1) :+ r.end
+    starts.zip(ends).map {
+      case (start, end) if r.isInclusive => start to end
+      case (start, end)                  => start until end
+    }
+  }
 }

--- a/util/src/main/scala/scala/scalanative/util/package.scala
+++ b/util/src/main/scala/scala/scalanative/util/package.scala
@@ -58,9 +58,19 @@ package object util {
     val chunkSize = (r.length / nchunks) max 1
     val starts    = r.by(chunkSize).take(nchunks)
     val ends      = starts.map(_ - 1).drop(1) :+ r.end
-    starts.zip(ends).map {
-      case (start, end) if r.isInclusive => start to end
-      case (start, end)                  => start until end
+
+    def buildRange(rangePair: (Int, Int),
+                   checkExclusive: Boolean = true): Range = {
+      val (start, end) = rangePair
+      if (checkExclusive && !r.isInclusive) start until end
+      else start to end
+    }
+
+    starts.zip(ends) match {
+      case Seq(range) => buildRange(range) :: Nil
+      case init :+ last =>
+        init.map(buildRange(_, checkExclusive = false)) :+ buildRange(last)
+      case _ => unsupported("no range defined")
     }
   }
 }


### PR DESCRIPTION
As mentioned in #1980 one of the remaining problems with a release full mode was failing while dumping lowered defns. 
This PR resolves the problem with dumping large `.hnir` files by writing directly chunked defns to separate files and merging them. 
