### PR TITLE
Annotate & test j.l.Iterable default methods

### DIFF
--- a/javalib/src/main/scala/java/lang/Iterable.scala
+++ b/javalib/src/main/scala/java/lang/Iterable.scala
@@ -1,13 +1,16 @@
-// Influenced by and corresponds to Scala.js commit SHA: f9fc1ae
+// Ported from Scala.js commit: f9fc1a dated: 2020-03-06
 
 package java.lang
 
 import java.util.Iterator
 import java.util.function.Consumer
 
+import scala.scalanative.annotation.JavaDefaultMethod
+
 trait Iterable[T] {
   def iterator(): Iterator[T]
 
+  @JavaDefaultMethod
   def forEach(action: Consumer[_ >: T]): Unit = {
     val iter = iterator()
     while (iter.hasNext())

--- a/unit-tests/src/test/scala/java/lang/IterableTest.scala
+++ b/unit-tests/src/test/scala/java/lang/IterableTest.scala
@@ -1,0 +1,74 @@
+// Ported from Scala.js commit: 6819668 dated: 2020-10-07
+
+package org.scalanative.testsuite.javalib.lang
+
+import java.lang.{Iterable => JIterable}
+import java.{util => ju}
+import java.util.function.Consumer
+
+import scala.reflect.ClassTag
+
+import org.junit.Test
+import org.junit.Assert._
+
+/** Tests the implementation of the java standard library Iterable
+ */
+trait IterableTest {
+
+  def factory: IterableFactory
+
+  @Test def empty(): Unit = {
+    val iter = factory.fromElements[Int]()
+    var hit  = false
+    iter.forEach(new Consumer[Int] {
+      def accept(x: Int): Unit = hit = true
+    })
+    assertTrue(!hit)
+  }
+
+  @Test def simpleSum(): Unit = {
+    val iter = factory.fromElements[Int](42, 50, 12, 0, -45, 102, 32, 75)
+    var sum  = 0
+    iter.forEach(new Consumer[Int] {
+      def accept(x: Int): Unit = sum = sum + x
+    })
+    assertEquals(268, sum)
+  }
+}
+
+class IterableDefaultTest extends IterableTest {
+  def factory: IterableFactory = new IterableFactory {
+    override def implementationName: String = "java.lang.Iterable"
+
+    def empty[E: ClassTag]: JIterable[E] = {
+      new JIterable[E] {
+        override def iterator(): ju.Iterator[E] = {
+          new ju.Iterator[E] {
+            override def hasNext(): Boolean = false
+            override def next(): E          = throw new NoSuchElementException()
+          }
+        }
+      }
+    }
+
+    def fromElements[E: ClassTag](elems: E*): JIterable[E] = {
+      new JIterable[E] {
+        override def iterator(): ju.Iterator[E] = {
+          val l: Iterator[E] = elems.toIterator
+          new ju.Iterator[E] {
+            override def hasNext(): Boolean = l.hasNext
+            override def next(): E          = l.next
+          }
+        }
+      }
+    }
+  }
+}
+
+trait IterableFactory {
+  def implementationName: String
+
+  def empty[E: ClassTag]: JIterable[E]
+
+  def fromElements[E: ClassTag](elems: E*): JIterable[E]
+}


### PR DESCRIPTION
This PR builds upon merged PR #1937 by re-porting Iterable.scala in order to pick up
the JavaDefaultMethod annotation.

The corresponding test was ported from Scala.js by Lorenzo G (lolgab) as part of 
his PR #1994.  To keep the JavaDefaultMethod changes together, I am submitting 
it here by his kind permission. He did the port; I added a bit of audit trail information
at the top.
Thank you Lolgab.

See Issue #1972 for background & discussion of JavaDefaultMethod annotation.
