### PR TITLE
Port two testsuite TrivialImmutable classes

### DIFF
--- a/unit-tests/src/test/scala/org/scalanative/testsuite/javalib/util/TrivialImmutableCollection.scala
+++ b/unit-tests/src/test/scala/org/scalanative/testsuite/javalib/util/TrivialImmutableCollection.scala
@@ -1,0 +1,100 @@
+// Ported from Scala.js commit: 6819668 dated: 2020-10-07
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+/** A trivial, "obviously correct" implementation of an immutable
+ *  `java.util.Collection[A]`.
+ *
+ *  It can be used as an argument to test other collections, notably for their
+ *  bulk operations such as `addAll()`, `removeAll()`, etc.
+ */
+final class TrivialImmutableCollection[A] private (contents: Array[AnyRef])
+    extends ju.Collection[A] {
+
+  def size(): Int = contents.length
+
+  def isEmpty(): Boolean = size() == 0
+
+  def contains(o: Any): Boolean = {
+    // scalastyle:off return
+    var i = 0
+    while (i != contents.length) {
+      if (ju.Objects.equals(o, contents(i)))
+        return true
+      i += 1
+    }
+    false
+    // scalastyle:on return
+  }
+
+  def iterator(): ju.Iterator[A] = {
+    new ju.Iterator[A] {
+      private var nextIndex: Int = 0
+
+      def hasNext(): Boolean = nextIndex != contents.length
+
+      def next(): A = {
+        if (!hasNext())
+          throw new ju.NoSuchElementException()
+        val result = contents(nextIndex).asInstanceOf[A]
+        nextIndex += 1
+        result
+      }
+    }
+  }
+
+  def toArray(): Array[AnyRef] =
+    contents.clone()
+
+  def toArray[T](a: Array[T with AnyRef]): Array[T with AnyRef] =
+    ju.Arrays.copyOf[T, AnyRef](contents, contents.length, a.getClass())
+
+  def add(e: A): Boolean =
+    throw new UnsupportedOperationException("TrivialImmutableCollection.add()")
+
+  def remove(o: Any): Boolean =
+    throw new UnsupportedOperationException(
+      "TrivialImmutableCollection.remove()")
+
+  def containsAll(c: ju.Collection[_]): Boolean = {
+    // scalastyle:off return
+    val iter = c.iterator()
+    while (iter.hasNext()) {
+      if (!contains(iter.next()))
+        return false
+    }
+    true
+    // scalastyle:on return
+  }
+
+  def addAll(c: ju.Collection[_ <: A]): Boolean =
+    throw new UnsupportedOperationException(
+      "TrivialImmutableCollection.addAll()")
+
+  def removeAll(c: ju.Collection[_]): Boolean =
+    throw new UnsupportedOperationException(
+      "TrivialImmutableCollection.removeAll()")
+
+  def retainAll(c: ju.Collection[_]): Boolean =
+    throw new UnsupportedOperationException(
+      "TrivialImmutableCollection.retainAll()")
+
+  def clear(): Unit =
+    throw new UnsupportedOperationException(
+      "TrivialImmutableCollection.clear()")
+
+  /** Returns the `i`th element of this collection.
+   *
+   *  This method is not part of the API of `java.util.Collection`. It is made
+   *  publicly available to users of `TrivialImmutableCollection` as a
+   *  convenience for tests.
+   */
+  def apply(i: Int): A = contents(i).asInstanceOf[A]
+}
+
+object TrivialImmutableCollection {
+  def apply[A](elems: A*): TrivialImmutableCollection[A] =
+    new TrivialImmutableCollection(elems.asInstanceOf[Seq[AnyRef]].toArray)
+}

--- a/unit-tests/src/test/scala/org/scalanative/testsuite/javalib/util/TrivialImmutableMap.scala
+++ b/unit-tests/src/test/scala/org/scalanative/testsuite/javalib/util/TrivialImmutableMap.scala
@@ -1,0 +1,39 @@
+// Ported from Scala.js commit: 6819668 on 2020-10-O7
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+import java.util.Map.Entry
+
+final class TrivialImmutableMap[K, V] private (contents: List[Entry[K, V]])
+    extends ju.AbstractMap[K, V] {
+
+  def entrySet(): ju.Set[Entry[K, V]] = {
+    new ju.AbstractSet[Entry[K, V]] {
+      def size(): Int = contents.size
+
+      def iterator(): ju.Iterator[Entry[K, V]] = {
+        new ju.Iterator[Entry[K, V]] {
+          private var remaining: List[Entry[K, V]] = contents
+
+          def hasNext(): Boolean = remaining.nonEmpty
+
+          def next(): Entry[K, V] = {
+            val head = remaining.head
+            remaining = remaining.tail
+            head
+          }
+        }
+      }
+    }
+  }
+}
+
+object TrivialImmutableMap {
+  def apply[K, V](contents: List[Entry[K, V]]): TrivialImmutableMap[K, V] =
+    new TrivialImmutableMap(contents)
+
+  def apply[K, V](contents: (K, V)*): TrivialImmutableMap[K, V] =
+    apply(contents.toList.map(kv =>
+      new ju.AbstractMap.SimpleImmutableEntry(kv._1, kv._2)))
+}


### PR DESCRIPTION
This PR ports two helper classes used by the testsuite.

TrivialImmutableCollection.scala was ported by Lorenzo G. (lolgab)
for his PR #1994.  By his kind permission, I have factored that test
out and am submitting it here.

TrivialImmutableMap.scala completes the set.