### PR TITLE
WIP: Fix 1664: Zero copy in posixlib time implementation

### DIFF
--- a/posixlib/src/main/resources/scala-native/time.c
+++ b/posixlib/src/main/resources/scala-native/time.c
@@ -1,95 +1,33 @@
+#include <stddef.h>
 #include <stdio.h>
 #include <sys/time.h>
 #include <time.h>
 
-struct scalanative_tm {
-    int tm_sec;
-    int tm_min;
-    int tm_hour;
-    int tm_mday;
-    int tm_mon;
-    int tm_year;
-    int tm_wday;
-    int tm_yday;
-    int tm_isdst;
-};
+#if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
+#ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING
+#warning "Size and order of C structures are not checked when -std < c11."
+#endif
+#else
+// Make the reasonable assumption that the order and size of members
+// used in link time libc matches that of compilation time .h files.
+// This is true with Scala Native default compilation and link options.
+//
+// It is possible, but not easy, to chose a combination of compile &
+// link time options which break this assumption. 
 
-static struct scalanative_tm scalanative_gmtime_buf;
-static struct scalanative_tm scalanative_localtime_buf;
+_Static_assert(sizeof(struct tm) <= 56,
+               "struct is larger than its declaration in time.scala");
 
-static void scalanative_tm_init(struct scalanative_tm *scala_tm,
-                                struct tm *tm) {
-    scala_tm->tm_sec = tm->tm_sec;
-    scala_tm->tm_min = tm->tm_min;
-    scala_tm->tm_hour = tm->tm_hour;
-    scala_tm->tm_mday = tm->tm_mday;
-    scala_tm->tm_mon = tm->tm_mon;
-    scala_tm->tm_year = tm->tm_year;
-    scala_tm->tm_wday = tm->tm_wday;
-    scala_tm->tm_yday = tm->tm_yday;
-    scala_tm->tm_isdst = tm->tm_isdst;
-}
-
-static void tm_init(struct tm *tm, struct scalanative_tm *scala_tm) {
-    tm->tm_sec = scala_tm->tm_sec;
-    tm->tm_min = scala_tm->tm_min;
-    tm->tm_hour = scala_tm->tm_hour;
-    tm->tm_mday = scala_tm->tm_mday;
-    tm->tm_mon = scala_tm->tm_mon;
-    tm->tm_year = scala_tm->tm_year;
-    tm->tm_wday = scala_tm->tm_wday;
-    tm->tm_yday = scala_tm->tm_yday;
-    tm->tm_isdst = scala_tm->tm_isdst;
-}
-
-char *scalanative_asctime_r(struct scalanative_tm *scala_tm, char *buf) {
-    struct tm tm;
-    tm_init(&tm, scala_tm);
-    return asctime_r(&tm, buf);
-}
-
-char *scalanative_asctime(struct scalanative_tm *scala_tm) {
-    struct tm tm;
-    tm_init(&tm, scala_tm);
-    return asctime(&tm);
-}
-
-struct scalanative_tm *scalanative_gmtime_r(const time_t *clock,
-                                            struct scalanative_tm *result) {
-    struct tm tm;
-    gmtime_r(clock, &tm);
-    scalanative_tm_init(result, &tm);
-    return result;
-}
-
-struct scalanative_tm *scalanative_gmtime(const time_t *clock) {
-    return scalanative_gmtime_r(clock, &scalanative_gmtime_buf);
-}
-
-struct scalanative_tm *scalanative_localtime_r(const time_t *clock,
-                                               struct scalanative_tm *result) {
-    struct tm tm;
-    localtime_r(clock, &tm);
-    scalanative_tm_init(result, &tm);
-    return result;
-}
-
-struct scalanative_tm *scalanative_localtime(const time_t *clock) {
-    return scalanative_localtime_r(clock, &scalanative_localtime_buf);
-}
-
-time_t scalanative_mktime(struct scalanative_tm *result) {
-    struct tm tm;
-    tm_init(&tm, result);
-    return mktime(&tm);
-}
-
-size_t scalanative_strftime(char *buf, size_t maxsize, const char *format,
-                            struct scalanative_tm *scala_tm) {
-    struct tm tm;
-    tm_init(&tm, scala_tm);
-    return strftime(buf, maxsize, format, &tm);
-}
+_Static_assert(offsetof(struct tm, tm_sec) == 0, "Unexpected offset");
+_Static_assert(offsetof(struct tm, tm_min) == 4, "Unexpected offset");
+_Static_assert(offsetof(struct tm, tm_hour) == 8, "Unexpected offset");
+_Static_assert(offsetof(struct tm, tm_mday) == 12, "Unexpected offset");
+_Static_assert(offsetof(struct tm, tm_mon) == 16, "Unexpected offset");
+_Static_assert(offsetof(struct tm, tm_year) == 20, "Unexpected offset");
+_Static_assert(offsetof(struct tm, tm_wday) == 24, "Unexpected offset");
+_Static_assert(offsetof(struct tm, tm_yday) == 28, "Unexpected offset");
+_Static_assert(offsetof(struct tm, tm_isdst) == 32, "Unexpected offset");
+#endif
 
 char **scalanative_tzname() { return tzname; }
 

--- a/unit-tests/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -51,7 +51,7 @@ class TimeTest {
       anno_zero_ptr.tm_wday = 1
       val cstr: CString = asctime(anno_zero_ptr)
       val str: String   = fromCString(cstr)
-      assertTrue("Mon Jan  1 00:00:00 1900\n".equals(str))
+      assertEquals("Mon Jan  1 00:00:00 1900\n", str)
     }
   }
 
