### PR TITLE
WIP: Port most of Scals.js j.u.Map environment & corresponding tests

### DIFF
--- a/javalib/src/main/scala/java/util/HashMap.scala
+++ b/javalib/src/main/scala/java/util/HashMap.scala
@@ -1,164 +1,716 @@
+// Ported from Scala.js commit: ded7d52 dated: 2020-10-12
+
 package java.util
 
-import scala.collection.mutable
+import scala.annotation.tailrec
 
-class HashMap[K, V] protected (inner: mutable.Map[AnyRef, V])
+import java.{util => ju}
+import java.util.function.{BiConsumer, BiFunction, Function}
+
+import ScalaOps._
+
+class HashMap[K, V](initialCapacity: Int, loadFactor: Float)
     extends AbstractMap[K, V]
     with Serializable
-    with Cloneable { self =>
+    with Cloneable {
+  self =>
 
-  protected def boxKey(key: K): AnyRef =
-    key.asInstanceOf[AnyRef]
-  protected def unboxKey(box: AnyRef): K =
-    box.asInstanceOf[K]
+  import HashMap._
+
+  if (initialCapacity < 0)
+    throw new IllegalArgumentException("initialCapacity < 0")
+  if (loadFactor <= 0.0f)
+    throw new IllegalArgumentException("loadFactor <= 0.0")
 
   def this() =
-    this(mutable.AnyRefMap.empty[AnyRef, V])
-
-  def this(initialCapacity: Int, loadFactor: Float) = {
-    this()
-    if (initialCapacity < 0)
-      throw new IllegalArgumentException("initialCapacity < 0")
-    else if (loadFactor < 0.0)
-      throw new IllegalArgumentException("loadFactor <= 0.0")
-  }
+    this(HashMap.DEFAULT_INITIAL_CAPACITY, HashMap.DEFAULT_LOAD_FACTOR)
 
   def this(initialCapacity: Int) =
     this(initialCapacity, HashMap.DEFAULT_LOAD_FACTOR)
 
   def this(m: Map[_ <: K, _ <: V]) = {
-    this()
+    this(m.size())
     putAll(m)
   }
 
-  override def clear(): Unit =
-    inner.clear()
+  /** The actual hash table.
+   *
+   *  In each bucket, nodes are sorted by increasing value of `hash`.
+   *
+   *  Deviation from the JavaDoc: we do not use `initialCapacity` as is for the
+   *  number of buckets. Instead we round it up to the next power of 2. This
+   *  allows some algorithms to be more efficient, notably `index()` and
+   *  `growTable()`. Since the number of buckets is not observable from the
+   *  outside, this deviation does not change any semantics.
+   */
+  private[this] var table = new Array[Node[K, V]](tableSizeFor(initialCapacity))
 
-  override def clone(): AnyRef = {
-    new HashMap(inner.clone())
+  /** The next size value at which to resize (capacity * load factor). */
+  private[this] var threshold: Int = newThreshold(table.length)
+
+  private[this] var contentSize: Int = 0
+
+  /* Internal API for LinkedHashMap: these methods are overridden in
+   * LinkedHashMap to implement its insertion- or access-order.
+   */
+
+  private[util] def newNode(key: K,
+                            hash: Int,
+                            value: V,
+                            previous: Node[K, V],
+                            next: Node[K, V]): Node[K, V] = {
+    new Node(key, hash, value, previous, next)
   }
 
-  override def containsKey(key: Any): Boolean =
-    inner.contains(boxKey(key.asInstanceOf[K]))
+  private[util] def nodeWasAccessed(node: Node[K, V]): Unit = ()
 
-  override def containsValue(value: Any): Boolean =
-    inner.valuesIterator.contains(value.asInstanceOf[V])
+  private[util] def nodeWasAdded(node: Node[K, V]): Unit = ()
 
-  override def entrySet(): Set[Map.Entry[K, V]] =
-    new EntrySet
+  private[util] def nodeWasRemoved(node: Node[K, V]): Unit = ()
 
-  override def get(key: Any): V = inner match {
-    case _: mutable.AnyRefMap[_, _] =>
-      val inner = this.inner.asInstanceOf[mutable.AnyRefMap[AnyRef, V]]
-      inner.getOrNull(boxKey(key.asInstanceOf[K]))
-    case _ =>
-      inner.get(boxKey(key.asInstanceOf[K])).getOrElse(null.asInstanceOf[V])
-  }
-
-  override def isEmpty(): Boolean =
-    inner.isEmpty
-
-  override def keySet(): Set[K] =
-    new KeySet
-
-  override def put(key: K, value: V): V =
-    inner.put(boxKey(key), value).getOrElse(null.asInstanceOf[V])
-
-  override def remove(key: Any): V = {
-    val boxedKey = boxKey(key.asInstanceOf[K])
-    inner.get(boxedKey).fold(null.asInstanceOf[V]) { value =>
-      inner -= boxedKey
-      value
-    }
-  }
+  // Public API
 
   override def size(): Int =
-    inner.size
+    contentSize
 
-  override def values(): Collection[V] =
-    new ValuesView
+  override def isEmpty(): Boolean =
+    contentSize == 0
 
-  private class EntrySet
-      extends AbstractSet[Map.Entry[K, V]]
-      with AbstractMapView[Map.Entry[K, V]] {
-    override def iterator(): Iterator[Map.Entry[K, V]] = {
-      new AbstractMapViewIterator[Map.Entry[K, V]] {
-        override protected def getNextForm(key: AnyRef): Map.Entry[K, V] = {
-          new AbstractMap.SimpleEntry(unboxKey(key), inner(key)) {
-            override def setValue(value: V): V = {
-              inner.update(key, value)
-              super.setValue(value)
-            }
+  override def get(key: Any): V =
+    getOrDefaultImpl(key, null.asInstanceOf[V])
+
+  override def containsKey(key: Any): Boolean =
+    findNode(key) ne null
+
+  override def put(key: K, value: V): V =
+    put0(key, value, ifAbsent = false)
+
+  override def putAll(m: Map[_ <: K, _ <: V]): Unit = {
+    m match {
+      case m: ju.HashMap[_, _] =>
+        val iter = m.nodeIterator()
+        while (iter.hasNext()) {
+          val next = iter.next()
+          put0(next.key, next.value, next.hash, ifAbsent = false)
+        }
+      case _ =>
+        super.putAll(m)
+    }
+  }
+
+  override def remove(key: Any): V = {
+    val node = remove0(key)
+    if (node eq null) null.asInstanceOf[V]
+    else node.value
+  }
+
+  override def clear(): Unit = {
+    ju.Arrays.fill(table.asInstanceOf[Array[AnyRef]], null)
+    contentSize = 0
+  }
+
+  override def containsValue(value: Any): Boolean =
+    valueIterator().scalaOps.exists(Objects.equals(value, _))
+
+  override def keySet(): ju.Set[K] =
+    new KeySet
+
+  override def values(): ju.Collection[V] =
+    new Values
+
+  def entrySet(): ju.Set[ju.Map.Entry[K, V]] =
+    new EntrySet
+
+  override def getOrDefault(key: Any, defaultValue: V): V =
+    getOrDefaultImpl(key, defaultValue)
+
+  /** Common implementation for get() and getOrDefault().
+   *
+   *  It is not directly inside the body of getOrDefault(), because subclasses
+   *  could override getOrDefault() to re-rely on get().
+   */
+  private def getOrDefaultImpl(key: Any, defaultValue: V): V = {
+    val node = findNode(key)
+    if (node eq null) {
+      defaultValue
+    } else {
+      nodeWasAccessed(node)
+      node.value
+    }
+  }
+
+  override def putIfAbsent(key: K, value: V): V =
+    put0(key, value, ifAbsent = true)
+
+  override def remove(key: Any, value: Any): Boolean = {
+    val (node, idx) = findNodeAndIndexForRemoval(key)
+    if ((node ne null) && Objects.equals(node.value, value)) {
+      remove0(node, idx)
+      true
+    } else {
+      false
+    }
+  }
+
+  override def replace(key: K, oldValue: V, newValue: V): Boolean = {
+    val node = findNode(key)
+    if ((node ne null) && Objects.equals(node.value, oldValue)) {
+      node.value = newValue
+      nodeWasAccessed(node)
+      true
+    } else {
+      false
+    }
+  }
+
+  override def replace(key: K, value: V): V = {
+    val node = findNode(key)
+    if (node ne null) {
+      val old = node.value
+      node.value = value
+      nodeWasAccessed(node)
+      old
+    } else {
+      null.asInstanceOf[V]
+    }
+  }
+
+  override def computeIfAbsent(key: K,
+                               mappingFunction: Function[_ >: K, _ <: V]): V = {
+    val (node, hash, idx, oldValue) = getNode0(key)
+    if (oldValue != null) {
+      oldValue
+    } else {
+      val newValue = mappingFunction.apply(key)
+      if (newValue != null)
+        put0(key, newValue, hash, node)
+      newValue
+    }
+  }
+
+  override def computeIfPresent(
+      key: K,
+      remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]): V = {
+    val (node, hash, idx, oldValue) = getNode0(key)
+    if (oldValue == null) {
+      oldValue
+    } else {
+      val newValue = remappingFunction.apply(key, oldValue)
+      putOrRemove0(key, hash, idx, node, newValue)
+    }
+  }
+
+  override def compute(
+      key: K,
+      remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]): V = {
+    val (node, hash, idx, oldValue) = getNode0(key)
+    val newValue                    = remappingFunction.apply(key, oldValue)
+    putOrRemove0(key, hash, idx, node, newValue)
+  }
+
+  override def merge(
+      key: K,
+      value: V,
+      remappingFunction: BiFunction[_ >: V, _ >: V, _ <: V]): V = {
+    Objects.requireNonNull(value)
+
+    val (node, hash, idx, oldValue) = getNode0(key)
+    val newValue =
+      if (oldValue == null) value
+      else remappingFunction.apply(oldValue, value)
+    putOrRemove0(key, hash, idx, node, newValue)
+  }
+
+  override def forEach(action: BiConsumer[_ >: K, _ >: V]): Unit = {
+    val len = table.length
+    var i   = 0
+    while (i != len) {
+      var node = table(i)
+      while (node ne null) {
+        action.accept(node.key, node.value)
+        node = node.next
+      }
+      i += 1
+    }
+  }
+
+  override def clone(): AnyRef =
+    new HashMap[K, V](this)
+
+  // Elementary operations
+
+  @inline private def index(hash: Int): Int =
+    hash & (table.length - 1)
+
+  @inline
+  private def findNode(key: Any): Node[K, V] = {
+    val hash = computeHash(key)
+    findNode0(key, hash, index(hash))
+  }
+
+  @inline
+  private def findNodeAndIndexForRemoval(key: Any): (Node[K, V], Int) = {
+    val hash = computeHash(key)
+    val idx  = index(hash)
+    val node = findNode0(key, hash, idx)
+    (node, idx)
+  }
+
+  private def findNode0(key: Any, hash: Int, idx: Int): Node[K, V] = {
+    @inline
+    @tailrec
+    def loop(node: Node[K, V]): Node[K, V] = {
+      if (node eq null) null
+      else if (hash == node.hash && Objects.equals(key, node.key)) node
+      else if (hash < node.hash) null
+      else loop(node.next)
+    }
+    loop(table(idx))
+  }
+
+  // Helpers for compute-like methods
+
+  @inline
+  private def getNode0(key: Any): (Node[K, V], Int, Int, V) = {
+    val hash = computeHash(key)
+    val idx  = index(hash)
+    val node = findNode0(key, hash, idx)
+    val value = if (node eq null) {
+      null.asInstanceOf[V]
+    } else {
+      nodeWasAccessed(node)
+      node.value
+    }
+    (node, hash, idx, value)
+  }
+
+  private def putOrRemove0(key: K,
+                           hash: Int,
+                           idx: Int,
+                           node: Node[K, V],
+                           newValue: V): V = {
+    if (newValue != null)
+      put0(key, newValue, hash, node)
+    else if (node ne null)
+      remove0(node, idx)
+    newValue
+  }
+
+  // Heavy lifting: modifications
+
+  /** Puts a key-value pair into this map.
+   *
+   *  If an entry already exists for the given key, `nodeWasAccessed` is
+   *  called, and, unless `ifAbsent` is true, its value is updated.
+   *
+   *  If no entry existed for the given key, a new entry is created with the
+   *  given value, and `nodeWasAdded` is called.
+   *
+   *  @param key the key to put
+   *  @param value the value to put
+   *  @param ifAbsent if true, do not override an existing mapping
+   *  @return the old value associated with `key`, or `null` if there was none
+   */
+  @inline
+  private[this] def put0(key: K, value: V, ifAbsent: Boolean): V =
+    put0(key, value, computeHash(key), ifAbsent)
+
+  /** Puts a key-value pair into this map.
+   *
+   *  If an entry already exists for the given key, `nodeWasAccessed` is
+   *  called, and, unless `ifAbsent` is true, its value is updated.
+   *
+   *  If no entry existed for the given key, a new entry is created with the
+   *  given value, and `nodeWasAdded` is called.
+   *
+   *  @param key the key to put
+   *  @param value the value to put
+   *  @param hash the **improved** hashcode of `key` (see computeHash)
+   *  @param ifAbsent if true, do not override an existing mapping
+   *  @return the old value associated with `key`, or `null` if there was none
+   */
+  private[this] def put0(key: K, value: V, hash: Int, ifAbsent: Boolean): V = {
+    // scalastyle:off return
+    val newContentSize = contentSize + 1
+    if (newContentSize >= threshold)
+      growTable()
+    val idx = index(hash)
+    val newNode = table(idx) match {
+      case null =>
+        val newNode = this.newNode(key, hash, value, null, null)
+        table(idx) = newNode
+        newNode
+      case first =>
+        var prev: Node[K, V] = null
+        var n                = first
+        while ((n ne null) && n.hash <= hash) {
+          if (n.hash == hash && Objects.equals(key, n.key)) {
+            nodeWasAccessed(n)
+            val old = n.value
+            if (!ifAbsent || (old == null))
+              n.value = value
+            return old
+          }
+          prev = n
+          n = n.next
+        }
+        val newNode = this.newNode(key, hash, value, prev, n)
+        if (prev eq null)
+          table(idx) = newNode
+        else
+          prev.next = newNode
+        if (n ne null)
+          n.previous = newNode
+        newNode
+    }
+    contentSize = newContentSize
+    nodeWasAdded(newNode)
+    null.asInstanceOf[V]
+    // scalastyle:on return
+  }
+
+  /** Puts a key-value pair into this map, given the result of an existing
+   *  lookup.
+   *
+   *  The parameter `node` must be the result of a lookup for the given key.
+   *  If null, this method assumes that there is no entry for the given key in
+   *  the map.
+   *
+   *  `nodeWasAccessed` is NOT called by this method, since it must already
+   *  have been called by the prerequisite lookup.
+   *
+   *  If no entry existed for the given key, a new entry is created with the
+   *  given value, and `nodeWasAdded` is called.
+   *
+   *  @param key the key to add
+   *  @param value the value to add
+   *  @param hash the **improved** hashcode of `key` (see computeHash)
+   *  @param node the entry for the given `key`, or `null` if there is no such entry
+   */
+  private[this] def put0(key: K,
+                         value: V,
+                         hash: Int,
+                         node: Node[K, V]): Unit = {
+    if (node ne null) {
+      node.value = value
+    } else {
+      val newContentSize = contentSize + 1
+      if (newContentSize >= threshold)
+        growTable()
+      val idx = index(hash)
+      val newNode = table(idx) match {
+        case null =>
+          val newNode = this.newNode(key, hash, value, null, null)
+          table(idx) = newNode
+          newNode
+        case first =>
+          var prev: Node[K, V] = null
+          var n                = first
+          while ((n ne null) && n.hash < hash) {
+            prev = n
+            n = n.next
+          }
+          val newNode = this.newNode(key, hash, value, prev, n)
+          if (prev eq null)
+            table(idx) = newNode
+          else
+            prev.next = newNode
+          if (n ne null)
+            n.previous = newNode
+          newNode
+      }
+      contentSize = newContentSize
+      nodeWasAdded(newNode)
+    }
+  }
+
+  /** Removes a key from this map if it exists.
+   *
+   *  @param key the key to remove
+   *  @return the node that contained `key` if it was present, otherwise null
+   */
+  private def remove0(key: Any): Node[K, V] = {
+    val (node, idx) = findNodeAndIndexForRemoval(key)
+    if (node ne null)
+      remove0(node, idx)
+    node
+  }
+
+  private[util] final def removeNode(node: Node[K, V]): Unit =
+    remove0(node, index(node.hash))
+
+  private def remove0(node: Node[K, V], idx: Int): Unit = {
+    val previous = node.previous
+    val next     = node.next
+    if (previous eq null)
+      table(idx) = next
+    else
+      previous.next = next
+    if (next ne null)
+      next.previous = previous
+    contentSize -= 1
+    nodeWasRemoved(node)
+  }
+
+  /** Grow the size of the table (always times 2). */
+  private[this] def growTable(): Unit = {
+    val oldTable = table
+    val oldlen   = oldTable.length
+    val newlen   = oldlen * 2
+    val newTable = new Array[Node[K, V]](newlen)
+    table = newTable
+    threshold = newThreshold(newlen)
+
+    /* Split the nodes of each bucket from the old table into the "low" and
+     * "high" indices of the new table. Since the new table contains exactly
+     * twice as many buckets as the old table, every index `i` from the old
+     * table is split into indices `i` and `oldlen + i` in the new table.
+     */
+    var i = 0
+    while (i < oldlen) {
+      var lastLow: Node[K, V]  = null
+      var lastHigh: Node[K, V] = null
+      var node                 = oldTable(i)
+      while (node ne null) {
+        if ((node.hash & oldlen) == 0) {
+          // go to low
+          node.previous = lastLow
+          if (lastLow eq null)
+            newTable(i) = node
+          else
+            lastLow.next = node
+          lastLow = node
+        } else {
+          // go to high
+          node.previous = lastHigh
+          if (lastHigh eq null)
+            newTable(oldlen + i) = node
+          else
+            lastHigh.next = node
+          lastHigh = node
+        }
+        node = node.next
+      }
+      if (lastLow ne null)
+        lastLow.next = null
+      if (lastHigh ne null)
+        lastHigh.next = null
+      i += 1
+    }
+  }
+
+  /** Rounds up `capacity` to a power of 2, with a maximum of 2^30. */
+  @inline private[this] def tableSizeFor(capacity: Int): Int =
+    Math.min(Integer.highestOneBit(Math.max(capacity - 1, 4)) * 2, 1 << 30)
+
+  @inline private[this] def newThreshold(size: Int): Int =
+    (size.toDouble * loadFactor.toDouble).toInt
+
+  // Iterators
+
+  private[util] def nodeIterator(): ju.Iterator[Node[K, V]] =
+    new NodeIterator
+
+  private[util] def keyIterator(): ju.Iterator[K] =
+    new KeyIterator
+
+  private[util] def valueIterator(): ju.Iterator[V] =
+    new ValueIterator
+
+  // The cast works around the lack of definition-site variance
+  private[util] final def entrySetIterator(): ju.Iterator[Map.Entry[K, V]] =
+    nodeIterator().asInstanceOf[ju.Iterator[Map.Entry[K, V]]]
+
+  private final class NodeIterator extends AbstractHashMapIterator[Node[K, V]] {
+    protected[this] def extract(node: Node[K, V]): Node[K, V] = node
+  }
+
+  private final class KeyIterator extends AbstractHashMapIterator[K] {
+    protected[this] def extract(node: Node[K, V]): K = node.key
+  }
+
+  private final class ValueIterator extends AbstractHashMapIterator[V] {
+    protected[this] def extract(node: Node[K, V]): V = node.value
+  }
+
+  private abstract class AbstractHashMapIterator[A] extends ju.Iterator[A] {
+    private[this] val len                  = table.length
+    private[this] var nextIdx: Int         = _ // 0
+    private[this] var nextNode: Node[K, V] = _ // null
+    private[this] var lastNode: Node[K, V] = _ // null
+
+    protected[this] def extract(node: Node[K, V]): A
+
+    /* Movements of `nextNode` and `nextIdx` are spread over `hasNext()` to
+     * simplify initial conditions, and preserving as much performance as
+     * possible while guaranteeing that constructing the iterator remains O(1)
+     * (the first linear behavior can happen when calling `hasNext()`, not
+     * before).
+     */
+
+    def hasNext(): Boolean = {
+      // scalastyle:off return
+      if (nextNode ne null) {
+        true
+      } else {
+        while (nextIdx < len) {
+          val node = table(nextIdx)
+          nextIdx += 1
+          if (node ne null) {
+            nextNode = node
+            return true
           }
         }
+        false
       }
+      // scalastyle:on return
+    }
+
+    def next(): A = {
+      if (!hasNext())
+        throw new NoSuchElementException("next on empty iterator")
+      val node = nextNode
+      lastNode = node
+      nextNode = node.next
+      extract(node)
+    }
+
+    override def remove(): Unit = {
+      val last = lastNode
+      if (last eq null)
+        throw new IllegalStateException(
+          "next must be called at least once before remove")
+      removeNode(last)
+      lastNode = null
     }
   }
 
-  private class KeySet extends AbstractSet[K] with AbstractMapView[K] {
-    override def remove(o: Any): Boolean = {
-      val boxedKey = boxKey(o.asInstanceOf[K])
-      val contains = inner.contains(boxedKey)
-      if (contains)
-        inner -= boxedKey
-      contains
-    }
+  // Views
 
-    override def iterator(): Iterator[K] = {
-      new AbstractMapViewIterator[K] {
-        protected def getNextForm(key: AnyRef): K =
-          unboxKey(key)
-      }
-    }
-  }
+  private final class KeySet extends AbstractSet[K] {
+    def iterator(): Iterator[K] =
+      keyIterator()
 
-  private class ValuesView extends AbstractMapView[V] {
-    override def size(): Int =
-      inner.size
+    def size(): Int =
+      self.size()
 
-    override def iterator(): Iterator[V] = {
-      new AbstractMapViewIterator[V] {
-        protected def getNextForm(key: AnyRef): V = inner(key)
-      }
-    }
-  }
+    override def contains(o: Any): Boolean =
+      containsKey(o)
 
-  private trait AbstractMapView[E] extends AbstractCollection[E] {
-    override def size(): Int =
-      inner.size
+    override def remove(o: Any): Boolean =
+      self.remove0(o) ne null
 
     override def clear(): Unit =
-      inner.clear()
+      self.clear()
   }
 
-  private abstract class AbstractMapViewIterator[E] extends Iterator[E] {
-    protected val innerIterator = inner.keySet.iterator
+  private final class Values extends AbstractCollection[V] {
+    def iterator(): ju.Iterator[V] =
+      valueIterator()
 
-    protected var lastKey: Option[AnyRef] = None
+    def size(): Int =
+      self.size()
 
-    protected def getNextForm(key: AnyRef): E
+    override def contains(o: Any): Boolean =
+      containsValue(o)
 
-    final override def next(): E = {
-      lastKey = Some(innerIterator.next())
-      getNextForm(lastKey.get)
+    override def clear(): Unit =
+      self.clear()
+  }
+
+  private final class EntrySet extends AbstractSet[Map.Entry[K, V]] {
+    def iterator(): Iterator[Map.Entry[K, V]] =
+      entrySetIterator()
+
+    def size(): Int =
+      self.size()
+
+    override def contains(o: Any): Boolean = o match {
+      case o: Map.Entry[_, _] =>
+        val node = findNode(o.getKey())
+        (node ne null) && Objects.equals(node.getValue(), o.getValue())
+      case _ =>
+        false
     }
 
-    final override def hasNext(): Boolean =
-      innerIterator.hasNext
-
-    final override def remove(): Unit = {
-      lastKey match {
-        case Some(key) =>
-          inner.remove(key)
-          lastKey = None
-        case None =>
-          throw new IllegalStateException
-      }
+    override def remove(o: Any): Boolean = o match {
+      case o: Map.Entry[_, _] =>
+        val key         = o.getKey()
+        val (node, idx) = findNodeAndIndexForRemoval(key)
+        if ((node ne null) && Objects.equals(node.getValue(), o.getValue())) {
+          remove0(node, idx)
+          true
+        } else {
+          false
+        }
+      case _ =>
+        false
     }
+
+    override def clear(): Unit =
+      self.clear()
   }
 }
 
 object HashMap {
-  private[HashMap] final val DEFAULT_INITIAL_CAPACITY = 16
-  private[HashMap] final val DEFAULT_LOAD_FACTOR      = 0.75f
+  private[util] final val DEFAULT_INITIAL_CAPACITY = 16
+  private[util] final val DEFAULT_LOAD_FACTOR      = 0.75f
+
+  /** Computes the improved hash of an original (`any.hashCode()`) hash. */
+  @inline private def improveHash(originalHash: Int): Int = {
+    /* Improve the hash by xoring the high 16 bits into the low 16 bits just in
+     * case entropy is skewed towards the high-value bits. We only use the
+     * lowest bits to determine the hash bucket.
+     *
+     * This function is also its own inverse. That is, for all ints i,
+     * improveHash(improveHash(i)) = i
+     * this allows us to retrieve the original hash when we need it, and that
+     * is why unimproveHash simply forwards to this method.
+     */
+    originalHash ^ (originalHash >>> 16)
+  }
+
+  /** Performs the inverse operation of improveHash.
+   *
+   *  In this case, it happens to be identical to improveHash.
+   */
+  @inline private def unimproveHash(improvedHash: Int): Int =
+    improveHash(improvedHash)
+
+  /** Computes the improved hash of this key */
+  @inline private def computeHash(k: Any): Int =
+    if (k == null) 0
+    else improveHash(k.hashCode())
+
+  private[util] class Node[K, V](val key: K,
+                                 val hash: Int,
+                                 var value: V,
+                                 var previous: Node[K, V],
+                                 var next: Node[K, V])
+      extends Map.Entry[K, V] {
+
+    def getKey(): K = key
+
+    def getValue(): V = value
+
+    def setValue(v: V): V = {
+      val oldValue = value
+      value = v
+      oldValue
+    }
+
+    override def equals(that: Any): Boolean = that match {
+      case that: Map.Entry[_, _] =>
+        Objects.equals(getKey(), that.getKey()) &&
+          Objects.equals(getValue(), that.getValue())
+      case _ =>
+        false
+    }
+
+    override def hashCode(): Int =
+      unimproveHash(hash) ^ Objects.hashCode(value)
+
+    override def toString(): String =
+      "" + getKey() + "=" + getValue()
+  }
 }

--- a/javalib/src/main/scala/java/util/IdentityHashMap.scala
+++ b/javalib/src/main/scala/java/util/IdentityHashMap.scala
@@ -1,13 +1,295 @@
+// Ported from Scala.js commit: 6819668 dated: 2020-10-07
+
 package java.util
 
-class IdentityHashMap[K, V] extends HashMap[K, V] {
+import java.{util => ju}
 
-  override def boxKey(key: K): AnyRef =
-    IdentityBox(key)
+import scala.annotation.tailrec
 
-  override def unboxKey(box: AnyRef): K =
-    box match {
-      case IdentityBox(value) => value.asInstanceOf[K]
-      case _                  => null.asInstanceOf[K]
+import ScalaOps._
+
+/* The additional `internal` parameter works around
+ * https://github.com/scala/bug/issues/11755
+ */
+class IdentityHashMap[K, V] private (
+    inner: HashMap[IdentityHashMap.IdentityBox[K], V],
+    internal: Boolean)
+    extends AbstractMap[K, V]
+    with Map[K, V]
+    with Serializable
+    with Cloneable {
+  self =>
+
+  import IdentityHashMap._
+
+  def this(expectedMaxSize: Int) = {
+    this(new HashMap[IdentityHashMap.IdentityBox[K], V](
+           expectedMaxSize,
+           HashMap.DEFAULT_LOAD_FACTOR),
+         internal = true)
+  }
+
+  def this() =
+    this(HashMap.DEFAULT_INITIAL_CAPACITY)
+
+  def this(initialMap: java.util.Map[_ <: K, _ <: V]) = {
+    this(initialMap.size())
+    putAll(initialMap)
+  }
+
+  override def clear(): Unit = inner.clear()
+
+  override def clone(): AnyRef = {
+    new IdentityHashMap(inner.clone().asInstanceOf[HashMap[IdentityBox[K], V]],
+                        internal = true)
+  }
+
+  override def containsKey(key: Any): Boolean =
+    inner.containsKey(IdentityBox(key))
+
+  override def containsValue(value: Any): Boolean =
+    inner.valueIterator().scalaOps.exists(same(_, value))
+
+  override def get(key: Any): V =
+    inner.get(IdentityBox(key))
+
+  override def isEmpty(): Boolean = inner.isEmpty()
+
+  override def put(key: K, value: V): V =
+    inner.put(IdentityBox(key), value)
+
+  override def remove(key: Any): V =
+    inner.remove(IdentityBox(key))
+
+  override def size(): Int = inner.size()
+
+  override def values(): Collection[V] = new Values
+
+  override def keySet(): ju.Set[K] = new KeySet
+
+  override def entrySet(): Set[Map.Entry[K, V]] = new EntrySet
+
+  // Views
+
+  private final class Values extends AbstractCollection[V] {
+    def iterator(): ju.Iterator[V] =
+      inner.valueIterator()
+
+    def size(): Int =
+      self.size()
+
+    override def contains(o: Any): Boolean =
+      containsValue(o)
+
+    override def remove(o: Any): Boolean = {
+      @tailrec
+      def findAndRemove(iter: Iterator[V]): Boolean = {
+        if (iter.hasNext()) {
+          if (same(iter.next(), o)) {
+            iter.remove()
+            true
+          } else {
+            findAndRemove(iter)
+          }
+        } else {
+          false
+        }
+      }
+      findAndRemove(iterator())
     }
+
+    override def removeAll(c: Collection[_]): Boolean =
+      c.scalaOps.foldLeft(false)((prev, elem) => this.remove(elem) || prev)
+
+    override def retainAll(c: Collection[_]): Boolean = {
+      val iter    = iterator()
+      var changed = false
+      while (iter.hasNext()) {
+        val elem = iter.next()
+        if (!findSame(elem, c)) {
+          iter.remove()
+          changed = true
+        }
+      }
+      changed
+    }
+
+    override def clear(): Unit =
+      self.clear()
+  }
+
+  private final class KeySet extends AbstractSet[K] {
+    def iterator(): Iterator[K] = {
+      new ju.Iterator[K] {
+        private val iter = inner.keyIterator()
+
+        def hasNext(): Boolean =
+          iter.hasNext()
+
+        def next(): K =
+          iter.next().inner
+
+        override def remove(): Unit =
+          iter.remove()
+      }
+    }
+
+    def size(): Int =
+      self.size()
+
+    override def contains(o: Any): Boolean =
+      containsKey(o)
+
+    override def remove(o: Any): Boolean = {
+      val hasKey = contains(o)
+      if (hasKey)
+        self.remove(o)
+      hasKey
+    }
+
+    override def removeAll(c: Collection[_]): Boolean = {
+      if (size() > c.size()) {
+        c.scalaOps.foldLeft(false)((prev, elem) => this.remove(elem) || prev)
+      } else {
+        @tailrec
+        def removeAll(iter: Iterator[K], modified: Boolean): Boolean = {
+          if (iter.hasNext()) {
+            if (findSame(iter.next(), c)) {
+              iter.remove()
+              removeAll(iter, true)
+            } else {
+              removeAll(iter, modified)
+            }
+          } else {
+            modified
+          }
+        }
+        removeAll(this.iterator, false)
+      }
+    }
+
+    override def retainAll(c: Collection[_]): Boolean = {
+      val iter    = iterator()
+      var changed = false
+      while (iter.hasNext()) {
+        val elem = iter.next()
+        if (!findSame(elem, c)) {
+          iter.remove()
+          changed = true
+        }
+      }
+      changed
+    }
+
+    override def clear(): Unit =
+      self.clear()
+  }
+
+  private final class EntrySet extends AbstractSet[Map.Entry[K, V]] {
+    def iterator(): Iterator[Map.Entry[K, V]] = {
+      new ju.Iterator[Map.Entry[K, V]] {
+        private val iter = inner.entrySetIterator()
+
+        def hasNext(): Boolean =
+          iter.hasNext()
+
+        def next(): Map.Entry[K, V] =
+          new MapEntry(iter.next())
+
+        override def remove(): Unit =
+          iter.remove()
+      }
+    }
+
+    def size(): Int =
+      inner.size()
+
+    override def contains(value: Any): Boolean = {
+      value match {
+        case value: Map.Entry[_, _] =>
+          val thatKey = value.getKey()
+          self.containsKey(thatKey) && same(self.get(thatKey), value.getValue())
+        case _ =>
+          false
+      }
+    }
+
+    override def remove(value: Any): Boolean = {
+      value match {
+        case value: Map.Entry[_, _] =>
+          val thatKey   = value.getKey()
+          val thatValue = value.getValue()
+          if (self.containsKey(thatKey) && same(self.get(thatKey), thatValue)) {
+            self.remove(thatKey)
+            true
+          } else {
+            false
+          }
+        case _ =>
+          false
+      }
+    }
+
+    override def clear(): Unit =
+      inner.clear()
+  }
+}
+
+object IdentityHashMap {
+  private final case class IdentityBox[+K](inner: K) {
+    override def equals(o: Any): Boolean = {
+      o match {
+        case o: IdentityBox[_] =>
+          same(inner, o.inner)
+        case _ =>
+          false
+      }
+    }
+
+    override def hashCode(): Int =
+      System.identityHashCode(inner.asInstanceOf[AnyRef])
+  }
+
+  @inline private def same(v1: Any, v2: Any): Boolean =
+    v1.asInstanceOf[AnyRef] eq v2.asInstanceOf[AnyRef]
+
+  private def findSame[K](elem: K, c: Collection[_]): Boolean = {
+    // scalastyle:off return
+    val iter = c.iterator()
+    while (iter.hasNext()) {
+      if (same(elem, iter.next()))
+        return true
+    }
+    false
+    // scalastyle:on return
+  }
+
+  private final class MapEntry[K, V](entry: Map.Entry[IdentityBox[K], V])
+      extends Map.Entry[K, V] {
+
+    override def equals(other: Any): Boolean =
+      other match {
+        case other: Map.Entry[_, _] =>
+          same(this.getKey(), other.getKey()) &&
+            same(this.getValue(), other.getValue())
+        case _ =>
+          false
+      }
+
+    def getKey(): K =
+      entry.getKey().inner
+
+    def getValue(): V =
+      entry.getValue()
+
+    override def hashCode(): Int =
+      entry.getKey().hashCode() ^ System.identityHashCode(
+        entry.getValue().asInstanceOf[AnyRef])
+
+    def setValue(value: V): V =
+      entry.setValue(value)
+
+    override def toString(): String =
+      "" + this.getKey() + "=" + this.getValue()
+  }
 }

--- a/javalib/src/main/scala/java/util/IdentityHashMap.scala
+++ b/javalib/src/main/scala/java/util/IdentityHashMap.scala
@@ -164,7 +164,7 @@ class IdentityHashMap[K, V] private (
             modified
           }
         }
-        removeAll(this.iterator, false)
+        removeAll(this.iterator(), false)
       }
     }
 

--- a/javalib/src/main/scala/java/util/LinkedHashMap.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashMap.scala
@@ -1,75 +1,181 @@
+// Ported from Scala.js commit: f7be410 dated: 2020-10-07
+
 package java.util
 
-import scala.collection.mutable
+import java.{util => ju}
+import java.util.function.BiConsumer
 
-class LinkedHashMap[K, V] private (inner: mutable.LinkedHashMap[AnyRef, V],
-                                   accessOrder: Boolean)
-    extends HashMap[K, V](inner) { self =>
+class LinkedHashMap[K, V](initialCapacity: Int,
+                          loadFactor: Float,
+                          accessOrder: Boolean)
+    extends HashMap[K, V](initialCapacity, loadFactor) {
+  self =>
 
-  override protected def boxKey(key: K): AnyRef =
-    Box(key)
-  override protected def unboxKey(box: AnyRef): K =
-    box.asInstanceOf[Box[K]].inner
+  import LinkedHashMap._
 
-  def this() =
-    this(mutable.LinkedHashMap.empty[AnyRef, V], false)
+  /** Node that was least recently created (or accessed under access-order). */
+  private var eldest: Node[K, V] = _
 
-  def this(initialCapacity: Int, loadFactor: Float, accessOrder: Boolean) = {
-    this(mutable.LinkedHashMap.empty[AnyRef, V], accessOrder)
-    if (initialCapacity < 0)
-      throw new IllegalArgumentException("initialCapacity < 0")
-    else if (loadFactor < 0.0)
-      throw new IllegalArgumentException("loadFactor <= 0.0")
-  }
+  /** Node that was most recently created (or accessed under access-order). */
+  private var youngest: Node[K, V] = _
 
   def this(initialCapacity: Int, loadFactor: Float) =
     this(initialCapacity, loadFactor, false)
 
   def this(initialCapacity: Int) =
-    this(initialCapacity, LinkedHashMap.DEFAULT_LOAD_FACTOR)
+    this(initialCapacity, HashMap.DEFAULT_LOAD_FACTOR)
+
+  def this() =
+    this(HashMap.DEFAULT_INITIAL_CAPACITY)
 
   def this(m: Map[_ <: K, _ <: V]) = {
-    this()
+    this(m.size())
     putAll(m)
   }
 
-  override def get(key: scala.Any): V = {
-    val value = super.get(key)
-    if (accessOrder) {
-      val boxedKey = Box(key.asInstanceOf[K])
-      if (value != null || containsKey(boxedKey)) {
-        inner.remove(boxedKey)
-        inner(boxedKey) = value
-      }
-    }
-    value
+  private def asMyNode(node: HashMap.Node[K, V]): Node[K, V] =
+    node.asInstanceOf[Node[K, V]]
+
+  private[util] override def newNode(
+      key: K,
+      hash: Int,
+      value: V,
+      previous: HashMap.Node[K, V],
+      next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+    new Node(key, hash, value, previous, next, null, null)
   }
 
-  override def put(key: K, value: V): V = {
-    val oldValue = {
-      if (accessOrder) {
-        val old = remove(key)
-        super.put(key, value)
-        old
-      } else {
-        super.put(key, value)
+  private[util] override def nodeWasAccessed(node: HashMap.Node[K, V]): Unit = {
+    if (accessOrder) {
+      val myNode = asMyNode(node)
+      if (myNode.younger ne null) {
+        removeFromOrderedList(myNode)
+        appendToOrderedList(myNode)
       }
     }
-    val iter = entrySet().iterator()
-    if (iter.hasNext() && removeEldestEntry(iter.next()))
-      iter.remove()
-    oldValue
+  }
+
+  private[util] override def nodeWasAdded(node: HashMap.Node[K, V]): Unit = {
+    appendToOrderedList(asMyNode(node))
+    if (removeEldestEntry(eldest))
+      removeNode(eldest)
+  }
+
+  private[util] override def nodeWasRemoved(node: HashMap.Node[K, V]): Unit =
+    removeFromOrderedList(asMyNode(node))
+
+  private def appendToOrderedList(node: Node[K, V]): Unit = {
+    val older = youngest
+    if (older ne null)
+      older.younger = node
+    else
+      eldest = node
+    node.older = older
+    node.younger = null
+    youngest = node
+  }
+
+  private def removeFromOrderedList(node: Node[K, V]): Unit = {
+    val older   = node.older
+    val younger = node.younger
+    if (older eq null)
+      eldest = younger
+    else
+      older.younger = younger
+    if (younger eq null)
+      youngest = older
+    else
+      younger.older = older
+  }
+
+  override def clear(): Unit = {
+    super.clear()
+
+    /* #4195 HashMap.clear() won't call `nodeWasRemoved` for every node, which
+     * would be inefficient, so `eldest` and `yougest` are not automatically
+     * updated. We must explicitly set them to `null` here.
+     */
+    eldest = null
+    youngest = null
   }
 
   protected def removeEldestEntry(eldest: Map.Entry[K, V]): Boolean = false
 
+  override def forEach(action: BiConsumer[_ >: K, _ >: V]): Unit = {
+    var node = eldest
+    while (node ne null) {
+      action.accept(node.key, node.value)
+      node = node.younger
+    }
+  }
+
+  private[util] override def nodeIterator(): ju.Iterator[HashMap.Node[K, V]] =
+    new NodeIterator
+
+  private[util] override def keyIterator(): ju.Iterator[K] =
+    new KeyIterator
+
+  private[util] override def valueIterator(): ju.Iterator[V] =
+    new ValueIterator
+
+  private final class NodeIterator
+      extends AbstractLinkedHashMapIterator[HashMap.Node[K, V]] {
+    protected[this] def extract(node: Node[K, V]): Node[K, V] = node
+  }
+
+  private final class KeyIterator extends AbstractLinkedHashMapIterator[K] {
+    protected[this] def extract(node: Node[K, V]): K = node.key
+  }
+
+  private final class ValueIterator extends AbstractLinkedHashMapIterator[V] {
+    protected[this] def extract(node: Node[K, V]): V = node.value
+  }
+
+  private abstract class AbstractLinkedHashMapIterator[A]
+      extends ju.Iterator[A] {
+    private[this] var nextNode: Node[K, V] = eldest
+    private[this] var lastNode: Node[K, V] = _
+
+    protected[this] def extract(node: Node[K, V]): A
+
+    def hasNext(): Boolean =
+      nextNode ne null
+
+    def next(): A = {
+      if (!hasNext())
+        throw new NoSuchElementException("next on empty iterator")
+      val node = nextNode
+      lastNode = node
+      nextNode = node.younger
+      extract(node)
+    }
+
+    override def remove(): Unit = {
+      val last = lastNode
+      if (last eq null)
+        throw new IllegalStateException(
+          "next must be called at least once before remove")
+      removeNode(last)
+      lastNode = null
+    }
+  }
+
   override def clone(): AnyRef = {
-    new LinkedHashMap(inner.clone(), accessOrder)
+    val result = new LinkedHashMap[K, V](size(), loadFactor, accessOrder)
+    result.putAll(this)
+    result
   }
 }
 
 object LinkedHashMap {
 
-  private[LinkedHashMap] final val DEFAULT_INITIAL_CAPACITY = 16
-  private[LinkedHashMap] final val DEFAULT_LOAD_FACTOR      = 0.75f
+  private final class Node[K, V](key: K,
+                                 hash: Int,
+                                 value: V,
+                                 previous: HashMap.Node[K, V],
+                                 next: HashMap.Node[K, V],
+                                 var older: Node[K, V],
+                                 var younger: Node[K, V])
+      extends HashMap.Node[K, V](key, hash, value, previous, next)
+
 }

--- a/javalib/src/main/scala/java/util/Map.scala
+++ b/javalib/src/main/scala/java/util/Map.scala
@@ -1,4 +1,12 @@
+// Ported from Scala.js  commit f7be410 dated: 2020-10-07
+
 package java.util
+
+import java.util.function.{BiConsumer, BiFunction, Function}
+
+import scala.scalanative.annotation.JavaDefaultMethod
+
+import ScalaOps._
 
 trait Map[K, V] {
   def size(): Int
@@ -15,10 +23,130 @@ trait Map[K, V] {
   def entrySet(): Set[Map.Entry[K, V]]
   def equals(o: Any): Boolean
   def hashCode(): Int
+
+  @JavaDefaultMethod
+  def getOrDefault(key: Any, defaultValue: V): V =
+    if (containsKey(key)) get(key)
+    else defaultValue
+
+  @JavaDefaultMethod
+  def forEach(action: BiConsumer[_ >: K, _ >: V]): Unit = {
+    for (entry <- entrySet().scalaOps)
+      action.accept(entry.getKey(), entry.getValue())
+  }
+
+  @JavaDefaultMethod
+  def replaceAll(function: BiFunction[_ >: K, _ >: V, _ <: V]): Unit = {
+    for (entry <- entrySet().scalaOps)
+      entry.setValue(function.apply(entry.getKey(), entry.getValue()))
+  }
+
+  @JavaDefaultMethod
+  def putIfAbsent(key: K, value: V): V = {
+    val prevValue = get(key)
+    if (prevValue == null)
+      put(key, value) // will return null
+    else
+      prevValue
+  }
+
+  @JavaDefaultMethod
+  def remove(key: Any, value: Any): Boolean = {
+    if (containsKey(key) && Objects.equals(get(key), value)) {
+      remove(key)
+      true
+    } else {
+      false
+    }
+  }
+
+  @JavaDefaultMethod
+  def replace(key: K, oldValue: V, newValue: V): Boolean = {
+    if (containsKey(key) && Objects.equals(get(key), oldValue)) {
+      put(key, newValue)
+      true
+    } else {
+      false
+    }
+  }
+
+  @JavaDefaultMethod
+  def replace(key: K, value: V): V =
+    if (containsKey(key)) put(key, value)
+    else null.asInstanceOf[V]
+
+  @JavaDefaultMethod
+  def computeIfAbsent(key: K, mappingFunction: Function[_ >: K, _ <: V]): V = {
+    val oldValue = get(key)
+    if (oldValue != null) {
+      oldValue
+    } else {
+      val newValue = mappingFunction.apply(key)
+      if (newValue != null)
+        put(key, newValue)
+      newValue
+    }
+  }
+
+  @JavaDefaultMethod
+  def computeIfPresent(
+      key: K,
+      remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]): V = {
+    val oldValue = get(key)
+    if (oldValue == null) {
+      oldValue
+    } else {
+      val newValue = remappingFunction.apply(key, oldValue)
+      putOrRemove(key, newValue)
+      newValue
+    }
+  }
+
+  @JavaDefaultMethod
+  def compute(key: K,
+              remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]): V = {
+    val oldValue = get(key)
+    val newValue = remappingFunction.apply(key, oldValue)
+
+    /* The "Implementation Requirements" section of the JavaDoc for this method
+     * does not correspond to the textual specification in the case where both
+     * a) there was a null mapping, and
+     * b) the remapping function returned null.
+     *
+     * The Implementation Requirements would leave the null mapping, whereas
+     * the specification says to remove it.
+     *
+     * We implement the specification, as it appears that the actual Map
+     * implementations on the JVM behave like the spec.
+     */
+    putOrRemove(key, newValue)
+
+    newValue
+  }
+
+  @JavaDefaultMethod
+  def merge(key: K,
+            value: V,
+            remappingFunction: BiFunction[_ >: V, _ >: V, _ <: V]): V = {
+    Objects.requireNonNull(value)
+
+    val oldValue = get(key)
+    val newValue =
+      if (oldValue == null) value
+      else remappingFunction.apply(oldValue, value)
+    putOrRemove(key, newValue)
+    newValue
+  }
+
+  private def putOrRemove(key: K, value: V): Unit = {
+    if (value != null)
+      put(key, value)
+    else
+      remove(key)
+  }
 }
 
 object Map {
-
   trait Entry[K, V] {
     def getKey(): K
     def getValue(): V

--- a/unit-tests/src/test/scala/java/util/AbstractMapTest.scala
+++ b/unit-tests/src/test/scala/java/util/AbstractMapTest.scala
@@ -1,6 +1,6 @@
-package java.util
+// Ported from Scala.js commit: 3786783 dated: 2019-10-11
 
-// Ported from Scala.js
+package org.scalanative.testsuite.javalib.util
 
 import java.{util => ju}
 

--- a/unit-tests/src/test/scala/java/util/HashMapTest.scala
+++ b/unit-tests/src/test/scala/java/util/HashMapTest.scala
@@ -1,4 +1,4 @@
-package java.util
+package org.scalanative.testsuite.javalib.util
 
 // Ported from Scala.js
 

--- a/unit-tests/src/test/scala/java/util/IdentityHashMapTest.scala
+++ b/unit-tests/src/test/scala/java/util/IdentityHashMapTest.scala
@@ -1,4 +1,4 @@
-package java.util
+package org.scalanative.testsuite.javalib.util
 
 // Ported from Scala.js
 
@@ -123,8 +123,8 @@ class IdentityHashMapFactory extends MapFactory {
   override def implementationName: String =
     "java.util.IdentityHashMap"
 
-  override def empty[K: ClassTag, V: ClassTag]: IdentityHashMap[K, V] =
-    new IdentityHashMap[K, V]
+  override def empty[K: ClassTag, V: ClassTag]: ju.IdentityHashMap[K, V] =
+    new ju.IdentityHashMap[K, V]
 
   def allowsNullKeys: Boolean           = true
   def allowsNullValues: Boolean         = true

--- a/unit-tests/src/test/scala/java/util/LinkedHashMapTest.scala
+++ b/unit-tests/src/test/scala/java/util/LinkedHashMapTest.scala
@@ -1,4 +1,4 @@
-package java.util
+package org.scalanative.testsuite.javalib.util
 
 // Ported from Scala.js
 

--- a/unit-tests/src/test/scala/java/util/MapTest.scala
+++ b/unit-tests/src/test/scala/java/util/MapTest.scala
@@ -74,23 +74,26 @@ trait MapTest {
     }
   }
   @Test def testSizeGetPutWithInts(): Unit = {
-    val mp = factory.empty[Int, Int]
+    if (!isIdentityHashMapOnScalaNative()) {
 
-    mp.put(100, 12345)
-    assertEquals(1, mp.size())
-    assertEquals(12345, mp.get(100))
-    mp.put(150, 54321)
-    assertEquals(2, mp.size())
-    assertEquals(54321, mp.get(150))
-    mp.put(100, 3)
-    assertEquals(2, mp.size())
-    assertEquals(3, mp.get(100))
+      val mp = factory.empty[Int, Int]
 
-    assertEquals(null, mp.get(42))
-    assertEquals(null, mp.get("THREE"))
-    assertEquals(null, mp.get(testObj(42)))
-    if (factory.allowsNullKeysQueries)
-      assertEquals(null, mp.get(null))
+      mp.put(100, 12345)
+      assertEquals(1, mp.size())
+      assertEquals(12345, mp.get(100))
+      mp.put(150, 54321)
+      assertEquals(2, mp.size())
+      assertEquals(54321, mp.get(150))
+      mp.put(100, 3)
+      assertEquals(2, mp.size())
+      assertEquals(3, mp.get(100))
+
+      assertEquals(null, mp.get(42))
+      assertEquals(null, mp.get("THREE"))
+      assertEquals(null, mp.get(testObj(42)))
+      if (factory.allowsNullKeysQueries)
+        assertEquals(null, mp.get(null))
+    }
   }
 
   @Test def testSizeGetPutWithIntsLargeMap(): Unit = {
@@ -150,27 +153,29 @@ trait MapTest {
   }
 
   @Test def testSizeGetPutWithDoublesCornerCasesOfEquals(): Unit = {
-    val mp = factory.empty[Double, Double]
+    if (!isIdentityHashMapOnScalaNative()) {
+      val mp = factory.empty[Double, Double]
 
-    mp.put(1.2345, 11111.0)
-    assertEquals(1, mp.size())
-    val one = mp.get(1.2345)
-    assertEquals(11111.0, one, 0.0)
+      mp.put(1.2345, 11111.0)
+      assertEquals(1, mp.size())
+      val one = mp.get(1.2345)
+      assertEquals(11111.0, one, 0.0)
 
-    mp.put(Double.NaN, 22222.0)
-    assertEquals(2, mp.size())
-    val two = mp.get(Double.NaN)
-    assertEquals(22222.0, two, 0.0)
+      mp.put(Double.NaN, 22222.0)
+      assertEquals(2, mp.size())
+      val two = mp.get(Double.NaN)
+      assertEquals(22222.0, two, 0.0)
 
-    mp.put(+0.0, 33333.0)
-    assertEquals(3, mp.size())
-    val three = mp.get(+0.0)
-    assertEquals(33333.0, three, 0.0)
+      mp.put(+0.0, 33333.0)
+      assertEquals(3, mp.size())
+      val three = mp.get(+0.0)
+      assertEquals(33333.0, three, 0.0)
 
-    mp.put(-0.0, 44444.0)
-    assertEquals(4, mp.size())
-    val four = mp.get(-0.0)
-    assertEquals(44444.0, four, 0.0)
+      mp.put(-0.0, 44444.0)
+      assertEquals(4, mp.size())
+      val four = mp.get(-0.0)
+      assertEquals(44444.0, four, 0.0)
+    }
   }
 
   @Test def testRemoveWithStrings(): Unit = {
@@ -192,21 +197,24 @@ trait MapTest {
   }
 
   @Test def testRemoveWithInts(): Unit = {
-    val mp = factory.empty[Int, String]
+    if (!isIdentityHashMapOnScalaNative()) {
 
-    mp.put(543, "one")
-    for (i <- 0 until 30)
-      mp.put(i, s"value $i")
-    assertEquals(31, mp.size())
-    assertEquals("one", mp.remove(543))
-    assertNull(mp.get(543))
-    assertNull(mp.remove(543))
+      val mp = factory.empty[Int, String]
 
-    assertNull(mp.remove("foobar"))
-    assertNull(mp.remove(42))
-    assertNull(mp.remove(testObj(42)))
-    if (factory.allowsNullKeys)
-      assertNull(mp.remove(null))
+      mp.put(543, "one")
+      for (i <- 0 until 30)
+        mp.put(i, s"value $i")
+      assertEquals(31, mp.size())
+      assertEquals("one", mp.remove(543))
+      assertNull(mp.get(543))
+      assertNull(mp.remove(543))
+
+      assertNull(mp.remove("foobar"))
+      assertNull(mp.remove(42))
+      assertNull(mp.remove(testObj(42)))
+      if (factory.allowsNullKeys)
+        assertNull(mp.remove(null))
+    }
   }
 
   @Test def testRemoveWithCustomObjects(): Unit = {
@@ -228,36 +236,39 @@ trait MapTest {
   }
 
   @Test def testRemoveWithDoublesCornerCasesOfEquals(): Unit = {
-    val mp = factory.empty[Double, String]
+    if (!isIdentityHashMapOnScalaNative()) {
 
-    mp.put(1.2345, "11111.0")
-    mp.put(Double.NaN, "22222.0")
-    mp.put(+0.0, "33333.0")
-    mp.put(-0.0, "44444.0")
+      val mp = factory.empty[Double, String]
 
-    assertEquals("11111.0", mp.get(1.2345))
-    assertEquals("22222.0", mp.get(Double.NaN))
-    assertEquals("33333.0", mp.get(+0.0))
-    assertEquals("44444.0", mp.get(-0.0))
+      mp.put(1.2345, "11111.0")
+      mp.put(Double.NaN, "22222.0")
+      mp.put(+0.0, "33333.0")
+      mp.put(-0.0, "44444.0")
 
-    assertEquals("44444.0", mp.remove(-0.0))
-    assertNull(mp.get(-0.0))
+      assertEquals("11111.0", mp.get(1.2345))
+      assertEquals("22222.0", mp.get(Double.NaN))
+      assertEquals("33333.0", mp.get(+0.0))
+      assertEquals("44444.0", mp.get(-0.0))
 
-    mp.put(-0.0, "55555.0")
+      assertEquals("44444.0", mp.remove(-0.0))
+      assertNull(mp.get(-0.0))
 
-    assertEquals("33333.0", mp.remove(+0.0))
-    assertNull(mp.get(+0.0))
+      mp.put(-0.0, "55555.0")
 
-    mp.put(+0.0, "66666.0")
+      assertEquals("33333.0", mp.remove(+0.0))
+      assertNull(mp.get(+0.0))
 
-    assertEquals("22222.0", mp.remove(Double.NaN))
-    assertNull(mp.get(Double.NaN))
+      mp.put(+0.0, "66666.0")
 
-    mp.put(Double.NaN, "77777.0")
+      assertEquals("22222.0", mp.remove(Double.NaN))
+      assertNull(mp.get(Double.NaN))
 
-    mp.clear()
+      mp.put(Double.NaN, "77777.0")
 
-    assertTrue(mp.isEmpty)
+      mp.clear()
+
+      assertTrue(mp.isEmpty)
+    }
   }
 
   @Test def testGetPutRemoveNullKeys(): Unit = {
@@ -489,23 +500,25 @@ trait MapTest {
   }
 
   @Test def testValuesIsViewForQueriesWithDoublesCornerCaseOfEquals(): Unit = {
-    val nummp     = factory.empty[Double, Double]
-    val numValues = nummp.values()
+    if (!isIdentityHashMapOnScalaNative()) {
+      val nummp     = factory.empty[Double, Double]
+      val numValues = nummp.values()
 
-    nummp.put(1, +0.0)
-    assertTrue(numValues.contains(+0.0))
-    assertFalse(numValues.contains(-0.0))
-    assertFalse(numValues.contains(Double.NaN))
+      nummp.put(1, +0.0)
+      assertTrue(numValues.contains(+0.0))
+      assertFalse(numValues.contains(-0.0))
+      assertFalse(numValues.contains(Double.NaN))
 
-    nummp.put(2, -0.0)
-    assertTrue(numValues.contains(+0.0))
-    assertTrue(numValues.contains(-0.0))
-    assertFalse(numValues.contains(Double.NaN))
+      nummp.put(2, -0.0)
+      assertTrue(numValues.contains(+0.0))
+      assertTrue(numValues.contains(-0.0))
+      assertFalse(numValues.contains(Double.NaN))
 
-    nummp.put(3, Double.NaN)
-    assertTrue(numValues.contains(+0.0))
-    assertTrue(numValues.contains(-0.0))
-    assertTrue(numValues.contains(Double.NaN))
+      nummp.put(3, Double.NaN)
+      assertTrue(numValues.contains(+0.0))
+      assertTrue(numValues.contains(-0.0))
+      assertTrue(numValues.contains(Double.NaN))
+    }
   }
 
   @Test def testValuesIsViewForRemoveWithStrings(): Unit = {
@@ -684,23 +697,25 @@ trait MapTest {
   }
 
   @Test def testKeySetIsViewForQueriesWithDoublesCornerCaseOfEquals(): Unit = {
-    val nummp     = factory.empty[Double, Double]
-    val numkeySet = nummp.keySet()
+    if (!isIdentityHashMapOnScalaNative()) {
+      val nummp     = factory.empty[Double, Double]
+      val numkeySet = nummp.keySet()
 
-    nummp.put(+0.0, 1)
-    assertTrue(numkeySet.contains(+0.0))
-    assertFalse(numkeySet.contains(-0.0))
-    assertFalse(numkeySet.contains(Double.NaN))
+      nummp.put(+0.0, 1)
+      assertTrue(numkeySet.contains(+0.0))
+      assertFalse(numkeySet.contains(-0.0))
+      assertFalse(numkeySet.contains(Double.NaN))
 
-    nummp.put(-0.0, 2)
-    assertTrue(numkeySet.contains(+0.0))
-    assertTrue(numkeySet.contains(-0.0))
-    assertFalse(numkeySet.contains(Double.NaN))
+      nummp.put(-0.0, 2)
+      assertTrue(numkeySet.contains(+0.0))
+      assertTrue(numkeySet.contains(-0.0))
+      assertFalse(numkeySet.contains(Double.NaN))
 
-    nummp.put(Double.NaN, 3)
-    assertTrue(numkeySet.contains(+0.0))
-    assertTrue(numkeySet.contains(-0.0))
-    assertTrue(numkeySet.contains(Double.NaN))
+      nummp.put(Double.NaN, 3)
+      assertTrue(numkeySet.contains(+0.0))
+      assertTrue(numkeySet.contains(-0.0))
+      assertTrue(numkeySet.contains(Double.NaN))
+    }
   }
 
   @Test def testKeySetIsViewForRemoveWithStrings(): Unit = {

--- a/unit-tests/src/test/scala/java/util/MapTest.scala
+++ b/unit-tests/src/test/scala/java/util/MapTest.scala
@@ -1,17 +1,28 @@
-package java.util
+// Ported from Scala.js commit: f7be410 dated: 2020-10-07
+//
+// Porting Notes:
+//   1) ConcurrentMap is not yet implemented on Scala Native.
+//      The corresponding import was deleted.
+//
+//   2) assumeNotIdentityHashMapOnJVM() has been removed in a number of
+//      places.  Folding Scala Native into the concept gets complex.
+//      A more limited isIdentityHashMapOnScalaNative() is used in two
+//      places.
 
-// Ported from Scala.js
+package org.scalanative.testsuite.javalib.util
 
 import java.{util => ju}
+import java.util.function.{BiConsumer, BiFunction, Function}
+
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
+
 import scala.scalanative.junit.utils.AssertThrows._
-import scala.collection.{immutable => im}
-import scala.collection.{mutable => mu}
+import scala.scalanative.junit.utils.Utils._
+import org.scalanative.testsuite.utils.Platform._
 
 import scala.reflect.ClassTag
-import scala.scalanative.junit.utils.CollectionConverters._
 
 trait MapTest {
   import MapTest._
@@ -20,19 +31,10 @@ trait MapTest {
 
   def testObj(i: Int): TestObj = TestObj(i)
 
-  // temporary until Platform is introduced
-  val executingInJVM = false
+  private def isIdentityHashMapOnScalaNative(): Boolean =
+    factory.isIdentityBased && executingInScalaNative
 
-  // replace when new IdentityHashMap from Scala.js
-  // private def assumeNotIdentityHashMapOnJVM(): Unit =
-  //   assumeFalse("JVM vs Native cache differences",
-  //               executingInJVM && factory.isIdentityBased)
-
-  // temp implementation
-  private def assumeNotIdentityHashMapOnJVM(): Unit =
-    assumeFalse("JVM vs Native cache differences", factory.isIdentityBased)
-
-  @Test def shouldStoreStrings(): Unit = {
+  @Test def testSizeGetPutWithStrings(): Unit = {
     val mp = factory.empty[String, String]
 
     assertEquals(0, mp.size())
@@ -42,21 +44,112 @@ trait MapTest {
     mp.put("TWO", "two")
     assertEquals(2, mp.size())
     assertEquals("two", mp.get("TWO"))
+    mp.put("ONE", "three")
+    assertEquals(2, mp.size())
+    assertEquals("three", mp.get("ONE"))
+
+    assertEquals(null, mp.get("THREE"))
+    assertEquals(null, mp.get(42))
+    assertEquals(null, mp.get(testObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, mp.get(null))
   }
 
-  @Test def shouldStoreIntegers(): Unit = {
-    assumeNotIdentityHashMapOnJVM()
+  @Test def testSizeGetPutWithStringsLargeMap(): Unit = {
+    if (!isIdentityHashMapOnScalaNative()) {
+      val largeMap = factory.empty[String, Int]
+      for (i <- 0 until 1000)
+        largeMap.put(i.toString(), i)
+      val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
+      assertEquals(expectedSize, largeMap.size())
+      for (i <- (1000 - expectedSize) until 1000)
+        assertEquals(i, largeMap.get(i.toString()))
+      assertNull(largeMap.get("1000"))
+
+      assertEquals(null, largeMap.get("THREE"))
+      assertEquals(null, largeMap.get(42))
+      assertEquals(null, largeMap.get(testObj(42)))
+      if (factory.allowsNullKeysQueries)
+        assertEquals(null, largeMap.get(null))
+    }
+  }
+  @Test def testSizeGetPutWithInts(): Unit = {
     val mp = factory.empty[Int, Int]
 
     mp.put(100, 12345)
     assertEquals(1, mp.size())
-    val one = mp.get(100)
-    assertEquals(12345, one)
+    assertEquals(12345, mp.get(100))
+    mp.put(150, 54321)
+    assertEquals(2, mp.size())
+    assertEquals(54321, mp.get(150))
+    mp.put(100, 3)
+    assertEquals(2, mp.size())
+    assertEquals(3, mp.get(100))
+
+    assertEquals(null, mp.get(42))
+    assertEquals(null, mp.get("THREE"))
+    assertEquals(null, mp.get(testObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, mp.get(null))
   }
 
-  @Test def shouldStoreDoublesAlsoInCornerCases() {
-    assumeNotIdentityHashMapOnJVM()
+  @Test def testSizeGetPutWithIntsLargeMap(): Unit = {
+    if (!isIdentityHashMapOnScalaNative()) {
+      val largeMap = factory.empty[Int, Int]
+      for (i <- 0 until 1000)
+        largeMap.put(i, i * 2)
+      val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
+      assertEquals(expectedSize, largeMap.size())
+      for (i <- (1000 - expectedSize) until 1000)
+        assertEquals(i * 2, largeMap.get(i))
+      assertNull(largeMap.get(1000))
 
+      assertEquals(null, largeMap.get(-42))
+      assertEquals(null, largeMap.get("THREE"))
+      assertEquals(null, largeMap.get(testObj(42)))
+      if (factory.allowsNullKeysQueries)
+        assertEquals(null, largeMap.get(null))
+    }
+  }
+
+  @Test def testSizeGetPutWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+
+    mp.put(testObj(100), TestObj(12345))
+    assertEquals(1, mp.size())
+    assertEquals(12345, mp.get(testObj(100)).num)
+    mp.put(testObj(150), TestObj(54321))
+    assertEquals(2, mp.size())
+    assertEquals(54321, mp.get(testObj(150)).num)
+    mp.put(testObj(100), TestObj(3))
+    assertEquals(2, mp.size())
+    assertEquals(3, mp.get(testObj(100)).num)
+
+    assertEquals(null, mp.get("THREE"))
+    assertEquals(null, mp.get(42))
+    assertEquals(null, mp.get(testObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, mp.get(null))
+  }
+
+  @Test def testSizeGetPutWithCustomObjectsLargeMap(): Unit = {
+    val largeMap = factory.empty[TestObj, Int]
+    for (i <- 0 until 1000)
+      largeMap.put(testObj(i), i * 2)
+    val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
+    assertEquals(expectedSize, largeMap.size())
+    for (i <- (1000 - expectedSize) until 1000)
+      assertEquals(i * 2, largeMap.get(testObj(i)))
+    assertNull(largeMap.get(1000))
+
+    assertEquals(null, largeMap.get(testObj(-42)))
+    assertEquals(null, largeMap.get("THREE"))
+    assertEquals(null, largeMap.get(42))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, largeMap.get(null))
+  }
+
+  @Test def testSizeGetPutWithDoublesCornerCasesOfEquals(): Unit = {
     val mp = factory.empty[Double, Double]
 
     mp.put(1.2345, 11111.0)
@@ -80,35 +173,61 @@ trait MapTest {
     assertEquals(44444.0, four, 0.0)
   }
 
-  @Test def shouldStoreCustomObjects(): Unit = {
-    case class TestObj(num: Int)
-    val mp = factory.empty[TestObj, TestObj]
-
-    val testKey = TestObj(100)
-    mp.put(testKey, TestObj(12345))
-    assertEquals(1, mp.size())
-    if (factory.isIdentityBased) {
-      val one = mp.get(testKey)
-      assertEquals(12345, one.num)
-    } else {
-      val one = mp.get(TestObj(100))
-      assertEquals(12345, one.num)
-    }
-  }
-
-  @Test def shouldRemoveStoredElements(): Unit = {
+  @Test def testRemoveWithStrings(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
-    assertEquals(1, mp.size())
+    for (i <- 0 until 30)
+      mp.put(s"key $i", s"value $i")
+    assertEquals(31, mp.size())
     assertEquals("one", mp.remove("ONE"))
-    val newOne = mp.get("ONE")
     assertNull(mp.get("ONE"))
+    assertNull(mp.remove("ONE"))
+
+    assertNull(mp.remove("foobar"))
+    assertNull(mp.remove(42))
+    assertNull(mp.remove(testObj(42)))
+    if (factory.allowsNullKeys)
+      assertNull(mp.remove(null))
   }
 
-  @Test def shouldRemoveStoredElementsInDoubleCornerCases() {
-    assumeNotIdentityHashMapOnJVM()
+  @Test def testRemoveWithInts(): Unit = {
+    val mp = factory.empty[Int, String]
 
+    mp.put(543, "one")
+    for (i <- 0 until 30)
+      mp.put(i, s"value $i")
+    assertEquals(31, mp.size())
+    assertEquals("one", mp.remove(543))
+    assertNull(mp.get(543))
+    assertNull(mp.remove(543))
+
+    assertNull(mp.remove("foobar"))
+    assertNull(mp.remove(42))
+    assertNull(mp.remove(testObj(42)))
+    if (factory.allowsNullKeys)
+      assertNull(mp.remove(null))
+  }
+
+  @Test def testRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, String]
+
+    mp.put(testObj(543), "one")
+    for (i <- 0 until 30)
+      mp.put(testObj(i), s"value $i")
+    assertEquals(31, mp.size())
+    assertEquals("one", mp.remove(testObj(543)))
+    assertNull(mp.get(testObj(543)))
+    assertNull(mp.remove(testObj(543)))
+
+    assertNull(mp.remove(testObj(42)))
+    assertNull(mp.remove("foobar"))
+    assertNull(mp.remove(42))
+    if (factory.allowsNullKeys)
+      assertNull(mp.remove(null))
+  }
+
+  @Test def testRemoveWithDoublesCornerCasesOfEquals(): Unit = {
     val mp = factory.empty[Double, String]
 
     mp.put(1.2345, "11111.0")
@@ -141,39 +260,68 @@ trait MapTest {
     assertTrue(mp.isEmpty)
   }
 
-  @Test def shouldPutOrFailOnNullKeys(): Unit = {
+  @Test def testGetPutRemoveNullKeys(): Unit = {
+    val mp = factory.empty[String, String]
+    for (i <- 0 until 30)
+      mp.put(s"key $i", s"value $i")
+
     if (factory.allowsNullKeys) {
-      val mp = factory.empty[String, String]
       mp.put(null, "one")
+      assertEquals(31, mp.size())
       assertEquals("one", mp.get(null))
+      assertEquals("one", mp.remove(null))
+      assertNull(mp.get(null))
+      assertNull(mp.remove(null))
     } else {
-      val mp = factory.empty[String, String]
       expectThrows(classOf[NullPointerException], mp.put(null, "one"))
     }
   }
 
-  @Test def shouldPutOrFailOnNullValues(): Unit = {
+  @Test def testGetPutRemoveNullValues(): Unit = {
+    val mp = factory.empty[String, String]
+    for (i <- 0 until 30)
+      mp.put(s"key $i", s"value $i")
+
     if (factory.allowsNullValues) {
-      val mp = factory.empty[String, String]
       mp.put("one", null)
+      assertEquals(31, mp.size())
+      assertNull(mp.get("one"))
+      assertNull(mp.remove("one"))
+      assertEquals(30, mp.size())
       assertNull(mp.get("one"))
     } else {
-      val mp = factory.empty[String, String]
       expectThrows(classOf[NullPointerException], mp.put("one", null))
     }
   }
 
-  @Test def shouldBeClearedWithOneOperation(): Unit = {
+  @Test def testClear(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
     mp.put("TWO", "two")
     assertEquals(2, mp.size())
     mp.clear()
+
+    // Test the content size
     assertEquals(0, mp.size())
+
+    // Test the hash table
+    assertNull(mp.get("ONE"))
+    assertNull(mp.get("TWO"))
+
+    // Test the iterators (different from the hash table for LinkedHashMap)
+    assertFalse(mp.entrySet().iterator().hasNext())
+    assertFalse(mp.keySet().iterator().hasNext())
+    assertFalse(mp.values().iterator().hasNext())
+
+    // can be reused after clear()
+    mp.put("TWO", "value 2")
+    mp.put("THREE", "value 3")
+    assertEquals("value 2", mp.get("TWO"))
+    assertEquals("value 3", mp.get("THREE"))
   }
 
-  @Test def shouldCheckContainedKeyPresence(): Unit = {
+  @Test def testContainsKey(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
@@ -182,10 +330,10 @@ trait MapTest {
     if (factory.allowsNullKeysQueries)
       assertFalse(mp.containsKey(null))
     else
-      expectThrows(classOf[Throwable], mp.containsKey(null))
+      expectThrows(classOf[NullPointerException], mp.containsKey(null))
   }
 
-  @Test def shouldCheckContainedValuePresence(): Unit = {
+  @Test def testContainsValue(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
@@ -194,29 +342,50 @@ trait MapTest {
     if (factory.allowsNullValuesQueries)
       assertFalse(mp.containsValue(null))
     else
-      expectThrows(classOf[Throwable], mp.containsValue(null))
+      expectThrows(classOf[NullPointerException], mp.containsValue(null))
   }
 
-  @Test def shouldGiveProperCollectionOverValues(): Unit = {
+  @Test def testPutAll(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
+
+    mp.putAll(TrivialImmutableMap("X" -> "y", "A" -> "b"))
+    assertEquals(3, mp.size())
+    assertEquals("one", mp.get("ONE"))
+    assertEquals("y", mp.get("X"))
+    assertEquals("b", mp.get("A"))
+
+    val nullMap = TrivialImmutableMap((null: String) -> "y", "X" -> "z")
+    if (factory.allowsNullKeys) {
+      mp.putAll(nullMap)
+      assertEquals("y", mp.get(null))
+      assertEquals("z", mp.get("X"))
+      assertEquals("one", mp.get("ONE"))
+      assertEquals("b", mp.get("A"))
+    } else {
+      expectThrows(classOf[NullPointerException], mp.putAll(nullMap))
+    }
+  }
+
+  @Test def testValuesSizeIteratorBasic(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+
     val values = mp.values()
-    assertEquals(1, values.size())
+    assertEquals(1, values.size)
     val iter = values.iterator
     assertTrue(iter.hasNext)
     assertEquals("one", iter.next)
     assertFalse(iter.hasNext)
   }
 
-  @Test def shouldGiveProperEntrySetOverKeyValuePairs(): Unit = {
+  @Test def testEntrySetSizeIteratorBasic(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
-    val entrySet = mp.entrySet
 
-    assertEquals(1, entrySet.size())
-
+    val entrySet = mp.entrySet()
+    assertEquals(1, entrySet.size)
     val iter = entrySet.iterator
     assertTrue(iter.hasNext)
     val next = iter.next
@@ -225,121 +394,104 @@ trait MapTest {
     assertEquals("one", next.getValue)
   }
 
-  @Test def shouldGiveProperKeySetOverKeys(): Unit = {
+  @Test def testKeySetSizeIteratorBasic(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
+
     val keySet = mp.keySet()
-
-    assertEquals(1, keySet.size())
-
+    assertEquals(1, keySet.size)
     val iter = keySet.iterator
     assertTrue(iter.hasNext)
     assertEquals("ONE", iter.next)
     assertFalse(iter.hasNext)
   }
 
-  @Test def shouldPutAWholeMapInto(): Unit = {
+  @Test def testValuesIsViewForSize(): Unit = {
     val mp = factory.empty[String, String]
-
-    val m = mu.Map[String, String]("X" -> "y")
-    mp.putAll(m.toJavaMap[String, String])
-    assertEquals(1, mp.size())
-    assertEquals("y", mp.get("X"))
-
-    val nullMap = mu.Map[String, String]((null: String) -> "y", "X" -> "y")
-
-    if (factory.allowsNullKeys) {
-      mp.putAll(nullMap.toJavaMap[String, String])
-      assertEquals("y", mp.get(null))
-      assertEquals("y", mp.get("X"))
-    } else {
-      expectThrows(classOf[NullPointerException],
-                   mp.putAll(nullMap.toJavaMap[String, String]))
-    }
-  }
-
-  class SimpleQueryableMap[K, V](inner: mu.HashMap[K, V])
-      extends ju.AbstractMap[K, V] {
-    def entrySet(): java.util.Set[java.util.Map.Entry[K, V]] = {
-      inner
-        .map {
-          case (k, v) =>
-            val entry = new ju.AbstractMap.SimpleImmutableEntry(k, v)
-            entry: java.util.Map.Entry[K, V]
-        }
-        .toSet
-        .toJavaSet
-    }
-  }
-
-  @Test def valuesShouldMirrorTheRelatedMapSize(): Unit = {
-    val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
-
     val values = mp.values()
-    assertEquals(2, values.size())
 
+    assertEquals(2, values.size)
     mp.put("THREE", "three")
-
-    assertEquals(3, values.size())
-
+    assertEquals(3, values.size)
     mp.remove("ONE")
-
-    assertEquals(2, values.size())
-
+    assertEquals(2, values.size)
     assertFalse(values.isEmpty)
-
     mp.clear()
-
-    assertEquals(0, values.size())
-
+    assertEquals(0, values.size)
     assertTrue(values.isEmpty)
-
-    val hm1 = mu.HashMap("ONE"          -> "one", "TWO" -> "two")
-    val hm2 = mu.HashMap("ONE"          -> null, "TWO"  -> "two")
-    val hm3 = mu.HashMap((null: String) -> "one", "TWO" -> "two")
-    val hm4 = mu.HashMap((null: String) -> null, "TWO"  -> "two")
-
-    assertEquals(2, new SimpleQueryableMap(hm1).values().size())
-    assertEquals(2, new SimpleQueryableMap(hm2).values().size())
-    assertEquals(2, new SimpleQueryableMap(hm3).values().size())
-    assertEquals(2, new SimpleQueryableMap(hm4).values().size())
   }
 
-  @Test def valuesShouldCheckSingleAndMultipleObjectsPresence(): Unit = {
+  @Test def testValuesIsViewForQueriesWithStrings(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
-
     val values = mp.values()
+
     assertTrue(values.contains("one"))
     assertTrue(values.contains("two"))
     assertFalse(values.contains("three"))
     if (factory.allowsNullValuesQueries)
       assertFalse(values.contains(null))
     else
-      expectThrows(classOf[Throwable], mp.values().contains(null))
+      expectThrows(classOf[NullPointerException], values.contains(null))
 
     mp.put("THREE", "three")
 
     assertTrue(values.contains("three"))
 
-    val coll1 = im.Set("one", "two", "three").toJavaSet
+    val coll1 = TrivialImmutableCollection("one", "two", "three")
     assertTrue(values.containsAll(coll1))
 
-    val coll2 = im.Set("one", "two", "three", "four").toJavaSet
+    val coll2 = TrivialImmutableCollection("one", "two", "three", "four")
     assertFalse(values.containsAll(coll2))
 
-    val coll3 = im.Set("one", "two", "three", null).toJavaSet
+    if (factory.allowsNullValuesQueries) {
+      val coll3 = TrivialImmutableCollection("one", "two", "three", null)
+      assertFalse(values.containsAll(coll3))
+    }
+  }
+
+  @Test def testValuesIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    val values = mp.values()
+
+    assertTrue(values.contains(testObj(11)))
+    assertTrue(values.contains(testObj(22)))
+    assertFalse(values.contains(testObj(33)))
+    if (factory.allowsNullValuesQueries)
+      assertFalse(values.contains(null))
+    else
+      expectThrows(classOf[NullPointerException], values.contains(null))
+
+    mp.put(testObj(3), testObj(33))
+
+    assertTrue(values.contains(testObj(33)))
+
+    val coll1 =
+      TrivialImmutableCollection(testObj(11), testObj(22), testObj(33))
+    assertTrue(values.containsAll(coll1))
+
+    val coll2 = TrivialImmutableCollection(testObj(11),
+                                           testObj(22),
+                                           testObj(33),
+                                           testObj(44))
     assertFalse(values.containsAll(coll2))
 
-    val nummp = factory.empty[Double, Double]
+    if (factory.allowsNullValuesQueries) {
+      val coll3 =
+        TrivialImmutableCollection(testObj(11), testObj(22), testObj(33), null)
+      assertFalse(values.containsAll(coll3))
+    }
+  }
 
+  @Test def testValuesIsViewForQueriesWithDoublesCornerCaseOfEquals(): Unit = {
+    val nummp     = factory.empty[Double, Double]
     val numValues = nummp.values()
+
     nummp.put(1, +0.0)
     assertTrue(numValues.contains(+0.0))
     assertFalse(numValues.contains(-0.0))
@@ -354,27 +506,14 @@ trait MapTest {
     assertTrue(numValues.contains(+0.0))
     assertTrue(numValues.contains(-0.0))
     assertTrue(numValues.contains(Double.NaN))
-
-    val hm1 = mu.HashMap(1.0         -> null, 2.0 -> 2.0)
-    val hm2 = mu.HashMap((null: Any) -> 1.0, 2.0  -> 2.0)
-    val hm3 = mu.HashMap((null: Any) -> null, 2.0 -> 2.0)
-
-    assertFalse(new SimpleQueryableMap(hm1).values().contains(1.0))
-    assertTrue(new SimpleQueryableMap(hm2).values().contains(1.0))
-    assertFalse(new SimpleQueryableMap(hm3).values().contains(1.0))
-
-    assertTrue(new SimpleQueryableMap(hm1).values().contains(null))
-    assertFalse(new SimpleQueryableMap(hm2).values().contains(null))
-    assertTrue(new SimpleQueryableMap(hm3).values().contains(null))
   }
 
-  @Test def valuesShouldSideEffectClearRemoveRetainOnTheRelatedMap(): Unit = {
+  @Test def testValuesIsViewForRemoveWithStrings(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
-
     val values = mp.values()
+
     assertFalse(values.isEmpty)
     assertFalse(mp.isEmpty)
 
@@ -387,9 +526,7 @@ trait MapTest {
     mp.put("TWO", "two")
 
     assertTrue(mp.containsKey("ONE"))
-
     values.remove("one")
-
     assertFalse(mp.containsKey("ONE"))
 
     mp.put("ONE", "one")
@@ -399,7 +536,7 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    values.removeAll(im.List("one", "two").toJavaList)
+    values.removeAll(TrivialImmutableCollection("one", "two"))
 
     assertFalse(mp.containsKey("ONE"))
     assertFalse(mp.containsKey("TWO"))
@@ -413,80 +550,143 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    values.retainAll(im.List("one", "two").toJavaList)
+    values.retainAll(TrivialImmutableCollection("one", "two"))
 
     assertTrue(mp.containsKey("ONE"))
     assertTrue(mp.containsKey("TWO"))
     assertFalse(mp.containsKey("THREE"))
   }
 
-  @Test def keySetShouldMirrorTheRelatedMapSize(): Unit = {
-    val mp = factory.empty[String, String]
+  @Test def testValuesIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    val values = mp.values()
 
-    mp.put("ONE", "one")
-    mp.put("TWO", "two")
+    assertFalse(values.isEmpty)
+    assertFalse(mp.isEmpty)
 
-    val keySet = mp.keySet()
-    assertEquals(2, keySet.size())
+    values.clear()
 
-    mp.put("THREE", "three")
+    assertTrue(values.isEmpty)
+    assertTrue(mp.isEmpty)
 
-    assertEquals(3, keySet.size())
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
 
-    mp.remove("ONE")
+    assertTrue(mp.containsKey(testObj(1)))
+    values.remove(testObj(11))
+    assertFalse(mp.containsKey(testObj(1)))
 
-    assertEquals(2, keySet.size())
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(3), testObj(33))
 
-    assertFalse(keySet.isEmpty)
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
 
-    mp.clear()
+    values.removeAll(TrivialImmutableCollection(testObj(11), testObj(22)))
 
-    assertEquals(0, keySet.size())
+    assertFalse(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
 
-    assertTrue(keySet.isEmpty)
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    mp.put(testObj(3), testObj(33))
 
-    val hm1 = mu.HashMap("ONE"          -> "one", "TWO" -> "two")
-    val hm2 = mu.HashMap("ONE"          -> null, "TWO"  -> "two")
-    val hm3 = mu.HashMap((null: String) -> "one", "TWO" -> "two")
-    val hm4 = mu.HashMap((null: String) -> null, "TWO"  -> "two")
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
 
-    assertEquals(2, new SimpleQueryableMap(hm1).keySet().size())
-    assertEquals(2, new SimpleQueryableMap(hm2).keySet().size())
-    assertEquals(2, new SimpleQueryableMap(hm3).keySet().size())
-    assertEquals(2, new SimpleQueryableMap(hm4).keySet().size())
+    values.retainAll(TrivialImmutableCollection(testObj(11), testObj(22)))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertFalse(mp.containsKey(testObj(3)))
   }
 
-  @Test def keySetShouldCheckSingleAndMultipleObjectsPresence(): Unit = {
+  @Test def testKeySetIsViewForSize(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
-
     val keySet = mp.keySet()
+
+    assertEquals(2, keySet.size)
+    mp.put("THREE", "three")
+    assertEquals(3, keySet.size)
+    mp.remove("ONE")
+    assertEquals(2, keySet.size)
+    assertFalse(keySet.isEmpty)
+    mp.clear()
+    assertEquals(0, keySet.size)
+    assertTrue(keySet.isEmpty)
+  }
+
+  @Test def testKeySetIsViewForQueriesWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val keySet = mp.keySet()
+
     assertTrue(keySet.contains("ONE"))
     assertTrue(keySet.contains("TWO"))
     assertFalse(keySet.contains("THREE"))
     if (factory.allowsNullKeysQueries)
       assertFalse(keySet.contains(null))
     else
-      expectThrows(classOf[Throwable], mp.keySet().contains(null))
+      expectThrows(classOf[NullPointerException], keySet.contains(null))
 
     mp.put("THREE", "three")
 
     assertTrue(keySet.contains("THREE"))
 
-    val coll1 = im.Set("ONE", "TWO", "THREE").toJavaSet
+    val coll1 = TrivialImmutableCollection("ONE", "TWO", "THREE")
     assertTrue(keySet.containsAll(coll1))
 
-    val coll2 = im.Set("ONE", "TWO", "THREE", "FOUR").toJavaSet
+    val coll2 = TrivialImmutableCollection("ONE", "TWO", "THREE", "FOUR")
     assertFalse(keySet.containsAll(coll2))
 
-    val coll3 = im.Set("ONE", "TWO", "THREE", null).toJavaSet
+    if (factory.allowsNullKeysQueries) {
+      val coll3 = TrivialImmutableCollection("ONE", "TWO", "THREE", null)
+      assertFalse(keySet.containsAll(coll3))
+    }
+  }
+
+  @Test def testKeySetIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+    val keySet = mp.keySet()
+
+    assertTrue(keySet.contains(testObj(1)))
+    assertTrue(keySet.contains(testObj(2)))
+    assertFalse(keySet.contains(testObj(3)))
+    if (factory.allowsNullKeysQueries)
+      assertFalse(keySet.contains(null))
+    else
+      expectThrows(classOf[NullPointerException], keySet.contains(null))
+
+    mp.put(testObj(3), TestObj(33))
+
+    assertTrue(keySet.contains(testObj(3)))
+
+    val coll1 = TrivialImmutableCollection(testObj(1), testObj(2), testObj(3))
+    assertTrue(keySet.containsAll(coll1))
+
+    val coll2 = TrivialImmutableCollection(testObj(1), testObj(2), testObj(4))
     assertFalse(keySet.containsAll(coll2))
 
-    val nummp = factory.empty[Double, Double]
+    if (factory.allowsNullKeysQueries) {
+      val coll3 = TrivialImmutableCollection(testObj(1), testObj(2), null)
+      assertFalse(keySet.containsAll(coll3))
+    }
+  }
 
+  @Test def testKeySetIsViewForQueriesWithDoublesCornerCaseOfEquals(): Unit = {
+    val nummp     = factory.empty[Double, Double]
     val numkeySet = nummp.keySet()
+
     nummp.put(+0.0, 1)
     assertTrue(numkeySet.contains(+0.0))
     assertFalse(numkeySet.contains(-0.0))
@@ -501,27 +701,14 @@ trait MapTest {
     assertTrue(numkeySet.contains(+0.0))
     assertTrue(numkeySet.contains(-0.0))
     assertTrue(numkeySet.contains(Double.NaN))
-
-    val hm1 = mu.HashMap(1.0         -> null, 2.0 -> 2.0)
-    val hm2 = mu.HashMap((null: Any) -> 1.0, 2.0  -> 2.0)
-    val hm3 = mu.HashMap((null: Any) -> null, 2.0 -> 2.0)
-
-    assertTrue(new SimpleQueryableMap(hm1).keySet().contains(1.0))
-    assertFalse(new SimpleQueryableMap(hm2).keySet().contains(1.0))
-    assertFalse(new SimpleQueryableMap(hm3).keySet().contains(1.0))
-
-    assertFalse(new SimpleQueryableMap(hm1).keySet().contains(null))
-    assertTrue(new SimpleQueryableMap(hm2).keySet().contains(null))
-    assertTrue(new SimpleQueryableMap(hm3).keySet().contains(null))
   }
 
-  @Test def keySetShouldSideEffectClearRemoveRetainOnTheRelatedMap(): Unit = {
+  @Test def testKeySetIsViewForRemoveWithStrings(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
-
     val keySet = mp.keySet()
+
     assertFalse(keySet.isEmpty)
     assertFalse(mp.isEmpty)
 
@@ -535,9 +722,7 @@ trait MapTest {
     mp.put("TWO", "two")
 
     assertTrue(mp.containsKey("ONE"))
-
     keySet.remove("ONE")
-
     assertFalse(mp.containsKey("ONE"))
 
     mp.put("ONE", "one")
@@ -547,7 +732,7 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    keySet.removeAll(im.List("ONE", "TWO").toJavaList)
+    keySet.removeAll(TrivialImmutableCollection("ONE", "TWO", "FIVE"))
 
     assertFalse(mp.containsKey("ONE"))
     assertFalse(mp.containsKey("TWO"))
@@ -561,11 +746,714 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    keySet.retainAll(im.List("ONE", "TWO").toJavaList)
+    keySet.retainAll(TrivialImmutableCollection("ONE", "TWO", "FIVE"))
 
     assertTrue(mp.containsKey("ONE"))
     assertTrue(mp.containsKey("TWO"))
     assertFalse(mp.containsKey("THREE"))
+
+    if (factory.allowsNullKeys) {
+      mp.put(null, "NULL")
+      assertTrue(mp.containsKey(null))
+      assertTrue(keySet.contains(null))
+      assertTrue(keySet.remove(null))
+      assertFalse(mp.containsKey(null))
+    }
+
+    if (factory.allowsNullValues) {
+      mp.put("NULL", null)
+      assertTrue(mp.containsKey("NULL"))
+      assertTrue(keySet.contains("NULL"))
+      assertTrue(keySet.remove("NULL"))
+      assertFalse(mp.containsKey("NULL"))
+    }
+  }
+
+  @Test def testKeySetIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+    val keySet = mp.keySet()
+
+    assertFalse(keySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    keySet.clear()
+
+    assertTrue(keySet.isEmpty)
+
+    assertTrue(mp.isEmpty)
+
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    keySet.remove(testObj(1))
+    assertFalse(mp.containsKey(testObj(1)))
+
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(3), TestObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    keySet.removeAll(
+      TrivialImmutableCollection(testObj(1), testObj(2), testObj(5)))
+
+    assertFalse(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+    mp.put(testObj(3), TestObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    keySet.retainAll(
+      TrivialImmutableCollection(testObj(1), testObj(2), testObj(5)))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertFalse(mp.containsKey(testObj(3)))
+
+    if (factory.allowsNullKeys) {
+      mp.put(null, TestObj(111))
+      assertTrue(mp.containsKey(null))
+      assertTrue(keySet.contains(null))
+      assertTrue(keySet.remove(null))
+      assertFalse(mp.containsKey(null))
+    }
+
+    if (factory.allowsNullValues) {
+      mp.put(testObj(4), null)
+      assertTrue(mp.containsKey(testObj(4)))
+      assertTrue(keySet.contains(testObj(4)))
+      assertTrue(keySet.remove(testObj(4)))
+      assertFalse(mp.containsKey(testObj(4)))
+    }
+  }
+
+  @Test def testEntrySetIsViewForSize(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val entrySet = mp.entrySet()
+
+    assertEquals(2, entrySet.size)
+    mp.put("THREE", "three")
+    assertEquals(3, entrySet.size)
+    mp.remove("ONE")
+    assertEquals(2, entrySet.size)
+    assertFalse(entrySet.isEmpty)
+    mp.clear()
+    assertEquals(0, entrySet.size)
+    assertTrue(entrySet.isEmpty)
+  }
+
+  @Test def testEntrySetIsViewForQueriesWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    if (factory.allowsNullKeys)
+      mp.put(null, "NULL")
+    if (factory.allowsNullValues)
+      mp.put("NULL", null)
+    val entrySet = mp.entrySet()
+
+    assertTrue(entrySet.contains(SIE("ONE", "one")))
+    assertTrue(entrySet.contains(SIE("TWO", "two")))
+    assertFalse(entrySet.contains(SIE("THREE", "three")))
+    assertFalse(entrySet.contains(SIE("ONE", "two")))
+    assertFalse(entrySet.contains(SIE("THREE", "one")))
+    if (factory.allowsNullValuesQueries) {
+      assertTrue(entrySet.contains(SIE("NULL", null)))
+      assertTrue(entrySet.contains(SIE(null, "NULL")))
+      assertFalse(entrySet.contains(SIE("NOTFOUND", null)))
+    }
+
+    mp.put("THREE", "three")
+
+    assertTrue(entrySet.contains(SIE("THREE", "three")))
+
+    val coll1 = TrivialImmutableCollection(SIE("ONE", "one"),
+                                           SIE("TWO", "two"),
+                                           SIE("THREE", "three"))
+    assertTrue(entrySet.containsAll(coll1))
+
+    val coll2 = TrivialImmutableCollection(SIE("ONE", "one"),
+                                           SIE("TWO", "two"),
+                                           SIE("THREE", "three"),
+                                           SIE("FOUR", "four"))
+    assertFalse(entrySet.containsAll(coll2))
+
+    val coll3 = TrivialImmutableCollection(SIE("ONE", "one"),
+                                           SIE("TWO", "four"),
+                                           SIE("THREE", "three"))
+    assertFalse(entrySet.containsAll(coll3))
+
+    val coll4 = TrivialImmutableCollection(SIE("ONE", "one"),
+                                           SIE("four", "two"),
+                                           SIE("THREE", "three"))
+    assertFalse(entrySet.containsAll(coll4))
+  }
+
+  @Test def testEntrySetIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    if (factory.allowsNullValues)
+      mp.put(testObj(5), null)
+    if (factory.allowsNullKeys)
+      mp.put(null, testObj(55))
+    val entrySet = mp.entrySet()
+
+    assertTrue(entrySet.contains(SIE(testObj(1), testObj(11))))
+    assertTrue(entrySet.contains(SIE(testObj(2), testObj(22))))
+    assertFalse(entrySet.contains(SIE(testObj(3), testObj(33))))
+    assertFalse(entrySet.contains(SIE(testObj(1), testObj(22))))
+    assertFalse(entrySet.contains(SIE(testObj(3), testObj(11))))
+    if (factory.allowsNullValuesQueries) {
+      assertTrue(entrySet.contains(SIE(testObj(5), null)))
+      assertFalse(entrySet.contains(SIE(testObj(6), null)))
+    }
+    if (factory.allowsNullKeysQueries)
+      assertTrue(entrySet.contains(SIE(null, testObj(55))))
+
+    if (factory.allowsNullValuesQueries)
+      assertFalse(entrySet.contains(SIE(testObj(7), null)))
+
+    mp.put(testObj(3), testObj(33))
+
+    assertTrue(entrySet.contains(SIE(testObj(3), testObj(33))))
+
+    val coll1 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+                                           SIE(testObj(2), testObj(22)),
+                                           SIE(testObj(3), testObj(33)))
+    assertTrue(entrySet.containsAll(coll1))
+
+    val coll2 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+                                           SIE(testObj(2), testObj(22)),
+                                           SIE(testObj(3), testObj(33)),
+                                           SIE(testObj(4), testObj(44)))
+    assertFalse(entrySet.containsAll(coll2))
+
+    val coll3 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+                                           SIE(testObj(2), testObj(44)),
+                                           SIE(testObj(3), testObj(33)))
+    assertFalse(entrySet.containsAll(coll3))
+
+    val coll4 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+                                           SIE(testObj(4), testObj(22)),
+                                           SIE(testObj(3), testObj(33)))
+    assertFalse(entrySet.containsAll(coll4))
+  }
+
+  @Test def testEntrySetIsViewForRemoveWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val entrySet = mp.entrySet()
+
+    assertFalse(entrySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    entrySet.clear()
+    assertTrue(entrySet.isEmpty)
+    assertTrue(mp.isEmpty)
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    if (factory.allowsNullKeys)
+      mp.put(null, "NULL")
+    if (factory.allowsNullValues)
+      mp.put("NULL", null)
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(entrySet.remove(SIE("ONE", "one")))
+    assertFalse(entrySet.remove(SIE("TWO", "four")))
+    assertFalse(entrySet.remove("TWO"))
+    assertFalse(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    if (factory.allowsNullKeysQueries)
+      assertTrue(mp.containsKey(null))
+    if (factory.allowsNullValuesQueries) {
+      assertTrue(mp.containsValue(null))
+      assertFalse(entrySet.remove(SIE("NOTFOUND", null)))
+    }
+
+    mp.put("ONE", "one")
+    mp.put("THREE", "three")
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    entrySet.removeAll(
+      TrivialImmutableCollection(SIE("ONE", "one"),
+                                 SIE("TWO", "two"),
+                                 SIE("THREE", "four"),
+                                 "THREE",
+                                 42))
+
+    assertFalse(mp.containsKey("ONE"))
+    assertFalse(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    mp.put("THREE", "three")
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    entrySet.retainAll(
+      TrivialImmutableCollection(SIE("ONE", "one"),
+                                 SIE("TWO", "two"),
+                                 SIE("THREE", "four"),
+                                 "THREE",
+                                 42))
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertFalse(mp.containsKey("THREE"))
+  }
+
+  @Test def testEntrySetIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    val entrySet = mp.entrySet()
+
+    assertFalse(entrySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    entrySet.clear()
+    assertTrue(entrySet.isEmpty)
+    assertTrue(mp.isEmpty)
+
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    if (factory.allowsNullKeys)
+      mp.put(null, testObj(55))
+    if (factory.allowsNullValues)
+      mp.put(testObj(5), null)
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(entrySet.remove(SIE(testObj(1), testObj(11))))
+    assertFalse(entrySet.remove(SIE(testObj(2), testObj(44))))
+    assertFalse(entrySet.remove(testObj(2))) // remove should take Map.Entry
+    assertFalse(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    if (factory.allowsNullKeysQueries)
+      assertTrue(mp.containsKey(null))
+    if (factory.allowsNullValuesQueries) {
+      assertTrue(mp.containsValue(null))
+      assertFalse(entrySet.remove(SIE(testObj(6), null)))
+    }
+
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(3), testObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    entrySet.removeAll(
+      TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+                                 SIE(testObj(2), testObj(22)),
+                                 SIE(testObj(3), testObj(44)),
+                                 testObj(3),
+                                 42))
+
+    assertFalse(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    mp.put(testObj(3), testObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    entrySet.retainAll(
+      TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+                                 SIE(testObj(2), testObj(22)),
+                                 SIE(testObj(3), testObj(44)),
+                                 testObj(3),
+                                 42))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertFalse(mp.containsKey(testObj(3)))
+  }
+
+  @Test def testEntrySetIsViewForSetValueWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val entrySet = mp.entrySet()
+
+    val entry = entrySet.iterator().next()
+    val key   = entry.getKey()
+    assertTrue(key == "ONE" || key == "TWO")
+    val expectedValue = if (key == "ONE") "one" else "two"
+
+    assertEquals(expectedValue, entry.getValue())
+    assertEquals(expectedValue, entry.setValue("new value"))
+    assertEquals("new value", entry.getValue())
+    assertEquals("new value", mp.get(key))
+  }
+
+  @Test def testEntrySetIsViewForSetValueWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+    val entrySet = mp.entrySet()
+
+    val entry = entrySet.iterator().next()
+    val key   = entry.getKey()
+    assertTrue(key.num == 1 || key.num == 2)
+    val expectedValue = TestObj(if (key.num == 1) 11 else 22)
+
+    assertEquals(expectedValue, entry.getValue())
+    assertEquals(expectedValue, entry.setValue(TestObj(56)))
+    assertEquals(TestObj(56), entry.getValue())
+    assertEquals(TestObj(56), mp.get(key))
+  }
+
+  @Test def testGetOrDefault(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one",
+                                       "TWO"   -> "two",
+                                       "THREE" -> "three")
+
+    assertEquals("one", mp.getOrDefault("ONE", "def"))
+    assertEquals("def", mp.getOrDefault("FOUR", "def"))
+    assertNull(mp.getOrDefault("FIVE", null))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertNull(mp.getOrDefault("nullable", "def"))
+    }
+  }
+
+  @Test def testForEach(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one",
+                                       "TWO"   -> "two",
+                                       "THREE" -> "three")
+
+    val b = List.newBuilder[(String, String)]
+    mp.forEach(new BiConsumer[String, String] {
+      def accept(key: String, value: String): Unit =
+        b += ((key, value))
+    })
+    val result = b.result()
+
+    val expected = List("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    if (factory.guaranteesInsertionOrder)
+      assertEquals(expected, result)
+    else
+      assertEquals(expected.toSet, result.toSet)
+  }
+
+  @Test def testReplaceAll(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one",
+                                       "TWO"   -> "two",
+                                       "THREE" -> "three")
+
+    mp.replaceAll(new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String =
+        s"$key -> $value"
+    })
+
+    assertEquals(3, mp.size())
+    assertEquals("ONE -> one", mp.get("ONE"))
+    assertEquals("TWO -> two", mp.get("TWO"))
+    assertEquals("THREE -> three", mp.get("THREE"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+
+      mp.replaceAll(new BiFunction[String, String, String] {
+        def apply(key: String, value: String): String =
+          if (key.startsWith("ONE")) null
+          else if (value == null) "it was null"
+          else value
+      })
+
+      assertTrue(mp.containsKey("ONE"))
+      assertNull(mp.get("ONE"))
+      assertEquals("it was null", mp.get("nullable"))
+    } else {
+      assertThrows(classOf[NullPointerException],
+                   mp.replaceAll(new BiFunction[String, String, String] {
+                     def apply(key: String, value: String): String = null
+                   }))
+    }
+  }
+
+  @Test def testPutIfAbsent(): Unit = {
+    val mp = factory.empty[String, String]
+    assertNull(mp.putIfAbsent("abc", "def"))
+    assertEquals("def", mp.get("abc"))
+    assertNull(mp.putIfAbsent("123", "456"))
+    assertEquals("456", mp.get("123"))
+    assertEquals("def", mp.putIfAbsent("abc", "def"))
+    assertEquals("def", mp.putIfAbsent("abc", "ghi"))
+    assertEquals("456", mp.putIfAbsent("123", "789"))
+    assertEquals("def", mp.putIfAbsent("abc", "jkl"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertNull(mp.putIfAbsent("nullable", "non null"))
+      assertEquals("non null", mp.get("nullable"))
+    }
+  }
+
+  @Test def testConditionalRemove(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one",
+                                       "TWO"   -> "two",
+                                       "THREE" -> "three")
+
+    assertFalse(mp.remove("non existing", "value"))
+    assertFalse(mp.containsKey("non existing"))
+
+    assertFalse(mp.remove("TWO", "one"))
+    assertEquals("two", mp.get("TWO"))
+    assertFalse(mp.remove("TWO", null))
+    assertEquals("two", mp.get("TWO"))
+
+    assertTrue(mp.remove("ONE", "one"))
+    assertFalse(mp.containsKey("ONE"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertFalse(mp.remove("nullable", "value"))
+      assertTrue(mp.containsKey("nullable"))
+      assertTrue(mp.remove("nullable", null))
+      assertFalse(mp.containsKey("nullable"))
+    }
+  }
+
+  @Test def testConditionalReplace(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one",
+                                       "TWO"   -> "two",
+                                       "THREE" -> "three")
+
+    assertTrue(mp.replace("ONE", "one", "four"))
+    assertEquals("four", mp.get("ONE"))
+    assertFalse(mp.replace("TWO", "not two", "five"))
+    assertEquals("two", mp.get("TWO"))
+    assertFalse(mp.replace("non existing", "foo", "bar"))
+    assertFalse(mp.containsKey("non existing"))
+
+    if (factory.allowsNullValues) {
+      assertFalse(mp.replace("ONE", null, "new value"))
+      assertEquals("four", mp.get("ONE"))
+
+      mp.put("nullable", null)
+      assertFalse(mp.replace("nullable", "not null", "new value"))
+      assertTrue(mp.replace("nullable", null, "nullable value"))
+      assertEquals("nullable value", mp.get("nullable"))
+
+      assertTrue(mp.replace("nullable", "nullable value", null))
+      assertTrue(mp.containsKey("nullable"))
+      assertNull(mp.get("nullable"))
+    } else {
+      assertThrows(classOf[NullPointerException],
+                   mp.replace("ONE", null, "one"))
+      assertThrows(classOf[NullPointerException],
+                   mp.replace("ONE", "four", null))
+    }
+  }
+
+  @Test def testUnconditionalReplace(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one",
+                                       "TWO"   -> "two",
+                                       "THREE" -> "three")
+
+    assertEquals("one", mp.replace("ONE", "four"))
+    assertEquals("four", mp.get("ONE"))
+    assertEquals("two", mp.get("TWO"))
+
+    assertNull(mp.replace("non existing", "value"))
+    assertFalse(mp.containsKey("non existing"))
+
+    if (factory.allowsNullValues) {
+      assertEquals("four", mp.replace("ONE", null))
+      assertTrue(mp.containsKey("ONE"))
+      assertNull(mp.get("ONE"))
+
+      assertNull(mp.replace("ONE", "new one"))
+      assertEquals("new one", mp.get("ONE"))
+    } else {
+      assertThrows(classOf[NullPointerException], mp.replace("ONE", null))
+      assertEquals("four", mp.get("ONE"))
+    }
+
+    if (factory.allowsNullKeys) {
+      assertEquals(null, mp.replace(null, "value"))
+      assertFalse(mp.containsKey(null))
+
+      mp.put(null, "null value")
+      assertEquals("null value", mp.replace(null, "new value"))
+      assertEquals("new value", mp.get(null))
+    } else {
+      assertThrows(classOf[NullPointerException], mp.replace(null, "one"))
+    }
+  }
+
+  @Test def testComputeIfAbsent(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one",
+                                       "TWO"   -> "two",
+                                       "THREE" -> "three")
+
+    val notCalled = new Function[String, String] {
+      def apply(key: String): String =
+        throw new AssertionError(
+          s"function should not have been called for $key")
+    }
+
+    val lengthAsString = new Function[String, String] {
+      def apply(key: String): String = key.length().toString()
+    }
+
+    val returnsNull = new Function[String, String] {
+      def apply(key: String): String = null
+    }
+
+    assertEquals("two", mp.computeIfAbsent("TWO", notCalled))
+    assertEquals("5", mp.computeIfAbsent("SEVEN", lengthAsString))
+    assertEquals("5", mp.get("SEVEN"))
+
+    assertNull(mp.computeIfAbsent("non existing", returnsNull))
+    assertFalse(mp.containsKey("non existing"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertEquals("8", mp.computeIfAbsent("nullable", lengthAsString))
+      assertEquals("8", mp.get("nullable"))
+    }
+  }
+
+  @Test def testComputeIfPresent(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one",
+                                       "TWO"   -> "two",
+                                       "THREE" -> "three")
+
+    val notCalled = new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String =
+        throw new AssertionError(
+          s"function should not have been called for $key")
+    }
+
+    val remappingFun = new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String = s"$key - $value"
+    }
+
+    val returnsNull = new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String = null
+    }
+
+    assertEquals("TWO - two", mp.computeIfPresent("TWO", remappingFun))
+    assertEquals("TWO - two", mp.get("TWO"))
+
+    assertNull(mp.computeIfPresent("ONE", returnsNull))
+    assertFalse(mp.containsKey("ONE"))
+
+    assertNull(mp.computeIfPresent("non existing", notCalled))
+    assertFalse(mp.containsKey("non existing"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertNull(mp.computeIfPresent("nullable", notCalled))
+      assertTrue(mp.containsKey("nullable"))
+      assertNull(mp.get("nullable"))
+    }
+  }
+
+  @Test def testCompute(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one",
+                                       "TWO"   -> "two",
+                                       "THREE" -> "three")
+
+    val remappingFun = new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String = s"$key - $value"
+    }
+
+    val returnsNull = new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String = null
+    }
+
+    assertEquals("TWO - two", mp.compute("TWO", remappingFun))
+    assertEquals("TWO - two", mp.get("TWO"))
+
+    assertEquals("SEVEN - null", mp.compute("SEVEN", remappingFun))
+    assertEquals("SEVEN - null", mp.get("SEVEN"))
+
+    assertNull(mp.compute("non existing", returnsNull))
+    assertFalse(mp.containsKey("non existing"))
+
+    assertNull(mp.compute("ONE", returnsNull))
+    assertFalse(mp.containsKey("ONE"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertNull(mp.compute("nullable", returnsNull))
+      assertFalse(mp.containsKey("nullable"))
+
+      mp.put("nullable", null)
+      assertEquals("nullable - null", mp.compute("nullable", remappingFun))
+      assertEquals("nullable - null", mp.get("nullable"))
+    }
+  }
+
+  @Test def testMerge(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one",
+                                       "TWO"   -> "two",
+                                       "THREE" -> "three")
+
+    val notCalled = new BiFunction[String, String, String] {
+      def apply(prevValue: String, newValue: String): String =
+        throw new AssertionError(
+          s"function should not have been called for $prevValue")
+    }
+
+    val remappingFun = new BiFunction[String, String, String] {
+      def apply(prevValue: String, newValue: String): String =
+        s"$prevValue - $newValue"
+    }
+
+    val returnsNull = new BiFunction[String, String, String] {
+      def apply(prevValue: String, newValue: String): String = null
+    }
+
+    assertEquals("two - def", mp.merge("TWO", "def", remappingFun))
+    assertEquals("two - def", mp.get("TWO"))
+
+    assertEquals("def", mp.merge("SEVEN", "def", notCalled))
+    assertEquals("def", mp.get("SEVEN"))
+
+    assertThrows(classOf[NullPointerException],
+                 mp.merge("non existing", null, notCalled))
+    assertThrows(classOf[NullPointerException],
+                 mp.merge("ONE", null, notCalled))
+
+    assertNull(mp.merge("ONE", "def", returnsNull))
+    assertFalse(mp.containsKey("ONE"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertEquals("def", mp.merge("nullable", "def", notCalled))
+      assertEquals("def", mp.get("nullable"))
+    }
   }
 }
 
@@ -578,6 +1466,14 @@ trait MapFactory {
 
   def empty[K: ClassTag, V: ClassTag]: ju.Map[K, V]
 
+  def fromKeyValuePairs[K: ClassTag, V: ClassTag](
+      pairs: (K, V)*): ju.Map[K, V] = {
+    val result = empty[K, V]
+    for ((key, value) <- pairs)
+      result.put(key, value)
+    result
+  }
+
   def allowsNullKeys: Boolean
 
   def allowsNullValues: Boolean
@@ -589,4 +1485,6 @@ trait MapFactory {
   def withSizeLimit: Option[Int] = None
 
   def isIdentityBased: Boolean = false
+
+  def guaranteesInsertionOrder: Boolean = false
 }

--- a/unit-tests/src/test/scala/java/util/TrivialImmutableMap.scala
+++ b/unit-tests/src/test/scala/java/util/TrivialImmutableMap.scala
@@ -1,0 +1,39 @@
+// Ported from Scala.js commit: 6819668 on 2020-10-O7
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+import java.util.Map.Entry
+
+final class TrivialImmutableMap[K, V] private (contents: List[Entry[K, V]])
+    extends ju.AbstractMap[K, V] {
+
+  def entrySet(): ju.Set[Entry[K, V]] = {
+    new ju.AbstractSet[Entry[K, V]] {
+      def size(): Int = contents.size
+
+      def iterator(): ju.Iterator[Entry[K, V]] = {
+        new ju.Iterator[Entry[K, V]] {
+          private var remaining: List[Entry[K, V]] = contents
+
+          def hasNext(): Boolean = remaining.nonEmpty
+
+          def next(): Entry[K, V] = {
+            val head = remaining.head
+            remaining = remaining.tail
+            head
+          }
+        }
+      }
+    }
+  }
+}
+
+object TrivialImmutableMap {
+  def apply[K, V](contents: List[Entry[K, V]]): TrivialImmutableMap[K, V] =
+    new TrivialImmutableMap(contents)
+
+  def apply[K, V](contents: (K, V)*): TrivialImmutableMap[K, V] =
+    apply(contents.toList.map(kv =>
+      new ju.AbstractMap.SimpleImmutableEntry(kv._1, kv._2)))
+}


### PR DESCRIPTION
--- WIP	commit message

A review comment at the bottom of the Conversation train below 
suggested that this PR be broken up into at least two: a small
one to port the default methods, and a larger one to port the
code to test those methods.

PR #2061 implements the j.u.Map methods by porting a single file j.u.Map.scala.

I am moving this PR to Work In Progress (WIP) state to remove it from 
consideration until after PR #2061 has been dispatched.

--- Obsolete WIP message, but gives context for review

1) This	submission is marked Work In Progress (WIP)
   because CollectionsTestBase depends on TrivialImmutableMap.scala.
   PR #2016 contains that file and is awaiting review.

   After that PR is merged, the commit containing the build-only
   copy in this submission can be reset and this submission promoted
   out of WIP.

2) `ArrayList.scala` & the newly ported `CopyOnWriteArrayList` warrant inspection in detail.
     I had to convert `inner` from a js.Array.  All tests pass but their may be better ways
     of doing things.  

3) `javalib.rst` contains an intended edit to document the newly ported `CopyOnWriteArrayList` and
     apparently extraneous edit to document `ConcurrentLinkedQueue`
    from merged PR #1944. The latter is not strictly related. It is worth
    fixing but not worth the cost of an entirely separate PR.

    I did a manual trial build of `javalib.rst` and visually inspected
    the	results	in the browser.	 The final results were	as expected
    and	there were no more errors in the html build after than before.
    I will create an Issue about those build issues, I think my	
    currently outstanding PR on	them has become	obsolete.




We implement the JavaDefaultMethods for Map.scala. Two concrete
Test methods exercise those default methods. These and the
implementations they require are either ported or re-ported from
Scala.js.   

AbstractMapTest.scala and LinkedHashMapTest.scala are abstract
and without a concrete implementation.  Normally they would be
considered dead code and would not appear.  The are included
here because they already exist in the Scala Native repository.
New dead code is not good but it is better than old dead code,
especially when the latter causes this PR to fail to build (package
 name changes in required files).

The two files while become active in a soon (two week or so)
PR which ports CollectionsOnMaps.
--- WIP	commit message

1) This	submission is marked Work In Progress (WIP)
   because CollectionsTestBase depends on TrivialImmutableMap.scala.
   PR #2016 contains that file and is awaiting review.

   After that PR is merged, the commit containing the build-only
   copy in this submission can be reset and this submission promoted
   out of WIP.

2) `ArrayList.scala` & the newly ported `CopyOnWriteArrayList` warrant inspection in detail.
     I had to convert `inner` from a js.Array.  All tests pass but their may be better ways
     of doing things.  

3) `javalib.rst` contains an intended edit to document the newly ported `CopyOnWriteArrayList` and
     apparently extraneous edit to document `ConcurrentLinkedQueue`
    from merged PR #1944. The latter is not strictly related. It is worth
    fixing but not worth the cost of an entirely separate PR.

    I did a manual trial build of `javalib.rst` and visually inspected
    the	results	in the browser.	 The final results were	as expected
    and	there were no more errors in the html build after than before.
    I will create an Issue about those build issues, I think my	
    currently outstanding PR on	them has become	obsolete.

--- PR commit message --

To be specified after PR 2061 is merged.
