### PR TITLE
Remove usage of JavaConverters from javalib

### DIFF
--- a/javalib/src/main/scala/java/lang/ProcessBuilder.scala
+++ b/javalib/src/main/scala/java/lang/ProcessBuilder.scala
@@ -118,11 +118,8 @@ final class ProcessBuilder(private var _command: List[String]) {
   }
   private var _directory = defaultDirectory
   private val _environment = {
-    import scala.collection.JavaConverters._
-    val env = System.getenv
-    val res = new java.util.HashMap[String, String]
-    env.asScala foreach { case (k, v) => res.put(k, v) }
-    res
+    val env = System.getenv()
+    new java.util.HashMap[String, String](env)
   }
   private var _redirectInput       = Redirect.PIPE
   private var _redirectOutput      = Redirect.PIPE

--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -1,7 +1,6 @@
 package java.lang
 
 import java.io.File
-import scala.collection.JavaConverters._
 import scala.scalanative.annotation.stub
 import scala.scalanative.libc.stdlib
 
@@ -34,11 +33,11 @@ object Runtime {
   private implicit class ProcessBuilderOps(val pb: ProcessBuilder)
       extends AnyVal {
     def setEnv(envp: Array[String]): ProcessBuilder = {
-      val env = pb.environment
+      val env = pb.environment()
       env.clear()
       envp match {
         case null =>
-          System.getenv.asScala.foreach { case (k, v) => env.put(k, v) }
+          env.putAll(System.getenv())
         case a =>
           envp.foreach {
             case null =>

--- a/javalib/src/main/scala/java/util/AbstractCollection.scala
+++ b/javalib/src/main/scala/java/util/AbstractCollection.scala
@@ -1,9 +1,8 @@
 package java.util
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
-
 import java.lang.{reflect => jlr}
+import java.util.ScalaOps._
 
 abstract class AbstractCollection[E] protected () extends Collection[E] {
   def iterator(): Iterator[E]
@@ -12,7 +11,7 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   def isEmpty(): Boolean = size == 0
 
   def contains(o: Any): Boolean =
-    iterator.asScala.exists(o === _)
+    iterator().scalaOps.exists(o === _)
 
   def toArray(): Array[AnyRef] =
     toArray(new Array[AnyRef](size))
@@ -51,10 +50,10 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   }
 
   def containsAll(c: Collection[_]): Boolean =
-    c.iterator.asScala.forall(this.contains(_))
+    c.iterator().scalaOps.forall(this.contains)
 
   def addAll(c: Collection[_ <: E]): Boolean =
-    c.asScala.foldLeft(false)((prev, elem) => add(elem) || prev)
+    c.scalaOps.foldLeft(false)((prev, elem) => add(elem) || prev)
 
   def removeAll(c: Collection[_]): Boolean =
     removeWhere(c.contains(_))
@@ -78,5 +77,5 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   }
 
   override def toString(): String =
-    iterator.asScala.mkString("[", ", ", "]")
+    iterator.scalaOps.mkString("[", ", ", "]")
 }

--- a/javalib/src/main/scala/java/util/AbstractMap.scala
+++ b/javalib/src/main/scala/java/util/AbstractMap.scala
@@ -1,7 +1,7 @@
 package java.util
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import java.util.ScalaOps._
 
 object AbstractMap {
 
@@ -84,17 +84,19 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
   def isEmpty(): Boolean = size == 0
 
   def containsValue(value: Any): Boolean =
-    entrySet.iterator.asScala.exists(value === _.getValue)
+    entrySet().iterator().scalaOps.exists(value === _.getValue())
 
   def containsKey(key: Any): Boolean =
-    entrySet.iterator.asScala.exists(entry => entry === key)
+    entrySet().iterator().scalaOps.exists(entry => entry === key)
 
   def get(key: Any): V = {
-    entrySet.iterator.asScala
-      .find(_.getKey === key)
+    entrySet()
+      .iterator()
+      .scalaOps
+      .find(_.getKey() === key)
       .fold[V] {
         null.asInstanceOf[V]
-      } { entry => entry.getValue }
+      } { entry => entry.getValue() }
   }
 
   def put(key: K, value: V): V =
@@ -117,7 +119,10 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
   }
 
   def putAll(m: Map[_ <: K, _ <: V]): Unit =
-    m.entrySet.iterator.asScala.foreach(e => put(e.getKey, e.getValue))
+    m.entrySet()
+      .iterator()
+      .scalaOps
+      .foreach(e => put(e.getKey(), e.getValue()))
 
   def clear(): Unit =
     entrySet.clear()
@@ -165,20 +170,23 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
     else {
       o match {
         case m: Map[_, _] =>
-          (self.size == m.size &&
-            entrySet.asScala.forall(item =>
-              m.get(item.getKey) === item.getValue))
+          (self.size() == m.size() &&
+            entrySet().scalaOps.forall(item =>
+              m.get(item.getKey()) === item.getValue()))
         case _ => false
       }
     }
   }
 
   override def hashCode(): Int =
-    entrySet.asScala.foldLeft(0)((prev, item) => item.hashCode + prev)
+    entrySet().scalaOps.foldLeft(0)((prev, item) => item.hashCode + prev)
 
   override def toString(): String = {
-    entrySet.iterator.asScala
-      .map(e => s"${e.getKey}=${e.getValue}")
+    entrySet()
+      .iterator()
+      .scalaOps
+      .map(e => s"${e.getKey()}=${e.getValue()}")
+      .scalaOps
       .mkString("{", ", ", "}")
   }
 }

