### PR TITLE
Support `java.util.Date` methods using `java.time.Instant`.

### DIFF
--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -1,5 +1,7 @@
 package java.util
 
+import java.time.Instant
+
 /** Ported from Scala JS and Apache Harmony
  * - omits deprecated methods
  * - toString not jdk compatible
@@ -34,5 +36,16 @@ class Date(var milliseconds: Long)
     milliseconds = time
 
   override def toString(): String = s"Date($milliseconds)"
+
+  def toInstant(): Instant = Instant.ofEpochMilli(getTime())
+
+  def from(instant: Instant): Date = {
+    try {
+      new Date(instant.toEpochMilli())
+    } catch {
+      case ex: ArithmeticException =>
+        throw new IllegalArgumentException(ex)
+    }
+  }
 
 }

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -38,7 +38,9 @@ class Date(var milliseconds: Long)
   override def toString(): String = s"Date($milliseconds)"
 
   def toInstant(): Instant = Instant.ofEpochMilli(getTime())
+}
 
+object Date {
   def from(instant: Instant): Date = {
     try {
       new Date(instant.toEpochMilli())
@@ -48,4 +50,5 @@ class Date(var milliseconds: Long)
     }
   }
 
+  def getMillisOf(date: Date): Long = date.milliseconds
 }

--- a/unit-tests-ext/src/test/scala/java/util/DateTestExt.scala
+++ b/unit-tests-ext/src/test/scala/java/util/DateTestExt.scala
@@ -13,7 +13,7 @@ class DateTestExt {
     def test(expectedEpochSecond: Long,
              expectedNano: Int,
              epochMilli: Long): Unit = {
-      val instant = Instant.ofEpochSecond(expectedEpochSecond, expectedNano
+      val instant = Instant.ofEpochSecond(expectedEpochSecond, expectedNano)
       val date    = new Date(epochMilli)
       assertEquals(instant, date.toInstant())
       assertEquals(date, Date.from(instant))

--- a/unit-tests-ext/src/test/scala/java/util/DateTestExt.scala
+++ b/unit-tests-ext/src/test/scala/java/util/DateTestExt.scala
@@ -1,0 +1,28 @@
+// Ported from Scala.js, commit: 54648372, dated: 2020-09-24
+package java.util
+
+import java.time.Instant
+import org.junit.Assert._
+import org.junit.Test
+
+/** Additional tests for `java.util.Date` that require javalib extension
+ *  dummies.
+ */
+class DateTestExt {
+  @Test def testToFromInstant(): Unit = {
+    def test(expectedEpochSecond: Long,
+             expectedNano: Int,
+             epochMilli: Long): Unit = {
+      val instant = Instant.ofEpochSecond(expectedEpochSecond, expectedNano
+      val date    = new Date(epochMilli)
+      assertEquals(instant, date.toInstant())
+      assertEquals(date, Date.from(instant))
+    }
+
+    test(123L, 456000000, 123456L)
+    test(8640000000000L, 1000000, 8640000000000001L)
+    test(-8640000000001L, 999000000, -8640000000000001L)
+    test(-9223372036854776L, 192000000, Long.MinValue)
+    test(9223372036854775L, 807000000, Long.MaxValue)
+  }
+}


### PR DESCRIPTION
This PR adds methods added in Java8 to `java.util.Date` that is method `toInstant` and `Date.from(_: Instant)`
It should be rebased on top of merged #2079 as it contains bootstrap of `testsExt` project and on top of #2087 where `Instant.ofEpochSeconds` method used in tests was implemented.