### PR TITLE
Remove target triple discovery code

### DIFF
--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -55,25 +55,40 @@ Scala Native Version       Scala Versions
 Sbt settings and tasks
 ----------------------
 
-===== ======================== =============== =========================================================
-Since Name                     Type            Description
-===== ======================== =============== =========================================================
-0.1   ``compile``              ``Analysis``    Compile Scala code to NIR
-0.1   ``run``                  ``Unit``        Compile, link and run the generated binary
-0.1   ``package``              ``File``        Similar to standard package with addition of NIR
-0.1   ``publish``              ``Unit``        Similar to standard publish with addition of NIR (1)
-0.1   ``nativeLink``           ``File``        Link NIR and generate native binary
-0.1   ``nativeClang``          ``File``        Path to ``clang`` command
-0.1   ``nativeClangPP``        ``File``        Path to ``clang++`` command
-0.1   ``nativeCompileOptions`` ``Seq[String]`` Extra options passed to clang verbatim during compilation
-0.1   ``nativeLinkingOptions`` ``Seq[String]`` Extra options passed to clang verbatim during linking
-0.1   ``nativeMode``           ``String``      One of ``"debug"``, ``"release-fast"`` or ``"release-full"`` (2)
-0.2   ``nativeGC``             ``String``      One of ``"none"``, ``"boehm"`` or ``"immix"`` (3)
-0.3.3 ``nativeLinkStubs``      ``Boolean``     Whether to link ``@stub`` definitions, or to ignore them
-0.4.0 ``nativeLTO``            ``String``      One of ``"none"``, ``"full"`` or ``"thin"`` (4)
-0.4.0 ``nativeCheck``          ``Boolean``     Shall the linker check intermediate results for correctness?
-0.4.0 ``nativeDump``           ``Boolean``     Shall the linker dump intermediate results to disk? 
-===== ======================== =============== =========================================================
+The settings now should be set via ``nativeConfig`` in `sbt`. Setting
+the options directly is now deprecated.
+
+.. code-block:: scala
+
+    import scala.scalanative.build._
+
+    nativeConfig ~= {
+      _.withLTO(LTO.thin)
+        .withMode(Mode.releaseFast)
+        .withGC(GC.commix)
+    }
+
+===== ======================== ================ =========================================================
+Since Name                     Type             Description
+===== ======================== ================ =========================================================
+0.1   ``compile``              ``Analysis``     Compile Scala code to NIR
+0.1   ``run``                  ``Unit``         Compile, link and run the generated binary
+0.1   ``package``              ``File``         Similar to standard package with addition of NIR
+0.1   ``publish``              ``Unit``         Similar to standard publish with addition of NIR (1)
+0.1   ``nativeLink``           ``File``         Link NIR and generate native binary
+0.1   ``nativeClang``          ``File``         Path to ``clang`` command
+0.1   ``nativeClangPP``        ``File``         Path to ``clang++`` command
+0.1   ``nativeCompileOptions`` ``Seq[String]``  Extra options passed to clang verbatim during compilation
+0.1   ``nativeLinkingOptions`` ``Seq[String]``  Extra options passed to clang verbatim during linking
+0.1   ``nativeMode``           ``String``       One of ``"debug"``, ``"release-fast"`` or ``"release-full"`` (2)
+0.2   ``nativeGC``             ``String``       One of ``"none"``, ``"boehm"`` or ``"immix"`` (3)
+0.3.3 ``nativeLinkStubs``      ``Boolean``      Whether to link ``@stub`` definitions, or to ignore them
+0.4.0 ``nativeConfig``         ``NativeConfig`` Configuration of the Scala Native plugin
+0.4.0 ``nativeLTO``            ``String``       One of ``"none"``, ``"full"`` or ``"thin"`` (4)
+0.4.0 ``targetTriple``         ``String``       The platform LLVM target triple
+0.4.0 ``nativeCheck``          ``Boolean``      Shall the linker check intermediate results for correctness?
+0.4.0 ``nativeDump``           ``Boolean``      Shall the linker dump intermediate results to disk?
+===== ======================== ================ =========================================================
 
 1. See `Publishing`_ and `Cross compilation`_ for details.
 2. See `Compilation modes`_ for details.