--- a/javalib/src/main/scala/java/util/AbstractSet.scala
+++ b/javalib/src/main/scala/java/util/AbstractSet.scala
@@ -1,7 +1,7 @@
 package java.util
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import ScalaOps._
 
 abstract class AbstractSet[E] protected ()
     extends AbstractCollection[E]
@@ -17,11 +17,11 @@ abstract class AbstractSet[E] protected ()
   }
 
   override def hashCode(): Int =
-    iterator.asScala.foldLeft(0)((prev, item) => item.hashCode + prev)
+    iterator().scalaOps.foldLeft(0)((prev, item) => item.hashCode + prev)
 
   override def removeAll(c: Collection[_]): Boolean = {
-    if (size > c.size)
-      c.asScala.foldLeft(false)((prev, elem) => this.remove(elem) || prev)
+    if (size() > c.size())
+      c.scalaOps.foldLeft(false)((prev, elem) => this.remove(elem) || prev)
     else {
       @tailrec
       def removeAll(iter: Iterator[E], modified: Boolean): Boolean = {

--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -22,10 +22,13 @@ class ArrayList[E] private (private[this] var inner: Array[Any],
             "Illegal Capacity: " + initialCapacity)
         }
         val initialArr =
-          Array.ofDim[Any](initialCollection.size() max initialCapacity)
-        import scala.collection.JavaConverters._
-        initialCollection.asScala
-          .copyToArray(initialArr)
+          Array.ofDim[Any](initialCollection.size().max(initialCapacity))
+
+        System.arraycopy(initialCollection.toArray(),
+                         0,
+                         initialArr,
+                         0,
+                         initialCollection.size())
         initialArr
       },
       initialCollection.size()

--- a/javalib/src/main/scala/java/util/HashSet.scala
+++ b/javalib/src/main/scala/java/util/HashSet.scala
@@ -1,7 +1,7 @@
 package java.util
 
 import scala.collection.mutable
-import scala.collection.JavaConverters._
+import ScalaOps._
 
 class HashSet[E]
     extends AbstractSet[E]
@@ -28,7 +28,7 @@ class HashSet[E]
     inner.remove(Box(o.asInstanceOf[E]))
 
   override def containsAll(c: Collection[_]): Boolean =
-    c.iterator.asScala.forall(e => contains(e))
+    c.iterator().scalaOps.forall(contains)
 
   override def removeAll(c: Collection[_]): Boolean = {
     val iter    = c.iterator

--- a/javalib/src/main/scala/java/util/Hashtable.scala
+++ b/javalib/src/main/scala/java/util/Hashtable.scala
@@ -3,7 +3,7 @@ package java.util
 import java.{util => ju}
 
 import scala.collection.mutable
-import scala.collection.JavaConverters._
+import ScalaOps._
 
 class Hashtable[K, V] private (inner: mutable.HashMap[Box[Any], V])
     extends ju.Dictionary[K, V]
@@ -29,11 +29,10 @@ class Hashtable[K, V] private (inner: mutable.HashMap[Box[Any], V])
   def isEmpty: Boolean =
     inner.isEmpty
 
-  def keys(): ju.Enumeration[K] =
-    inner.keysIterator.map(_.inner.asInstanceOf[K]).asJavaEnumeration
+  def keys(): ju.Enumeration[K] = Collections.enumeration(keySet())
 
   def elements(): ju.Enumeration[V] =
-    inner.valuesIterator.asJavaEnumeration
+    Collections.enumeration(values())
 
   def contains(value: Any): Boolean =
     containsValue(value)
@@ -71,8 +70,7 @@ class Hashtable[K, V] private (inner: mutable.HashMap[Box[Any], V])
   }
 
   def putAll(m: ju.Map[_ <: K, _ <: V]): Unit =
-    m.asScala.iterator.foreach(kv =>
-      inner.put(Box(kv._1.asInstanceOf[AnyRef]), kv._2))
+    m.entrySet().scalaOps.foreach { e => inner.put(Box(e.getKey), e.getValue) }
 
   def clear(): Unit =
     inner.clear()
@@ -85,8 +83,11 @@ class Hashtable[K, V] private (inner: mutable.HashMap[Box[Any], V])
       .map(kv => kv._1.inner + "=" + kv._2)
       .mkString("{", ", ", "}")
 
-  def keySet(): ju.Set[K] =
-    inner.keySet.map(_.inner.asInstanceOf[K]).asJava
+  def keySet(): ju.Set[K] = {
+    val b = new LinkedHashSet[K]()
+    inner.keySet.foreach { key => b.add(key.inner.asInstanceOf[K]) }
+    b
+  }
 
   def entrySet(): ju.Set[ju.Map.Entry[K, V]] = {
     class UnboxedEntry(
@@ -101,13 +102,21 @@ class Hashtable[K, V] private (inner: mutable.HashMap[Box[Any], V])
       }
       override def hashCode(): Int = boxedEntry.hashCode()
     }
-    inner.asJava
-      .entrySet()
-      .asScala
-      .map(new UnboxedEntry(_): ju.Map.Entry[K, V])
-      .asJava
+
+    val entries = new LinkedHashSet[ju.Map.Entry[K, V]]
+    inner.foreach {
+      case (key, value) =>
+        val entry = new UnboxedEntry(
+          new ju.AbstractMap.SimpleEntry[Box[Any], V](key, value)
+        )
+        entries.add(entry)
+    }
+    entries
   }
 
