### PR TITLE
Remove usages of scala.collection.JavaConverters

### DIFF
--- a/junit-test/output-jvm/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
+++ b/junit-test/output-jvm/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
@@ -31,11 +31,11 @@ object JUnitTestPlatformImpl {
   }
 
   def readLines(file: String): List[String] = {
-    val buf = new UnrolledBuffer[String]()
-    val it  = Files.readAllLines(Paths.get(file), UTF_8).iterator()
+    val builder = List.newBuilder[String]
+    val it      = Files.readAllLines(Paths.get(file), UTF_8).iterator()
     while (it.hasNext) {
-      buf += it.next()
+      builder += it.next()
     }
-    buf.toList
+    builder.result()
   }
 }

--- a/junit-test/output-jvm/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
+++ b/junit-test/output-jvm/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
@@ -7,7 +7,6 @@ import java.nio.file._
 import java.util.LinkedList
 import sbt.testing._
 import scala.annotation.tailrec
-import scala.collection.mutable.UnrolledBuffer
 import scala.concurrent.Future
 
 object JUnitTestPlatformImpl {

--- a/junit-test/output-jvm/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
+++ b/junit-test/output-jvm/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
@@ -4,11 +4,10 @@ package scala.scalanative.junit.utils
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file._
-
+import java.util.LinkedList
 import sbt.testing._
-
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.collection.mutable.UnrolledBuffer
 import scala.concurrent.Future
 
 object JUnitTestPlatformImpl {
@@ -25,9 +24,18 @@ object JUnitTestPlatformImpl {
     }
   }
 
-  def writeLines(lines: List[String], file: String): Unit =
-    Files.write(Paths.get(file), lines.asJava, UTF_8)
+  def writeLines(lines: List[String], file: String): Unit = {
+    val jLines = new LinkedList[String]()
+    lines.foreach(jLines.add)
+    Files.write(Paths.get(file), jLines, UTF_8)
+  }
 
-  def readLines(file: String): List[String] =
-    Files.readAllLines(Paths.get(file), UTF_8).asScala.toList
+  def readLines(file: String): List[String] = {
+    val buf = new UnrolledBuffer[String]()
+    val it  = Files.readAllLines(Paths.get(file), UTF_8).iterator()
+    while (it.hasNext) {
+      buf += it.next()
+    }
+    buf.toList
+  }
 }

--- a/junit-test/output-native/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
+++ b/junit-test/output-native/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
@@ -4,10 +4,10 @@ package scala.scalanative.junit.utils
 
 import java.nio.file.{Files, Paths}
 import java.nio.charset.StandardCharsets.UTF_8
+import java.util.LinkedList
 
 import sbt.testing._
-
-import scala.collection.JavaConverters._
+import scala.collection.mutable.UnrolledBuffer
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -34,9 +34,18 @@ object JUnitTestPlatformImpl {
     p.future
   }
 
-  def writeLines(lines: List[String], file: String): Unit =
-    Files.write(Paths.get(file), lines.asJava, UTF_8)
+  def writeLines(lines: List[String], file: String): Unit = {
+    val jLines = new LinkedList[String]()
+    lines.foreach(jLines.add)
+    Files.write(Paths.get(file), jLines, UTF_8)
+  }
 
-  def readLines(file: String): List[String] =
-    Files.readAllLines(Paths.get(file), UTF_8).asScala.toList
+  def readLines(file: String): List[String] = {
+    val buf = new UnrolledBuffer[String]()
+    val it  = Files.readAllLines(Paths.get(file), UTF_8).iterator()
+    while (it.hasNext) {
+      buf += it.next()
+    }
+    buf.toList
+  }
 }

--- a/junit-test/output-native/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
+++ b/junit-test/output-native/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
@@ -41,11 +41,11 @@ object JUnitTestPlatformImpl {
   }
 
   def readLines(file: String): List[String] = {
-    val buf = new UnrolledBuffer[String]()
-    val it  = Files.readAllLines(Paths.get(file), UTF_8).iterator()
+    val builder = List.newBuilder[String]
+    val it      = Files.readAllLines(Paths.get(file), UTF_8).iterator()
     while (it.hasNext) {
-      buf += it.next()
+      builder += it.next()
     }
-    buf.toList
+    builder.result()
   }
 }

--- a/junit-test/output-native/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
+++ b/junit-test/output-native/src/test/scala/scala/scalanative/junit/utils/JUnitTestPlatformImpl.scala
@@ -7,7 +7,6 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.util.LinkedList
 
 import sbt.testing._
-import scala.collection.mutable.UnrolledBuffer
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/unit-tests/src/main/scala/scala/scalanative/compat/CollectionConverters.scala
+++ b/unit-tests/src/main/scala/scala/scalanative/compat/CollectionConverters.scala
@@ -1,0 +1,61 @@
+package scala.scalanative.compat
+
+import java.util.{LinkedHashMap, LinkedHashSet, LinkedList}
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+/** Set of helper method replacing problematic Scala collection.JavaConverters as they cause problems
+ * in cross compile between 2.13+ and older Scala versions */
+object CollectionConverters {
+  implicit class ScalaToJavaCollections[T: ClassTag](
+      private val self: Iterable[T]) {
+    def toJavaList: LinkedList[T] = {
+      val list = new LinkedList[T]()
+      self.foreach(list.add)
+      list
+    }
+
+    def toJavaSet: java.util.Set[T] = {
+      val s = new LinkedHashSet[T]()
+      self.foreach(s.add)
+      s
+    }
+
+    def toJavaMap[K, V](implicit ev: T =:= (K, V)): java.util.Map[K, V] = {
+      val m = new LinkedHashMap[K, V]()
+      self.iterator.asInstanceOf[Iterator[(K, V)]].foreach {
+        case (k, v) => m.put(k, v)
+      }
+      m
+    }
+  }
+
+  implicit class JavaToScalaCollections[T: ClassTag](
+      private val self: java.util.Collection[T]) {
+    private def buf        = self.iterator().toScalaSeq
+    def toScalaSeq: Seq[T] = buf.toSeq
+    def toScalaMap[K: ClassTag, V: ClassTag](
+        implicit ev: T =:= java.util.Map.Entry[K, V]): mutable.Map[K, V] = {
+      val map = mutable.Map.empty[K, V]
+      self
+        .iterator()
+        .asInstanceOf[Iterator[java.util.Map.Entry[K, V]]]
+        .foreach { v => map.put(v.getKey(), v.getValue()) }
+      map
+    }
+    def toScalaSet: Set[T] = self.iterator().toScalaSet
+  }
+
+  implicit class JavaIteratorToScala[T: ClassTag](
+      private val self: java.util.Iterator[T]) {
+    val toScalaSeq: mutable.UnrolledBuffer[T] = {
+      val b = new mutable.UnrolledBuffer[T]()
+      while (self.hasNext) {
+        b += self.next()
+      }
+      b
+    }
+    def toScalaSet: Set[T] = toScalaSeq.toSet
+  }
+
+}

--- a/unit-tests/src/test/scala/java/nio/file/FilesTest.scala
+++ b/unit-tests/src/test/scala/java/nio/file/FilesTest.scala
@@ -5,7 +5,6 @@ import java.io._
 import java.nio.file.attribute._
 
 import java.util.function.BiPredicate
-import scala.collection.JavaConverters._
 import PosixFilePermission._
 import StandardCopyOption._
 
