### PR TITLE
Fix #1993: Port ju.ConcurrentLinkedQueue from Scala.js

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
@@ -1,0 +1,155 @@
+// Ported from Scala.js commit: 6819668 dated: 2020-10-07
+
+package java.util.concurrent
+
+import java.util._
+import java.util.ScalaOps._
+
+class ConcurrentLinkedQueue[E]()
+    extends AbstractQueue[E]
+    with Queue[E]
+    with Serializable {
+
+  def this(c: Collection[_ <: E]) = {
+    this()
+    addAll(c)
+  }
+
+  import ConcurrentLinkedQueue._
+
+  private var head: Node[E] = null
+  private var last: Node[E] = null
+
+  private var _size: Double = 0
+
+  override def add(e: E): Boolean = {
+    if (e == null) {
+      throw new NullPointerException()
+    } else {
+      val oldLast = last
+
+      last = new Node(e)
+
+      _size += 1
+
+      if (oldLast ne null)
+        oldLast.next = last
+      else
+        head = last
+
+      true
+    }
+  }
+
+  override def offer(e: E): Boolean =
+    add(e)
+
+  override def poll(): E = {
+    if (isEmpty()) null.asInstanceOf[E]
+    else {
+      val oldHead = head
+      head = oldHead.next
+
+      if (head eq null)
+        last = null
+
+      _size -= 1
+      oldHead.value
+    }
+  }
+
+  override def peek(): E =
+    if (isEmpty()) null.asInstanceOf[E]
+    else head.value
+
+  override def isEmpty(): Boolean =
+    _size == 0
+
+  override def size(): Int =
+    _size.toInt
+
+  private def getNodeAt(index: Int): Node[E] = {
+    var current: Node[E] = head
+    for (_ <- 0 until index)
+      current = current.next
+    current
+  }
+
+  private def removeNode(node: Node[E]): Unit = {
+    if (node eq head) {
+      poll()
+    } else if (head ne null) {
+      var prev             = head
+      var current: Node[E] = head.next
+
+      while ((current ne null) && (current ne node)) {
+        prev = current
+        current = current.next
+      }
+
+      if (current eq null) {
+        null.asInstanceOf[E]
+      } else {
+        _size -= 1
+
+        prev.next = current.next
+        if (current eq last)
+          last = prev
+      }
+    }
+  }
+
+  override def iterator(): Iterator[E] = {
+    new Iterator[E] {
+
+      private var nextNode: Node[Node[E]] = {
+        val originalHead: Node[Node[E]] =
+          if (head ne null) new Node(head)
+          else null
+
+        var current = originalHead
+        while (current ne null) {
+          val newNode: Node[Node[E]] =
+            if (current.value.next ne null) new Node(current.value.next)
+            else null
+
+          current.next = newNode
+          current = newNode
+        }
+
+        originalHead
+      }
+
+      private var lastNode: Node[Node[E]] = null
+
+      def hasNext(): Boolean =
+        nextNode ne null
+
+      def next(): E = {
+        if (nextNode eq null)
+          throw new NoSuchElementException()
+
+        lastNode = nextNode
+        nextNode = nextNode.next
+
+        lastNode.value.value
+      }
+
+      override def remove(): Unit = {
+        if (lastNode eq null)
+          throw new IllegalStateException()
+
+        removeNode(lastNode.value)
+
+        lastNode = null
+      }
+    }
+  }
+
+}
+
+object ConcurrentLinkedQueue {
+
+  private final class Node[T](var value: T, var next: Node[T] = null)
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
@@ -20,7 +20,7 @@ class ConcurrentLinkedQueue[E]()
   private var head: Node[E] = null
   private var last: Node[E] = null
 
-  private var _size: Double = 0
+  private var _size: Long = 0L
 
   override def add(e: E): Boolean = {
     if (e == null) {
@@ -66,7 +66,7 @@ class ConcurrentLinkedQueue[E]()
     _size == 0
 
   override def size(): Int =
-    _size.toInt
+    if (_size > Int.MaxValue) Int.MaxValue else _size.toInt
 
   private def getNodeAt(index: Int): Node[E] = {
     var current: Node[E] = head

--- a/unit-tests/src/test/scala/java/util/concurrent/ConcurrentLinkedQueueTest.scala
+++ b/unit-tests/src/test/scala/java/util/concurrent/ConcurrentLinkedQueueTest.scala
@@ -1,0 +1,184 @@
+// Ported from Scala.js commit: 222e14c dated: 2019-09-12
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.{util => ju}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.javalib.util.{
+  AbstractCollectionFactory,
+  AbstractCollectionTest,
+  TrivialImmutableCollection
+}
+
+import scala.reflect.ClassTag
+
+class ConcurrentLinkedQueueTest extends AbstractCollectionTest {
+
+  override def factory: ConcurrentLinkedQueueFactory =
+    new ConcurrentLinkedQueueFactory
+
+  @Test def should_store_and_remove_ordered_integers(): Unit = {
+    val pq = factory.empty[Int]
+
+    assertEquals(0, pq.size())
+    assertTrue(pq.add(111))
+    assertEquals(1, pq.size())
+    assertTrue(pq.add(222))
+    assertEquals(2, pq.size())
+    assertEquals(111, pq.poll())
+    assertEquals(1, pq.size())
+    assertEquals(222, pq.poll())
+    assertTrue(pq.add(222))
+    assertTrue(pq.add(222))
+    assertTrue(pq.remove(222))
+    assertTrue(pq.remove(222))
+    assertFalse(pq.remove(222))
+  }
+
+  @Test def should_store_and_remove_strings(): Unit = {
+    val pq = factory.empty[String]
+
+    assertEquals(0, pq.size())
+    assertTrue(pq.add("aaa"))
+    assertEquals(1, pq.size())
+    assertTrue(pq.add("bbb"))
+    assertEquals(2, pq.size())
+    assertEquals("aaa", pq.poll())
+    assertEquals(1, pq.size())
+    assertEquals("bbb", pq.poll())
+    assertTrue(pq.add("bbb"))
+    assertTrue(pq.add("bbb"))
+    assertTrue(pq.remove("bbb"))
+    assertTrue(pq.remove("bbb"))
+    assertFalse(pq.remove("bbb"))
+    assertNull(pq.poll())
+  }
+
+  @Test def should_store_Double_even_in_corner_cases(): Unit = {
+    val pq = factory.empty[Double]
+
+    assertTrue(pq.add(1.0))
+    assertTrue(pq.add(+0.0))
+    assertTrue(pq.add(-0.0))
+    assertTrue(pq.add(Double.NaN))
+
+    assertTrue(pq.poll.equals(1.0))
+
+    assertTrue(pq.poll.equals(+0.0))
+
+    assertTrue(pq.poll.equals(-0.0))
+
+    assertTrue(pq.peek.isNaN)
+
+    assertTrue(pq.remove(Double.NaN))
+
+    assertTrue(pq.isEmpty)
+  }
+
+  @Test def could_be_instantiated_with_a_prepopulated_Collection(): Unit = {
+    val l  = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val pq = factory.newFrom(l)
+
+    assertEquals(5, pq.size())
+    for (i <- List(1, 5, 2, 3, 4)) {
+      assertEquals(i, pq.poll())
+    }
+    assertTrue(pq.isEmpty)
+  }
+
+  @Test def should_be_cleared_in_a_single_operation(): Unit = {
+    val l  = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val pq = factory.newFrom(l)
+
+    assertEquals(5, pq.size())
+    pq.clear()
+    assertEquals(0, pq.size())
+  }
+
+  @Test def should_add_multiple_elemnt_in_one_operation(): Unit = {
+    val l  = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val pq = factory.empty[Int]
+
+    assertEquals(0, pq.size())
+    pq.addAll(l)
+    assertEquals(5, pq.size())
+    pq.add(6)
+    assertEquals(6, pq.size())
+  }
+
+  @Test def should_check_contained_values_even_in_double_corner_cases()
+      : Unit = {
+    val pq = factory.empty[Double]
+
+    assertTrue(pq.add(11111.0))
+    assertEquals(1, pq.size())
+    assertTrue(pq.contains(11111.0))
+    assertEquals(11111.0, pq.iterator.next(), 0.0)
+
+    assertTrue(pq.add(Double.NaN))
+    assertEquals(2, pq.size())
+    assertTrue(pq.contains(Double.NaN))
+    assertFalse(pq.contains(+0.0))
+    assertFalse(pq.contains(-0.0))
+
+    assertTrue(pq.remove(Double.NaN))
+    assertTrue(pq.add(+0.0))
+    assertEquals(2, pq.size())
+    assertFalse(pq.contains(Double.NaN))
+    assertTrue(pq.contains(+0.0))
+    assertFalse(pq.contains(-0.0))
+
+    assertTrue(pq.remove(+0.0))
+    assertTrue(pq.add(-0.0))
+    assertEquals(2, pq.size())
+    assertFalse(pq.contains(Double.NaN))
+    assertFalse(pq.contains(+0.0))
+    assertTrue(pq.contains(-0.0))
+
+    assertTrue(pq.add(+0.0))
+    assertTrue(pq.add(Double.NaN))
+    assertTrue(pq.contains(Double.NaN))
+    assertTrue(pq.contains(+0.0))
+    assertTrue(pq.contains(-0.0))
+  }
+
+  @Test def should_provide_a_weakly_consistent_iterator(): Unit = {
+    val queue = factory.empty[Int]
+    queue.add(1)
+    queue.add(2)
+    val iter1 = queue.iterator()
+    assertEquals(1, iter1.next())
+    assertTrue(iter1.hasNext)
+    queue.remove(2)
+    assertTrue(iter1.hasNext)
+    assertEquals(2, iter1.next())
+    assertFalse(iter1.hasNext)
+
+    val queue2 = factory.empty[Int]
+    queue2.add(1)
+    queue2.add(2)
+    queue2.add(3)
+    val iter2 = queue2.iterator()
+    assertEquals(1, iter2.next())
+    iter2.remove()
+    assertEquals(2, iter2.next())
+    assertEquals(3, iter2.next())
+  }
+}
+
+class ConcurrentLinkedQueueFactory extends AbstractCollectionFactory {
+  override def implementationName: String =
+    "java.util.concurrent.ConcurrentLinkedQueue"
+
+  override def empty[E: ClassTag]: ConcurrentLinkedQueue[E] =
+    new ConcurrentLinkedQueue[E]()
+
+  def newFrom[E](coll: ju.Collection[E]): ConcurrentLinkedQueue[E] =
+    new ConcurrentLinkedQueue[E](coll)
+
+  override def allowsNullElement: Boolean = false
+}


### PR DESCRIPTION
Fixes: #1993 .
I commented out a test using `Collection#removeIf` because it was failing to link.
Added a comment and a `@Ignore` annotation.
Other than this, I just copy-pasted the files and changed the licensing comment and the package names accordingly to other files in the repository.

I needed to reformat the files. It would be nice if we used the same Scalafmt settings so we could copy-paste the files from Scala.js without edits.