### PR TITLE
Fix #2025: Remove BoxedUnitArray

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -26,11 +26,10 @@
 package scala.scalanative
 package runtime
 
-import scala.runtime.BoxedUnit
 import scalanative.unsafe._
 import scalanative.runtime.Intrinsics._
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 34)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 33)
 
 sealed abstract class Array[T]
     extends java.io.Serializable
@@ -153,80 +152,11 @@ object Array {
   }
 }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 168)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 167)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 169)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
-
-final class BoxedUnitArray private () extends Array[BoxedUnit] {
-
-  @inline def stride: CSize =
-    8
-
-  @inline def atRaw(i: Int): RawPtr =
-    if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      elemRawPtr(rawptr, 16 + 8 * i)
-    }
-
-  @inline def apply(i: Int): BoxedUnit =
-    if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 197)
-      loadObject(ith).asInstanceOf[BoxedUnit]
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 199)
-    }
-
-  @inline def update(i: Int, value: BoxedUnit): Unit =
-    if (i < 0 || i >= length) {
-      throwOutOfBounds(i)
-    } else {
-      val rawptr = castObjectToRawPtr(this)
-      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 210)
-      storeObject(ith, value.asInstanceOf[Object])
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 212)
-    }
-
-  @inline override def clone(): BoxedUnitArray = {
-    val arrty   = toRawType(classOf[BoxedUnitArray])
-    val arrsize = 16 + 8 * length
-    val arr     = GC.alloc(arrty, arrsize)
-    val src     = castObjectToRawPtr(this)
-    libc.memcpy(arr, src, arrsize)
-    castRawPtrToObject(arr).asInstanceOf[BoxedUnitArray]
-  }
-}
-
-object BoxedUnitArray {
-
-  @inline def alloc(length: Int): BoxedUnitArray = {
-    val arrty   = toRawType(classOf[BoxedUnitArray])
-    val arrsize = 16 + 8 * length
-    val arr     = GC.alloc(arrty, arrsize)
-    storeInt(elemRawPtr(arr, 8), length)
-    storeInt(elemRawPtr(arr, 12), 8.toInt)
-    castRawPtrToObject(arr).asInstanceOf[BoxedUnitArray]
-  }
-
-  @inline def snapshot(length: Int, data: RawPtr): BoxedUnitArray = {
-    val arr  = alloc(length)
-    val dst  = arr.atRaw(0)
-    val src  = data
-    val size = 8 * length
-    libc.memcpy(dst, src, size)
-    arr
-  }
-}
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 173)
 
 final class BooleanArray private () extends Array[Boolean] {
 
@@ -247,9 +177,7 @@ final class BooleanArray private () extends Array[Boolean] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 1 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 195)
       loadBoolean(ith)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 199)
     }
 
   @inline def update(i: Int, value: Boolean): Unit =
@@ -258,9 +186,7 @@ final class BooleanArray private () extends Array[Boolean] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 1 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 208)
       storeBoolean(ith, value)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 212)
     }
 
   @inline override def clone(): BooleanArray = {
@@ -293,9 +219,9 @@ object BooleanArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 169)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 173)
 
 final class CharArray private () extends Array[Char] {
 
@@ -316,9 +242,7 @@ final class CharArray private () extends Array[Char] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 2 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 195)
       loadChar(ith)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 199)
     }
 
   @inline def update(i: Int, value: Char): Unit =
@@ -327,9 +251,7 @@ final class CharArray private () extends Array[Char] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 2 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 208)
       storeChar(ith, value)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 212)
     }
 
   @inline override def clone(): CharArray = {
@@ -362,9 +284,9 @@ object CharArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 169)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 173)
 
 final class ByteArray private () extends Array[Byte] {
 
@@ -385,9 +307,7 @@ final class ByteArray private () extends Array[Byte] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 1 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 195)
       loadByte(ith)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 199)
     }
 
   @inline def update(i: Int, value: Byte): Unit =
@@ -396,9 +316,7 @@ final class ByteArray private () extends Array[Byte] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 1 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 208)
       storeByte(ith, value)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 212)
     }
 
   @inline override def clone(): ByteArray = {
@@ -431,9 +349,9 @@ object ByteArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 169)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 173)
 
 final class ShortArray private () extends Array[Short] {
 
@@ -454,9 +372,7 @@ final class ShortArray private () extends Array[Short] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 2 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 195)
       loadShort(ith)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 199)
     }
 
   @inline def update(i: Int, value: Short): Unit =
@@ -465,9 +381,7 @@ final class ShortArray private () extends Array[Short] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 2 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 208)
       storeShort(ith, value)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 212)
     }
 
   @inline override def clone(): ShortArray = {
@@ -500,9 +414,9 @@ object ShortArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 169)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 173)
 
 final class IntArray private () extends Array[Int] {
 
@@ -523,9 +437,7 @@ final class IntArray private () extends Array[Int] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 4 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 195)
       loadInt(ith)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 199)
     }
 
   @inline def update(i: Int, value: Int): Unit =
@@ -534,9 +446,7 @@ final class IntArray private () extends Array[Int] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 4 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 208)
       storeInt(ith, value)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 212)
     }
 
   @inline override def clone(): IntArray = {
@@ -569,9 +479,9 @@ object IntArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 169)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 173)
 
 final class LongArray private () extends Array[Long] {
 
@@ -592,9 +502,7 @@ final class LongArray private () extends Array[Long] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 8 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 195)
       loadLong(ith)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 199)
     }
 
   @inline def update(i: Int, value: Long): Unit =
@@ -603,9 +511,7 @@ final class LongArray private () extends Array[Long] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 8 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 208)
       storeLong(ith, value)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 212)
     }
 
   @inline override def clone(): LongArray = {
@@ -638,9 +544,9 @@ object LongArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 169)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 173)
 
 final class FloatArray private () extends Array[Float] {
 
@@ -661,9 +567,7 @@ final class FloatArray private () extends Array[Float] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 4 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 195)
       loadFloat(ith)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 199)
     }
 
   @inline def update(i: Int, value: Float): Unit =
@@ -672,9 +576,7 @@ final class FloatArray private () extends Array[Float] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 4 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 208)
       storeFloat(ith, value)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 212)
     }
 
   @inline override def clone(): FloatArray = {
@@ -707,9 +609,9 @@ object FloatArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 169)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 173)
 
 final class DoubleArray private () extends Array[Double] {
 
@@ -730,9 +632,7 @@ final class DoubleArray private () extends Array[Double] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 8 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 195)
       loadDouble(ith)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 199)
     }
 
   @inline def update(i: Int, value: Double): Unit =
@@ -741,9 +641,7 @@ final class DoubleArray private () extends Array[Double] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 8 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 208)
       storeDouble(ith, value)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 212)
     }
 
   @inline override def clone(): DoubleArray = {
@@ -776,9 +674,9 @@ object DoubleArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 169)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
+// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 173)
 
 final class ObjectArray private () extends Array[Object] {
 
@@ -799,9 +697,7 @@ final class ObjectArray private () extends Array[Object] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 8 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 195)
       loadObject(ith)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 199)
     }
 
   @inline def update(i: Int, value: Object): Unit =
