### PR TITLE
Avoid j.l.Class.newInstance(), which is deprecated since JDK 9

### DIFF
--- a/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompiler.scala
@@ -35,7 +35,7 @@ object NIRCompiler {
   def getCompiler(): api.NIRCompiler = {
     val clazz =
       classLoader.loadClass("scala.scalanative.NIRCompiler")
-    clazz.newInstance match {
+    clazz.getDeclaredConstructor().newInstance() match {
       case compiler: api.NIRCompiler => compiler
       case other =>
         throw new ReflectiveOperationException(


### PR DESCRIPTION
`java.lang.Class.newInstance` was marked as deprecated since JDK9 and JDK15 removed almost all old deprecated methods.