### PR TITLE
WIP: Implement CollectionsOnSets and related Set Tests

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentSkipListSet.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentSkipListSet.scala
@@ -1,0 +1,108 @@
+// Ported from Scala.js commit: 1337656 dated: 2020-06-04
+
+package java.util.concurrent
+
+import java.util._
+
+class ConcurrentSkipListSet[E] private (inner: TreeSet[E])
+    extends AbstractSet[E]
+    with NavigableSet[E]
+    with Cloneable
+    with Serializable {
+
+  def this(collection: Collection[_ <: E]) =
+    this(new TreeSet[E](collection))
+
+  def this() =
+    this(new TreeSet[E]())
+
+  def this(comparator: Comparator[_ >: E]) =
+    this(new TreeSet[E](comparator))
+
+  def this(sortedSet: SortedSet[E]) =
+    this(new TreeSet[E](sortedSet))
+
+  override def clone(): ConcurrentSkipListSet[E] =
+    new ConcurrentSkipListSet(this)
+
+  def size(): Int =
+    inner.size()
+
+  override def isEmpty(): Boolean =
+    inner.isEmpty()
+
+  override def contains(o: Any): Boolean =
+    if (o == null) false
+    else inner.contains(o)
+
+  override def add(e: E): Boolean =
+    if (e == null) throw new NullPointerException()
+    else inner.add(e)
+
+  override def remove(o: Any): Boolean =
+    if (o == null) throw new NullPointerException()
+    else inner.remove(o)
+
+  override def clear(): Unit =
+    inner.clear()
+
+  def iterator(): Iterator[E] =
+    inner.iterator()
+
+  def descendingIterator(): Iterator[E] =
+    inner.descendingIterator()
+
+  override def removeAll(c: Collection[_]): Boolean =
+    inner.removeAll(c)
+
+  def lower(e: E): E =
+    inner.lower(e)
+
+  def floor(e: E): E =
+    inner.floor(e)
+
+  def ceiling(e: E): E =
+    inner.ceiling(e)
+
+  def higher(e: E): E =
+    inner.higher(e)
+
+  def pollFirst(): E =
+    inner.pollFirst()
+
+  def pollLast(): E =
+    inner.pollLast()
+
+  def comparator(): Comparator[_ >: E] =
+    inner.comparator()
+
+  def first(): E =
+    inner.first()
+
+  def last(): E =
+    inner.last()
+
+  def subSet(fromElement: E,
+             fromInclusive: Boolean,
+             toElement: E,
+             toInclusive: Boolean): NavigableSet[E] =
+    inner.subSet(fromElement, fromInclusive, toElement, toInclusive)
+
+  def headSet(toElement: E, inclusive: Boolean): NavigableSet[E] =
+    inner.headSet(toElement, inclusive)
+
+  def tailSet(fromElement: E, inclusive: Boolean): NavigableSet[E] =
+    inner.tailSet(fromElement, inclusive)
+
+  def subSet(fromElement: E, toElement: E): NavigableSet[E] =
+    inner.subSet(fromElement, true, toElement, false)
+
+  def headSet(toElement: E): NavigableSet[E] =
+    inner.headSet(toElement, false)
+
+  def tailSet(fromElement: E): NavigableSet[E] =
+    inner.tailSet(fromElement, true)
+
+  def descendingSet(): NavigableSet[E] =
+    inner.descendingSet()
+}

--- a/unit-tests/src/test/scala/java/util/AbstractSetTest.scala
+++ b/unit-tests/src/test/scala/java/util/AbstractSetTest.scala
@@ -1,0 +1,16 @@
+// Ported from Scala.js commit: 434b8ce dated: 2019-08-19
+
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+import scala.reflect.ClassTag
+
+abstract class AbstractSetTest extends SetTest {
+  def factory: AbstractSetFactory
+}
+
+trait AbstractSetFactory extends SetFactory {
+  def empty[E: ClassTag]: ju.AbstractSet[E]
+}

--- a/unit-tests/src/test/scala/java/util/CollectionsOnCheckedSetTest.scala
+++ b/unit-tests/src/test/scala/java/util/CollectionsOnCheckedSetTest.scala
@@ -1,0 +1,62 @@
+// Ported from Scala.js commit: 222e14c dated: 2019-09-11
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+import scala.reflect.ClassTag
+
+trait CollectionsOnCheckedSetTest extends CollectionsOnSetsTest {
+
+  def originalFactory: SetFactory
+
+  def factory: SetFactory = {
+    new SetFactory {
+      override def implementationName: String =
+        s"checkedSet(${originalFactory.implementationName})"
+
+      override def empty[E](implicit ct: ClassTag[E]): ju.Set[E] = {
+        ju.Collections.checkedSet(originalFactory.empty[E],
+            ct.runtimeClass.asInstanceOf[Class[E]])
+      }
+
+      override def allowsNullElement: Boolean =
+        originalFactory.allowsNullElement
+    }
+  }
+}
+
+trait CollectionsOnCheckedSortedSetTest extends CollectionsOnSortedSetsTest {
+
+  def originalFactory: SortedSetFactory
+
+  def factory: SortedSetFactory = {
+    new SortedSetFactory {
+      override def implementationName: String =
+        s"checkedSortedSet(${originalFactory.implementationName})"
+
+      override def empty[E](implicit ct: ClassTag[E]): ju.SortedSet[E] = {
+        ju.Collections.checkedSortedSet(originalFactory.empty[E],
+            ct.runtimeClass.asInstanceOf[Class[E]])
+      }
+
+      override def allowsNullElement: Boolean =
+        originalFactory.allowsNullElement
+    }
+  }
+}
+
+class CollectionsOnCheckedSetHashSetFactoryTest
+    extends CollectionsOnCheckedSetTest {
+  def originalFactory: SetFactory = new HashSetFactory
+}
+
+class CollectionsOnCheckedSetCollectionLinkedHashSetFactoryTest
+    extends CollectionsOnCheckedSetTest {
+  def originalFactory: SetFactory = new LinkedHashSetFactory
+}
+
+class CollectionsOnCheckedSetCollectionConcurrentSkipListSetFactoryTest
+    extends CollectionsOnCheckedSetTest {
+  def originalFactory: SetFactory = new concurrent.ConcurrentSkipListSetFactory
+}

