### PR TITLE
Never use a memory after it's freed

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Zone.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Zone.scala
@@ -59,11 +59,15 @@ object Zone {
     }
 
     final override def close(): Unit = {
-      while (node != null) {
-        libc.free(node.head)
-        node = node.tail
+      if (closed) {
+        throw new IllegalStateException("zone allocator is closed")
       }
       closed = true
+      while (node != null) {
+        val head = node.head
+        node = node.tail
+        libc.free(head)
+      }
     }
   }
 }

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/ZoneTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/ZoneTest.scala
@@ -65,5 +65,6 @@ class ZoneTest {
 
     assertThrows(classOf[IllegalStateException],
                  zone.alloc(64.toUInt * sizeof[Int]))
+    assertThrows(classOf[IllegalStateException], zone.close())
   }
 }


### PR DESCRIPTION
This commit is fixed a root cause that we seen for a while as failed test on macOS: https://github.com/scala-native/scala-native/issues/1918

macOS has strict allocator and it has `abort` that is crahsed like:
```
tests-out(33579,0x1129fde00) malloc: Incorrect checksum for freed object 0x7fb19ec05c40: probably modified after being freed.
```

It is happened because `Zone.close()` used an object to get the next zone's object *after* it was freed.

Because memory allocation is tricky and can be done via `mmap` or via `sbrk` it isn't happened each time when we close zone.

I also close the zone as soon as `close()` is called and phorbide to close it several times because it will be an issue as soon multithreading is here.

Yes, this issue exists at `0.4.0-M2`.