### PR TITLE
Scala 2.13.4 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.13.3, 2.12.12, 2.11.12]
+        scala: [2.13.4, 2.12.12, 2.11.12]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
@@ -109,13 +109,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.13.3, 2.12.12, 2.11.12]
+        scala: [2.13.4, 2.12.12, 2.11.12]
         build-mode: [ debug , release-fast ]
         gc: [ boehm, immix, commix ]
         # Create holes in grid to lower number of tests.
         # Excluded entries should have low impact on overall project coverage
         exclude:
-          - scala: 2.13.3
+          - scala: 2.13.4
             build-mode: debug
             gc: boehm
           - scala: 2.12.12
@@ -166,7 +166,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [ 2.13.3, 2.12.12, 2.11.12 ]
+        scala: [ 2.13.4, 2.12.12, 2.11.12 ]
         build-mode: [ debug, release-fast ]
     steps:
       - uses: actions/checkout@v2
@@ -210,7 +210,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.13.3, 2.12.12, 2.11.12]
+        scala: [2.13.4, 2.12.12, 2.11.12]
     steps:
       - uses: actions/checkout@v2
       - name: Calculate binary version

--- a/javalib/src/main/scala/java/io/PushbackReader.scala
+++ b/javalib/src/main/scala/java/io/PushbackReader.scala
@@ -27,7 +27,7 @@ class PushbackReader(in: Reader, size: Int) extends FilterReader(in) {
       throw new IOException("Stream closed")
     }
 