--- a/unit-tests/src/test/scala/java/util/CollectionsOnSetsTest.scala
+++ b/unit-tests/src/test/scala/java/util/CollectionsOnSetsTest.scala
@@ -1,0 +1,60 @@
+// Ported from Scala.js commit: 6fbe7b2 dated: 2019-08-14
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju, lang => jl}
+
+import org.junit.Test
+
+import scala.reflect.ClassTag
+
+trait CollectionsOnSetsTest extends CollectionsOnCollectionsTest {
+  def factory: SetFactory
+
+  @Test def unmodifiableSet():Unit = {
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val set = factory.empty[E]
+      testSetUnmodifiability(ju.Collections.unmodifiableSet(set), toElem(0))
+      set.addAll(rangeOfElems(toElem))
+      testSetUnmodifiability(ju.Collections.unmodifiableSet(set), toElem(0))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+}
+
+trait CollectionsOnSortedSetsTest extends CollectionsOnSetsTest {
+  def factory: SortedSetFactory
+
+  @Test def unmodifiableSortedSet():Unit = {
+    def test[E: ClassTag](toElem: Int => E): Unit = {
+      val sortedSet = factory.empty[E]
+      testSortedSetUnmodifiability(ju.Collections.unmodifiableSortedSet(sortedSet),
+        toElem(0))
+      sortedSet.addAll(rangeOfElems(toElem))
+      testSortedSetUnmodifiability(ju.Collections.unmodifiableSortedSet(sortedSet),
+        toElem(0))
+    }
+
+    test[jl.Integer](_.toInt)
+    test[jl.Long](_.toLong)
+    test[jl.Double](_.toDouble)
+    test[String](_.toString)
+  }
+}
+
+class CollectionsOnHashSetFactoryTest extends CollectionsOnSetsTest {
+  def factory: SetFactory = new HashSetFactory
+}
+
+class CollectionsOnLinkedHashSetFactoryTest extends CollectionsOnSetsTest {
+  def factory: SetFactory = new LinkedHashSetFactory
+}
+
+class CollectionsOnConcurrentSkipListSetFactoryTest
+    extends CollectionsOnSetsTest {
+  def factory: SetFactory = new concurrent.ConcurrentSkipListSetFactory
+}

--- a/unit-tests/src/test/scala/java/util/CollectionsOnSynchronizedSetTest.scala
+++ b/unit-tests/src/test/scala/java/util/CollectionsOnSynchronizedSetTest.scala
@@ -1,0 +1,58 @@
+// Ported from Scala.js commit: 222e14c dated: 2019-09-11
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+import scala.reflect.ClassTag
+
+trait CollectionsOnSynchronizedSetTest extends CollectionsOnSetsTest {
+
+  def originalFactory: SetFactory
+
+  def factory: SetFactory = {
+    new SetFactory {
+      override def implementationName: String =
+        s"synchronizedSet(${originalFactory.implementationName})"
+
+      override def empty[E: ClassTag]: ju.Set[E] =
+        ju.Collections.synchronizedSet(originalFactory.empty[E])
+
+      override def allowsNullElement: Boolean =
+        originalFactory.allowsNullElement
+    }
+  }
+}
+
+trait CollectionsOnSynchronizedSortedSetTest extends CollectionsOnSortedSetsTest {
+
+  def originalFactory: SortedSetFactory
+
+  def factory: SortedSetFactory = {
+    new SortedSetFactory {
+      override def implementationName: String =
+        s"synchronizedSortedSet(${originalFactory.implementationName})"
+
+      override def empty[E: ClassTag]: ju.SortedSet[E] =
+        ju.Collections.synchronizedSortedSet(originalFactory.empty[E])
+
+      override def allowsNullElement: Boolean =
+        originalFactory.allowsNullElement
+    }
+  }
+}
+
+class CollectionsOnSynchronizedSetHashSetFactoryTest
+    extends CollectionsOnSynchronizedSetTest {
+  def originalFactory: SetFactory = new HashSetFactory
+}
+
+class CollectionsOnSynchronizedSetCollectionLinkedHashSetFactoryTest
+    extends CollectionsOnSynchronizedSetTest {
+  def originalFactory: SetFactory = new LinkedHashSetFactory
+}
+
+class CollectionsOnSynchronizedSetCollectionConcurrentSkipListSetFactoryTest
+    extends CollectionsOnSynchronizedSetTest {
+  def originalFactory: SetFactory = new concurrent.ConcurrentSkipListSetFactory
+}

--- a/unit-tests/src/test/scala/java/util/HashSetTest.scala
+++ b/unit-tests/src/test/scala/java/util/HashSetTest.scala
@@ -1,0 +1,21 @@
+// Ported from Scala.js commit: 222e14c dated: 2019-09-11
+
+package org.scalanative.testsuite.javalib.util
+
+import scala.language.implicitConversions
+
+import java.{util => ju}
+
+import scala.reflect.ClassTag
+
+class HashSetTest extends AbstractSetTest {
+  def factory: HashSetFactory = new HashSetFactory
+}
+
+class HashSetFactory extends AbstractSetFactory {
+  def implementationName: String =
+    "java.util.HashSet"
+
+  def empty[E: ClassTag]: ju.HashSet[E] =
+    new ju.HashSet[E]()
+}

--- a/unit-tests/src/test/scala/java/util/LinkedHashSetTest.scala
+++ b/unit-tests/src/test/scala/java/util/LinkedHashSetTest.scala
@@ -1,0 +1,49 @@
+// Ported from Scala.js commit: 6fbe7b2 dated: 2019-08-14
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.reflect.ClassTag
+
+class LinkedHashSetTest extends HashSetTest {
+
+  override def factory: LinkedHashSetFactory = new LinkedHashSetFactory
+
+  @Test def shouldIterateOverElementsInSnOrderedManner(): Unit = {
+    val hs = factory.empty[String]
+
+    val l1 = TrivialImmutableCollection("ONE", "TWO", null)
+    assertTrue(hs.addAll(l1))
+    assertEquals(3, hs.size)
+
+    val iter1 = hs.iterator()
+    for (i <- 0 until 3) {
+      assertTrue(iter1.hasNext())
+      assertEquals(l1(i), iter1.next())
+    }
+    assertFalse(iter1.hasNext())
+
+    val l2 = TrivialImmutableCollection("ONE", "TWO", null, "THREE")
+    assertTrue(hs.add(l2(3)))
+
+    val iter2 = hs.iterator()
+    for (i <- 0 until 4) {
+      assertTrue(iter2.hasNext())
+      assertEquals(l2(i), iter2.next())
+    }
+    assertFalse(iter2.hasNext())
+  }
+
+}
+
+class LinkedHashSetFactory extends HashSetFactory {
+  override def implementationName: String =
+    "java.util.LinkedHashSet"
+
+  override def empty[E: ClassTag]: ju.LinkedHashSet[E] =
+    new ju.LinkedHashSet[E]()
+}

--- a/unit-tests/src/test/scala/java/util/NavigableSetTest.scala
+++ b/unit-tests/src/test/scala/java/util/NavigableSetTest.scala
@@ -1,0 +1,129 @@
+// Ported from Scala.js commit: 6fbe7b2 dated: 2019-08-14
+
+package org.scalanative.testsuite.javalib.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.{util => ju}
+
+import org.scalanative.testsuite.javalib.util.concurrent.ConcurrentSkipListSetFactory
+
+import scala.reflect.ClassTag
+
+trait NavigableSetTest extends SetTest {
+
+  def factory: NavigableSetFactory
+
+  @Test def `shouldRetrieveCeilingOrderedElements`(): Unit = {
+    val lInt  = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val nsInt = factory.empty[Int]
+
+    nsInt.addAll(lInt)
+
+    assertEquals(1, nsInt.ceiling(-10))
+    assertEquals(1, nsInt.ceiling(0))
+    assertEquals(1, nsInt.ceiling(1))
+    assertEquals(5, nsInt.ceiling(5))
+
+    val lString  = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val nsString = factory.empty[String]
+
+    nsString.addAll(lString)
+
+    assertEquals("a", nsString.ceiling("00000"))
+    assertEquals("a", nsString.ceiling("0"))
+    assertEquals("a", nsString.ceiling("a"))
+    assertEquals("d", nsString.ceiling("d"))
+    assertNull(nsString.ceiling("z"))
+  }
+
+  @Test def `shouldRetrieveFloorOrderedElements`(): Unit = {
+    val lInt  = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val nsInt = factory.empty[Int]
+
+    nsInt.addAll(lInt)
+
+    assertEquals(5, nsInt.floor(10))
+    assertEquals(5, nsInt.floor(5))
+    assertEquals(3, nsInt.floor(3))
+    assertEquals(1, nsInt.floor(1))
+
+    val lString  = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val nsString = factory.empty[String]
+
+    nsString.addAll(lString)
+
+    assertEquals("e", nsString.floor("zzzzz"))
+    assertEquals("d", nsString.floor("d"))
+    assertEquals("b", nsString.floor("b"))
+    assertEquals("a", nsString.floor("a"))
+    assertNull(nsString.floor("0"))
+  }
+
+  @Test def `shouldRetrieveHigherOrderedElements`(): Unit = {
+    val lInt  = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val nsInt = factory.empty[Int]
+
+    nsInt.addAll(lInt)
+
+    assertEquals(5, nsInt.higher(4))
+    assertEquals(4, nsInt.higher(3))
+    assertEquals(2, nsInt.higher(1))
+    assertEquals(1, nsInt.higher(-10))
+
+    val lString  = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val nsString = factory.empty[String]
+
+    nsString.addAll(lString)
+
+    assertNull(nsString.higher("zzzzz"))
+    assertEquals("e", nsString.higher("d"))
+    assertEquals("c", nsString.higher("b"))
+    assertEquals("b", nsString.higher("a"))
+    assertEquals("a", nsString.higher("0"))
+  }
+
+  @Test def `shouldRetrieveLowerOrderedElements`(): Unit = {
+    val lInt  = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val nsInt = factory.empty[Int]
+
+    nsInt.addAll(lInt)
+
+    assertEquals(4, nsInt.lower(5))
+    assertEquals(3, nsInt.lower(4))
+    assertEquals(2, nsInt.lower(3))
+    assertEquals(5, nsInt.lower(10))
+
+    val lString  = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val nsString = factory.empty[String]
+
+    nsString.addAll(lString)
+
+    assertEquals("e", nsString.lower("zzzzz"))
+    assertEquals("c", nsString.lower("d"))
+    assertEquals("a", nsString.lower("b"))
+    assertNull(nsString.lower("a"))
+    assertNull(nsString.lower("0"))
+  }
+
+  @Test def shouldPollFirstAndLastElements(): Unit = {
+    val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val ns   = factory.empty[Int]
+
+    ns.addAll(lInt)
+
+    assertTrue(ns.contains(1))
+    assertEquals(1, ns.pollFirst())
+    assertFalse(ns.contains(1))
+    assertEquals(5, ns.pollLast())
+    assertEquals(2, ns.pollFirst())
+    assertEquals(4, ns.pollLast())
+    assertEquals(3, ns.pollFirst())
+    assertTrue(ns.isEmpty())
+  }
+}
+
+trait NavigableSetFactory extends SetFactory {
+  def empty[E: ClassTag]: ju.NavigableSet[E]
+}

--- a/unit-tests/src/test/scala/java/util/SetTest.scala
+++ b/unit-tests/src/test/scala/java/util/SetTest.scala
@@ -1,0 +1,196 @@
+// Ported from Scala.js commit: 49f9a8b dated: 2020-07-26
+
+package org.scalanative.testsuite.javalib.util
+
+import scala.language.implicitConversions
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.Utils._
+
+import java.{util => ju, lang => jl}
+
+import scala.reflect.ClassTag
+
+trait SetTest extends CollectionTest {
+
+  def factory: SetFactory
+
+  @Test def shouldCheckSetSize(): Unit = {
+    val hs = factory.empty[String]
+
+    assertEquals(0, hs.size())
+    assertTrue(hs.add("ONE"))
+    assertEquals(1, hs.size())
+    assertTrue(hs.add("TWO"))
+    assertEquals(2, hs.size())
+  }
+
+  @Test def shouldStoreIntegers_Set(): Unit = {
+    val hs = factory.empty[Int]
+
+    assertTrue(hs.add(100))
+    assertEquals(1, hs.size())
+    assertTrue(hs.contains(100))
+    assertEquals(100, hs.iterator.next())
+  }
+
+  @Test def shouldStoreObjectsWithSameHashCodeButDifferentTypes(): Unit = {
+    val hs = factory.empty[AnyRef]
+    trait A extends Comparable[A] {
+      def compareTo(o: A): Int = toString.compareTo(o.toString)
+    }
+    object B extends A {
+      override def hashCode(): Int = 42
+    }
+    object C extends A {
+      override def hashCode(): Int = 42
+    }
+
+    assertTrue(hs.add(B))
+    assertTrue(hs.add(C))
+    assertEquals(2, hs.size())
+  }
+
+  @Test def shouldStoreDoublesAlsoInCornerCases(): Unit = {
+    val hs = factory.empty[Double]
+
+    assertTrue(hs.add(11111.0))
+    assertEquals(1, hs.size())
+    assertTrue(hs.contains(11111.0))
+    assertEquals(11111.0, hs.iterator.next(), 0.0)
+
+    assertTrue(hs.add(Double.NaN))
+    assertEquals(2, hs.size())
+    assertTrue(hs.contains(Double.NaN))
+    assertFalse(hs.contains(+0.0))
+    assertFalse(hs.contains(-0.0))
+
+    assertTrue(hs.remove(Double.NaN))
+    assertTrue(hs.add(+0.0))
+    assertEquals(2, hs.size())
+    assertFalse(hs.contains(Double.NaN))
+    assertTrue(hs.contains(+0.0))
+    assertFalse(hs.contains(-0.0))
+
+    assertTrue(hs.remove(+0.0))
+    assertTrue(hs.add(-0.0))
+    assertEquals(2, hs.size())
+    assertFalse(hs.contains(Double.NaN))
+    assertFalse(hs.contains(+0.0))
+    assertTrue(hs.contains(-0.0))
+
+    assertTrue(hs.add(+0.0))
+    assertTrue(hs.add(Double.NaN))
+    assertTrue(hs.contains(Double.NaN))
+    assertTrue(hs.contains(+0.0))
+    assertTrue(hs.contains(-0.0))
+  }
+
+  @Test def shouldStoreCustomObjects_Set(): Unit = {
+    case class TestObj(num: Int) extends jl.Comparable[TestObj] {
+      override def compareTo(o: TestObj): Int = o.num - num
+    }
+
+    val hs = factory.empty[TestObj]
+
+    assertTrue(hs.add(TestObj(100)))
+    assertEquals(1, hs.size())
+    assertTrue(hs.contains(TestObj(100)))
+    assertEquals(100, hs.iterator.next().num)
+  }
+
+  @Test def shouldRemoveStoredElements_Set(): Unit = {
+    val hs = factory.empty[String]
+
+    assertEquals(0, hs.size())
+    assertTrue(hs.add("ONE"))
+    assertFalse(hs.add("ONE"))
+    assertEquals(1, hs.size())
+    assertTrue(hs.add("TWO"))
+    assertEquals(2, hs.size())
+    assertTrue(hs.remove("ONE"))
+    assertFalse(hs.remove("ONE"))
+    assertEquals(1, hs.size())
+    assertTrue(hs.remove("TWO"))
+    assertEquals(0, hs.size())
+
+    assertTrue(hs.add("ONE"))
+    assertTrue(hs.add("TWO"))
+    assertEquals(2, hs.size())
+    assertTrue(hs.removeAll(TrivialImmutableCollection("ONE", "TWO")))
+    assertEquals(0, hs.size())
+
+    assertTrue(hs.add("ONE"))
+    assertTrue(hs.add("TWO"))
+    assertEquals(2, hs.size())
+    assertTrue(hs.retainAll(TrivialImmutableCollection("ONE", "THREE")))
+    assertEquals(1, hs.size())
+    assertTrue(hs.contains("ONE"))
+    assertFalse(hs.contains("TWO"))
+  }
+
+  @Test def shouldBeClearedWithOneOperation_Set(): Unit = {
+    val hs = factory.empty[String]
+
+    assertTrue(hs.add("ONE"))
+    assertTrue(hs.add("TWO"))
+    assertEquals(2, hs.size())
+
+    hs.clear()
+    assertEquals(0, hs.size())
+    assertTrue(hs.isEmpty)
+  }
+
+  @Test def shouldCheckContainedElemsPresence(): Unit = {
+    val hs = factory.empty[String]
+
+    assertTrue(hs.add("ONE"))
+    assertTrue(hs.contains("ONE"))
+    assertFalse(hs.contains("TWO"))
+    if (factory.allowsNullElement) {
+      assertFalse(hs.contains(null))
+      assertTrue(hs.add(null))
+      assertTrue(hs.contains(null))
+    } else {
+      expectThrows(classOf[Exception], hs.add(null))
+    }
+  }
+
+  @Test def shouldPutAWholeCollectionInto(): Unit = {
+    val hs = factory.empty[String]
+
+    val l = TrivialImmutableCollection("ONE", "TWO", null)
+
+    if (factory.allowsNullElement) {
+      assertTrue(hs.addAll(l))
+      assertEquals(3, hs.size)
+      assertTrue(hs.contains("ONE"))
+      assertTrue(hs.contains("TWO"))
+      assertTrue(hs.contains(null))
+    } else {
+      expectThrows(classOf[Exception], hs.addAll(l))
+    }
+  }
+
+  @Test def shouldIterateOverElements(): Unit = {
+    val hs = factory.empty[String]
+
+    val l = {
+      if (factory.allowsNullElement)
+        List("ONE", "TWO", null)
+      else
+        List("ONE", "TWO", "THREE")
+    }
+    assertTrue(hs.addAll(TrivialImmutableCollection(l: _*)))
+    assertEquals(3, hs.size)
+
+    assertIteratorSameElementsAsSet(l: _*)(hs.iterator())
+  }
+}
+
+trait SetFactory extends CollectionFactory {
+  def empty[E: ClassTag]: ju.Set[E]
+}

--- a/unit-tests/src/test/scala/java/util/SortedSetTest.scala
+++ b/unit-tests/src/test/scala/java/util/SortedSetTest.scala
@@ -1,0 +1,132 @@
+// Ported from Scala.js commit: 6fbe7b2 dated: 2019-08-14
+
+package org.scalanative.testsuite.javalib.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.{util => ju}
+
+import scala.reflect.ClassTag
+
+trait SortedSetTest extends SetTest {
+
+  def factory: SortedSetFactory
+
+  @Test def shouldRetrieveTheFirstElement(): Unit = {
+    val ssInt = factory.empty[Int]
+
+    assertTrue(ssInt.add(1000))
+    assertTrue(ssInt.add(10))
+    assertEquals(10, ssInt.first)
+
+    val ssString = factory.empty[String]
+
+    assertTrue(ssString.add("pluto"))
+    assertTrue(ssString.add("pippo"))
+    assertEquals("pippo", ssString.first)
+
+    val ssDouble = factory.empty[Double]
+
+    assertTrue(ssDouble.add(+10000.987))
+    assertTrue(ssDouble.add(-0.987))
+    assertEquals(-0.987, ssDouble.first, 0.0)
+  }
+
+  @Test def shouldRetrieveTheLastElement(): Unit = {
+    val ssInt = factory.empty[Int]
+
+    assertTrue(ssInt.add(1000))
+    assertTrue(ssInt.add(10))
+    assertEquals(1000, ssInt.last)
+
+    val ssString = factory.empty[String]
+
+    assertTrue(ssString.add("pluto"))
+    assertTrue(ssString.add("pippo"))
+    assertEquals("pluto", ssString.last)
+
+    val ssDouble = factory.empty[Double]
+
+    assertTrue(ssDouble.add(+10000.987))
+    assertTrue(ssDouble.add(-0.987))
+    assertEquals(10000.987, ssDouble.last, 0.0)
+  }
+
+  val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
+
+  @Test def shouldReturnAProperHeadSet(): Unit = {
+    val ss = factory.empty[Int]
+
+    ss.addAll(l)
+
+    val hs1 = ss.headSet(3)
+    val l1 = TrivialImmutableCollection(1, 2)
+    assertTrue(hs1.containsAll(l1))
+    assertTrue(hs1.removeAll(l1))
+    assertTrue(hs1.isEmpty)
+    assertEquals(3, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(3, 4, 5)))
+
+    ss.addAll(l)
+
+    val hs2 = ss.headSet(4)
+    val l2 = TrivialImmutableCollection(1, 2, 3)
+    assertTrue(hs2.containsAll(l2))
+    assertTrue(hs2.removeAll(l2))
+    assertTrue(hs2.isEmpty)
+    assertEquals(2, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(4, 5)))
+  }
+
+  @Test def shouldReturnAProperTailSet(): Unit = {
+    val ss = factory.empty[Int]
+
+    ss.addAll(l)
+
+    val ts1 = ss.tailSet(3)
+    val l3 = TrivialImmutableCollection(3, 4, 5)
+    assertTrue(ts1.containsAll(l3))
+    assertTrue(ts1.removeAll(l3))
+    assertTrue(ts1.isEmpty)
+    assertEquals(2, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(1, 2)))
+
+    ss.addAll(l)
+
+    val ts2 = ss.tailSet(4)
+    val l4 = TrivialImmutableCollection(4, 5)
+    assertTrue(ts2.containsAll(l4))
+    assertTrue(ts2.removeAll(l4))
+    assertTrue(ts2.isEmpty)
+    assertEquals(3, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(1, 2, 3)))
+  }
+
+  @Test def shouldReturnAProperSubSet(): Unit = {
+    val ss = factory.empty[Int]
+
+    ss.addAll(l)
+
+    val ss1 = ss.subSet(2, 4)
+    val l5 = TrivialImmutableCollection(2, 3)
+    assertTrue(ss1.containsAll(l5))
+    assertTrue(ss1.removeAll(l5))
+    assertTrue(ss1.isEmpty)
+    assertEquals(3, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(1, 4, 5)))
+
+    ss.addAll(l)
+
+    val ss2 = ss.subSet(1, 5)
+    assertTrue(ss2.containsAll(l5))
+    assertTrue(ss2.removeAll(l5))
+    assertFalse(ss2.isEmpty)
+    assertEquals(3, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(1, 4, 5)))
+  }
+}
+
+trait SortedSetFactory extends SetFactory {
+  def empty[E: ClassTag]: ju.SortedSet[E]
+}

