### PR TITLE
Annotate & test j.u.f.Predicate default method

### DIFF
--- a/javalib/src/main/scala/java/util/function/Predicate.scala
+++ b/javalib/src/main/scala/java/util/function/Predicate.scala
@@ -1,20 +1,45 @@
+// Ported from Scala.js commit: 137c11d dated: 2019-07-03
+
 package java.util.function
 
+import java.{util => ju}
+
+import scala.scalanative.annotation.JavaDefaultMethod
+
+@FunctionalInterface
 trait Predicate[T] { self =>
   def test(t: T): Boolean
 
-  def negate(): Predicate[T] = new Predicate[T] {
-    override def test(t: T): Boolean =
-      !self.test(t)
+  @JavaDefaultMethod
+  def and(other: Predicate[_ >: T]): Predicate[T] = {
+    new Predicate[T] {
+      def test(t: T): Boolean =
+        self.test(t) && other.test(t) // the order and short-circuit are by-spec
+    }
   }
 
-  def and(other: Predicate[_ >: T]): Predicate[T] = new Predicate[T] {
-    override def test(t: T): Boolean =
-      test(t) && other.test(t)
+  @JavaDefaultMethod
+  def negate(): Predicate[T] = {
+    new Predicate[T] {
+      def test(t: T): Boolean =
+        !self.test(t)
+    }
   }
 
-  def or(other: Predicate[_ >: T]): Predicate[T] = new Predicate[T] {
-    override def test(t: T): Boolean =
-      test(t) || other.test(t)
+  @JavaDefaultMethod
+  def or(other: Predicate[_ >: T]): Predicate[T] = {
+    new Predicate[T] {
+      def test(t: T): Boolean =
+        self.test(t) || other.test(t) // the order and short-circuit are by-spec
+    }
+  }
+}
+
+object Predicate {
+  def isEqual[T](targetRef: Any): Predicate[T] = {
+    new Predicate[T] {
+      def test(t: T): Boolean =
+        ju.Objects.equals(targetRef, t)
+    }
   }
 }

--- a/unit-tests/src/test/scala/java/util/function/PredicateTest.scala
+++ b/unit-tests/src/test/scala/java/util/function/PredicateTest.scala
@@ -1,0 +1,84 @@
+// Ported from Scala.js commit: 137c11d dated: 2019-07-03
+
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.Predicate
+
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.scalanative.junit.utils.AssertThrows._
+
+class PredicateTest {
+  import PredicateTest._
+
+  private val largerThan10 = makePredicate[Int](_ > 10)
+  private val even         = makePredicate[Int](_ % 2 == 0)
+
+  private val throwingPredicate =
+    makePredicate[Any](x => throw new ThrowingPredicateException(x))
+
+  private val dontCallPredicate =
+    makePredicate[Any](x =>
+      throw new AssertionError(s"dontCallPredicate.test($x)"))
+
+  @Test def and(): Unit = {
+    // Truth table
+    val evenAndLargerThan10 = largerThan10.and(even)
+    assertTrue(evenAndLargerThan10.test(22))
+    assertFalse(evenAndLargerThan10.test(21))
+    assertFalse(evenAndLargerThan10.test(6))
+    assertFalse(evenAndLargerThan10.test(5))
+
+    // Short-circuit
+    assertFalse(largerThan10.and(dontCallPredicate).test(5))
+    assertThrows(classOf[ThrowingPredicateException],
+                 throwingPredicate.and(dontCallPredicate).test(5))
+  }
+
+  @Test def negate(): Unit = {
+    // Truth table
+    val notLargerThan10 = largerThan10.negate()
+    assertTrue(notLargerThan10.test(5))
+    assertFalse(notLargerThan10.test(15))
+  }
+
+  @Test def or(): Unit = {
+    // Truth table
+    val evenOrLargerThan10 = largerThan10.or(even)
+    assertTrue(evenOrLargerThan10.test(22))
+    assertTrue(evenOrLargerThan10.test(21))
+    assertTrue(evenOrLargerThan10.test(6))
+    assertFalse(evenOrLargerThan10.test(5))
+
+    // Short-circuit
+    assertTrue(largerThan10.or(dontCallPredicate).test(15))
+    assertThrows(classOf[ThrowingPredicateException],
+                 throwingPredicate.or(dontCallPredicate).test(15))
+  }
+
+  @Test def isEqual(): Unit = {
+    val isEqualToPair = Predicate.isEqual[Any]((3, 4))
+    assertTrue(isEqualToPair.test((3, 4)))
+    assertFalse(isEqualToPair.test((5, 6)))
+    assertFalse(isEqualToPair.test("foo"))
+    assertFalse(isEqualToPair.test(null))
+
+    val isEqualToNull = Predicate.isEqual[Any](null)
+    assertFalse(isEqualToNull.test((3, 4)))
+    assertFalse(isEqualToNull.test((5, 6)))
+    assertFalse(isEqualToNull.test("foo"))
+    assertTrue(isEqualToNull.test(null))
+  }
+}
+
+object PredicateTest {
+  final class ThrowingPredicateException(x: Any)
+      extends Exception(s"throwing predicate called with $x")
+
+  def makePredicate[T](f: T => Boolean): Predicate[T] = {
+    new Predicate[T] {
+      def test(t: T): Boolean = f(t)
+    }
+  }
+}


### PR DESCRIPTION
This PR builds upon merged PR #1937 by porting j.u.f.Predicate.scala
and its corresponding PredicateTest from Scala.js.

The previously existing Predicate.scala is overwritten to keep
the source and its test synchronized.

See Issue #1972 for background & discussion of JavaDefaultMethod
annotation.