### PR TITLE
Fix #2045: Implement testsuite.utils.Platform

### DIFF
--- a/unit-tests/src/test/scala/java/lang/ThreadTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ThreadTest.scala
@@ -11,10 +11,12 @@ package java.lang
 import org.junit.Test
 import org.junit.Assert._
 
-class ThreadTest {
+import org.scalanative.testsuite.utils.Platform.{
+  executingInJVM,
+  executingInScalaNative
+}
 
-  val executingInJVM         = false
-  val executingInScalaNative = true
+class ThreadTest {
 
   @Test def getNameAndSetName(): Unit = {
     if (!executingInJVM) {

--- a/unit-tests/src/test/scala/java/util/PropertiesTest.scala
+++ b/unit-tests/src/test/scala/java/util/PropertiesTest.scala
@@ -14,10 +14,9 @@ import org.junit.Assume._
 import scala.scalanative.junit.utils.AssertThrows._
 import scala.scalanative.junit.utils.Utils._
 
-class PropertiesTest {
-  // remove when Platform is implemented
-  val hasCompliantAsInstanceOfs = true
+import org.scalanative.testsuite.utils.Platform.hasCompliantAsInstanceOfs
 
+class PropertiesTest {
   // ported from Scala.js
   @Test def setProperty(): Unit = {
     val prop = new Properties()

--- a/unit-tests/src/test/scala/utils/Platform.scala
+++ b/unit-tests/src/test/scala/utils/Platform.scala
@@ -1,0 +1,20 @@
+package org.scalanative.testsuite.utils
+
+// See also the scala.scalanative.runtime.Platform package.
+
+import scala.scalanative.buildinfo.ScalaNativeBuildInfo
+
+object Platform {
+
+  def scalaVersion: String = ScalaNativeBuildInfo.scalaVersion
+
+  final val executingInJVM = false
+
+  final val executingInScalaJS = false
+
+  final val executingInScalaNative = true
+
+  final val hasCompliantArrayIndexOutOfBounds = true
+
+  final val hasCompliantAsInstanceOfs = true
+}


### PR DESCRIPTION
We provide configuration information specific to the testing environment.
This information supplements that in the scala.scalanative.runtime.Platform
package.