### PR TITLE
Support boehm installed from macports

### DIFF
--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -107,6 +107,9 @@ The `optimize` setting is controlled via the `SCALANATIVE_OPTIMIZE` environment
 variable. Valid values are `true` and `false`. The default value is `true`.
 This setting controls whether the Interflow optimizer is enabled or not.
 
+The path to used include and library dirs is controlled via environment variables
+the `SCALANATIVE_INCLUDE_DIRS` and `SCALANATIVE_LIB_DIRS`.
+
 Setting the GC setting via `sbt`
 --------------------------------
 The GC setting is only used during the link phase of the Scala Native


### PR DESCRIPTION
Right now the code base contains hardcoded path to boehm that is installed by brew.

MacOS world has an alternative that is called macports and it installs everything inside `/opt/local`.

This commit fixed build scala native application with boehm GC on system where boehm is installed via macports.

It also introduced two more environment variables `SCALANATIVE_INCLUDE_DIRS` and `SCALANATIVE_INCLUDE_DIRS` that allows to control which dirs should be used without hardcode inside `build.sbt`.