### PR TITLE
Fix #2035: Guard virtual lookup of non virtual methods

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -479,7 +479,7 @@ object Lower {
       def genClassVirtualLookup(cls: Class): Unit = {
         val vindex = vtable(cls).index(sig)
         assert(vindex != -1,
-               s"Virtual table of ${cls.name} have not contained $sig ")
+               s"The virtual table of ${cls.name} does not contain $sig")
 
         val typeptr = let(Op.Load(Type.Ptr, obj), unwind)
         val methptrptr = let(
@@ -530,7 +530,7 @@ object Lower {
           .resolve(sig)
           .getOrElse {
             unsupported(
-              s"Did not found signature of method $sig in ${cls.name}")
+              s"Did not find the signature of method $sig in ${cls.name}")
           }
         let(n, Op.Copy(Val.Global(method, Type.Ptr)), unwind)
       }


### PR DESCRIPTION
This PR fixes silent, yet potentially deadly bugs in `Lower` phase. Due to not exhaustive enough checks, it could silently generate invalid pointer arithmetic operation, leading to a segmentation fault in the runtime, eg. in the case when the non-virtual method was dynamically dispatched.
Changes of this PR include determinating in advance how the given `Sig.Method` should be dispatched: 
-  If `Sig` in a given class is non-virtual (e.g constructor,  extern call) it would always be statically dispatched
- If the result of statistical analysis proves that `Sig` of given `Class` does not contain virtual calls it would be also statically dispatched
- If target of method invocation is `null` (eg. `null.asInstanceOf[T].method`) it always would end-up with `NullPointerOperationException`
- If any other case virtual method lookup would be used to determine the correct method target based on traits dispatch table or class virtual methods table. 

Additionally code that would previously silently generate errors would now be checked and will throw an exception.  

Resolves #2035 

