### PR TITLE
WIP: Implement CollectionsOnCollections & CollectionsOnLists

### DIFF
--- a/unit-tests/src/test/scala/java/util/CollectionsOnCollectionsTest.scala
+++ b/unit-tests/src/test/scala/java/util/CollectionsOnCollectionsTest.scala
@@ -1,0 +1,165 @@
+// Ported from Scala.js commit: 6fbe7b2 dated: 2019-08-14
+
+package org.scalanative.testsuite.javalib.util
+
+import java.util.Comparator
+import java.{lang => jl, util => ju}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.utils.CollectionsTestBase
+
+import scala.reflect.ClassTag
+
+trait CollectionsOnCollectionsTest extends CollectionsTestBase {
+
+  def factory: CollectionFactory
+
+  def testMinMax1[T <: AnyRef with Comparable[T]: ClassTag](
+      factory: CollectionFactory,
+      toElem: Int => T,
+      isMin: Boolean): Unit = {
+    val coll = factory.empty[T]
+    coll.addAll(rangeOfElems(toElem))
+
+    val minMax = if (isMin) range.head else range.last
+    def getMinMax(): T =
+      if (isMin) ju.Collections.min(coll)
+      else ju.Collections.max(coll)
+
+    assertEquals(0, getMinMax().compareTo(toElem(minMax)))
+
+    coll match {
+      case list: ju.List[_] =>
+        ju.Collections.shuffle(list, new ju.Random(42))
+        assertEquals(0, getMinMax().compareTo(toElem(minMax)))
+        ju.Collections.shuffle(list, new ju.Random(100000))
+        assertEquals(0, getMinMax().compareTo(toElem(minMax)))
+      case _ =>
+    }
+  }
+
+  def testMinMax2[T: ClassTag](factory: CollectionFactory,
+                               toElem: Int => T,
+                               isMin: Boolean,
+                               cmp: ju.Comparator[T]): Unit = {
+    val coll = factory.empty[T]
+    coll.addAll(rangeOfElems(toElem))
+
+    val minMax = if (isMin) range.head else range.last
+    def getMinMax: T =
+      if (isMin) ju.Collections.min(coll, cmp)
+      else ju.Collections.max(coll, cmp)
+
+    assertEquals(0, cmp.compare(getMinMax, toElem(minMax)))
+
+    coll match {
+      case list: ju.List[_] =>
+        ju.Collections.shuffle(list, new ju.Random(42))
+        assertEquals(0, cmp.compare(getMinMax, toElem(minMax)))
+        ju.Collections.shuffle(list, new ju.Random(100000))
+        assertEquals(0, cmp.compare(getMinMax, toElem(minMax)))
+      case _ =>
+    }
+  }
+
+  @Test def minOnComparables(): Unit = {
+    def test[T <: AnyRef with Comparable[T]: ClassTag](toElem: Int => T): Unit =
+      testMinMax1(factory, toElem, true)
+
+    test[jl.Integer](jl.Integer.valueOf)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+  }
+
+  @Test def minWithComparator(): Unit = {
+    def test[T: ClassTag](toElem: Int => T, cmpFun: (T, T) => Int): Unit = {
+      testMinMax2(factory, toElem, true, new Comparator[T] {
+        override def compare(o1: T, o2: T): Int = cmpFun(o1, o2)
+      })
+    }
+
+    test[jl.Integer](_.toInt, (x: jl.Integer, y: jl.Integer) => x.compareTo(y))
+    test[jl.Long](_.toLong, (x: jl.Long, y: jl.Long) => x.compareTo(y))
+    test[jl.Double](_.toDouble, (x: jl.Double, y: jl.Double) => x.compareTo(y))
+  }
+
+  @Test def maxOnComparables(): Unit = {
+    def test[T <: AnyRef with Comparable[T]: ClassTag](toElem: Int => T): Unit =
+      testMinMax1(factory, toElem, false)
+
+    test[jl.Integer](jl.Integer.valueOf)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+  }
+
+  @Test def maxWithComparator(): Unit = {
+    def test[T: ClassTag](toElem: Int => T, cmpFun: (T, T) => Int): Unit = {
+      testMinMax2(factory, toElem, false, new Comparator[T] {
+        override def compare(o1: T, o2: T): Int = cmpFun(o1, o2)
+      })
+    }
+
+    test[jl.Integer](_.toInt, (x: jl.Integer, y: jl.Integer) => x.compareTo(y))
+    test[jl.Long](_.toLong, (x: jl.Long, y: jl.Long) => x.compareTo(y))
+    test[jl.Double](_.toDouble, (x: jl.Double, y: jl.Double) => x.compareTo(y))
+  }
+
+  @Test def frequency(): Unit = {
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val coll = factory.empty[E]
+
+      def expectAllFrequenciesToBe(n: Int): Unit = {
+        for (i <- range)
+          assertEquals(n, ju.Collections.frequency(coll, toElem(i)))
+      }
+
+      expectAllFrequenciesToBe(0)
+      coll.addAll(rangeOfElems(toElem))
+      expectAllFrequenciesToBe(1)
+      coll.addAll(rangeOfElems(toElem))
+      coll match {
+        case _: ju.Set[_]  => expectAllFrequenciesToBe(1)
+        case _: ju.List[_] => expectAllFrequenciesToBe(2)
+        case _             => // Undefined behaviour
+      }
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+
+  @Test def addAll(): Unit = {
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val coll = factory.empty[E]
+      assertFalse(ju.Collections.addAll(coll))
+      assertTrue(coll.isEmpty)
+      assertTrue(ju.Collections.addAll(coll, toElem(0), toElem(1)))
+      assertTrue(coll.contains(toElem(0)))
+      assertTrue(coll.contains(toElem(1)))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+  }
+
+  @Test def unmodifiableCollection(): Unit = {
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val coll = factory.empty[E]
+      testCollectionUnmodifiability(ju.Collections.unmodifiableCollection(coll),
+                                    toElem(0))
+      coll.addAll(rangeOfElems(toElem))
+      testCollectionUnmodifiability(ju.Collections.unmodifiableCollection(coll),
+                                    toElem(0))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+}

--- a/unit-tests/src/test/scala/java/util/CollectionsOnListsTest.scala
+++ b/unit-tests/src/test/scala/java/util/CollectionsOnListsTest.scala
@@ -16,34 +16,31 @@ import scala.reflect.ClassTag
 object CollectionsOnListTest extends CollectionsTestBase {
 
   // Test: sort[T<:Comparable[T]](List[T])
-  def sort_on_comparables(factory: ListFactory): Unit = {
-    test_sort_on_comparables[CustomComparable](factory,
-                                               new CustomComparable(_),
-                                               false)
-    test_sort_on_comparables[jl.Integer](factory, jl.Integer.valueOf)
-    test_sort_on_comparables[jl.Long](factory, _.toLong)
-    test_sort_on_comparables[jl.Double](factory, _.toDouble)
+  def sortOnComparables(factory: ListFactory): Unit = {
+    testSortOnComparables[CustomComparable](factory,
+                                            new CustomComparable(_),
+                                            false)
+    testSortOnComparables[jl.Integer](factory, jl.Integer.valueOf)
+    testSortOnComparables[jl.Long](factory, _.toLong)
+    testSortOnComparables[jl.Double](factory, _.toDouble)
   }
 
   // Test: sort[T](List[T], Comparator[T])
-  def sort_with_comparator(factory: ListFactory): Unit = {
-    test_sort_with_comparator[CustomComparable](factory,
-                                                new CustomComparable(_),
-                                                (x, y) => x.compareTo(y),
-                                                false)
-    test_sort_with_comparator[jl.Integer](factory,
-                                          _.toInt,
-                                          (x, y) => x.compareTo(y))
-    test_sort_with_comparator[jl.Long](factory,
-                                       _.toLong,
+  def sortWithComparator(factory: ListFactory): Unit = {
+    testSortWithComparator[CustomComparable](factory,
+                                             new CustomComparable(_),
+                                             (x, y) => x.compareTo(y),
+                                             false)
+    testSortWithComparator[jl.Integer](factory,
+                                       _.toInt,
                                        (x, y) => x.compareTo(y))
-    test_sort_with_comparator[jl.Double](factory,
-                                         _.toDouble,
-                                         (x, y) => x.compareTo(y))
+    testSortWithComparator[jl.Long](factory, _.toLong, (x, y) => x.compareTo(y))
+    testSortWithComparator[jl.Double](factory,
+                                      _.toDouble,
+                                      (x, y) => x.compareTo(y))
   }
 
-  private def test_sort_on_comparables[
-      T <: AnyRef with Comparable[T]: ClassTag](
+  private def testSortOnComparables[T <: AnyRef with Comparable[T]: ClassTag](
       factory: ListFactory,
       toElem: Int => T,
       absoluteOrder: Boolean = true): Unit = {
@@ -78,11 +75,11 @@ object CollectionsOnListTest extends CollectionsTestBase {
     }
   }
 
-  private def test_sort_with_comparator[T: ClassTag](factory: ListFactory,
-                                                     toElem: Int => T,
-                                                     cmpFun: (T, T) => Int,
-                                                     absoluteOrder: Boolean =
-                                                       true): Unit = {
+  private def testSortWithComparator[T: ClassTag](
+      factory: ListFactory,
+      toElem: Int => T,
+      cmpFun: (T, T) => Int,
+      absoluteOrder: Boolean = true): Unit = {
 
     val list = factory.empty[T]
 
@@ -124,10 +121,10 @@ trait CollectionsOnListTest extends CollectionsOnCollectionsTest {
   def factory: ListFactory
 
   @Test def sortOnComparables(): Unit =
-    CollectionsOnListTest.sort_on_comparables(factory)
+    CollectionsOnListTest.sortOnComparables(factory)
 
   @Test def sortWithComparator(): Unit =
-    CollectionsOnListTest.sort_with_comparator(factory)
+    CollectionsOnListTest.sortWithComparator(factory)
 
   @Test def binarySearchOnComparables(): Unit = {
     // Test: binarySearch[T](list: List[Comparable[T]], T)

--- a/unit-tests/src/test/scala/java/util/CollectionsOnListsTest.scala
+++ b/unit-tests/src/test/scala/java/util/CollectionsOnListsTest.scala
@@ -1,0 +1,509 @@
+// Ported from Scala.js commit: 43f6d38 dated: 2020-10-05
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{lang => jl, util => ju}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalanative.testsuite.javalib.util.concurrent.CopyOnWriteArrayListFactory
+import scala.scalanative.junit.utils.AssertThrows._
+import org.scalanative.testsuite.utils.CollectionsTestBase
+
+import scala.reflect.ClassTag
+
+object CollectionsOnListTest extends CollectionsTestBase {
+
+  // Test: sort[T<:Comparable[T]](List[T])
+  def sort_on_comparables(factory: ListFactory): Unit = {
+    test_sort_on_comparables[CustomComparable](factory,
+                                               new CustomComparable(_),
+                                               false)
+    test_sort_on_comparables[jl.Integer](factory, jl.Integer.valueOf)
+    test_sort_on_comparables[jl.Long](factory, _.toLong)
+    test_sort_on_comparables[jl.Double](factory, _.toDouble)
+  }
+
+  // Test: sort[T](List[T], Comparator[T])
+  def sort_with_comparator(factory: ListFactory): Unit = {
+    test_sort_with_comparator[CustomComparable](factory,
+                                                new CustomComparable(_),
+                                                (x, y) => x.compareTo(y),
+                                                false)
+    test_sort_with_comparator[jl.Integer](factory,
+                                          _.toInt,
+                                          (x, y) => x.compareTo(y))
+    test_sort_with_comparator[jl.Long](factory,
+                                       _.toLong,
+                                       (x, y) => x.compareTo(y))
+    test_sort_with_comparator[jl.Double](factory,
+                                         _.toDouble,
+                                         (x, y) => x.compareTo(y))
+  }
+
+  private def test_sort_on_comparables[
+      T <: AnyRef with Comparable[T]: ClassTag](
+      factory: ListFactory,
+      toElem: Int => T,
+      absoluteOrder: Boolean = true): Unit = {
+
+    val list = factory.empty[T]
+
+    def testIfSorted(rangeValues: Boolean): Unit = {
+      for (i <- range.init)
+        assertTrue(list.get(i).compareTo(list.get(i + 1)) <= 0)
+      if (absoluteOrder && rangeValues) {
+        for (i <- range)
+          assertEquals(0, list.get(i).compareTo(toElem(i)))
+      }
+    }
+
+    list.addAll(rangeOfElems(toElem))
+    ju.Collections.sort(list)
+    testIfSorted(true)
+
+    list.clear()
+    list.addAll(TrivialImmutableCollection(range.reverse.map(toElem): _*))
+    ju.Collections.sort(list)
+    testIfSorted(true)
+
+    for (seed <- List(0, 1, 42, -5432, 2341242)) {
+      val rnd = new scala.util.Random(seed)
+      list.clear()
+      list.addAll(
+        TrivialImmutableCollection(range.map(_ => toElem(rnd.nextInt())): _*))
+      ju.Collections.sort(list)
+      testIfSorted(false)
+    }
+  }
+
+  private def test_sort_with_comparator[T: ClassTag](factory: ListFactory,
+                                                     toElem: Int => T,
+                                                     cmpFun: (T, T) => Int,
+                                                     absoluteOrder: Boolean =
+                                                       true): Unit = {
+
+    val list = factory.empty[T]
+
+    def testIfSorted(rangeValues: Boolean): Unit = {
+      for (i <- range.init)
+        assertTrue(cmpFun(list.get(i), list.get(i + 1)) <= 0)
+      if (absoluteOrder && rangeValues) {
+        for (i <- range)
+          assertEquals(0, cmpFun(list.get(i), toElem(i)))
+      }
+    }
+
+    val cmp = new ju.Comparator[T] {
+      override def compare(o1: T, o2: T): Int = cmpFun(o1, o2)
+    }
+
+    list.addAll(rangeOfElems(toElem))
+    ju.Collections.sort(list, cmp)
+    testIfSorted(true)
+
+    list.clear()
+    list.addAll(TrivialImmutableCollection(range.reverse.map(toElem): _*))
+    ju.Collections.sort(list, cmp)
+    testIfSorted(true)
+
+    for (seed <- List(0, 1, 42, -5432, 2341242)) {
+      val rnd = new scala.util.Random(seed)
+      list.clear()
+      list.addAll(
+        TrivialImmutableCollection(range.map(_ => toElem(rnd.nextInt())): _*))
+      ju.Collections.sort(list, cmp)
+      testIfSorted(false)
+    }
+  }
+}
+
+trait CollectionsOnListTest extends CollectionsOnCollectionsTest {
+
+  def factory: ListFactory
+
+  @Test def sortOnComparables(): Unit =
+    CollectionsOnListTest.sort_on_comparables(factory)
+
+  @Test def sortWithComparator(): Unit =
+    CollectionsOnListTest.sort_with_comparator(factory)
+
+  @Test def binarySearchOnComparables(): Unit = {
+    // Test: binarySearch[T](list: List[Comparable[T]], T)
+    def test[T <: AnyRef with Comparable[T]: ClassTag](
+        toElem: Int => T): Unit = {
+      val list = factory.fromElements[T](range.map(toElem).sorted: _*)
+
+      for (i <- Seq(range.head,
+                    range.last,
+                    range(range.size / 3),
+                    range(range.size / 2),
+                    range(3 * range.size / 5))) {
+        assertEquals(i, ju.Collections.binarySearch(list, toElem(i)))
+      }
+
+      // If not found it should return: -(insertion point) - 1
+      assertEquals(-1, ju.Collections.binarySearch(list, toElem(-1)))
+      assertEquals(-1, ju.Collections.binarySearch(list, toElem(-42)))
+      assertEquals(-range.size - 1,
+                   ju.Collections.binarySearch(list, toElem(range.last + 1)))
+      assertEquals(-range.size - 1,
+                   ju.Collections.binarySearch(list, toElem(range.last + 42)))
+      list.remove(range.last / 2)
+      assertEquals(-(range.last / 2) - 1,
+                   ju.Collections.binarySearch(list, toElem(range.last / 2)))
+    }
+
+    test[jl.Integer](jl.Integer.valueOf)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+  }
+
+  @Test def binarySearch_with_comparator(): Unit = {
+    // Test: binarySearch[T](List[T], key: T, Comparator[T]))
+    def test[T: ClassTag](toElem: Int => T, cmpFun: (T, T) => Int): Unit = {
+      val cmp = new ju.Comparator[T] {
+        override def compare(o1: T, o2: T): Int = cmpFun(o1, o2)
+      }
+
+      val list = factory.fromElements[T](
+        range.map(toElem).sortWith(cmpFun(_, _) < 0): _*)
+
+      for (i <- Seq(range.head,
+                    range.last,
+                    range(range.size / 3),
+                    range(range.size / 2),
+                    range(3 * range.size / 5))) {
+        assertEquals(i, ju.Collections.binarySearch(list, toElem(i), cmp))
+      }
+
+      // If not found it should return: -(insertion point) - 1
+      assertEquals(-1, ju.Collections.binarySearch(list, toElem(-1), cmp))
+      assertEquals(-1, ju.Collections.binarySearch(list, toElem(-42), cmp))
+      assertEquals(
+        -range.size - 1,
+        ju.Collections.binarySearch(list, toElem(range.last + 1), cmp))
+      assertEquals(
+        -range.size - 1,
+        ju.Collections.binarySearch(list, toElem(range.last + 42), cmp))
+      list.remove(range.last / 2)
+      assertEquals(
+        -(range.last / 2) - 1,
+        ju.Collections.binarySearch(list, toElem(range.last / 2), cmp))
+    }
+
+    test[jl.Integer](_.toInt, (x, y) => x.compareTo(y))
+    test[jl.Long](_.toLong, (x, y) => x.compareTo(y))
+    test[jl.Double](_.toDouble, (x, y) => x.compareTo(y))
+  }
+
+  @Test def reverse(): Unit = {
+    // Test: reverse(list: List[_])
+    def test[T: ClassTag](toElem: Int => T): Unit = {
+      val list = factory.fromElements[T](range.map(toElem): _*)
+
+      def testIfInOrder(reversed: Boolean): Unit = {
+        for (i <- range) {
+          val expected =
+            if (reversed) range.last - i
+            else i
+          assertEquals(toElem(expected), list.get(i))
+        }
+      }
+
+      ju.Collections.reverse(list)
+      testIfInOrder(true)
+
+      ju.Collections.reverse(list)
+      testIfInOrder(false)
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+
+  @Test def shuffle(): Unit = {
+    def testShuffle(shuffle: ju.List[_] => Unit): Unit = {
+      def test[E: ClassTag](toElem: Int => E): Unit = {
+        val list = factory.empty[E]
+        ju.Collections.shuffle(list)
+        assertEquals(0, list.size)
+        list.addAll(rangeOfElems(toElem))
+        shuffle(list)
+        assertEquals(range.size, list.size)
+        assertTrue(list.containsAll(rangeOfElems(toElem)))
+      }
+      test[jl.Integer](_.toInt)
+      test[jl.Long](_.toLong)
+      test[jl.Double](_.toDouble)
+      test[String](_.toString)
+    }
+
+    // Test: shuffle(list: List[_])
+    // Relies on the correctness of shuffle(list: List[_], rnd: Random)
+    // Tests for this version are omitted because they are not reproducible
+
+    // Test: shuffle(list: List[_], rnd: Random)
+    testShuffle(ju.Collections.shuffle(_, new ju.Random(0)))
+    testShuffle(ju.Collections.shuffle(_, new ju.Random(42)))
+    testShuffle(ju.Collections.shuffle(_, new ju.Random(-1243)))
+    testShuffle(ju.Collections.shuffle(_, new ju.Random(94325)))
+  }
+
+  @Test def swap(): Unit = {
+    // Test: swap(List[_], Int, Int)
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val list = factory.fromElements[E](range.map(toElem): _*)
+
+      ju.Collections.swap(list, 0, 1)
+      assertEquals(toElem(1), list.get(0))
+      assertEquals(toElem(0), list.get(1))
+      for (i <- range.drop(2))
+        assertEquals(toElem(i), list.get(i))
+
+      ju.Collections.swap(list, 0, range.last)
+      assertEquals(toElem(range.last), list.get(0))
+      assertEquals(toElem(0), list.get(1))
+      for (i <- range.drop(2).init)
+        assertEquals(toElem(i), list.get(i))
+      assertEquals(toElem(1), list.get(range.last))
+
+      ju.Collections.swap(list, 0, range.last)
+      assertEquals(toElem(1), list.get(0))
+      assertEquals(toElem(0), list.get(1))
+      for (i <- range.drop(2))
+        assertEquals(toElem(i), list.get(i))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+
+  @Test def fill(): Unit = {
+    // Test: fill[E](List[E], E)
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val list = factory.fromElements[E](range.map(toElem): _*)
+
+      ju.Collections.fill(list, toElem(0))
+      for (i <- range)
+        assertEquals(toElem(0), list.get(i))
+
+      ju.Collections.fill(list, toElem(42))
+      for (i <- range)
+        assertEquals(toElem(42), list.get(i))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+
+  @Test def copy(): Unit = {
+    // Test: copy[E](List[E], List[E])
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val source = factory.empty[E]
+      val dest   = factory.empty[E]
+
+      // Lists of same size
+      range.foreach(i => source.add(toElem(i)))
+      range.foreach(i => dest.add(toElem(-i)))
+      ju.Collections.copy(dest, source)
+      for (i <- range)
+        assertEquals(toElem(i), dest.get(i))
+
+      // source.size < dest.size
+      source.clear()
+      dest.clear()
+      range.take(range.size / 2).foreach(i => source.add(toElem(i)))
+      range.foreach(i => dest.add(toElem(-i)))
+      ju.Collections.copy(dest, source)
+      for (i <- range.take(range.size / 2))
+        assertEquals(toElem(i), dest.get(i))
+      for (i <- range.drop(range.size / 2))
+        assertEquals(toElem(-i), dest.get(i))
+
+      // source.size > dest.size
+      source.clear()
+      dest.clear()
+      range.foreach(i => source.add(toElem(i)))
+      range.take(range.size / 2).foreach(i => dest.add(toElem(-i)))
+      expectThrows(classOf[IndexOutOfBoundsException],
+                   ju.Collections.copy(dest, source))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+
+  @Test def rotate(): Unit = {
+    def modulo(a: Int, b: Int): Int = ((a % b) + b) % b
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val list = factory.fromElements[E](range.map(toElem): _*)
+
+      ju.Collections.rotate(list, 0)
+      for (i <- range)
+        assertEquals(toElem(i), list.get(i))
+
+      ju.Collections.rotate(list, list.size)
+      for (i <- range)
+        assertEquals(toElem(i), list.get(i))
+
+      ju.Collections.rotate(list, 1)
+      for (i <- range)
+        assertEquals(toElem(modulo(i - 1, range.size)), list.get(i))
+
+      ju.Collections.rotate(list, 1)
+      for (i <- range)
+        assertEquals(toElem(modulo(i - 2, range.size)), list.get(i))
+
+      ju.Collections.rotate(list, -5)
+      for (i <- range)
+        assertEquals(toElem(modulo(i + 3, range.size)), list.get(i))
+
+      list.clear()
+      list.addAll(TrivialImmutableCollection((0 until 6).map(toElem): _*))
+      ju.Collections.rotate(list, 2)
+      for (i <- 0 until 6)
+        assertEquals(toElem(modulo(i - 2, 6)), list.get(i))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+
+  @Test def replaceAll(): Unit = {
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val list = factory.fromElements[E](range.map(toElem): _*)
+
+      ju.Collections.replaceAll(list, toElem(range.last), toElem(0))
+      for (i <- range.init)
+        assertEquals(toElem(i), list.get(i))
+      assertEquals(toElem(0), list.get(list.size() - 1))
+
+      ju.Collections.replaceAll(list, toElem(range(range.size - 2)), toElem(0))
+      for (i <- range.dropRight(2))
+        assertEquals(toElem(i), list.get(i))
+      assertEquals(toElem(0), list.get(list.size() - 2))
+      assertEquals(toElem(0), list.get(list.size() - 1))
+
+      ju.Collections.replaceAll(list, toElem(0), toElem(-1))
+      for (i <- range.tail.dropRight(2))
+        assertEquals(toElem(i), list.get(i))
+      assertEquals(toElem(-1), list.get(0))
+      assertEquals(toElem(-1), list.get(list.size() - 2))
+      assertEquals(toElem(-1), list.get(list.size() - 1))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+
+  @Test def indexOfSubList(): Unit = {
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val source = factory.empty[E]
+      val target = factory.empty[E]
+
+      assertEquals(0, ju.Collections.indexOfSubList(source, target))
+
+      source.addAll(rangeOfElems(toElem))
+      assertEquals(0, ju.Collections.indexOfSubList(source, target))
+
+      target.addAll(rangeOfElems(toElem))
+      assertEquals(0, ju.Collections.indexOfSubList(source, target))
+
+      source.addAll(rangeOfElems(toElem))
+      assertEquals(0, ju.Collections.indexOfSubList(source, target))
+
+      source.addAll(rangeOfElems(toElem))
+      assertEquals(0, ju.Collections.indexOfSubList(source, target))
+
+      source.remove(0)
+      assertEquals(range.size - 1,
+                   ju.Collections.indexOfSubList(source, target))
+
+      target.add(0, toElem(-5))
+      assertEquals(-1, ju.Collections.indexOfSubList(source, target))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+
+  @Test def lastIndexOfSubList(): Unit = {
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val source = factory.empty[E]
+      val target = factory.empty[E]
+
+      assertEquals(0, ju.Collections.lastIndexOfSubList(source, target))
+
+      source.addAll(rangeOfElems(toElem))
+      assertEquals(range.size,
+                   ju.Collections.lastIndexOfSubList(source, target))
+
+      target.addAll(rangeOfElems(toElem))
+      assertEquals(0, ju.Collections.lastIndexOfSubList(source, target))
+
+      source.addAll(rangeOfElems(toElem))
+      assertEquals(range.size,
+                   ju.Collections.lastIndexOfSubList(source, target))
+
+      source.addAll(rangeOfElems(toElem))
+      assertEquals(2 * range.size,
+                   ju.Collections.lastIndexOfSubList(source, target))
+
+      source.remove(source.size - 1)
+      assertEquals(range.size,
+                   ju.Collections.lastIndexOfSubList(source, target))
+
+      target.add(0, toElem(-5))
+      assertEquals(-1, ju.Collections.lastIndexOfSubList(source, target))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+
+  @Test def unmodifiableList(): Unit = {
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val immuList = ju.Collections.unmodifiableList(factory.empty[E])
+      testListUnmodifiability(immuList, toElem(0))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+}
+
+class CollectionsOnAbstractListTest extends CollectionsOnListTest {
+  def factory: ListFactory = new AbstractListFactory
+}
+
+class CollectionsOnArrayListTest extends CollectionsOnListTest {
+  def factory: ListFactory = new ArrayListFactory
+}
+
+class CollectionsOnLinkedListTest extends CollectionsOnListTest {
+  def factory: ListFactory = new LinkedListFactory
+}
+
+class CollectionsOnCopyOnWriteArrayListTest extends CollectionsOnListTest {
+  def factory: ListFactory = new CopyOnWriteArrayListFactory
+}

--- a/unit-tests/src/test/scala/java/util/CollectionsOnListsTest.scala
+++ b/unit-tests/src/test/scala/java/util/CollectionsOnListsTest.scala
@@ -160,7 +160,7 @@ trait CollectionsOnListTest extends CollectionsOnCollectionsTest {
     test[jl.Double](_.toDouble)
   }
 
-  @Test def binarySearch_with_comparator(): Unit = {
+  @Test def binarySearchWithComparator(): Unit = {
     // Test: binarySearch[T](List[T], key: T, Comparator[T]))
     def test[T: ClassTag](toElem: Int => T, cmpFun: (T, T) => Int): Unit = {
       val cmp = new ju.Comparator[T] {


### PR DESCRIPTION
--- WIP commit message

  * This submission is marked Work In Progress (WIP)
    because it depends upon files PR #2052, which is awaiting review.

    Until then, it will fail to build & execute.  All tests pass
    locally.

    After that PR is merged, this work can be promoted to a full PR
    and this section deleted.

  * This PR is a pretty much pure port from Scala.js. Location
     of AssertThrows was changed. There are probably some 
     scalafmt changes also.

  * The enquiring mind might wonder why two *ListTest candidates
    are not part of this work.

    CollectionsOnCheckedListTest.scala and
    CollectionsOnSynchronizedListTest.scala both depend upon
    CollectionsOnCheckedCollectionTest.scala

    CollectionsOnCheckedCollectionTest.scala will follow once the tests
    it requires, such as ArrayDequeTest.scala have been ported.
    (ArrayDequeTest exists but does not have a factory. It also
    has at least one Scala Native "@Ignore".)

    Work for a future PR, after CollectionsOnMaps, CollectionsOnSets,

--- PR commit message --

We port CollectionsOnCollections.scala and CollectionsOnLists.scala
to increase test coverage of j.u.List and classes which extend it.