### PR TITLE
Implement the default methods of j.u.List.

### DIFF
--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -1,9 +1,45 @@
+// Ported from Scala.js commit: ad7d82f dated: 2020-10-05
+
 package java.util
 
+import java.util.function.UnaryOperator
+
+import scala.scalanative.annotation.JavaDefaultMethod
+
 trait List[E] extends Collection[E] {
+  @JavaDefaultMethod
+  def replaceAll(operator: UnaryOperator[E]): Unit = {
+    val iter = listIterator()
+    while (iter.hasNext())
+      iter.set(operator.apply(iter.next()))
+  }
+
+  @JavaDefaultMethod
+  def sort(c: Comparator[_ >: E]): Unit = {
+    val arrayBuf = toArray()
+    Arrays.sort[AnyRef with E](arrayBuf.asInstanceOf[Array[AnyRef with E]], c)
+
+    val len = arrayBuf.length
+
+    if (this.isInstanceOf[RandomAccess]) {
+      var i = 0
+      while (i != len) {
+        set(i, arrayBuf(i).asInstanceOf[E])
+        i += 1
+      }
+    } else {
+      var i    = 0
+      val iter = listIterator()
+      while (i != len) {
+        iter.next()
+        iter.set(arrayBuf(i).asInstanceOf[E])
+        i += 1
+      }
+    }
+  }
+
   def get(index: Int): E
   def set(index: Int, element: E): E
-  def add(element: E): Boolean
   def add(index: Int, element: E): Unit
   def remove(index: Int): E
   def indexOf(o: Any): Int
@@ -11,11 +47,5 @@ trait List[E] extends Collection[E] {
   def listIterator(): ListIterator[E]
   def listIterator(index: Int): ListIterator[E]
   def subList(fromIndex: Int, toIndex: Int): List[E]
-  def addAll(c: Collection[_ <: E]): Boolean
   def addAll(index: Int, c: Collection[_ <: E]): Boolean
-  def clear(): Unit
-  def isEmpty(): Boolean
-  def iterator(): Iterator[E]
-  def contains(o: Any): Boolean
-  def size(): Int
 }


### PR DESCRIPTION
This PR builds upon merged PRs #1937  & #2040 by adding the JavaDefaultMethod
annotation to the trait

The discerning reader will notice that there is no ListTest.scala in this PR.
I believe that it reduces the tangle of complexity to do a test which
exercises the List trait in a separate PR.  I almost always like to see
code and something which exercises it in the same PR.
Here I think the dance requires something else.

Scala Native currently has no ListTest.scala. Scala.js
ListTest is a trait and needs a concrete Test to exercise
it, such as LinkedListTest.  Both ListTest and
LinkedListTest have a number of prerequisites.
Almost all of them, such as CollectionsTestBase are
Not Yet Implemented in Scala Native.  One, 
`TrivialImmutableCollection` is implemented in pending PR #2037 

I propose that concerns be kept separate, with this, albeit untested, PR focused
on JavaDefaultMethods and a larger LinkedList & supporting
infrastructure PR be created (days, not weeks). That would provide
provide tests for the JavaDefaultMethods implemented in this PR.

See Issue #1972 for background & discussion of JavaDefaultMethod
annotation.