### PR TITLE
Throw an OutOfMemoryError if malloc cannot allocate

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Zone.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Zone.scala
@@ -51,6 +51,9 @@ object Zone {
         throw new IllegalStateException("zone allocator is closed")
       }
       val rawptr = libc.malloc(size)
+      if (rawptr == null) {
+        throw new OutOfMemoryError(s"Unable to allocate $size bytes")
+      }
       node = new Node(rawptr, node)
       fromRawPtr[Byte](rawptr)
     }


### PR DESCRIPTION
Malloc may returns `NULL` when it can't allocate required memory.