### PR TITLE
Implement j.u.Collection.removeIf.

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractCollection.scala
+++ b/javalib/src/main/scala/java/util/AbstractCollection.scala
@@ -1,8 +1,12 @@
+// Ported from Scala.js commit: 1337656 dated: 2020-06-04
+
 package java.util
 
 import scala.annotation.tailrec
+
+import ScalaOps._
+
 import java.lang.{reflect => jlr}
-import java.util.ScalaOps._
 
 abstract class AbstractCollection[E] protected () extends Collection[E] {
   def iterator(): Iterator[E]
@@ -11,7 +15,7 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   def isEmpty(): Boolean = size() == 0
 
   def contains(o: Any): Boolean =
-    iterator().scalaOps.exists(o === _)
+    this.scalaOps.exists(Objects.equals(o, _))
 
   def toArray(): Array[AnyRef] =
     toArray(new Array[AnyRef](size()))
@@ -25,7 +29,8 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
           .asInstanceOf[Array[T]]
 
     val iter = iterator()
-    for (i <- 0 until size()) toFill(i) = iter.next().asInstanceOf[T]
+    for (i <- 0 until size())
+      toFill(i) = iter.next().asInstanceOf[T]
     if (toFill.length > size())
       toFill(size()) = null.asInstanceOf[T]
     toFill
@@ -38,19 +43,21 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
     @tailrec
     def findAndRemove(iter: Iterator[E]): Boolean = {
       if (iter.hasNext()) {
-        if (iter.next() === o) {
+        if (Objects.equals(iter.next(), o)) {
           iter.remove()
           true
-        } else
+        } else {
           findAndRemove(iter)
-      } else
+        }
+      } else {
         false
+      }
     }
     findAndRemove(iterator())
   }
 
   def containsAll(c: Collection[_]): Boolean =
-    c.iterator().scalaOps.forall(this.contains)
+    c.scalaOps.forall(this.contains(_))
 
   def addAll(c: Collection[_ <: E]): Boolean =
     c.scalaOps.foldLeft(false)((prev, elem) => add(elem) || prev)
@@ -77,5 +84,5 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   }
 
   override def toString(): String =
-    iterator().scalaOps.mkString("[", ", ", "]")
+    this.scalaOps.mkString("[", ", ", "]")
 }

--- a/javalib/src/main/scala/java/util/Collection.scala
+++ b/javalib/src/main/scala/java/util/Collection.scala
@@ -1,4 +1,10 @@
+// Ported from Scala.js commit: f122aa5 dated: 2019-07-03
+
 package java.util
