### PR TITLE
Annotate j.u.f.BiConsumer default methods.

### DIFF
--- a/javalib/src/main/scala/java/util/function/BiConsumer.scala
+++ b/javalib/src/main/scala/java/util/function/BiConsumer.scala
@@ -1,10 +1,16 @@
+// Corresponds to Scala.js commit: f86ed6 c2f5a43 dated: 2020-09-06
+// Design note: Do not use lambdas with Scala Native and Scala 2.11
+
 package java.util.function
+
+import scala.scalanative.annotation.JavaDefaultMethod
 
 trait BiConsumer[T, U] {
   self =>
 
   def accept(t: T, u: U): Unit
 
+  @JavaDefaultMethod
   def andThen(after: BiConsumer[T, U]): BiConsumer[T, U] =
     new BiConsumer[T, U]() {
       override def accept(t: T, u: U): Unit = {
@@ -12,5 +18,4 @@ trait BiConsumer[T, U] {
         after.accept(t, u)
       }
     }
-
 }

--- a/unit-tests/src/test/scala/java/util/function/BiConsumerTest.scala
+++ b/unit-tests/src/test/scala/java/util/function/BiConsumerTest.scala
@@ -1,40 +1,88 @@
-package java.util.function
+// Ported from Scala.js commit: c2f5a43 dated: 2020-09-06
 
-import org.junit.Ignore
-import org.junit.Before
-import org.junit.Test
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.BiConsumer
+
 import org.junit.Assert._
+import org.junit.Test
+
+import scala.scalanative.junit.utils.AssertThrows._
 
 class BiConsumerTest {
-  var result = 0
+  import BiConsumerTest._
 
-  @Before
-  def setUp(): Unit = {
-    result = 0
-  }
+  @Test def accept(): Unit = {
+    // Side-effects
+    var left: Int  = 0
+    var right: Int = 0
 
-  val addT = new BiConsumer[Int, Int] {
-    override def accept(t: Int, u: Int): Unit = {
-      result = result + (t + u)
+    val add: BiConsumer[Int, Int] = makeBiConsumer { (t, u) =>
+      left += t
+      right += u
     }
+
+    add.accept(1, 2)
+    assertEquals(1, left)
+    assertEquals(2, right)
+
+    add.accept(2, 3)
+    assertEquals(3, left)
+    assertEquals(5, right)
   }
 
-  val timesT = new BiConsumer[Int, Int] {
-    override def accept(t: Int, u: Int): Unit = {
-      result = result + (t * u)
+  @Test def andThen(): Unit = {
+    // Side-effects
+    var left: Int  = 0
+    var right: Int = 0
+
+    val add: BiConsumer[Int, Int] = makeBiConsumer { (t, u) =>
+      left += t
+      right += u
     }
+
+    val multiply: BiConsumer[Int, Int] = makeBiConsumer { (t, u) =>
+      left *= t
+      right *= u
+    }
+
+    val addAndMultiply = add.andThen(multiply)
+
+    addAndMultiply.accept(2, 4)
+    assertEquals(4, left)
+    assertEquals(16, right)
+
+    addAndMultiply.accept(3, 6)
+    assertEquals(21, left)   // (4+3) * 3
+    assertEquals(132, right) // (16+6) * 6
+
+    // Consume, then throw
+    assertThrows(classOf[ThrowingConsumerException],
+                 add.andThen(throwingConsumer).accept(1, 2))
+    assertEquals(22, left)
+    assertEquals(134, right)
+
+    assertThrows(classOf[ThrowingConsumerException],
+                 throwingConsumer.andThen(dontCallConsumer).accept(0, 0))
+
+  }
+}
+
+object BiConsumerTest {
+  final class ThrowingConsumerException(x: Any, y: Any)
+      extends Exception(s"throwing consumer called with ($x, $y)")
+
+  private val throwingConsumer: BiConsumer[Int, Int] = makeBiConsumer {
+    (t, u) => throw new ThrowingConsumerException(t, u)
   }
 
-  @Test def biConsumerApply(): Unit = {
-    assertTrue(result == 0)
-    addT.accept(2, 2)
-    assertTrue(result == 4)
+  private val dontCallConsumer: BiConsumer[Int, Int] = makeBiConsumer {
+    (t, u) => throw new AssertionError(s"dontCallConsumer.accept($t, $u)")
   }
 
-  @Ignore("#1229 - 2.11 does not have default method support")
-  @Test def biConsumerAndThen(): Unit = {
-    // assertTrue(result == 0)
-    // addT.andThen(timesT).accept(2, 3)
-    // assertTrue(result == 11)
+  def makeBiConsumer[T, U](f: (T, U) => Unit): BiConsumer[T, U] = {
+    new BiConsumer[T, U] {
+      def accept(t: T, u: U): Unit = f(t, u)
+    }
   }
 }


### PR DESCRIPTION
This PR builds upon merged PRs #1937 & $#2040 by annotating the existing
j.u.f.BiConsumer.scala and porting its corresponding BiConsumerTest
from Scala.js.

The existing file was edited rather than re-ported from the most current
Scala.js commit because the latter uses lambdas and those
do not play well when using Scala Native with Scala 2.11.

See Issue #1972 for background & discussion of JavaDefaultMethod
annotation.