### PR TITLE
Fix #2074: Compare unsigned types by value in equals/hashCode

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/unsigned/UByte.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/UByte.scala
@@ -266,7 +266,7 @@ final class UByte private[scalanative] (
   @inline override def hashCode(): Int = underlying.##
 
   @inline override def equals(obj: Any): Boolean = obj match {
-    case that: UByte => this == that
+    case that: UByte => this.underlying == that.underlying
     case _           => false
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/UByte.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/UByte.scala
@@ -263,6 +263,13 @@ final class UByte private[scalanative] (
 
   @inline final override def toString(): String = toInt.toString()
 
+  @inline override def hashCode(): Int = underlying.##
+
+  @inline override def equals(obj: Any): Boolean = obj match {
+    case that: UByte => this == that
+    case _           => false
+  }
+
   // "Rich" API
 
   @inline final def max(that: UByte): UByte =

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/UInt.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/UInt.scala
@@ -276,7 +276,7 @@ final class UInt private[scalanative] (private[scalanative] val underlying: Int)
   @inline override def hashCode(): Int = underlying.##
 
   @inline override def equals(obj: Any): Boolean = obj match {
-    case that: UInt => this == that
+    case that: UInt => this.underlying == that.underlying
     case _          => false
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/UInt.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/UInt.scala
@@ -273,6 +273,13 @@ final class UInt private[scalanative] (private[scalanative] val underlying: Int)
   @inline final override def toString(): String =
     JInteger.toUnsignedString(underlying)
 
+  @inline override def hashCode(): Int = underlying.##
+
+  @inline override def equals(obj: Any): Boolean = obj match {
+    case that: UInt => this == that
+    case _          => false
+  }
+
   // "Rich" API
 
   @inline final def max(that: UInt): UInt = if (this >= that) this else that

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/ULong.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/ULong.scala
@@ -272,7 +272,7 @@ final class ULong private[scalanative] (
   @inline override def hashCode(): Int = underlying.##
 
   @inline override def equals(obj: Any): Boolean = obj match {
-    case that: ULong => this == that
+    case that: ULong => this.underlying == that.underlying
     case _           => false
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/ULong.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/ULong.scala
@@ -269,6 +269,13 @@ final class ULong private[scalanative] (
   @inline final override def toString(): String =
     JLong.toUnsignedString(underlying)
 
+  @inline override def hashCode(): Int = underlying.##
+
+  @inline override def equals(obj: Any): Boolean = obj match {
+    case that: ULong => this == that
+    case _           => false
+  }
+
   // "Rich" API
 
   @inline final def max(that: ULong): ULong = if (this >= that) this else that

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/UShort.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/UShort.scala
@@ -263,6 +263,13 @@ final class UShort private[scalanative] (
 
   @inline final override def toString(): String = toInt.toString()
 
+  @inline override def hashCode(): Int = underlying.##
+
+  @inline override def equals(obj: Any): Boolean = obj match {
+    case that: UShort => this == that
+    case _            => false
+  }
+
   // "Rich" API
 
   @inline final def max(that: UShort): UShort =

--- a/nativelib/src/main/scala/scala/scalanative/unsigned/UShort.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsigned/UShort.scala
@@ -266,7 +266,7 @@ final class UShort private[scalanative] (
   @inline override def hashCode(): Int = underlying.##
 
   @inline override def equals(obj: Any): Boolean = obj match {
-    case that: UShort => this == that
+    case that: UShort => this.underlying == that.underlying
     case _            => false
   }
 

--- a/unit-tests/src/test/scala/scala/scalanative/unsigned/UnsignedEqualityTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsigned/UnsignedEqualityTest.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 
 class UnsignedEqualityTest {
 
-  def testEquality[T <: AnyRef](u1: T, u2: T, u3: T): Unit = {
+  def testEquality(u1: AnyRef, u2: AnyRef, u3: AnyRef): Unit = {
     assertFalse(u1.eq(u2))
     assertFalse(u1.eq(u3))
     assertFalse(u2.eq(u3))

--- a/unit-tests/src/test/scala/scala/scalanative/unsigned/UnsignedEqualityTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsigned/UnsignedEqualityTest.scala
@@ -1,0 +1,41 @@
+package scala.scalanative.unsigned
+
+import org.junit.Test
+import org.junit.Assert._
+
+class UnsignedEqualityTest {
+
+  def testEquality[T <: AnyRef](u1: T, u2: T, u3: T): Unit = {
+    assertFalse(u1.eq(u2))
+    assertFalse(u1.eq(u3))
+    assertFalse(u2.eq(u3))
+
+    assertTrue(u1 == u2)
+    assertEquals(u1, u2)
+    assertNotEquals(u1, u3)
+
+    assertEquals(u1.hashCode(), u2.hashCode())
+    assertNotEquals(u1.hashCode(), u3.hashCode())
+  }
+
+  @Test def testUByteEquals(): Unit = {
+    testEquality(1.toUByte, 1.toUByte, 2.toUByte)
+    assertNotEquals(1.toUByte, 1.toUShort)
+  }
+
+  @Test def testUShortEquals(): Unit = {
+    testEquality(1.toUShort, 1.toUShort, 2.toUShort)
+    assertNotEquals(1.toShort, 1.toUByte)
+  }
+
+  @Test def testUIntEquals(): Unit = {
+    testEquality(1.toUInt, 1.toUInt, 2.toUInt)
+    assertNotEquals(1.toUInt, 1.toULong)
+  }
+
+  @Test def testULongEquals(): Unit = {
+    testEquality(1.toULong, 1.toULong, 2.toULong)
+    assertNotEquals(1.toULong, 1.toUInt)
+  }
+
+}


### PR DESCRIPTION
This PR adds overrides for `Object.equals` and `Object.hashCode` methods in unsigned types. 

Resolves #2074 