-  def values(): ju.Collection[V] =
-    inner.asJava.values
+  def values(): ju.Collection[V] = {
+    val b = new LinkedList[V]()
+    inner.values.foreach(b.add)
+    b
+  }
 }

--- a/javalib/src/main/scala/java/util/LinkedList.scala
+++ b/javalib/src/main/scala/java/util/LinkedList.scala
@@ -1,7 +1,6 @@
 package java.util
 
-import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import ScalaOps._
 
 class LinkedList[E]()
     extends AbstractSequentialList[E]
@@ -100,7 +99,7 @@ class LinkedList[E]()
   }
 
   override def contains(o: Any): Boolean =
-    iterator().asScala.exists(_ === o)
+    iterator().scalaOps.exists(_ === o)
 
   override def size(): Int =
     if (_size < Integer.MAX_VALUE) _size.toInt else Integer.MAX_VALUE

--- a/javalib/src/main/scala/java/util/NavigableView.scala
+++ b/javalib/src/main/scala/java/util/NavigableView.scala
@@ -115,12 +115,10 @@ private[util] class NavigableView[E](original: NavigableSet[E],
   }
 
   def first(): E =
-    iterator().scalaOps.headOption
-      .getOrElse(null.asInstanceOf[E])
+    iterator().scalaOps.headOption.getOrElse(null.asInstanceOf[E])
 
   def last(): E =