@@ -810,9 +706,7 @@ final class ObjectArray private () extends Array[Object] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, 16 + 8 * i)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 208)
       storeObject(ith, value)
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 212)
     }
 
   @inline override def clone(): ObjectArray = {

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -25,7 +25,6 @@
 package scala.scalanative
 package runtime
 
-import scala.runtime.BoxedUnit
 import scalanative.unsafe._
 import scalanative.runtime.Intrinsics._
 
@@ -154,7 +153,7 @@ object Array {
 }
 
 %{
-   types = {'BoxedUnit': sizePtr, 'Boolean': 1, 'Char': 2, 'Byte': 1, 'Short': 2,
+   types = {'Boolean': 1, 'Char': 2, 'Byte': 1, 'Short': 2,
             'Int': 4, 'Long': 8, 'Float': 4, 'Double': 8, 'Object': sizePtr}
 }%
 % # BEWARE: Order of iteration of the dictionary depends on version of Python
@@ -169,7 +168,7 @@ object Array {
 % for T, sizeT in types.items():
 
 %{
-   alloc = 'GC.alloc_atomic' if T != 'Object' and T != 'BoxedUnit' else 'GC.alloc'
+   alloc = 'GC.alloc_atomic' if T != 'Object' else 'GC.alloc'
 }%
 
 final class ${T}Array private () extends Array[${T}] {
@@ -191,11 +190,7 @@ final class ${T}Array private () extends Array[${T}] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, ${sizeHeader} + ${sizeT} * i)
-      % if T != 'BoxedUnit':
       load${T}(ith)
-      % else:
-      loadObject(ith).asInstanceOf[BoxedUnit]
-      % end
     }
 
   @inline def update(i: Int, value: ${T}): Unit =
@@ -204,11 +199,7 @@ final class ${T}Array private () extends Array[${T}] {
     } else {
       val rawptr = castObjectToRawPtr(this)
       val ith    = elemRawPtr(rawptr, ${sizeHeader} + ${sizeT} * i)
-      % if T != 'BoxedUnit':
       store${T}(ith, value)
-      % else:
-      storeObject(ith, value.asInstanceOf[Object])
-      % end
     }
 
   @inline override def clone(): ${T}Array = {

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -126,24 +126,21 @@ object Type {
   }
 
   val typeToArray = Map[Type, Global](
-    Type.Bool    -> Global.Top("scala.scalanative.runtime.BooleanArray"),
-    Type.Char    -> Global.Top("scala.scalanative.runtime.CharArray"),
-    Type.Byte    -> Global.Top("scala.scalanative.runtime.ByteArray"),
-    Type.Short   -> Global.Top("scala.scalanative.runtime.ShortArray"),
-    Type.Int     -> Global.Top("scala.scalanative.runtime.IntArray"),
-    Type.Long    -> Global.Top("scala.scalanative.runtime.LongArray"),
-    Type.Float   -> Global.Top("scala.scalanative.runtime.FloatArray"),
-    Type.Double  -> Global.Top("scala.scalanative.runtime.DoubleArray"),
-    Rt.BoxedUnit -> Global.Top("scala.scalanative.runtime.BoxedUnitArray"),
-    Rt.Object    -> Global.Top("scala.scalanative.runtime.ObjectArray")
+    Type.Bool   -> Global.Top("scala.scalanative.runtime.BooleanArray"),
+    Type.Char   -> Global.Top("scala.scalanative.runtime.CharArray"),
+    Type.Byte   -> Global.Top("scala.scalanative.runtime.ByteArray"),
+    Type.Short  -> Global.Top("scala.scalanative.runtime.ShortArray"),
+    Type.Int    -> Global.Top("scala.scalanative.runtime.IntArray"),
+    Type.Long   -> Global.Top("scala.scalanative.runtime.LongArray"),
+    Type.Float  -> Global.Top("scala.scalanative.runtime.FloatArray"),
+    Type.Double -> Global.Top("scala.scalanative.runtime.DoubleArray"),
+    Rt.Object   -> Global.Top("scala.scalanative.runtime.ObjectArray")
   )
   val arrayToType =
     typeToArray.map { case (k, v) => (v, k) }
   def toArrayClass(ty: Type): Global = ty match {
     case _ if typeToArray.contains(ty) =>
       typeToArray(ty)
-    case Type.Ref(name, _, _) if name == Rt.BoxedUnit.name =>
-      typeToArray(Rt.BoxedUnit)
     case _ =>
       typeToArray(Rt.Object)
   }

--- a/scalalib/overrides-2.13/scala/Array.scala
+++ b/scalalib/overrides-2.13/scala/Array.scala
@@ -46,8 +46,8 @@ object Array {
   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
   @SerialVersionUID(3L)
   private class ArrayFactory[A : ClassTag](dummy: Array.type) extends Factory[A, Array[A]] with Serializable {
-	def fromSpecific(it: IterableOnce[A]): Array[A] = Array.from[A](it)
-	def newBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder[A]
+    def fromSpecific(it: IterableOnce[A]): Array[A] = Array.from[A](it)
+    def newBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder[A]
   }
 
   /**
@@ -69,23 +69,23 @@ object Array {
    *  @return    an array consisting of elements of the iterable collection
    */
   def from[A : ClassTag](it: IterableOnce[A]): Array[A] = it match {
-	case it: Iterable[A] => it.toArray[A]
-	case _ => it.iterator.toArray[A]
+    case it: Iterable[A] => it.toArray[A]
+    case _ => it.iterator.toArray[A]
   }
 
   private def slowcopy(src : AnyRef,
-	srcPos : Int,
-	dest : AnyRef,
-	destPos : Int,
-	length : Int): Unit = {
-	var i = srcPos
-	var j = destPos
-	val srcUntil = srcPos + length
-	while (i < srcUntil) {
-	  array_update(dest, j, array_apply(src, i))
-	  i += 1
-	  j += 1
-	}
+    srcPos : Int,
+    dest : AnyRef,
+    destPos : Int,
+    length : Int): Unit = {
+    var i = srcPos
+    var j = destPos
+    val srcUntil = srcPos + length
+    while (i < srcUntil) {
+      array_update(dest, j, array_apply(src, i))
+      i += 1
+      j += 1
+    }
   }
 
   /** Copy one array to another.
@@ -104,11 +104,11 @@ object Array {
    *  @see `java.lang.System#arraycopy`
    */
   def copy(src: AnyRef, srcPos: Int, dest: AnyRef, destPos: Int, length: Int): Unit = {
-	val srcClass = src.getClass
-	if (srcClass.isArray && dest.getClass.isAssignableFrom(srcClass))
-	  java.lang.System.arraycopy(src, srcPos, dest, destPos, length)
-	else
-	  slowcopy(src, srcPos, dest, destPos, length)
+    val srcClass = src.getClass
+    if (srcClass.isArray && dest.getClass.isAssignableFrom(srcClass))
+      java.lang.System.arraycopy(src, srcPos, dest, destPos, length)
+    else
+      slowcopy(src, srcPos, dest, destPos, length)
   }
 
   /** Copy one array to another, truncating or padding with default values (if
@@ -123,15 +123,15 @@ object Array {
   def copyOf[A](original: Array[A], newLength: Int): Array[A] = ((original: @unchecked) match {
 //  We cannot distinguish Array[BoxedUnit] from Array[Object] in Scala Native
 //	case x: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
-	case x: Array[AnyRef]     => java.util.Arrays.copyOf(x, newLength)
-	case x: Array[Int]        => java.util.Arrays.copyOf(x, newLength)
-	case x: Array[Double]     => java.util.Arrays.copyOf(x, newLength)
-	case x: Array[Long]       => java.util.Arrays.copyOf(x, newLength)
-	case x: Array[Float]      => java.util.Arrays.copyOf(x, newLength)
-	case x: Array[Char]       => java.util.Arrays.copyOf(x, newLength)
-	case x: Array[Byte]       => java.util.Arrays.copyOf(x, newLength)
-	case x: Array[Short]      => java.util.Arrays.copyOf(x, newLength)
-	case x: Array[Boolean]    => java.util.Arrays.copyOf(x, newLength)
+    case x: Array[AnyRef]     => java.util.Arrays.copyOf(x, newLength)
+    case x: Array[Int]        => java.util.Arrays.copyOf(x, newLength)
+    case x: Array[Double]     => java.util.Arrays.copyOf(x, newLength)
+    case x: Array[Long]       => java.util.Arrays.copyOf(x, newLength)
+    case x: Array[Float]      => java.util.Arrays.copyOf(x, newLength)
+    case x: Array[Char]       => java.util.Arrays.copyOf(x, newLength)
+    case x: Array[Byte]       => java.util.Arrays.copyOf(x, newLength)
+    case x: Array[Short]      => java.util.Arrays.copyOf(x, newLength)
+    case x: Array[Boolean]    => java.util.Arrays.copyOf(x, newLength)
   }).asInstanceOf[Array[A]]
 
   /** Copy one array to another, truncating or padding with default values (if
@@ -148,28 +148,28 @@ object Array {
    * @see `java.util.Arrays#copyOf`
    */
   def copyAs[A](original: Array[_], newLength: Int)(implicit ct: ClassTag[A]): Array[A] = {
-	val runtimeClass = ct.runtimeClass
-	if (runtimeClass == Void.TYPE) newUnitArray(newLength).asInstanceOf[Array[A]]
-	else {
-	  val destClass = runtimeClass.asInstanceOf[Class[A]]
-	  if (destClass.isAssignableFrom(original.getClass.getComponentType)) {
-		if (destClass.isPrimitive) copyOf[A](original.asInstanceOf[Array[A]], newLength)
-		else {
-		  val destArrayClass = java.lang.reflect.Array.newInstance(destClass, 0).getClass.asInstanceOf[Class[Array[AnyRef]]]
-		  java.util.Arrays.copyOf(original.asInstanceOf[Array[AnyRef]], newLength, destArrayClass).asInstanceOf[Array[A]]
-		}
-	  } else {
-		val dest = new Array[A](newLength)
-		Array.copy(original, 0, dest, 0, original.length)
-		dest
-	  }
-	}
+    val runtimeClass = ct.runtimeClass
+    if (runtimeClass == Void.TYPE) newUnitArray(newLength).asInstanceOf[Array[A]]
+    else {
+      val destClass = runtimeClass.asInstanceOf[Class[A]]
+      if (destClass.isAssignableFrom(original.getClass.getComponentType)) {
+        if (destClass.isPrimitive) copyOf[A](original.asInstanceOf[Array[A]], newLength)
+        else {
+          val destArrayClass = java.lang.reflect.Array.newInstance(destClass, 0).getClass.asInstanceOf[Class[Array[AnyRef]]]
+          java.util.Arrays.copyOf(original.asInstanceOf[Array[AnyRef]], newLength, destArrayClass).asInstanceOf[Array[A]]
+        }
+      } else {
+        val dest = new Array[A](newLength)
+        Array.copy(original, 0, dest, 0, original.length)
+        dest
+      }
+    }
   }
 
   private def newUnitArray(len: Int): Array[Unit] = {
-	val result = new Array[Unit](len)
-	java.util.Arrays.fill(result.asInstanceOf[Array[AnyRef]], ())
-	result
+    val result = new Array[Unit](len)
+    java.util.Arrays.fill(result.asInstanceOf[Array[AnyRef]], ())
+    result
   }
 
   /** Returns an array of length 0 */
@@ -183,150 +183,150 @@ object Array {
   // Subject to a compiler optimization in Cleanup.
   // Array(e0, ..., en) is translated to { val a = new Array(3); a(i) = ei; a }
   def apply[T: ClassTag](xs: T*): Array[T] = {
-	val array = new Array[T](xs.length)
-	val iterator = xs.iterator
-	var i = 0
-	while (iterator.hasNext) {
-	  array(i) = iterator.next(); i += 1
-	}
-	array
+    val array = new Array[T](xs.length)
+    val iterator = xs.iterator
+    var i = 0
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
+    array
   }
 
   /** Creates an array of `Boolean` objects */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
-	val array = new Array[Boolean](xs.length + 1)
-	array(0) = x
-	val iterator = xs.iterator
-	var i = 1
-	while (iterator.hasNext) {
-	  array(i) = iterator.next(); i += 1
-	}
-	array
+    val array = new Array[Boolean](xs.length + 1)
+    array(0) = x
+    val iterator = xs.iterator
+    var i = 1
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
+    array
   }
 
   /** Creates an array of `Byte` objects */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Byte, xs: Byte*): Array[Byte] = {
-	val array = new Array[Byte](xs.length + 1)
-	array(0) = x
-	val iterator = xs.iterator
-	var i = 1
-	while (iterator.hasNext) {
-	  array(i) = iterator.next(); i += 1
-	}
-	array
+    val array = new Array[Byte](xs.length + 1)
+    array(0) = x
+    val iterator = xs.iterator
+    var i = 1
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
+    array
   }
 
   /** Creates an array of `Short` objects */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Short, xs: Short*): Array[Short] = {
-	val array = new Array[Short](xs.length + 1)
-	array(0) = x
-	val iterator = xs.iterator
-	var i = 1
-	while (iterator.hasNext) {
-	  array(i) = iterator.next(); i += 1
-	}
-	array
+    val array = new Array[Short](xs.length + 1)
+    array(0) = x
+    val iterator = xs.iterator
+    var i = 1
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
+    array
   }
 
   /** Creates an array of `Char` objects */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Char, xs: Char*): Array[Char] = {
-	val array = new Array[Char](xs.length + 1)
-	array(0) = x
-	val iterator = xs.iterator
-	var i = 1
-	while (iterator.hasNext) {
-	  array(i) = iterator.next(); i += 1
-	}
-	array
+    val array = new Array[Char](xs.length + 1)
+    array(0) = x
+    val iterator = xs.iterator
+    var i = 1
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
+    array
   }
 
   /** Creates an array of `Int` objects */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Int, xs: Int*): Array[Int] = {
-	val array = new Array[Int](xs.length + 1)
-	array(0) = x
-	val iterator = xs.iterator
-	var i = 1
-	while (iterator.hasNext) {
-	  array(i) = iterator.next(); i += 1
-	}
-	array
+    val array = new Array[Int](xs.length + 1)
+    array(0) = x
+    val iterator = xs.iterator
+    var i = 1
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
+    array
   }
 
   /** Creates an array of `Long` objects */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Long, xs: Long*): Array[Long] = {
-	val array = new Array[Long](xs.length + 1)
-	array(0) = x
-	val iterator = xs.iterator
-	var i = 1
-	while (iterator.hasNext) {
-	  array(i) = iterator.next(); i += 1
-	}
-	array
+    val array = new Array[Long](xs.length + 1)
+    array(0) = x
+    val iterator = xs.iterator
+    var i = 1
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
+    array
   }
 
   /** Creates an array of `Float` objects */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Float, xs: Float*): Array[Float] = {
-	val array = new Array[Float](xs.length + 1)
-	array(0) = x
-	val iterator = xs.iterator
-	var i = 1
-	while (iterator.hasNext) {
-	  array(i) = iterator.next(); i += 1
-	}
-	array
+    val array = new Array[Float](xs.length + 1)
+    array(0) = x
+    val iterator = xs.iterator
+    var i = 1
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
+    array
   }
 
   /** Creates an array of `Double` objects */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Double, xs: Double*): Array[Double] = {
-	val array = new Array[Double](xs.length + 1)
-	array(0) = x
-	val iterator = xs.iterator
-	var i = 1
-	while (iterator.hasNext) {
-	  array(i) = iterator.next(); i += 1
-	}
-	array
+    val array = new Array[Double](xs.length + 1)
+    array(0) = x
+    val iterator = xs.iterator
+    var i = 1
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
+    array
   }
 
   /** Creates an array of `Unit` objects */
   def apply(x: Unit, xs: Unit*): Array[Unit] = {
-	val array = new Array[Unit](xs.length + 1)
-	array(0) = x
-	val iterator = xs.iterator
-	var i = 1
-	while (iterator.hasNext) {
-	  array(i) = iterator.next(); i += 1
-	}
-	array
+    val array = new Array[Unit](xs.length + 1)
+    array(0) = x
+    val iterator = xs.iterator
+    var i = 1
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
+    array
   }
 
   /** Creates array with given dimensions */
   def ofDim[T: ClassTag](n1: Int): Array[T] =