@@ -152,6 +167,16 @@ of release builds. There are three possible modes that are currently supported:
    Offers both better compilation speed and
    better runtime performance of the generated code
    than the legacy FullLTO mode.
+
+Cross compilation using target triple
+-------------------------------------
+
+The target triple can be set to allow cross compilation (introduced in 0.4.0).
+Use the following approach in `sbt` to set the target triple:
+
+.. code-block:: scala
+
+    nativeConfig ~= { _.withTargetTriple("x86_64-apple-macosx10.14.0") }
 
 Publishing
 ----------

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -54,7 +54,6 @@ object ScalaNativePlugin extends AutoPlugin {
     val nativeDump =
       taskKey[Boolean](
         "Shall native toolchain dump intermediate NIR to disk during linking?")
-
   }
 
   @deprecated("use autoImport instead", "0.3.7")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -54,6 +54,9 @@ object ScalaNativePlugin extends AutoPlugin {
     val nativeDump =
       taskKey[Boolean](
         "Shall native toolchain dump intermediate NIR to disk during linking?")
+
+    val nativeTarget =
+      taskKey[String]("The LLVM target triple for cross compiling.")
   }
 
   @deprecated("use autoImport instead", "0.3.7")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -55,8 +55,6 @@ object ScalaNativePlugin extends AutoPlugin {
       taskKey[Boolean](
         "Shall native toolchain dump intermediate NIR to disk during linking?")
 
-    val targetTriple =
-      taskKey[String]("The optional LLVM target triple for cross compiling.")
   }
 
   @deprecated("use autoImport instead", "0.3.7")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -55,8 +55,8 @@ object ScalaNativePlugin extends AutoPlugin {
       taskKey[Boolean](
         "Shall native toolchain dump intermediate NIR to disk during linking?")
 
-    val nativeTarget =
-      taskKey[String]("The LLVM target triple for cross compiling.")
+    val targetTriple =
+      taskKey[String]("The optional LLVM target triple for cross compiling.")
   }
 
   @deprecated("use autoImport instead", "0.3.7")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -43,6 +43,7 @@ object ScalaNativePluginInternal {
     nativeClangPP := nativeConfig.value.clangPP.toFile,
     nativeCompileOptions := nativeConfig.value.compileOptions,
     nativeLinkingOptions := nativeConfig.value.linkingOptions,
+    nativeTarget := nativeConfig.value.targetTriple,
     nativeMode := nativeConfig.value.mode.name,
     nativeGC := nativeConfig.value.gc.name,
     nativeLTO := nativeConfig.value.lto.name,
@@ -82,9 +83,6 @@ object ScalaNativePluginInternal {
   )
 
   lazy val scalaNativeConfigSettings: Seq[Setting[_]] = Seq(
-    nativeTarget := { // placeholder for future use
-      ""
-    },
     nativeLink / artifactPath := {
       crossTarget.value / (moduleName.value + "-out")
     },
@@ -101,6 +99,7 @@ object ScalaNativePluginInternal {
         .withClangPP(nativeClangPP.value.toPath)
         .withCompileOptions(nativeCompileOptions.value)
         .withLinkingOptions(nativeLinkingOptions.value)
+        .withTargetTriple(nativeTarget.value)
         .withGC(build.GC(nativeGC.value))
         .withMode(build.Mode(nativeMode.value))
         .withLTO(build.LTO(nativeLTO.value))
@@ -124,7 +123,6 @@ object ScalaNativePluginInternal {
           .withMainClass(maincls)
           .withClassPath(classpath)
           .withWorkdir(cwd)
-          .withTargetTriple(nativeTarget.value)
           .withCompilerConfig(nativeConfig.value)
       }
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -43,7 +43,6 @@ object ScalaNativePluginInternal {
     nativeClangPP := nativeConfig.value.clangPP.toFile,
     nativeCompileOptions := nativeConfig.value.compileOptions,
     nativeLinkingOptions := nativeConfig.value.linkingOptions,
-    targetTriple := nativeConfig.value.targetTriple.getOrElse(""),
     nativeMode := nativeConfig.value.mode.name,
     nativeGC := nativeConfig.value.gc.name,
     nativeLTO := nativeConfig.value.lto.name,
@@ -99,7 +98,6 @@ object ScalaNativePluginInternal {
         .withClangPP(nativeClangPP.value.toPath)
         .withCompileOptions(nativeCompileOptions.value)
         .withLinkingOptions(nativeLinkingOptions.value)
-        .withTargetTriple(toOption(targetTriple.value))
         .withGC(build.GC(nativeGC.value))
         .withMode(build.Mode(nativeMode.value))
         .withLTO(build.LTO(nativeLTO.value))
@@ -220,8 +218,5 @@ object ScalaNativePluginInternal {
     if (l.compareAndSet(prev, r :: prev)) r
     else registerResource(l, r)
   }
-
-  def toOption(s: String): Option[String] =
-    if (s.trim().isEmpty()) None else Some(s)
 
 }

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -21,9 +21,6 @@ object ScalaNativePluginInternal {
   val nativeWarnOldJVM =
     taskKey[Unit]("Warn if JVM 7 or older is used.")
 
-  val nativeTarget =
-    taskKey[String]("Target triple.")
-
   val nativeWorkdir =
     taskKey[File]("Working directory for intermediate build files.")
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -43,7 +43,7 @@ object ScalaNativePluginInternal {
     nativeClangPP := nativeConfig.value.clangPP.toFile,
     nativeCompileOptions := nativeConfig.value.compileOptions,
     nativeLinkingOptions := nativeConfig.value.linkingOptions,
-    nativeTarget := nativeConfig.value.targetTriple,
+    targetTriple := nativeConfig.value.targetTriple.getOrElse(""),
     nativeMode := nativeConfig.value.mode.name,
     nativeGC := nativeConfig.value.gc.name,
     nativeLTO := nativeConfig.value.lto.name,
@@ -99,7 +99,7 @@ object ScalaNativePluginInternal {
         .withClangPP(nativeClangPP.value.toPath)
         .withCompileOptions(nativeCompileOptions.value)
         .withLinkingOptions(nativeLinkingOptions.value)
-        .withTargetTriple(nativeTarget.value)
+        .withTargetTriple(toOption(targetTriple.value))
         .withGC(build.GC(nativeGC.value))
         .withMode(build.Mode(nativeMode.value))
         .withLTO(build.LTO(nativeLTO.value))
@@ -220,5 +220,8 @@ object ScalaNativePluginInternal {
     if (l.compareAndSet(prev, r :: prev)) r
     else registerResource(l, r)
   }
+
+  def toOption(s: String): Option[String] =
+    if (s.trim().isEmpty()) None else Some(s)
 
 }

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -85,12 +85,10 @@ object ScalaNativePluginInternal {
   )
 
   lazy val scalaNativeConfigSettings: Seq[Setting[_]] = Seq(
-    nativeTarget := interceptBuildException {
-      val cwd   = nativeWorkdir.value.toPath
-      val clang = nativeClang.value.toPath
-      Discover.targetTriple(clang, cwd)
+    nativeTarget := { // placeholder for future use
+      ""
     },
-    artifactPath in nativeLink := {
+    nativeLink / artifactPath := {
       crossTarget.value / (moduleName.value + "-out")
     },
     nativeWorkdir := {
@@ -114,7 +112,7 @@ object ScalaNativePluginInternal {
         .withDump(nativeDump.value)
     },
     nativeLink := {
-      val outpath = (artifactPath in nativeLink).value
+      val outpath = (nativeLink / artifactPath).value
       val config = {
         val mainClass = selectMainClass.value.getOrElse {
           throw new MessageOnlyException("No main class detected.")
@@ -140,7 +138,7 @@ object ScalaNativePluginInternal {
       outpath
     },
     run := {
-      val env    = (envVars in run).value.toSeq
+      val env    = (run / envVars).value.toSeq
       val logger = streams.value.log
       val binary = nativeLink.value.getAbsolutePath
       val args   = spaceDelimited("<arg>").parsed

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -70,8 +70,7 @@ object Build {
       val nativelib    = NativeLib.findNativeLib(nativelibs)
       val unpackedLibs = nativelibs.map(LLVM.unpackNativeCode(_))
 
-      val msg = s"Compiling to native code (${targetTripleMsg(config)})"
-      val objectPaths = config.logger.time(msg) {
+      val objectPaths = config.logger.time("Compiling to native code") {
         val nativelibConfig =
           fconfig.withCompilerConfig(
             _.withCompileOptions("-O2" +: fconfig.compileOptions))
@@ -86,7 +85,4 @@ object Build {
 
       LLVM.link(config, linked, objectPaths, outpath)
     }
-
-  private def targetTripleMsg(config: Config): String =
-    config.compilerConfig.targetTriple.getOrElse("default target triple")
 }

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -72,7 +72,8 @@ object Build {
       val nativelib    = NativeLib.findNativeLib(nativelibs)
       val unpackedLibs = nativelibs.map(LLVM.unpackNativeCode(_))
 
-    val objectPaths = config.logger.time("Compiling to native code") {
+    val msg = s"Compiling to native code (${targetTripleMsg(config)})"
+    val objectPaths = config.logger.time(msg) {
       val nativelibConfig =
         fconfig.withCompilerConfig(
           _.withCompileOptions("-O2" +: fconfig.compileOptions))
@@ -83,5 +84,10 @@ object Build {
     }
 
     LLVM.link(config, linked, objectPaths, outpath)
+  }
+
+  private def targetTripleMsg(config: Config): String = {
+    val tt = config.targetTriple
+    if (tt.nonEmpty) tt else "default target triple"
   }
 }

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -90,8 +90,6 @@ object Build {
       LLVM.link(config, linked, objectPaths, outpath)
     }
 
-  private def targetTripleMsg(config: Config): String = {
-    val tt = config.compilerConfig.targetTriple
-    if (tt.nonEmpty) tt else "default target triple"
-  }
+  private def targetTripleMsg(config: Config): String =
+    config.compilerConfig.targetTriple.getOrElse("default target triple")
 }

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -24,8 +24,6 @@ object Build {
    *  val clangpp  = Discover.clangpp()
    *  val linkopts = Discover.linkingOptions()
    *  val compopts = Discover.compileOptions()
-   *  // Empty string or target triple if cross compiling
-   *  val triple   = ""
    *
    *  val outpath  = workdir.resolve("out")
    *
@@ -39,7 +37,6 @@ object Build {
    *         .withClangPP(clangpp)
    *         .withLinkingOptions(linkopts)
    *         .withCompileOptions(compopts)
-   *         .withTargetTriple(triple)
    *         .withLinkStubs(true)
    *       }
    *      .withMainClass(main)

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -6,9 +6,6 @@ import java.nio.file.{Path, Paths}
 /** An object describing how to configure the Scala Native toolchain. */
 sealed trait Config {
 
-  /** Target triple that defines current OS, ABI and CPU architecture. */
-  def targetTriple: String
-
   /** Directory to emit intermediate compilation results. */
   def workdir: Path
 
@@ -26,9 +23,6 @@ sealed trait Config {
   def logger: Logger
 
   def compilerConfig: NativeConfig
-
-  /** Create a new config with given target triple. */
-  def withTargetTriple(value: String): Config
 
   /** Create a new config with given directory. */
   def withWorkdir(value: Path): Config
@@ -90,7 +84,6 @@ object Config {
       mainClass = "",
       classPath = Seq.empty,
       workdir = Paths.get(""),
-      targetTriple = "",
       logger = Logger.default,
       compilerConfig = NativeConfig.empty
     )
@@ -99,7 +92,6 @@ object Config {
                                 mainClass: String,
                                 classPath: Seq[Path],
                                 workdir: Path,
-                                targetTriple: String,
                                 logger: Logger,
                                 compilerConfig: NativeConfig)
       extends Config {
@@ -114,9 +106,6 @@ object Config {
 
     def withWorkdir(value: Path): Config =
       copy(workdir = value)
-
-    def withTargetTriple(value: String): Config =
-      copy(targetTriple = value)
 
     def withLogger(value: Logger): Config =
       copy(logger = value)

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -75,36 +75,6 @@ object Discover {
     libs
   }
 
-  /** Detect the target architecture.
-   *
-   *  @param clang   A path to the executable `clang`.
-   *  @param workdir A working directory where the compilation will take place.
-   *  @return The detected target triple describing the target architecture.
-   */
-  def targetTriple(clang: Path, workdir: Path): String = {
-    // Use non-standard extension to not include the ll file when linking (#639)
-    val targetc  = workdir.resolve("target").resolve("c.probe")
-    val targetll = workdir.resolve("target").resolve("ll.probe")
-    val compilec =
-      Seq(clang.abs, "-S", "-xc", "-emit-llvm", "-o", targetll.abs, targetc.abs)
-    def fail =
-      throw new BuildException("Failed to detect native target.")
-
-    IO.write(targetc, "int probe;".getBytes("UTF-8"))
-    val exit = Process(compilec, workdir.toFile).!
-    if (exit != 0) {
-      fail
-    } else {
-      val linesIter = Files.readAllLines(targetll).iterator()
-      while (linesIter.hasNext()) {
-        val line = linesIter.next()
-        if (line.startsWith("target triple"))
-          return line.split("\"").apply(1)
-      }
-      fail
-    }
-  }
-
   /** Tests whether the clang compiler is recent enough.
    *  It is determined through looking up a built-in #define which
    *  is more reliable than testing for a specific version.

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -125,7 +125,8 @@ private[scalanative] object LLVM {
     // delete .o files for all excluded source files
     excludePaths.foreach { path =>
       val opath = Paths.get(path + oExt)
-      if (Files.exists(opath)) Files.delete(opath)
+      if (Files.exists(opath))
+        Files.delete(opath)
     }
 
     val fltoOpt   = flto(config)

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -84,13 +84,13 @@ private[scalanative] object LLVM {
    * @param config        The configuration of the toolchain.
    * @param linkerResult  The results from the linker.
    * @param nativelibPath The generated location of the Scala Native nativelib.
-   * @param nativelibs    The Paths to the native libs
-   * @return `libPath`    The nativelibPath plus `scala-native`
+   * @param nativelibs    The paths to the native libraries.
+   * @return              The paths to the produced `.o` files.
    */
   def compileNativelibs(config: Config,
                         linkerResult: linker.Result,
                         nativelibs: Seq[Path],
-                        nativelibPath: Path): Path = {
+                        nativelibPath: Path): Seq[Path] = {
     val workdir = config.workdir
     // search starting at workdir `native` to find
     // code across all native component libraries
@@ -120,10 +120,10 @@ private[scalanative] object LLVM {
       }
     }
 
-    val (incPaths, excPaths) = paths.partition(include(_))
+    val (includePaths, excludePaths) = paths.partition(include(_))
 
     // delete .o files for all excluded source files
-    excPaths.foreach { path =>
+    excludePaths.foreach { path =>
       val opath = Paths.get(path + oExt)
       if (Files.exists(opath)) Files.delete(opath)
     }
@@ -132,9 +132,10 @@ private[scalanative] object LLVM {
     val targetOpt = target(config)
 
     // generate .o files for all included source files in parallel
-    incPaths.par.foreach { path =>
-      val opath = path + oExt
-      if (!Files.exists(Paths.get(opath))) {
+    includePaths.par.map { path =>
+      val opath   = path + oExt
+      val objPath = Paths.get(opath)
+      if (!Files.exists(objPath)) {
         val isCpp    = path.endsWith(cppExt)
         val compiler = if (isCpp) config.clangPP.abs else config.clang.abs
         val stdflag  = if (isCpp) "-std=c++11" else "-std=gnu11"
@@ -150,16 +151,16 @@ private[scalanative] object LLVM {
           sys.error("Failed to compile native library runtime code.")
         }
       }
-    }
-    libPath
+      objPath
+    }.seq
   }
 
   /**
    * Compile the given ll files to object files
    *
    * @param config  The configuration of the toolchain.
-   * @param llPaths The paths to the ll files.
-   * @return The Seq of paths of the o files.
+   * @param llPaths The directory paths containing `.ll` files.
+   * @return        The paths of the `.o` files.
    */
   def compile(config: Config, llPaths: Seq[Path]): Seq[Path] = {
     val optimizationOpt =
@@ -185,21 +186,19 @@ private[scalanative] object LLVM {
   }
 
   /**
-   * Links a collection of `.ll` files and the `.o` files
+   * Links a collection of `.ll.o` files and the `.o` files
    * from the `nativelib`, other libaries, and the
    * application project into the native binary.
    *
    * @param config       The configuration of the toolchain.
    * @param linkerResult The results from the linker.
-   * @param llPaths      The list of `.ll` files to link.
-   * @param nativelibs   The Paths to the native libs
+   * @param objectPaths  The paths to all the `.o` files.
    * @param outpath      The path where to write the resulting binary.
    * @return `outpath`
    */
   def link(config: Config,
            linkerResult: linker.Result,
-           llPaths: Seq[Path],
-           nativelibs: Seq[Path],
+           objectsPaths: Seq[Path],
            outpath: Path): Path = {
     val workdir = config.workdir
     val links = {
@@ -213,11 +212,9 @@ private[scalanative] object LLVM {
     val linkopts = config.linkingOptions ++ links.map("-l" + _)
     val flags =
       flto(config) ++ Seq("-rdynamic", "-o", outpath.abs) ++ target(config)
-    val objPatterns = NativeLib.destObjPatterns(workdir, nativelibs)
-    val opaths      = IO.getAll(workdir, objPatterns).map(_.abs)
-    val paths       = llPaths.map(_.abs) ++ opaths
-    val compile     = config.clangPP.abs +: (flags ++ paths ++ linkopts)
-    val ltoName     = lto(config).getOrElse("none")
+    val paths   = objectsPaths.map(_.abs)
+    val compile = config.clangPP.abs +: (flags ++ paths ++ linkopts)
+    val ltoName = lto(config).getOrElse("none")
 
     config.logger.time(
       s"Linking native code (${config.gc.name} gc, $ltoName lto)") {

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -238,7 +238,7 @@ private[scalanative] object LLVM {
     } { name => Seq(s"-flto=$name") }
 
   private def target(config: Config): Seq[String] = {
-    val tt = config.targetTriple
+    val tt = config.compilerConfig.targetTriple
     if (tt.isEmpty()) Seq("-Wno-override-module")
     else Seq("-target", tt)
   }

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -237,9 +237,9 @@ private[scalanative] object LLVM {
       Seq()
     } { name => Seq(s"-flto=$name") }
 
-  private def target(config: Config): Seq[String] = {
-    val tt = config.compilerConfig.targetTriple
-    if (tt.isEmpty()) Seq("-Wno-override-module")
-    else Seq("-target", tt)
-  }
+  private def target(config: Config): Seq[String] =
+    config.compilerConfig.targetTriple match {
+      case Some(tt) => Seq("-target", tt)
+      case None     => Seq("-Wno-override-module")
+    }
 }

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -24,6 +24,9 @@ sealed trait NativeConfig {
   /** The compilation options passed to LLVM. */
   def compileOptions: Seq[String]
 
+  /** Target triple that defines current OS, ABI and CPU architecture. */
+  def targetTriple: String
+
   /** Should stubs be linked? */
   def linkStubs: Boolean
 
@@ -57,6 +60,9 @@ sealed trait NativeConfig {
   /** Create a new config with given compilation options. */
   def withCompileOptions(value: Seq[String]): NativeConfig
 
+  /** Create a new config with given optimize value */
+  def withTargetTriple(value: String): NativeConfig
+
   /** Create a new config with given behavior for stubs. */
   def withLinkStubs(value: Boolean): NativeConfig
 
@@ -82,6 +88,7 @@ object NativeConfig {
       clangPP = Paths.get(""),
       linkingOptions = Seq.empty,
       compileOptions = Seq.empty,
+      targetTriple = "",
       gc = GC.default,
       lto = LTO.default,
       mode = Mode.default,
@@ -95,6 +102,7 @@ object NativeConfig {
                                 clangPP: Path,
                                 linkingOptions: Seq[String],
                                 compileOptions: Seq[String],
+                                targetTriple: String,
                                 gc: GC,
                                 mode: Mode,
                                 lto: LTO,
@@ -116,6 +124,9 @@ object NativeConfig {
     def withCompileOptions(value: Seq[String]): NativeConfig =
       copy(compileOptions = value)
 
+    def withTargetTriple(value: String): NativeConfig =
+      copy(targetTriple = value)
+
     def withGC(value: GC): NativeConfig =
       copy(gc = value)
 
@@ -134,7 +145,7 @@ object NativeConfig {
     def withDump(value: Boolean): NativeConfig =
       copy(dump = value)
 
-    override def withOptimize(value: Boolean): NativeConfig =
+    def withOptimize(value: Boolean): NativeConfig =
       copy(optimize = value)
 
     override def toString: String =
@@ -143,6 +154,7 @@ object NativeConfig {
         | - clangPP:         $clangPP
         | - linkingOptions:  $linkingOptions
         | - compileOptions:  $compileOptions
+        | - targetTriple:    $targetTriple
         | - GC:              $gc
         | - mode:            $mode
         | - LTO:             $lto

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -63,6 +63,9 @@ sealed trait NativeConfig {
   /** Create a new config given a target triple. */
   def withTargetTriple(value: Option[String]): NativeConfig
 
+  /** Create a new config given a target triple. */
+  def withTargetTriple(value: String): NativeConfig
+
   /** Create a new config with given behavior for stubs. */
   def withLinkStubs(value: Boolean): NativeConfig
 
@@ -126,6 +129,11 @@ object NativeConfig {
 
     def withTargetTriple(value: Option[String]): NativeConfig =
       copy(targetTriple = value)
+
+    def withTargetTriple(value: String): NativeConfig = {
+      val optValue = if (value.trim().isEmpty()) None else Some(value)
+      withTargetTriple(optValue)
+    }
 
     def withGC(value: GC): NativeConfig =
       copy(gc = value)

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -24,8 +24,8 @@ sealed trait NativeConfig {
   /** The compilation options passed to LLVM. */
   def compileOptions: Seq[String]
 
-  /** Target triple that defines current OS, ABI and CPU architecture. */
-  def targetTriple: String
+  /** Optional target triple that defines current OS, ABI and CPU architecture. */
+  def targetTriple: Option[String]
 
   /** Should stubs be linked? */
   def linkStubs: Boolean
@@ -60,8 +60,8 @@ sealed trait NativeConfig {
   /** Create a new config with given compilation options. */
   def withCompileOptions(value: Seq[String]): NativeConfig
 
-  /** Create a new config with given optimize value */
-  def withTargetTriple(value: String): NativeConfig
+  /** Create a new config given a target triple. */
+  def withTargetTriple(value: Option[String]): NativeConfig
 
   /** Create a new config with given behavior for stubs. */
   def withLinkStubs(value: Boolean): NativeConfig
@@ -88,7 +88,7 @@ object NativeConfig {
       clangPP = Paths.get(""),
       linkingOptions = Seq.empty,
       compileOptions = Seq.empty,
-      targetTriple = "",
+      targetTriple = None,
       gc = GC.default,
       lto = LTO.default,
       mode = Mode.default,
@@ -102,7 +102,7 @@ object NativeConfig {
                                 clangPP: Path,
                                 linkingOptions: Seq[String],
                                 compileOptions: Seq[String],
-                                targetTriple: String,
+                                targetTriple: Option[String],
                                 gc: GC,
                                 mode: Mode,
                                 lto: LTO,
@@ -124,7 +124,7 @@ object NativeConfig {
     def withCompileOptions(value: Seq[String]): NativeConfig =
       copy(compileOptions = value)
 
-    def withTargetTriple(value: String): NativeConfig =
+    def withTargetTriple(value: Option[String]): NativeConfig =
       copy(targetTriple = value)
 
     def withGC(value: GC): NativeConfig =

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -131,8 +131,7 @@ object NativeConfig {
       copy(targetTriple = value)
 
     def withTargetTriple(value: String): NativeConfig = {
-      val optValue = if (value.trim().isEmpty()) None else Some(value)
-      withTargetTriple(optValue)
+      withTargetTriple(Some(value))
     }
 
     def withGC(value: GC): NativeConfig =

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -63,17 +63,6 @@ private[scalanative] object NativeLib {
     srcExtensions.mkString(s"glob:${pathPat}**{", ",", "}")
   }
 
-  /**
-   * Allow all the object files ".o" to be found with one
-   * directory recursion.
-   *
-   * @param workdir    The base working directory
-   * @param nativelibs The Paths to the native libs
-   * @return the object file pattern
-   */
-  def destObjPatterns(workdir: Path, nativelibs: Seq[Path]): String =
-    s"glob:${destPathPattern(workdir, nativelibs)}**${oExt}"
-
   private def destPathPattern(workdir: Path, nativelibs: Seq[Path]): String = {
     val workdirStr = workdir.toString()
     val nativeDirs = nativelibs.map(_.getFileName().toString())

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -86,12 +86,11 @@ private[scalanative] object ScalaNative {
 
   /** Given low-level assembly, emit LLVM IR for it to the buildDirectory. */
   def codegen(config: Config, linked: linker.Result): Seq[Path] = {
-    config.logger.time("Generating intermediate code") {
+    val llPaths = config.logger.time("Generating intermediate code") {
       CodeGen(config, linked)
     }
-    val produced = IO.getAll(config.workdir, "glob:**.ll")
-    config.logger.info(s"Produced ${produced.length} files")
-    produced
+    config.logger.info(s"Produced ${llPaths.length} files")
+    llPaths
   }
 
   /** Run NIR checker on the linker result. */

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -45,8 +45,9 @@ object CodeGen {
   private def emit(config: build.Config, assembly: Seq[Defn])(
       implicit meta: Metadata): Seq[Path] =
     Scope { implicit in =>
-      val env     = assembly.map(defn => defn.name -> defn).toMap
-      val workdir = VirtualDirectory.real(config.workdir)
+      val env          = assembly.map(defn => defn.name -> defn).toMap
+      val workdir      = VirtualDirectory.real(config.workdir)
+      val targetTriple = config.compilerConfig.targetTriple
 
       // Partition into multiple LLVM IR files proportional to number
       // of available processesors. This prevents LLVM from optimizing
@@ -56,7 +57,7 @@ object CodeGen {
           .map {
             case (id, defns) =>
               val sorted = defns.sortBy(_.name.show)
-              new Impl(config.targetTriple, env, sorted)
+              new Impl(targetTriple, env, sorted)
                 .gen(id.toString, workdir)
           }
           .toSeq
@@ -68,7 +69,7 @@ object CodeGen {
       def single(): Seq[Path] = {
         val sorted = assembly.sortBy(_.name.show)
         Seq(
-          new Impl(config.targetTriple, env, sorted)
+          new Impl(targetTriple, env, sorted)
             .gen(id = "out", workdir))
       }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -47,7 +47,7 @@ object CodeGen {
     Scope { implicit in =>
       val env          = assembly.map(defn => defn.name -> defn).toMap
       val workdir      = VirtualDirectory.real(config.workdir)
-      val targetTriple = config.compilerConfig.targetTriple
+      val targetTriple = config.compilerConfig.targetTriple.getOrElse("")
 
       // Partition into multiple LLVM IR files proportional to number
       // of available processesors. This prevents LLVM from optimizing


### PR DESCRIPTION
After several rounds of discussion first around cross compiling and removing the target triple discovery and now removing the target triple, I am more convinced than ever that this is a prudent direction.

First @lolgab proposed this target triple PR https://github.com/scala-native/scala-native/pull/1904 when I was proposing this https://github.com/scala-native/scala-native/pull/1905

Now @catap is basically saying the same thing with this PR https://github.com/scala-native/scala-native/pull/2031 After some discussion I suggested that I put together a more conservative PR in hoping we could get some consensus.

This is a more conservative PR as it doesn't completely remove target triple code which is advertised as being needed here: http://clang.llvm.org/docs/CrossCompilation.html#general-cross-compilation-options-in-clang

A future PR can address exposing target triple and other related improvements. If the target triple is set correctly for the platform then there are no errors.

For full disclosure this also includes changing the internal plugin to use `sbt` slash syntax and swipes a super small change `.o` -> `oExt` as small clean up changes.

Thank you @lolgab and @catap for pushing for these changes and if this is ok then maybe we can add user support for target triple if the community agrees.