### PR TITLE
Fix #2044: Throw JVM-compliant ArrayIndexOutOfBoundsException for array ops

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -51,10 +51,10 @@ sealed abstract class Array[T]
   /** Raw pointer to the element. */
   def atRaw(i: Int): RawPtr
 
-  /** Loads element at i, throws IndexOutOfBoundsException. */
+  /** Loads element at i, throws ArrayIndexOutOfBoundsException. */
   def apply(i: Int): T
 
-  /** Stores value to element i, throws IndexOutOfBoundsException. */
+  /** Stores value to element i, throws ArrayIndexOutOfBoundsException. */
   def update(i: Int, value: T): Unit
 
   /** Create a shallow copy of given array. */
@@ -92,11 +92,11 @@ object Array {
     } else if (getRawType(from) != getRawType(to)) {
       throw new ArrayStoreException("Invalid array copy.")
     } else if (len < 0) {
-      throw new IndexOutOfBoundsException("length is negative")
+      throw new ArrayIndexOutOfBoundsException("length is negative")
     } else if (fromPos < 0 || fromPos + len > from.length) {
-      throw new IndexOutOfBoundsException(fromPos.toString)
+      throwOutOfBounds(fromPos)
     } else if (toPos < 0 || toPos + len > to.length) {
-      throw new IndexOutOfBoundsException(toPos.toString)
+      throwOutOfBounds(toPos)
     } else if (len == 0) {
       ()
     } else {
@@ -137,11 +137,11 @@ object Array {
     } else if (getRawType(left) != getRawType(right)) {
       throw new ArrayStoreException("Invalid array copy.")
     } else if (len < 0) {
-      throw new IndexOutOfBoundsException("length is negative")
+      throw new ArrayIndexOutOfBoundsException("length is negative")
     } else if (leftPos < 0 || leftPos + len > left.length) {
-      throw new IndexOutOfBoundsException(leftPos.toString)
+      throwOutOfBounds(leftPos)
     } else if (rightPos < 0 || rightPos + len > right.length) {
-      throw new IndexOutOfBoundsException(rightPos.toString)
+      throwOutOfBounds(rightPos)
     } else if (len == 0) {
       0
     } else {

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -51,10 +51,10 @@ sealed abstract class Array[T]
   /** Raw pointer to the element. */
   def atRaw(i: Int): RawPtr
 
-  /** Loads element at i, throws IndexOutOfBoundsException. */
+  /** Loads element at i, throws ArrayIndexOutOfBoundsException. */
   def apply(i: Int): T
 
-  /** Stores value to element i, throws IndexOutOfBoundsException. */
+  /** Stores value to element i, throws ArrayIndexOutOfBoundsException. */
   def update(i: Int, value: T): Unit
 
   /** Create a shallow copy of given array. */
@@ -92,11 +92,11 @@ object Array {
     } else if (getRawType(from) != getRawType(to)) {
       throw new ArrayStoreException("Invalid array copy.")
     } else if (len < 0) {
-      throw new IndexOutOfBoundsException("length is negative")
+      throw new ArrayIndexOutOfBoundsException("length is negative")
     } else if (fromPos < 0 || fromPos + len > from.length) {
-      throw new IndexOutOfBoundsException(fromPos.toString)
+      throwOutOfBounds(fromPos)
     } else if (toPos < 0 || toPos + len > to.length) {
-      throw new IndexOutOfBoundsException(toPos.toString)
+      throwOutOfBounds(toPos)
     } else if (len == 0) {
       ()
     } else {
@@ -137,11 +137,11 @@ object Array {
     } else if (getRawType(left) != getRawType(right)) {
       throw new ArrayStoreException("Invalid array copy.")
     } else if (len < 0) {
-      throw new IndexOutOfBoundsException("length is negative")
+      throw new ArrayIndexOutOfBoundsException("length is negative")
     } else if (leftPos < 0 || leftPos + len > left.length) {
-      throw new IndexOutOfBoundsException(leftPos.toString)
+      throwOutOfBounds(leftPos)
     } else if (rightPos < 0 || rightPos + len > right.length) {
-      throw new IndexOutOfBoundsException(rightPos.toString)
+      throwOutOfBounds(rightPos)
     } else if (len == 0) {
       0
     } else {

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -104,7 +104,7 @@ package object runtime {
 
   /** Called by the generated code in case of out of bounds on array access. */
   @noinline def throwOutOfBounds(i: Int): Nothing =
-    throw new IndexOutOfBoundsException(i.toString)
+    throw new ArrayIndexOutOfBoundsException(i.toString)
 
   /** Called by the generated code in case of missing method on reflective call. */
   @noinline def throwNoSuchMethod(sig: String): Nothing =

--- a/unit-tests/src/test/scala/scala/ArrayDoubleCopyTest.scala
+++ b/unit-tests/src/test/scala/scala/ArrayDoubleCopyTest.scala
@@ -103,29 +103,29 @@ class ArrayDoubleCopyTest {
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfLengthIsNegative(): Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 0, arr2, 5, -1))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfToPosPlusLenGreaterThanToLength()
       : Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 0, arr2, 5, 10))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfFromPosPlusLenGreaterThanFromLength()
       : Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 5, arr2, 0, 10))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfToPosIsNegative(): Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 0, arr2, -1, 10))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfFromPosIsNegative(): Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, -1, arr2, 0, 10))
   }
 

--- a/unit-tests/src/test/scala/scala/ArrayIntCopyTest.scala
+++ b/unit-tests/src/test/scala/scala/ArrayIntCopyTest.scala
@@ -102,29 +102,29 @@ class ArrayIntCopyTest {
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfLengthIsNegative(): Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 0, arr2, 5, -1))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfToPosPlusLenGreaterThanToLength()
       : Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 0, arr2, 5, 10))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfFromPosPlusLenGreaterThanFromLength()
       : Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 5, arr2, 0, 10))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfToPosIsNegative(): Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 0, arr2, -1, 10))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfFromPosIsNegative(): Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, -1, arr2, 0, 10))
   }
 

--- a/unit-tests/src/test/scala/scala/ArrayObjectCopyTest.scala
+++ b/unit-tests/src/test/scala/scala/ArrayObjectCopyTest.scala
@@ -117,29 +117,29 @@ class ArrayObjectCopyTest {
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfLengthIsNegative(): Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 0, arr2, 5, -1))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfToPosPlusLenGreaterThanToLength()
       : Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 0, arr2, 5, 10))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfFromPosPlusLenGreaterThanFromLength()
       : Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 5, arr2, 0, 10))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfToPosIsNegative(): Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, 0, arr2, -1, 10))
   }
 
   @Test def throwsIndexOutOfBoundsExceptionIfFromPosIsNegative(): Unit = {
-    assertThrows(classOf[java.lang.IndexOutOfBoundsException],
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
                  java.lang.System.arraycopy(arr, -1, arr2, 0, 10))
   }
 


### PR DESCRIPTION
Resolves #2044 

This PR changes exception thrown on invalid Array index access, from `IndexOutOfBounds` to `ArrayIndexOutOfBounds` to mimic the behavior of JVM