### PR TITLE
Fix #2049: Use natural ordering for Arrays#sort with null comparator

### DIFF
--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -782,7 +782,8 @@ object Arrays {
   }
 
   @noinline def deepHashCode(a: Array[AnyRef]): Int = {
-    @inline def getHash(elem: AnyRef): Int = {
+    @inline
+    def getHash(elem: AnyRef): Int = {
       elem match {
         case elem: Array[AnyRef]  => deepHashCode(elem)
         case elem: Array[Long]    => hashCode(elem)
@@ -845,7 +846,8 @@ object Arrays {
   @noinline def toString(a: Array[AnyRef]): String =
     toStringImpl[AnyRef](a)
 
-  @inline private def toStringImpl[T](a: Array[T]): String = {
+  @inline
+  private def toStringImpl[T](a: Array[T]): String = {
     if (a == null) {
       "null"
     } else {

--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -27,64 +27,82 @@ object Arrays {
     def compare(x: Double, y: Double): Int = java.lang.Double.compare(x, y)
   }
 
-  @noinline def sort(a: Array[Int]): Unit =
+  @noinline
+  def sort(a: Array[Int]): Unit =
     sortImpl(a)
 
-  @noinline def sort(a: Array[Int], fromIndex: Int, toIndex: Int): Unit =
+  @noinline
+  def sort(a: Array[Int], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Int](a, fromIndex, toIndex)
 
-  @noinline def sort(a: Array[Long]): Unit =
+  @noinline
+  def sort(a: Array[Long]): Unit =
     sortImpl(a)
 
-  @noinline def sort(a: Array[Long], fromIndex: Int, toIndex: Int): Unit =
+  @noinline
+  def sort(a: Array[Long], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Long](a, fromIndex, toIndex)
 
-  @noinline def sort(a: Array[Short]): Unit =
+  @noinline
+  def sort(a: Array[Short]): Unit =
     sortImpl(a)
 
-  @noinline def sort(a: Array[Short], fromIndex: Int, toIndex: Int): Unit =
+  @noinline
+  def sort(a: Array[Short], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Short](a, fromIndex, toIndex)
 
-  @noinline def sort(a: Array[Char]): Unit =
+  @noinline
+  def sort(a: Array[Char]): Unit =
     sortImpl(a)
 
-  @noinline def sort(a: Array[Char], fromIndex: Int, toIndex: Int): Unit =
+  @noinline
+  def sort(a: Array[Char], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Char](a, fromIndex, toIndex)
 
-  @noinline def sort(a: Array[Byte]): Unit =
+  @noinline
+  def sort(a: Array[Byte]): Unit =
     sortImpl(a)
 
-  @noinline def sort(a: Array[Byte], fromIndex: Int, toIndex: Int): Unit =
+  @noinline
+  def sort(a: Array[Byte], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Byte](a, fromIndex, toIndex)
 
-  @noinline def sort(a: Array[Float]): Unit =
+  @noinline
+  def sort(a: Array[Float]): Unit =
     sortImpl(a)
 
-  @noinline def sort(a: Array[Float], fromIndex: Int, toIndex: Int): Unit =
+  @noinline
+  def sort(a: Array[Float], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Float](a, fromIndex, toIndex)
 
-  @noinline def sort(a: Array[Double]): Unit =
+  @noinline
+  def sort(a: Array[Double]): Unit =
     sortImpl(a)
 
-  @noinline def sort(a: Array[Double], fromIndex: Int, toIndex: Int): Unit =
+  @noinline
+  def sort(a: Array[Double], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Double](a, fromIndex, toIndex)
 
-  @noinline def sort(a: Array[AnyRef]): Unit =
+  @noinline
+  def sort(a: Array[AnyRef]): Unit =
     sortAnyRefImpl(a)
 
-  @noinline def sort(a: Array[AnyRef], fromIndex: Int, toIndex: Int): Unit =
+  @noinline
+  def sort(a: Array[AnyRef], fromIndex: Int, toIndex: Int): Unit =
     sortRangeAnyRefImpl(a, fromIndex, toIndex)
 
-  @noinline def sort[T <: AnyRef](array: Array[T],
-                                  comparator: Comparator[_ >: T]): Unit = {
+  @noinline
+  def sort[T <: AnyRef](array: Array[T],
+                        comparator: Comparator[_ >: T]): Unit = {
     implicit val ord = toOrdering(comparator).asInstanceOf[Ordering[AnyRef]]
     sortAnyRefImpl(array.asInstanceOf[Array[AnyRef]])
   }
 
-  @noinline def sort[T <: AnyRef](array: Array[T],
-                                  fromIndex: Int,
-                                  toIndex: Int,
-                                  comparator: Comparator[_ >: T]): Unit = {
+  @noinline
+  def sort[T <: AnyRef](array: Array[T],
+                        fromIndex: Int,
+                        toIndex: Int,
+                        comparator: Comparator[_ >: T]): Unit = {
     implicit val ord = toOrdering(comparator).asInstanceOf[Ordering[AnyRef]]
     sortRangeAnyRefImpl(array.asInstanceOf[Array[AnyRef]], fromIndex, toIndex)
   }

--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -1,10 +1,12 @@
+// Ported from Scala.js commit: ba618ed dated: 2020-10-05
+
 package java.util
 
 import scala.annotation.tailrec
 
 import scala.reflect.ClassTag
 
-import scala.collection.immutable
+import ScalaOps._
 
 object Arrays {
 
@@ -73,18 +75,16 @@ object Arrays {
   @noinline def sort(a: Array[AnyRef], fromIndex: Int, toIndex: Int): Unit =
     sortRangeAnyRefImpl(a, fromIndex, toIndex)
 
-  @noinline
-  def sort[T <: AnyRef](array: Array[T],
-                        comparator: Comparator[_ >: T]): Unit = {
+  @noinline def sort[T <: AnyRef](array: Array[T],
+                                  comparator: Comparator[_ >: T]): Unit = {
     implicit val ord = toOrdering(comparator).asInstanceOf[Ordering[AnyRef]]
     sortAnyRefImpl(array.asInstanceOf[Array[AnyRef]])
   }
 
-  @noinline
-  def sort[T <: AnyRef](array: Array[T],
-                        fromIndex: Int,
-                        toIndex: Int,
-                        comparator: Comparator[_ >: T]): Unit = {
+  @noinline def sort[T <: AnyRef](array: Array[T],
+                                  fromIndex: Int,
+                                  toIndex: Int,
+                                  comparator: Comparator[_ >: T]): Unit = {
     implicit val ord = toOrdering(comparator).asInstanceOf[Ordering[AnyRef]]
     sortRangeAnyRefImpl(array.asInstanceOf[Array[AnyRef]], fromIndex, toIndex)
   }
@@ -94,8 +94,8 @@ object Arrays {
       a: Array[T],
       fromIndex: Int,
       toIndex: Int)(implicit ord: Ordering[T]): Unit = {
-    checkIndicesForCopyOfRange(a.length, fromIndex, toIndex)
-    quickSort[T](a, fromIndex, toIndex)
+    checkRangeIndices(a, fromIndex, toIndex)
+    stableMergeSort[T](a, fromIndex, toIndex)
   }
 
   @inline
@@ -103,141 +103,98 @@ object Arrays {
       a: Array[AnyRef],
       fromIndex: Int,
       toIndex: Int)(implicit ord: Ordering[AnyRef]): Unit = {
-    checkIndicesForCopyOfRange(a.length, fromIndex, toIndex)
-    quickSortAnyRef(a, fromIndex, toIndex)
+    checkRangeIndices(a, fromIndex, toIndex)
+    stableMergeSortAnyRef(a, fromIndex, toIndex)
   }
 
   @inline
   private def sortImpl[@specialized T: ClassTag: Ordering](a: Array[T]): Unit =
-    quickSort[T](a, 0, a.length)
+    stableMergeSort[T](a, 0, a.length)
 
   @inline
   private def sortAnyRefImpl(a: Array[AnyRef])(
       implicit ord: Ordering[AnyRef]): Unit =
-    quickSortAnyRef(a, 0, a.length)
+    stableMergeSortAnyRef(a, 0, a.length)
 
-  // Implementation of sorting based on Scala 2.11.7 scala.util.Sorting
-  private final val qSortThreshold = 16
+  private final val inPlaceSortThreshold = 16
 
-  /** Sort array `a` with quicksort, using the Ordering on its elements.
-   * This algorithm sorts in place, so no additional memory is used aside from
-   * what might be required to box individual elements during comparison.
+  /** Sort array `a` with merge sort and insertion sort,
+   *  using the Ordering on its elements.
    */
+  @inline
+  private def stableMergeSort[@specialized K: ClassTag](
+      a: Array[K],
+      start: Int,
+      end: Int)(implicit ord: Ordering[K]): Unit = {
+    if (end - start > inPlaceSortThreshold)
+      stableSplitMerge(a, new Array[K](a.length), start, end)
+    else
+      insertionSort(a, start, end)
+  }
+
   @noinline
-  private def quickSort[@specialized K](a: Array[K], i0: Int, iN: Int)(
-      implicit ord: Ordering[K]): Unit = {
-    if (iN - i0 < qSortThreshold) {
-      insertionSort(a, i0, iN)
+  private def stableSplitMerge[@specialized K](
+      a: Array[K],
+      temp: Array[K],
+      start: Int,
+      end: Int)(implicit ord: Ordering[K]): Unit = {
+    val length = end - start
+    if (length > inPlaceSortThreshold) {
+      val middle = start + (length / 2)
+      stableSplitMerge(a, temp, start, middle)
+      stableSplitMerge(a, temp, middle, end)
+      stableMerge(a, temp, start, middle, end)
+      System.arraycopy(temp, start, a, start, length)
     } else {
-      val iK = (i0 + iN) >>> 1 // Unsigned div by 2
-      // Find index of median of first, central, and last elements
-      var pL = {
-        if (ord.compare(a(i0), a(iN - 1)) <= 0) {
-          if (ord.compare(a(i0), a(iK)) >= 0) i0
-          else if (ord.compare(a(iN - 1), a(iK)) < 0) iN - 1
-          else iK
-        } else {
-          if (ord.compare(a(i0), a(iK)) < 0) i0
-          else if (ord.compare(a(iN - 1), a(iK)) <= 0) iN - 1
-          else iK
-        }
-      }
-      val pivot = a(pL)
-      // pL is the start of the pivot block; move it into the middle if needed
-      if (pL != iK) {
-        a(pL) = a(iK)
-        a(iK) = pivot
-        pL = iK
-      }
-      // Elements equal to the pivot will be in range pL until pR
-      var pR = pL + 1
-      // Items known to be less than pivot are below iA (range i0 until iA)
-      var iA = i0
-      // Items known to be greater than pivot are at or above iB (range iB until iN)
-      var iB = iN
-      // Scan through everything in the buffer before the pivot(s)
-      while (pL - iA > 0) {
-        val current = a(iA)
-        ord.compare(current, pivot) match {
-          case 0 =>
-            // Swap current out with pivot block
-            a(iA) = a(pL - 1)
-            a(pL - 1) = current
-            pL -= 1
-          case x if x < 0 =>
-            // Already in place.  Just update indicies.
-            iA += 1
-          case _ if iB > pR =>
-            // Wrong side.  There's room on the other side, so swap
-            a(iA) = a(iB - 1)
-            a(iB - 1) = current
-            iB -= 1
-          case _ =>
-            // Wrong side and there is no room.  Swap by rotating pivot block.
-            a(iA) = a(pL - 1)
-            a(pL - 1) = a(pR - 1)
-            a(pR - 1) = current
-            pL -= 1
-            pR -= 1
-            iB -= 1
-        }
-      }
-      // Get anything remaining in buffer after the pivot(s)
-      while (iB - pR > 0) {
-        val current = a(iB - 1)
-        ord.compare(current, pivot) match {
-          case 0 =>
-            // Swap current out with pivot block
-            a(iB - 1) = a(pR)
-            a(pR) = current
-            pR += 1
-          case x if x > 0 =>
-            // Already in place.  Just update indices.
-            iB -= 1
-          case _ =>
-            // Wrong side and we already know there is no room.  Swap by rotating pivot block.
-            a(iB - 1) = a(pR)
-            a(pR) = a(pL)
-            a(pL) = current
-            iA += 1
-            pL += 1
-            pR += 1
-        }
-      }
-      // Use tail recursion on large half (Sedgewick's method) so we don't blow
-      // up the stack if pivots are poorly chosen
-      if (iA - i0 < iN - iB) {
-        quickSort(a, i0, iA) // True recursion
-        quickSort(a, iB, iN) // Should be tail recursion
+      insertionSort(a, start, end)
+    }
+  }
+
+  @inline
+  private def stableMerge[@specialized K](
+      a: Array[K],
+      temp: Array[K],
+      start: Int,
+      middle: Int,
+      end: Int)(implicit ord: Ordering[K]): Unit = {
+    var outIndex     = start
+    var leftInIndex  = start
+    var rightInIndex = middle
+    while (outIndex < end) {
+      if (leftInIndex < middle &&
+          (rightInIndex >= end || ord.lteq(a(leftInIndex), a(rightInIndex)))) {
+        temp(outIndex) = a(leftInIndex)
+        leftInIndex += 1
       } else {
-        quickSort(a, iB, iN) // True recursion
-        quickSort(a, i0, iA) // Should be tail recursion
+        temp(outIndex) = a(rightInIndex)
+        rightInIndex += 1
       }
+      outIndex += 1
     }
   }
 
   // Ordering[T] might be slow especially for boxed primitives, so use binary
   // search variant of insertion sort
-  // Caller must pass iN >= i0 or math will fail.  Also, i0 >= 0.
+  // Caller must pass end >= start or math will fail.  Also, start >= 0.
   @noinline
   private final def insertionSort[@specialized T](
       a: Array[T],
-      i0: Int,
-      iN: Int)(implicit ord: Ordering[T]): Unit = {
-    val n = iN - i0
+      start: Int,
+      end: Int)(implicit ord: Ordering[T]): Unit = {
+    val n = end - start
     if (n >= 2) {
-      if (ord.compare(a(i0), a(i0 + 1)) > 0) {
-        val temp = a(i0)
-        a(i0) = a(i0 + 1)
-        a(i0 + 1) = temp
+      if (ord.compare(a(start), a(start + 1)) > 0) {
+        val temp = a(start)
+        a(start) = a(start + 1)
+        a(start + 1) = temp
       }
       var m = 2
       while (m < n) {
         // Speed up already-sorted case by checking last element first
-        val next = a(i0 + m)
-        if (ord.compare(next, a(i0 + m - 1)) < 0) {
-          var iA = i0
-          var iB = i0 + m - 1
+        val next = a(start + m)
+        if (ord.compare(next, a(start + m - 1)) < 0) {
+          var iA = start
+          var iB = start + m - 1
           while (iB - iA > 1) {
             val ix = (iA + iB) >>> 1 // Use bit shift to get unsigned div by 2
             if (ord.compare(next, a(ix)) < 0)
@@ -246,7 +203,7 @@ object Arrays {
               iA = ix
           }
           val ix = iA + (if (ord.compare(next, a(iA)) < 0) 0 else 1)
-          var i  = i0 + m
+          var i  = start + m
           while (i > ix) {
             a(i) = a(i - 1)
             i -= 1
@@ -258,116 +215,76 @@ object Arrays {
     }
   }
 
-  @noinline
-  private def quickSortAnyRef(a: Array[AnyRef], i0: Int, iN: Int)(
+  /** Sort array `a` with merge sort and insertion sort,
+   *  using the Ordering on its elements.
+   */
+  @inline
+  private def stableMergeSortAnyRef(a: Array[AnyRef], start: Int, end: Int)(
       implicit ord: Ordering[AnyRef]): Unit = {
-    if (iN - i0 < qSortThreshold) {
-      insertionSortAnyRef(a, i0, iN)
+    if (end - start > inPlaceSortThreshold)
+      stableSplitMergeAnyRef(a, new Array(a.length), start, end)
+    else
+      insertionSortAnyRef(a, start, end)
+  }
+
+  @noinline
+  private def stableSplitMergeAnyRef(
+      a: Array[AnyRef],
+      temp: Array[AnyRef],
+      start: Int,
+      end: Int)(implicit ord: Ordering[AnyRef]): Unit = {
+    val length = end - start
+    if (length > inPlaceSortThreshold) {
+      val middle = start + (length / 2)
+      stableSplitMergeAnyRef(a, temp, start, middle)
+      stableSplitMergeAnyRef(a, temp, middle, end)
+      stableMergeAnyRef(a, temp, start, middle, end)
+      System.arraycopy(temp, start, a, start, length)
     } else {
-      val iK = (i0 + iN) >>> 1 // Unsigned div by 2
-      // Find index of median of first, central, and last elements
-      var pL = {
-        if (ord.compare(a(i0), a(iN - 1)) <= 0) {
-          if (ord.compare(a(i0), a(iK)) >= 0) i0
-          else if (ord.compare(a(iN - 1), a(iK)) < 0) iN - 1
-          else iK
-        } else {
-          if (ord.compare(a(i0), a(iK)) < 0) i0
-          else if (ord.compare(a(iN - 1), a(iK)) <= 0) iN - 1
-          else iK
-        }
-      }
-      val pivot = a(pL)
-      // pL is the start of the pivot block; move it into the middle if needed
-      if (pL != iK) {
-        a(pL) = a(iK)
-        a(iK) = pivot
-        pL = iK
-      }
-      // Elements equal to the pivot will be in range pL until pR
-      var pR = pL + 1
-      // Items known to be less than pivot are below iA (range i0 until iA)
-      var iA = i0
-      // Items known to be greater than pivot are at or above iB (range iB until iN)
-      var iB = iN
-      // Scan through everything in the buffer before the pivot(s)
-      while (pL - iA > 0) {
-        val current = a(iA)
-        ord.compare(current, pivot) match {
-          case 0 =>
-            // Swap current out with pivot block
-            a(iA) = a(pL - 1)
-            a(pL - 1) = current
-            pL -= 1
-          case x if x < 0 =>
-            // Already in place.  Just update indicies.
-            iA += 1
-          case _ if iB > pR =>
-            // Wrong side.  There's room on the other side, so swap
-            a(iA) = a(iB - 1)
-            a(iB - 1) = current
-            iB -= 1
-          case _ =>
-            // Wrong side and there is no room.  Swap by rotating pivot block.
-            a(iA) = a(pL - 1)
-            a(pL - 1) = a(pR - 1)
-            a(pR - 1) = current
-            pL -= 1
-            pR -= 1
-            iB -= 1
-        }
-      }
-      // Get anything remaining in buffer after the pivot(s)
-      while (iB - pR > 0) {
-        val current = a(iB - 1)
-        ord.compare(current, pivot) match {
-          case 0 =>
-            // Swap current out with pivot block
-            a(iB - 1) = a(pR)
-            a(pR) = current
-            pR += 1
-          case x if x > 0 =>
-            // Already in place.  Just update indices.
-            iB -= 1
-          case _ =>
-            // Wrong side and we already know there is no room.  Swap by rotating pivot block.
-            a(iB - 1) = a(pR)
-            a(pR) = a(pL)
-            a(pL) = current
-            iA += 1
-            pL += 1
-            pR += 1
-        }
-      }
-      // Use tail recursion on large half (Sedgewick's method) so we don't blow
-      // up the stack if pivots are poorly chosen
-      if (iA - i0 < iN - iB) {
-        quickSortAnyRef(a, i0, iA) // True recursion
-        quickSortAnyRef(a, iB, iN) // Should be tail recursion
+      insertionSortAnyRef(a, start, end)
+    }
+  }
+
+  @inline
+  private def stableMergeAnyRef(
+      a: Array[AnyRef],
+      temp: Array[AnyRef],
+      start: Int,
+      middle: Int,
+      end: Int)(implicit ord: Ordering[AnyRef]): Unit = {
+    var outIndex     = start
+    var leftInIndex  = start
+    var rightInIndex = middle
+    while (outIndex < end) {
+      if (leftInIndex < middle &&
+          (rightInIndex >= end || ord.lteq(a(leftInIndex), a(rightInIndex)))) {
+        temp(outIndex) = a(leftInIndex)
+        leftInIndex += 1
       } else {
-        quickSortAnyRef(a, iB, iN) // True recursion
-        quickSortAnyRef(a, i0, iA) // Should be tail recursion
+        temp(outIndex) = a(rightInIndex)
+        rightInIndex += 1
       }
+      outIndex += 1
     }
   }
 
   @noinline
-  private final def insertionSortAnyRef(a: Array[AnyRef], i0: Int, iN: Int)(
+  private final def insertionSortAnyRef(a: Array[AnyRef], start: Int, end: Int)(
       implicit ord: Ordering[AnyRef]): Unit = {
-    val n = iN - i0
+    val n = end - start
     if (n >= 2) {
-      if (ord.compare(a(i0), a(i0 + 1)) > 0) {
-        val temp = a(i0)
-        a(i0) = a(i0 + 1)
-        a(i0 + 1) = temp
+      if (ord.compare(a(start), a(start + 1)) > 0) {
+        val temp = a(start)
+        a(start) = a(start + 1)
+        a(start + 1) = temp
       }
       var m = 2
       while (m < n) {
         // Speed up already-sorted case by checking last element first
-        val next = a(i0 + m)
-        if (ord.compare(next, a(i0 + m - 1)) < 0) {
-          var iA = i0
-          var iB = i0 + m - 1
+        val next = a(start + m)
+        if (ord.compare(next, a(start + m - 1)) < 0) {
+          var iA = start
+          var iB = start + m - 1
           while (iB - iA > 1) {
             val ix = (iA + iB) >>> 1 // Use bit shift to get unsigned div by 2
             if (ord.compare(next, a(ix)) < 0)
@@ -376,7 +293,7 @@ object Arrays {
               iA = ix
           }
           val ix = iA + (if (ord.compare(next, a(iA)) < 0) 0 else 1)
-          var i  = i0 + m
+          var i  = start + m
           while (i > ix) {
             a(i) = a(i - 1)
             i -= 1
@@ -391,110 +308,102 @@ object Arrays {
   @noinline def binarySearch(a: Array[Long], key: Long): Int =
     binarySearchImpl[Long](a, 0, a.length, key, _ < _)
 
-  @noinline
-  def binarySearch(a: Array[Long],
-                   startIndex: Int,
-                   endIndex: Int,
-                   key: Long): Int = {
-    checkRangeIndices(a.length, startIndex, endIndex)
+  @noinline def binarySearch(a: Array[Long],
+                             startIndex: Int,
+                             endIndex: Int,
+                             key: Long): Int = {
+    checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Long](a, startIndex, endIndex, key, _ < _)
   }
 
   @noinline def binarySearch(a: Array[Int], key: Int): Int =
     binarySearchImpl[Int](a, 0, a.length, key, _ < _)
 
-  @noinline
-  def binarySearch(a: Array[Int],
-                   startIndex: Int,
-                   endIndex: Int,
-                   key: Int): Int = {
-    checkRangeIndices(a.length, startIndex, endIndex)
+  @noinline def binarySearch(a: Array[Int],
+                             startIndex: Int,
+                             endIndex: Int,
+                             key: Int): Int = {
+    checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Int](a, startIndex, endIndex, key, _ < _)
   }
 
   @noinline def binarySearch(a: Array[Short], key: Short): Int =
     binarySearchImpl[Short](a, 0, a.length, key, _ < _)
 
-  @noinline
-  def binarySearch(a: Array[Short],
-                   startIndex: Int,
-                   endIndex: Int,
-                   key: Short): Int = {
-    checkRangeIndices(a.length, startIndex, endIndex)
+  @noinline def binarySearch(a: Array[Short],
+                             startIndex: Int,
+                             endIndex: Int,
+                             key: Short): Int = {
+    checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Short](a, startIndex, endIndex, key, _ < _)
   }
 
   @noinline def binarySearch(a: Array[Char], key: Char): Int =
     binarySearchImpl[Char](a, 0, a.length, key, _ < _)
 
-  @noinline
-  def binarySearch(a: Array[Char],
-                   startIndex: Int,
-                   endIndex: Int,
-                   key: Char): Int = {
-    checkRangeIndices(a.length, startIndex, endIndex)
+  @noinline def binarySearch(a: Array[Char],
+                             startIndex: Int,
+                             endIndex: Int,
+                             key: Char): Int = {
+    checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Char](a, startIndex, endIndex, key, _ < _)
   }
 
   @noinline def binarySearch(a: Array[Byte], key: Byte): Int =
     binarySearchImpl[Byte](a, 0, a.length, key, _ < _)
 
-  @noinline
-  def binarySearch(a: Array[Byte],
-                   startIndex: Int,
-                   endIndex: Int,
-                   key: Byte): Int = {
-    checkRangeIndices(a.length, startIndex, endIndex)
+  @noinline def binarySearch(a: Array[Byte],
+                             startIndex: Int,
+                             endIndex: Int,
+                             key: Byte): Int = {
+    checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Byte](a, startIndex, endIndex, key, _ < _)
   }
 
   @noinline def binarySearch(a: Array[Double], key: Double): Int =
     binarySearchImpl[Double](a, 0, a.length, key, _ < _)
 
-  @noinline
-  def binarySearch(a: Array[Double],
-                   startIndex: Int,
-                   endIndex: Int,
-                   key: Double): Int = {
-    checkRangeIndices(a.length, startIndex, endIndex)
+  @noinline def binarySearch(a: Array[Double],
+                             startIndex: Int,
+                             endIndex: Int,
+                             key: Double): Int = {
+    checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Double](a, startIndex, endIndex, key, _ < _)
   }
 
   @noinline def binarySearch(a: Array[Float], key: Float): Int =
     binarySearchImpl[Float](a, 0, a.length, key, _ < _)
 
-  @noinline
-  def binarySearch(a: Array[Float],
-                   startIndex: Int,
-                   endIndex: Int,
-                   key: Float): Int = {
-    checkRangeIndices(a.length, startIndex, endIndex)
+  @noinline def binarySearch(a: Array[Float],
+                             startIndex: Int,
+                             endIndex: Int,
+                             key: Float): Int = {
+    checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Float](a, startIndex, endIndex, key, _ < _)
   }
 
   @noinline def binarySearch(a: Array[AnyRef], key: AnyRef): Int =
     binarySearchImplRef(a, 0, a.length, key)
 
-  @noinline
-  def binarySearch(a: Array[AnyRef],
-                   startIndex: Int,
-                   endIndex: Int,
-                   key: AnyRef): Int = {
-    checkRangeIndices(a.length, startIndex, endIndex)
+  @noinline def binarySearch(a: Array[AnyRef],
+                             startIndex: Int,
+                             endIndex: Int,
+                             key: AnyRef): Int = {
+    checkRangeIndices(a, startIndex, endIndex)
     binarySearchImplRef(a, startIndex, endIndex, key)
   }
 
-  @noinline
-  def binarySearch[T](a: Array[T], key: T, c: Comparator[_ >: T]): Int =
+  @noinline def binarySearch[T](a: Array[T],
+                                key: T,
+                                c: Comparator[_ >: T]): Int =
     binarySearchImpl[T](a, 0, a.length, key, (a, b) => c.compare(a, b) < 0)
 
-  @noinline
-  def binarySearch[T](a: Array[T],
-                      startIndex: Int,
-                      endIndex: Int,
-                      key: T,
-                      c: Comparator[_ >: T]): Int = {
-    checkRangeIndices(a.length, startIndex, endIndex)
+  @noinline def binarySearch[T](a: Array[T],
+                                startIndex: Int,
+                                endIndex: Int,
+                                key: T,
+                                c: Comparator[_ >: T]): Int = {
+    checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[T](a,
                         startIndex,
                         endIndex,
@@ -580,80 +489,103 @@ object Arrays {
 
   @inline
   private def equalsImpl[T](a: Array[T], b: Array[T]): Boolean = {
-    (a eq b) || (a != null && b != null && a.length == b.length &&
-    a.indices.forall(i => a(i) == b(i)))
+    // scalastyle:off return
+    if (a eq b)
+      return true
+    if (a == null || b == null)
+      return false
+    val len = a.length
+    if (b.length != len)
+      return false
+    var i = 0
+    while (i != len) {
+      if (a(i) != b(i))
+        return false
+      i += 1
+    }
+    true
+    // scalastyle:on return
   }
 
   @noinline def fill(a: Array[Long], value: Long): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline
-  def fill(a: Array[Long], fromIndex: Int, toIndex: Int, value: Long): Unit =
+  @noinline def fill(a: Array[Long],
+                     fromIndex: Int,
+                     toIndex: Int,
+                     value: Long): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
   @noinline def fill(a: Array[Int], value: Int): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline
-  def fill(a: Array[Int], fromIndex: Int, toIndex: Int, value: Int): Unit =
+  @noinline def fill(a: Array[Int],
+                     fromIndex: Int,
+                     toIndex: Int,
+                     value: Int): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
   @noinline def fill(a: Array[Short], value: Short): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline
-  def fill(a: Array[Short], fromIndex: Int, toIndex: Int, value: Short): Unit =
+  @noinline def fill(a: Array[Short],
+                     fromIndex: Int,
+                     toIndex: Int,
+                     value: Short): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
   @noinline def fill(a: Array[Char], value: Char): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline
-  def fill(a: Array[Char], fromIndex: Int, toIndex: Int, value: Char): Unit =
+  @noinline def fill(a: Array[Char],
+                     fromIndex: Int,
+                     toIndex: Int,
+                     value: Char): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
   @noinline def fill(a: Array[Byte], value: Byte): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline
-  def fill(a: Array[Byte], fromIndex: Int, toIndex: Int, value: Byte): Unit =
+  @noinline def fill(a: Array[Byte],
+                     fromIndex: Int,
+                     toIndex: Int,
+                     value: Byte): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
   @noinline def fill(a: Array[Boolean], value: Boolean): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline
-  def fill(a: Array[Boolean],
-           fromIndex: Int,
-           toIndex: Int,
-           value: Boolean): Unit =
+  @noinline def fill(a: Array[Boolean],
+                     fromIndex: Int,
+                     toIndex: Int,
+                     value: Boolean): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
   @noinline def fill(a: Array[Double], value: Double): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline
-  def fill(a: Array[Double],
-           fromIndex: Int,
-           toIndex: Int,
-           value: Double): Unit =
+  @noinline def fill(a: Array[Double],
+                     fromIndex: Int,
+                     toIndex: Int,
+                     value: Double): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
   @noinline def fill(a: Array[Float], value: Float): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline
-  def fill(a: Array[Float], fromIndex: Int, toIndex: Int, value: Float): Unit =
+  @noinline def fill(a: Array[Float],
+                     fromIndex: Int,
+                     toIndex: Int,
+                     value: Float): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
   @noinline def fill(a: Array[AnyRef], value: AnyRef): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline
-  def fill(a: Array[AnyRef],
-           fromIndex: Int,
-           toIndex: Int,
-           value: AnyRef): Unit =
+  @noinline def fill(a: Array[AnyRef],
+                     fromIndex: Int,
+                     toIndex: Int,
+                     value: AnyRef): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
   @inline
@@ -663,7 +595,7 @@ object Arrays {
                           value: T,
                           checkIndices: Boolean = true): Unit = {
     if (checkIndices)
-      checkRangeIndices(a.length, fromIndex, toIndex)
+      checkRangeIndices(a, fromIndex, toIndex)
     var i = fromIndex
     while (i != toIndex) {
       a(i) = value
@@ -671,14 +603,13 @@ object Arrays {
     }
   }
 
-  @noinline
-  def copyOf[T <: AnyRef](original: Array[T], newLength: Int): Array[T] = {
+  @noinline def copyOf[T <: AnyRef](original: Array[T],
+                                    newLength: Int): Array[T] = {
     implicit val tagT = ClassTag[T](original.getClass.getComponentType)
     copyOfImpl(original, newLength)
   }
 
-  @noinline
-  def copyOf[T <: AnyRef, U <: AnyRef](
+  @noinline def copyOf[T <: AnyRef, U <: AnyRef](
       original: Array[U],
       newLength: Int,
       newType: Class[_ <: Array[T]]): Array[T] = {
@@ -704,12 +635,11 @@ object Arrays {
   @noinline def copyOf(original: Array[Float], newLength: Int): Array[Float] =
     copyOfImpl(original, newLength)
 
-  @noinline
-  def copyOf(original: Array[Double], newLength: Int): Array[Double] =
+  @noinline def copyOf(original: Array[Double], newLength: Int): Array[Double] =
     copyOfImpl(original, newLength)
 
-  @noinline
-  def copyOf(original: Array[Boolean], newLength: Int): Array[Boolean] =
+  @noinline def copyOf(original: Array[Boolean],
+                       newLength: Int): Array[Boolean] =
     copyOfImpl(original, newLength)
 
   @inline
@@ -722,16 +652,14 @@ object Arrays {
     ret
   }
 
-  @noinline
-  def copyOfRange[T <: AnyRef](original: Array[T],
-                               from: Int,
-                               to: Int): Array[T] = {
+  @noinline def copyOfRange[T <: AnyRef](original: Array[T],
+                                         from: Int,
+                                         to: Int): Array[T] = {
     copyOfRangeImpl[T](original, from, to)(
       ClassTag(original.getClass.getComponentType)).asInstanceOf[Array[T]]
   }
 
-  @noinline
-  def copyOfRange[T <: AnyRef, U <: AnyRef](
+  @noinline def copyOfRange[T <: AnyRef, U <: AnyRef](
       original: Array[U],
       from: Int,
       to: Int,
@@ -740,47 +668,53 @@ object Arrays {
       ClassTag(newType.getComponentType)).asInstanceOf[Array[T]]
   }
 
-  @noinline
-  def copyOfRange(original: Array[Byte], start: Int, end: Int): Array[Byte] =
+  @noinline def copyOfRange(original: Array[Byte],
+                            start: Int,
+                            end: Int): Array[Byte] =
     copyOfRangeImpl[Byte](original, start, end)
 
-  @noinline
-  def copyOfRange(original: Array[Short], start: Int, end: Int): Array[Short] =
+  @noinline def copyOfRange(original: Array[Short],
+                            start: Int,
+                            end: Int): Array[Short] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline
-  def copyOfRange(original: Array[Int], start: Int, end: Int): Array[Int] =
+  @noinline def copyOfRange(original: Array[Int],
+                            start: Int,
+                            end: Int): Array[Int] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline
-  def copyOfRange(original: Array[Long], start: Int, end: Int): Array[Long] =
+  @noinline def copyOfRange(original: Array[Long],
+                            start: Int,
+                            end: Int): Array[Long] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline
-  def copyOfRange(original: Array[Char], start: Int, end: Int): Array[Char] =
+  @noinline def copyOfRange(original: Array[Char],
+                            start: Int,
+                            end: Int): Array[Char] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline
-  def copyOfRange(original: Array[Float], start: Int, end: Int): Array[Float] =
+  @noinline def copyOfRange(original: Array[Float],
+                            start: Int,
+                            end: Int): Array[Float] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline
-  def copyOfRange(original: Array[Double],
-                  start: Int,
-                  end: Int): Array[Double] =
+  @noinline def copyOfRange(original: Array[Double],
+                            start: Int,
+                            end: Int): Array[Double] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline
-  def copyOfRange(original: Array[Boolean],
-                  start: Int,
-                  end: Int): Array[Boolean] =
+  @noinline def copyOfRange(original: Array[Boolean],
+                            start: Int,
+                            end: Int): Array[Boolean] =
     copyOfRangeImpl(original, start, end)
 
   @inline
   private def copyOfRangeImpl[T: ClassTag](original: Array[T],
                                            start: Int,
                                            end: Int): Array[T] = {
-    checkIndicesForCopyOfRange(original.length, start, end)
+    if (start > end)
+      throw new IllegalArgumentException("" + start + " > " + end)
+
     val retLength  = end - start
     val copyLength = Math.min(retLength, original.length - start)
     val ret        = new Array[T](retLength)
@@ -791,15 +725,6 @@ object Arrays {
   @inline private def checkArrayLength(len: Int): Unit = {
     if (len < 0)
       throw new NegativeArraySizeException
-  }
-
-  @inline private def checkIndicesForCopyOfRange(len: Int,
-                                                 start: Int,
-                                                 end: Int): Unit = {
-    if (start > end)
-      throw new IllegalArgumentException(s"$start > end")
-    if (start < 0 || start > len)
-      throw new ArrayIndexOutOfBoundsException
   }
 
   @noinline def asList[T <: AnyRef](a: Array[T]): List[T] = {
@@ -819,40 +744,42 @@ object Arrays {
   }
 
   @noinline def hashCode(a: Array[Long]): Int =
-    hashCodeImpl[Long](a)
+    hashCodeImpl[Long](a, _.hashCode())
 
   @noinline def hashCode(a: Array[Int]): Int =
-    hashCodeImpl[Int](a)
+    hashCodeImpl[Int](a, _.hashCode())
 
   @noinline def hashCode(a: Array[Short]): Int =
-    hashCodeImpl[Short](a)
+    hashCodeImpl[Short](a, _.hashCode())
 
   @noinline def hashCode(a: Array[Char]): Int =
-    hashCodeImpl[Char](a)
+    hashCodeImpl[Char](a, _.hashCode())
 
   @noinline def hashCode(a: Array[Byte]): Int =
-    hashCodeImpl[Byte](a)
+    hashCodeImpl[Byte](a, _.hashCode())
 
   @noinline def hashCode(a: Array[Boolean]): Int =
-    hashCodeImpl[Boolean](a)
+    hashCodeImpl[Boolean](a, _.hashCode())
 
   @noinline def hashCode(a: Array[Float]): Int =
-    hashCodeImpl[Float](a)
+    hashCodeImpl[Float](a, _.hashCode())
 
   @noinline def hashCode(a: Array[Double]): Int =
-    hashCodeImpl[Double](a)
+    hashCodeImpl[Double](a, _.hashCode())
 
   @noinline def hashCode(a: Array[AnyRef]): Int =
-    hashCodeImpl[AnyRef](a)
+    hashCodeImpl[AnyRef](a, Objects.hashCode(_))
 
   @inline
-  private def hashCodeImpl[T](a: Array[T],
-                              elementHashCode: T => Int = (x: T) =>
-                                x.asInstanceOf[AnyRef].hashCode): Int = {
-    if (a == null) 0
-    else
-      a.foldLeft(1)((acc, x) =>
-        31 * acc + (if (x == null) 0 else elementHashCode(x)))
+  private def hashCodeImpl[T](a: Array[T], elementHashCode: T => Int): Int = {
+    if (a == null) {
+      0
+    } else {
+      var acc = 1
+      for (i <- 0 until a.length)
+        acc = 31 * acc + elementHashCode(a(i))
+      acc
+    }
   }
 
   @noinline def deepHashCode(a: Array[AnyRef]): Int = {
@@ -868,16 +795,29 @@ object Arrays {
         case elem: Array[Boolean] => hashCode(elem)
         case elem: Array[Float]   => hashCode(elem)
         case elem: Array[Double]  => hashCode(elem)
-        case _                    => elem.hashCode
+        case _                    => Objects.hashCode(elem)
       }
     }
     hashCodeImpl(a, getHash)
   }
 
   @noinline def deepEquals(a1: Array[AnyRef], a2: Array[AnyRef]): Boolean = {
-    if (a1 eq a2) true
-    else if (a1 == null || a2 == null || a1.length != a2.length) false
-    else a1.indices.forall(i => Objects.deepEquals(a1(i), a2(i)))
+    // scalastyle:off return
+    if (a1 eq a2)
+      return true
+    if (a1 == null || a2 == null)
+      return false
+    val len = a1.length
+    if (a2.length != len)
+      return false
+    var i = 0
+    while (i != len) {
+      if (!Objects.deepEquals(a1(i), a2(i)))
+        return false
+      i += 1
+    }
+    true
+    // scalastyle:on return
   }
 
   @noinline def toString(a: Array[Long]): String =
@@ -909,21 +849,35 @@ object Arrays {
 
   @inline
   private def toStringImpl[T](a: Array[T]): String = {
-    if (a == null) "null"
-    else a.mkString("[", ", ", "]")
+    if (a == null) {
+      "null"
+    } else {
+      var result = "["
+      val len    = a.length
+      var i      = 0
+      while (i != len) {
+        if (i != 0)
+          result += ", "
+        result += a(i)
+        i += 1
+      }
+      result + "]"
+    }
   }
 
   @noinline def deepToString(a: Array[AnyRef]): String =
-    deepToStringImpl(a, immutable.HashSet.empty[AsRef])
+    deepToStringImpl(a, new java.util.HashSet[AsRef])
 
   private def deepToStringImpl(a: Array[AnyRef],
-                               branch: immutable.Set[AsRef]): String = {
+                               branch: java.util.Set[AsRef]): String = {
     @inline
     def valueToString(e: AnyRef): String = {
       if (e == null) "null"
       else {
         e match {
-          case e: Array[AnyRef]  => deepToStringImpl(e, branch + new AsRef(a))
+          case e: Array[AnyRef] =>
+            branch.add(new AsRef(a))
+            deepToStringImpl(e, branch)
           case e: Array[Long]    => toString(e)
           case e: Array[Int]     => toString(e)
           case e: Array[Short]   => toString(e)
@@ -942,22 +896,29 @@ object Arrays {
   }
 
   @inline
-  private def checkRangeIndices(length: Int, start: Int, end: Int): Unit = {
+  private def checkRangeIndices[@specialized T](a: Array[T],
+                                                start: Int,
+                                                end: Int): Unit = {
     if (start > end)
       throw new IllegalArgumentException(
         "fromIndex(" + start + ") > toIndex(" + end + ")")
+
+    // bounds checks
     if (start < 0)
-      throw new ArrayIndexOutOfBoundsException(
-        "Array index out of range: " + start)
-    if (end > length)
-      throw new ArrayIndexOutOfBoundsException(
-        "Array index out of range: " + end)
+      a(start)
+
+    if (end > 0)
+      a(end - 1)
   }
 
   @inline
-  private def toOrdering[T](cmp: Comparator[T]): Ordering[T] = {
-    new Ordering[T] {
-      def compare(x: T, y: T): Int = cmp.compare(x, y)
+  private def toOrdering[T <: AnyRef](cmp: Comparator[_ >: T]): Ordering[T] = {
+    if (cmp == null) {
+      naturalOrdering[T]
+    } else {
+      new Ordering[T] {
+        def compare(x: T, y: T): Int = cmp.compare(x, y)
+      }
     }
   }
 

--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -26,68 +26,52 @@ object Arrays {
     def compare(x: Double, y: Double): Int = java.lang.Double.compare(x, y)
   }
 
-  @noinline
-  def sort(a: Array[Int]): Unit =
+  @noinline def sort(a: Array[Int]): Unit =
     sortImpl(a)
 
-  @noinline
-  def sort(a: Array[Int], fromIndex: Int, toIndex: Int): Unit =
+  @noinline def sort(a: Array[Int], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Int](a, fromIndex, toIndex)
 
-  @noinline
-  def sort(a: Array[Long]): Unit =
+  @noinline def sort(a: Array[Long]): Unit =
     sortImpl(a)
 
-  @noinline
-  def sort(a: Array[Long], fromIndex: Int, toIndex: Int): Unit =
+  @noinline def sort(a: Array[Long], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Long](a, fromIndex, toIndex)
 
-  @noinline
-  def sort(a: Array[Short]): Unit =
+  @noinline def sort(a: Array[Short]): Unit =
     sortImpl(a)
 
-  @noinline
-  def sort(a: Array[Short], fromIndex: Int, toIndex: Int): Unit =
+  @noinline def sort(a: Array[Short], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Short](a, fromIndex, toIndex)
 
-  @noinline
-  def sort(a: Array[Char]): Unit =
+  @noinline def sort(a: Array[Char]): Unit =
     sortImpl(a)
 
-  @noinline
-  def sort(a: Array[Char], fromIndex: Int, toIndex: Int): Unit =
+  @noinline def sort(a: Array[Char], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Char](a, fromIndex, toIndex)
 
-  @noinline
-  def sort(a: Array[Byte]): Unit =
+  @noinline def sort(a: Array[Byte]): Unit =
     sortImpl(a)
 
-  @noinline
-  def sort(a: Array[Byte], fromIndex: Int, toIndex: Int): Unit =
+  @noinline def sort(a: Array[Byte], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Byte](a, fromIndex, toIndex)
 
-  @noinline
-  def sort(a: Array[Float]): Unit =
+  @noinline def sort(a: Array[Float]): Unit =
     sortImpl(a)
 
-  @noinline
-  def sort(a: Array[Float], fromIndex: Int, toIndex: Int): Unit =
+  @noinline def sort(a: Array[Float], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Float](a, fromIndex, toIndex)
 
-  @noinline
-  def sort(a: Array[Double]): Unit =
+  @noinline def sort(a: Array[Double]): Unit =
     sortImpl(a)
 
-  @noinline
-  def sort(a: Array[Double], fromIndex: Int, toIndex: Int): Unit =
+  @noinline def sort(a: Array[Double], fromIndex: Int, toIndex: Int): Unit =
     sortRangeImpl[Double](a, fromIndex, toIndex)
 
-  @noinline
-  def sort(a: Array[AnyRef]): Unit =
+  @noinline def sort(a: Array[AnyRef]): Unit =
     sortAnyRefImpl(a)
 
-  @noinline
-  def sort(a: Array[AnyRef], fromIndex: Int, toIndex: Int): Unit =
+  @noinline def sort(a: Array[AnyRef], fromIndex: Int, toIndex: Int): Unit =
     sortRangeAnyRefImpl(a, fromIndex, toIndex)
 
   @noinline
@@ -322,8 +306,7 @@ object Arrays {
     }
   }
 
-  @noinline
-  def binarySearch(a: Array[Long], key: Long): Int =
+  @noinline def binarySearch(a: Array[Long], key: Long): Int =
     binarySearchImpl[Long](a, 0, a.length, key, _ < _)
 
   @noinline
@@ -335,8 +318,7 @@ object Arrays {
     binarySearchImpl[Long](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline
-  def binarySearch(a: Array[Int], key: Int): Int =
+  @noinline def binarySearch(a: Array[Int], key: Int): Int =
     binarySearchImpl[Int](a, 0, a.length, key, _ < _)
 
   @noinline
@@ -348,8 +330,7 @@ object Arrays {
     binarySearchImpl[Int](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline
-  def binarySearch(a: Array[Short], key: Short): Int =
+  @noinline def binarySearch(a: Array[Short], key: Short): Int =
     binarySearchImpl[Short](a, 0, a.length, key, _ < _)
 
   @noinline
@@ -361,8 +342,7 @@ object Arrays {
     binarySearchImpl[Short](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline
-  def binarySearch(a: Array[Char], key: Char): Int =
+  @noinline def binarySearch(a: Array[Char], key: Char): Int =
     binarySearchImpl[Char](a, 0, a.length, key, _ < _)
 
   @noinline
@@ -374,8 +354,7 @@ object Arrays {
     binarySearchImpl[Char](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline
-  def binarySearch(a: Array[Byte], key: Byte): Int =
+  @noinline def binarySearch(a: Array[Byte], key: Byte): Int =
     binarySearchImpl[Byte](a, 0, a.length, key, _ < _)
 
   @noinline
@@ -387,8 +366,7 @@ object Arrays {
     binarySearchImpl[Byte](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline
-  def binarySearch(a: Array[Double], key: Double): Int =
+  @noinline def binarySearch(a: Array[Double], key: Double): Int =
     binarySearchImpl[Double](a, 0, a.length, key, _ < _)
 
   @noinline
@@ -400,8 +378,7 @@ object Arrays {
     binarySearchImpl[Double](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline
-  def binarySearch(a: Array[Float], key: Float): Int =
+  @noinline def binarySearch(a: Array[Float], key: Float): Int =
     binarySearchImpl[Float](a, 0, a.length, key, _ < _)
 
   @noinline
@@ -413,8 +390,7 @@ object Arrays {
     binarySearchImpl[Float](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline
-  def binarySearch(a: Array[AnyRef], key: AnyRef): Int =
+  @noinline def binarySearch(a: Array[AnyRef], key: AnyRef): Int =
     binarySearchImplRef(a, 0, a.length, key)
 
   @noinline
@@ -493,44 +469,34 @@ object Arrays {
     }
   }
 
-  @noinline
-  def equals(a: Array[Long], b: Array[Long]): Boolean =
+  @noinline def equals(a: Array[Long], b: Array[Long]): Boolean =
     equalsImpl(a, b)
 
-  @noinline
-  def equals(a: Array[Int], b: Array[Int]): Boolean =
+  @noinline def equals(a: Array[Int], b: Array[Int]): Boolean =
     equalsImpl(a, b)
 
-  @noinline
-  def equals(a: Array[Short], b: Array[Short]): Boolean =
+  @noinline def equals(a: Array[Short], b: Array[Short]): Boolean =
     equalsImpl(a, b)
 
-  @noinline
-  def equals(a: Array[Char], b: Array[Char]): Boolean =
+  @noinline def equals(a: Array[Char], b: Array[Char]): Boolean =
     equalsImpl(a, b)
 
-  @noinline
-  def equals(a: Array[Byte], b: Array[Byte]): Boolean =
+  @noinline def equals(a: Array[Byte], b: Array[Byte]): Boolean =
     equalsImpl(a, b)
 
-  @noinline
-  def equals(a: Array[Boolean], b: Array[Boolean]): Boolean =
+  @noinline def equals(a: Array[Boolean], b: Array[Boolean]): Boolean =
     equalsImpl(a, b)
 
-  @noinline
-  def equals(a: Array[Double], b: Array[Double]): Boolean =
+  @noinline def equals(a: Array[Double], b: Array[Double]): Boolean =
     equalsImpl(a, b)
 
-  @noinline
-  def equals(a: Array[Float], b: Array[Float]): Boolean =
+  @noinline def equals(a: Array[Float], b: Array[Float]): Boolean =
     equalsImpl(a, b)
 
-  @noinline
-  def equals(a: Array[AnyRef], b: Array[AnyRef]): Boolean =
+  @noinline def equals(a: Array[AnyRef], b: Array[AnyRef]): Boolean =
     equalsImpl(a, b)
 
-  @inline
-  private def equalsImpl[T](a: Array[T], b: Array[T]): Boolean = {
+  @inline private def equalsImpl[T](a: Array[T], b: Array[T]): Boolean = {
     // scalastyle:off return
     if (a eq b)
       return true
@@ -549,48 +515,42 @@ object Arrays {
     // scalastyle:on return
   }
 
-  @noinline
-  def fill(a: Array[Long], value: Long): Unit =
+  @noinline def fill(a: Array[Long], value: Long): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
   @noinline
   def fill(a: Array[Long], fromIndex: Int, toIndex: Int, value: Long): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline
-  def fill(a: Array[Int], value: Int): Unit =
+  @noinline def fill(a: Array[Int], value: Int): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
   @noinline
   def fill(a: Array[Int], fromIndex: Int, toIndex: Int, value: Int): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline
-  def fill(a: Array[Short], value: Short): Unit =
+  @noinline def fill(a: Array[Short], value: Short): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
   @noinline
   def fill(a: Array[Short], fromIndex: Int, toIndex: Int, value: Short): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline
-  def fill(a: Array[Char], value: Char): Unit =
+  @noinline def fill(a: Array[Char], value: Char): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
   @noinline
   def fill(a: Array[Char], fromIndex: Int, toIndex: Int, value: Char): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline
-  def fill(a: Array[Byte], value: Byte): Unit =
+  @noinline def fill(a: Array[Byte], value: Byte): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
   @noinline
   def fill(a: Array[Byte], fromIndex: Int, toIndex: Int, value: Byte): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline
-  def fill(a: Array[Boolean], value: Boolean): Unit =
+  @noinline def fill(a: Array[Boolean], value: Boolean): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
   @noinline
@@ -600,8 +560,7 @@ object Arrays {
            value: Boolean): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline
-  def fill(a: Array[Double], value: Double): Unit =
+  @noinline def fill(a: Array[Double], value: Double): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
   @noinline
@@ -611,16 +570,14 @@ object Arrays {
            value: Double): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline
-  def fill(a: Array[Float], value: Float): Unit =
+  @noinline def fill(a: Array[Float], value: Float): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
   @noinline
   def fill(a: Array[Float], fromIndex: Int, toIndex: Int, value: Float): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline
-  def fill(a: Array[AnyRef], value: AnyRef): Unit =
+  @noinline def fill(a: Array[AnyRef], value: AnyRef): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
   @noinline
@@ -660,28 +617,22 @@ object Arrays {
     copyOfImpl(original, newLength)
   }
 
-  @noinline
-  def copyOf(original: Array[Byte], newLength: Int): Array[Byte] =
+  @noinline def copyOf(original: Array[Byte], newLength: Int): Array[Byte] =
     copyOfImpl(original, newLength)
 
-  @noinline
-  def copyOf(original: Array[Short], newLength: Int): Array[Short] =
+  @noinline def copyOf(original: Array[Short], newLength: Int): Array[Short] =
     copyOfImpl(original, newLength)
 
-  @noinline
-  def copyOf(original: Array[Int], newLength: Int): Array[Int] =
+  @noinline def copyOf(original: Array[Int], newLength: Int): Array[Int] =
     copyOfImpl(original, newLength)
 
-  @noinline
-  def copyOf(original: Array[Long], newLength: Int): Array[Long] =
+  @noinline def copyOf(original: Array[Long], newLength: Int): Array[Long] =
     copyOfImpl(original, newLength)
 
-  @noinline
-  def copyOf(original: Array[Char], newLength: Int): Array[Char] =
+  @noinline def copyOf(original: Array[Char], newLength: Int): Array[Char] =
     copyOfImpl(original, newLength)
 
-  @noinline
-  def copyOf(original: Array[Float], newLength: Int): Array[Float] =
+  @noinline def copyOf(original: Array[Float], newLength: Int): Array[Float] =
     copyOfImpl(original, newLength)
 
   @noinline
@@ -775,8 +726,7 @@ object Arrays {
       throw new NegativeArraySizeException
   }
 
-  @noinline
-  def asList[T <: AnyRef](a: Array[T]): List[T] = {
+  @noinline def asList[T <: AnyRef](a: Array[T]): List[T] = {
     new AbstractList[T] with RandomAccess {
       def size(): Int =
         a.length
@@ -792,40 +742,31 @@ object Arrays {
     }
   }
 
-  @noinline
-  def hashCode(a: Array[Long]): Int =
+  @noinline def hashCode(a: Array[Long]): Int =
     hashCodeImpl[Long](a, _.hashCode())
 
-  @noinline
-  def hashCode(a: Array[Int]): Int =
+  @noinline def hashCode(a: Array[Int]): Int =
     hashCodeImpl[Int](a, _.hashCode())
 
-  @noinline
-  def hashCode(a: Array[Short]): Int =
+  @noinline def hashCode(a: Array[Short]): Int =
     hashCodeImpl[Short](a, _.hashCode())
 
-  @noinline
-  def hashCode(a: Array[Char]): Int =
+  @noinline def hashCode(a: Array[Char]): Int =
     hashCodeImpl[Char](a, _.hashCode())
 
-  @noinline
-  def hashCode(a: Array[Byte]): Int =
+  @noinline def hashCode(a: Array[Byte]): Int =
     hashCodeImpl[Byte](a, _.hashCode())
 
-  @noinline
-  def hashCode(a: Array[Boolean]): Int =
+  @noinline def hashCode(a: Array[Boolean]): Int =
     hashCodeImpl[Boolean](a, _.hashCode())
 
-  @noinline
-  def hashCode(a: Array[Float]): Int =
+  @noinline def hashCode(a: Array[Float]): Int =
     hashCodeImpl[Float](a, _.hashCode())
 
-  @noinline
-  def hashCode(a: Array[Double]): Int =
+  @noinline def hashCode(a: Array[Double]): Int =
     hashCodeImpl[Double](a, _.hashCode())
 
-  @noinline
-  def hashCode(a: Array[AnyRef]): Int =
+  @noinline def hashCode(a: Array[AnyRef]): Int =
     hashCodeImpl[AnyRef](a, Objects.hashCode(_))
 
   @inline
@@ -840,10 +781,8 @@ object Arrays {
     }
   }
 
-  @noinline
-  def deepHashCode(a: Array[AnyRef]): Int = {
-    @inline
-    def getHash(elem: AnyRef): Int = {
+  @noinline def deepHashCode(a: Array[AnyRef]): Int = {
+    @inline def getHash(elem: AnyRef): Int = {
       elem match {
         case elem: Array[AnyRef]  => deepHashCode(elem)
         case elem: Array[Long]    => hashCode(elem)
@@ -860,8 +799,7 @@ object Arrays {
     hashCodeImpl(a, getHash)
   }
 
-  @noinline
-  def deepEquals(a1: Array[AnyRef], a2: Array[AnyRef]): Boolean = {
+  @noinline def deepEquals(a1: Array[AnyRef], a2: Array[AnyRef]): Boolean = {
     // scalastyle:off return
     if (a1 eq a2)
       return true
@@ -880,44 +818,34 @@ object Arrays {
     // scalastyle:on return
   }
 
-  @noinline
-  def toString(a: Array[Long]): String =
+  @noinline def toString(a: Array[Long]): String =
     toStringImpl[Long](a)
 
-  @noinline
-  def toString(a: Array[Int]): String =
+  @noinline def toString(a: Array[Int]): String =
     toStringImpl[Int](a)
 
-  @noinline
-  def toString(a: Array[Short]): String =
+  @noinline def toString(a: Array[Short]): String =
     toStringImpl[Short](a)
 
-  @noinline
-  def toString(a: Array[Char]): String =
+  @noinline def toString(a: Array[Char]): String =
     toStringImpl[Char](a)
 
-  @noinline
-  def toString(a: Array[Byte]): String =
+  @noinline def toString(a: Array[Byte]): String =
     toStringImpl[Byte](a)
 
-  @noinline
-  def toString(a: Array[Boolean]): String =
+  @noinline def toString(a: Array[Boolean]): String =
     toStringImpl[Boolean](a)
 
-  @noinline
-  def toString(a: Array[Float]): String =
+  @noinline def toString(a: Array[Float]): String =
     toStringImpl[Float](a)
 
-  @noinline
-  def toString(a: Array[Double]): String =
+  @noinline def toString(a: Array[Double]): String =
     toStringImpl[Double](a)
 
-  @noinline
-  def toString(a: Array[AnyRef]): String =
+  @noinline def toString(a: Array[AnyRef]): String =
     toStringImpl[AnyRef](a)
 
-  @inline
-  private def toStringImpl[T](a: Array[T]): String = {
+  @inline private def toStringImpl[T](a: Array[T]): String = {
     if (a == null) {
       "null"
     } else {
@@ -934,14 +862,12 @@ object Arrays {
     }
   }
 
-  @noinline
-  def deepToString(a: Array[AnyRef]): String =
+  @noinline def deepToString(a: Array[AnyRef]): String =
     deepToStringImpl(a, new java.util.HashSet[AsRef])
 
   private def deepToStringImpl(a: Array[AnyRef],
                                branch: java.util.Set[AsRef]): String = {
-    @inline
-    def valueToString(e: AnyRef): String = {
+    @inline def valueToString(e: AnyRef): String = {
       if (e == null) "null"
       else {
         e match {

--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -9,7 +9,6 @@ import scala.reflect.ClassTag
 import ScalaOps._
 
 object Arrays {
-
   @inline
   private final implicit def naturalOrdering[T <: AnyRef]: Ordering[T] = {
     new Ordering[T] {
@@ -323,104 +322,120 @@ object Arrays {
     }
   }
 
-  @noinline def binarySearch(a: Array[Long], key: Long): Int =
+  @noinline
+  def binarySearch(a: Array[Long], key: Long): Int =
     binarySearchImpl[Long](a, 0, a.length, key, _ < _)
 
-  @noinline def binarySearch(a: Array[Long],
-                             startIndex: Int,
-                             endIndex: Int,
-                             key: Long): Int = {
+  @noinline
+  def binarySearch(a: Array[Long],
+                   startIndex: Int,
+                   endIndex: Int,
+                   key: Long): Int = {
     checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Long](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline def binarySearch(a: Array[Int], key: Int): Int =
+  @noinline
+  def binarySearch(a: Array[Int], key: Int): Int =
     binarySearchImpl[Int](a, 0, a.length, key, _ < _)
 
-  @noinline def binarySearch(a: Array[Int],
-                             startIndex: Int,
-                             endIndex: Int,
-                             key: Int): Int = {
+  @noinline
+  def binarySearch(a: Array[Int],
+                   startIndex: Int,
+                   endIndex: Int,
+                   key: Int): Int = {
     checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Int](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline def binarySearch(a: Array[Short], key: Short): Int =
+  @noinline
+  def binarySearch(a: Array[Short], key: Short): Int =
     binarySearchImpl[Short](a, 0, a.length, key, _ < _)
 
-  @noinline def binarySearch(a: Array[Short],
-                             startIndex: Int,
-                             endIndex: Int,
-                             key: Short): Int = {
+  @noinline
+  def binarySearch(a: Array[Short],
+                   startIndex: Int,
+                   endIndex: Int,
+                   key: Short): Int = {
     checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Short](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline def binarySearch(a: Array[Char], key: Char): Int =
+  @noinline
+  def binarySearch(a: Array[Char], key: Char): Int =
     binarySearchImpl[Char](a, 0, a.length, key, _ < _)
 
-  @noinline def binarySearch(a: Array[Char],
-                             startIndex: Int,
-                             endIndex: Int,
-                             key: Char): Int = {
+  @noinline
+  def binarySearch(a: Array[Char],
+                   startIndex: Int,
+                   endIndex: Int,
+                   key: Char): Int = {
     checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Char](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline def binarySearch(a: Array[Byte], key: Byte): Int =
+  @noinline
+  def binarySearch(a: Array[Byte], key: Byte): Int =
     binarySearchImpl[Byte](a, 0, a.length, key, _ < _)
 
-  @noinline def binarySearch(a: Array[Byte],
-                             startIndex: Int,
-                             endIndex: Int,
-                             key: Byte): Int = {
+  @noinline
+  def binarySearch(a: Array[Byte],
+                   startIndex: Int,
+                   endIndex: Int,
+                   key: Byte): Int = {
     checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Byte](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline def binarySearch(a: Array[Double], key: Double): Int =
+  @noinline
+  def binarySearch(a: Array[Double], key: Double): Int =
     binarySearchImpl[Double](a, 0, a.length, key, _ < _)
 
-  @noinline def binarySearch(a: Array[Double],
-                             startIndex: Int,
-                             endIndex: Int,
-                             key: Double): Int = {
+  @noinline
+  def binarySearch(a: Array[Double],
+                   startIndex: Int,
+                   endIndex: Int,
+                   key: Double): Int = {
     checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Double](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline def binarySearch(a: Array[Float], key: Float): Int =
+  @noinline
+  def binarySearch(a: Array[Float], key: Float): Int =
     binarySearchImpl[Float](a, 0, a.length, key, _ < _)
 
-  @noinline def binarySearch(a: Array[Float],
-                             startIndex: Int,
-                             endIndex: Int,
-                             key: Float): Int = {
+  @noinline
+  def binarySearch(a: Array[Float],
+                   startIndex: Int,
+                   endIndex: Int,
+                   key: Float): Int = {
     checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[Float](a, startIndex, endIndex, key, _ < _)
   }
 
-  @noinline def binarySearch(a: Array[AnyRef], key: AnyRef): Int =
+  @noinline
+  def binarySearch(a: Array[AnyRef], key: AnyRef): Int =
     binarySearchImplRef(a, 0, a.length, key)
 
-  @noinline def binarySearch(a: Array[AnyRef],
-                             startIndex: Int,
-                             endIndex: Int,
-                             key: AnyRef): Int = {
+  @noinline
+  def binarySearch(a: Array[AnyRef],
+                   startIndex: Int,
+                   endIndex: Int,
+                   key: AnyRef): Int = {
     checkRangeIndices(a, startIndex, endIndex)
     binarySearchImplRef(a, startIndex, endIndex, key)
   }
 
-  @noinline def binarySearch[T](a: Array[T],
-                                key: T,
-                                c: Comparator[_ >: T]): Int =
+  @noinline
+  def binarySearch[T](a: Array[T], key: T, c: Comparator[_ >: T]): Int =
     binarySearchImpl[T](a, 0, a.length, key, (a, b) => c.compare(a, b) < 0)
 
-  @noinline def binarySearch[T](a: Array[T],
-                                startIndex: Int,
-                                endIndex: Int,
-                                key: T,
-                                c: Comparator[_ >: T]): Int = {
+  @noinline
+  def binarySearch[T](a: Array[T],
+                      startIndex: Int,
+                      endIndex: Int,
+                      key: T,
+                      c: Comparator[_ >: T]): Int = {
     checkRangeIndices(a, startIndex, endIndex)
     binarySearchImpl[T](a,
                         startIndex,
@@ -478,31 +493,40 @@ object Arrays {
     }
   }
 
-  @noinline def equals(a: Array[Long], b: Array[Long]): Boolean =
+  @noinline
+  def equals(a: Array[Long], b: Array[Long]): Boolean =
     equalsImpl(a, b)
 
-  @noinline def equals(a: Array[Int], b: Array[Int]): Boolean =
+  @noinline
+  def equals(a: Array[Int], b: Array[Int]): Boolean =
     equalsImpl(a, b)
 
-  @noinline def equals(a: Array[Short], b: Array[Short]): Boolean =
+  @noinline
+  def equals(a: Array[Short], b: Array[Short]): Boolean =
     equalsImpl(a, b)
 
-  @noinline def equals(a: Array[Char], b: Array[Char]): Boolean =
+  @noinline
+  def equals(a: Array[Char], b: Array[Char]): Boolean =
     equalsImpl(a, b)
 
-  @noinline def equals(a: Array[Byte], b: Array[Byte]): Boolean =
+  @noinline
+  def equals(a: Array[Byte], b: Array[Byte]): Boolean =
     equalsImpl(a, b)
 
-  @noinline def equals(a: Array[Boolean], b: Array[Boolean]): Boolean =
+  @noinline
+  def equals(a: Array[Boolean], b: Array[Boolean]): Boolean =
     equalsImpl(a, b)
 
-  @noinline def equals(a: Array[Double], b: Array[Double]): Boolean =
+  @noinline
+  def equals(a: Array[Double], b: Array[Double]): Boolean =
     equalsImpl(a, b)
 
-  @noinline def equals(a: Array[Float], b: Array[Float]): Boolean =
+  @noinline
+  def equals(a: Array[Float], b: Array[Float]): Boolean =
     equalsImpl(a, b)
 
-  @noinline def equals(a: Array[AnyRef], b: Array[AnyRef]): Boolean =
+  @noinline
+  def equals(a: Array[AnyRef], b: Array[AnyRef]): Boolean =
     equalsImpl(a, b)
 
   @inline
@@ -525,85 +549,85 @@ object Arrays {
     // scalastyle:on return
   }
 
-  @noinline def fill(a: Array[Long], value: Long): Unit =
+  @noinline
+  def fill(a: Array[Long], value: Long): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline def fill(a: Array[Long],
-                     fromIndex: Int,
-                     toIndex: Int,
-                     value: Long): Unit =
+  @noinline
+  def fill(a: Array[Long], fromIndex: Int, toIndex: Int, value: Long): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline def fill(a: Array[Int], value: Int): Unit =
+  @noinline
+  def fill(a: Array[Int], value: Int): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline def fill(a: Array[Int],
-                     fromIndex: Int,
-                     toIndex: Int,
-                     value: Int): Unit =
+  @noinline
+  def fill(a: Array[Int], fromIndex: Int, toIndex: Int, value: Int): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline def fill(a: Array[Short], value: Short): Unit =
+  @noinline
+  def fill(a: Array[Short], value: Short): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline def fill(a: Array[Short],
-                     fromIndex: Int,
-                     toIndex: Int,
-                     value: Short): Unit =
+  @noinline
+  def fill(a: Array[Short], fromIndex: Int, toIndex: Int, value: Short): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline def fill(a: Array[Char], value: Char): Unit =
+  @noinline
+  def fill(a: Array[Char], value: Char): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline def fill(a: Array[Char],
-                     fromIndex: Int,
-                     toIndex: Int,
-                     value: Char): Unit =
+  @noinline
+  def fill(a: Array[Char], fromIndex: Int, toIndex: Int, value: Char): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline def fill(a: Array[Byte], value: Byte): Unit =
+  @noinline
+  def fill(a: Array[Byte], value: Byte): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline def fill(a: Array[Byte],
-                     fromIndex: Int,
-                     toIndex: Int,
-                     value: Byte): Unit =
+  @noinline
+  def fill(a: Array[Byte], fromIndex: Int, toIndex: Int, value: Byte): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline def fill(a: Array[Boolean], value: Boolean): Unit =
+  @noinline
+  def fill(a: Array[Boolean], value: Boolean): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline def fill(a: Array[Boolean],
-                     fromIndex: Int,
-                     toIndex: Int,
-                     value: Boolean): Unit =
+  @noinline
+  def fill(a: Array[Boolean],
+           fromIndex: Int,
+           toIndex: Int,
+           value: Boolean): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline def fill(a: Array[Double], value: Double): Unit =
+  @noinline
+  def fill(a: Array[Double], value: Double): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline def fill(a: Array[Double],
-                     fromIndex: Int,
-                     toIndex: Int,
-                     value: Double): Unit =
+  @noinline
+  def fill(a: Array[Double],
+           fromIndex: Int,
+           toIndex: Int,
+           value: Double): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline def fill(a: Array[Float], value: Float): Unit =
+  @noinline
+  def fill(a: Array[Float], value: Float): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline def fill(a: Array[Float],
-                     fromIndex: Int,
-                     toIndex: Int,
-                     value: Float): Unit =
+  @noinline
+  def fill(a: Array[Float], fromIndex: Int, toIndex: Int, value: Float): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
-  @noinline def fill(a: Array[AnyRef], value: AnyRef): Unit =
+  @noinline
+  def fill(a: Array[AnyRef], value: AnyRef): Unit =
     fillImpl(a, 0, a.length, value, checkIndices = false)
 
-  @noinline def fill(a: Array[AnyRef],
-                     fromIndex: Int,
-                     toIndex: Int,
-                     value: AnyRef): Unit =
+  @noinline
+  def fill(a: Array[AnyRef],
+           fromIndex: Int,
+           toIndex: Int,
+           value: AnyRef): Unit =
     fillImpl(a, fromIndex, toIndex, value)
 
   @inline
@@ -621,13 +645,14 @@ object Arrays {
     }
   }
 
-  @noinline def copyOf[T <: AnyRef](original: Array[T],
-                                    newLength: Int): Array[T] = {
+  @noinline
+  def copyOf[T <: AnyRef](original: Array[T], newLength: Int): Array[T] = {
     implicit val tagT = ClassTag[T](original.getClass.getComponentType)
     copyOfImpl(original, newLength)
   }
 
-  @noinline def copyOf[T <: AnyRef, U <: AnyRef](
+  @noinline
+  def copyOf[T <: AnyRef, U <: AnyRef](
       original: Array[U],
       newLength: Int,
       newType: Class[_ <: Array[T]]): Array[T] = {
@@ -635,29 +660,36 @@ object Arrays {
     copyOfImpl(original, newLength)
   }
 
-  @noinline def copyOf(original: Array[Byte], newLength: Int): Array[Byte] =
+  @noinline
+  def copyOf(original: Array[Byte], newLength: Int): Array[Byte] =
     copyOfImpl(original, newLength)
 
-  @noinline def copyOf(original: Array[Short], newLength: Int): Array[Short] =
+  @noinline
+  def copyOf(original: Array[Short], newLength: Int): Array[Short] =
     copyOfImpl(original, newLength)
 
-  @noinline def copyOf(original: Array[Int], newLength: Int): Array[Int] =
+  @noinline
+  def copyOf(original: Array[Int], newLength: Int): Array[Int] =
     copyOfImpl(original, newLength)
 
-  @noinline def copyOf(original: Array[Long], newLength: Int): Array[Long] =
+  @noinline
+  def copyOf(original: Array[Long], newLength: Int): Array[Long] =
     copyOfImpl(original, newLength)
 
-  @noinline def copyOf(original: Array[Char], newLength: Int): Array[Char] =
+  @noinline
+  def copyOf(original: Array[Char], newLength: Int): Array[Char] =
     copyOfImpl(original, newLength)
 
-  @noinline def copyOf(original: Array[Float], newLength: Int): Array[Float] =
+  @noinline
+  def copyOf(original: Array[Float], newLength: Int): Array[Float] =
     copyOfImpl(original, newLength)
 
-  @noinline def copyOf(original: Array[Double], newLength: Int): Array[Double] =
+  @noinline
+  def copyOf(original: Array[Double], newLength: Int): Array[Double] =
     copyOfImpl(original, newLength)
 
-  @noinline def copyOf(original: Array[Boolean],
-                       newLength: Int): Array[Boolean] =
+  @noinline
+  def copyOf(original: Array[Boolean], newLength: Int): Array[Boolean] =
     copyOfImpl(original, newLength)
 
   @inline
@@ -670,14 +702,16 @@ object Arrays {
     ret
   }
 
-  @noinline def copyOfRange[T <: AnyRef](original: Array[T],
-                                         from: Int,
-                                         to: Int): Array[T] = {
+  @noinline
+  def copyOfRange[T <: AnyRef](original: Array[T],
+                               from: Int,
+                               to: Int): Array[T] = {
     copyOfRangeImpl[T](original, from, to)(
       ClassTag(original.getClass.getComponentType)).asInstanceOf[Array[T]]
   }
 
-  @noinline def copyOfRange[T <: AnyRef, U <: AnyRef](
+  @noinline
+  def copyOfRange[T <: AnyRef, U <: AnyRef](
       original: Array[U],
       from: Int,
       to: Int,
@@ -686,44 +720,40 @@ object Arrays {
       ClassTag(newType.getComponentType)).asInstanceOf[Array[T]]
   }
 
-  @noinline def copyOfRange(original: Array[Byte],
-                            start: Int,
-                            end: Int): Array[Byte] =
+  @noinline
+  def copyOfRange(original: Array[Byte], start: Int, end: Int): Array[Byte] =
     copyOfRangeImpl[Byte](original, start, end)
 
-  @noinline def copyOfRange(original: Array[Short],
-                            start: Int,
-                            end: Int): Array[Short] =
+  @noinline
+  def copyOfRange(original: Array[Short], start: Int, end: Int): Array[Short] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline def copyOfRange(original: Array[Int],
-                            start: Int,
-                            end: Int): Array[Int] =
+  @noinline
+  def copyOfRange(original: Array[Int], start: Int, end: Int): Array[Int] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline def copyOfRange(original: Array[Long],
-                            start: Int,
-                            end: Int): Array[Long] =
+  @noinline
+  def copyOfRange(original: Array[Long], start: Int, end: Int): Array[Long] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline def copyOfRange(original: Array[Char],
-                            start: Int,
-                            end: Int): Array[Char] =
+  @noinline
+  def copyOfRange(original: Array[Char], start: Int, end: Int): Array[Char] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline def copyOfRange(original: Array[Float],
-                            start: Int,
-                            end: Int): Array[Float] =
+  @noinline
+  def copyOfRange(original: Array[Float], start: Int, end: Int): Array[Float] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline def copyOfRange(original: Array[Double],
-                            start: Int,
-                            end: Int): Array[Double] =
+  @noinline
+  def copyOfRange(original: Array[Double],
+                  start: Int,
+                  end: Int): Array[Double] =
     copyOfRangeImpl(original, start, end)
 
-  @noinline def copyOfRange(original: Array[Boolean],
-                            start: Int,
-                            end: Int): Array[Boolean] =
+  @noinline
+  def copyOfRange(original: Array[Boolean],
+                  start: Int,
+                  end: Int): Array[Boolean] =
     copyOfRangeImpl(original, start, end)
 
   @inline
@@ -745,7 +775,8 @@ object Arrays {
       throw new NegativeArraySizeException
   }
 
-  @noinline def asList[T <: AnyRef](a: Array[T]): List[T] = {
+  @noinline
+  def asList[T <: AnyRef](a: Array[T]): List[T] = {
     new AbstractList[T] with RandomAccess {
       def size(): Int =
         a.length
@@ -761,31 +792,40 @@ object Arrays {
     }
   }
 
-  @noinline def hashCode(a: Array[Long]): Int =
+  @noinline
+  def hashCode(a: Array[Long]): Int =
     hashCodeImpl[Long](a, _.hashCode())
 
-  @noinline def hashCode(a: Array[Int]): Int =
+  @noinline
+  def hashCode(a: Array[Int]): Int =
     hashCodeImpl[Int](a, _.hashCode())
 
-  @noinline def hashCode(a: Array[Short]): Int =
+  @noinline
+  def hashCode(a: Array[Short]): Int =
     hashCodeImpl[Short](a, _.hashCode())
 
-  @noinline def hashCode(a: Array[Char]): Int =
+  @noinline
+  def hashCode(a: Array[Char]): Int =
     hashCodeImpl[Char](a, _.hashCode())
 
-  @noinline def hashCode(a: Array[Byte]): Int =
+  @noinline
+  def hashCode(a: Array[Byte]): Int =
     hashCodeImpl[Byte](a, _.hashCode())
 
-  @noinline def hashCode(a: Array[Boolean]): Int =
+  @noinline
+  def hashCode(a: Array[Boolean]): Int =
     hashCodeImpl[Boolean](a, _.hashCode())
 
-  @noinline def hashCode(a: Array[Float]): Int =
+  @noinline
+  def hashCode(a: Array[Float]): Int =
     hashCodeImpl[Float](a, _.hashCode())
 
-  @noinline def hashCode(a: Array[Double]): Int =
+  @noinline
+  def hashCode(a: Array[Double]): Int =
     hashCodeImpl[Double](a, _.hashCode())
 
-  @noinline def hashCode(a: Array[AnyRef]): Int =
+  @noinline
+  def hashCode(a: Array[AnyRef]): Int =
     hashCodeImpl[AnyRef](a, Objects.hashCode(_))
 
   @inline
@@ -800,7 +840,8 @@ object Arrays {
     }
   }
 
-  @noinline def deepHashCode(a: Array[AnyRef]): Int = {
+  @noinline
+  def deepHashCode(a: Array[AnyRef]): Int = {
     @inline
     def getHash(elem: AnyRef): Int = {
       elem match {
@@ -819,7 +860,8 @@ object Arrays {
     hashCodeImpl(a, getHash)
   }
 
-  @noinline def deepEquals(a1: Array[AnyRef], a2: Array[AnyRef]): Boolean = {
+  @noinline
+  def deepEquals(a1: Array[AnyRef], a2: Array[AnyRef]): Boolean = {
     // scalastyle:off return
     if (a1 eq a2)
       return true
@@ -838,31 +880,40 @@ object Arrays {
     // scalastyle:on return
   }
 
-  @noinline def toString(a: Array[Long]): String =
+  @noinline
+  def toString(a: Array[Long]): String =
     toStringImpl[Long](a)
 
-  @noinline def toString(a: Array[Int]): String =
+  @noinline
+  def toString(a: Array[Int]): String =
     toStringImpl[Int](a)
 
-  @noinline def toString(a: Array[Short]): String =
+  @noinline
+  def toString(a: Array[Short]): String =
     toStringImpl[Short](a)
 
-  @noinline def toString(a: Array[Char]): String =
+  @noinline
+  def toString(a: Array[Char]): String =
     toStringImpl[Char](a)
 
-  @noinline def toString(a: Array[Byte]): String =
+  @noinline
+  def toString(a: Array[Byte]): String =
     toStringImpl[Byte](a)
 
-  @noinline def toString(a: Array[Boolean]): String =
+  @noinline
+  def toString(a: Array[Boolean]): String =
     toStringImpl[Boolean](a)
 
-  @noinline def toString(a: Array[Float]): String =
+  @noinline
+  def toString(a: Array[Float]): String =
     toStringImpl[Float](a)
 
-  @noinline def toString(a: Array[Double]): String =
+  @noinline
+  def toString(a: Array[Double]): String =
     toStringImpl[Double](a)
 
-  @noinline def toString(a: Array[AnyRef]): String =
+  @noinline
+  def toString(a: Array[AnyRef]): String =
     toStringImpl[AnyRef](a)
 
   @inline
@@ -883,7 +934,8 @@ object Arrays {
     }
   }
 
-  @noinline def deepToString(a: Array[AnyRef]): String =
+  @noinline
+  def deepToString(a: Array[AnyRef]): String =
     deepToStringImpl(a, new java.util.HashSet[AsRef])
 
   private def deepToStringImpl(a: Array[AnyRef],

--- a/unit-tests/src/test/scala/java/util/ArraysTest.scala
+++ b/unit-tests/src/test/scala/java/util/ArraysTest.scala
@@ -6,7 +6,6 @@ import language.implicitConversions
 
 import org.junit.Assert._
 import org.junit.Assume._
-import org.junit.Ignore
 import org.junit.Test
 
 import scala.scalanative.junit.utils.AssertThrows._

--- a/unit-tests/src/test/scala/java/util/ArraysTest.scala
+++ b/unit-tests/src/test/scala/java/util/ArraysTest.scala
@@ -18,15 +18,11 @@ import scala.reflect.ClassTag
 
 object ArraysTest extends ArraysTest
 
-/** This is also used in the typedarray package to test scala.Arrays backed
- *  by TypedArrays
- */
 class ArraysTest {
   // To invoke org.junit.Assert.assertArrayEquals on Array[T]
   implicit def array2erasedArray[T](arr: Array[T]): Array[AnyRef] =
     arr.map(_.asInstanceOf[AnyRef])
 
-  /** Overridden by typedarray tests */
   def Array[T: ClassTag](v: T*): scala.Array[T] = scala.Array(v: _*)
 
   val stringComparator = new Comparator[String]() {

--- a/unit-tests/src/test/scala/java/util/ArraysTest.scala
+++ b/unit-tests/src/test/scala/java/util/ArraysTest.scala
@@ -23,8 +23,6 @@ class ArraysTest {
   implicit def array2erasedArray[T](arr: Array[T]): Array[AnyRef] =
     arr.map(_.asInstanceOf[AnyRef])
 
-  def Array[T: ClassTag](v: T*): scala.Array[T] = scala.Array(v: _*)
-
   val stringComparator = new Comparator[String]() {
     def compare(s1: String, s2: String): Int = s1.compareTo(s2)
   }

--- a/unit-tests/src/test/scala/java/util/ArraysTest.scala
+++ b/unit-tests/src/test/scala/java/util/ArraysTest.scala
@@ -1,18 +1,1177 @@
-package java.util
+// Ported from Scala.js commit: ba618ed dated: 2020-10-05
 
-import org.junit.Test
+package org.scalanative.testsuite.javalib.util
+
+import language.implicitConversions
+
 import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Ignore
+import org.junit.Test
 
+import scala.scalanative.junit.utils.AssertThrows._
+import org.scalanative.testsuite.utils.Platform._
+
+import java.util.{Arrays, Comparator}
+
+import scala.reflect.ClassTag
+
+object ArraysTest extends ArraysTest
+
+/** This is also used in the typedarray package to test scala.Arrays backed
+ *  by TypedArrays
+ */
 class ArraysTest {
-  @Test def asList(): Unit = {
-    val array = Array("a", "c")
-    val list  = Arrays.asList(array: _*)
-    array.update(1, "b")
-    assertTrue(list.size() == 2)
-    assertTrue(list.get(0) == "a")
-    assertTrue(list.get(1) == "b")
+  // To invoke org.junit.Assert.assertArrayEquals on Array[T]
+  implicit def array2erasedArray[T](arr: Array[T]): Array[AnyRef] =
+    arr.map(_.asInstanceOf[AnyRef])
 
-    list.set(0, "1")
-    assertTrue(array(0) == "1")
+  /** Overridden by typedarray tests */
+  def Array[T: ClassTag](v: T*): scala.Array[T] = scala.Array(v: _*)
+
+  val stringComparator = new Comparator[String]() {
+    def compare(s1: String, s2: String): Int = s1.compareTo(s2)
+  }
+
+  @Test def sort_Int(): Unit =
+    testSort[Int](_.toInt, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
+
+  @Test def sort_Long(): Unit =
+    testSort[Long](_.toLong, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
+
+  @Test def sort_Short(): Unit =
+    testSort[Short](_.toShort,
+                    new Array(_),
+                    Arrays.sort(_),
+                    Arrays.sort(_, _, _))
+
+  @Test def sort_Byte(): Unit =
+    testSort[Byte](_.toByte, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
+
+  @Test def sort_Char(): Unit =
+    testSort[Char](_.toChar, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
+
+  @Test def sort_Float(): Unit =
+    testSort[Float](_.toFloat,
+                    new Array(_),
+                    Arrays.sort(_),
+                    Arrays.sort(_, _, _))
+
+  @Test def sort_Double(): Unit =
+    testSort[Double](_.toDouble,
+                     new Array(_),
+                     Arrays.sort(_),
+                     Arrays.sort(_, _, _))
+
+  @Test def sort_String(): Unit =
+    testSort[AnyRef](_.toString,
+                     new Array(_),
+                     Arrays.sort(_),
+                     Arrays.sort(_, _, _))
+
+  @Test def sort_String_with_null_Comparator(): Unit =
+    testSort[AnyRef](_.toString,
+                     new Array(_),
+                     Arrays.sort(_, null),
+                     Arrays.sort(_, _, _, null))
+
+  private def testSort[T: ClassTag](
+      elem: Int => T,
+      newArray: Int => Array[T],
+      sort: Array[T] => Unit,
+      sort2: (Array[T], Int, Int) => Unit): Unit = {
+    val values = Array(5, 3, 6, 1, 2, 4).map(elem)
+    val arr    = newArray(values.length)
+
+    for (i <- 0 until values.length)
+      arr(i) = values(i)
+    sort(arr)
+    assertArrayEquals(arr, Array(1, 2, 3, 4, 5, 6).map(elem))
+
+    for (i <- 0 until values.length)
+      arr(i) = values(i)
+    sort2(arr, 0, 3)
+    assertArrayEquals(arr, Array(3, 5, 6, 1, 2, 4).map(elem))
+
+    sort2(arr, 2, 5)
+    assertArrayEquals(arr, Array(3, 5, 1, 2, 6, 4).map(elem))
+
+    sort2(arr, 0, 6)
+    assertArrayEquals(arr, Array(1, 2, 3, 4, 5, 6).map(elem))
+
+    // check zero length doesn't fail.
+    sort2(arr, 1, 1)
+  }
+
+  @Test def sort_is_stable_issue_2400(): Unit = {
+    case class N(i: Int)
+
+    val cmp = new Comparator[N] {
+      def compare(o1: N, o2: N): Int = 0
+    }
+
+    def isStable(a: scala.Array[N]): Boolean =
+      a.zipWithIndex.forall { case (n, i) => n.i == i }
+
+    for (size <- Seq(2, 4, 5, 15, 16, 19, 32, 33, 63, 64, 65, 4356)) {
+      val sxs = scala.Array.tabulate(size)(i => N(i))
+      Arrays.sort(sxs, cmp)
+
+      assertTrue(s"Arrays.sort wasn't stable on array of size $size.'",
+                 isStable(sxs))
+    }
+  }
+
+  @Test def sortWithComparator(): Unit = {
+    val scalajs: Array[String] = Array("S", "c", "a", "l", "a", ".", "j", "s")
+    val sorted                 = Array[String](".", "S", "a", "a", "c", "j", "l", "s")
+
+    Arrays.sort(scalajs, stringComparator)
+    assertArrayEquals(sorted, scalajs)
+  }
+
+  @Test def sortIsStable(): Unit = {
+    case class A(n: Int)
+    val cmp = new Comparator[A]() {
+      def compare(a1: A, a2: A): Int = a1.n.compareTo(a2.n)
+    }
+    val scalajs: Array[A] = Array(A(1), A(2), A(2), A(3), A(1), A(2), A(3))
+    val sorted = Array[A](scalajs(0),
+                          scalajs(4),
+                          scalajs(1),
+                          scalajs(2),
+                          scalajs(5),
+                          scalajs(3),
+                          scalajs(6))
+
+    Arrays.sort(scalajs, cmp)
+    assertArrayEquals(sorted, scalajs)
+    scalajs.zip(sorted).forall(pair => pair._1 eq pair._2)
+  }
+
+  @Test def sortIllegalArgumentException(): Unit = {
+    val array = Array(0, 1, 3, 4)
+
+    val e1 =
+      expectThrows(classOf[IllegalArgumentException], Arrays.sort(array, 3, 2))
+    assertEquals("fromIndex(3) > toIndex(2)", e1.getMessage)
+
+    // start/end comparison is made before index ranges checks
+    val e2 =
+      expectThrows(classOf[IllegalArgumentException], Arrays.sort(array, 7, 5))
+    assertEquals("fromIndex(7) > toIndex(5)", e2.getMessage)
+  }
+
+  @Test def sortArrayIndexOutOfBoundsException(): Unit = {
+    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
+               hasCompliantArrayIndexOutOfBounds)
+
+    val array = Array(0, 1, 3, 4)
+
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+                 Arrays.sort(array, -1, 4))
+
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+                 Arrays.sort(array, 0, 5))
+  }
+
+  @Test def fill_Boolean(): Unit = {
+    val booleans = new Array[Boolean](6)
+    Arrays.fill(booleans, false)
+    assertArrayEquals(Array(false, false, false, false, false, false), booleans)
+
+    Arrays.fill(booleans, true)
+    assertArrayEquals(Array(true, true, true, true, true, true), booleans)
+  }
+
+  @Test def fill_Boolean_with_start_and_end_index(): Unit = {
+    val booleans = new Array[Boolean](6)
+    Arrays.fill(booleans, 1, 4, true)
+    assertArrayEquals(Array(false, true, true, true, false, false), booleans)
+  }
+
+  @Test def fill_Byte(): Unit = {
+    val bytes = new Array[Byte](6)
+    Arrays.fill(bytes, 42.toByte)
+    assertArrayEquals(Array[Byte](42, 42, 42, 42, 42, 42), bytes)
+
+    Arrays.fill(bytes, -1.toByte)
+    assertArrayEquals(Array[Byte](-1, -1, -1, -1, -1, -1), bytes)
+  }
+
+  @Test def fill_Byte_with_start_and_end_index(): Unit = {
+    val bytes = new Array[Byte](6)
+    Arrays.fill(bytes, 1, 4, 42.toByte)
+    assertArrayEquals(Array[Byte](0, 42, 42, 42, 0, 0), bytes)
+
+    Arrays.fill(bytes, 2, 5, -1.toByte)
+    assertArrayEquals(Array[Byte](0, 42, -1, -1, -1, 0), bytes)
+  }
+
+  @Test def fill_Short(): Unit = {
+    val shorts = new Array[Short](6)
+    Arrays.fill(shorts, 42.toShort)
+    assertArrayEquals(Array[Short](42, 42, 42, 42, 42, 42), shorts)
+
+    Arrays.fill(shorts, -1.toShort)
+    assertArrayEquals(Array[Short](-1, -1, -1, -1, -1, -1), shorts)
+  }
+
+  @Test def fill_Short_with_start_and_end_index(): Unit = {
+    val shorts = new Array[Short](6)
+    Arrays.fill(shorts, 1, 4, 42.toShort)
+    assertArrayEquals(Array[Short](0, 42, 42, 42, 0, 0), shorts)
+
+    Arrays.fill(shorts, 2, 5, -1.toShort)
+    assertArrayEquals(Array[Short](0, 42, -1, -1, -1, 0), shorts)
+  }
+
+  @Test def fill_Int(): Unit = {
+    val ints = new Array[Int](6)
+    Arrays.fill(ints, 42)
+    assertArrayEquals(Array(42, 42, 42, 42, 42, 42), ints)
+
+    Arrays.fill(ints, -1)
+    assertArrayEquals(Array(-1, -1, -1, -1, -1, -1), ints)
+  }
+
+  @Test def fill_Int_with_start_and_end_index(): Unit = {
+    val ints = new Array[Int](6)
+    Arrays.fill(ints, 1, 4, 42)
+    assertArrayEquals(Array(0, 42, 42, 42, 0, 0), ints)
+
+    Arrays.fill(ints, 2, 5, -1)
+    assertArrayEquals(Array(0, 42, -1, -1, -1, 0), ints)
+  }
+
+  @Test def fill_Long(): Unit = {
+    val longs = new Array[Long](6)
+    Arrays.fill(longs, 42L)
+    assertArrayEquals(Array(42L, 42L, 42L, 42L, 42L, 42L), longs)
+
+    Arrays.fill(longs, -1L)
+    assertArrayEquals(Array(-1L, -1L, -1L, -1L, -1L, -1L), longs)
+  }
+
+  @Test def fill_Long_with_start_and_end_index(): Unit = {
+    val longs = new Array[Long](6)
+    Arrays.fill(longs, 1, 4, 42L)
+    assertArrayEquals(Array(0L, 42L, 42L, 42L, 0L, 0L), longs)
+
+    Arrays.fill(longs, 2, 5, -1L)
+    assertArrayEquals(Array(0L, 42L, -1L, -1L, -1L, 0L), longs)
+  }
+
+  @Test def fill_Float(): Unit = {
+    val floats = new Array[Float](6)
+    Arrays.fill(floats, 42.0f)
+    assertArrayEquals(Array(42.0f, 42.0f, 42.0f, 42.0f, 42.0f, 42.0f), floats)
+
+    Arrays.fill(floats, -1.0f)
+    assertArrayEquals(Array(-1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f), floats)
+  }
+
+  @Test def fill_Float_with_start_and_end_index(): Unit = {
+    val floats = new Array[Float](6)
+    Arrays.fill(floats, 1, 4, 42.0f)
+    assertArrayEquals(Array(0.0f, 42.0f, 42.0f, 42.0f, 0.0f, 0.0f), floats)
+
+    Arrays.fill(floats, 2, 5, -1.0f)
+    assertArrayEquals(Array(0.0f, 42.0f, -1.0f, -1.0f, -1.0f, 0.0f), floats)
+  }
+
+  @Test def fill_Double(): Unit = {
+    val doubles = new Array[Double](6)
+    Arrays.fill(doubles, 42.0)
+    assertArrayEquals(Array(42.0, 42.0, 42.0, 42.0, 42.0, 42.0), doubles)
+
+    Arrays.fill(doubles, -1.0f)
+    assertArrayEquals(Array(-1.0, -1.0, -1.0, -1.0, -1.0, -1.0), doubles)
+  }
+
+  @Test def fill_Double_with_start_and_end_index(): Unit = {
+    val doubles = new Array[Double](6)
+    Arrays.fill(doubles, 1, 4, 42.0)
+    assertArrayEquals(Array(0.0, 42.0, 42.0, 42.0, 0.0, 0.0), doubles)
+
+    Arrays.fill(doubles, 2, 5, -1.0)
+    assertArrayEquals(Array(0.0, 42.0, -1.0, -1.0, -1.0, 0.0), doubles)
+  }
+
+  @Test def fill_AnyRef(): Unit = {
+    val array = new Array[AnyRef](6)
+    Arrays.fill(array, "a")
+    assertArrayEquals(Array[AnyRef]("a", "a", "a", "a", "a", "a"), array)
+
+    Arrays.fill(array, "b")
+    assertArrayEquals(Array[AnyRef]("b", "b", "b", "b", "b", "b"), array)
+  }
+
+  @Test def fill_AnyRef_with_start_and_end_index(): Unit = {
+    val bytes = new Array[AnyRef](6)
+    Arrays.fill(bytes, 1, 4, "a")
+    assertArrayEquals(Array[AnyRef](null, "a", "a", "a", null, null), bytes)
+
+    Arrays.fill(bytes, 2, 5, "b")
+    assertArrayEquals(Array[AnyRef](null, "a", "b", "b", "b", null), bytes)
+  }
+
+  @Test def binarySearch_with_start_and_end_index_on_Long(): Unit = {
+    val longs: Array[Long] = Array(1, 2, 3, 5, 6, 7)
+    var ret                = Arrays.binarySearch(longs, 0, 6, 5)
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(longs, 0, 6, 0)
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(longs, 0, 6, 4)
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(longs, 0, 6, 8)
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_on_Long(): Unit = {
+    val longs: Array[Long] = Array(1, 2, 3, 5, 6, 7)
+    var ret                = Arrays.binarySearch(longs, 5)
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(longs, 0)
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(longs, 4)
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(longs, 8)
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_with_start_and_end_index_on_Int(): Unit = {
+    val ints: Array[Int] = Array(1, 2, 3, 5, 6, 7)
+    var ret              = Arrays.binarySearch(ints, 0, 6, 5)
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(ints, 0, 6, 0)
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(ints, 0, 6, 4)
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(ints, 0, 6, 8)
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_on_Int(): Unit = {
+    val ints: Array[Int] = Array(1, 2, 3, 5, 6, 7)
+    var ret              = Arrays.binarySearch(ints, 5)
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(ints, 0)
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(ints, 4)
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(ints, 8)
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_with_start_and_end_index_on_Short(): Unit = {
+    val shorts: Array[Short] = Array(1, 2, 3, 5, 6, 7)
+    var ret                  = Arrays.binarySearch(shorts, 0, 6, 5.toShort)
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(shorts, 0, 6, 0.toShort)
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(shorts, 0, 6, 4.toShort)
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(shorts, 0, 6, 8.toShort)
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_on_Short(): Unit = {
+    val shorts: Array[Short] = Array(1, 2, 3, 5, 6, 7)
+    var ret                  = Arrays.binarySearch(shorts, 5.toShort)
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(shorts, 0.toShort)
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(shorts, 4.toShort)
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(shorts, 8.toShort)
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_with_start_and_end_index_on_Char(): Unit = {
+    val chars: Array[Char] = Array('b', 'c', 'd', 'f', 'g', 'h')
+    var ret                = Arrays.binarySearch(chars, 0, 6, 'f')
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(chars, 0, 6, 'a')
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(chars, 0, 6, 'e')
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(chars, 0, 6, 'i')
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_on_Char(): Unit = {
+    val chars: Array[Char] = Array('b', 'c', 'd', 'f', 'g', 'h')
+    var ret                = Arrays.binarySearch(chars, 'f')
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(chars, 'a')
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(chars, 'e')
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(chars, 'i')
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_with_start_and_end_index_on_Double(): Unit = {
+    val doubles: Array[Double] = Array(0.1, 0.2, 0.3, 0.5, 0.6, 0.7)
+    var ret                    = Arrays.binarySearch(doubles, 0, 6, 0.5)
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(doubles, 0, 6, 0.0)
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(doubles, 0, 6, 0.4)
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(doubles, 0, 6, 0.8)
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_on_Double(): Unit = {
+    val doubles: Array[Double] = Array(0.1, 0.2, 0.3, 0.5, 0.6, 0.7)
+    var ret                    = Arrays.binarySearch(doubles, 0.5)
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(doubles, 0.0)
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(doubles, 0.4)
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(doubles, 0.8)
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_with_start_and_end_index_on_Float(): Unit = {
+    val floats: Array[Float] = Array(0.1f, 0.2f, 0.3f, 0.5f, 0.6f, 0.7f)
+    var ret                  = Arrays.binarySearch(floats, 0, 6, 0.5f)
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(floats, 0, 6, 0.0f)
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(floats, 0, 6, 0.4f)
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(floats, 0, 6, 0.8f)
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_on_Float(): Unit = {
+    val floats: Array[Float] = Array(0.1f, 0.2f, 0.3f, 0.5f, 0.6f, 0.7f)
+    var ret                  = Arrays.binarySearch(floats, 0.5f)
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(floats, 0.0f)
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(floats, 0.4f)
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(floats, 0.8f)
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_with_start_and_end_index_on_AnyRef(): Unit = {
+    val strings: Array[AnyRef] = Array("aa", "abc", "cc", "zz", "zzzs", "zzzt")
+    var ret                    = Arrays.binarySearch(strings, 0, 6, "zz")
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(strings, 0, 6, "a")
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(strings, 0, 6, "cd")
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(strings, 0, 6, "zzzz")
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearch_on_AnyRef(): Unit = {
+    val strings: Array[AnyRef] = Array("aa", "abc", "cc", "zz", "zzzs", "zzzt")
+    var ret                    = Arrays.binarySearch(strings, "zz")
+    assertEquals(3, ret)
+
+    ret = Arrays.binarySearch(strings, "a")
+    assertEquals(-1, ret)
+
+    ret = Arrays.binarySearch(strings, "cd")
+    assertEquals(-4, ret)
+
+    ret = Arrays.binarySearch(strings, "zzzz")
+    assertEquals(-7, ret)
+  }
+
+  @Test def binarySearchIllegalArgumentException(): Unit = {
+    val array = Array(0, 1, 3, 4)
+
+    val e1 = expectThrows(classOf[IllegalArgumentException],
+                          Arrays.binarySearch(array, 3, 2, 2))
+    assertEquals("fromIndex(3) > toIndex(2)", e1.getMessage)
+
+    // start/end comparison is made before index ranges checks
+    val e2 = expectThrows(classOf[IllegalArgumentException],
+                          Arrays.binarySearch(array, 7, 5, 2))
+    assertEquals("fromIndex(7) > toIndex(5)", e2.getMessage)
+  }
+
+  @Test def binarySearchArrayIndexOutOfBoundsException(): Unit = {
+    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
+               hasCompliantArrayIndexOutOfBounds)
+
+    val array = Array(0, 1, 3, 4)
+
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+                 Arrays.binarySearch(array, -1, 4, 2))
+
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+                 Arrays.binarySearch(array, 0, 5, 2))
+  }
+
+  @Test def copyOf_Int(): Unit = {
+    val ints: Array[Int] = Array(1, 2, 3)
+    val intscopy         = Arrays.copyOf(ints, 5)
+    assertArrayEquals(Array(1, 2, 3, 0, 0), intscopy)
+  }
+
+  @Test def copyOf_Long(): Unit = {
+    val longs: Array[Long] = Array(1, 2, 3)
+    val longscopy          = Arrays.copyOf(longs, 5)
+    assertArrayEquals(Array[Long](1, 2, 3, 0, 0), longscopy)
+  }
+
+  @Test def copyOf_Short(): Unit = {
+    val shorts: Array[Short] = Array(1, 2, 3)
+    val shortscopy           = Arrays.copyOf(shorts, 5)
+    assertArrayEquals(Array[Short](1, 2, 3, 0, 0), shortscopy)
+  }
+
+  @Test def copyOf_Byte(): Unit = {
+    val bytes: Array[Byte] = Array(42, 43, 44)
+    val floatscopy         = Arrays.copyOf(bytes, 5)
+    assertArrayEquals(Array[Byte](42, 43, 44, 0, 0), floatscopy)
+  }
+
+  @Test def copyOf_Char(): Unit = {
+    val chars: Array[Char] = Array('a', 'b', '0')
+    val charscopy          = Arrays.copyOf(chars, 5)
+    assertEquals(0.toChar, charscopy(4))
+  }
+
+  @Test def copyOf_Double(): Unit = {
+    val doubles: Array[Double] = Array(0.1, 0.2, 0.3)
+    val doublescopy            = Arrays.copyOf(doubles, 5)
+    assertArrayEquals(Array[Double](0.1, 0.2, 0.3, 0, 0), doublescopy)
+  }
+
+  @Test def copyOf_Float(): Unit = {
+    val floats: Array[Float] = Array(0.1f, 0.2f, 0.3f)
+    val floatscopy           = Arrays.copyOf(floats, 5)
+    assertArrayEquals(Array[Float](0.1f, 0.2f, 0.3f, 0f, 0f), floatscopy)
+  }
+
+  @Test def copyOf_Boolean(): Unit = {
+    val bools: Array[Boolean] = Array(false, true, false)
+    val boolscopy             = Arrays.copyOf(bools, 5)
+    assertArrayEquals(Array[Boolean](false, true, false, false, false),
+                      boolscopy)
+  }
+
+  @Test def copyOf_AnyRef(): Unit = {
+    val anyrefs: Array[AnyRef] = Array("a", "b", "c")
+    val anyrefscopy            = Arrays.copyOf(anyrefs, 5)
+    assertEquals(classOf[Array[AnyRef]], anyrefscopy.getClass())
+    assertArrayEquals(Array[AnyRef]("a", "b", "c", null, null), anyrefscopy)
+
+    val sequences: Array[CharSequence] = Array("a", "b", "c")
+    val sequencescopy                  = Arrays.copyOf(sequences, 2)
+    assertEquals(classOf[Array[CharSequence]], sequencescopy.getClass())
+    assertArrayEquals(Array[CharSequence]("a", "b"), sequencescopy)
+  }
+
+  @Test def copyOf_AnyRef_with_change_of_type(): Unit = {
+    class A
+    case class B(x: Int) extends A
+
+    val bs: Array[AnyRef] = Array(B(1), B(2), B(3))
+    val bscopyAsA         = Arrays.copyOf(bs, 5, classOf[Array[A]])
+    assertEquals(classOf[Array[A]], bscopyAsA.getClass())
+    assertArrayEquals(Array[A](B(1), B(2), B(3), null, null), bscopyAsA)
+  }
+
+  @Test def copyOfRange_AnyRef(): Unit = {
+    val anyrefs: Array[AnyRef] = Array("a", "b", "c", "d", "e")
+    val anyrefscopy            = Arrays.copyOfRange(anyrefs, 2, 4)
+    assertEquals(classOf[Array[AnyRef]], anyrefscopy.getClass())
+    assertArrayEquals(Array[AnyRef]("c", "d"), anyrefscopy)
+
+    val sequences: Array[CharSequence] = Array("a", "b", "c", "d", "e")
+    val sequencescopy                  = Arrays.copyOfRange(sequences, 1, 5)
+    assertEquals(classOf[Array[CharSequence]], sequencescopy.getClass())
+    assertArrayEquals(Array[CharSequence]("b", "c", "d", "e"), sequencescopy)
+  }
+
+  @Test def copyOfRange_AnyRef_with_change_of_type(): Unit = {
+    class A
+    case class B(x: Int) extends A
+    val bs: Array[B] = Array(B(1), B(2), B(3), B(4), B(5))
+    val bscopyAsA    = Arrays.copyOfRange(bs, 2, 4, classOf[Array[A]])
+    assertEquals(classOf[Array[A]], bscopyAsA.getClass())
+    assertArrayEquals(Array[A](B(3), B(4)), bscopyAsA)
+  }
+
+  @Test def copyOfRange_AnyRef_ArrayIndexOutOfBoundsException(): Unit = {
+    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
+               hasCompliantArrayIndexOutOfBounds)
+
+    val anyrefs: Array[AnyRef] = Array("a", "b", "c", "d", "e")
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+                 Arrays.copyOfRange(anyrefs, -1, 4))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+                 Arrays.copyOfRange(anyrefs, 6, 8))
+  }
+
+  @Test def asList(): Unit = {
+    val list = Arrays.asList(1, 2, 3)
+    assertEquals(list.size(), 3)
+    assertEquals(list.get(0), 1)
+    assertEquals(list.get(1), 2)
+    assertEquals(list.get(2), 3)
+  }
+
+  @Test def hashCode_Boolean(): Unit = {
+    assertEquals(0, Arrays.hashCode(null: Array[Boolean]))
+    assertEquals(1, Arrays.hashCode(Array[Boolean]()))
+    assertEquals(1268, Arrays.hashCode(Array[Boolean](false)))
+    assertEquals(40359, Arrays.hashCode(Array[Boolean](true, false)))
+  }
+
+  @Test def hashCode_Chars(): Unit = {
+    assertEquals(0, Arrays.hashCode(null: Array[Char]))
+    assertEquals(1, Arrays.hashCode(Array[Char]()))
+    assertEquals(128, Arrays.hashCode(Array[Char]('a')))
+    assertEquals(4068, Arrays.hashCode(Array[Char]('c', '&')))
+    assertEquals(74792, Arrays.hashCode(Array[Char]('-', '5', 'q')))
+    assertEquals(88584920,
+                 Arrays.hashCode(Array[Char]('.', ' ', '\u4323', 'v', '~')))
+  }
+
+  @Test def hashCode_Bytes(): Unit = {
+    assertEquals(0, Arrays.hashCode(null: Array[Byte]))
+    assertEquals(1, Arrays.hashCode(Array[Byte]()))
+    assertEquals(32, Arrays.hashCode(Array[Byte](1)))
+    assertEquals(1053, Arrays.hashCode(Array[Byte](7, -125)))
+    assertEquals(32719, Arrays.hashCode(Array[Byte](3, 0, 45)))
+    assertEquals(30065878, Arrays.hashCode(Array[Byte](0, 45, 100, 1, 1)))
+  }
+
+  @Test def hashCode_Shorts(): Unit = {
+    assertEquals(0, Arrays.hashCode(null: Array[Short]))
+    assertEquals(1, Arrays.hashCode(Array[Short]()))
+    assertEquals(32, Arrays.hashCode(Array[Short](1)))
+    assertEquals(1053, Arrays.hashCode(Array[Short](7, -125)))
+    assertEquals(37208, Arrays.hashCode(Array[Short](3, 0, 4534)))
+    assertEquals(30065878, Arrays.hashCode(Array[Short](0, 45, 100, 1, 1)))
+  }
+
+  @Test def hashCode_Ints(): Unit = {
+    assertEquals(0, Arrays.hashCode(null: Array[Int]))
+    assertEquals(1, Arrays.hashCode(Array[Int]()))
+    assertEquals(32, Arrays.hashCode(Array[Int](1)))
+    assertEquals(1053, Arrays.hashCode(Array[Int](7, -125)))
+    assertEquals(37208, Arrays.hashCode(Array[Int](3, 0, 4534)))
+    assertEquals(-1215441431,
+                 Arrays.hashCode(Array[Int](0, 45, 100, 1, 1, Int.MaxValue)))
+  }
+
+  @Test def hashCode_Longs(): Unit = {
+    assertEquals(0, Arrays.hashCode(null: Array[Long]))
+    assertEquals(1, Arrays.hashCode(Array[Long]()))
+    assertEquals(32, Arrays.hashCode(Array[Long](1L)))
+    assertEquals(1302, Arrays.hashCode(Array[Long](7L, -125L)))
+    assertEquals(37208, Arrays.hashCode(Array[Long](3L, 0L, 4534L)))
+    assertEquals(
+      -1215441431,
+      Arrays.hashCode(Array[Long](0L, 45L, 100L, 1L, 1L, Int.MaxValue)))
+    assertEquals(
+      -1952288964,
+      Arrays.hashCode(
+        Array[Long](0L, 34573566354545L, 100L, 1L, 1L, Int.MaxValue)))
+  }
+
+  @Test def hashCode_Floats(): Unit = {
+    assertEquals(0, Arrays.hashCode(null: Array[Float]))
+    assertEquals(1, Arrays.hashCode(Array[Float]()))
+
+    if (!executingInScalaJS) {
+      assertEquals(1065353247, Arrays.hashCode(Array[Float](1f)))
+      assertEquals(-1629433727, Arrays.hashCode(Array[Float](7.2f, -125.2f)))
+      assertEquals(-6999572, Arrays.hashCode(Array[Float](302.1f, 0.0f, 4534f)))
+      assertEquals(
+        717093070,
+        Arrays.hashCode(Array[Float](0.0f, 45f, -100f, 1.1f, -1f, 3567f)))
+    } else {
+      assertEquals(32, Arrays.hashCode(Array[Float](1f)))
+      assertEquals(-2082726591, Arrays.hashCode(Array[Float](7.2f, -125.2f)))
+      assertEquals(-1891539602,
+                   Arrays.hashCode(Array[Float](302.1f, 0.0f, 4534f)))
+      assertEquals(
+        -1591440133,
+        Arrays.hashCode(Array[Float](0.0f, 45f, -100f, 1.1f, -1f, 3567f)))
+    }
+  }
+
+  @Test def hashCode_Doubles(): Unit = {
+    assertEquals(0, Arrays.hashCode(null: Array[Double]))
+    assertEquals(1, Arrays.hashCode(Array[Double]()))
+
+    assertEquals(-1503133662, Arrays.hashCode(Array[Double](1.1)))
+    assertEquals(-2075734168, Arrays.hashCode(Array[Double](7.3, -125.23)))
+    assertEquals(-557562564, Arrays.hashCode(Array[Double](3.9, 0.2, 4534.9)))
+
+    if (!executingInScalaJS) {
+      assertEquals(-1513729058,
+                   Arrays.hashCode(Array[Double](0.1, 45.1, -100.0, 1.1, 1.7)))
+      assertEquals(
+        -722318447,
+        Arrays.hashCode(
+          Array[Double](0.0, 34573566354545.9, 100.2, 1.1, 1.2, Int.MaxValue)))
+    } else {
+      assertEquals(-1750344582,
+                   Arrays.hashCode(Array[Double](0.1, 45.1, -100.0, 1.1, 1.7)))
+      assertEquals(
+        -1764602991,
+        Arrays.hashCode(
+          Array[Double](0.0, 34573566354545.9, 100.2, 1.1, 1.2, Int.MaxValue)))
+    }
+  }
+
+  @Test def hashCode_AnyRef(): Unit = {
+    assertEquals(0, Arrays.hashCode(null: Array[AnyRef]))
+    assertEquals(1, Arrays.hashCode(Array[AnyRef]()))
+    assertEquals(961, Arrays.hashCode(Array[AnyRef](null, null)))
+    assertEquals(126046, Arrays.hashCode(Array[AnyRef]("a", "b", null)))
+    assertEquals(-1237252983,
+                 Arrays.hashCode(Array[AnyRef](null, "a", "b", null, "fooooo")))
+  }
+
+  @Test def deepHashCode(): Unit = {
+    assertEquals(0, Arrays.deepHashCode(null: Array[AnyRef]))
+    assertEquals(1, Arrays.deepHashCode(Array[AnyRef]()))
+    assertEquals(961, Arrays.deepHashCode(Array[AnyRef](null, null)))
+    assertEquals(126046, Arrays.deepHashCode(Array[AnyRef]("a", "b", null)))
+    assertEquals(
+      -1237252983,
+      Arrays.deepHashCode(Array[AnyRef](null, "a", "b", null, "fooooo")))
+    assertEquals(962, Arrays.deepHashCode(Array[AnyRef](null, Array[AnyRef]())))
+    assertEquals(
+      993,
+      Arrays.deepHashCode(Array[AnyRef](Array[AnyRef](), Array[AnyRef]())))
+    assertEquals(
+      63,
+      Arrays.deepHashCode(Array[AnyRef](Array[AnyRef](Array[AnyRef]()))))
+    assertEquals(
+      63,
+      Arrays.deepHashCode(Array[AnyRef](Array[AnyRef](Array[Int]()))))
+    assertEquals(
+      63,
+      Arrays.deepHashCode(Array[AnyRef](Array[AnyRef](Array[Double]()))))
+    assertEquals(
+      94,
+      Arrays.deepHashCode(Array[AnyRef](Array[AnyRef](Array[Int](1)))))
+    assertEquals(
+      94,
+      Arrays.deepHashCode(
+        Array[AnyRef](Array[AnyRef](Array[AnyRef](1.asInstanceOf[AnyRef])))))
+  }
+
+  @Test def equals_Booleans(): Unit = {
+    val a1 = Array(true, false)
+
+    assertTrue(Arrays.equals(a1, a1))
+    assertTrue(Arrays.equals(a1, Array(true, false)))
+
+    assertFalse(Arrays.equals(a1, Array(true)))
+    assertFalse(Arrays.equals(a1, Array(false)))
+    assertFalse(Arrays.equals(a1, Array[Boolean]()))
+    assertFalse(Arrays.equals(a1, Array(false, true)))
+    assertFalse(Arrays.equals(a1, Array(false, true, false)))
+  }
+
+  @Test def equals_Bytes(): Unit = {
+    val a1 = Array[Byte](1, -7, 10)
+
+    assertTrue(Arrays.equals(null: Array[Byte], null: Array[Byte]))
+    assertTrue(Arrays.equals(a1, a1))
+    assertTrue(Arrays.equals(a1, Array[Byte](1, -7, 10)))
+
+    assertFalse(Arrays.equals(a1, null))
+    assertFalse(Arrays.equals(a1, Array[Byte](3)))
+    assertFalse(Arrays.equals(a1, Array[Byte](1)))
+    assertFalse(Arrays.equals(a1, Array[Byte]()))
+    assertFalse(Arrays.equals(a1, Array[Byte](1, -7, 11)))
+    assertFalse(Arrays.equals(a1, Array[Byte](1, -7, 11, 20)))
+  }
+
+  @Test def equals_Chars(): Unit = {
+    val a1 = Array[Char]('a', '0', '-')
+
+    assertTrue(Arrays.equals(null: Array[Char], null: Array[Char]))
+    assertTrue(Arrays.equals(a1, a1))
+    assertTrue(Arrays.equals(a1, Array[Char]('a', '0', '-')))
+
+    assertFalse(Arrays.equals(a1, null))
+    assertFalse(Arrays.equals(a1, Array[Char]('z')))
+    assertFalse(Arrays.equals(a1, Array[Char]('a')))
+    assertFalse(Arrays.equals(a1, Array[Char]()))
+    assertFalse(Arrays.equals(a1, Array[Char]('a', '0', '+')))
+    assertFalse(Arrays.equals(a1, Array[Char]('a', '0', '-', 'z')))
+  }
+
+  @Test def equals_Shorts(): Unit = {
+    val a1 = Array[Short](1, -7, 10)
+
+    assertTrue(Arrays.equals(null: Array[Short], null: Array[Short]))
+    assertTrue(Arrays.equals(a1, a1))
+    assertTrue(Arrays.equals(a1, Array[Short](1, -7, 10)))
+
+    assertFalse(Arrays.equals(a1, null))
+    assertFalse(Arrays.equals(a1, Array[Short](3)))
+    assertFalse(Arrays.equals(a1, Array[Short](1)))
+    assertFalse(Arrays.equals(a1, Array[Short]()))
+    assertFalse(Arrays.equals(a1, Array[Short](1, -7, 11)))
+    assertFalse(Arrays.equals(a1, Array[Short](1, -7, 11, 20)))
+  }
+
+  @Test def equals_Ints(): Unit = {
+    val a1 = Array[Int](1, -7, 10)
+
+    assertTrue(Arrays.equals(null: Array[Int], null: Array[Int]))
+    assertTrue(Arrays.equals(a1, a1))
+    assertTrue(Arrays.equals(a1, Array[Int](1, -7, 10)))
+
+    assertFalse(Arrays.equals(a1, null))
+    assertFalse(Arrays.equals(a1, Array[Int](3)))
+    assertFalse(Arrays.equals(a1, Array[Int](1)))
+    assertFalse(Arrays.equals(a1, Array[Int]()))
+    assertFalse(Arrays.equals(a1, Array[Int](1, -7, 11)))
+    assertFalse(Arrays.equals(a1, Array[Int](1, -7, 11, 20)))
+  }
+
+  @Test def equals_Longs(): Unit = {
+    val a1 = Array[Long](1L, -7L, 10L)
+
+    assertTrue(Arrays.equals(null: Array[Long], null: Array[Long]))
+    assertTrue(Arrays.equals(a1, a1))
+    assertTrue(Arrays.equals(a1, Array[Long](1L, -7L, 10L)))
+
+    assertFalse(Arrays.equals(a1, null))
+    assertFalse(Arrays.equals(a1, Array[Long](3L)))
+    assertFalse(Arrays.equals(a1, Array[Long](1L)))
+    assertFalse(Arrays.equals(a1, Array[Long]()))
+    assertFalse(Arrays.equals(a1, Array[Long](1L, -7L, 11L)))
+    assertFalse(Arrays.equals(a1, Array[Long](1L, -7L, 11L, 20L)))
+  }
+
+  @Test def equals_Floats(): Unit = {
+    val a1 = Array[Float](1.1f, -7.4f, 10.0f)
+
+    assertTrue(Arrays.equals(null: Array[Float], null: Array[Float]))
+    assertTrue(Arrays.equals(a1, a1))
+    assertTrue(Arrays.equals(a1, Array[Float](1.1f, -7.4f, 10.0f)))
+
+    assertFalse(Arrays.equals(a1, null))
+    assertFalse(Arrays.equals(a1, Array[Float](3.0f)))
+    assertFalse(Arrays.equals(a1, Array[Float](1.1f)))
+    assertFalse(Arrays.equals(a1, Array[Float]()))
+    assertFalse(Arrays.equals(a1, Array[Float](1.1f, -7.4f, 11.0f)))
+    assertFalse(Arrays.equals(a1, Array[Float](1.1f, -7.4f, 10.0f, 20.0f)))
+  }
+
+  @Test def equals_Doubles(): Unit = {
+    val a1 = Array[Double](1.1, -7.4, 10.0)
+
+    assertTrue(Arrays.equals(null: Array[Double], null: Array[Double]))
+    assertTrue(Arrays.equals(a1, a1))
+    assertTrue(Arrays.equals(a1, Array[Double](1.1, -7.4, 10.0)))
+
+    assertFalse(Arrays.equals(a1, null))
+    assertFalse(Arrays.equals(a1, Array[Double](3.0)))
+    assertFalse(Arrays.equals(a1, Array[Double](1.1)))
+    assertFalse(Arrays.equals(a1, Array[Double]()))
+    assertFalse(Arrays.equals(a1, Array[Double](1.1, -7.4, 11.0)))
+    assertFalse(Arrays.equals(a1, Array[Double](1.1, -7.4, 10.0, 20.0)))
+  }
+
+  @Test def equals_AnyRefs(): Unit = {
+    // scalastyle:off equals.hash.code
+    class A(private val x: Int) {
+      override def equals(that: Any): Boolean = that match {
+        case that: A => this.x == that.x
+        case _       => false
+      }
+    }
+    // scalastyle:on equals.hash.code
+
+    def A(x: Int): A = new A(x)
+
+    val a1 = Array[AnyRef](A(1), A(-7), A(10))
+
+    assertTrue(Arrays.equals(null: Array[AnyRef], null: Array[AnyRef]))
+    assertTrue(Arrays.equals(a1, a1))
+    assertTrue(Arrays.equals(a1, Array[AnyRef](A(1), A(-7), A(10))))
+
+    assertFalse(Arrays.equals(a1, null))
+    assertFalse(Arrays.equals(a1, Array[AnyRef](A(3))))
+    assertFalse(Arrays.equals(a1, Array[AnyRef](A(1))))
+    assertFalse(Arrays.equals(a1, Array[AnyRef]()))
+    assertFalse(Arrays.equals(a1, Array[AnyRef](A(1), null, A(11))))
+    assertFalse(Arrays.equals(a1, Array[AnyRef](A(1), A(-7), A(11), A(20))))
+  }
+
+  @Test def deepEquals(): Unit = {
+    assertTrue(Arrays.deepEquals(null: Array[AnyRef], null: Array[AnyRef]))
+    assertTrue(Arrays.deepEquals(Array[AnyRef](), Array[AnyRef]()))
+    assertTrue(
+      Arrays.deepEquals(Array[AnyRef](null, null), Array[AnyRef](null, null)))
+    assertTrue(
+      Arrays.deepEquals(Array[AnyRef]("a", "b", null),
+                        Array[AnyRef]("a", "b", null)))
+    assertTrue(
+      Arrays.deepEquals(Array[AnyRef](null, "a", "b", null, "fooooo"),
+                        Array[AnyRef](null, "a", "b", null, "fooooo")))
+    assertTrue(
+      Arrays.deepEquals(Array[AnyRef](null, Array[AnyRef]()),
+                        Array[AnyRef](null, Array[AnyRef]())))
+    assertTrue(
+      Arrays.deepEquals(Array[AnyRef](Array[AnyRef](), Array[AnyRef]()),
+                        Array[AnyRef](Array[AnyRef](), Array[AnyRef]())))
+    assertTrue(
+      Arrays.deepEquals(Array[AnyRef](Array[AnyRef](Array[AnyRef]())),
+                        Array[AnyRef](Array[AnyRef](Array[AnyRef]()))))
+    assertTrue(
+      Arrays.deepEquals(Array[AnyRef](Array[AnyRef](Array[Int]())),
+                        Array[AnyRef](Array[AnyRef](Array[Int]()))))
+    assertTrue(
+      Arrays.deepEquals(Array[AnyRef](Array[AnyRef](Array[Double]())),
+                        Array[AnyRef](Array[AnyRef](Array[Double]()))))
+    assertTrue(
+      Arrays.deepEquals(Array[AnyRef](Array[AnyRef](Array[Int](1))),
+                        Array[AnyRef](Array[AnyRef](Array[Int](1)))))
+    assertTrue(
+      Arrays.deepEquals(
+        Array[AnyRef](Array[AnyRef](Array[AnyRef](1.asInstanceOf[AnyRef]))),
+        Array[AnyRef](Array[AnyRef](Array[AnyRef](1.asInstanceOf[AnyRef])))))
+
+    assertFalse(Arrays.deepEquals(null: Array[AnyRef], Array[AnyRef]()))
+    assertFalse(Arrays.deepEquals(Array[AnyRef](), null: Array[AnyRef]))
+    assertFalse(
+      Arrays.deepEquals(Array[AnyRef](Array[AnyRef](), null),
+                        Array[AnyRef](null, null)))
+    assertFalse(
+      Arrays.deepEquals(Array[AnyRef](null, Array[AnyRef]()),
+                        Array[AnyRef](null, null)))
+    assertFalse(
+      Arrays.deepEquals(Array[AnyRef]("a", "b", null),
+                        Array[AnyRef]("a", "c", null)))
+    assertFalse(
+      Arrays.deepEquals(Array[AnyRef](null, "a", "b", null, "fooooo"),
+                        Array[AnyRef](null, "a", "b", "c", "fooooo")))
+    assertFalse(
+      Arrays.deepEquals(Array[AnyRef](null, Array[AnyRef]()),
+                        Array[AnyRef](null, Array[AnyRef](null))))
+    assertFalse(
+      Arrays.deepEquals(Array[AnyRef](Array[AnyRef](), Array[AnyRef]()),
+                        Array[AnyRef](Array[AnyRef](), Array[AnyRef](null))))
+    assertFalse(
+      Arrays.deepEquals(Array[AnyRef](Array[AnyRef](Array[AnyRef]())),
+                        Array[AnyRef](Array[AnyRef](Array[AnyRef](null)))))
+    assertFalse(
+      Arrays.deepEquals(Array[AnyRef](Array[AnyRef](Array[Int]())),
+                        Array[AnyRef](Array[AnyRef](Array[Int](1)))))
+    assertFalse(
+      Arrays.deepEquals(Array[AnyRef](Array[AnyRef](Array[Double]())),
+                        Array[AnyRef](Array[AnyRef](Array[Double](1.0)))))
+    assertFalse(
+      Arrays.deepEquals(Array[AnyRef](Array[AnyRef](Array[Int](1))),
+                        Array[AnyRef](Array[AnyRef](Array[Int](2)))))
+    assertFalse(
+      Arrays.deepEquals(
+        Array[AnyRef](Array[AnyRef](Array[AnyRef](1.asInstanceOf[AnyRef]))),
+        Array[AnyRef](Array[AnyRef](Array[AnyRef](2.asInstanceOf[AnyRef])))))
+  }
+
+  @Test def toString_Long(): Unit = {
+    assertEquals("null", Arrays.toString(null: Array[Long]))
+    assertEquals("[]", Arrays.toString(Array[Long]()))
+    assertEquals("[0]", Arrays.toString(Array[Long](0L)))
+    assertEquals("[1]", Arrays.toString(Array[Long](1L)))
+    assertEquals("[2, 3]", Arrays.toString(Array[Long](2L, 3)))
+    assertEquals("[1, 2, 3, 4, 5]",
+                 Arrays.toString(Array[Long](1L, 2L, 3L, 4L, 5L)))
+    assertEquals("[1, -2, 3, 9223372036854775807]",
+                 Arrays.toString(Array[Long](1L, -2L, 3L, Long.MaxValue)))
+  }
+
+  @Test def toString_Int(): Unit = {
+    assertEquals("null", Arrays.toString(null: Array[Int]))
+    assertEquals("[]", Arrays.toString(Array[Int]()))
+    assertEquals("[0]", Arrays.toString(Array[Int](0)))
+    assertEquals("[1]", Arrays.toString(Array[Int](1)))
+    assertEquals("[2, 3]", Arrays.toString(Array[Int](2, 3)))
+    assertEquals("[1, 2, 3, 4, 5]", Arrays.toString(Array[Int](1, 2, 3, 4, 5)))
+    assertEquals("[1, -2, 3, 2147483647]",
+                 Arrays.toString(Array[Int](1, -2, 3, Int.MaxValue)))
+  }
+
+  @Test def toString_Short(): Unit = {
+    assertEquals("null", Arrays.toString(null: Array[Short]))
+    assertEquals("[]", Arrays.toString(Array[Short]()))
+    assertEquals("[0]", Arrays.toString(Array[Short](0)))
+    assertEquals("[1]", Arrays.toString(Array[Short](1)))
+    assertEquals("[2, 3]", Arrays.toString(Array[Short](2, 3)))
+    assertEquals("[1, 2, 3, 4, 5]",
+                 Arrays.toString(Array[Short](1, 2, 3, 4, 5)))
+    assertEquals("[1, -2, 3, 32767]",
+                 Arrays.toString(Array[Short](1, -2, 3, Short.MaxValue)))
+  }
+
+  @Test def toString_Byte(): Unit = {
+    assertEquals("null", Arrays.toString(null: Array[Byte]))
+    assertEquals("[]", Arrays.toString(Array[Byte]()))
+    assertEquals("[0]", Arrays.toString(Array[Byte](0)))
+    assertEquals("[1]", Arrays.toString(Array[Byte](1)))
+    assertEquals("[2, 3]", Arrays.toString(Array[Byte](2, 3)))
+    assertEquals("[1, 2, 3, 4, 5]", Arrays.toString(Array[Byte](1, 2, 3, 4, 5)))
+    assertEquals("[1, -2, 3, 127]",
+                 Arrays.toString(Array[Byte](1, -2, 3, Byte.MaxValue)))
+  }
+
+  @Test def toString_Boolean(): Unit = {
+    assertEquals("null", Arrays.toString(null: Array[Boolean]))
+    assertEquals("[]", Arrays.toString(Array[Boolean]()))
+    assertEquals("[true]", Arrays.toString(Array[Boolean](true)))
+    assertEquals("[false]", Arrays.toString(Array[Boolean](false)))
+    assertEquals("[true, false]", Arrays.toString(Array[Boolean](true, false)))
+    assertEquals("[true, true, false, false]",
+                 Arrays.toString(Array[Boolean](true, true, false, false)))
+  }
+
+  @Test def toString_Float(): Unit = {
+    assertEquals("null", Arrays.toString(null: Array[Float]))
+    assertEquals("[]", Arrays.toString(Array[Float]()))
+
+    if (!executingInScalaJS) {
+      assertEquals("[0.0]", Arrays.toString(Array[Float](0.0f)))
+      assertEquals("[1.1]", Arrays.toString(Array[Float](1.1f)))
+      assertEquals("[2.2, 3.0]", Arrays.toString(Array[Float](2.2f, 3f)))
+      assertEquals("[1.0, 2.0, 3.0, 4.0, 5.0]",
+                   Arrays.toString(Array[Float](1f, 2f, 3f, 4f, 5f)))
+      assertEquals("[1.0, -2.0, 3.0, 3.4028235E38]",
+                   Arrays.toString(Array[Float](1f, -2f, 3f, Float.MaxValue)))
+    } else {
+      assumeFalse("Assumes Float.toString JS semantics.", executingInJVM)
+      assertEquals("[0.0]", Arrays.toString(Array[Float](0.0f)))
+      assertEquals("[1.100000023841858]", Arrays.toString(Array[Float](1.1f)))
+
+      assertEquals("[2.200000047683716, 3]",
+                   Arrays.toString(Array[Float](2.2f, 3f)))
+      assertEquals("[1, 2, 3, 4, 5]",
+                   Arrays.toString(Array[Float](1f, 2f, 3f, 4f, 5f)))
+      assertEquals("[1, -2, 3, 3.4028234663852886e+38]",
+                   Arrays.toString(Array[Float](1f, -2f, 3f, Float.MaxValue)))
+    }
+  }
+
+  @Test def toString_Double(): Unit = {
+    assertEquals("null", Arrays.toString(null: Array[Double]))
+    assertEquals("[]", Arrays.toString(Array[Double]()))
+
+    if (!executingInScalaJS) {
+      assertEquals("[0.0]", Arrays.toString(Array[Double](0.0d)))
+      assertEquals("[1.1]", Arrays.toString(Array[Double](1.1d)))
+      assertEquals("[2.2, 3.0]", Arrays.toString(Array[Double](2.2d, 3d)))
+      assertEquals("[1.0, 2.0, 3.0, 4.0, 5.0]",
+                   Arrays.toString(Array[Double](1d, 2d, 3d, 4d, 5d)))
+      assertEquals("[1.0, -2.0, 3.0, 1.7976931348623157E308]",
+                   Arrays.toString(Array[Double](1d, -2d, 3d, Double.MaxValue)))
+    } else {
+      assumeFalse("Assumes Double.toString JS semantics.", executingInJVM)
+      assertEquals("[0]", Arrays.toString(Array[Double](0.0d)))
+      assertEquals("[1.1]", Arrays.toString(Array[Double](1.1d)))
+      assertEquals("[2.2, 3]", Arrays.toString(Array[Double](2.2d, 3d)))
+      assertEquals("[1, 2, 3, 4, 5]",
+                   Arrays.toString(Array[Double](1d, 2d, 3d, 4d, 5d)))
+      assertEquals("[1, -2, 3, 1.7976931348623157e+308]",
+                   Arrays.toString(Array[Double](1d, -2d, 3d, Double.MaxValue)))
+    }
+  }
+
+  @Test def toString_AnyRef(): Unit = {
+    class C(num: Int) {
+      override def toString: String = s"C($num)"
+    }
+    assertEquals("null", Arrays.toString(null: Array[AnyRef]))
+    assertEquals("[]", Arrays.toString(Array[AnyRef]()))
+    assertEquals("[abc]", Arrays.toString(Array[AnyRef]("abc")))
+    assertEquals("[a, b, c]", Arrays.toString(Array[AnyRef]("a", "b", "c")))
+    assertEquals("[C(1)]", Arrays.toString(Array[AnyRef](new C(1))))
+    assertEquals(
+      "[C(1), abc, 1, null]",
+      Arrays.toString(Array[AnyRef](new C(1), "abc", Int.box(1), null)))
+  }
+
+  @Test def deepToString(): Unit = {
+    assertEquals("null", Arrays.deepToString(null: Array[AnyRef]))
+    assertEquals("[abc]", Arrays.deepToString(Array[AnyRef]("abc")))
+    assertEquals("[a, b, c]", Arrays.deepToString(Array[AnyRef]("a", "b", "c")))
+    assertEquals("[[1, 2, 3]]",
+                 Arrays.deepToString(Array[AnyRef](Array[Int](1, 2, 3))))
+    assertEquals("[[1, 2, 3], [4, 5, 6]]",
+                 Arrays.deepToString(
+                   Array[AnyRef](Array[Int](1, 2, 3), Array[Int](4, 5, 6))))
+    assertEquals("[[]]", Arrays.deepToString(Array[AnyRef](Array[AnyRef]())))
+    assertEquals(
+      "[[[]]]",
+      Arrays.deepToString(Array[AnyRef](Array[AnyRef](Array[AnyRef]()))))
+    assertEquals(
+      "[[[[1, 2, 3]]], [4, 5, 6]]",
+      Arrays.deepToString(
+        Array[AnyRef](Array[AnyRef](Array[AnyRef](Array[Int](1, 2, 3))),
+                      Array[Int](4, 5, 6))))
+
+    val recArr = Array[AnyRef](null, null)
+    recArr(0) = recArr
+    assertEquals("[[...], null]", Arrays.deepToString(recArr))
+    assertEquals("[[[...], null]]", Arrays.deepToString(Array[AnyRef](recArr)))
+    assertEquals("[[[...], null]]", Arrays.deepToString(Array[AnyRef](recArr)))
+    recArr(1) =
+      Array[AnyRef](null, Array[AnyRef](null, recArr, Array[AnyRef](recArr)))
+    assertEquals("[[...], [null, [null, [...], [[...]]]]]",
+                 Arrays.deepToString(recArr))
   }
 }


### PR DESCRIPTION
We re-port Arrays.scala from Scala.js to pick up the title fix.
An added benefit is that the various sorts are now stable, as
as described in the Java 8 documentation.

The implementation of the deepToString method is retained on a
"first do no harm" basis.  The Scala.js origin uses JavaScript
dynamic arrays. ArrayDeque is an obvious replacement but that
might cause a performance regression.

ArraysTest.scala is ported to exercise the title fix. In addition,
the ported ArraysTest gives much better code coverage throughout.