### PR TITLE
Allow JVM-compilant binary operations with Nothing

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1401,7 +1401,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       case (nir.Type.Bool, nir.Type.Bool) =>
         nir.Type.Bool
       case (nir.Type.I(lwidth, _), nir.Type.I(rwidth, _))
-          if lwidth < 32 && rwidth < 32 =>
+        if lwidth < 32 && rwidth < 32 =>
         nir.Type.Int
       case (nir.Type.I(lwidth, _), nir.Type.I(rwidth, _)) =>
         if (lwidth >= rwidth) lty else rty
@@ -1415,6 +1415,9 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         Rt.Object
       case (ty1, ty2) if ty1 == ty2 =>
         ty1
+      case (Type.Nothing, ty) => ty
+      case (ty, Type.Nothing) => ty
+
       case _ =>
         abort(s"can't perform binary operation between $lty and $rty")
     }

--- a/unit-tests/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -2,6 +2,7 @@ package scala.scalanative
 
 import org.junit.Test
 import org.junit.Assert._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 import scalanative.unsigned._
 import scalanative.unsafe._
@@ -351,6 +352,12 @@ class IssuesTest {
 
   @Test def test_Issue809(): Unit = {
     assertTrue(null.asInstanceOf[AnyRef].## == 0)
+  }
+
+  @Test def test_Issue899(): Unit = {
+    def giveNothing: Any = throw new RuntimeException()
+
+    assertThrows(classOf[RuntimeException], giveNothing == true)
   }
 
   @Test def test_Issue900(): Unit = {


### PR DESCRIPTION
This PR fixes a minor bug leading to the crashing of the NIR generation phase. 
Method `binaryOperationType` have not defined behavior for `nir.Type.Nothing` which may exist in user code, eq. `sys.error("foo") == true`.

Resolves #899