### PR TITLE
Fix #1121: Allow ScalaDoc generation not to emit warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -768,7 +768,7 @@ lazy val junitPlugin =
 
 val commonJUnitTestOutputsSettings = Def.settings(
   nameSettings,
-  disabledDocsSettings,
+  noPublishSettings,
   Compile / publishArtifact := false,
   Test / parallelExecution := false,
   Test / unmanagedSourceDirectories +=

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {
-  val javaDocBaseURL: String = "http://docs.oracle.com/javase/8/docs/api/"
+  val javaDocBaseURL: String = "https://docs.oracle.com/javase/8/docs/api/"
   // partially ported from Scala.js
   Def.settings(
     autoAPIMappings := true,

--- a/build.sbt
+++ b/build.sbt
@@ -41,11 +41,9 @@ lazy val docsSettings: Seq[Setting[_]] = {
           def matches(path: String, name: String): Boolean =
             path.endsWith(s"${java.io.File.separator}$name.jar")
 
-          val jar = jars
-            .find(matches(_, "rt"))                   // most JREs
-            .orElse(jars.find(matches(_, "classes"))) // Java 6 on Mac OS X
-            .get
-          Some(file(jar))
+          jars
+            .find(matches(_, "rt")) // most JREs
+            .map(file)
         } else {
           // JDK >= 9, maybe sbt gives us a fake rt.jar in `scala.ext.dirs`
           val scalaExtDirs = Option(System.getProperty("scala.ext.dirs"))

--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,13 @@ lazy val docsSettings: Seq[Setting[_]] = {
   // partially ported from Scala.js
   Def.settings(
     autoAPIMappings := true,
-    exportJars := true,                                    // required so ScalaDoc linking works
-    scalacOptions in (Compile, doc) -= "-Xfatal-warnings", // needed only for 2.11 docs to mitigate not found java.lang members
+    exportJars := true, // required so ScalaDoc linking works
+    scalacOptions in (Compile, doc) := {
+      val prev = (scalacOptions in (Compile, doc)).value
+      if (scalaVersion.value.startsWith("2.11."))
+        prev.filter(_ != "-Xfatal-warnings")
+      else prev
+    },
     // Add Java Scaladoc mapping
     apiMappings ++= {
       val optRTJar = {

--- a/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
@@ -22,8 +22,10 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
 
   val name: String = "Scala Native JUnit plugin"
 
-  val components: List[NscPluginComponent] =
-    List(ScalaNativeJUnitPluginComponent)
+  val components: List[NscPluginComponent] = global match {
+    case _: doc.ScaladocGlobal => Nil
+    case _                     => List(ScalaNativeJUnitPluginComponent)
+  }
 
   val description: String = "Makes JUnit test classes invokable in Scala Native"
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirPlugin.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirPlugin.scala
@@ -7,7 +7,10 @@ import scala.tools.nsc.plugins._
 class NirPlugin(val global: Global) extends Plugin {
   val name        = "nir"
   val description = "Compile to Scala Native IR (NIR)"
-  val components  = List[PluginComponent](prepNativeInterop, nirGen)
+  val components: List[PluginComponent] = global match {
+    case _: doc.ScaladocGlobal => List(prepNativeInterop)
+    case _                     => List(prepNativeInterop, nirGen)
+  }
 
   /** A trick to avoid early initializers while still enforcing that `global`
    *  is initialized early.


### PR DESCRIPTION
This PR resolves #1121. Due to common issue when generating docs we  could get the warning `dropping dependency on node with no phase object: mixin` causing failure due to scalacOption `-Xfatal-warnings`

PR makes components list in NativePlugin and JUnitNativePlugin dynamic, based on global. This fix removes sproucious warnings. Additionally, it adds `docsSettings` containing extra `apiMappings` for Java. They're added only to projects using them, and throwing errors when generating docs. 
Generation of ScalaDoc was disabled in the following projects:
 * `javalib` - ends up with `MalformedInputException: Input length = 1`
* `scalalib` - ScalaDoc should not be generated
* projects using `noPublish` settings, eg: `tests`, `sandbox`, `junitTestOutputsX`