### PR TITLE
Upgrade build to sbt 1.4.4

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version = 1.4.2
+sbt.version = 1.4.4
 


### PR DESCRIPTION
Sbt 1.4.4 [Release Notes](https://github.com/sbt/sbt/releases/tag/v1.4.4)

A bug in Sbt 1.4.3 prevented Scala Native from completing the
build and test cycle.

I have been building Scala Native pretty intensively for several
days, doing full build & test cycles without problem.