-    iterator().scalaOps.lastOption
-      .getOrElse(null.asInstanceOf[E])
+    iterator().scalaOps.lastOption.getOrElse(null.asInstanceOf[E])
 
   def subSet(fromElement: E,
              fromInclusive: Boolean,

--- a/javalib/src/main/scala/java/util/NavigableView.scala
+++ b/javalib/src/main/scala/java/util/NavigableView.scala
@@ -1,8 +1,8 @@
 package java.util
 
-import scala.math.Ordering
+import ScalaOps._
+import ScalaCompatOps._
 import scala.collection.mutable
-import scala.collection.JavaConverters._
 
 private[util] class NavigableView[E](original: NavigableSet[E],
                                      inner: () => mutable.SortedSet[Box[E]],
@@ -14,8 +14,7 @@ private[util] class NavigableView[E](original: NavigableSet[E],
     with NavigableSet[E]
     with SortedSet[E] {
 
-  def size(): Int =
-    iterator.asScala.size
+  def size(): Int = iterator().scalaOps.count(_ => true)
 
   override def contains(o: Any): Boolean =
     inner().contains(Box(o.asInstanceOf[E]))
@@ -64,7 +63,7 @@ private[util] class NavigableView[E](original: NavigableSet[E],
     _iterator(inner().iterator.map(_.inner))
 
   def descendingIterator(): Iterator[E] =
-    _iterator(iterator.asScala.toList.reverse.iterator)
+    _iterator(iterator().scalaOps.toSeq.reverseIterator)
 
   override def removeAll(c: Collection[_]): Boolean = {
     val iter    = c.iterator()
@@ -77,16 +76,16 @@ private[util] class NavigableView[E](original: NavigableSet[E],
     original.addAll(c)
 
   def lower(e: E): E =
-    headSet(e, false).asScala.lastOption.getOrElse(null.asInstanceOf[E])
+    headSet(e, false).scalaOps.lastOption.getOrElse(null.asInstanceOf[E])
 
   def floor(e: E): E =
-    headSet(e, true).asScala.lastOption.getOrElse(null.asInstanceOf[E])
+    headSet(e, true).scalaOps.lastOption.getOrElse(null.asInstanceOf[E])
 
   def ceiling(e: E): E =
-    tailSet(e, true).asScala.headOption.getOrElse(null.asInstanceOf[E])
+    tailSet(e, true).scalaOps.headOption.getOrElse(null.asInstanceOf[E])
 
   def higher(e: E): E =
-    tailSet(e, false).asScala.headOption.getOrElse(null.asInstanceOf[E])
+    tailSet(e, false).scalaOps.headOption.getOrElse(null.asInstanceOf[E])
 
   def pollFirst(): E = {
     val polled = inner().headOption
@@ -115,17 +114,13 @@ private[util] class NavigableView[E](original: NavigableSet[E],
     }
   }
 
-  def first(): E = {
-    val iter = iterator()
-    if (iter.hasNext) iter.next
-    else null.asInstanceOf[E]
-  }
+  def first(): E =
+    iterator().scalaOps.headOption
+      .getOrElse(null.asInstanceOf[E])
 
-  def last(): E = {
-    val iter = iterator()
-    if (iter.hasNext) iter.asScala.toTraversable.last
-    else null.asInstanceOf[E]
-  }
+  def last(): E =
+    iterator().scalaOps.lastOption
+      .getOrElse(null.asInstanceOf[E])
 
   def subSet(fromElement: E,
              fromInclusive: Boolean,
@@ -137,10 +132,10 @@ private[util] class NavigableView[E](original: NavigableSet[E],
 
     val subSetFun = { () =>
       val toTs =
-        if (toInclusive) innerNow.to(boxedTo)
-        else innerNow.until(boxedTo)
-      if (fromInclusive) toTs.from(boxedFrom)
-      else toTs.from(boxedFrom) - boxedFrom
+        if (toInclusive) innerNow.compatOps.rangeTo(boxedTo)
+        else innerNow.compatOps.rangeUntil(boxedTo)
+      if (fromInclusive) toTs.compatOps.rangeFrom(boxedFrom)
+      else toTs.compatOps.rangeFrom(boxedFrom).diff(Set(boxedFrom))
     }
 
     new NavigableView(this,
@@ -156,8 +151,8 @@ private[util] class NavigableView[E](original: NavigableSet[E],
     val boxed    = Box(toElement)
 
     val headSetFun =
-      if (inclusive)() => innerNow.to(boxed)
-      else () => innerNow.until(boxed)
+      if (inclusive)() => innerNow.compatOps.rangeTo(boxed)
+      else () => innerNow.compatOps.rangeUntil(boxed)
 
     new NavigableView(this, headSetFun, None, true, Some(toElement), inclusive)
   }
@@ -167,8 +162,8 @@ private[util] class NavigableView[E](original: NavigableSet[E],
     val boxed    = Box(fromElement)
 
     val tailSetFun =
-      if (inclusive)() => innerNow.from(boxed)
-      else () => innerNow.from(boxed) - boxed
+      if (inclusive)() => innerNow.compatOps.rangeFrom(boxed)
+      else () => innerNow.compatOps.rangeFrom(boxed).diff(Set(boxed))
 
     new NavigableView(this,
                       tailSetFun,

--- a/javalib/src/main/scala/java/util/ScalaCompatOps.scala
+++ b/javalib/src/main/scala/java/util/ScalaCompatOps.scala
@@ -1,0 +1,37 @@
+package java.util
+
+import scala.collection.mutable
+
+private[util] object ScalaCompatOps {
+
+  implicit class ToScalaMutableSortedSetCompatOps[A] private[ScalaCompatOps] (
+      private val self: mutable.SortedSet[A])
+      extends AnyVal {
+    def compatOps: ScalaMutableSetCompatOps[A] =
+      new ScalaMutableSetCompatOps[A](self)
+  }
+
+  class ScalaMutableSetCompatOps[A] private[ScalaCompatOps] (
+      private val self: mutable.SortedSet[A])
+      extends AnyVal {
+
+    def rangeUntil(until: A): mutable.SortedSet[A] =
+      self.rangeImpl(None, Some(until))
+
+    def rangeFrom(from: A): mutable.SortedSet[A] =
+      self.rangeImpl(Some(from), None)
+
+    def rangeTo(to: A): mutable.SortedSet[A] = {
+      val i = rangeFrom(to).iterator
+      if (i.isEmpty) self
+      else {
+        val next = i.next()
+        if (defaultOrdering.compare(next, to) == 0)
+          if (i.isEmpty) self
+          else rangeUntil(i.next())
+        else
+          rangeUntil(next)
+      }
+    }
+  }
+}

--- a/javalib/src/main/scala/java/util/ScalaOps.scala
+++ b/javalib/src/main/scala/java/util/ScalaOps.scala
@@ -177,14 +177,10 @@ private[java] object ScalaOps {
       else throw new NoSuchElementException("empty.last")
 
     @inline def min(comp: Comparator[_ >: A]): A =
-      reduceLeft[A] {
-        case (l, r) => if (comp.compare(l, r) <= 0) l else r
-      }
+      reduceLeft[A]((l, r) => if (comp.compare(l, r) <= 0) l else r)
 
     @inline def max(comp: Comparator[_ >: A]): A =
-      reduceLeft[A] {
-        case (l, r) => if (comp.compare(l, r) >= 0) l else r
-      }
+      reduceLeft[A]((l, r) => if (comp.compare(l, r) >= 0) l else r)
 
     @inline def toSeq: Seq[A] = {
       val buf = Seq.newBuilder[A]

--- a/javalib/src/main/scala/java/util/ScalaOps.scala
+++ b/javalib/src/main/scala/java/util/ScalaOps.scala
@@ -15,24 +15,6 @@ package java.util
 /** Make some Scala collection APIs available on Java collections. */
 private[java] object ScalaOps {
 
-  implicit class IntScalaOps private[ScalaOps] (val __self: Int)
-      extends AnyVal {
-    @inline def until(end: Int): SimpleRange =
-      new SimpleRange(__self, end)
-  }
-
-  @inline
-  final class SimpleRange(start: Int, end: Int) {
-    @inline
-    def foreach[U](f: Int => U): Unit = {
-      var i = start
-      while (i < end) {
-        f(i)
-        i += 1
-      }
-    }
-  }
-
   implicit class ToJavaIterableOps[A] private[ScalaOps] (
       val __self: java.lang.Iterable[A])
       extends AnyVal {

--- a/javalib/src/main/scala/java/util/ScalaOps.scala
+++ b/javalib/src/main/scala/java/util/ScalaOps.scala
@@ -50,6 +50,27 @@ private[java] object ScalaOps {
 
     @inline def mkString(start: String, sep: String, end: String): String =
       __self.iterator().scalaOps.mkString(start, sep, end)
+
+    @inline def min(comp: Comparator[_ >: A]): A =
+      __self.iterator().scalaOps.min(comp)
+
+    @inline def max(comp: Comparator[_ >: A]): A =
+      __self.iterator().scalaOps.max(comp)
+
+    @inline def headOption: Option[A] =
+      __self.iterator().scalaOps.headOption
+
+    @inline def head: A =
+      __self.iterator().scalaOps.head
+
+    @inline def lastOption: Option[A] =
+      __self.iterator().scalaOps.lastOption
+
+    @inline def last: A =
+      __self.iterator().scalaOps.last
+
+    @inline def toSeq: Seq[A] =
+      __self.iterator().scalaOps.toSeq
   }
 
   implicit class ToJavaIteratorOps[A] private[ScalaOps] (
@@ -64,6 +85,11 @@ private[java] object ScalaOps {
     @inline def foreach[U](f: A => U): Unit = {
       while (__self.hasNext())
         f(__self.next())
+    }
+
+    @inline def map[U](f: A => U): Iterator[U] = new Iterator[U] {
+      override def hasNext: Boolean = __self.hasNext
+      override def next(): U        = f(__self.next())
     }
 
     @inline def count(f: A => Boolean): Int =
@@ -123,6 +149,47 @@ private[java] object ScalaOps {
         result += __self.next()
       }
       result + end
+    }
+
+    @inline def headOption: Option[A] = {
+      if (__self.hasNext()) Some(__self.next())
+      else None
+    }
+
+    @inline def head: A = {
+      if (__self.hasNext()) __self.next()
+      else throw new NoSuchElementException("empty.head")
+    }
+
+    @inline def lastOption: Option[A] = {
+      if (!__self.hasNext()) None
+      else {
+        var last: A = __self.next()
+        while (__self.hasNext()) {
+          last = __self.next()
+        }
+        Some(last)
+      }
+    }
+
+    @inline def last: A =
+      if (__self.hasNext()) lastOption.get
+      else throw new NoSuchElementException("empty.last")
+
+    @inline def min(comp: Comparator[_ >: A]): A =
+      reduceLeft[A] {
+        case (l, r) => if (comp.compare(l, r) <= 0) l else r
+      }
+
+    @inline def max(comp: Comparator[_ >: A]): A =
+      reduceLeft[A] {
+        case (l, r) => if (comp.compare(l, r) >= 0) l else r
+      }
+
+    @inline def toSeq: Seq[A] = {
+      val buf = Seq.newBuilder[A]
+      foreach(buf += _)
+      buf.result()
     }
   }
 

--- a/javalib/src/main/scala/java/util/TreeSet.scala
+++ b/javalib/src/main/scala/java/util/TreeSet.scala
@@ -166,9 +166,9 @@ class TreeSet[E](_comparator: Comparator[_ >: E])
     val headSetFun = { () =>
       // the creation of a new TreeSet is to avoid a mysterious bug with scala 2.10
       var base = new mutable.TreeSet[Box[E]]
-      if (inclusive) {
+      if (inclusive)
         base ++= inner.compatOps.rangeTo(boxed)
-      } else
+      else
         base ++= inner.compatOps.rangeUntil(boxed)
 
       base

--- a/javalib/src/main/scala/java/util/TreeSet.scala
+++ b/javalib/src/main/scala/java/util/TreeSet.scala
@@ -1,10 +1,9 @@
 package java.util
 
-import java.lang.Comparable
 import scala.collection.mutable
 import scala.math.Ordering
-
-import scala.collection.JavaConverters._
+import ScalaOps._
+import ScalaCompatOps._
 
 class TreeSet[E](_comparator: Comparator[_ >: E])
     extends AbstractSet[E]
@@ -167,10 +166,10 @@ class TreeSet[E](_comparator: Comparator[_ >: E])
     val headSetFun = { () =>
       // the creation of a new TreeSet is to avoid a mysterious bug with scala 2.10
       var base = new mutable.TreeSet[Box[E]]
-      if (inclusive)
-        base ++= inner.to(boxed)
-      else
-        base ++= inner.until(boxed)
+      if (inclusive) {
+        base ++= inner.compatOps.rangeTo(boxed)
+      } else
+        base ++= inner.compatOps.rangeUntil(boxed)
 
       base
     }
@@ -183,7 +182,7 @@ class TreeSet[E](_comparator: Comparator[_ >: E])
     val tailSetFun = { () =>
       // the creation of a new TreeSet is to avoid a mysterious bug with scala 2.10
       var base = new mutable.TreeSet[Box[E]]
-      base ++= inner.from(boxed)
+      base ++= inner.compatOps.rangeFrom(boxed)
       if (!inclusive)
         base -= boxed
 
@@ -216,16 +215,16 @@ class TreeSet[E](_comparator: Comparator[_ >: E])
     inner.last.inner
 
   def lower(e: E): E =
-    headSet(e, false).asScala.lastOption.getOrElse(null.asInstanceOf[E])
+    headSet(e, false).scalaOps.lastOption.getOrElse(null.asInstanceOf[E])
 
   def floor(e: E): E =
-    headSet(e, true).asScala.lastOption.getOrElse(null.asInstanceOf[E])
+    headSet(e, true).scalaOps.lastOption.getOrElse(null.asInstanceOf[E])
 
   def ceiling(e: E): E =
-    tailSet(e, true).asScala.headOption.getOrElse(null.asInstanceOf[E])
+    tailSet(e, true).scalaOps.headOption.getOrElse(null.asInstanceOf[E])
 
   def higher(e: E): E =
-    tailSet(e, false).asScala.headOption.getOrElse(null.asInstanceOf[E])
+    tailSet(e, false).scalaOps.headOption.getOrElse(null.asInstanceOf[E])
 
   def pollFirst(): E = {
     val polled = inner.headOption


### PR DESCRIPTION
This PR contains extracted changes from #1916 removing usages of `scala.collection.JavaConverters` from javalib module. This change is needed to enable Scala 2.13 support since the usage of this helper module is highly problematic in cross-compile. 