### PR TITLE
Annotate j.u.Iterator default methods as @JavaDefaultMethod.

### DIFF
--- a/javalib/src/main/scala/java/util/Iterator.scala
+++ b/javalib/src/main/scala/java/util/Iterator.scala
@@ -2,15 +2,19 @@
 
 package java.util
 
+import scala.scalanative.annotation.JavaDefaultMethod
+
 import java.util.function.Consumer
 
 trait Iterator[E] {
   def hasNext(): Boolean
   def next(): E
 
+  @JavaDefaultMethod
   def remove(): Unit =
     throw new UnsupportedOperationException("remove")
 
+  @JavaDefaultMethod
   def forEachRemaining(action: Consumer[_ >: E]): Unit = {
     while (hasNext())
       action.accept(next())

--- a/unit-tests/src/test/scala/java/util/IteratorTest.scala
+++ b/unit-tests/src/test/scala/java/util/IteratorTest.scala
@@ -1,0 +1,64 @@
+// Ported from Scala.js commit: f86ed65 dated: 2020-10-07
+
+package org.scalanative.testsuite.javalib.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.{util => ju}
+import java.util.function.Consumer
+
+import scala.scalanative.junit.utils.AssertThrows._
+
+class IteratorTest {
+  @Test def testRemove(): Unit = {
+    val iter = new ju.Iterator[String] {
+      def hasNext(): Boolean = true
+      def next(): String     = "foo"
+    }
+
+    assertThrows(classOf[UnsupportedOperationException], iter.remove())
+    iter.next()
+    assertThrows(classOf[UnsupportedOperationException], iter.remove())
+  }
+
+  @Test def testForEachRemaining(): Unit = {
+    val elems     = Array("one", "two", "three", "four")
+    val elemsList = elems.toList
+
+    class Iter extends ju.Iterator[String] {
+      private var index = 0
+
+      def hasNext(): Boolean = index < elems.length
+
+      def next(): String = {
+        if (!hasNext())
+          throw new NoSuchElementException
+        index += 1
+        elems(index - 1)
+      }
+    }
+
+    // from scratch
+    val iter1    = new Iter
+    val builder1 = List.newBuilder[String]
+    iter1.forEachRemaining(new Consumer[String] {
+      def accept(elem: String): Unit =
+        builder1 += elem
+    })
+    assertEquals(elemsList, builder1.result())
+
+    // after some calls to next()
+    val iter2 = new Iter
+    iter2.next()
+    iter2.next()
+    val builder2 = List.newBuilder[String]
+    iter2.forEachRemaining(new Consumer[String] {
+      def accept(elem: String): Unit =
+        builder2 += elem
+    })
+    assertEquals(elemsList.drop(2), builder2.result())
+  }
+}
+
+// -30- //

--- a/unit-tests/src/test/scala/java/util/IteratorTest.scala
+++ b/unit-tests/src/test/scala/java/util/IteratorTest.scala
@@ -60,5 +60,3 @@ class IteratorTest {
     assertEquals(elemsList.drop(2), builder2.result())
   }
 }
-
-// -30- //


### PR DESCRIPTION
This PR builds upon merged PR #1937 by adding the JavaDefaultMethod annotation to the trait and
porting the test for the trait.

See Issue #1972 for background & discussion of JavaDefaultMethod annotation.

This PR is WIP because it will fail to build until after PR #1997
is merged and this PR rebased upon it.