### PR TITLE
Prevent a memory overflow in unit tests

### DIFF
--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CArrayOpsTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CArrayOpsTest.scala
@@ -14,7 +14,7 @@ class CArrayOpsTest {
     val ptr   = alloc.asInstanceOf[Ptr[Int]]
 
     assertTrue(ptr == carr.at(0))
-    (1 to 100).foreach { i => assertTrue((ptr + i) == carr.at(i)) }
+    (1 to 31).foreach { i => assertTrue((ptr + i) == carr.at(i)) }
   }
 
   @Test def applyUpdate(): Unit = {


### PR DESCRIPTION
This test allocated on stack an array with 32 elements but walking for 100 elements.

Nobody knows that it touches in memory and which side effects it creates.

Technically it should be safe, but nobody knows :)