-	new Array[T](n1)
+    new Array[T](n1)
   /** Creates a 2-dimensional array */
   def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
-	val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
-	for (i <- 0 until n1) arr(i) = new Array[T](n2)
-	arr
-	// tabulate(n1)(_ => ofDim[T](n2))
+    val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
+    for (i <- 0 until n1) arr(i) = new Array[T](n2)
+    arr
+    // tabulate(n1)(_ => ofDim[T](n2))
   }
   /** Creates a 3-dimensional array */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
-	tabulate(n1)(_ => ofDim[T](n2, n3))
+    tabulate(n1)(_ => ofDim[T](n2, n3))
   /** Creates a 4-dimensional array */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
-	tabulate(n1)(_ => ofDim[T](n2, n3, n4))
+    tabulate(n1)(_ => ofDim[T](n2, n3, n4))
   /** Creates a 5-dimensional array */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
-	tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
+    tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
 
   /** Concatenates all arrays into a single array.
    *
@@ -334,10 +334,10 @@ object Array {
    *  @return   the array created from concatenating `xss`
    */
   def concat[T: ClassTag](xss: Array[T]*): Array[T] = {
-	val b = newBuilder[T]
-	b.sizeHint(xss.map(_.length).sum)
-	for (xs <- xss) b ++= xs
-	b.result()
+    val b = newBuilder[T]
+    b.sizeHint(xss.map(_.length).sum)
+    for (xs <- xss) b ++= xs
+    b.result()
   }
 
   /** Returns an array that contains the results of some element computation a number
@@ -355,17 +355,17 @@ object Array {
    *  `elem`.
    */
   def fill[T: ClassTag](n: Int)(elem: => T): Array[T] = {
-	if (n <= 0) {
-	  empty[T]
-	} else {
-	  val array = new Array[T](n)
-	  var i = 0
-	  while (i < n) {
-		array(i) = elem
-		i += 1
-	  }
-	  array
-	}
+    if (n <= 0) {
+      empty[T]
+    } else {
+      val array = new Array[T](n)
+      var i = 0
+      while (i < n) {
+        array(i) = elem
+        i += 1
+      }
+      array
+    }
   }
 
   /** Returns a two-dimensional array that contains the results of some element
@@ -376,7 +376,7 @@ object Array {
    *  @param   elem the element computation
    */
   def fill[T: ClassTag](n1: Int, n2: Int)(elem: => T): Array[Array[T]] =