-    if (pos < buf.length()) {
+    if (pos < buf.length) {
       val r = buf(pos)
       pos += 1
       r
@@ -42,7 +42,7 @@ class PushbackReader(in: Reader, size: Int) extends FilterReader(in) {
         throw new IOException("Stream closed")
       }
 
-      if (offset < 0 || count < 0 || offset > buffer.length() - count) {
+      if (offset < 0 || count < 0 || offset > buffer.length - count) {
         throw new IndexOutOfBoundsException()
       }
 
@@ -50,7 +50,7 @@ class PushbackReader(in: Reader, size: Int) extends FilterReader(in) {
       var newOffset   = offset
       var copyLength  = 0
 
-      if (pos < buf.length()) {
+      if (pos < buf.length) {
         copyLength = if (buf.length - pos >= count) count else buf.length - pos
         System.arraycopy(buf, pos, buffer, newOffset, copyLength)
         newOffset += copyLength
@@ -84,7 +84,7 @@ class PushbackReader(in: Reader, size: Int) extends FilterReader(in) {
     throw new IOException("mark/reset not supported")
 
   def unread(buffer: Array[Char]): Unit =
-    unread(buffer, 0, buffer.length())
+    unread(buffer, 0, buffer.length)
 
   def unread(buffer: Array[Char], offset: Int, length: Int): Unit =
     lock.synchronized {
@@ -94,7 +94,7 @@ class PushbackReader(in: Reader, size: Int) extends FilterReader(in) {
       if (length > pos) {
         throw new IOException("Pushback buffer full")
       }
-      if (offset > buffer.length() - length || offset < 0) {
+      if (offset > buffer.length - length || offset < 0) {
         throw new ArrayIndexOutOfBoundsException()
       }
       if (length < 0) {
@@ -126,7 +126,7 @@ class PushbackReader(in: Reader, size: Int) extends FilterReader(in) {
     if (count == 0) {
       0
     } else {
-      val availableFromBuffer = buf.length() - pos
+      val availableFromBuffer = buf.length - pos
       if (availableFromBuffer > 0) {
         val requiredFromIn = count - availableFromBuffer
         if (requiredFromIn <= 0) {

--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -281,7 +281,7 @@ object Character {
     val indexMinus1 = index - 1
     val indexMinus2 = index - 2
 
-    val low = seq.charAt(indexMinus1)
+    val low = seq(indexMinus1)
 
     if (indexMinus2 < 0) {
       low

--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -398,7 +398,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     }
 
     val (unscaled, bufLength) = {
-      val u = ArrayCharSequence(in).subSequence(begin, index).toString
+      val u = new String(in, begin, index - begin)
       val b = index - begin
       // A decimal point was found
       if ((index <= last) && (in(index) == '.')) {
@@ -413,8 +413,8 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
           index += 1
         }
         _scale = index - begin
-        val subSeq = ArrayCharSequence(in).subSequence(begin, begin + _scale)
-        (u + subSeq.toString, b + _scale)
+        val subString = new String(in, begin, _scale)
+        (u + subString, b + _scale)
       } else {
         _scale = 0
         (u, b)

--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -398,7 +398,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     }
 
     val (unscaled, bufLength) = {
-      val u = in.subSequence(begin, index).toString
+      val u = ArrayCharSequence(in).subSequence(begin, index).toString
       val b = index - begin
       // A decimal point was found
       if ((index <= last) && (in(index) == '.')) {
@@ -413,7 +413,8 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
           index += 1
         }
         _scale = index - begin
-        (u + in.subSequence(begin, begin + _scale).toString, b + _scale)
+        val subSeq = ArrayCharSequence(in).subSequence(begin, begin + _scale)
+        (u + subSeq.toString, b + _scale)
       } else {
         _scale = 0
         (u, b)

--- a/javalib/src/main/scala/java/text/DecimalFormat.scala
+++ b/javalib/src/main/scala/java/text/DecimalFormat.scala
@@ -417,10 +417,11 @@ class DecimalFormat extends NumberFormat {
       case Pattern(PositivePattern(prefix, number, suffix), negative) =>
         prefix.map(_.value.mkString).foreach(setPositivePrefix)
         suffix.map(_.value.mkString).foreach(setPositiveSuffix)
-        negative.map {
+        negative.foreach {
           case NegativePattern(prefix, _, suffix) =>
             prefix.map(_.value.mkString).foreach(setNegativePrefix)
             suffix.map(_.value.mkString).foreach(setNegativeSuffix)
+          case _ => throw new MatchError(negative)
         }
         number match {
           case Number(Integer(max, min, grp), frac, exp) =>
@@ -437,9 +438,11 @@ class DecimalFormat extends NumberFormat {
               case Fraction(max, min) =>
                 setMaximumFractionDigits(max)
                 setMinimumFractionDigits(min)
+              case _ => throw new MatchError(frac)
             }
             decimalSepShown = frac.isDefined
             sciExpoDigits = exp.map(_.exp).getOrElse(0)
+          case _ => throw new MatchError(number)
         }
       case _ => throw new IllegalArgumentException
     }

--- a/javalib/src/main/scala/java/util/Objects.scala
+++ b/javalib/src/main/scala/java/util/Objects.scala
@@ -15,7 +15,7 @@ object Objects {
   @inline
   def equals(a: Any, b: Any): Boolean =
     if (a == null) b == null
-    else a.equals(b)
+    else a.asInstanceOf[AnyRef].equals(b)
 
   @inline
   def deepEquals(a: Any, b: Any): Boolean = {

--- a/javalib/src/main/scala/java/util/package.scala
+++ b/javalib/src/main/scala/java/util/package.scala
@@ -5,12 +5,7 @@ package object util {
   implicit private[util] class CompareNullablesOps(val self: Any)
       extends AnyVal {
     @inline
-    def ===(that: Any): Boolean = {
-      val aself = self.asInstanceOf[AnyRef]
-      val athat = that.asInstanceOf[AnyRef]
-      if (aself eq null) athat eq null
-      else aself.equals(athat)
-    }
+    def ===(that: Any): Boolean = Objects.equals(self, that)
 
     @inline
     def =:=(that: Any): Boolean = {

--- a/javalib/src/main/scala/java/util/package.scala
+++ b/javalib/src/main/scala/java/util/package.scala
@@ -5,9 +5,12 @@ package object util {
   implicit private[util] class CompareNullablesOps(val self: Any)
       extends AnyVal {
     @inline
-    def ===(that: Any): Boolean =
-      if (self.asInstanceOf[AnyRef] eq null) that.asInstanceOf[AnyRef] eq null
-      else self.equals(that)
+    def ===(that: Any): Boolean = {
+      val aself = self.asInstanceOf[AnyRef]
+      val athat = that.asInstanceOf[AnyRef]
+      if (aself eq null) athat eq null
+      else aself.equals(athat)
+    }
 
     @inline
     def =:=(that: Any): Boolean = {

--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -55,7 +55,7 @@ object Assert {
 
   @inline
   private def isEquals(expected: Any, actual: Any): Boolean =
-    expected.equals(actual)
+    expected == actual
 
   @noinline
   def assertEquals(expected: Any, actual: Any): Unit =

--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -3,6 +3,7 @@
  */
 package org.junit
 
+import java.util.Objects
 import org.hamcrest.{Matcher, MatcherAssert}
 import org.junit.internal.{ExactComparisonCriteria, InexactComparisonCriteria}
 
@@ -55,7 +56,7 @@ object Assert {
 
   @inline
   private def isEquals(expected: Any, actual: Any): Boolean =
-    expected == actual
+    Objects.equals(expected, actual)
 
   @noinline
   def assertEquals(expected: Any, actual: Any): Unit =

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -3,7 +3,7 @@ package build
 object ScalaVersions {
   val scala211: String = "2.11.12"
   val scala212: String = "2.12.12"
-  val scala213: String = "2.13.3"
+  val scala213: String = "2.13.4"
 
   val sbt10Version: String               = "1.1.6" // minimum version
   val sbt10ScalaVersion: String          = scala212

--- a/unit-tests/src/test/scala/java/lang/StringTest.scala
+++ b/unit-tests/src/test/scala/java/lang/StringTest.scala
@@ -399,7 +399,7 @@ class StringTest {
     // case of one high surrogate
     val hChar = '\ud801'
     val hStr  = hChar.toString
-    assertTrue(Character.isHighSurrogate(hChar) equals true)
+    assertTrue(Character.isHighSurrogate(hChar))
     assertTrue(hStr.length equals 1)
     assertTrue(hStr.toUpperCase equals hStr)
     // toUpperCase should consider String's offset


### PR DESCRIPTION
This PR adds support for Scala 2.13.4. `build.sbt` and CI would use this version to test 2.13 binary version

It fixes usages of no longer implicit `ArraySequenceOps` as well as pseudo-non-exhaustive match cases.