### PR TITLE
Allow extern definitions defined outside extern objects

### DIFF
--- a/clib/src/main/scala/scala/scalanative/libc/complex.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/complex.scala
@@ -26,7 +26,6 @@ import scalanative.unsafe._
  * http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/complex.h.html
  *
  */
-@extern
 object complex {
   import Nat._2
   type CFloatComplex  = CStruct2[CFloat, CFloat]

--- a/clib/src/main/scala/scala/scalanative/libc/ctype.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/ctype.scala
@@ -3,7 +3,6 @@ package libc
 
 import scalanative.unsafe._
 
-@extern
 object ctype {
   def isascii(c: CInt): CInt     = extern
   def isalnum(c: CInt): CInt     = extern

--- a/clib/src/main/scala/scala/scalanative/libc/errno.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/errno.scala
@@ -3,7 +3,6 @@ package libc
 
 import scalanative.unsafe._
 
-@extern
 object errno {
   @name("scalanative_errno")
   def errno: CInt = extern

--- a/clib/src/main/scala/scala/scalanative/libc/float.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/float.scala
@@ -6,7 +6,6 @@ import scalanative.unsafe._
 /**
  * Bindings for float.h
  */
-@extern
 object float {
 
   // Macros

--- a/clib/src/main/scala/scala/scalanative/libc/math.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/math.scala
@@ -3,7 +3,6 @@ package libc
 
 import scalanative.unsafe._
 
-@extern
 object math {
 
   // Basic operations

--- a/clib/src/main/scala/scala/scalanative/libc/signal.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/signal.scala
@@ -3,7 +3,6 @@ package libc
 
 import scalanative.unsafe._
 
-@extern
 object signal {
 
   // Signals

--- a/clib/src/main/scala/scala/scalanative/libc/stdio.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdio.scala
@@ -3,7 +3,6 @@ package libc
 
 import scalanative.unsafe._
 
-@extern
 object stdio {
 
   // File access

--- a/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
@@ -3,7 +3,6 @@ package libc
 
 import scalanative.unsafe._
 
-@extern
 object stdlib {
 
   // Memory management

--- a/clib/src/main/scala/scala/scalanative/libc/string.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/string.scala
@@ -3,7 +3,6 @@ package libc
 
 import scalanative.unsafe._
 
-@extern
 object string {
   def strcpy(dest: CString, src: CString): CString                     = extern
   def strncpy(dest: CString, src: CString, count: CSize): CString      = extern

--- a/javalib/src/main/scala/java/lang/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/UnixProcess.scala
@@ -111,7 +111,6 @@ private[lang] class UnixProcess private (
 
 object UnixProcess {
   @link("pthread")
-  @extern
   private[this] object ProcessMonitor {
     @name("scalanative_process_monitor_check_result")
     def checkResult(pid: Int): CInt = extern

--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -10,7 +10,6 @@ import scalanative.runtime.{Array => _, _}
 // These two methods are generated at link-time by the toolchain
 // using current closed-world knowledge of classes and traits in
 // the current application.
-@extern
 object rtti {
   def __check_class_has_trait(classId: Int, traitId: Int): scala.Boolean =
     extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -8,7 +8,6 @@ import scalanative.unsafe._
  *
  * @see [[http://hboehm.info/gc/gcinterface.html C Interface]]
  */
-@extern
 object GC {
   @name("scalanative_alloc")
   def alloc(rawty: RawPtr, size: CSize): RawPtr = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/LLVMIntrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/LLVMIntrinsics.scala
@@ -6,7 +6,6 @@ import scalanative.unsafe._
 /**
  * @see [[http://llvm.org/releases/3.7.0/docs/LangRef.html#intrinsic-functions LLVM intrinsics functions]]
  */
-@extern
 object LLVMIntrinsics {
   @struct class IntOverflow(val value: Int, val flag: Boolean)
   @struct class LongOverflow(val value: Long, val flag: Boolean)

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
@@ -3,7 +3,6 @@ package runtime
 
 import scala.scalanative.unsafe.{CInt, CString, CFuncPtr2, Ptr, extern, name}
 
-@extern
 object Platform {
   @name("scalanative_platform_is_mac")
   def isMac(): Boolean = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Shutdown.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Shutdown.scala
@@ -17,7 +17,6 @@ private[runtime] object Shutdown {
   NativeShutdown.init(() => runHooks())
 }
 
-@extern
 private[runtime] object NativeShutdown {
   @name("scalanative_native_shutdown_init")
   def init(func: CFuncPtr0[Unit]): Unit = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
@@ -6,7 +6,6 @@ import scalanative.unsafe._
 // Minimal bindings for the subset of libc used by the nativelib.
 // This is done purely to avoid circular dependency between clib
 // and nativelib. The actual bindings should go to clib namespace.
-@extern
 object libc {
   def malloc(size: CSize): RawPtr                              = extern
   def free(ptr: RawPtr): Unit                                  = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/time.scala
@@ -3,7 +3,6 @@ package runtime
 
 import scala.scalanative.unsafe.{CLongLong, extern}
 
-@extern
 object time {
   def scalanative_nano_time: CLongLong           = extern
   def scalanative_current_time_millis: CLongLong = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
@@ -3,7 +3,6 @@ package runtime
 
 import scalanative.unsafe._
 
-@extern
 object unwind {
   @name("scalanative_unwind_get_context")
   def get_context(context: Ptr[Byte]): CInt = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/zlib.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/zlib.scala
@@ -3,7 +3,6 @@ package scala.scalanative.runtime
 import scala.scalanative.unsafe._
 
 @link("z")
-@extern
 object zlib {
   type voidpf     = Ptr[Byte]
   type voidp      = Ptr[Byte]

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/extern.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/extern.scala
@@ -1,7 +1,0 @@
-package scala.scalanative
-package unsafe
-
-/** An annotation that is used to mark objects that
- *  contain externally-defined members.
- */
-final class extern extends scala.annotation.StaticAnnotation

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/extern.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/extern.scala
@@ -1,0 +1,7 @@
+package scala.scalanative
+package unsafe
+
+/** An annotation internally used in NativePlugin used to mark externally-defined members.
+ *  Is applied only in PrepNativeInterop phase
+ */
+sealed trait extern extends scala.annotation.StaticAnnotation

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -23,7 +23,6 @@ trait NirDefinitions {
     lazy val NameClass   = getRequiredClass("scala.scalanative.unsafe.name")
     lazy val LinkClass   = getRequiredClass("scala.scalanative.unsafe.link")
     lazy val ExternClass = getRequiredClass("scala.scalanative.unsafe.extern")
-    lazy val PinClass    = getRequiredClass("scala.scalanative.unsafe.pin")
     lazy val StubClass   = getRequiredClass("scala.scalanative.annotation.stub")
 
     lazy val AlwaysInlineClass = getRequiredClass(

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
@@ -60,7 +60,7 @@ trait NirGenName[G <: Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     owner.member {
-      if (sym.owner.isExternModule) {
+      if (sym.isExtern) {
         nir.Sig.Extern(id)
       } else {
         nir.Sig.Field(id, scope)
@@ -80,9 +80,9 @@ trait NirGenName[G <: Global with Singleton] { self: NirGenPhase[G] =>
 
     if (sym == String_+) {
       genMethodName(StringConcatMethod)
-    } else if (sym.owner.isExternModule) {
+    } else if (sym.isExtern) {
       if (sym.isSetter) {
-        val id0 = sym.name.dropSetter.decoded.toString
+        val id0 = sym.name.dropSetter.decoded
         owner.member(nir.Sig.Extern(id0))
       } else {
         owner.member(nir.Sig.Extern(id))

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -623,9 +623,11 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
           buf += externDefn
 
-        case Apply(Select(Super(_, _), _), _)    => ()
-        case _ if curMethodSym.hasFlag(ACCESSOR) => ()
-        case _                                   => unsupported("methods in extern objects must have extern body")
+        // 2.11 only, call to extern inherited from trait
+        case Apply(ref: RefTree, _) if ref.symbol.isExtern => ()
+        case Apply(Select(Super(_, _), _), _)              => ()
+        case _ if curMethodSym.hasFlag(ACCESSOR)           => ()
+        case _                                             => unsupported("methods in extern objects must have extern body")
       }
     }
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -140,14 +140,10 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def genClassAttrs(cd: ClassDef): Attrs = {
       val sym = cd.symbol
       val annotationAttrs = sym.annotations.collect {
-        case ann if ann.symbol == ExternClass =>
-          Attr.Extern
-        case ann if ann.symbol == LinkClass =>
-          val Apply(_, Seq(Literal(Constant(name: String)))) = ann.tree
-          Attr.Link(name)
         case ann if ann.symbol == StubClass =>
           Attr.Stub
-      }
+      } ++ links(sym)
+
       val abstractAttr =
         if (sym.isAbstract) Seq(Attr.Abstract) else Seq()
 
@@ -163,10 +159,13 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
 
     def genClassFields(sym: Symbol)(implicit pos: nir.Position): Unit = {
-      val attrs = nir.Attrs(isExtern = sym.isExternModule)
-
       for (f <- sym.info.decls
            if !f.isMethod && f.isTerm && !f.isModule) {
+
+        val attrs = nir.Attrs(
+          isExtern = f.isExtern,
+          links = links(f)
+        )
         val ty   = genType(f.tpe)
         val name = genFieldName(f)
 
@@ -570,7 +569,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val attrs    = genMethodAttrs(sym)
         val name     = genMethodName(sym)
         val sig      = genMethodSig(sym)
-        val isStatic = owner.isExternModule || isImplClass(owner)
+        val isExtern = dd.symbol.isExtern
+        val isStatic = isExtern || isImplClass(owner)
 
         dd.rhs match {
           case EmptyTree
@@ -586,14 +586,10 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           case EmptyTree =>
             buf += Defn.Declare(attrs, name, sig)
 
-          case _ if dd.name == nme.CONSTRUCTOR && owner.isExternModule =>
-            validateExternCtor(dd.rhs)
-            ()
-
           case _ if dd.name == nme.CONSTRUCTOR && owner.isStruct =>
             ()
 
-          case rhs if owner.isExternModule =>
+          case rhs if isExtern =>
             checkExplicitReturnTypeAnnotation(dd)
             genExternMethod(attrs, name, sig, rhs)
 
@@ -608,7 +604,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             scoped(
               curMethodSig := sig
             ) {
-              val body = genMethodBody(dd, rhs, isStatic, isExtern = false)
+              val body = genMethodBody(dd, rhs, isStatic)
               buf += Defn.Define(attrs, name, sig, body)
             }
         }
@@ -621,18 +617,15 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                         rhs: Tree): Unit = {
       rhs match {
         case Apply(ref: RefTree, Seq()) if ref.symbol == ExternMethod =>
-          val moduleName  = genTypeName(curClassSym)
           val externAttrs = Attrs(isExtern = true)
           val externSig   = genExternMethodSig(curMethodSym)
           val externDefn  = Defn.Declare(externAttrs, name, externSig)(rhs.pos)
 
           buf += externDefn
 
-        case _ if curMethodSym.hasFlag(ACCESSOR) =>
-          ()
-
-        case rhs =>
-          unsupported("methods in extern objects must have extern body")
+        case Apply(Select(Super(_, _), _), _)    => ()
+        case _ if curMethodSym.hasFlag(ACCESSOR) => ()
+        case _                                   => unsupported("methods in extern objects must have extern body")
       }
     }
 
@@ -674,19 +667,22 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           case ann if ann.symbol == NoOptimizeClass   => Attr.NoOpt
           case ann if ann.symbol == NoSpecializeClass => Attr.NoSpecialize
         }
+      val optExtern = if (sym.isExtern) Some(Attr.Extern) else None
+      val optLinks  = links(sym)
 
-      Attrs.fromSeq(inlineAttrs ++ stubAttrs ++ optAttrs)
+      Attrs.fromSeq(
+        inlineAttrs ++ stubAttrs ++ optAttrs ++ optLinks ++ optExtern)
     }
 
     def genMethodBody(dd: DefDef,
                       bodyp: Tree,
-                      isStatic: Boolean,
-                      isExtern: Boolean): Seq[nir.Inst] = {
+                      isStatic: Boolean): Seq[nir.Inst] = {
       val fresh = curFresh.get
       val buf   = new ExprBuffer()(fresh)
 
       implicit val pos: nir.Position = bodyp.pos
 
+      val isExtern  = dd.symbol.isExtern
       val paramSyms = genParamSyms(dd, isStatic)
       val params = paramSyms.map {
         case None =>
@@ -736,7 +732,26 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         }
       }
 
-      def genBody(): Val = bodyp match {
+      def prepBody(): Tree = {
+        val hasExernFields =
+          dd.symbol.owner.info.decls.exists(f => f.isField && f.isExtern)
+        val isCtor =
+          dd.name == nme.CONSTRUCTOR || dd.name == nme.MIXIN_CONSTRUCTOR
+        val ctorWithExternFields = isCtor && hasExernFields
+
+        bodyp match {
+          case Block(stats, last) if ctorWithExternFields =>
+            val newStats = stats.filter {
+              // Constructor for extern var would try to initialize it using extern() leading to exception
+              case Assign(_, Apply(fn, Seq())) => fn.symbol != ExternMethod
+              case _                           => true
+            }
+            treeCopy.Block(bodyp, newStats, last)
+          case _ => bodyp
+        }
+      }
+
+      def genBody(): Val = prepBody() match {
         // Tailrec emits magical labeldefs that can hijack this reference is
         // current method. This requires special treatment on our side.
         case Block(List(ValDef(_, nme.THIS, _, _)),
@@ -764,7 +779,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             buf.genReturn(nir.Val.Unit)
           }
 
-        case _ =>
+        case body =>
           scoped(
             curMethodThis := {
               if (isStatic) None
@@ -773,7 +788,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             curMethodIsExtern := isExtern
           ) {
             buf.genReturn {
-              withOptSynchronized(_.genExpr(bodyp))
+              withOptSynchronized(_.genExpr(body))
             }
           }
       }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenType.scala
@@ -164,7 +164,7 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
     val owner    = sym.owner
     val paramtys = genMethodSigParamsImpl(sym, isExtern)
     val selfty =
-      if (isExtern || owner.isExtern || isImplClass(owner)) None
+      if (isExtern || sym.isExtern || isImplClass(owner)) None
       else Some(genType(owner.tpe))
     val retty =
       if (sym.isClassConstructor) nir.Type.Unit
@@ -185,7 +185,11 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
       }
     }.toMap
 
-    sym.tpe.params.map {
+    val params =
+      if (isExtern && isImplClass(sym.owner)) sym.tpe.params.tail
+      else sym.tpe.params
+
+    params.map {
       case p
           if wereRepeated.getOrElse(p.name, false) &&
             sym.isExtern =>

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -1,6 +1,7 @@
 package scala.scalanative
 package nscplugin
 
+import scala.scalanative.nir.Attr
 import scala.tools.nsc.Global
 import scalanative.util._
 
@@ -9,7 +10,6 @@ trait NirGenUtil[G <: Global with Singleton] { self: NirGenPhase[G] =>
   import definitions._
   import nirAddons._
   import nirDefinitions._
-  import SimpleType.fromSymbol
 
   def genParamSyms(dd: DefDef, isStatic: Boolean): Seq[Option[Symbol]] = {
     val vp     = dd.vparamss
@@ -97,4 +97,12 @@ trait NirGenUtil[G <: Global with Singleton] { self: NirGenPhase[G] =>
     unwrapClassTagOption(tree).getOrElse {
       unsupported(s"can't recover runtime class tag from $tree")
     }
+
+  def links(symbol: Symbol): List[Attr.Link] = {
+    symbol.annotations.collect {
+      case ann if ann.symbol == LinkClass =>
+        val Apply(_, Seq(Literal(Constant(name: String)))) = ann.tree
+        Attr.Link(name)
+    }
+  }
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -196,6 +196,10 @@ abstract class PrepNativeInterop[G <: Global with Singleton](val global: G)
           )
           super.transform(tree)
 
+        case ValOrDefDef(_, _, _, rhs) if rhs.symbol == ExternMethod =>
+          tree.symbol.withAnnotation(AnnotationInfo.marker(ExternClass.tpe))
+          super.transform(tree)
+
         case _ =>
           super.transform(tree)
       }

--- a/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
@@ -7,7 +7,6 @@ import scalanative.posix.inttypes._
 import scalanative.posix.sys.socket.socklen_t
 import scalanative.posix.netinet.in.{in_addr, in_addr_t}
 
-@extern
 object inet {
 
   @name("scalanative_htonl")

--- a/posixlib/src/main/scala/scala/scalanative/posix/cpio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/cpio.scala
@@ -3,7 +3,6 @@ package posix
 
 import scalanative.unsafe._
 
-@extern
 object cpio {
   @name("scalanative_c_issock")
   def C_ISSOCK: CUnsignedShort = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
@@ -3,7 +3,6 @@ package posix
 
 import scala.scalanative.unsafe._, Nat._
 
-@extern
 object dirent {
 
   type _256 = Digit3[_2, _5, _6]

--- a/posixlib/src/main/scala/scala/scalanative/posix/errno.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/errno.scala
@@ -3,7 +3,6 @@ package posix
 
 import scalanative.unsafe.{CInt, extern, name}
 
-@extern
 object errno {
   @name("scalanative_e2big")
   def E2BIG: CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
@@ -4,7 +4,6 @@ package posix
 import scalanative.unsafe._
 import scalanative.posix.sys.stat.mode_t
 
-@extern
 object fcntl {
 
   def open(pathname: CString, flags: CInt): CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/getopt.scala
@@ -3,7 +3,6 @@ package posix
 
 import scalanative.unsafe._
 
-@extern
 object getopt {
   var optarg: CString = extern
   var opterr: CInt    = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/grp.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/grp.scala
@@ -4,7 +4,6 @@ package posix
 import scalanative.unsafe.{CInt, CString, CStruct3, extern, name, Ptr}
 import scalanative.posix.sys.stat.gid_t
 
-@extern
 object grp {
   type group = CStruct3[CString, // gr_name
                         gid_t,        // gr_gid

--- a/posixlib/src/main/scala/scala/scalanative/posix/limits.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/limits.scala
@@ -3,7 +3,6 @@ package posix
 
 import scalanative.unsafe.{extern, name, CInt}
 
-@extern
 object limits {
   @name("scalanative_path_max")
   def PATH_MAX: CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
@@ -4,7 +4,6 @@ import scalanative.unsafe._
 import scalanative.posix.sys.socket
 import scalanative.posix.netinet.in
 
-@extern
 object netdb {
   type addrinfo = CStruct8[CInt,
                            CInt,

--- a/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
@@ -6,7 +6,6 @@ import scalanative.unsafe._
 import scalanative.posix.inttypes._
 import scalanative.posix.sys.socket
 
-@extern
 object in {
   type in_port_t = uint16_t
   type in_addr_t = uint32_t

--- a/posixlib/src/main/scala/scala/scalanative/posix/netinet/tcp.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netinet/tcp.scala
@@ -2,7 +2,6 @@ package scala.scalanative.posix.netinet
 
 import scalanative.unsafe._
 
-@extern
 object tcp {
 
   @name("scalanative_TCP_NODELAY")

--- a/posixlib/src/main/scala/scala/scalanative/posix/poll.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/poll.scala
@@ -3,7 +3,6 @@ package posix
 
 import scalanative.unsafe._
 
-@extern
 object poll {
 
   // See Usage note below. Valid values capped by FOPEN_MAX in underlying OS.

--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -17,7 +17,6 @@ import scala.scalanative.posix.sys.types._
 // SUSv2 version is used for compatibility
 // see http://pubs.opengroup.org/onlinepubs/007908799/xsh/threads.html
 
-@extern
 object pthread {
 
   def pthread_atfork(prepare: routine, parent: routine, child: routine): CInt =

--- a/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
@@ -4,7 +4,6 @@ package posix
 import scalanative.unsafe.{CInt, CString, CStruct5, extern, name, Ptr}
 import scalanative.posix.sys.stat.{uid_t, gid_t}
 
-@extern
 object pwd {
 
   type passwd = CStruct5[CString, // pw_name

--- a/posixlib/src/main/scala/scala/scalanative/posix/regex.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/regex.scala
@@ -3,7 +3,6 @@ package posix
 
 import scalanative.unsafe._
 
-@extern
 object regex {
 
   @name("regcomp")

--- a/posixlib/src/main/scala/scala/scalanative/posix/sched.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sched.scala
@@ -4,7 +4,6 @@ import scala.scalanative.unsafe.{CInt, CSize, CStruct1, CStruct5, Ptr, extern}
 import scala.scalanative.posix.time.timespec
 import scala.scalanative.posix.sys.types.pid_t
 
-@extern
 object sched {
 
   def sched_setparam(pid: pid_t, param: Ptr[sched_param]): CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
@@ -3,7 +3,6 @@ package posix
 
 import scala.scalanative.unsafe.{CInt, CString, extern}
 
-@extern
 object stdlib {
   def setenv(name: CString, value: CString, overwrite: CInt): CInt = extern
   def unsetenv(name: CString): CInt                                = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/ioctl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/ioctl.scala
@@ -2,7 +2,6 @@ package scala.scalanative.posix.sys
 
 import scalanative.unsafe._
 
-@extern
 object ioctl {
 
   @name("scalanative_ioctl")

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
@@ -3,7 +3,6 @@ package scala.scalanative.posix.sys
 import scalanative.unsafe._
 import scalanative.unsafe.Nat._
 
-@extern
 object select {
 
   // posix requires this file declares suseconds_t. Use single point of truth.

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -4,7 +4,6 @@ package sys
 
 import scalanative.unsafe._
 
-@extern
 object socket {
   type socklen_t   = CUnsignedInt
   type sa_family_t = CUnsignedShort

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
@@ -6,7 +6,6 @@ import scalanative.unsafe._
 import scalanative.posix.time._
 import scalanative.posix.unistd.off_t
 
-@extern
 object stat {
   type dev_t     = CUnsignedLong
   type ino_t     = CUnsignedLongLong

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/statvfs.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/statvfs.scala
@@ -4,7 +4,6 @@ package sys
 
 import scalanative.unsafe._
 
-@extern
 object statvfs {
 
   type fsblkcnt_t = CUnsignedLong

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/time.scala
@@ -5,7 +5,6 @@ package sys
 import scalanative.unsafe.{CInt, CLong, CLongInt, CStruct2, Ptr, extern}
 import scalanative.posix.sys.types.{suseconds_t, time_t}
 
-@extern
 object time {
 
   type timeval = CStruct2[time_t, suseconds_t]

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/types.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/types.scala
@@ -4,7 +4,6 @@ package posix.sys
 import scala.scalanative.unsigned._
 import scala.scalanative.unsafe._
 
-@extern
 object types {
 
   type blkcnt_t = CLong

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/uio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/uio.scala
@@ -4,7 +4,6 @@ package sys
 
 import scalanative.unsafe._
 
-@extern
 object uio {
   type iovec = CStruct2[Ptr[Byte], // iov_base
                         CSize] // iov_len

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/utsname.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/utsname.scala
@@ -3,12 +3,11 @@ package scala.scalanative.posix.sys
 import scala.scalanative.unsafe._
 import scala.scalanative.unsafe.Nat._
 
-@extern
 object utsname {
   type _256        = Digit3[_2, _5, _6]
   private type str = CArray[Byte, _256]
   type utsname     = CStruct5[str, str, str, str, str]
-  @extern def uname(utsname: Ptr[utsname]): CInt = extern
+  def uname(utsname: Ptr[utsname]): CInt = extern
 }
 
 object uname {

--- a/posixlib/src/main/scala/scala/scalanative/posix/syslog.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/syslog.scala
@@ -3,7 +3,6 @@ package posix
 
 import scalanative.unsafe._
 
-@extern
 object syslog {
   @name("scalanative_closelog")
   def closelog(): Unit = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/termios.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/termios.scala
@@ -15,7 +15,6 @@ import scalanative.unsafe.{
 import scalanative.unsafe.Nat._
 import posix.sys.types.pid_t
 
-@extern
 object termios {
 
   // types

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -4,7 +4,6 @@ package posix
 import scala.scalanative.unsafe._
 import scala.scalanative.posix.sys.types, types._
 
-@extern
 object time {
 
   type time_t   = types.time_t

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -4,7 +4,6 @@ package posix
 import scalanative.unsafe._
 import scalanative.posix.sys.stat.{uid_t, gid_t}
 
-@extern
 object unistd {
 
   type off_t = CLongLong

--- a/posixlib/src/main/scala/scala/scalanative/posix/utime.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/utime.scala
@@ -3,7 +3,6 @@ package posix
 
 import scalanative.unsafe._
 
-@extern
 object utime {
   type utimbuf = CStruct2[time.time_t, // actime
                           time.time_t] // modtime

--- a/scripted-tests/run/link-order/Main.scala
+++ b/scripted-tests/run/link-order/Main.scala
@@ -6,7 +6,6 @@ object Main {
 }
 
 @link("link-order-test")
-@extern
 object Util {
   def forty_two(): CInt = extern
 }

--- a/scripted-tests/run/native-code-include/src/main/scala/Main.scala
+++ b/scripted-tests/run/native-code-include/src/main/scala/Main.scala
@@ -1,6 +1,5 @@
 import scalanative.unsafe._
 
-@extern
 object myapi {
   def add3(in: CLongLong): CLongLong = extern
 }

--- a/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -68,7 +68,6 @@ class NIRCompilerTest extends AnyFlatSpec with Matchers with Inspectors {
     val code =
       """import scala.scalanative.unsafe.extern
         |
-        |@extern
         |object Dummy {
         |  def foo() = extern
         |}""".stripMargin

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
@@ -81,6 +81,7 @@ class ExternTest {
     }
 
     case class Ext() extends ExtClass() with ExtTrait
+
   }
 
   @Test def allowsToUseExternNotDefineInObject(): Unit = {
@@ -97,6 +98,5 @@ class ExternTest {
     assertEquals(
       expectedLength,
       ext.extClass(stackalloc[Byte](bufsize), bufsize, testFormat, testString))
-    )
   }
 }

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
@@ -12,12 +12,10 @@ object ExternTest {
    * These also are having problems at the top level with our CI
    * with the current Docker configuration, see #1991
    */
-  @extern
   object Ext1 {
     def snprintf(buf: CString, size: CSize, format: CString, l: CString): Int =
       extern
   }
-  @extern
   object Ext2 {
     @name("snprintf")
     def p(buf: CString, size: CSize, format: CString, i: Int): Int = extern

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
@@ -1,38 +1,8 @@
 package scala.scalanative
 package unsafe
 
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
-
-import scalanative.unsafe._
-
-object ExternTest {
-  /* These can be nested inside an object but not a class - see #897
-   * These also are having problems at the top level with our CI
-   * with the current Docker configuration, see #1991
-   */
-  object Ext1 {
-    def snprintf(buf: CString, size: CSize, format: CString, l: CString): Int =
-      extern
-  }
-  object Ext2 {
-    @name("snprintf")
-    def p(buf: CString, size: CSize, format: CString, i: Int): Int = extern
-  }
-
-  // workaround for CI
-  def runTest(): Unit = {
-    import scalanative.libc.string
-    val bufsize = 10L
-    val buf1    = stackalloc[Byte](bufsize)
-    val buf2    = stackalloc[Byte](bufsize)
-    Ext1.snprintf(buf1, bufsize, c"%s", c"hello")
-    assertTrue(string.strcmp(buf1, c"hello") == 0)
-    Ext2.p(buf2, bufsize, c"%d", 1)
-    assertTrue(string.strcmp(buf2, c"1") == 0)
-  }
-}
 
 class ExternTest {
 
@@ -62,15 +32,71 @@ class ExternTest {
     }
   }
 
+  object Ext1 {
+    def snprintf(buf: CString, size: CSize, format: CString, l: CString): Int =
+      extern
+  }
+
+  object Ext2 {
+    @name("snprintf")
+    def p(buf: CString, size: CSize, format: CString, i: Int): Int = extern
+  }
+
   @Test def sameExternNameInTwoDifferentObjects_Issue1652(): Unit = {
-    ExternTest.runTest()
+    import scalanative.libc.string
+    val bufsize = 10L
+    val buf1    = stackalloc[Byte](bufsize)
+    val buf2    = stackalloc[Byte](bufsize)
+    Ext1.snprintf(buf1, bufsize, c"%s", c"hello")
+    assertTrue(string.strcmp(buf1, c"hello") == 0)
+    Ext2.p(buf2, bufsize, c"%d", 1)
+    assertTrue(string.strcmp(buf2, c"1") == 0)
   }
 
   val cb: CFuncPtr0[CInt] = () => 42
+
   @Test def allowsToUseGenericFunctionAsArgument(): Unit = {
     val res0 = testlib.exec0(cb) //expected CFuncPtr0[Int]
     val res1 = testlib.exec(cb)  //expected CFuncPtr
     assertTrue(res0 == 42)
     assertTrue(res1 == 42)
+  }
+
+  object Ext3 {
+
+    trait ExtTrait {
+      @name("snprintf")
+      def extTrait(buf: CString,
+                   size: CSize,
+                   format: CString,
+                   l: CString): Int = extern
+    }
+
+    abstract class ExtClass() {
+      @name("snprintf")
+      def extClass(buf: CString,
+                   size: CSize,
+                   format: CString,
+                   l: CString): Int = extern
+    }
+
+    case class Ext() extends ExtClass() with ExtTrait
+  }
+
+  @Test def allowsToUseExternNotDefineInObject(): Unit = {
+    val ext            = Ext3.Ext()
+    val bufsize        = 10L
+    val testFormat     = c"%s"
+    val testString     = c"hello"
+    val expectedLength = 5
+
+    assertEquals(
+      expectedLength,
+      ext.extTrait(stackalloc[Byte](bufsize), bufsize, testFormat, testString))
+
+    assertEquals(
+      expectedLength,
+      ext.extClass(stackalloc[Byte](bufsize), bufsize, testFormat, testString))
+    )
   }
 }

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/testlib.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/testlib.scala
@@ -1,7 +1,6 @@
 package scala.scalanative.unsafe
 
 // used by ExternTest
-@extern
 object testlib {
   // C code in testlib.c
   @name("exec")


### PR DESCRIPTION
This PR implements #897 for extern definitions. It also resolves #1991. 
It includes all not yet implemented features from the proposal, that is:


>* `@extern object` no more.
>* `def $name(..$args): $T = extern` can appear in any class, module or trait. 
>* `val $name: $T = extern` can appear in any class, module or trait.
>* `var $name: $T = extern` can appear in any class, module or trait.
>* `@link("...")` can appear on any class, module, trait, method or field. If the given definition is reachable at link-time, linker >would link with the corresponding native library automatically.

This PR should be followed by changes to #2060 including changes to syntax rules if it would be merged earlier, or should be rebased and adjusted in otherwise. 