### PR TITLE
Fix #1999: Clear errno before readdir in posixlib dirent.c

### DIFF
--- a/posixlib/src/main/resources/scala-native/dirent.c
+++ b/posixlib/src/main/resources/scala-native/dirent.c
@@ -32,6 +32,7 @@ void scalanative_dirent_init(struct dirent *dirent,
 }
 
 int scalanative_readdir(DIR *dirp, struct scalanative_dirent *buf) {
+    errno = 0;
     struct dirent *orig_buf = readdir(dirp);
     if (orig_buf != NULL) {
         scalanative_dirent_init(orig_buf, buf);


### PR DESCRIPTION
The Posix standard recommends setting errno before calling readdir.
This fix will help distinguish the current intermittent errors in
DirectoryStreamTest: are they stale errno or are they
describing a real condition?

This is a targeted surgical change. I will create an Issue for other issues
discovered whilst creating this PR.