### PR TITLE
Annotate j.u.f.BiFunction default methods.

### DIFF
--- a/javalib/src/main/scala/java/util/function/BiFunction.scala
+++ b/javalib/src/main/scala/java/util/function/BiFunction.scala
@@ -1,11 +1,17 @@
+// Corresponds to Scala.js commit:  d3a9711 dated: 2020-09-06
+// Design note: Do not use lambdas with Scala Native and Scala 2.11
+
 package java.util.function
 
+import scala.scalanative.annotation.JavaDefaultMethod
+
 trait BiFunction[T, U, R] { self =>
+  def apply(t: T, u: U): R
+
+  @JavaDefaultMethod
   def andThen[V](after: Function[_ >: R, _ <: V]): BiFunction[T, U, V] = {
     new BiFunction[T, U, V] {
-      override def apply(t: T, u: U): V = after.apply(self.apply(t, u))
+      def apply(t: T, u: U): V = after.apply(self.apply(t, u))
     }
   }
-
-  def apply(t: T, u: U): R
 }

--- a/unit-tests/src/test/scala/java/util/function/BiFunctionTest.scala
+++ b/unit-tests/src/test/scala/java/util/function/BiFunctionTest.scala
@@ -1,26 +1,34 @@
-package java.util.function
+// Ported from Scala.js commit: d3a9711 dated: 2020-09-06
 
-import org.junit.Ignore
-import org.junit.Test
+package org.scalanative.testsuite.javalib.util.function
+
+import java.util.function.{Function, BiFunction}
+
 import org.junit.Assert._
+import org.junit.Test
 
 class BiFunctionTest {
-  val f = new BiFunction[Integer, Integer, Integer] {
-    override def apply(x: Integer, y: Integer): Integer = {
-      x + y
+  import BiFunctionTest._
+
+  @Test def createAndApply(): Unit = {
+    assertEquals(3, addBiFunc(1, 2))
+  }
+
+  @Test def andThen(): Unit = {
+    assertEquals(4, addBiFunc.andThen(incFunc)(1, 2))
+  }
+}
+
+object BiFunctionTest {
+  private val addBiFunc: BiFunction[Int, Int, Int] = {
+    new BiFunction[Int, Int, Int] {
+      def apply(t: Int, u: Int): Int = t + u
     }
   }
 
-  @Test def biFunctionApplyIntegerInteger(): Unit = {
-    assertEquals(f(1, 2), 3)
-  }
-
-  val ff = new Function[Integer, Integer] {
-    override def apply(x: Integer): Integer = x + 1
-  }
-
-  @Ignore("#1229 - 2.11 does not have default method support")
-  @Test def biFunctionAndThen(): Unit = {
-    // assertEquals(f.andThen(ff)(1, 2), 4)
+  private val incFunc: Function[Int, Int] = {
+    new Function[Int, Int] {
+      def apply(t: Int): Int = t + 1
+    }
   }
 }


### PR DESCRIPTION
This PR builds upon merged PRs #1937 & #2040 by annotating the existing
j.u.f.BiFunction.scala and porting its corresponding BiFunctionTest
from Scala.js.

The existing file was edited rather than re-ported from the most current
Scala.js commit because the latter uses lambdas and those
do not play well when using Scala Native with Scala 2.11.