@@ -62,7 +62,7 @@ class TimeTest {
       anno_zero_ptr.tm_wday = 1
       val cstr: CString = asctime_r(anno_zero_ptr, alloc[Byte](26))
       val str: String   = fromCString(cstr)
-      assertTrue("Mon Jan  1 00:00:00 1900\n".equals(str))
+      assertEquals("Mon Jan  1 00:00:00 1900\n", str)
     }
   }
 
@@ -108,8 +108,7 @@ class TimeTest {
       strftime(isoDatePtr, 70.toULong, c"%FT%TZ", timePtr)
 
       val isoDateString: String = fromCString(isoDatePtr)
-
-      assertTrue("1900-01-01T00:00:00Z".equals(isoDateString))
+      assertEquals("1900-01-01T00:00:00Z", isoDateString)
     }
   }
 
@@ -124,7 +123,7 @@ class TimeTest {
       strftime(datePtr, 70.toULong, c"%A %c", timePtr)
 
       val dateString: String = fromCString(datePtr)
-      assertTrue("Monday Mon Jan  1 00:00:00 1900".equals(dateString))
+      assertEquals("Monday Mon Jan  1 00:00:00 1900", dateString)
     }
   }
 
@@ -136,7 +135,7 @@ class TimeTest {
       val result =
         strptime(c"December 31, 2016 23:59:60", c"%B %d, %Y %Q", tmPtr)
 
-      assertTrue(s"expected null result, got pointer", result == null)
+      assertNull(result)
     }
   }
 
@@ -148,7 +147,7 @@ class TimeTest {
       val result =
         strptime(c"December 32, 2016 23:59:60", c"%B %d, %Y %T", tmPtr)
 
-      assertTrue(s"expected null result, got pointer", result == null)
+      assertNull(result)
     }
   }
 
@@ -159,7 +158,7 @@ class TimeTest {
       val result =
         strptime(c"December 32, 2016 23:59", c"%B %d, %Y %T", tmPtr)
 
-      assertTrue(s"expected null result, got pointer", result == null)
+      assertNull(result)
     }
   }
 
@@ -171,35 +170,28 @@ class TimeTest {
       val result =
         strptime(c"December 31, 2016 23:59:60", c"%B %d, %Y %T", tmPtr)
 
-      assertTrue(s"error: unexpected null returned", result != null)
+      assertNotNull(s"error: unexpected null returned", result)
 
       val expectedYear = 116
-      assertTrue(s"tm_year: ${tmPtr.tm_year} != expected: ${expectedYear}",
-                 tmPtr.tm_year == expectedYear)
+      assertEquals("tm_year", tmPtr.tm_year, expectedYear)
 
       val expectedMonth = 11
-      assertTrue(s"tm_mon: ${tmPtr.tm_mon} != expected: ${expectedMonth}",
-                 tmPtr.tm_mon == expectedMonth)
+      assertEquals("tm_mon", tmPtr.tm_mon, expectedMonth)
 
       val expectedMday = 31
-      assertTrue(s"tm_mon: ${tmPtr.tm_mday} != expected: ${expectedMday}",
-                 tmPtr.tm_mday == expectedMday)
+      assertEquals(s"tm_mday", tmPtr.tm_mday, expectedMday)
 
       val expectedHour = 23
-      assertTrue(s"tm_mon: ${tmPtr.tm_hour} != expected: ${expectedHour}",
-                 tmPtr.tm_hour == expectedHour)
+      assertEquals(s"tm_hour", tmPtr.tm_hour, expectedHour)
 
       val expectedMin = 59
-      assertTrue(s"tm_min: ${tmPtr.tm_min} != expected: ${expectedMin}",
-                 tmPtr.tm_min == expectedMin)
+      assertEquals(s"tm_min", tmPtr.tm_min, expectedMin)
 
       val expectedSec = 60
-      assertTrue(s"tm_sec: ${tmPtr.tm_sec} != expected: ${expectedSec}",
-                 tmPtr.tm_sec == expectedSec)
+      assertEquals(s"tm_sec", tmPtr.tm_sec, expectedSec)
 
       val expectedIsdst = 0
-      assertTrue(s"tm_isdst: ${tmPtr.tm_isdst} != expected: ${expectedIsdst}",
-                 tmPtr.tm_isdst == expectedIsdst)
+      assertEquals(s"tm_isdst", tmPtr.tm_isdst, expectedIsdst)
     }
   }
 
@@ -210,11 +202,10 @@ class TimeTest {
       val result =
         strptime(c"December 31, 2016 23:59:60 UTC", c"%B %d, %Y %T ", tmPtr)
 
-      assertTrue(s"error: null returned", result != null)
+      assertNotNull("strptime", result)
 
       val expected = 'U'
-      assertTrue(s"character: ${!result} != expected: ${expected}",
-                 !result == expected)
+      assertNotEquals("result", result, expected)
     }
   }
 }


### PR DESCRIPTION
We re-work the declaration and implementation of posixlib time to use
reasonable & checked pre-conditions to eliminate both the need to
copy structures and a layer of glue code.

This approach provides code simplification and a runtime performance boost
It originated as an attempt to correct, and does indeed correct, three flaws:
  1) a 0.4.0 regression in POSIX strftime where	it could read beyond
     the end of	allocated memory.

  2) a flaw in strptime where it could write beyond the end allocated memory.

  3) a flaw where localtime was not calling tzset() as required by
     POSIX and described in linux man pages.
