### PR TITLE
epoch time and timezone inside tm

### DIFF
--- a/posixlib/src/main/resources/scala-native/time.c
+++ b/posixlib/src/main/resources/scala-native/time.c
@@ -1,3 +1,5 @@
+#define __USE_BSD /* for tm_gmtoff and tm_zone */
+
 #include <stdio.h>
 #include <sys/time.h>
 #include <time.h>
@@ -12,6 +14,8 @@ struct scalanative_tm {
     int tm_wday;
     int tm_yday;
     int tm_isdst;
+    long tm_gmtoff;
+    char *tm_zone;
 };
 
 static struct scalanative_tm scalanative_gmtime_buf;
@@ -28,6 +32,8 @@ static void scalanative_tm_init(struct scalanative_tm *scala_tm,
     scala_tm->tm_wday = tm->tm_wday;
     scala_tm->tm_yday = tm->tm_yday;
     scala_tm->tm_isdst = tm->tm_isdst;
+    scala_tm->tm_gmtoff = tm->tm_gmtoff;
+    scala_tm->tm_zone = tm->tm_zone;
 }
 
 static void tm_init(struct tm *tm, struct scalanative_tm *scala_tm) {
@@ -40,6 +46,8 @@ static void tm_init(struct tm *tm, struct scalanative_tm *scala_tm) {
     tm->tm_wday = scala_tm->tm_wday;
     tm->tm_yday = scala_tm->tm_yday;
     tm->tm_isdst = scala_tm->tm_isdst;
+    tm->tm_gmtoff = scala_tm->tm_gmtoff;
+    tm->tm_zone = scala_tm->tm_zone;
 }
 
 char *scalanative_asctime_r(struct scalanative_tm *scala_tm, char *buf) {

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -10,7 +10,17 @@ object time {
   type time_t   = types.time_t
   type clock_t  = types.clock_t
   type timespec = CStruct2[time_t, CLong]
-  type tm       = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
+  type tm = CStruct11[CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CInt,
+                      CLong,
+                      CString]
 
   @name("scalanative_asctime")
   def asctime(time_ptr: Ptr[tm]): CString = extern
@@ -57,23 +67,27 @@ object timeOps {
   }
 
   implicit class tmOps(val ptr: Ptr[tm]) extends AnyVal {
-    def tm_sec: CInt              = ptr._1
-    def tm_min: CInt              = ptr._2
-    def tm_hour: CInt             = ptr._3
-    def tm_mday: CInt             = ptr._4
-    def tm_mon: CInt              = ptr._5
-    def tm_year: CInt             = ptr._6
-    def tm_wday: CInt             = ptr._7
-    def tm_yday: CInt             = ptr._8
-    def tm_isdst: CInt            = ptr._9
-    def tm_sec_=(v: CInt): Unit   = ptr._1 = v
-    def tm_min_=(v: CInt): Unit   = ptr._2 = v
-    def tm_hour_=(v: CInt): Unit  = ptr._3 = v
-    def tm_mday_=(v: CInt): Unit  = ptr._4 = v
-    def tm_mon_=(v: CInt): Unit   = ptr._5 = v
-    def tm_year_=(v: CInt): Unit  = ptr._6 = v
-    def tm_wday_=(v: CInt): Unit  = ptr._7 = v
-    def tm_yday_=(v: CInt): Unit  = ptr._8 = v
-    def tm_isdst_=(v: CInt): Unit = ptr._9 = v
+    def tm_sec: CInt                = ptr._1
+    def tm_min: CInt                = ptr._2
+    def tm_hour: CInt               = ptr._3
+    def tm_mday: CInt               = ptr._4
+    def tm_mon: CInt                = ptr._5
+    def tm_year: CInt               = ptr._6
+    def tm_wday: CInt               = ptr._7
+    def tm_yday: CInt               = ptr._8
+    def tm_isdst: CInt              = ptr._9
+    def tm_gmtoff: CLong            = ptr._10
+    def tm_zone: CString            = ptr._11
+    def tm_sec_=(v: CInt): Unit     = ptr._1 = v
+    def tm_min_=(v: CInt): Unit     = ptr._2 = v
+    def tm_hour_=(v: CInt): Unit    = ptr._3 = v
+    def tm_mday_=(v: CInt): Unit    = ptr._4 = v
+    def tm_mon_=(v: CInt): Unit     = ptr._5 = v
+    def tm_year_=(v: CInt): Unit    = ptr._6 = v
+    def tm_wday_=(v: CInt): Unit    = ptr._7 = v
+    def tm_yday_=(v: CInt): Unit    = ptr._8 = v
+    def tm_isdst_=(v: CInt): Unit   = ptr._9 = v
+    def tm_gmtoff_=(v: CLong): Unit = ptr._10 = v
+    def tm_zone_=(v: CString): Unit = ptr._11 = v
   }
 }


### PR DESCRIPTION
Modern unix like linux, darwin and etc has extended version of time structure `struct tm` that includes `tm_gmtoff` and `tm_zone`.

This fields might has different name like `__tm_gmtoff` and `__tm_zone` and it is controlled by define.

The most easy to use is `__USE_BSD` that enabled it at name `tm_gmtoff` and `tm_zone` where it isn't enabled by default.

This commit brokes compatibility with non Linux and BSD based system, and I doubt that SN can be used right now somewhere else.

Anyway, it fixed a memory corruption that happened because Scala-Native expects that `struct tm` hasn't got this two fiels and it allocated less memory and call of `mktime` corrupt some memory.