+
+import java.util.function.Predicate
+
+import scala.scalanative.annotation.JavaDefaultMethod
 
 trait Collection[E] extends java.lang.Iterable[E] {
   def size(): Int
@@ -12,6 +18,20 @@ trait Collection[E] extends java.lang.Iterable[E] {
   def containsAll(c: Collection[_]): Boolean
   def addAll(c: Collection[_ <: E]): Boolean
   def removeAll(c: Collection[_]): Boolean
+
+  @JavaDefaultMethod
+  def removeIf(filter: Predicate[_ >: E]): Boolean = {
+    var result = false
+    val iter   = iterator()
+    while (iter.hasNext()) {
+      if (filter.test(iter.next())) {
+        iter.remove()
+        result = true
+      }
+    }
+    result
+  }
+
   def retainAll(c: Collection[_]): Boolean
   def clear(): Unit
   def equals(o: Any): Boolean

--- a/unit-tests/src/test/scala/java/util/AbstractCollectionTest.scala
+++ b/unit-tests/src/test/scala/java/util/AbstractCollectionTest.scala
@@ -1,0 +1,93 @@
+// Ported from Scala.js commit: 934ba73 dated: 2019-08-14
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+import scala.reflect.ClassTag
+
+class AbstractCollectionTest extends CollectionTest {
+  def factory: AbstractCollectionFactory = new AbstractCollectionFactory
+}
+
+class AbstractCollectionFactory extends CollectionFactory {
+  import AbstractCollectionFactory._
+
+  override def implementationName: String =
+    "java.util.AbstractCollection"
+
+  override def empty[E: ClassTag]: ju.AbstractCollection[E] =
+    new AbstractCollectionImpl[E]
+
+}
+
+object AbstractCollectionFactory {
+  /* A mutable implementation of `java.util.Collection[E]` that relies on all
+   * the default behaviors implemented in `j.u.AbstractCollection`.
+   *
+   * Every modification allocates a new internal `Array`. This property is used
+   * to reliably detect concurrent modifications.
+   */
+  private final class AbstractCollectionImpl[E]
+      extends ju.AbstractCollection[E] {
+    private var inner = new Array[AnyRef](0)
+
+    override def add(elem: E): Boolean = {
+      inner = ju.Arrays.copyOf(inner, inner.length + 1)
+      inner(inner.length - 1) = elem.asInstanceOf[AnyRef]
+      true
+    }
+
+    def size(): Int =
+      inner.length
+
+    def iterator(): ju.Iterator[E] =
+      new AbstractCollectionImplIterator(inner)
+
+    private final class AbstractCollectionImplIterator[E](
+        private var iterInner: Array[AnyRef])
+        extends ju.Iterator[E] {
+
+      private[this] var nextIndex: Int     = 0
+      private[this] var canRemove: Boolean = false
+
+      def hasNext(): Boolean = {
+        checkConcurrentModification()
+        nextIndex != inner.length
+      }
+
+      def next(): E = {
+        checkConcurrentModification()
+        if (nextIndex == inner.length)
+          throw new ju.NoSuchElementException()
+
+        val elem = inner(nextIndex).asInstanceOf[E]
+        nextIndex += 1
+        canRemove = true
+        elem
+      }
+
+      override def remove(): Unit = {
+        checkConcurrentModification()
+        if (!canRemove)
+          throw new IllegalStateException("remove() called before next()")
+
+        nextIndex -= 1
+        val newInner = ju.Arrays.copyOf(iterInner, iterInner.length - 1)
+        var i        = nextIndex
+        while (i != newInner.length) {
+          newInner(i) = iterInner(i + 1)
+          i += 1
+        }
+        inner = newInner
+        iterInner = newInner
+        canRemove = false
+      }
+
+      private def checkConcurrentModification(): Unit = {
+        if (inner ne iterInner)
+          throw new ju.ConcurrentModificationException()
+      }
+    }
+  }
+}

--- a/unit-tests/src/test/scala/java/util/CollectionTest.scala
+++ b/unit-tests/src/test/scala/java/util/CollectionTest.scala
@@ -1,0 +1,296 @@
+// Ported from Scala.js commit: f9fc1ae dated: 2020-03-06
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju, lang => jl}
+
+import org.junit.{Ignore, Test}
+import org.junit.Assert._
+
+import org.scalanative.testsuite.javalib.lang.IterableFactory
+import org.scalanative.testsuite.javalib.lang.IterableTest
+
+import scala.reflect.ClassTag
+
+import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.Utils._
+
+trait CollectionTest extends IterableTest {
+
+  def factory: CollectionFactory
+
+  @Test def shouldStoreStrings(): Unit = {
+    val coll = factory.empty[String]
+
+    assertEquals(0, coll.size())
+    coll.add("one")
+    assertEquals(1, coll.size())
+
+    coll.clear()
+    assertEquals(0, coll.size())
+    assertFalse(coll.addAll(TrivialImmutableCollection[String]()))
+    assertEquals(0, coll.size())
+
+    assertTrue(coll.addAll(TrivialImmutableCollection("one")))
+    assertEquals(1, coll.size())
+
+    coll.clear()
+    assertTrue(coll.addAll(TrivialImmutableCollection("one", "two", "one")))
+    assertTrue(coll.size() >= 1)
+  }
+
+  @Test def shouldStoreIntegers(): Unit = {
+    val coll = factory.empty[Int]
+
+    assertEquals(0, coll.size())
+    coll.add(1)
+    assertEquals(1, coll.size())
+
+    coll.clear()
+    assertEquals(0, coll.size())
+    assertFalse(coll.addAll(TrivialImmutableCollection[Int]()))
+    assertEquals(0, coll.size())
+
+    assertTrue(coll.addAll(TrivialImmutableCollection(1)))
+    assertEquals(1, coll.size())
+
+    coll.clear()
+    assertTrue(coll.addAll(TrivialImmutableCollection(1, 2, 1)))
+    assertTrue(coll.size() >= 1)
+  }
+
+  @Test def shouldStoreDoubles(): Unit = {
+    val coll = factory.empty[Double]
+
+    assertEquals(0, coll.size())
+    coll.add(1.234)
+    assertEquals(1, coll.size())
+
+    coll.clear()
+    assertEquals(0, coll.size())
+    assertFalse(coll.addAll(TrivialImmutableCollection[Double]()))
+    assertEquals(0, coll.size())
+
+    assertTrue(coll.addAll(TrivialImmutableCollection(1.234)))
+    assertEquals(1, coll.size())
+
+    coll.clear()
+    assertTrue(coll.addAll(TrivialImmutableCollection(1.234, 2.345, 1.234)))
+    assertTrue(coll.size() >= 1)
+
+    coll.clear()
+    coll.add(+0.0)
+    assertTrue(coll.contains(+0.0))
+    assertFalse(coll.contains(-0.0))
+
+    coll.clear()
+    coll.add(-0.0)
+    assertFalse(coll.contains(+0.0))
+    assertTrue(coll.contains(-0.0))
+
+    coll.clear()
+    coll.add(Double.NaN)
+    assertEquals(1, coll.size())
+    assertTrue(coll.contains(Double.NaN))
+  }
+
+  @Test def shouldStoreCustomObjects(): Unit = {
+    case class TestObj(num: Int) extends jl.Comparable[TestObj] {
+      def compareTo(o: TestObj): Int =
+        o.num.compareTo(num)
+    }
+
+    val coll = factory.empty[TestObj]
+
+    coll.add(TestObj(100))
+    assertEquals(1, coll.size())
+    assertTrue(coll.contains(TestObj(100)))
+    assertFalse(coll.contains(TestObj(200)))
+  }
+
+  @Test def shouldRemoveStoredElements(): Unit = {
+    val coll = factory.empty[String]
+
+    coll.add("one")
+    coll.add("two")
+    coll.add("three")
+    coll.add("two")
+
+    val initialSize = coll.size()
+    assertFalse(coll.remove("four"))
+    assertEquals(initialSize, coll.size())
+    assertTrue(coll.remove("two"))
+    assertEquals(initialSize - 1, coll.size())
+    assertTrue(coll.remove("one"))
+    assertEquals(initialSize - 2, coll.size())
+  }
+
+  @Test def shouldRemoveStoredElementsOnDoubleCornerCases(): Unit = {
+    val coll = factory.empty[Double]
+
+    coll.add(1.234)
+    coll.add(2.345)
+    coll.add(Double.NaN)
+    coll.add(+0.0)
+    coll.add(-0.0)
+
+    // coll == ArrayCollection(1.234, 2.345, NaN, +0.0, -0.0)
+    assertTrue(coll.remove(Double.NaN))
+    // coll == ArrayCollection(1.234, 2.345, +0.0, -0.0)
+    assertEquals(4, coll.size())
+    assertTrue(coll.remove(2.345))
+    // coll == ArrayCollection(1.234, +0.0, -0.0)
+    assertEquals(3, coll.size())
+    assertTrue(coll.remove(1.234))
+    // coll == ArrayCollection(+0.0, -0.0)
+    assertEquals(2, coll.size())
+    assertTrue(coll.remove(-0.0))
+    // coll == ArrayCollection(NaN, +0.0)
+    assertEquals(1, coll.size())
+
+    coll.clear()
+
+    assertTrue(coll.isEmpty)
+  }
+
+  @Test def shouldBeClearedWithOneOperation(): Unit = {
+    val coll = factory.empty[String]
+
+    coll.add("one")
+    coll.add("two")
+    assertEquals(2, coll.size)
+    coll.clear()
+    assertEquals(0, coll.size)
+  }
+
+  @Test def shouldCheckContainedPresence(): Unit = {
+    val coll = factory.empty[String]
+
+    coll.add("one")
+    assertTrue(coll.contains("one"))
+    assertFalse(coll.contains("two"))
+    if (factory.allowsNullElementQuery) {
+      assertFalse(coll.contains(null))
+    } else {
+      expectThrows(classOf[Exception], coll.contains(null))
+    }
+  }
+
+  @Test def shouldCheckContainedPresenceForDoubleCornerCases(): Unit = {
+    val coll = factory.empty[Double]
+
+    coll.add(-0.0)
+    assertTrue(coll.contains(-0.0))
+    assertFalse(coll.contains(+0.0))
+
+    coll.clear()
+
+    coll.add(+0.0)
+    assertFalse(coll.contains(-0.0))
+    assertTrue(coll.contains(+0.0))
+  }
+
+  @Test def shouldGiveProperIteratorOverElements(): Unit = {
+    val coll = factory.empty[String]
+    coll.add("one")
+    coll.add("two")
+    coll.add("three")
+    coll.add("three")
+    coll.add("three")
+
+    assertIteratorSameElementsAsSetDupesAllowed("one", "two", "three")(
+      coll.iterator())
+  }
+
+  // Issue: https://github.com/scala-native/scala-native/issues/1972
+  @Ignore(
+    "removeIf is a JavaDefaultMethod which is not supported yet on Scala 2.11")
+  @Test def removeIf(): Unit = {
+    // val coll = factory.fromElements[Int](42, 50, 12, 0, -45, 102, 32, 75)
+    // assertEquals(8, coll.size())
+
+    // assertTrue(coll.removeIf(new java.util.function.Predicate[Int] {
+    //   def test(x: Int): Boolean = x >= 50
+    // }))
+    // assertEquals(5, coll.size())
+    // assertIteratorSameElementsAsSet(-45, 0, 12, 32, 42)(coll.iterator())
+
+    // assertFalse(coll.removeIf(new java.util.function.Predicate[Int] {
+    //   def test(x: Int): Boolean = x >= 45
+    // }))
+    // assertEquals(5, coll.size())
+    // assertIteratorSameElementsAsSet(-45, 0, 12, 32, 42)(coll.iterator())
+  }
+
+  @Test def toStringShouldConvertEmptyCollection(): Unit = {
+    val coll = factory.empty[Double]
+    assertEquals("[]", coll.toString())
+  }
+
+  @Test def toStringShouldConvertOneElementCollection(): Unit = {
+    val coll = factory.fromElements[Double](1.01)
+    // JavaScript displays n.0 as n, so one trailing digit must be non-zero.
+    assertEquals("[1.01]", coll.toString())
+  }
+
+  @Test def toStringShouldUseCommaSpace(): Unit = {
+    // Choose Doubles which display the same in Java and Scala.js.
+    // JavaScript displays n.0 as n, so one trailing digit must be non-zero.
+    val elements = Seq(88.42, -23.36, 60.173)
+
+    val coll = factory.fromElements[Double](elements: _*)
+
+    val result = coll.toString()
+
+    // The order of elements returned by each collection is defined
+    // by the collection. Be prepared to handle the general case of any
+    // order here. Specific collections should test the order they specify.
+    val expected = elements.permutations.map(_.mkString("[", ", ", "]")).toSet
+
+    assertTrue(s"result '${result}' not in expected set '${expected}'",
+               expected.contains(result))
+  }
+
+  @Test def toStringShouldHandleNullElements(): Unit = {
+    if (factory.allowsNullElement) {
+      val elements = Seq(-1, -2, null, -3)
+
+      val coll = factory.fromElements[Any](elements: _*)
+
+      val result = coll.toString()
+
+      val expected = elements.permutations.map(_.mkString("[", ", ", "]")).toSet
+      assertTrue(s"result '${result}' not in expected set '${expected}'",
+                 expected.contains(result))
+    }
+  }
+
+  @Test def toStringInCustomClassShouldWork(): Unit = {
+    case class Custom(name: String, id: Int) extends Ordered[Custom] {
+      def compare(that: Custom): Int = this.id - that.id
+    }
+
+    val elements = Seq(Custom("A", 1), Custom("b", 2), Custom("C", 3))
+
+    val coll = factory.fromElements[Custom](elements: _*)
+
+    val result   = coll.toString()
+    val expected = elements.permutations.map(_.mkString("[", ", ", "]")).toSet
+    assertTrue(s"result '${result}' not in expected set '${expected}'",
+               expected.contains(result))
+  }
+
+}
+
+trait CollectionFactory extends IterableFactory {
+  def empty[E: ClassTag]: ju.Collection[E]
+  def allowsMutationThroughIterator: Boolean = true
+  def allowsNullElementQuery: Boolean        = true
+  def allowsNullElement: Boolean             = true
+
+  override def fromElements[E: ClassTag](elems: E*): ju.Collection[E] = {
+    val coll = empty[E]
+    coll.addAll(TrivialImmutableCollection(elems: _*))
+    coll
+  }
+}

--- a/unit-tests/src/test/scala/java/util/CollectionTest.scala
+++ b/unit-tests/src/test/scala/java/util/CollectionTest.scala
@@ -4,7 +4,7 @@ package org.scalanative.testsuite.javalib.util
 
 import java.{util => ju, lang => jl}
 
-import org.junit.{Ignore, Test}
+import org.junit.Test
 import org.junit.Assert._
 
 import org.scalanative.testsuite.javalib.lang.IterableFactory
@@ -202,24 +202,21 @@ trait CollectionTest extends IterableTest {
       coll.iterator())
   }
 
