### PR TITLE
Fix #415: Report usage positions of missing definitions when linking

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -9,6 +9,7 @@ import sbt.complete.DefaultParsers._
 import scala.annotation.tailrec
 import scala.scalanative.util.Scope
 import scala.scalanative.build.{Build, BuildException, Discover}
+import scala.scalanative.linker.LinkingException
 import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
 import scala.scalanative.sbtplugin.Utilities._
 import scala.scalanative.testinterface.adapter.TestAdapter
@@ -214,7 +215,8 @@ object ScalaNativePluginInternal {
   private def interceptBuildException[T](op: => T): T = {
     try op
     catch {
-      case ex: BuildException => throw new MessageOnlyException(ex.getMessage)
+      case ex: BuildException   => throw new MessageOnlyException(ex.getMessage)
+      case ex: LinkingException => throw new MessageOnlyException(ex.getMessage)
     }
   }
 

--- a/tools/src/main/scala/scala/scalanative/linker/LinkingException.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinkingException.scala
@@ -1,0 +1,4 @@
+package scala.scalanative.linker
+
+/** Exception that is thrown when a Scala Native linking fails. */
+final class LinkingException(message: String) extends Exception(message)

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -3,7 +3,6 @@ package linker
 
 import java.nio.file.{Path, Paths}
 import scala.collection.mutable
-import scala.scalanative.build.BuildException
 import scalanative.nir._
 
 class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
@@ -757,7 +756,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
               log.error(s"\tat ${pos.path.toString}:${pos.line}")
             }
       }
-      throw new BuildException(
+      throw new LinkingException(
         "Undefined definitions found in reachability phase")
     }
   }

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -740,7 +740,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
   private def addMissing(global: Global, pos: Position): Unit = {
     val prev = missing.getOrElse(global, Set.empty)
     val position = NonReachablePosition(path = Paths.get(pos.source.getPath),
-                                        column = pos.column + 1)
+                                        line = pos.line + 1)
     missing(global) = prev + position
   }
 
@@ -752,9 +752,9 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
         case (global, positions) =>
           log.error(s"Not found $global")
           positions.toList
-            .sortBy(p => (p.path, p.column))
+            .sortBy(p => (p.path, p.line))
             .foreach { pos =>
-              log.error(s"\tat ${pos.path.toString}:${pos.column}")
+              log.error(s"\tat ${pos.path.toString}:${pos.line}")
             }
 
       }
@@ -773,7 +773,7 @@ object Reach {
     reachability.result()
   }
 
-  private[scalanative] case class NonReachablePosition(path: Path, column: Int)
+  private[scalanative] case class NonReachablePosition(path: Path, line: Int)
 
   case class ReachabilityFailureException(msg: String)
       extends RuntimeException(msg)

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -3,7 +3,7 @@ package linker
 
 import java.nio.file.{Path, Paths}
 import scala.collection.mutable
-import scala.util.control.NoStackTrace
+import scala.scalanative.build.BuildException
 import scalanative.nir._
 
 class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
@@ -756,9 +756,8 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
             .foreach { pos =>
               log.error(s"\tat ${pos.path.toString}:${pos.line}")
             }
-
       }
-      throw ReachabilityFailureException(
+      throw new BuildException(
         "Undefined definitions found in reachability phase")
     }
   }
@@ -774,8 +773,4 @@ object Reach {
   }
 
   private[scalanative] case class NonReachablePosition(path: Path, line: Int)
-
-  case class ReachabilityFailureException(msg: String)
-      extends RuntimeException(msg)
-      with NoStackTrace
 }


### PR DESCRIPTION
This PR adds aggregation of missing definitions with their usage positions when performing static reachability phase. 
Currently, when some definition is missing, we would result in a single exception due to usage of `Map.apply` which does not contain any greater context. 
Thanks to this PR we would get list of all missing definitions with places of their usage, eg.:
```
    [error] Found 2 missing definitions while linking
    [error] Not found Top(java.time.Instant$)
    [error] 	at <project_dir>/javalib/src/main/scala/java/nio/file/attribute/FileTime.scala:9
    [error] Not found Top(java.util.Locale$)
    [error] 	at <project_dir>/javalib/src/main/scala/java/lang/String.scala:11
    [error] 	at <project_dir>/javalib/src/main/scala/java/lang/String.scala:43
    [error] 	at <project_dir>/javalib/src/main/scala/java/text/DateFormatSymbols.scala:28
    [error] 	at <project_dir>/javalib/src/main/scala/java/text/DecimalFormat.scala:60
    [error] 	at <project_dir>/javalib/src/main/scala/java/util/Formatter.scala:6
    [error] 	at <project_dir>/javalib/src/main/scala/java/util/Formatter.scala:45
    [error] 	at <project_dir>/javalib/src/main/scala/java/util/Formatter.scala:53
    [error] stack trace is suppressed; run last tests / Test / nativeLink for the full output
    [error] (tests / Test / nativeLink) scala.scalanative.linker.Reach$ReachabilityFailureException: Undefined definitions found in reachability phase

```
Resolves #415