### PR TITLE
Use clang 6.0 in CI

### DIFF
--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -35,7 +35,7 @@ RUN \
   apt-get update && \
   apt-get install -y sbt
 
-RUN apt-get update && apt-get install -y clang-5.0 zlib1g-dev libgc-dev
+RUN apt-get update && apt-get install -y clang-6.0 zlib1g-dev libgc-dev
 
 ENV LC_ALL "C.UTF-8"
 


### PR DESCRIPTION
This PR updated the testing image to use clang with version 6.0, which is a minimal fully compatible version. 
Documentation for users would be updated in following up PR

Clang 6.0 or newer is needed to deal with issues described in #1991, that is dealing with multiple external definitions to the same method with different types occurring in debug mode (when we're external definition can be declared in multiple `*.ll` files)

Closes #1991 