### PR TITLE
Removing `nativeTarget` to make cross-compilation easy to use.

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -1,9 +1,7 @@
 package scala.scalanative
 package sbtplugin
 
-import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicReference
-import java.nio.file.Files
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import sbt.Keys._
 import sbt._
@@ -20,9 +18,6 @@ object ScalaNativePluginInternal {
 
   val nativeWarnOldJVM =
     taskKey[Unit]("Warn if JVM 7 or older is used.")
-
-  val nativeTarget =
-    taskKey[String]("Target triple.")
 
   val nativeWorkdir =
     taskKey[File]("Working directory for intermediate build files.")
@@ -83,11 +78,6 @@ object ScalaNativePluginInternal {
   )
 
   lazy val scalaNativeConfigSettings: Seq[Setting[_]] = Seq(
-    nativeTarget := interceptBuildException {
-      val cwd   = nativeWorkdir.value.toPath
-      val clang = nativeClang.value.toPath
-      Discover.targetTriple(clang, cwd)
-    },
     artifactPath in nativeLink := {
       crossTarget.value / (moduleName.value + "-out")
     },
@@ -127,7 +117,6 @@ object ScalaNativePluginInternal {
           .withMainClass(maincls)
           .withClassPath(classpath)
           .withWorkdir(cwd)
-          .withTargetTriple(nativeTarget.value)
           .withCompilerConfig(nativeConfig.value)
       }
 

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -6,9 +6,6 @@ import java.nio.file.{Path, Paths}
 /** An object describing how to configure the Scala Native toolchain. */
 sealed trait Config {
 
-  /** Target triple that defines current OS, ABI and CPU architecture. */
-  def targetTriple: String
-
   /** Directory to emit intermediate compilation results. */
   def workdir: Path
 
@@ -26,9 +23,6 @@ sealed trait Config {
   def logger: Logger
 
   def compilerConfig: NativeConfig
-
-  /** Create a new config with given target triple. */
-  def withTargetTriple(value: String): Config
 
   /** Create a new config with given directory. */
   def withWorkdir(value: Path): Config
@@ -90,7 +84,6 @@ object Config {
       mainClass = "",
       classPath = Seq.empty,
       workdir = Paths.get(""),
-      targetTriple = "",
       logger = Logger.default,
       compilerConfig = NativeConfig.empty
     )
@@ -99,7 +92,6 @@ object Config {
                                 mainClass: String,
                                 classPath: Seq[Path],
                                 workdir: Path,
-                                targetTriple: String,
                                 logger: Logger,
                                 compilerConfig: NativeConfig)
       extends Config {
@@ -114,9 +106,6 @@ object Config {
 
     def withWorkdir(value: Path): Config =
       copy(workdir = value)
-
-    def withTargetTriple(value: String): Config =
-      copy(targetTriple = value)
 
     def withLogger(value: Logger): Config =
       copy(logger = value)

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -55,7 +55,7 @@ object CodeGen {
         partitionBy(assembly, procs)(_.name.top.mangle).par.foreach {
           case (id, defns) =>
             val sorted = defns.sortBy(_.name.show)
-            new Impl(config.targetTriple, env, sorted)
+            new Impl(env, sorted)
               .gen(id.toString, workdir)
         }
 
@@ -64,7 +64,7 @@ object CodeGen {
       // Clang's LTO is not available.
       def single(): Unit = {
         val sorted = assembly.sortBy(_.name.show)
-        new Impl(config.targetTriple, env, sorted)
+        new Impl(env, sorted)
           .gen(id = "out", workdir)
       }
 
@@ -75,9 +75,8 @@ object CodeGen {
       }
     }
 
-  private final class Impl(targetTriple: String,
-                           env: Map[Global, Defn],
-                           defns: Seq[Defn])(implicit meta: Metadata) {
+  private final class Impl(env: Map[Global, Defn], defns: Seq[Defn])(
+      implicit meta: Metadata) {
     import Impl._
 
     private var currentBlockName: Local = _
@@ -165,12 +164,6 @@ object CodeGen {
 
     def genPrelude()(implicit sb: ShowBuilder): Unit = {
       import sb._
-      if (targetTriple.nonEmpty) {
-        str("target triple = \"")
-        str(targetTriple)
-        str("\"")
-        newline()
-      }
       line("declare i32 @llvm.eh.typeid.for(i8*)")
       line("declare i32 @__gxx_personality_v0(...)")
       line("declare i8* @__cxa_begin_catch(i8*)")


### PR DESCRIPTION
The idea of this commit is quite simple: scala-native creates universal IR code that should be compiled by any target-plugin inside LLVM.

Current target selection logic make impossible cross-compilation and the only reason why it uses is ride off from clang's warning message:
```
warning: overriding the module target triple with x86_64-apple-macosx11.0.0 [-Woverride-module]
```

The better way to do it is using option `-Wno-override-module` and removing `nativeTarget` and all code that is using it.

This allows to enduser to control how he would like to cross-sompile it.

For example when I added to `sandbox` sub-project:
```
.settings(nativeCompileOptions ++= Seq("-arch", "x86_64", "-arch", "arm64"))
.settings(nativeLinkingOptions ++= Seq("-arch", "x86_64", "-arch", "arm64"))
```
I have universal binary that is working on both architecures.
```
catap@Kirills-mini-m1 scala-native % file sandbox/target/scala-2.11/sandbox-out
sandbox/target/scala-2.11/sandbox-out: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
sandbox/target/scala-2.11/sandbox-out (for architecture x86_64):	Mach-O 64-bit executable x86_64
sandbox/target/scala-2.11/sandbox-out (for architecture arm64):	Mach-O 64-bit executable arm64
catap@Kirills-mini-m1 scala-native %
```

So, this is a way to fix https://github.com/scala-native/scala-native/issues/2030