@@ -13,6 +12,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scalanative.junit.utils.AssertThrows._
+import scala.scalanative.compat.CollectionConverters._
 
 class FilesTest {
   import FilesTest._
@@ -181,7 +181,7 @@ class FilesTest {
       val foo = dirFile.toPath.resolve("foo")
       Files.createFile(foo)
       Files.write(foo, "foo".getBytes)
-      val permissions = Set(OWNER_EXECUTE, OWNER_READ, OWNER_WRITE).asJava
+      val permissions = Set(OWNER_EXECUTE, OWNER_READ, OWNER_WRITE).toJavaSet
       Files.setPosixFilePermissions(foo, permissions)
       val fooCopy = dirFile.toPath.resolve("foocopy")
       Files.copy(foo, fooCopy, COPY_ATTRIBUTES)
@@ -191,7 +191,8 @@ class FilesTest {
       assertTrue(attrs.lastModifiedTime == copyAttrs.lastModifiedTime)
       assertTrue(attrs.lastAccessTime == copyAttrs.lastAccessTime)
       assertTrue(attrs.creationTime == copyAttrs.creationTime)
-      assertTrue(attrs.permissions.asScala == copyAttrs.permissions.asScala)
+      assertTrue(
+        attrs.permissions.toScalaSet == copyAttrs.permissions.toScalaSet)
     }
   }
 
@@ -915,7 +916,7 @@ class FilesTest {
       // Follow the broken link; expect a NoSuchFileException to be thrown.
 
       assertThrows(classOf[NoSuchFileException], {
-        val fvoSet = Set(FileVisitOption.FOLLOW_LINKS).asJava
+        val fvoSet = Set(FileVisitOption.FOLLOW_LINKS).toJavaSet
         Files.walkFileTree(dirPath, fvoSet, Int.MaxValue, visitor)
       })
     }
@@ -1261,7 +1262,7 @@ class FilesTest {
 
       val newF0 = target.resolve("f0")
       assertTrue(Files.exists(newF0))
-      assertTrue(Files.lines(newF0).iterator.asScala.mkString == "foo")
+      assertTrue(Files.lines(newF0).iterator().toScalaSeq.mkString == "foo")
     }
   }
   @Test def filesMoveDirectory(): Unit = {

--- a/unit-tests/src/test/scala/java/nio/file/FilesTest.scala
+++ b/unit-tests/src/test/scala/java/nio/file/FilesTest.scala
@@ -12,7 +12,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scalanative.junit.utils.AssertThrows._
-import scala.scalanative.compat.CollectionConverters._
+import scala.scalanative.junit.utils.CollectionConverters._
 
 class FilesTest {
   import FilesTest._

--- a/unit-tests/src/test/scala/java/nio/file/attribute/PosixFilePermissionsTest.scala
+++ b/unit-tests/src/test/scala/java/nio/file/attribute/PosixFilePermissionsTest.scala
@@ -1,9 +1,7 @@
 package java.nio.file.attribute
 
-import scala.collection.JavaConverters._
-
 import PosixFilePermission._
-
+import scala.scalanative.compat.CollectionConverters._
 import org.junit.Test
 import org.junit.Assert._
 
@@ -12,106 +10,113 @@ class PosixFilePermissionsTest {
   @Test def anEmptyPermissionsSetProducesTheRightString(): Unit = {
     assertTrue(
       PosixFilePermissions
-        .toString(Set.empty[PosixFilePermission].asJava) == "---------")
+        .toString(Set.empty[PosixFilePermission].toJavaSet) == "---------")
   }
 
   @Test def justOwnerReadPermissionProducesTheRightString(): Unit = {
     assertTrue(
-      PosixFilePermissions.toString(Set(OWNER_READ).asJava) == "r--------")
+      PosixFilePermissions.toString(Set(OWNER_READ).toJavaSet) == "r--------")
   }
 
   @Test def justOwnerWritePermissionProducesTheRightString(): Unit = {
     assertTrue(
-      PosixFilePermissions.toString(Set(OWNER_WRITE).asJava) == "-w-------")
+      PosixFilePermissions.toString(Set(OWNER_WRITE).toJavaSet) == "-w-------")
   }
 
   @Test def justOwnerExecutepermissionProducesTheRightString(): Unit = {
     assertTrue(
-      PosixFilePermissions.toString(Set(OWNER_EXECUTE).asJava) == "--x------")
+      PosixFilePermissions
+        .toString(Set(OWNER_EXECUTE).toJavaSet) == "--x------")
   }
 
   @Test def justGroupReadpermissionProducesTheRightString(): Unit = {
     assertTrue(
-      PosixFilePermissions.toString(Set(GROUP_READ).asJava) == "---r-----")
+      PosixFilePermissions.toString(Set(GROUP_READ).toJavaSet) == "---r-----")
   }
 
   @Test def justGroupWritepermissionProducesTheRightString(): Unit = {
     assertTrue(
-      PosixFilePermissions.toString(Set(GROUP_WRITE).asJava) == "----w----")
+      PosixFilePermissions.toString(Set(GROUP_WRITE).toJavaSet) == "----w----")
   }
 
   @Test def justGroupExecutepermissionProducesTheRightString(): Unit = {
     assertTrue(
-      PosixFilePermissions.toString(Set(GROUP_EXECUTE).asJava) == "-----x---")
+      PosixFilePermissions
+        .toString(Set(GROUP_EXECUTE).toJavaSet) == "-----x---")
   }
 
   @Test def justOthersReadpermissionProducesTheRightString(): Unit = {
     assertTrue(
-      PosixFilePermissions.toString(Set(OTHERS_READ).asJava) == "------r--")
+      PosixFilePermissions.toString(Set(OTHERS_READ).toJavaSet) == "------r--")
   }
 
   @Test def justOthersWritepermissionProducesTheRightString(): Unit = {
     assertTrue(
-      PosixFilePermissions.toString(Set(OTHERS_WRITE).asJava) == "-------w-")
+      PosixFilePermissions.toString(Set(OTHERS_WRITE).toJavaSet) == "-------w-")
   }
 
   @Test def justOthersExecutepermissionProducesTheRightString(): Unit = {
     assertTrue(
-      PosixFilePermissions.toString(Set(OTHERS_EXECUTE).asJava) == "--------x")
+      PosixFilePermissions
+        .toString(Set(OTHERS_EXECUTE).toJavaSet) == "--------x")
   }
 
   @Test def parsingTheEmptyPermissionsGivesAnEmptySet(): Unit = {
     assertTrue(
       PosixFilePermissions
-        .fromString("---------") == Set.empty[PosixFilePermission].asJava)
+        .fromString("---------") == Set.empty[PosixFilePermission].toJavaSet)
   }
 
   @Test def parsingOwnerReadpermissionProducesTheRightPermissions(): Unit = {
     assertTrue(
-      PosixFilePermissions.fromString("r--------") == Set(OWNER_READ).asJava)
+      PosixFilePermissions.fromString("r--------") == Set(OWNER_READ).toJavaSet)
   }
 
   @Test def parsingOwnerWritepermissionProducesTheRightPermissions(): Unit = {
     assertTrue(
-      PosixFilePermissions.fromString("-w-------") == Set(OWNER_WRITE).asJava)
+      PosixFilePermissions
+        .fromString("-w-------") == Set(OWNER_WRITE).toJavaSet)
   }
 
   @Test def parsingOwnerExecutepermissionProducesTheRightPermissions(): Unit = {
     assertTrue(
       PosixFilePermissions
-        .fromString("--x------") == Set(OWNER_EXECUTE).asJava)
+        .fromString("--x------") == Set(OWNER_EXECUTE).toJavaSet)
   }
 
   @Test def parsingGroupReadpermissionProducesTheRightPermissions(): Unit = {
     assertTrue(
-      PosixFilePermissions.fromString("---r-----") == Set(GROUP_READ).asJava)
+      PosixFilePermissions.fromString("---r-----") == Set(GROUP_READ).toJavaSet)
   }
 
   @Test def parsingGroupWritepermissionProducesTheRightPermissions(): Unit = {
     assertTrue(
-      PosixFilePermissions.fromString("----w----") == Set(GROUP_WRITE).asJava)
+      PosixFilePermissions
+        .fromString("----w----") == Set(GROUP_WRITE).toJavaSet)
   }
 
   @Test def parsingGroupExecutepermissionProducesTheRightPermissions(): Unit = {
     assertTrue(
       PosixFilePermissions
-        .fromString("-----x---") == Set(GROUP_EXECUTE).asJava)
+        .fromString("-----x---") == Set(GROUP_EXECUTE).toJavaSet)
   }
 
   @Test def parsingOthersReadpermissionProducesTheRightPermissions(): Unit = {
     assertTrue(
-      PosixFilePermissions.fromString("------r--") == Set(OTHERS_READ).asJava)
+      PosixFilePermissions
+        .fromString("------r--") == Set(OTHERS_READ).toJavaSet)
   }
 
   @Test def parsingOthersWritepermissionProducesTheRightPermissions(): Unit = {
     assertTrue(
-      PosixFilePermissions.fromString("-------w-") == Set(OTHERS_WRITE).asJava)
+      PosixFilePermissions
+        .fromString("-------w-") == Set(OTHERS_WRITE).toJavaSet)
   }
 
   @Test def parsingOthersExecutepermissionProducesTheRightPermissions()
       : Unit = {
     assertTrue(
       PosixFilePermissions
-        .fromString("--------x") == Set(OTHERS_EXECUTE).asJava)
+        .fromString("--------x") == Set(OTHERS_EXECUTE).toJavaSet)
   }
 }

