### PR TITLE
Annotate  & test j.u.f.Function default methods

### DIFF
--- a/javalib/src/main/scala/java/util/function/Function.scala
+++ b/javalib/src/main/scala/java/util/function/Function.scala
@@ -1,22 +1,23 @@
+// Ported from Scala.js commit: eb637e3 dated: 2020-09-06
+
 package java.util.function
 
-trait Function[T, R] { self =>
-  def andThen[V](after: Function[_ >: R, _ <: V]): Function[T, V] =
-    new Function[T, V] {
-      override def apply(t: T): V = after.apply(self.apply(t))
-    }
+import scala.scalanative.annotation.JavaDefaultMethod
 
-  def compose[V](before: Function[_ >: V, _ <: T]): Function[V, R] =
-    new Function[V, R] {
-      override def apply(v: V): R = self.apply(before.apply(v))
-    }
-
+trait Function[T, R] {
   def apply(t: T): R
+
+  @JavaDefaultMethod
+  def andThen[V](after: Function[_ >: R, _ <: V]): Function[T, V] = { (t: T) =>
+    after.apply(apply(t))
+  }
+
+  @JavaDefaultMethod
+  def compose[V](before: Function[_ >: V, _ <: T]): Function[V, R] = { (v: V) =>
+    apply(before.apply(v))
+  }
 }
 
 object Function {
-  def identity[T](): Function[T, T] =
-    new Function[T, T] {
-      override def apply(t: T): T = t
-    }
+  def identity[T](): Function[T, T] = (t: T) => t
 }

--- a/javalib/src/main/scala/java/util/function/Function.scala
+++ b/javalib/src/main/scala/java/util/function/Function.scala
@@ -1,23 +1,31 @@
-// Ported from Scala.js commit: eb637e3 dated: 2020-09-06
+// Influenced Scala.js commit: eb637e3 dated: 2020-09-06
+//
+// Design Note: Once Scala Native no longer supports Scala 2.11,
+//              OK to use Scala.js code with lambdas.
 
 package java.util.function
 
 import scala.scalanative.annotation.JavaDefaultMethod
 
-trait Function[T, R] {
+trait Function[T, R] { self =>
   def apply(t: T): R
 
   @JavaDefaultMethod
-  def andThen[V](after: Function[_ >: R, _ <: V]): Function[T, V] = { (t: T) =>
-    after.apply(apply(t))
-  }
+  def andThen[V](after: Function[_ >: R, _ <: V]): Function[T, V] =
+    new Function[T, V] {
+      override def apply(t: T): V = after.apply(self.apply(t))
+    }
 
   @JavaDefaultMethod
-  def compose[V](before: Function[_ >: V, _ <: T]): Function[V, R] = { (v: V) =>
-    apply(before.apply(v))
-  }
+  def compose[V](before: Function[_ >: V, _ <: T]): Function[V, R] =
+    new Function[V, R] {
+      override def apply(v: V): R = self.apply(before.apply(v))
+    }
 }
 
 object Function {
-  def identity[T](): Function[T, T] = (t: T) => t
+  def identity[T](): Function[T, T] =
+    new Function[T, T] {
+      override def apply(t: T): T = t
+    }
 }

--- a/unit-tests/src/test/scala/java/util/function/FunctionTest.scala
+++ b/unit-tests/src/test/scala/java/util/function/FunctionTest.scala
@@ -1,0 +1,48 @@
+// Ported from Scala.js commit: eb637e3 dated: 200-09-06
+
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.Function
+
+import org.junit.Assert._
+import org.junit.Test
+
+class FunctionTest {
+  import FunctionTest._
+
+  @Test def identity(): Unit = {
+    assertEquals(10, identityFunc(10))
+  }
+
+  @Test def create_and_apply(): Unit = {
+    assertEquals(2, doubleFunc(1))
+  }
+
+  @Test def compose(): Unit = {
+    // i.e. before
+    assertEquals(21, incFunc.compose(doubleFunc)(10))
+  }
+
+  @Test def andThen(): Unit = {
+    // i.e. after
+    assertEquals(22, incFunc.andThen(doubleFunc)(10))
+  }
+
+  @Test def identity_compose_andThen(): Unit = {
+    // i.e. (self + 1) * 2
+    val combined = identityFunc.andThen(doubleFunc).compose(incFunc)
+    assertEquals(42, combined(20))
+  }
+}
+
+object FunctionTest {
+  private val identityFunc: Function[Int, Int] = Function.identity[Int]()
+  private val doubleFunc: Function[Int, Int]   = makeFunction(x => x * 2)
+  private val incFunc: Function[Int, Int]      = makeFunction(x => x + 1)
+
+  private[this] def makeFunction[T, R](f: T => R): Function[T, R] = {
+    new Function[T, R] {
+      def apply(t: T): R = f(t)
+    }
+  }
+}


### PR DESCRIPTION
This PR builds upon merged PR #1937 by annotating the existing Function.scala and
porting its corresponding test from Scala.js.

This approach was taken to avoid the lambda in  the Scala.js implementation 
of Function.scala. That implementation is probably better, but does not
compile in Scala Native using Scala 2.11.12.

See Issue #1972 for background & discussion of JavaDefaultMethod annotation.