-	tabulate(n1)(_ => fill(n2)(elem))
+    tabulate(n1)(_ => fill(n2)(elem))
 
   /** Returns a three-dimensional array that contains the results of some element
    *  computation a number of times.
@@ -387,7 +387,7 @@ object Array {
    *  @param   elem the element computation
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int)(elem: => T): Array[Array[Array[T]]] =
-	tabulate(n1)(_ => fill(n2, n3)(elem))
+    tabulate(n1)(_ => fill(n2, n3)(elem))
 
   /** Returns a four-dimensional array that contains the results of some element
    *  computation a number of times.
@@ -399,7 +399,7 @@ object Array {
    *  @param   elem the element computation
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => T): Array[Array[Array[Array[T]]]] =
-	tabulate(n1)(_ => fill(n2, n3, n4)(elem))
+    tabulate(n1)(_ => fill(n2, n3, n4)(elem))
 
   /** Returns a five-dimensional array that contains the results of some element
    *  computation a number of times.
@@ -412,7 +412,7 @@ object Array {
    *  @param   elem the element computation
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => T): Array[Array[Array[Array[Array[T]]]]] =
-	tabulate(n1)(_ => fill(n2, n3, n4, n5)(elem))
+    tabulate(n1)(_ => fill(n2, n3, n4, n5)(elem))
 
   /** Returns an array containing values of a given function over a range of integer
    *  values starting from 0.
@@ -422,17 +422,17 @@ object Array {
    *  @return A traversable consisting of elements `f(0),f(1), ..., f(n - 1)`
    */
   def tabulate[T: ClassTag](n: Int)(f: Int => T): Array[T] = {
-	if (n <= 0) {
-	  empty[T]
-	} else {
-	  val array = new Array[T](n)
-	  var i = 0
-	  while (i < n) {
-		array(i) = f(i)
-		i += 1
-	  }
-	  array
-	}
+    if (n <= 0) {
+      empty[T]
+    } else {
+      val array = new Array[T](n)
+      var i = 0
+      while (i < n) {
+        array(i) = f(i)
+        i += 1
+      }
+      array
+    }
   }
 
   /** Returns a two-dimensional array containing values of a given function
@@ -443,7 +443,7 @@ object Array {
    *  @param   f   The function computing element values
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int)(f: (Int, Int) => T): Array[Array[T]] =
-	tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
+    tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
 
   /** Returns a three-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
@@ -454,7 +454,7 @@ object Array {
    *  @param   f   The function computing element values
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => T): Array[Array[Array[T]]] =
-	tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
+    tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
 
   /** Returns a four-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
@@ -466,7 +466,7 @@ object Array {
    *  @param   f   The function computing element values
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => T): Array[Array[Array[Array[T]]]] =
-	tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
+    tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
 
   /** Returns a five-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
@@ -479,7 +479,7 @@ object Array {
    *  @param   f   The function computing element values
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => T): Array[Array[Array[Array[Array[T]]]]] =
-	tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
+    tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
 
   /** Returns an array containing a sequence of increasing integers in a range.
    *
@@ -498,17 +498,17 @@ object Array {
    *  @return      the array with values in `start, start + step, ...` up to, but excluding `end`
    */
   def range(start: Int, end: Int, step: Int): Array[Int] = {
-	if (step == 0) throw new IllegalArgumentException("zero step")
-	val array = new Array[Int](immutable.Range.count(start, end, step, isInclusive = false))
+    if (step == 0) throw new IllegalArgumentException("zero step")
+    val array = new Array[Int](immutable.Range.count(start, end, step, isInclusive = false))
 
-	var n = 0
-	var i = start
-	while (if (step < 0) end < i else i < end) {
-	  array(n) = i
-	  i += step
-	  n += 1
-	}
-	array
+    var n = 0
+    var i = start
+    while (if (step < 0) end < i else i < end) {
+      array(n) = i
+      i += step
+      n += 1
+    }
+    array
   }
 
   /** Returns an array containing repeated applications of a function to a start value.
@@ -519,37 +519,37 @@ object Array {
    *  @return      the array returning `len` values in the sequence `start, f(start), f(f(start)), ...`
    */
   def iterate[T: ClassTag](start: T, len: Int)(f: T => T): Array[T] = {
-	if (len > 0) {
-	  val array = new Array[T](len)
-	  var acc = start
-	  var i = 1
-	  array(0) = acc
+    if (len > 0) {
+      val array = new Array[T](len)
+      var acc = start
+      var i = 1
+      array(0) = acc
 
-	  while (i < len) {
-		acc = f(acc)
-		array(i) = acc
-		i += 1
-	  }
-	  array
-	} else {
-	  empty[T]
-	}
+      while (i < len) {
+        acc = f(acc)
+        array(i) = acc
+        i += 1
+      }
+      array
+    } else {
+      empty[T]
+    }
   }
 
   def equals(xs: Array[AnyRef], ys: Array[AnyRef]): Boolean = {
-	if (xs eq ys)
-	  return true
-	if (xs.length != ys.length)
-	  return false
+    if (xs eq ys)
+      return true
+    if (xs.length != ys.length)
+      return false
 
-	val len = xs.length
-	var i = 0
-	while (i < len) {
-	  if (xs(i) != ys(i))
-		return false
-	  i += 1
-	}
-	true
+    val len = xs.length
+    var i = 0
+    while (i < len) {
+      if (xs(i) != ys(i))
+        return false
+      i += 1
+    }
+    true
   }
 
   /** Called in a pattern match like `{ case Array(x,y,z) => println('3 elements')}`.
@@ -560,12 +560,12 @@ object Array {
   def unapplySeq[T](x: Array[T]): UnapplySeqWrapper[T] = new UnapplySeqWrapper(x)
 
   final class UnapplySeqWrapper[T](private val a: Array[T]) extends AnyVal {
-	def isEmpty: Boolean = false
-	def get: UnapplySeqWrapper[T] = this
-	def lengthCompare(len: Int): Int = a.lengthCompare(len)
-	def apply(i: Int): T = a(i)
-	def drop(n: Int): scala.Seq[T] = ArraySeq.unsafeWrapArray(a.drop(n)) // clones the array, also if n == 0
-	def toSeq: scala.Seq[T] = a.toSeq // clones the array
+    def isEmpty: Boolean = false
+    def get: UnapplySeqWrapper[T] = this
+    def lengthCompare(len: Int): Int = a.lengthCompare(len)
+    def apply(i: Int): T = a(i)
+    def drop(n: Int): scala.Seq[T] = ArraySeq.unsafeWrapArray(a.drop(n)) // clones the array, also if n == 0
+    def toSeq: scala.Seq[T] = a.toSeq // clones the array
   }
 }
 

--- a/scalalib/overrides-2.13/scala/Array.scala
+++ b/scalalib/overrides-2.13/scala/Array.scala
@@ -1,0 +1,673 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+//import scala.collection.generic._
+import scala.collection.{Factory, immutable, mutable}
+import mutable.ArrayBuilder
+import immutable.ArraySeq
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+import scala.runtime.BoxedUnit
+import scala.runtime.ScalaRunTime.{array_apply, array_update}
+
+/** Utility methods for operating on arrays.
+ *  For example:
+ *  {{{
+ *  val a = Array(1, 2)
+ *  val b = Array.ofDim[Int](2)
+ *  val c = Array.concat(a, b)
+ *  }}}
+ *  where the array objects `a`, `b` and `c` have respectively the values
+ *  `Array(1, 2)`, `Array(0, 0)` and `Array(1, 2, 0, 0)`.
+ */
+object Array {
+  val emptyBooleanArray = new Array[Boolean](0)
+  val emptyByteArray    = new Array[Byte](0)
+  val emptyCharArray    = new Array[Char](0)
+  val emptyDoubleArray  = new Array[Double](0)
+  val emptyFloatArray   = new Array[Float](0)
+  val emptyIntArray     = new Array[Int](0)
+  val emptyLongArray    = new Array[Long](0)
+  val emptyShortArray   = new Array[Short](0)
+  val emptyObjectArray  = new Array[Object](0)
+
+  /** Provides an implicit conversion from the Array object to a collection Factory */
+  implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
+  @SerialVersionUID(3L)
+  private class ArrayFactory[A : ClassTag](dummy: Array.type) extends Factory[A, Array[A]] with Serializable {
+	def fromSpecific(it: IterableOnce[A]): Array[A] = Array.from[A](it)
+	def newBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder[A]
+  }
+
+  /**
+   * Returns a new [[scala.collection.mutable.ArrayBuilder]].
+   */
+  def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](t)
+
+  /** Build an array from the iterable collection.
+   *
+   *  {{{
+   *  scala> val a = Array.from(Seq(1, 5))
+   *  val a: Array[Int] = Array(1, 5)
+   *
+   *  scala> val b = Array.from(Range(1, 5))
+   *  val b: Array[Int] = Array(1, 2, 3, 4)
+   *  }}}
+   *
+   *  @param  it the iterable collection
+   *  @return    an array consisting of elements of the iterable collection
+   */
+  def from[A : ClassTag](it: IterableOnce[A]): Array[A] = it match {
+	case it: Iterable[A] => it.toArray[A]
+	case _ => it.iterator.toArray[A]
+  }
+
+  private def slowcopy(src : AnyRef,
+	srcPos : Int,
+	dest : AnyRef,
+	destPos : Int,
+	length : Int): Unit = {
+	var i = srcPos
+	var j = destPos
+	val srcUntil = srcPos + length
+	while (i < srcUntil) {
+	  array_update(dest, j, array_apply(src, i))
+	  i += 1
+	  j += 1
+	}
+  }
+
+  /** Copy one array to another.
+   *  Equivalent to Java's
+   *    `System.arraycopy(src, srcPos, dest, destPos, length)`,
+   *  except that this also works for polymorphic and boxed arrays.
+   *
+   *  Note that the passed-in `dest` array will be modified by this call.
+   *
+   *  @param src the source array.
+   *  @param srcPos  starting position in the source array.
+   *  @param dest destination array.
+   *  @param destPos starting position in the destination array.
+   *  @param length the number of array elements to be copied.
+   *
+   *  @see `java.lang.System#arraycopy`
+   */
+  def copy(src: AnyRef, srcPos: Int, dest: AnyRef, destPos: Int, length: Int): Unit = {
+	val srcClass = src.getClass
+	if (srcClass.isArray && dest.getClass.isAssignableFrom(srcClass))
+	  java.lang.System.arraycopy(src, srcPos, dest, destPos, length)
+	else
+	  slowcopy(src, srcPos, dest, destPos, length)
+  }
+
+  /** Copy one array to another, truncating or padding with default values (if
+   * necessary) so the copy has the specified length.
+   *
+   * Equivalent to Java's
+   *   `java.util.Arrays.copyOf(original, newLength)`,
+   * except that this works for primitive and object arrays in a single method.
+   *
+   * @see `java.util.Arrays#copyOf`
+   */
+  def copyOf[A](original: Array[A], newLength: Int): Array[A] = ((original: @unchecked) match {
+//  We cannot distinguish Array[BoxedUnit] from Array[Object] in Scala Native
+//	case x: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
+	case x: Array[AnyRef]     => java.util.Arrays.copyOf(x, newLength)
+	case x: Array[Int]        => java.util.Arrays.copyOf(x, newLength)
+	case x: Array[Double]     => java.util.Arrays.copyOf(x, newLength)
+	case x: Array[Long]       => java.util.Arrays.copyOf(x, newLength)
+	case x: Array[Float]      => java.util.Arrays.copyOf(x, newLength)
+	case x: Array[Char]       => java.util.Arrays.copyOf(x, newLength)
+	case x: Array[Byte]       => java.util.Arrays.copyOf(x, newLength)
+	case x: Array[Short]      => java.util.Arrays.copyOf(x, newLength)
+	case x: Array[Boolean]    => java.util.Arrays.copyOf(x, newLength)
+  }).asInstanceOf[Array[A]]
+
+  /** Copy one array to another, truncating or padding with default values (if
+   * necessary) so the copy has the specified length. The new array can have
+   * a different type than the original one as long as the values are
+   * assignment-compatible. When copying between primitive and object arrays,
+   * boxing and unboxing are supported.
+   *
+   * Equivalent to Java's
+   *   `java.util.Arrays.copyOf(original, newLength, newType)`,
+   * except that this works for all combinations of primitive and object arrays
+   * in a single method.
+   *
+   * @see `java.util.Arrays#copyOf`
+   */
+  def copyAs[A](original: Array[_], newLength: Int)(implicit ct: ClassTag[A]): Array[A] = {
+	val runtimeClass = ct.runtimeClass
+	if (runtimeClass == Void.TYPE) newUnitArray(newLength).asInstanceOf[Array[A]]
+	else {
+	  val destClass = runtimeClass.asInstanceOf[Class[A]]
+	  if (destClass.isAssignableFrom(original.getClass.getComponentType)) {
+		if (destClass.isPrimitive) copyOf[A](original.asInstanceOf[Array[A]], newLength)
+		else {
+		  val destArrayClass = java.lang.reflect.Array.newInstance(destClass, 0).getClass.asInstanceOf[Class[Array[AnyRef]]]
+		  java.util.Arrays.copyOf(original.asInstanceOf[Array[AnyRef]], newLength, destArrayClass).asInstanceOf[Array[A]]
+		}
+	  } else {
+		val dest = new Array[A](newLength)
+		Array.copy(original, 0, dest, 0, original.length)
+		dest
+	  }
+	}
+  }
+
+  private def newUnitArray(len: Int): Array[Unit] = {
+	val result = new Array[Unit](len)
+	java.util.Arrays.fill(result.asInstanceOf[Array[AnyRef]], ())
+	result
+  }
+
+  /** Returns an array of length 0 */
+  def empty[T: ClassTag]: Array[T] = new Array[T](0)
+
+  /** Creates an array with given elements.
+   *
+   *  @param xs the elements to put in the array
+   *  @return an array containing all elements from xs.
+   */
+  // Subject to a compiler optimization in Cleanup.
+  // Array(e0, ..., en) is translated to { val a = new Array(3); a(i) = ei; a }
+  def apply[T: ClassTag](xs: T*): Array[T] = {
+	val array = new Array[T](xs.length)
+	val iterator = xs.iterator
+	var i = 0
+	while (iterator.hasNext) {
+	  array(i) = iterator.next(); i += 1
+	}
+	array
+  }
+
+  /** Creates an array of `Boolean` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
+	val array = new Array[Boolean](xs.length + 1)
+	array(0) = x
+	val iterator = xs.iterator
+	var i = 1
+	while (iterator.hasNext) {
+	  array(i) = iterator.next(); i += 1
+	}
+	array
+  }
+
+  /** Creates an array of `Byte` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Byte, xs: Byte*): Array[Byte] = {
+	val array = new Array[Byte](xs.length + 1)
+	array(0) = x
+	val iterator = xs.iterator
+	var i = 1
+	while (iterator.hasNext) {
+	  array(i) = iterator.next(); i += 1
+	}
+	array
+  }
+
+  /** Creates an array of `Short` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Short, xs: Short*): Array[Short] = {
+	val array = new Array[Short](xs.length + 1)
+	array(0) = x
+	val iterator = xs.iterator
+	var i = 1
+	while (iterator.hasNext) {
+	  array(i) = iterator.next(); i += 1
+	}
+	array
+  }
+
+  /** Creates an array of `Char` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Char, xs: Char*): Array[Char] = {
+	val array = new Array[Char](xs.length + 1)
+	array(0) = x
+	val iterator = xs.iterator
+	var i = 1
+	while (iterator.hasNext) {
+	  array(i) = iterator.next(); i += 1
+	}
+	array
+  }
+
+  /** Creates an array of `Int` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Int, xs: Int*): Array[Int] = {
+	val array = new Array[Int](xs.length + 1)
+	array(0) = x
+	val iterator = xs.iterator
+	var i = 1
+	while (iterator.hasNext) {
+	  array(i) = iterator.next(); i += 1
+	}
+	array
+  }
+
+  /** Creates an array of `Long` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Long, xs: Long*): Array[Long] = {
+	val array = new Array[Long](xs.length + 1)
+	array(0) = x
+	val iterator = xs.iterator
+	var i = 1
+	while (iterator.hasNext) {
+	  array(i) = iterator.next(); i += 1
+	}
+	array
+  }
+
+  /** Creates an array of `Float` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Float, xs: Float*): Array[Float] = {
+	val array = new Array[Float](xs.length + 1)
+	array(0) = x
+	val iterator = xs.iterator
+	var i = 1
+	while (iterator.hasNext) {
+	  array(i) = iterator.next(); i += 1
+	}
+	array
+  }
+
+  /** Creates an array of `Double` objects */
+  // Subject to a compiler optimization in Cleanup, see above.
+  def apply(x: Double, xs: Double*): Array[Double] = {
+	val array = new Array[Double](xs.length + 1)
+	array(0) = x
+	val iterator = xs.iterator
+	var i = 1
+	while (iterator.hasNext) {
+	  array(i) = iterator.next(); i += 1
+	}
+	array
+  }
+
+  /** Creates an array of `Unit` objects */
+  def apply(x: Unit, xs: Unit*): Array[Unit] = {
+	val array = new Array[Unit](xs.length + 1)
+	array(0) = x
+	val iterator = xs.iterator
+	var i = 1
+	while (iterator.hasNext) {
+	  array(i) = iterator.next(); i += 1
+	}
+	array
+  }
+
+  /** Creates array with given dimensions */
+  def ofDim[T: ClassTag](n1: Int): Array[T] =
+	new Array[T](n1)
+  /** Creates a 2-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
+	val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
+	for (i <- 0 until n1) arr(i) = new Array[T](n2)
+	arr
+	// tabulate(n1)(_ => ofDim[T](n2))
+  }
+  /** Creates a 3-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
+	tabulate(n1)(_ => ofDim[T](n2, n3))
+  /** Creates a 4-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
+	tabulate(n1)(_ => ofDim[T](n2, n3, n4))
+  /** Creates a 5-dimensional array */
+  def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
+	tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
+
+  /** Concatenates all arrays into a single array.
+   *
+   *  @param xss the given arrays
+   *  @return   the array created from concatenating `xss`
+   */
+  def concat[T: ClassTag](xss: Array[T]*): Array[T] = {
+	val b = newBuilder[T]
+	b.sizeHint(xss.map(_.length).sum)
+	for (xs <- xss) b ++= xs
+	b.result()
+  }
+
+  /** Returns an array that contains the results of some element computation a number
+   *  of times.
+   *
+   *  Note that this means that `elem` is computed a total of n times:
+   *  {{{
+   * scala> Array.fill(3){ math.random }
+   * res3: Array[Double] = Array(0.365461167592537, 1.550395944913685E-4, 0.7907242137333306)
+   *  }}}
+   *
+   *  @param   n  the number of elements desired
+   *  @param   elem the element computation
+   *  @return an Array of size n, where each element contains the result of computing
+   *  `elem`.
+   */
+  def fill[T: ClassTag](n: Int)(elem: => T): Array[T] = {
+	if (n <= 0) {
+	  empty[T]
+	} else {
+	  val array = new Array[T](n)
+	  var i = 0
+	  while (i < n) {
+		array(i) = elem
+		i += 1
+	  }
+	  array
+	}
+  }
+
+  /** Returns a two-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int)(elem: => T): Array[Array[T]] =
+	tabulate(n1)(_ => fill(n2)(elem))
+
+  /** Returns a three-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int, n3: Int)(elem: => T): Array[Array[Array[T]]] =
+	tabulate(n1)(_ => fill(n2, n3)(elem))
+
+  /** Returns a four-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => T): Array[Array[Array[Array[T]]]] =
+	tabulate(n1)(_ => fill(n2, n3, n4)(elem))
+
+  /** Returns a five-dimensional array that contains the results of some element
+   *  computation a number of times.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   elem the element computation
+   */
+  def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => T): Array[Array[Array[Array[Array[T]]]]] =
+	tabulate(n1)(_ => fill(n2, n3, n4, n5)(elem))
+
+  /** Returns an array containing values of a given function over a range of integer
+   *  values starting from 0.
+   *
+   *  @param  n   The number of elements in the array
+   *  @param  f   The function computing element values
+   *  @return A traversable consisting of elements `f(0),f(1), ..., f(n - 1)`
+   */
+  def tabulate[T: ClassTag](n: Int)(f: Int => T): Array[T] = {
+	if (n <= 0) {
+	  empty[T]
+	} else {
+	  val array = new Array[T](n)
+	  var i = 0
+	  while (i < n) {
+		array(i) = f(i)
+		i += 1
+	  }
+	  array
+	}
+  }
+
+  /** Returns a two-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int)(f: (Int, Int) => T): Array[Array[T]] =
+	tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
+
+  /** Returns a three-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => T): Array[Array[Array[T]]] =
+	tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
+
+  /** Returns a four-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => T): Array[Array[Array[Array[T]]]] =
+	tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
+
+  /** Returns a five-dimensional array containing values of a given function
+   *  over ranges of integer values starting from `0`.
+   *
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   f   The function computing element values
+   */
+  def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => T): Array[Array[Array[Array[Array[T]]]]] =
+	tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
+
+  /** Returns an array containing a sequence of increasing integers in a range.
+   *
+   *  @param start  the start value of the array
+   *  @param end    the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @return  the array with values in range `start, start + 1, ..., end - 1`
+   *  up to, but excluding, `end`.
+   */
+  def range(start: Int, end: Int): Array[Int] = range(start, end, 1)
+
+  /** Returns an array containing equally spaced values in some integer interval.
+   *
+   *  @param start the start value of the array
+   *  @param end   the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @param step  the increment value of the array (may not be zero)
+   *  @return      the array with values in `start, start + step, ...` up to, but excluding `end`
+   */
+  def range(start: Int, end: Int, step: Int): Array[Int] = {
+	if (step == 0) throw new IllegalArgumentException("zero step")
+	val array = new Array[Int](immutable.Range.count(start, end, step, isInclusive = false))
+
+	var n = 0
+	var i = start
+	while (if (step < 0) end < i else i < end) {
+	  array(n) = i
+	  i += step
+	  n += 1
+	}
+	array
+  }
+
+  /** Returns an array containing repeated applications of a function to a start value.
+   *
+   *  @param start the start value of the array
+   *  @param len   the number of elements returned by the array
+   *  @param f     the function that is repeatedly applied
+   *  @return      the array returning `len` values in the sequence `start, f(start), f(f(start)), ...`
+   */
+  def iterate[T: ClassTag](start: T, len: Int)(f: T => T): Array[T] = {
+	if (len > 0) {
+	  val array = new Array[T](len)
+	  var acc = start
+	  var i = 1
+	  array(0) = acc
+
+	  while (i < len) {
+		acc = f(acc)
+		array(i) = acc
+		i += 1
+	  }
+	  array
+	} else {
+	  empty[T]
+	}
+  }
+
+  def equals(xs: Array[AnyRef], ys: Array[AnyRef]): Boolean = {
+	if (xs eq ys)
+	  return true
+	if (xs.length != ys.length)
+	  return false
+
+	val len = xs.length
+	var i = 0
+	while (i < len) {
+	  if (xs(i) != ys(i))
+		return false
+	  i += 1
+	}
+	true
+  }
+
+  /** Called in a pattern match like `{ case Array(x,y,z) => println('3 elements')}`.
+   *
+   *  @param x the selector value
+   *  @return  sequence wrapped in a [[scala.Some]], if `x` is an Array, otherwise `None`
+   */
+  def unapplySeq[T](x: Array[T]): UnapplySeqWrapper[T] = new UnapplySeqWrapper(x)
+
+  final class UnapplySeqWrapper[T](private val a: Array[T]) extends AnyVal {
+	def isEmpty: Boolean = false
+	def get: UnapplySeqWrapper[T] = this
+	def lengthCompare(len: Int): Int = a.lengthCompare(len)
+	def apply(i: Int): T = a(i)
+	def drop(n: Int): scala.Seq[T] = ArraySeq.unsafeWrapArray(a.drop(n)) // clones the array, also if n == 0
+	def toSeq: scala.Seq[T] = a.toSeq // clones the array
+  }
+}
+
+/** Arrays are mutable, indexed collections of values. `Array[T]` is Scala's representation
+ *  for Java's `T[]`.
+ *
+ *  {{{
+ *  val numbers = Array(1, 2, 3, 4)
+ *  val first = numbers(0) // read the first element
+ *  numbers(3) = 100 // replace the 4th array element with 100
+ *  val biggerNumbers = numbers.map(_ * 2) // multiply all numbers by two
+ *  }}}
+ *
+ *  Arrays make use of two common pieces of Scala syntactic sugar, shown on lines 2 and 3 of the above
+ *  example code.
+ *  Line 2 is translated into a call to `apply(Int)`, while line 3 is translated into a call to
+ *  `update(Int, T)`.
+ *
+ *  Two implicit conversions exist in [[scala.Predef]] that are frequently applied to arrays: a conversion
+ *  to [[scala.collection.ArrayOps]] (shown on line 4 of the example above) and a conversion
+ *  to [[scala.collection.mutable.ArraySeq]] (a subtype of [[scala.collection.Seq]]).
+ *  Both types make available many of the standard operations found in the Scala collections API.
+ *  The conversion to `ArrayOps` is temporary, as all operations defined on `ArrayOps` return an `Array`,
+ *  while the conversion to `ArraySeq` is permanent as all operations return a `ArraySeq`.
+ *
+ *  The conversion to `ArrayOps` takes priority over the conversion to `ArraySeq`. For instance,
+ *  consider the following code:
+ *
+ *  {{{
+ *  val arr = Array(1, 2, 3)
+ *  val arrReversed = arr.reverse
+ *  val seqReversed : collection.Seq[Int] = arr.reverse
+ *  }}}
+ *
+ *  Value `arrReversed` will be of type `Array[Int]`, with an implicit conversion to `ArrayOps` occurring
+ *  to perform the `reverse` operation. The value of `seqReversed`, on the other hand, will be computed
+ *  by converting to `ArraySeq` first and invoking the variant of `reverse` that returns another
+ *  `ArraySeq`.
+ *
+ *  @see [[http://www.scala-lang.org/files/archive/spec/2.13/ Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
+ *  @see [[http://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.
+ *  @see [[http://docs.scala-lang.org/overviews/collections/arrays.html "The Scala 2.8 Collections' API"]] section on `Array` by Martin Odersky for more information.
+ *  @hideImplicitConversion scala.Predef.booleanArrayOps
+ *  @hideImplicitConversion scala.Predef.byteArrayOps
+ *  @hideImplicitConversion scala.Predef.charArrayOps
+ *  @hideImplicitConversion scala.Predef.doubleArrayOps
+ *  @hideImplicitConversion scala.Predef.floatArrayOps
+ *  @hideImplicitConversion scala.Predef.intArrayOps
+ *  @hideImplicitConversion scala.Predef.longArrayOps
+ *  @hideImplicitConversion scala.Predef.refArrayOps
+ *  @hideImplicitConversion scala.Predef.shortArrayOps
+ *  @hideImplicitConversion scala.Predef.unitArrayOps
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapRefArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapIntArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapDoubleArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapLongArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapFloatArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapCharArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapByteArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapShortArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapBooleanArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.wrapUnitArray
+ *  @hideImplicitConversion scala.LowPriorityImplicits.genericWrapArray
+ *  @define coll array
+ *  @define Coll `Array`
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ *  @define collectExample
+ *  @define undefinedorder
+ */
+final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable {
+
+  /** The length of the array */
+  def length: Int = throw new Error()
+
+  /** The element at given index.
+   *
+   *  Indices start at `0`; `xs.apply(0)` is the first element of array `xs`.
+   *  Note the indexing syntax `xs(i)` is a shorthand for `xs.apply(i)`.
+   *
+   *  @param    i   the index
+   *  @return       the element at the given index
+   *  @throws       ArrayIndexOutOfBoundsException if `i < 0` or `length <= i`
+   */
+  def apply(i: Int): T = throw new Error()
+
+  /** Update the element at given index.
+   *
+   *  Indices start at `0`; `xs.update(i, x)` replaces the i^th^ element in the array.
+   *  Note the syntax `xs(i) = x` is a shorthand for `xs.update(i, x)`.
+   *
+   *  @param    i   the index
+   *  @param    x   the value to be written at index `i`
+   *  @throws       ArrayIndexOutOfBoundsException if `i < 0` or `length <= i`
+   */
+  def update(i: Int, x: T): Unit = { throw new Error() }
+
+  /** Clone the Array.
+   *
+   *  @return A clone of the Array.
+   */
+  override def clone(): Array[T] = throw new Error()
+}

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -289,8 +289,7 @@ object Generate {
     }
 
     def genArrayIds(): Unit = {
-      val tpes = Seq("BoxedUnit",
-                     "Boolean",
+      val tpes = Seq("Boolean",
                      "Char",
                      "Byte",
                      "Short",

--- a/unit-tests/src/test/scala-2.12/scala/Issue2025.scala
+++ b/unit-tests/src/test/scala-2.12/scala/Issue2025.scala
@@ -1,0 +1,51 @@
+package scala
+
+import org.junit.Test
+import org.junit.Assert._
+import scala.language.implicitConversions
+import scala.collection.mutable.ArraySeq
+
+// Collection Compat Issues
+class Issue2025 {
+
+  // from ArraySeqTest.t6727_and_t6440_and_8627
+  @Test def lazyListUnit(): Unit = {
+    assertTrue(
+      Stream.continually(()).filter(_ => true).take(2) == Seq((), ())
+    )
+    assertTrue(
+      Stream.continually(()).filterNot(_ => false).take(2) == Seq((), ())
+    )
+  }
+
+  // from LazyListTest.slice
+  @Test def implicitFailsAtRuntime(): Unit = {
+    //There is no real array wrapper in Scala 2.12- collections
+    implicit def array2ArraySeq[T](array: Array[T]): ArraySeq[T] =
+      genericArrayOps(array).to[ArraySeq]
+
+    def unit1(): Unit = {}
+    def unit2(): Unit = {}
+    assertEquals("Units are equal", unit1, unit2)
+    // unitArray is actually an instance of Immutable[BoxedUnit], the check to which is actually checked slice
+    // implementation of ofRef
+    val unitArray: ArraySeq[Unit] = Array(unit1, unit2, unit1, unit2)
+    check(unitArray, Array(unit1, unit1), Array(unit1, unit1))
+
+  }
+
+  private def check[T](
+      array: ArraySeq[T],
+      expectedSliceResult1: ArraySeq[T],
+      expectedSliceResult2: ArraySeq[T]
+  ) {
+    assertEquals(array, array.slice(-1, 4))
+    assertEquals(array, array.slice(0, 5))
+    assertEquals(array, array.slice(-1, 5))
+    assertEquals(expectedSliceResult1, array.slice(0, 2))
+    assertEquals(expectedSliceResult2, array.slice(1, 3))
+    assertEquals(ArraySeq.empty[Nothing], array.slice(1, 1))
+    assertEquals(ArraySeq.empty[Nothing], array.slice(2, 1))
+  }
+
+}

--- a/unit-tests/src/test/scala-2.13/scala/Issue2025.scala
+++ b/unit-tests/src/test/scala-2.13/scala/Issue2025.scala
@@ -1,0 +1,51 @@
+package scala
+
+import org.junit.Test
+import org.junit.Assert._
+import scala.language.implicitConversions
+import scala.collection.immutable.ArraySeq
+
+// Collection Compat Issues
+class Issue2025 {
+
+  // from ArraySeqTest.t6727_and_t6440_and_8627
+  @Test def lazyListUnit(): Unit = {
+    assertTrue(
+      LazyList.continually(()).filter(_ => true).take(2) == Seq((), ())
+    )
+    assertTrue(
+      LazyList.continually(()).filterNot(_ => false).take(2) == Seq((), ())
+    )
+  }
+
+  // from LazyListTest.slice
+  @Test def implicitFailsAtRuntime(): Unit = {
+    // fails at runtime
+    implicit def array2ArraySeq[T](array: Array[T]): ArraySeq[T] =
+      ArraySeq.unsafeWrapArray(array)
+
+    def unit1(): Unit = {}
+    def unit2(): Unit = {}
+    assertEquals("Units are equal", unit1, unit2)
+    // unitArray is actually an instance of Immutable[BoxedUnit], the check to which is actually checked slice
+    // implementation of ofRef
+    val unitArray: ArraySeq[Unit] = Array(unit1, unit2, unit1, unit2)
+    check(unitArray, Array(unit1, unit1), Array(unit1, unit1))
+
+  }
+
+  private def check[T](
+      array: ArraySeq[T],
+      expectedSliceResult1: ArraySeq[T],
+      expectedSliceResult2: ArraySeq[T]
+  ) {
+    assertEquals(array, array.slice(-1, 4))
+    assertEquals(array, array.slice(0, 5))
+    assertEquals(array, array.slice(-1, 5))
+    assertEquals(expectedSliceResult1, array.slice(0, 2))
+    assertEquals(expectedSliceResult2, array.slice(1, 3))
+    assertEquals(ArraySeq.empty[Nothing], array.slice(1, 1))
+    assertEquals(ArraySeq.empty[Nothing], array.slice(2, 1))
+  }
+
+}


### PR DESCRIPTION
This PR introduces another approach in order to resolve #2025. 
PR #2032 tried to change the inheritance of concrete array types, due to problems with casts and matching. 
This approach removes `BoxedUnitArray` from concrete array implementations. Its dictated by the fact that `Array[Unit]` is always translated to `Array[BoxedUnit]` which makes it an instance of `Array[AnyRef]`. 

Due to the limited information set of `Class[_]` we cannot get the correct Class.componentType. This may lead to problems at runtime. Only types with implemented component types were concreate `TArray` instances. One of them was removed `BoxedUnitArray`. This PR introduces regression as we no longer can distinguish `Array[BoxedUnit]` from other instances of `Array[_ <: AnyRef]`

Additional scalaib 2.13 override was added in order to fix the only existing usage of pattern matching on `Array[BoxedUnit]` in Scala stdlib. 