### PR TITLE
Fix #1972: Implement JavaDefaultMethods on Scala 2.11

### DIFF
--- a/javalib/src/main/scala/java/util/Comparator.scala
+++ b/javalib/src/main/scala/java/util/Comparator.scala
@@ -1,7 +1,14 @@
+// Ported from Scala.js commit SHA1: 9dc4d5b dated: 2018-10-11
+
 package java.util
+
+import scala.scalanative.annotation.JavaDefaultMethod
 
 trait Comparator[A] {
   def compare(o1: A, o2: A): Int
   def equals(obj: Any): Boolean
-  def reversed(): Comparator[A] = Collections.reverseOrder(this)
+
+  @JavaDefaultMethod
+  def reversed(): Comparator[A] =
+    Collections.reverseOrder(this)
 }

--- a/nativelib/src/main/scala/scala/scalanative/annotation/JavaDefaultMethod.scala
+++ b/nativelib/src/main/scala/scala/scalanative/annotation/JavaDefaultMethod.scala
@@ -1,0 +1,14 @@
+// Ported from Scala.js commit SHA1: 9dc4d5b dated: 2020-10-18
+
+package scala.scalanative
+package annotation
+
+/** Mark a concrete trait method as a Java default method.
+ *
+ *  This annotation can be used on concrete trait methods to mark them as
+ *  Java default methods. This should be used *only* to implement interfaces
+ *  of the JDK that have default methods in Java.
+ *
+ *  Otherwise using this annotation is unspecified.
+ */
+class JavaDefaultMethod extends scala.annotation.StaticAnnotation

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -346,4 +346,7 @@ trait NirDefinitions {
       getRequiredClass(
         "scala.scalanative.reflect.annotation.EnableReflectiveInstantiation")
   }
+
+  lazy val JavaDefaultMethodAnnotation =
+    getRequiredClass("scala.scalanative.annotation.JavaDefaultMethod")
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -676,12 +676,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           case rhs
               if (isScala211 &&
                 sym.hasAnnotation(JavaDefaultMethodAnnotation) &&
-                !sym.owner.name.decoded.endsWith("$class")) =>
-          // The obvious scala 2.11 sym.isImplClass becomes deprecated
-          // in Scala 2.12.
-          //
+                !isImplClass(sym.owner)) =>
           // Have a concrete method with JavaDefaultMethodAnnotation; a blivet.
-          // Do not emit, not even as abstract
+          // Do not emit, not even as abstract.
 
           case rhs =>
             scoped(

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -676,8 +676,12 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           case rhs
               if (isScala211 &&
                 sym.hasAnnotation(JavaDefaultMethodAnnotation) &&
-                (!sym.owner.isImplClass)) =>
-          // do not emit, not even as abstract
+                !sym.owner.name.decoded.endsWith("$class")) =>
+          // The obvious scala 2.11 sym.isImplClass becomes deprecated
+          // in Scala 2.12.
+          //
+          // Have a concrete method with JavaDefaultMethodAnnotation; a blivet.
+          // Do not emit, not even as abstract
 
           case rhs =>
             scoped(

--- a/unit-tests/src/test/scala/compiler/DefaultMethodsTest.scala
+++ b/unit-tests/src/test/scala/compiler/DefaultMethodsTest.scala
@@ -1,0 +1,35 @@
+// Ported from Scala.js commit SHA1: ac06525 dated: 2016-01-05
+
+package org.scalanative.testsuite.compiler
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.{util => ju}
+
+class DefaultMethodsTest {
+
+  @Test def canOverrideDefaultMethod(): Unit = {
+    var counter = 0
+
+    class SpecialIntComparator extends ju.Comparator[Int] {
+      def compare(o1: Int, o2: Int): Int =
+        o1.compareTo(o2)
+
+      override def reversed(): ju.Comparator[Int] = {
+        counter += 1
+        super.reversed()
+      }
+    }
+
+    val c = new SpecialIntComparator
+    assertTrue(c.compare(5, 7) < 0)
+    assertEquals(0, counter)
+
+    val reversed = c.reversed()
+    assertEquals(1, counter)
+    assertTrue(reversed.compare(5, 7) > 0)
+  }
+}
+
+// -30- //

--- a/unit-tests/src/test/scala/compiler/DefaultMethodsTest.scala
+++ b/unit-tests/src/test/scala/compiler/DefaultMethodsTest.scala
@@ -31,5 +31,3 @@ class DefaultMethodsTest {
     assertTrue(reversed.compare(5, 7) > 0)
   }
 }
-
-// -30- //

--- a/unit-tests/src/test/scala/java/util/ComparatorTest.scala
+++ b/unit-tests/src/test/scala/java/util/ComparatorTest.scala
@@ -1,0 +1,31 @@
+// Ported from Scala.js commit SHA1: d94325e dated: 2020-10-08
+
+package java.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.{util => ju}
+
+class ComparatorTest {
+  @Test def reversed(): Unit = {
+    class IntComparator extends ju.Comparator[Int] {
+      def compare(a: Int, b: Int): Int = {
+        /* Using Int.MinValue makes sure that Comparator.reversed() does not
+         * use the naive implementation of negating the original comparator's
+         * result.
+         */
+        if (a == b) 0
+        else if (a < b) Int.MinValue
+        else Int.MaxValue
+      }
+    }
+
+    val comparator = new IntComparator
+    val reversed   = comparator.reversed()
+
+    assertEquals(0, reversed.compare(5, 5))
+    assertTrue(reversed.compare(3, 1) < 0)
+    assertTrue(reversed.compare(6, 8) > 0)
+  }
+}


### PR DESCRIPTION
This work is informed by ScalaJS PR 2141 "Fix #1269: Add support for default methods."

Documentation:

  * None needed. The JavaDefaultMethod annotation is part of nativelib, which is not part of the `Libraries` section
     of documentation for users.  The file itself clearly states "JDK only".

Testing:

  Safety -

  + Built and tested ("test-all") in debug mode using sbt 1.4.2 with
    each of Scala 2.11, 2.12, 2.13 on X86_64 only. All tests pass.

  Efficacy -

  + Passes a fresh port of Scala.js ComparatorTest.scala used to test
    the prior DefaultMethod defect in Scala.js

  + In my private environment using Scala 2.11, it passes challenged by
    a simplified port of Scala.js MapTest.scala running against
    a port of Scala.js Map.scala using the JavaDefaultMethod Annotation.

    The exercises methods with multiple parameters and methods with
    same name but different signatures.

    If the grand scheme of things, the change of this PR will run
    against standard ported Scala.K's MapTest.scala.