### PR TITLE
Annotate j.u.f.Consumer default method

### DIFF
--- a/javalib/src/main/scala/java/util/function/Consumer.scala
+++ b/javalib/src/main/scala/java/util/function/Consumer.scala
@@ -1,15 +1,15 @@
 package java.util.function
 
-trait Consumer[T] {
-  self =>
+import scala.scalanative.annotation.JavaDefaultMethod
 
+trait Consumer[T] { self =>
   def accept(t: T): Unit
 
+  @JavaDefaultMethod
   def andThen(after: Consumer[T]): Consumer[T] = new Consumer[T]() {
-    override def accept(t: T): Unit = {
+    def accept(t: T): Unit = {
       self.accept(t)
       after.accept(t)
     }
   }
-
 }

--- a/unit-tests/src/test/scala/java/util/function/ConsumerTest.scala
+++ b/unit-tests/src/test/scala/java/util/function/ConsumerTest.scala
@@ -1,40 +1,65 @@
-package java.util.function
+// Ported from Scala.js commit: 7fd9ebb dated: 2020=01-06
 
-import org.junit.Ignore
-import org.junit.Before
-import org.junit.Test
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.Consumer
+
 import org.junit.Assert._
+import org.junit.Test
+
+import scala.scalanative.junit.utils.AssertThrows._
 
 class ConsumerTest {
-  var amount = 1
+  import ConsumerTest._
 
-  @Before
-  def setUp(): Unit = {
-    var amount = 1
+  @Test def accept(): Unit = {
+    // Side-effects
+    var current: Int = 0
+    val add          = makeConsumer[Int](num => current += num)
+
+    add.accept(1)
+    assertTrue(current == 1)
+
+    add.accept(2)
+    assertTrue(current == 3)
   }
 
-  val addT = new Consumer[Int] {
-    override def accept(t: Int): Unit = {
-      amount = amount + t
+  @Test def andThen(): Unit = {
+    // Side-effects
+    var current: Int   = 0
+    val add            = makeConsumer[Int](num => current += num)
+    val multiply       = makeConsumer[Int](num => current *= num)
+    val addAndMultiply = add.andThen(multiply)
+
+    addAndMultiply.accept(2)
+    assertTrue(current == 4)
+
+    addAndMultiply.accept(3)
+    assertTrue(current == 21)
+
+    // Sequential operations
+    val throwingConsumer =
+      makeConsumer[Any](x => throw new ThrowingConsumerException(x))
+    val dontCallConsumer =
+      makeConsumer[Any](x =>
+        throw new AssertionError(s"dontCallConsumer.accept($x)"))
+
+    assertThrows(classOf[ThrowingConsumerException],
+                 throwingConsumer.andThen(dontCallConsumer).accept(0))
+
+    assertThrows(classOf[ThrowingConsumerException],
+                 add.andThen(throwingConsumer).accept(1))
+    assertTrue(current == 22)
+  }
+}
+
+object ConsumerTest {
+  final class ThrowingConsumerException(x: Any)
+      extends Exception(s"throwing consumer called with $x")
+
+  def makeConsumer[T](f: T => Unit): Consumer[T] = {
+    new Consumer[T] {
+      def accept(t: T): Unit = f(t)
     }
-  }
-
-  val timesT = new Consumer[Int] {
-    override def accept(t: Int): Unit = {
-      amount = amount * t
-    }
-  }
-
-  @Test def consumerApply(): Unit = {
-    assertTrue(amount == 1)
-    addT.accept(2)
-    assertTrue(amount == 3)
-  }
-
-  @Ignore("#1229 - 2.11 does not have default method support")
-  @Test def consumerAndThen(): Unit = {
-    // assertTrue(amount == 1)
-    // addT.andThen(timesT).accept(2)
-    // assertTrue(amount == 6)
   }
 }


### PR DESCRIPTION
This PR builds upon merged PR #1937 by adding the JavaDefaultMethod
annotation to the trait and porting the test for the trait.

Note Well: Scala.js j.u.f.Consumer.scala carries a `@FunctionalInterface`
           annotation.  I did not port that over. I believe that it enforcing
           "single abstract method only" adds no value to Scala Native
            javalib, especially since the j.u.f methods will have come
            from Scala.js, which already checks for that requirement.

See Issue #1972 for background & discussion of JavaDefaultMethod annotation.