--- a/unit-tests/src/test/scala/java/util/concurrent/ConcurrentSkipListSetTest.scala
+++ b/unit-tests/src/test/scala/java/util/concurrent/ConcurrentSkipListSetTest.scala
@@ -1,0 +1,418 @@
+// Ported from Scala.js commit: 8c4f448 dated: 2019-07-31
+
+package org.scalanative.testsuite.javalib.util.concurrent
+
+import java.util.concurrent.ConcurrentSkipListSet
+import java.{util => ju}
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+
+import org.scalanative.testsuite.javalib.util.NavigableSetFactory
+import org.scalanative.testsuite.javalib.util.TrivialImmutableCollection
+
+import scala.scalanative.junit.utils.AssertThrows._
+import org.scalanative.testsuite.utils.Platform._
+
+import scala.reflect.ClassTag
+
+// TODO extends AbstractSetTest with NavigableSetTest
+class ConcurrentSkipListSetTest {
+
+  def factory: ConcurrentSkipListSetFactory = new ConcurrentSkipListSetFactory
+
+  @Test def shouldStoreAndRemoveOrderedIntegers(): Unit = {
+    val csls = factory.empty[Int]
+
+    assertEquals(0, csls.size())
+    assertTrue(csls.add(222))
+    assertEquals(1, csls.size())
+    assertTrue(csls.add(111))
+    assertEquals(2, csls.size())
+    assertEquals(111, csls.first)
+    assertTrue(csls.remove(111))
+
+    assertEquals(1, csls.size())
+    assertEquals(222, csls.first)
+
+    assertTrue(csls.remove(222))
+    assertEquals(0, csls.size())
+    assertTrue(csls.isEmpty)
+    assertFalse(csls.remove(333))
+    expectThrows(classOf[NoSuchElementException], csls.first)
+  }
+
+  @Test def shouldStoreAndRemoveSrderedStrings(): Unit = {
+    val csls = factory.empty[String]
+
+    assertEquals(0, csls.size())
+    assertTrue(csls.add("222"))
+    assertEquals(1, csls.size())
+    assertTrue(csls.add("111"))
+    assertEquals(2, csls.size())
+    assertEquals("111", csls.first)
+    assertTrue(csls.remove("111"))
+
+    assertEquals(1, csls.size())
+    assertEquals("222", csls.first)
+
+    assertTrue(csls.remove("222"))
+    assertEquals(0, csls.size())
+    assertFalse(csls.remove("333"))
+    assertTrue(csls.isEmpty)
+  }
+
+  @Test def shouldStoreObjectsWithCustomComparables(): Unit = {
+    case class Rect(x: Int, y: Int)
+
+    val areaComp = new ju.Comparator[Rect] {
+      def compare(a: Rect, b: Rect): Int = (a.x * a.y) - (b.x * b.y)
+    }
+
+    val csls = new ConcurrentSkipListSet[Rect](areaComp)
+
+    assertTrue(csls.add(Rect(1, 2)))
+    assertTrue(csls.add(Rect(2, 3)))
+    assertTrue(csls.add(Rect(1, 3)))
+
+    val first = csls.first()
+    assertEquals(1, first.x)
+    assertEquals(2, first.y)
+
+    assertTrue(csls.remove(first))
+    assertFalse(csls.remove(first))
+
+    val second = csls.first()
+    assertEquals(1, second.x)
+    assertEquals(3, second.y)
+
+    assertTrue(csls.remove(second))
+
+    val third = csls.first()
+    assertEquals(2, third.x)
+    assertEquals(3, third.y)
+
+    assertTrue(csls.remove(third))
+
+    assertTrue(csls.isEmpty)
+  }
+
+  @Test def shouldStoreOrderedDoubleEvenInCornerCases(): Unit = {
+    val csls = factory.empty[Double]
+
+    assertTrue(csls.add(1.0))
+    assertTrue(csls.add(+0.0))
+    assertTrue(csls.add(-0.0))
+    assertTrue(csls.add(Double.NaN))
+
+    assertTrue(csls.first.equals(-0.0))
+
+    assertTrue(csls.remove(-0.0))
+
+    assertTrue(csls.first.equals(+0.0))
+
+    assertTrue(csls.remove(+0.0))
+
+    assertTrue(csls.first.equals(1.0))
+
+    assertTrue(csls.remove(1.0))
+
+    assertTrue(csls.first.isNaN)
+
+    assertTrue(csls.remove(Double.NaN))
+
+    assertTrue(csls.isEmpty)
+  }
+
+  @Test def couldBeInstantiatedWithPrepopulatedCollection(): Unit = {
+    val l    = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val csls = factory.newFrom(l)
+
+    assertEquals(5, csls.size())
+    for (i <- 1 to 5) {
+      assertEquals(i, csls.first)
+      assertTrue(csls.remove(i))
+    }
+    assertTrue(csls.isEmpty)
+  }
+
+  @Test def should_be_cleared_in_a_single_operation(): Unit = {
+    val l    = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val csls = factory.newFrom(l)
+
+    assertEquals(5, csls.size())
+    csls.clear()
+    assertEquals(0, csls.size())
+  }
+
+  @Test def shouldAddMultipleElemntInOneOperation(): Unit = {
+    val l    = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val csls = factory.empty[Int]
+
+    assertEquals(0, csls.size())
+    csls.addAll(l)
+    assertEquals(5, csls.size())
+    csls.add(6)
+    assertEquals(6, csls.size())
+  }
+
+  @Test def shouldCheckContainedValuesEvenInDoubleCornerCases(): Unit = {
+    val csls = factory.empty[Double]
+
+    assertTrue(csls.add(11111.0))
+    assertEquals(1, csls.size())
+    assertTrue(csls.contains(11111.0))
+    assertEquals(11111.0, csls.iterator.next(), 0.0)
+
+    assertTrue(csls.add(Double.NaN))
+    assertEquals(2, csls.size())
+    assertTrue(csls.contains(Double.NaN))
+    assertFalse(csls.contains(+0.0))
+    assertFalse(csls.contains(-0.0))
+
+    assertTrue(csls.remove(Double.NaN))
+    assertTrue(csls.add(+0.0))
+    assertEquals(2, csls.size())
+    assertFalse(csls.contains(Double.NaN))
+    assertTrue(csls.contains(+0.0))
+    assertFalse(csls.contains(-0.0))
+
+    assertTrue(csls.remove(+0.0))
+    assertTrue(csls.add(-0.0))
+    assertEquals(2, csls.size())
+    assertFalse(csls.contains(Double.NaN))
+    assertFalse(csls.contains(+0.0))
+    assertTrue(csls.contains(-0.0))
+
+    assertTrue(csls.add(+0.0))
+    assertTrue(csls.add(Double.NaN))
+    assertTrue(csls.contains(Double.NaN))
+    assertTrue(csls.contains(+0.0))
+    assertTrue(csls.contains(-0.0))
+  }
+
+  @Test def `shouldRetrieveTheFirstOrderedElement`(): Unit = {
+    val cslsInt = factory.empty[Int]
+
+    assertTrue(cslsInt.add(1000))
+    assertTrue(cslsInt.add(10))
+    assertEquals(10, cslsInt.first)
+
+    val cslsString = factory.empty[String]
+
+    assertTrue(cslsString.add("pluto"))
+    assertTrue(cslsString.add("pippo"))
+    assertEquals("pippo", cslsString.first)
+
+    val cslsDouble = factory.empty[Double]
+
+    assertTrue(cslsDouble.add(+10000.987))
+    assertTrue(cslsDouble.add(-0.987))
+    assertEquals(-0.987, cslsDouble.first, 0.0)
+  }
+
+  @Test def `shouldRetrieveTheLastOrderedElement`(): Unit = {
+    val cslsInt = factory.empty[Int]
+
+    assertTrue(cslsInt.add(1000))
+    assertTrue(cslsInt.add(10))
+    assertEquals(1000, cslsInt.last)
+
+    val cslsString = factory.empty[String]
+
+    assertTrue(cslsString.add("pluto"))
+    assertTrue(cslsString.add("pippo"))
+    assertEquals("pluto", cslsString.last)
+
+    val cslsDouble = factory.empty[Double]
+
+    assertTrue(cslsDouble.add(+10000.987))
+    assertTrue(cslsDouble.add(-0.987))
+    assertEquals(10000.987, cslsDouble.last, 0.0)
+  }
+
+  @Test def `shouldRetrieveCeilingOrderedElements`(): Unit = {
+    val lInt    = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val cslsInt = new ConcurrentSkipListSet[Int](lInt)
+
+    assertEquals(1, cslsInt.ceiling(-10))
+    assertEquals(1, cslsInt.ceiling(0))
+    assertEquals(1, cslsInt.ceiling(1))
+    assertEquals(5, cslsInt.ceiling(5))
+
+    val lString    = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val cslsString = new ConcurrentSkipListSet[String](lString)
+
+    assertEquals("a", cslsString.ceiling("00000"))
+    assertEquals("a", cslsString.ceiling("0"))
+    assertEquals("a", cslsString.ceiling("a"))
+    assertEquals("d", cslsString.ceiling("d"))
+    assertNull(cslsString.ceiling("z"))
+  }
+
+  @Test def `shouldRetrieveFloorOrderedElements`(): Unit = {
+    val lInt    = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val cslsInt = new ConcurrentSkipListSet[Int](lInt)
+
+    assertEquals(5, cslsInt.floor(10))
+    assertEquals(5, cslsInt.floor(5))
+    assertEquals(3, cslsInt.floor(3))
+    assertEquals(1, cslsInt.floor(1))
+
+    val lString    = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val cslsString = new ConcurrentSkipListSet[String](lString)
+
+    assertEquals("e", cslsString.floor("zzzzz"))
+    assertEquals("d", cslsString.floor("d"))
+    assertEquals("b", cslsString.floor("b"))
+    assertEquals("a", cslsString.floor("a"))
+    assertNull(cslsString.floor("0"))
+  }
+
+  @Test def `shouldRetrieveHigherOrderedElements`(): Unit = {
+    val lInt    = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val cslsInt = new ConcurrentSkipListSet[Int](lInt)
+
+    assertEquals(5, cslsInt.higher(4))
+    assertEquals(4, cslsInt.higher(3))
+    assertEquals(2, cslsInt.higher(1))
+    assertEquals(1, cslsInt.higher(-10))
+
+    val lString    = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val cslsString = new ConcurrentSkipListSet[String](lString)
+
+    assertNull(cslsString.higher("zzzzz"))
+    assertEquals("e", cslsString.higher("d"))
+    assertEquals("c", cslsString.higher("b"))
+    assertEquals("b", cslsString.higher("a"))
+    assertEquals("a", cslsString.higher("0"))
+  }
+
+  @Test def `shouldRetrieveLowerOrderedElements`(): Unit = {
+    val lInt    = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val cslsInt = new ConcurrentSkipListSet[Int](lInt)
+
+    assertEquals(4, cslsInt.lower(5))
+    assertEquals(3, cslsInt.lower(4))
+    assertEquals(2, cslsInt.lower(3))
+    assertEquals(5, cslsInt.lower(10))
+
+    val lString    = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val cslsString = new ConcurrentSkipListSet[String](lString)
+
+    assertEquals("e", cslsString.lower("zzzzz"))
+    assertEquals("c", cslsString.lower("d"))
+    assertEquals("a", cslsString.lower("b"))
+    assertNull(cslsString.lower("a"))
+    assertNull(cslsString.lower("0"))
+  }
+
+  @Test def shouldPollFirstAndLastElements(): Unit = {
+    val l    = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val csls = new ConcurrentSkipListSet[Int](l)
+
+    assertTrue(csls.contains(1))
+    assertEquals(1, csls.pollFirst())
+    assertFalse(csls.contains(1))
+    assertEquals(5, csls.pollLast())
+    assertEquals(2, csls.pollFirst())
+    assertEquals(4, csls.pollLast())
+    assertEquals(3, csls.pollFirst())
+    assertTrue(csls.isEmpty())
+  }
+
+  @Test def shouldGetPartialViewsThatAreBackedOnTheOriginalList(): Unit = {
+    val l    = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val csls = new ConcurrentSkipListSet[Int](l)
+
+    val hs1 = csls.headSet(3)
+    val l1  = TrivialImmutableCollection(1, 2)
+    assertTrue(hs1.containsAll(l1))
+    assertTrue(hs1.removeAll(l1))
+    assertTrue(hs1.isEmpty)
+    assertEquals(3, csls.size)
+    assertTrue(csls.containsAll(TrivialImmutableCollection(3, 4, 5)))
+
+    csls.addAll(l)
+
+    val hs2 = csls.headSet(3, true)
+    val l2  = TrivialImmutableCollection(1, 2, 3)
+    assertTrue(hs2.containsAll(l2))
+    assertTrue(hs2.removeAll(l2))
+    assertTrue(hs2.isEmpty)
+    assertEquals(2, csls.size)
+    assertTrue(csls.containsAll(TrivialImmutableCollection(4, 5)))
+
+    csls.addAll(l)
+
+    val ts1 = csls.tailSet(3)
+    val l3  = TrivialImmutableCollection(3, 4, 5)
+    assertTrue(ts1.containsAll(l3))
+    assertTrue(ts1.removeAll(l3))
+    assertTrue(ts1.isEmpty)
+    assertEquals(2, csls.size)
+    assertTrue(csls.containsAll(TrivialImmutableCollection(1, 2)))
+
+    csls.addAll(l)
+
+    val ts2 = csls.tailSet(3, false)
+    val l4  = TrivialImmutableCollection(4, 5)
+    assertTrue(ts2.containsAll(l4))
+    assertTrue(ts2.removeAll(l4))
+    assertTrue(ts2.isEmpty)
+    assertEquals(3, csls.size)
+    assertTrue(csls.containsAll(TrivialImmutableCollection(1, 2, 3)))
+
+    csls.addAll(l)
+
+    val ss1 = csls.subSet(2, true, 3, true)
+    val l5  = TrivialImmutableCollection(2, 3)
+    assertTrue(ss1.containsAll(l5))
+    assertTrue(ss1.removeAll(l5))
+    assertTrue(ss1.isEmpty)
+    assertEquals(3, csls.size)
+    assertTrue(csls.containsAll(TrivialImmutableCollection(1, 4, 5)))
+
+    csls.addAll(l)
+
+    val ss2 = csls.subSet(1, false, 4, false)
+    assertTrue(ss2.containsAll(l5))
+    assertTrue(ss2.removeAll(l5))
+    assertTrue(ss2.isEmpty)
+    assertEquals(3, csls.size)
+    assertTrue(csls.containsAll(TrivialImmutableCollection(1, 4, 5)))
+  }
+
+  @Test def shouldThrowExceptionOnNonComparableObjects(): Unit = {
+    assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
+    assumeFalse("Ignored on JVM due to possible race condition", executingInJVM)
+    // Behaviour based on JDK8 modulo (improbable) race conditions.
+
+    class TestObj(num: Int)
+
+    val csls = new ConcurrentSkipListSet[TestObj]()
+
+    assertEquals(0, csls.size())
+    expectThrows(classOf[ClassCastException], {
+      // Throw either when the first or second element is added
+      csls.add(new TestObj(111))
+      csls.add(new TestObj(222))
+    })
+    assertNull(csls.comparator)
+  }
+}
+
+class ConcurrentSkipListSetFactory extends NavigableSetFactory {
+  def implementationName: String =
+    "java.util.concurrent.ConcurrentSkipListSet"
+
+  def empty[E: ClassTag]: ju.concurrent.ConcurrentSkipListSet[E] =
+    new ConcurrentSkipListSet[E]
+
+  def newFrom[E](
+      coll: ju.Collection[E]): ju.concurrent.ConcurrentSkipListSet[E] =
+    new ConcurrentSkipListSet[E](coll)
+
+  override def allowsNullElement: Boolean = false
+}


### PR DESCRIPTION
  --- WIP commit message
   
   This submission is marked Work In Progress (WIP)
    because it depends upon files PRs #2052 & 2054 which are awaiting review.

    Until then, it will fail to build & execute. All tests pass
    locally.

    After that PR is merged, this work can be promoted to a full PR
    and this section deleted.

    CollectionsOnSetFromMapTest is deferred because it requires a
    file from PR #2016, awaiting review.

    TreeSet.scala is not strictly needed for this submission but
    is absence is notable.  I ported it but it still two occurrences
    of what I suspect to be the same pair of errors. I will debug
    whilst this submission sits in WIP state.

  --- PR commit message --

We port CollectionsOnSets.scala and a number of related Set Test files.
In particular, the ConcurrentSkipListSet class is implemented.