--- a/unit-tests/src/test/scala/java/nio/file/attribute/PosixFilePermissionsTest.scala
+++ b/unit-tests/src/test/scala/java/nio/file/attribute/PosixFilePermissionsTest.scala
@@ -1,7 +1,7 @@
 package java.nio.file.attribute
 
 import PosixFilePermission._
-import scala.scalanative.compat.CollectionConverters._
+import scala.scalanative.junit.utils.CollectionConverters._
 import org.junit.Test
 import org.junit.Assert._
 

--- a/unit-tests/src/test/scala/java/util/ArrayDequeTest.scala
+++ b/unit-tests/src/test/scala/java/util/ArrayDequeTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.scalanative.junit.utils.AssertThrows._
-import scala.scalanative.compat.CollectionConverters._
+import scala.scalanative.junit.utils.CollectionConverters._
 
 class ArrayDequeTest {
 

--- a/unit-tests/src/test/scala/java/util/ArrayDequeTest.scala
+++ b/unit-tests/src/test/scala/java/util/ArrayDequeTest.scala
@@ -1,12 +1,11 @@
 package java.util
 
-import scala.collection.JavaConverters._
-
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
 
 import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.compat.CollectionConverters._
 
 class ArrayDequeTest {
 
@@ -68,7 +67,7 @@ class ArrayDequeTest {
   @Test def constructorCollectionInteger(): Unit = {
     // for AnyVal
     val is = Seq(1, 2, 3)
-    val ad = new ArrayDeque(is.asJava)
+    val ad = new ArrayDeque(is.toJavaList)
     assertTrue("a1", ad.size() == 3)
     assertFalse("a2", ad.isEmpty())
 
@@ -81,8 +80,7 @@ class ArrayDequeTest {
   @Test def constructorCollectionString(): Unit = {
     // for AnyRef
     val is = Seq(1, 2, 3).map(_.toString)
-    import scala.collection.JavaConverters._
-    val ad = new ArrayDeque(is.asJava)
+    val ad = new ArrayDeque(is.toJavaList)
     assertTrue("a1", ad.size() == 3)
     assertFalse("a2", ad.isEmpty())
 
@@ -164,7 +162,7 @@ class ArrayDequeTest {
   }
 
   @Test def clear(): Unit = {
-    val ad1 = new ArrayDeque(Seq(1, 2, 3, 2).asJava)
+    val ad1 = new ArrayDeque(Seq(1, 2, 3, 2).toJavaList)
     ad1.clear()
     assertTrue(ad1.isEmpty())
     // makes sure that clear()ing an already empty list is safe.
@@ -172,7 +170,7 @@ class ArrayDequeTest {
   }
 
   @Test def testClone(): Unit = {
-    val ad1 = new ArrayDeque(Seq(1, 2, 3, 2).asJava)
+    val ad1 = new ArrayDeque(Seq(1, 2, 3, 2).toJavaList)
     val ad2 = ad1.clone()
 
     val element = 1
@@ -189,7 +187,7 @@ class ArrayDequeTest {
   @Test def containsAny(): Unit = {
     val needle = Math.PI
     val is     = Seq(1.1, 2.2, 3.3, needle, 4.0)
-    val ad     = new ArrayDeque(is.asJava)
+    val ad     = new ArrayDeque(is.toJavaList)
 
     val result = ad.contains(needle)
     assertTrue(s"'${ad.toString}' does not contain '${needle}'", result)
@@ -200,9 +198,9 @@ class ArrayDequeTest {
     // ConcurrentModificationException
 
     val is = Seq(1, 2, 3)
-    val ad = new ArrayDeque(is.asJava)
+    val ad = new ArrayDeque(is.toJavaList)
 
-    val result   = ad.descendingIterator.asScala.toArray
+    val result   = ad.descendingIterator.toScalaSeq.toArray
     val expected = is.reverse.toArray
 
     assertTrue(s"element: result} != expected: ${expected})",
@@ -218,7 +216,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq(33, 22, 11)
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.element
 
@@ -243,7 +241,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq("33", "22", "11")
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.getFirst
 
@@ -268,7 +266,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq(-33, -22, -11)
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.getLast
 
@@ -291,9 +289,9 @@ class ArrayDequeTest {
     // ConcurrentModificationException
 
     val is = Seq(-11, 0, 1)
-    val ad = new ArrayDeque(is.asJava)
+    val ad = new ArrayDeque(is.toJavaList)
 
-    val result   = ad.iterator.asScala.toArray
+    val result   = ad.iterator.toScalaSeq.toArray
     val expected = is.toArray
 
     assertTrue(s"element: ${result} != expected: ${expected})",
@@ -383,7 +381,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq("33", "22", "11")
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.peek
 
@@ -409,7 +407,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq("33", "22", "11")
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.peekFirst
 
@@ -435,7 +433,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq(-33, -22, -11)
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.peekLast
 
@@ -461,7 +459,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq(33, 22, 11)
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.poll
 
@@ -487,7 +485,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq(33, 22, 11)
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.pollFirst
 
@@ -512,7 +510,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq(-33, -22, -11)
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.pollLast
 
@@ -537,7 +535,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq(33, 22, 11)
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.pop
 
@@ -586,7 +584,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq(33, 22, 11)
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.remove
 
@@ -605,7 +603,7 @@ class ArrayDequeTest {
   @Test def removeAny(): Unit = {
     val haystack = "Looking for a needle in a haystack"
     val words    = haystack.split(" ").toSeq
-    val ad       = new ArrayDeque(words.asJava)
+    val ad       = new ArrayDeque(words.toJavaList)
 
     locally {
       val adClone    = ad.clone()
@@ -666,7 +664,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq(33, 22, 11)
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.removeFirst
 
@@ -685,7 +683,7 @@ class ArrayDequeTest {
   @Test def removeFirstOccurrenceAny(): Unit = {
     val haystack = "Square needle || round needle || shiny needle"
     val words    = haystack.split(" ").toSeq
-    val ad       = new ArrayDeque(words.asJava)
+    val ad       = new ArrayDeque(words.toJavaList)
 
     locally {
       val adClone    = ad.clone()
@@ -748,7 +746,7 @@ class ArrayDequeTest {
 
     locally {
       val is = Seq(-33, -22, -11)
-      val ad = new ArrayDeque(is.asJava)
+      val ad = new ArrayDeque(is.toJavaList)
 
       val result = ad.removeLast
 
@@ -767,7 +765,7 @@ class ArrayDequeTest {
   @Test def removeLastOccurrenceAny(): Unit = {
     val haystack = "Square needle || round needle || shiny needle"
     val words    = haystack.split(" ").toSeq
-    val ad       = new ArrayDeque(words.asJava)
+    val ad       = new ArrayDeque(words.toJavaList)
 
     locally {
       val adClone    = ad.clone()
@@ -830,12 +828,14 @@ class ArrayDequeTest {
   }
 
   @Test def toArrayNullThrowsNullPointerException(): Unit = {
-    val al1 = new ArrayDeque[String](Seq("apple", "banana", "cherry").asJava)
+    val al1 =
+      new ArrayDeque[String](Seq("apple", "banana", "cherry").toJavaList)
     assertThrows(classOf[NullPointerException], al1.toArray(null))
   }
 
   @Test def toArrayArrayMinusArrayIsShorter(): Unit = {
-    val al1  = new ArrayDeque[String](Seq("apple", "banana", "cherry").asJava)
+    val al1 =
+      new ArrayDeque[String](Seq("apple", "banana", "cherry").toJavaList)
     val ain  = Array.empty[String]
     val aout = al1.toArray(ain)
     assertTrue(ain ne aout)
@@ -843,7 +843,8 @@ class ArrayDequeTest {
   }
 
   @Test def toArrayArrayMinusArrayIsTheSameLengthOrLonger(): Unit = {
-    val al1  = new ArrayDeque[String](Seq("apple", "banana", "cherry").asJava)
+    val al1 =
+      new ArrayDeque[String](Seq("apple", "banana", "cherry").toJavaList)
     val ain  = Array.fill(4)("foo")
     val aout = al1.toArray(ain)
     assertTrue(ain eq aout)
@@ -854,7 +855,7 @@ class ArrayDequeTest {
     class SuperClass
     class SubClass extends SuperClass
     val in   = Seq.fill(2)(new SubClass)
-    val al1  = new ArrayDeque[SubClass](in.asJava)
+    val al1  = new ArrayDeque[SubClass](in.toJavaList)
     val aout = al1.toArray(Array.empty[SuperClass])
     assertTrue(in.toArray sameElements aout)
   }
@@ -872,7 +873,7 @@ class ArrayDequeTest {
 
     locally { // This is the case which is failing on ScalaNative.
       // The difference is that this Deque is not Empty.
-      val ad = new ArrayDeque(Seq(new SubClass).asJava)
+      val ad = new ArrayDeque(Seq(new SubClass).toJavaList)
 
       assertThrows(classOf[ArrayStoreException],
                    ad.toArray(Array.empty[NotSuperClass]))

--- a/unit-tests/src/test/scala/java/util/ArrayListTest.scala
+++ b/unit-tests/src/test/scala/java/util/ArrayListTest.scala
@@ -2,7 +2,7 @@ package java.util
 
 import org.junit.Test
 import org.junit.Assert._
-import scala.scalanative.compat.CollectionConverters._
+import scala.scalanative.junit.utils.CollectionConverters._
 import scala.scalanative.junit.utils.AssertThrows._
 
 class ArrayListTest {

--- a/unit-tests/src/test/scala/java/util/ArrayListTest.scala
+++ b/unit-tests/src/test/scala/java/util/ArrayListTest.scala
@@ -1,10 +1,8 @@
 package java.util
 
-import scala.collection.JavaConverters._
-
 import org.junit.Test
 import org.junit.Assert._
-
+import scala.scalanative.compat.CollectionConverters._
 import scala.scalanative.junit.utils.AssertThrows._
 
 class ArrayListTest {
@@ -24,26 +22,25 @@ class ArrayListTest {
   @Test def constructorCollectionInteger(): Unit = {
     // for AnyVal
     val is = Seq(1, 2, 3)
-    val al = new ArrayList(is.asJava)
+    val al = new ArrayList(is.toJavaList)
     assertTrue(al.size() == 3)
     assertTrue(!al.isEmpty())
     assertTrue(al.get(0) == 1)
     assertTrue(al.get(1) == 2)
     assertTrue(al.get(2) == 3)
-    assertTrue(al.asScala == Seq(1, 2, 3))
+    assertTrue(al.toScalaSeq == Seq(1, 2, 3))
   }
 
   @Test def constructorCollectionString(): Unit = {
     // for AnyRef
     val is = Seq(1, 2, 3).map(_.toString)
-    import scala.collection.JavaConverters._
-    val al = new ArrayList(is.asJava)
+    val al = new ArrayList(is.toJavaList)
     assertTrue(al.size() == 3)
     assertTrue(!al.isEmpty())
     assertTrue(al.get(0) == "1")
     assertTrue(al.get(1) == "2")
     assertTrue(al.get(2) == "3")
-    assertTrue(al.asScala == Seq("1", "2", "3"))
+    assertTrue(al.toScalaSeq == Seq("1", "2", "3"))
   }
 
   @Test def constructorNullThrowsNullPointerException(): Unit = {
@@ -53,7 +50,7 @@ class ArrayListTest {
   @Test def equalsForEmptyLists(): Unit = {
     val e1  = new ArrayList()
     val e2  = new ArrayList()
-    val ne1 = new ArrayList(Seq(1).asJava)
+    val ne1 = new ArrayList(Seq(1).toJavaList)
     assertTrue(e1 == e2)
     assertTrue(e2 == e1)
     assertTrue(e1 != ne1)
@@ -61,9 +58,9 @@ class ArrayListTest {
   }
 
   @Test def equalsForNonEmptyLists(): Unit = {
-    val ne1a = new ArrayList(Seq(1, 2, 3).asJava)
-    val ne1b = new ArrayList(Seq(1, 2, 3).asJava)
-    val ne2  = new ArrayList(Seq(1).asJava)
+    val ne1a = new ArrayList(Seq(1, 2, 3).toJavaList)
+    val ne1b = new ArrayList(Seq(1, 2, 3).toJavaList)
+    val ne2  = new ArrayList(Seq(1).toJavaList)
     assertTrue(ne1a == ne1b)
     assertTrue(ne1b == ne1a)
     assertTrue(ne1a != ne2)
@@ -73,8 +70,8 @@ class ArrayListTest {
   }
 
   @Test def trimToSizeForNonEmptyListsWithDifferentCapacities(): Unit = {
-    val al1 = new ArrayList(Seq(1, 2, 3).asJava)
-    val al2 = new ArrayList(Seq(1, 2, 3).asJava)
+    val al1 = new ArrayList(Seq(1, 2, 3).toJavaList)
+    val al2 = new ArrayList(Seq(1, 2, 3).toJavaList)
     al2.ensureCapacity(100)
     val al3 = new ArrayList[Int](50)
     al3.add(1)
@@ -92,8 +89,8 @@ class ArrayListTest {
   }
 
   @Test def trimToSizeForNonEmptyLists(): Unit = {
-    val al1 = new ArrayList(Seq(1, 2, 3).asJava)
-    val al2 = new ArrayList(Seq(1, 2, 3).asJava)
+    val al1 = new ArrayList(Seq(1, 2, 3).toJavaList)
+    val al2 = new ArrayList(Seq(1, 2, 3).toJavaList)
     al2.ensureCapacity(100)
     val al3 = new ArrayList[Int](50)
     al3.add(1)
@@ -109,7 +106,7 @@ class ArrayListTest {
   @Test def size(): Unit = {
     val al1 = new ArrayList[Int]()
     assertTrue(al1.size() == 0)
-    val al2 = new ArrayList[Int](Seq(1, 2, 3).asJava)
+    val al2 = new ArrayList[Int](Seq(1, 2, 3).toJavaList)
     assertTrue(al2.size() == 3)
     val al3 = new ArrayList[Int](10)
     // not to be confused with its capacity.
@@ -119,7 +116,7 @@ class ArrayListTest {
   @Test def isEmpty(): Unit = {
     val al1 = new ArrayList[Int]()
     assertTrue(al1.isEmpty())
-    val al2 = new ArrayList[Int](Seq(1, 2, 3).asJava)
+    val al2 = new ArrayList[Int](Seq(1, 2, 3).toJavaList)
     assertTrue(!al2.isEmpty())
     val al3 = new ArrayList[Int](10)
     // not to be confused with its capacity.
@@ -127,17 +124,17 @@ class ArrayListTest {
   }
 
   @Test def indexOfAny(): Unit = {
-    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
     assertTrue(al1.indexOf(2) == 1)
   }
 
   @Test def lastIndexOfAny(): Unit = {
-    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
     assertTrue(al1.lastIndexOf(2) == 3)
   }
 
   @Test def testClone(): Unit = {
-    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
     val al2 = al1.clone().asInstanceOf[ArrayList[Int]]
     assertTrue(al1 == al2)
     al1.add(1)
@@ -147,7 +144,7 @@ class ArrayListTest {
   }
 
   @Test def cloneWithSizeNotEqualCapacity(): Unit = {
-    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
     al1.ensureCapacity(20)
     val al2 = al1.clone().asInstanceOf[ArrayList[Int]]
     assertTrue(al1 == al2)
@@ -158,7 +155,7 @@ class ArrayListTest {
   }
 
   @Test def toArray(): Unit = {
-    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
     assertTrue(
       (Array(1, 2, 3, 2).map(_.asInstanceOf[AnyRef])) sameElements
         (al1.toArray()))
@@ -186,7 +183,7 @@ class ArrayListTest {
   }
 
   @Test def toArrayArrayWhenArrayIsShorter(): Unit = {
-    val al1  = new ArrayList[String](Seq("apple", "banana", "cherry").asJava)
+    val al1  = new ArrayList[String](Seq("apple", "banana", "cherry").toJavaList)
     val ain  = Array.empty[String]
     val aout = al1.toArray(ain)
     assertTrue(ain ne aout)
@@ -194,7 +191,7 @@ class ArrayListTest {
   }
 
   @Test def toArrayArrayWhenArrayIsWithTheSameLengthOrLonger(): Unit = {
-    val al1  = new ArrayList[String](Seq("apple", "banana", "cherry").asJava)
+    val al1  = new ArrayList[String](Seq("apple", "banana", "cherry").toJavaList)
     val ain  = Array.fill(4)("foo")
     val aout = al1.toArray(ain)
     assertTrue(ain eq aout)
@@ -205,7 +202,7 @@ class ArrayListTest {
     class SuperClass
     class SubClass extends SuperClass
     val in   = Seq.fill(2)(new SubClass)
-    val al1  = new ArrayList[SubClass](in.asJava)
+    val al1  = new ArrayList[SubClass](in.toJavaList)
     val aout = al1.toArray(Array.empty[SuperClass])
     assertTrue(in.toArray sameElements aout)
   }
@@ -222,12 +219,12 @@ class ArrayListTest {
   }
 
   @Test def toArrayNullThrowsNull(): Unit = {
-    val al1 = new ArrayList[String](Seq("apple", "banana", "cherry").asJava)
+    val al1 = new ArrayList[String](Seq("apple", "banana", "cherry").toJavaList)
     assertThrows(classOf[NullPointerException], al1.toArray(null))
   }
 
   @Test def getInt(): Unit = {
-    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
     assertTrue(al1.get(0) == 1)
     assertTrue(al1.get(1) == 2)
     assertTrue(al1.get(2) == 3)
@@ -237,33 +234,33 @@ class ArrayListTest {
   }
 
   @Test def setInt(): Unit = {
-    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
     assertTrue(al1.set(1, 4) == 2)
-    assertTrue(Seq(1, 4, 3, 2) == al1.asScala)
+    assertTrue(Seq(1, 4, 3, 2) == al1.toScalaSeq)
   }
 
   @Test def add(): Unit = {
     val al1 = new ArrayList[Int]()
     al1.add(1)
-    assertTrue(al1.asScala == Seq(1))
+    assertTrue(al1.toScalaSeq == Seq(1))
     al1.add(2)
-    assertTrue(al1.asScala == Seq(1, 2))
+    assertTrue(al1.toScalaSeq == Seq(1, 2))
   }
 
   @Test def addInt(): Unit = {
     val al1 = new ArrayList[Int]()
     al1.add(0, 1)
-    assertTrue(al1.asScala == Seq(1))
+    assertTrue(al1.toScalaSeq == Seq(1))
     al1.add(0, 2)
-    assertTrue(al1.asScala == Seq(2, 1))
+    assertTrue(al1.toScalaSeq == Seq(2, 1))
   }
 
   @Test def addIntWhenTheCapacityHasToBeExpanded(): Unit = {
     val al1 = new ArrayList[Int](0)
     al1.add(0, 1)
-    assertTrue(al1.asScala == Seq(1))
+    assertTrue(al1.toScalaSeq == Seq(1))
     al1.add(0, 2)
-    assertTrue(al1.asScala == Seq(2, 1))
+    assertTrue(al1.toScalaSeq == Seq(2, 1))
   }
 
   @Test def addAll(): Unit = {
@@ -279,7 +276,7 @@ class ArrayListTest {
   }
 
   @Test def removeInt(): Unit = {
-    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2, 3).asJava)
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2, 3).toJavaList)
     // remove last
     assertTrue(al1.remove(4) == 3)
     // remove head
@@ -287,20 +284,20 @@ class ArrayListTest {
     // remove middle
     assertTrue(al1.remove(1) == 3)
     assertThrows(classOf[IndexOutOfBoundsException], al1.remove(4))
-    assertTrue(Seq(2, 2) == al1.asScala)
+    assertTrue(Seq(2, 2) == al1.toScalaSeq)
   }
 
   @Test def removeAny(): Unit = {
-    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
     assertTrue(al1.remove(2: Any) == true)
-    assertTrue(Seq(1, 3, 2) == al1.asScala)
+    assertTrue(Seq(1, 3, 2) == al1.toScalaSeq)
     assertTrue(al1.remove(4: Any) == false)
-    assertTrue(Seq(1, 3, 2) == al1.asScala)
+    assertTrue(Seq(1, 3, 2) == al1.toScalaSeq)
   }
 
   @Test def removeRangeFromToIndenticalInvalidIndices(): Unit = {
-    val aList    = new ArrayList[Int](Seq(-175, 24, 7, 44).asJava)
-    val expected = new ArrayList[Int](Seq(-175, 24, 7, 44).asJava) // ibid.
+    val aList    = new ArrayList[Int](Seq(-175, 24, 7, 44).toJavaList)
+    val expected = new ArrayList[Int](Seq(-175, 24, 7, 44).toJavaList) // ibid.
 
     // Yes, the indices are invalid but no exception is expected because
     // they are identical, which is tested first. That is called a 'quirk'
@@ -312,7 +309,7 @@ class ArrayListTest {
   }
 
   @Test def removeRangeFromToInvalidIndices(): Unit = {
-    val aList = new ArrayList[Int](Seq(175, -24, -7, -44).asJava)
+    val aList = new ArrayList[Int](Seq(175, -24, -7, -44).toJavaList)
 
     assertThrows(classOf[java.lang.ArrayIndexOutOfBoundsException],
                  aList.removeRange(-1, 2)) // fromIndex < 0
@@ -332,8 +329,8 @@ class ArrayListTest {
   }
 
   @Test def removeRangeFromToFirstTwoElements(): Unit = {
-    val aList    = new ArrayList[Int](Seq(284, -27, 995, 500, 267, 904).asJava)
-    val expected = new ArrayList[Int](Seq(995, 500, 267, 904).asJava)
+    val aList    = new ArrayList[Int](Seq(284, -27, 995, 500, 267, 904).toJavaList)
+    val expected = new ArrayList[Int](Seq(995, 500, 267, 904).toJavaList)
 
     aList.removeRange(0, 2)
 
@@ -341,8 +338,8 @@ class ArrayListTest {
   }
 
   @Test def removeRangeFromToFirstTwoElementsAtHead(): Unit = {
-    val aList    = new ArrayList[Int](Seq(284, -27, 995, 500, 267, 904).asJava)
-    val expected = new ArrayList[Int](Seq(995, 500, 267, 904).asJava)
+    val aList    = new ArrayList[Int](Seq(284, -27, 995, 500, 267, 904).toJavaList)
+    val expected = new ArrayList[Int](Seq(995, 500, 267, 904).toJavaList)
 
     aList.removeRange(0, 2)
 
@@ -350,8 +347,8 @@ class ArrayListTest {
   }
 
   @Test def removeRangeFromToTwoElementsFromMiddle(): Unit = {
-    val aList    = new ArrayList[Int](Seq(7, 9, -1, 20).asJava)
-    val expected = new ArrayList[Int](Seq(7, 20).asJava)
+    val aList    = new ArrayList[Int](Seq(7, 9, -1, 20).toJavaList)
+    val expected = new ArrayList[Int](Seq(7, 20).toJavaList)
 
     aList.removeRange(1, 3)
 
@@ -359,8 +356,8 @@ class ArrayListTest {
   }
 
   @Test def removeRangeFromToLastTwoElementsAtTail(): Unit = {
-    val aList    = new ArrayList[Int](Seq(50, 72, 650, 12, 7, 28, 3).asJava)
-    val expected = new ArrayList[Int](Seq(50, 72, 650, 12, 7).asJava)
+    val aList    = new ArrayList[Int](Seq(50, 72, 650, 12, 7, 28, 3).toJavaList)
+    val expected = new ArrayList[Int](Seq(50, 72, 650, 12, 7).toJavaList)
 
     aList.removeRange(aList.size - 2, aList.size)
 
@@ -368,8 +365,8 @@ class ArrayListTest {
   }
 
   @Test def removeRangeFromToEntireListAllElements(): Unit = {
-    val aList    = new ArrayList[Int](Seq(50, 72, 650, 12, 7, 28, 3).asJava)
-    val expected = new ArrayList[Int](Seq().asJava)
+    val aList    = new ArrayList[Int](Seq(50, 72, 650, 12, 7, 28, 3).toJavaList)
+    val expected = new ArrayList[Int](Seq().toJavaList)
 
     aList.removeRange(0, aList.size)
 
@@ -377,7 +374,7 @@ class ArrayListTest {
   }
 
   @Test def clear(): Unit = {
-    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al1 = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
     al1.clear()
     assertTrue(al1.isEmpty())
     // makes sure that clear()ing an already empty list is safe
@@ -389,13 +386,13 @@ class ArrayListTest {
   }
 
   @Test def containsAny(): Unit = {
-    val al = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
     assertTrue(al.contains(1))
     assertTrue(!al.contains(5))
   }
 
   @Test def testToString(): Unit = {
-    val al = new ArrayList[Int](Seq(1, 2, 3, 2).asJava)
+    val al = new ArrayList[Int](Seq(1, 2, 3, 2).toJavaList)
 
     // Note well the space/blank after the commas. This matches Scala JVM.
     val expected = "[1, 2, 3, 2]"

--- a/unit-tests/src/test/scala/java/util/LinkedHashMapTest.scala
+++ b/unit-tests/src/test/scala/java/util/LinkedHashMapTest.scala
@@ -7,7 +7,7 @@ import org.junit.Test
 import org.junit.Assert._
 import scala.collection.{immutable => im}
 import scala.reflect.ClassTag
-import scala.scalanative.compat.CollectionConverters._
+import scala.scalanative.junit.utils.CollectionConverters._
 
 class LinkedHashMapInsertionOrderTest extends LinkedHashMapTest
 

--- a/unit-tests/src/test/scala/java/util/LinkedHashMapTest.scala
+++ b/unit-tests/src/test/scala/java/util/LinkedHashMapTest.scala
@@ -2,14 +2,12 @@ package java.util
 
 // Ported from Scala.js
 
-import java.{util => ju, lang => jl}
-
+import java.{lang => jl, util => ju}
 import org.junit.Test
 import org.junit.Assert._
-
-import scala.collection.JavaConversions._
 import scala.collection.{immutable => im}
 import scala.reflect.ClassTag
+import scala.scalanative.compat.CollectionConverters._
 
 class LinkedHashMapInsertionOrderTest extends LinkedHashMapTest
 
@@ -49,17 +47,17 @@ abstract class LinkedHashMapTest extends HashMapTest {
     val expectedSize = withSizeLimit.getOrElse(100)
 
     assertEquals(expectedSize, lhm.entrySet().size())
-    for ((entry, index) <- lhm.entrySet().zipWithIndex) {
+    for ((entry, index) <- lhm.entrySet().toScalaSeq.zipWithIndex) {
       assertEquals(expectedKey(index), entry.getKey)
       assertEquals(expectedValue(index), entry.getValue)
     }
 
     assertEquals(expectedSize, lhm.keySet().size())
-    for ((key, index) <- lhm.keySet().zipWithIndex)
+    for ((key, index) <- lhm.keySet().toScalaSeq.zipWithIndex)
       assertEquals(expectedKey(index), key)
 
     assertEquals(expectedSize, lhm.entrySet().size())
-    for ((value, index) <- lhm.values().zipWithIndex)
+    for ((value, index) <- lhm.values().toScalaSeq.zipWithIndex)
       assertEquals(expectedValue(index), value)
   }
 
@@ -78,17 +76,17 @@ abstract class LinkedHashMapTest extends HashMapTest {
     val expectedSize = if (withSizeLimit.isDefined) 33 else 66
 
     assertEquals(expectedSize, lhm.entrySet().size())
-    for ((entry, index) <- lhm.entrySet().zipWithIndex) {
+    for ((entry, index) <- lhm.entrySet().toScalaSeq.zipWithIndex) {
       assertEquals(expectedKey(index), entry.getKey)
       assertEquals(expectedValue(index), entry.getValue)
     }
 
     assertEquals(expectedSize, lhm.keySet().size())
-    for ((key, index) <- lhm.keySet().zipWithIndex)
+    for ((key, index) <- lhm.keySet().toScalaSeq.zipWithIndex)
       assertEquals(expectedKey(index), key)
 
     assertEquals(expectedSize, lhm.entrySet().size())
-    for ((value, index) <- lhm.values().zipWithIndex)
+    for ((value, index) <- lhm.values().toScalaSeq.zipWithIndex)
       assertEquals(expectedValue(index), value)
   }
 
@@ -96,12 +94,12 @@ abstract class LinkedHashMapTest extends HashMapTest {
     val lhm = factory.empty[jl.Integer, String]
     (0 until 100).foreach(key => lhm.put(key, s"elem $key"))
 
-    lhm(0) = "new 0"
-    lhm(100) = "elem 100"
-    lhm(42) = "new 42"
-    lhm(52) = "new 52"
-    lhm(1) = "new 1"
-    lhm(98) = "new 98"
+    lhm.put(0, "new 0")
+    lhm.put(100, "elem 100")
+    lhm.put(42, "new 42")
+    lhm.put(52, "new 52")
+    lhm.put(1, "new 1")
+    lhm.put(98, "new 98")
 
     val expectedKey = {
       if (factory.accessOrder) {
@@ -127,17 +125,17 @@ abstract class LinkedHashMapTest extends HashMapTest {
 
     assertEquals(expectedSize, lhm.entrySet().size())
 
-    for ((entry, index) <- lhm.entrySet().zipWithIndex) {
+    for ((entry, index) <- lhm.entrySet().toScalaSeq.zipWithIndex) {
       assertEquals(expectedKey(index), entry.getKey)
       assertEquals(expectedElem(index), entry.getValue)
     }
 
     assertEquals(expectedSize, lhm.keySet().size())
-    for ((key, index) <- lhm.keySet().zipWithIndex)
+    for ((key, index) <- lhm.keySet().toScalaSeq.zipWithIndex)
       assertEquals(expectedKey(index), key)
 
     assertEquals(expectedSize, lhm.entrySet().size())
-    for ((value, index) <- lhm.values().zipWithIndex)
+    for ((value, index) <- lhm.values().toScalaSeq.zipWithIndex)
       assertEquals(expectedElem(index), value)
   }
 
@@ -181,17 +179,17 @@ abstract class LinkedHashMapTest extends HashMapTest {
     val expectedSize = withSizeLimit.getOrElse(100)
 
     assertEquals(expectedSize, lhm.entrySet().size())
-    for ((entry, index) <- lhm.entrySet().zipWithIndex) {
+    for ((entry, index) <- lhm.entrySet().toScalaSeq.zipWithIndex) {
       assertEquals(expectedKey(index), entry.getKey)
       assertEquals(expectedValue(index), entry.getValue)
     }
 
     assertEquals(expectedSize, lhm.keySet().size())
-    for ((key, index) <- lhm.keySet().zipWithIndex)
+    for ((key, index) <- lhm.keySet().toScalaSeq.zipWithIndex)
       assertEquals(expectedKey(index), key)
 
     assertEquals(expectedSize, lhm.entrySet().size())
-    for ((value, index) <- lhm.values().zipWithIndex)
+    for ((value, index) <- lhm.values().toScalaSeq.zipWithIndex)
       assertEquals(expectedValue(index), value)
   }
 }

--- a/unit-tests/src/test/scala/java/util/MapTest.scala
+++ b/unit-tests/src/test/scala/java/util/MapTest.scala
@@ -3,18 +3,15 @@ package java.util
 // Ported from Scala.js
 
 import java.{util => ju}
-
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-
 import scala.scalanative.junit.utils.AssertThrows._
-
-import scala.collection.JavaConversions._
 import scala.collection.{immutable => im}
 import scala.collection.{mutable => mu}
 
 import scala.reflect.ClassTag
+import scala.scalanative.compat.CollectionConverters
 
 trait MapTest {
   import MapTest._
@@ -246,28 +243,32 @@ trait MapTest {
     val mp = factory.empty[String, String]
 
     val m = mu.Map[String, String]("X" -> "y")
-    mp.putAll(mutableMapAsJavaMap(m))
+    mp.putAll(m.toJavaMap[String, String])
     assertEquals(1, mp.size())
     assertEquals("y", mp.get("X"))
 
     val nullMap = mu.Map[String, String]((null: String) -> "y", "X" -> "y")
 
     if (factory.allowsNullKeys) {
-      mp.putAll(mutableMapAsJavaMap(nullMap))
+      mp.putAll(nullMap.toJavaMap[String, String])
       assertEquals("y", mp.get(null))
       assertEquals("y", mp.get("X"))
     } else {
       expectThrows(classOf[NullPointerException],
-                   mp.putAll(mutableMapAsJavaMap(nullMap)))
+                   mp.putAll(nullMap.toJavaMap[String, String]))
     }
   }
 
   class SimpleQueryableMap[K, V](inner: mu.HashMap[K, V])
       extends ju.AbstractMap[K, V] {
     def entrySet(): java.util.Set[java.util.Map.Entry[K, V]] = {
-      setAsJavaSet(inner.map {
-        case (k, v) => new ju.AbstractMap.SimpleImmutableEntry(k, v)
-      }.toSet)
+      inner
+        .map {
+          case (k, v) => new ju.AbstractMap.SimpleImmutableEntry(k, v)
+        }
+        .toSet
+        .toJavaSet
+        .asInstanceOf[java.util.Set[java.util.Map.Entry[K, V]]]
     }
   }
 
@@ -320,19 +321,20 @@ trait MapTest {
     if (factory.allowsNullValuesQueries)
       assertFalse(values.contains(null))
     else
-      expectThrows(classOf[Throwable], mp.contains(null))
+      expectThrows(classOf[Throwable],
+                   mp.entrySet().toScalaMap[String, String].contains(null))
 
     mp.put("THREE", "three")
 
     assertTrue(values.contains("three"))
 
-    val coll1 = asJavaCollection(im.Set("one", "two", "three"))
+    val coll1 = im.Set("one", "two", "three").toJavaSet
     assertTrue(values.containsAll(coll1))
 
-    val coll2 = asJavaCollection(im.Set("one", "two", "three", "four"))
+    val coll2 = im.Set("one", "two", "three", "four").toJavaSet
     assertFalse(values.containsAll(coll2))
 
-    val coll3 = asJavaCollection(im.Set("one", "two", "three", null))
+    val coll3 = im.Set("one", "two", "three", null).toJavaSet
     assertFalse(values.containsAll(coll2))
 
     val nummp = factory.empty[Double, Double]
@@ -397,7 +399,7 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    values.removeAll(asJavaCollection(im.List("one", "two")))
+    values.removeAll(im.List("one", "two").toJavaList)
 
     assertFalse(mp.containsKey("ONE"))
     assertFalse(mp.containsKey("TWO"))
@@ -411,7 +413,7 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    values.retainAll(asJavaCollection(im.List("one", "two")))
+    values.retainAll(im.List("one", "two").toJavaList)
 
     assertTrue(mp.containsKey("ONE"))
     assertTrue(mp.containsKey("TWO"))
@@ -467,22 +469,20 @@ trait MapTest {
     if (factory.allowsNullKeysQueries)
       assertFalse(keySet.contains(null))
     else
-      expectThrows(classOf[Throwable], mp.contains(null))
+      expectThrows(classOf[Throwable],
+                   mp.entrySet().toScalaMap[String, String].contains(null))
 
     mp.put("THREE", "three")
 
     assertTrue(keySet.contains("THREE"))
 
-    val coll1 =
-      asJavaCollection(im.Set("ONE", "TWO", "THREE"))
+    val coll1 = im.Set("ONE", "TWO", "THREE").toJavaSet
     assertTrue(keySet.containsAll(coll1))
 
-    val coll2 =
-      asJavaCollection(im.Set("ONE", "TWO", "THREE", "FOUR"))
+    val coll2 = im.Set("ONE", "TWO", "THREE", "FOUR").toJavaSet
     assertFalse(keySet.containsAll(coll2))
 
-    val coll3 =
-      asJavaCollection(im.Set("ONE", "TWO", "THREE", null))
+    val coll3 = im.Set("ONE", "TWO", "THREE", null).toJavaSet
     assertFalse(keySet.containsAll(coll2))
 
     val nummp = factory.empty[Double, Double]
@@ -548,7 +548,7 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    keySet.removeAll(asJavaCollection(im.List("ONE", "TWO")))
+    keySet.removeAll(im.List("ONE", "TWO").toJavaList)
 
     assertFalse(mp.containsKey("ONE"))
     assertFalse(mp.containsKey("TWO"))
@@ -562,7 +562,7 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    keySet.retainAll(asJavaCollection(im.List("ONE", "TWO")))
+    keySet.retainAll(im.List("ONE", "TWO").toJavaList)
 
     assertTrue(mp.containsKey("ONE"))
     assertTrue(mp.containsKey("TWO"))

--- a/unit-tests/src/test/scala/java/util/MapTest.scala
+++ b/unit-tests/src/test/scala/java/util/MapTest.scala
@@ -11,7 +11,7 @@ import scala.collection.{immutable => im}
 import scala.collection.{mutable => mu}
 
 import scala.reflect.ClassTag
-import scala.scalanative.compat.CollectionConverters
+import scala.scalanative.junit.utils.CollectionConverters._
 
 trait MapTest {
   import MapTest._

--- a/unit-tests/src/test/scala/java/util/MapTest.scala
+++ b/unit-tests/src/test/scala/java/util/MapTest.scala
@@ -272,6 +272,7 @@ trait MapTest {
         .toJavaSet
     }
   }
+
   @Test def valuesShouldMirrorTheRelatedMapSize(): Unit = {
     val mp = factory.empty[String, String]
 
@@ -321,8 +322,7 @@ trait MapTest {
     if (factory.allowsNullValuesQueries)
       assertFalse(values.contains(null))
     else
-      expectThrows(classOf[Throwable],
-                   mp.entrySet().toScalaMap[String, String].contains(null))
+      expectThrows(classOf[Throwable], mp.values().contains(null))
 
     mp.put("THREE", "three")
 
@@ -469,8 +469,7 @@ trait MapTest {
     if (factory.allowsNullKeysQueries)
       assertFalse(keySet.contains(null))
     else
-      expectThrows(classOf[Throwable],
-                   mp.entrySet().toScalaMap[String, String].contains(null))
+      expectThrows(classOf[Throwable], mp.keySet().contains(null))
 
     mp.put("THREE", "three")
 

--- a/unit-tests/src/test/scala/java/util/MapTest.scala
+++ b/unit-tests/src/test/scala/java/util/MapTest.scala
@@ -264,14 +264,14 @@ trait MapTest {
     def entrySet(): java.util.Set[java.util.Map.Entry[K, V]] = {
       inner
         .map {
-          case (k, v) => new ju.AbstractMap.SimpleImmutableEntry(k, v)
+          case (k, v) =>
+            val entry = new ju.AbstractMap.SimpleImmutableEntry(k, v)
+            entry: java.util.Map.Entry[K, V]
         }
         .toSet
         .toJavaSet
-        .asInstanceOf[java.util.Set[java.util.Map.Entry[K, V]]]
     }
   }
-
   @Test def valuesShouldMirrorTheRelatedMapSize(): Unit = {
     val mp = factory.empty[String, String]
 

--- a/unit-tests/src/test/scala/java/util/regex/PatternTest.scala
+++ b/unit-tests/src/test/scala/java/util/regex/PatternTest.scala
@@ -8,7 +8,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.compat.CollectionConverters._
+import scala.scalanative.junit.utils.CollectionConverters._
 import scalanative.junit.utils._, AssertThrows._, ThrowsHelper._
 
 class PatternTest {

--- a/unit-tests/src/test/scala/java/util/regex/PatternTest.scala
+++ b/unit-tests/src/test/scala/java/util/regex/PatternTest.scala
@@ -4,12 +4,11 @@ package regex
 import java.util.stream.{Stream => jStream}
 
 import scala.collection.immutable.List
-import scala.collection.JavaConverters._
-
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
 
+import scala.scalanative.compat.CollectionConverters._
 import scalanative.junit.utils._, AssertThrows._, ThrowsHelper._
 
 class PatternTest {
@@ -679,7 +678,7 @@ class PatternTest {
                                  expected: Array[String],
                                  marker: String): Unit = {
 
-    val result = st.iterator.asScala.toArray
+    val result = st.iterator.toScalaSeq.toArray
 
     assertTrue(s"${marker} result.size: ${result.size} != ${expected.size}",
                result.size == expected.size)

--- a/unit-tests/src/test/scala/scala/scalanative/regex/ParserSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/ParserSuite.scala
@@ -3,7 +3,7 @@ package regex
 
 import java.util
 import java.util.regex.PatternSyntaxException
-import scala.scalanative.compat.CollectionConverters._
+import scala.scalanative.junit.utils.CollectionConverters._
 
 import ScalaTestCompat.fail
 

--- a/unit-tests/src/test/scala/scala/scalanative/regex/ParserSuite.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/regex/ParserSuite.scala
@@ -3,6 +3,7 @@ package regex
 
 import java.util
 import java.util.regex.PatternSyntaxException
+import scala.scalanative.compat.CollectionConverters._
 
 import ScalaTestCompat.fail
 
@@ -438,8 +439,7 @@ object ParserSuite extends tests.Suite {
     }
     re.runes = new Array[Int](runes.size)
     var j = 0
-    import scala.collection.JavaConverters._
-    for (i <- runes.asScala) {
+    runes.toScalaSeq.foreach { i =>
       re.runes(j) = i
       j += 1
     }

--- a/unit-tests/src/test/scala/utils/CollectionConverters.scala
+++ b/unit-tests/src/test/scala/utils/CollectionConverters.scala
@@ -1,4 +1,4 @@
-package scala.scalanative.compat
+package scala.scalanative.junit.utils
 
 import java.util.{LinkedHashMap, LinkedHashSet, LinkedList}
 import scala.collection.mutable

--- a/unit-tests/src/test/scala/utils/CollectionConverters.scala
+++ b/unit-tests/src/test/scala/utils/CollectionConverters.scala
@@ -4,7 +4,8 @@ import java.util.{LinkedHashMap, LinkedHashSet, LinkedList}
 import scala.collection.mutable
 
 /** Set of helper method replacing problematic Scala collection.JavaConverters as they cause problems
- * in cross compile between 2.13+ and older Scala versions */
+ *  in cross compile between 2.13+ and older Scala versions
+ */
 object CollectionConverters {
   implicit class ScalaToJavaCollections[T](private val self: Iterable[T]) {
     def toJavaList: LinkedList[T] = {
@@ -31,7 +32,6 @@ object CollectionConverters {
 
   implicit class JavaToScalaCollections[T](
       private val self: java.util.Collection[T]) {
-    private def iterator   = self.iterator()
     def toScalaSeq: Seq[T] = self.iterator().toScalaSeq
     def toScalaSet: Set[T] = self.iterator().toScalaSet
     def toScalaMap[K, V](

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -2,7 +2,6 @@ package scala.scalanative
 package io
 
 import java.io.Writer
-import scala.collection.JavaConverters._
 import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.file._

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -7,7 +7,8 @@ import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.file._
 import java.nio.channels._
-import scalanative.util.{acquire, defer, Scope}
+import java.util.HashMap
+import scalanative.util.{Scope, acquire, defer}
 
 sealed trait VirtualDirectory {
 
@@ -129,12 +130,11 @@ object VirtualDirectory {
       this.path.resolve(path)
 
     override def files: Seq[Path] =
-      Files
-        .walk(path, Integer.MAX_VALUE, FileVisitOption.FOLLOW_LINKS)
-        .iterator()
-        .asScala
-        .map(fp => path.relativize(fp))
-        .toSeq
+      jIteratorToSeq {
+        Files
+          .walk(path, Integer.MAX_VALUE, FileVisitOption.FOLLOW_LINKS)
+          .iterator()
+      }.map(fp => path.relativize(fp))
   }
 
   private final class JarDirectory(path: Path)(implicit in: Scope)
@@ -143,7 +143,9 @@ object VirtualDirectory {
       acquire {
         val uri = URI.create(s"jar:${path.toUri}")
         try {
-          FileSystems.newFileSystem(uri, Map("create" -> "false").asJava)
+          val params = new HashMap[String, String]()
+          params.put("create", "false")
+          FileSystems.newFileSystem(uri, params)
         } catch {
           case e: FileSystemAlreadyExistsException =>
             FileSystems.getFileSystem(uri)
@@ -151,14 +153,15 @@ object VirtualDirectory {
       }
 
     override def files: Seq[Path] = {
-      val roots = fileSystem.getRootDirectories.asScala.toSeq
+      val roots = jIteratorToSeq(fileSystem.getRootDirectories.iterator())
 
       roots
         .flatMap { path =>
-          Files
-            .walk(path, Integer.MAX_VALUE, FileVisitOption.FOLLOW_LINKS)
-            .iterator()
-            .asScala
+          jIteratorToSeq {
+            Files
+              .walk(path, Integer.MAX_VALUE, FileVisitOption.FOLLOW_LINKS)
+              .iterator()
+          }
         }
     }
   }

--- a/util/src/main/scala/scala/scalanative/io/package.scala
+++ b/util/src/main/scala/scala/scalanative/io/package.scala
@@ -1,18 +1,16 @@
 package scala.scalanative
 
 import java.nio.file.Path
-import scala.collection.mutable
-import scala.reflect.ClassTag
 
 package object io {
-  private[io] def jIteratorToSeq[T: ClassTag](
-      it: java.util.Iterator[T]): Seq[T] = {
-    val buf = mutable.UnrolledBuffer.empty[T]
+  private[io] def jIteratorToSeq[T](it: java.util.Iterator[T]): Seq[T] = {
+    val buf = Seq.newBuilder[T]
     while (it.hasNext) {
       buf += it.next()
     }
-    buf.toSeq
+    buf.result()
   }
+
   def packageNameFromPath(path: Path): String = {
     val fileName = path.getFileName.toString
     val base     = fileName.split('.').init.mkString(".")

--- a/util/src/main/scala/scala/scalanative/io/package.scala
+++ b/util/src/main/scala/scala/scalanative/io/package.scala
@@ -1,16 +1,28 @@
 package scala.scalanative
 
 import java.nio.file.Path
-import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.reflect.ClassTag
 
 package object io {
+  private[io] def jIteratorToSeq[T: ClassTag](
+      it: java.util.Iterator[T]): Seq[T] = {
+    val buf = mutable.UnrolledBuffer.empty[T]
+    while (it.hasNext) {
+      buf += it.next()
+    }
+    buf.toSeq
+  }
   def packageNameFromPath(path: Path): String = {
     val fileName = path.getFileName.toString
     val base     = fileName.split('.').init.mkString(".")
 
     Option(path.getParent) match {
-      case Some(parent) => parent.resolve(base).asScala.mkString(".")
-      case None         => base
+      case Some(parent) =>
+        jIteratorToSeq {
+          parent.resolve(base).iterator()
+        }.mkString(".")
+      case None => base
     }
   }
 }


### PR DESCRIPTION
This PR contains cherry-picked changes from #1916 removing usages of problematic JavaConventers and is needed for Scala 2.13 support 

There are still some remaining usages:
- `java.util` collections implementation - they would be removed in separate PR
- `scalanative.build` - remaining usages are safe to remain as long as the plugin can be compiled only in scala 2.12