### PR TITLE
Enforce usage of fixed notation for time in JUnit reporter

### DIFF
--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
@@ -24,7 +24,7 @@ private[junit] final class Reporter(eventHandler: EventHandler,
         Ansi.c(s", ", Ansi.BLUE) +
         Ansi.c(s"$ignored ignored",
                if (ignored == 0) Ansi.BLUE else Ansi.YELLOW) +
-        Ansi.c(s", $total total, ${timeInSeconds}s", Ansi.BLUE)
+        Ansi.c(f", $total total, $timeInSeconds%.3fs", Ansi.BLUE)
     }
 
     log(infoOrDebug, msg)
@@ -41,7 +41,7 @@ private[junit] final class Reporter(eventHandler: EventHandler,
   def reportTestFinished(method: String,
                          succeeded: Boolean,
                          timeInSeconds: Double): Unit = {
-    logTestInfo(_.debug, Some(method), s"finished, took $timeInSeconds sec")
+    logTestInfo(_.debug, Some(method), f"finished, took $timeInSeconds%.3f sec")
 
     if (succeeded)
       emitEvent(Some(method), Status.Success)
@@ -102,9 +102,10 @@ private[junit] final class Reporter(eventHandler: EventHandler,
       ""
     }
 
-    val m = formatTest(method, Ansi.RED)
+    val m             = formatTest(method, Ansi.RED)
+    val timeFormatted = f"$timeInSeconds%.3f"
     val msg =
-      s"$prefix$m failed: $fmtName${ex.getMessage}, took $timeInSeconds sec"
+      s"$prefix$m failed: $fmtName${ex.getMessage}, took $timeFormatted sec"
     log(level, msg)
   }
 

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
@@ -102,10 +102,9 @@ private[junit] final class Reporter(eventHandler: EventHandler,
       ""
     }
 
-    val m             = formatTest(method, Ansi.RED)
-    val timeFormatted = f"$timeInSeconds%.3f"
+    val m = formatTest(method, Ansi.RED)
     val msg =
-      s"$prefix$m failed: $fmtName${ex.getMessage}, took $timeFormatted sec"
+      f"$prefix$m failed: $fmtName${ex.getMessage}, took $timeInSeconds%.3f sec"
     log(level, msg)
   }
 


### PR DESCRIPTION
After appling changes in #2074 JUnit Reporter, for some unknown reason, started to log test duration using scientific / exponent notation which lead to failures in `junitTestOutputsNative/test`. 

This PR enforces usage of fixed notation with precision limited to 3 digits. 