### PR TITLE
WIP: Fix 1664: Correct 0.4.0 regression in POSIX strftime & a memory flaw in strptime

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -30,6 +30,7 @@ object time {
   def localtime_r(time: Ptr[time_t], tm: Ptr[tm]): Ptr[tm] = extern
   @name("scalanative_mktime")
   def mktime(time: Ptr[tm]): time_t = extern
+  @name("scalanative_strftime")
   def strftime(str: Ptr[CChar],
                count: CSize,
                format: CString,

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -4,6 +4,9 @@ package posix
 import scala.scalanative.unsafe._
 import scala.scalanative.posix.sys.types, types._
 
+// XSI comment before method indicates it is defined in
+// extended POSIX X/Open System Interfaces, not base POSIX.
+
 @extern
 object time {
 
@@ -17,7 +20,7 @@ object time {
   // the arguments or return value do not need that layer & its
   // annotation.
   //
-  // time_t is a simple type, not a structure, so it do not need to be
+  // time_t is a simple type, not a structure, so it does not need to be
   // transformed.
   //
   // Structures, such as timespec or tm, are subject to differing total
@@ -57,6 +60,7 @@ object time {
                format: CString,
                time: Ptr[tm]): CSize = extern
 
+  // XSI
   @name("scalanative_strptime")
   def strptime(str: Ptr[CChar], format: CString, time: Ptr[tm]): CString =
     extern
@@ -67,9 +71,11 @@ object time {
   @name("scalanative_daylight")
   def daylight(): CInt = extern
 
+  // XSI
   @name("scalanative_timezone")
   def timezone(): CLong = extern
 
+  // XSI
   @name("scalanative_tzname")
   def tzname(): Ptr[CStruct2[CString, CString]] = extern
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -12,37 +12,64 @@ object time {
   type timespec = CStruct2[time_t, CLong]
   type tm       = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
 
+  // Some methods here have a @name annotation and some do not.
+  // Methods where a @name extern "glue" layer would simply pass through
+  // the arguments or return value do not need that layer & its
+  // annotation.
+  //
+  // time_t is a simple type, not a structure, so it do not need to be
+  // transformed.
+  //
+  // Structures, such as timespec or tm, are subject to differing total
+  // sizes(tail padding), ordering of elements, and intervening padding.
+  // Expect an @name annotation and "glue" layer implementation to handle
+  // them.
+
   @name("scalanative_asctime")
   def asctime(time_ptr: Ptr[tm]): CString = extern
+
   @name("scalanative_asctime_r")
   def asctime_r(time_ptr: Ptr[tm], buf: Ptr[CChar]): CString = extern
-  def clock(): clock_t                                       = extern
-  def ctime(time: Ptr[time_t]): CString                      = extern
-  def ctime_r(time: Ptr[time_t], buf: Ptr[CChar]): CString   = extern
-  def difftime(time_end: CLong, time_beg: CLong): CDouble    = extern
+
+  def clock(): clock_t                                     = extern
+  def ctime(time: Ptr[time_t]): CString                    = extern
+  def ctime_r(time: Ptr[time_t], buf: Ptr[CChar]): CString = extern
+  def difftime(time_end: CLong, time_beg: CLong): CDouble  = extern
+
   @name("scalanative_gmtime")
   def gmtime(time: Ptr[time_t]): Ptr[tm] = extern
+
   @name("scalanative_gmtime_r")
   def gmtime_r(time: Ptr[time_t], tm: Ptr[tm]): Ptr[tm] = extern
+
   @name("scalanative_localtime")
   def localtime(time: Ptr[time_t]): Ptr[tm] = extern
+
   @name("scalanative_localtime_r")
   def localtime_r(time: Ptr[time_t], tm: Ptr[tm]): Ptr[tm] = extern
+
   @name("scalanative_mktime")
   def mktime(time: Ptr[tm]): time_t = extern
+
   @name("scalanative_strftime")
   def strftime(str: Ptr[CChar],
                count: CSize,
                format: CString,
                time: Ptr[tm]): CSize = extern
+
+  @name("scalanative_strptime")
   def strptime(str: Ptr[CChar], format: CString, time: Ptr[tm]): CString =
     extern
+
   def time(arg: Ptr[time_t]): time_t = extern
   def tzset(): Unit                  = extern
+
   @name("scalanative_daylight")
   def daylight(): CInt = extern
+
   @name("scalanative_timezone")
   def timezone(): CLong = extern
+
   @name("scalanative_tzname")
   def tzname(): Ptr[CStruct2[CString, CString]] = extern
 }


### PR DESCRIPTION
We correct the definition of strftime so that the Scala Native "glue"
layer which handles translations of structure sizes is used. We also
correct a flaw in strptime where it could write memory outside of
that provided to it.

This PR updates and supersedes PR #1667. See that PR for discussion
and history.