### PR TITLE
Fix #2084 Allow identifiers containing double-quote characters

### DIFF
--- a/docs/contrib/mangling.rst
+++ b/docs/contrib/mangling.rst
@@ -59,3 +59,8 @@ that uses a notation inspired by
 
     <name> ::=
         <length number> [-] <chars>    // raw identifier of given length; `-` separator is only used when <chars> starts with digit or `-` itself
+
+
+Mangling identifiers containing special characters follows Scala JVM conventions.
+Each double-quote `"` character is always converted to `$u0022`
+

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
@@ -124,7 +124,7 @@ trait NirGenName[G <: Global with Singleton] {
        * We're replacing them with unicode to allow distinction between x / `x` and `"x"`.
        * It follows Scala JVM naming convention.
        */
-      id.replaceAllLiterally("\"", "$u0022")
+      id.replace("\"", "$u0022")
     }
   }
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenName.scala
@@ -4,7 +4,9 @@ package nscplugin
 import scala.tools.nsc.Global
 import scalanative.util.unreachable
 
-trait NirGenName[G <: Global with Singleton] { self: NirGenPhase[G] =>
+trait NirGenName[G <: Global with Singleton] {
+  self: NirGenPhase[G] =>
+
   import global.{Name => _, _}, definitions._
   import nirAddons.nirDefinitions._
   import SimpleType.{fromSymbol, fromType}
@@ -102,16 +104,14 @@ trait NirGenName[G <: Global with Singleton] { self: NirGenPhase[G] =>
 
   private def nativeIdOf(sym: Symbol): String = {
     sym.getAnnotation(NameClass).flatMap(_.stringArg(0)).getOrElse {
-      if (sym.isField) {
+      val id: String = if (sym.isField) {
         val id0 = sym.name.decoded.toString
         if (id0.charAt(id0.length() - 1) != ' ') id0
         else id0.substring(0, id0.length() - 1) // strip trailing ' '
       } else if (sym.isMethod) {
         val name                = sym.name.decoded
         val isScalaHashOrEquals = name.startsWith("__scala_")
-        if (sym.owner == NObjectClass) {
-          name.substring(2) // strip the __
-        } else if (isScalaHashOrEquals) {
+        if (sym.owner == NObjectClass || isScalaHashOrEquals) {
           name.substring(2) // strip the __
         } else {
           name
@@ -119,6 +119,12 @@ trait NirGenName[G <: Global with Singleton] { self: NirGenPhase[G] =>
       } else {
         scalanative.util.unreachable
       }
+      /*
+       * Double quoted identifiers are not allowed in CLang.
+       * We're replacing them with unicode to allow distinction between x / `x` and `"x"`.
+       * It follows Scala JVM naming convention.
+       */
+      id.replaceAllLiterally("\"", "$u0022")
     }
   }
 }

--- a/tools/src/test/scala/scala/scalanative/linker/IdentifiersSuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/IdentifiersSuite.scala
@@ -1,0 +1,68 @@
+package scala.scalanative.linker
+
+import scala.scalanative.nir.{Global, Rt, Sig, Type}
+
+class IdentifiersSuite extends ReachabilitySuite {
+
+  testReachable("replaces double-quoted identifiers") {
+    val source = """
+        |object `"Foo"Bar"` {
+        |  val x: `"Foo"Bar"`.type       = this
+        |  val `"x"`: `"Foo"Bar"`.type   = this
+        |  val `"x"x"`: `"Foo"Bar"`.type = this
+        |  
+        |  def y(): `"Foo"Bar"`.type     = this
+        |  def `"y"`(): `"Foo"Bar"`.type   = this
+        |  def `"y"y"`(): `"Foo"Bar"`.type = this
+        |}
+        |
+        |object Main {
+        |     import `"Foo"Bar"`._
+        |     x
+        |     `x`
+        |     `"x"`
+        |     `"x"x"`
+        |     `$u0022x"`
+        |     `"x$u0022`
+        |     `"x$u0022x"`
+        |    
+        |     y()
+        |     `y`()
+        |     `"y"`()
+        |     `"y"y"`()
+        |     `$u0022y"`()
+        |     `"y$u0022`()
+        |     `"y$u0022y"`()
+        |}
+        |""".stripMargin
+
+    val FooBar = Global.Top("$u0022Foo$u0022Bar$u0022$")
+    val Main   = Global.Top("Main$")
+
+    val entry         = Main
+    val privateFooBar = Sig.Scope.Private(FooBar)
+
+    val reachable = Seq(
+      Rt.Object.name,
+      Rt.Object.name.member(Sig.Ctor(Seq.empty)),
+      Main,
+      Main.member(Sig.Ctor(Seq.empty)),
+      FooBar,
+      FooBar.member(Sig.Ctor(Seq.empty)),
+      // fields
+      FooBar.member(Sig.Field("x", privateFooBar)),
+      FooBar.member(Sig.Field("$u0022x$u0022", privateFooBar)),
+      FooBar.member(Sig.Field("$u0022x$u0022x$u0022", privateFooBar)),
+      // accessors
+      FooBar.member(Sig.Method("x", Seq(Type.Ref(FooBar)))),
+      FooBar.member(Sig.Method("$u0022x$u0022", Seq(Type.Ref(FooBar)))),
+      FooBar.member(Sig.Method("$u0022x$u0022x$u0022", Seq(Type.Ref(FooBar)))),
+      // methods
+      FooBar.member(Sig.Method("y", Seq(Type.Ref(FooBar)))),
+      FooBar.member(Sig.Method("$u0022y$u0022", Seq(Type.Ref(FooBar)))),
+      FooBar.member(Sig.Method("$u0022y$u0022y$u0022", Seq(Type.Ref(FooBar))))
+    )
+    (source, entry, reachable)
+  }
+
+}


### PR DESCRIPTION
This PR fixes bugs with identifiers mangling when it contains the double-quoted characters. 
Allowing such identifiers is legal in Scala JVM. In the case of SN, such characters were not handled leading to CLang compilation errors - unexpected double-quote character was ending global name string leading to syntax errors. 

The problem has not occurred on class types names, as each `\"` in them were already replaced with `$u0022`. This naming convention is now also used for fields and methods allowing to resolve #2084 

Alternatively, Unicode escape could be replaced with the back-tick character  \` , however this approach allows use to reaming same naming for both `Top` and `Member` globals. 