### PR TITLE
Fix #1711: Ignore non-jar non-directory elements on the classpath

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -117,11 +117,9 @@ object ScalaNativePluginInternal {
         val mainClass = selectMainClass.value.getOrElse {
           throw new MessageOnlyException("No main class detected.")
         }
-        val classpath = fullClasspath.value
-          .map(_.data.toPath)
-          .filter(f => Files.exists(f))
-        val maincls = mainClass + "$"
-        val cwd     = nativeWorkdir.value.toPath
+        val classpath = fullClasspath.value.map(_.data.toPath)
+        val maincls   = mainClass + "$"
+        val cwd       = nativeWorkdir.value.toPath
 
         val logger = streams.value.log.toLogger
         build.Config.empty

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -52,26 +52,28 @@ object Build {
    *  @return `outpath`, the path to the resulting native binary.
    */
   def build(config: Config, outpath: Path): Path = config.logger.time("Total") {
-    val workdir = config.workdir
-    val entries = ScalaNative.entries(config)
-    val linked  = ScalaNative.link(config, entries)
-    ScalaNative.logLinked(config, linked)
-    val optimized = ScalaNative.optimize(config, linked)
+    val fclasspath = NativeLib.filterClasspath(config.classPath)
+    val fconfig = config.withClassPath(fclasspath)
+    val workdir = fconfig.workdir
+    val entries = ScalaNative.entries(fconfig)
+    val linked  = ScalaNative.link(fconfig, entries)
+    ScalaNative.logLinked(fconfig, linked)
+    val optimized = ScalaNative.optimize(fconfig, linked)
 
     IO.getAll(workdir, "glob:**.ll").foreach(Files.delete)
-    ScalaNative.codegen(config, optimized)
+    ScalaNative.codegen(fconfig, optimized)
     val generated = IO.getAll(workdir, "glob:**.ll")
 
-    val nativelibs   = NativeLib.findNativeLibs(config.classPath, workdir)
+    val nativelibs   = NativeLib.findNativeLibs(fconfig.classPath, workdir)
     val nativelib    = NativeLib.findNativeLib(nativelibs)
     val unpackedLibs = nativelibs.map(LLVM.unpackNativeCode(_))
 
     val objectFiles = config.logger.time("Compiling to native code") {
       val nativelibConfig =
-        config.withCompilerConfig(
-          _.withCompileOptions("-O2" +: config.compileOptions))
+        fconfig.withCompilerConfig(
+          _.withCompileOptions("-O2" +: fconfig.compileOptions))
       LLVM.compileNativelibs(nativelibConfig, linked, unpackedLibs, nativelib)
-      LLVM.compile(config, generated)
+      LLVM.compile(fconfig, generated)
     }
 
     LLVM.link(config, linked, objectFiles, unpackedLibs, outpath)

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -53,7 +53,8 @@ object Build {
    */
   def build(config: Config, outpath: Path): Path = config.logger.time("Total") {
     val fclasspath = NativeLib.filterClasspath(config.classPath)
-    val fconfig = config.withClassPath(fclasspath)
+    val fconfig    = config.withClassPath(fclasspath)
+
     val workdir = fconfig.workdir
     val entries = ScalaNative.entries(fconfig)
     val linked  = ScalaNative.link(fconfig, entries)

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -161,7 +161,7 @@ private[scalanative] object NativeLib {
    * to empty directories in the classpath or anything other
    * than a jar file.
    *
-   * Issues #911:
+   * Issue #911:
    * Linking fails in a pure testing project with source only
    * in src/test/scala.
    *

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package build
 
 import java.io.File
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 import java.util.regex._
 
 /** Original jar or dir path and generated dir path for native code */
@@ -155,6 +155,26 @@ private[scalanative] object NativeLib {
           s"Native Library 'nativelib' not found: $nativeLibs")
     }
   }
+
+  /**
+   * The linker uses the VirtualDirectory which is sensitive
+   * to empty directories in the classpath or anything other
+   * than a jar file.
+   *
+   * Issues #911:
+   * Linking fails in a pure testing project with source only
+   * in src/test/scala.
+   *
+   * Issue #1711:
+   * Files put in the lib directory in sbt such as somelib.so will end up
+   * on the classpath. Linking fails if the entries on the classpath are
+   * not either jars or directories.
+   *
+   * @param classpath - build tool classpath
+   * @return filtered classpath for Scala Native tools
+   */
+  def filterClasspath(classpath: Seq[Path]): Seq[Path] =
+    classpath.filter(p => Files.exists(p) && (isJar(p) || Files.isDirectory(p)))
 
   private val jarPattern = Pattern.compile(jarSrcRegex)
 


### PR DESCRIPTION
We could consider allowing the build to include external libraries to link in the future.

This fix avoids passing non-jar files in the classpath into the build interior.

It centralizes the classpath filters into one location making it easier to maintain but also moving it out of the plugin and into tools. Moving it out of the plugin means that tool integrators just pass the classpath and it is up to Scala Native to do sanity checks to avoid breaking the build. There was a previous filter for Issue #911 which was moved from the plugin. 

This was tested both for the `.so` file in the _sbt_ `lib` directory and the no files in main for the previous issue.