-  // Issue: https://github.com/scala-native/scala-native/issues/1972
-  @Ignore(
-    "removeIf is a JavaDefaultMethod which is not supported yet on Scala 2.11")
   @Test def removeIf(): Unit = {
-    // val coll = factory.fromElements[Int](42, 50, 12, 0, -45, 102, 32, 75)
-    // assertEquals(8, coll.size())
+    val coll = factory.fromElements[Int](42, 50, 12, 0, -45, 102, 32, 75)
+    assertEquals(8, coll.size())
 
-    // assertTrue(coll.removeIf(new java.util.function.Predicate[Int] {
-    //   def test(x: Int): Boolean = x >= 50
-    // }))
-    // assertEquals(5, coll.size())
-    // assertIteratorSameElementsAsSet(-45, 0, 12, 32, 42)(coll.iterator())
+    assertTrue(coll.removeIf(new java.util.function.Predicate[Int] {
+      def test(x: Int): Boolean = x >= 50
+    }))
+    assertEquals(5, coll.size())
+    assertIteratorSameElementsAsSet(-45, 0, 12, 32, 42)(coll.iterator())
 
-    // assertFalse(coll.removeIf(new java.util.function.Predicate[Int] {
-    //   def test(x: Int): Boolean = x >= 45
-    // }))
-    // assertEquals(5, coll.size())
-    // assertIteratorSameElementsAsSet(-45, 0, 12, 32, 42)(coll.iterator())
+    assertFalse(coll.removeIf(new java.util.function.Predicate[Int] {
+      def test(x: Int): Boolean = x >= 45
+    }))
+    assertEquals(5, coll.size())
+    assertIteratorSameElementsAsSet(-45, 0, 12, 32, 42)(coll.iterator())
   }
 
   @Test def toStringShouldConvertEmptyCollection(): Unit = {

--- a/unit-tests/src/test/scala/java/util/TrivialImmutableCollection.scala
+++ b/unit-tests/src/test/scala/java/util/TrivialImmutableCollection.scala
@@ -1,0 +1,100 @@
+// Ported from Scala.js commit: 6819668 dated: 2020-10-07
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+/** A trivial, "obviously correct" implementation of an immutable
+ *  `java.util.Collection[A]`.
+ *
+ *  It can be used as an argument to test other collections, notably for their
+ *  bulk operations such as `addAll()`, `removeAll()`, etc.
+ */
+final class TrivialImmutableCollection[A] private (contents: Array[AnyRef])
+    extends ju.Collection[A] {
+
+  def size(): Int = contents.length
+
+  def isEmpty(): Boolean = size() == 0
+
+  def contains(o: Any): Boolean = {
+    // scalastyle:off return
+    var i = 0
+    while (i != contents.length) {
+      if (ju.Objects.equals(o, contents(i)))
+        return true
+      i += 1
+    }
+    false
+    // scalastyle:on return
+  }
+
+  def iterator(): ju.Iterator[A] = {
+    new ju.Iterator[A] {
+      private var nextIndex: Int = 0
+
+      def hasNext(): Boolean = nextIndex != contents.length
+
+      def next(): A = {
+        if (!hasNext())
+          throw new ju.NoSuchElementException()
+        val result = contents(nextIndex).asInstanceOf[A]
+        nextIndex += 1
+        result
+      }
+    }
+  }
+
+  def toArray(): Array[AnyRef] =
+    contents.clone()
+
+  def toArray[T](a: Array[T with AnyRef]): Array[T with AnyRef] =
+    ju.Arrays.copyOf[T, AnyRef](contents, contents.length, a.getClass())
+
+  def add(e: A): Boolean =
+    throw new UnsupportedOperationException("TrivialImmutableCollection.add()")
+
+  def remove(o: Any): Boolean =
+    throw new UnsupportedOperationException(
+      "TrivialImmutableCollection.remove()")
+
+  def containsAll(c: ju.Collection[_]): Boolean = {
+    // scalastyle:off return
+    val iter = c.iterator()
+    while (iter.hasNext()) {
+      if (!contains(iter.next()))
+        return false
+    }
+    true
+    // scalastyle:on return
+  }
+
+  def addAll(c: ju.Collection[_ <: A]): Boolean =
+    throw new UnsupportedOperationException(
+      "TrivialImmutableCollection.addAll()")
+
+  def removeAll(c: ju.Collection[_]): Boolean =
+    throw new UnsupportedOperationException(
+      "TrivialImmutableCollection.removeAll()")
+
+  def retainAll(c: ju.Collection[_]): Boolean =
+    throw new UnsupportedOperationException(
+      "TrivialImmutableCollection.retainAll()")
+
+  def clear(): Unit =
+    throw new UnsupportedOperationException(
+      "TrivialImmutableCollection.clear()")
+
+  /** Returns the `i`th element of this collection.
+   *
+   *  This method is not part of the API of `java.util.Collection`. It is made
+   *  publicly available to users of `TrivialImmutableCollection` as a
+   *  convenience for tests.
+   */
+  def apply(i: Int): A = contents(i).asInstanceOf[A]
+}
+
+object TrivialImmutableCollection {
+  def apply[A](elems: A*): TrivialImmutableCollection[A] =
+    new TrivialImmutableCollection(elems.asInstanceOf[Seq[AnyRef]].toArray)
+}


### PR DESCRIPTION
This PR builds upon merged PRs #1937 & #2040 by re-porting Collection.scala and
AbstractCollection.scala from Scala.js. 

The corresponding tests and TrivialImmutableCollection.scala  were freshly ported from Scala.js by
Lorenzo G (lolgab) as part of his PR #1994 and are used by his kind permission. 

Collection.scala provides the default methods. AbstractCollectionTest provides a concrete
factory type which exercises the methods of both Collection.scala & AbstractCollection.scala.
