### PR TITLE
Port localized String.to{Lower, Upper}Case from Scala.js

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -1191,7 +1191,6 @@ object Character {
   private[lang] final val CombiningClassIsNone = 0
   private[lang] final val CombiningClassIsAbove = 1
   private[lang] final val CombiningClassIsOther = 2
- 
   
   /* Ported from Scala.js, commit: ac38a148, dated: 2020-09-25
    * Indices representing the start of ranges of codePoint that have the same

--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -410,12 +410,10 @@ object Character {
   private[this] def getTypeLT256(codePoint: Int): scala.Byte =
     charTypesFirst256(codePoint)
 
+  // Ported from Scala.js, commit: ac38a148, dated: 2020-09-25
   private[this] def getTypeGE256(codePoint: Int): scala.Byte = {
-    // the idx is increased by 1 due to the differences in indexing
-    // between charTypeIndices and charType
-    val idx = Arrays.binarySearch(charTypeIndices, codePoint) + 1
-    // in the case where idx is negative (-insertionPoint - 1)
-    charTypes(Math.abs(idx))
+    charTypes(
+      findIndexOfRange(charTypeIndices, codePoint, hasEmptyRanges = false))
   }
 
   // Two digit() constructors, digitWithValidRadix(), and
@@ -749,8 +747,9 @@ object Character {
     isMirrored(c.toInt)
 
   def isMirrored(codePoint: Int): scala.Boolean = {
-    val idx = Arrays.binarySearch(isMirroredIndices, codePoint) + 1
-    (Math.abs(idx) & 1) != 0
+    val indexOfRange =
+      findIndexOfRange(isMirroredIndices, codePoint, hasEmptyRanges = false)
+    (indexOfRange & 1) != 0
   }
 
   /* Conversions */
@@ -1189,6 +1188,118 @@ object Character {
   private[this] lazy val isMirroredIndices =
     uncompressDeltas(isMirroredIndicesDeltas)
 
+  private[lang] final val CombiningClassIsNone = 0
+  private[lang] final val CombiningClassIsAbove = 1
+  private[lang] final val CombiningClassIsOther = 2
+ 
+  
+  /* Ported from Scala.js, commit: ac38a148, dated: 2020-09-25
+   * Indices representing the start of ranges of codePoint that have the same
+   * `combiningClassNoneOrAboveOrOther` result. The results cycle modulo 3 at
+   * every range:
+   *
+   * - 0 for the range [0, array(0))
+   * - 1 for the range [array(0), array(1))
+   * - 2 for the range [array(1), array(2))
+   * - 0 for the range [array(2), array(3))
+   * - etc.
+   *
+   * In general, for a range ending at `array(i)` (excluded), the result is
+   * `i % 3`.
+   *
+   * A range can be empty, i.e., it can happen that `array(i) == array(i + 1)`
+   * (but then it is different from `array(i - 1)` and `array(i + 2)`).
+   *
+   * They where generated with the following script, which can be pasted into
+   * a Scala REPL.
+
+  val url = new java.net.URL("http://unicode.org/Public/UCD/latest/ucd/UnicodeData.txt")
+  val cpToValue = scala.io.Source.fromURL(url, "UTF-8")
+    .getLines()
+    .filter(!_.startsWith("#"))
+    .map(_.split(';'))
+    .map { arr =>
+      val cp = Integer.parseInt(arr(0), 16)
+      val value = arr(3).toInt match {
+        case 0   => 0
+        case 230 => 1
+        case _   => 2
+      }
+      cp -> value
+    }
+    .toMap
+    .withDefault(_ => 0)
+
+  var lastValue = 0
+  val indicesBuilder = List.newBuilder[Int]
+  for (cp <- 0 to Character.MAX_CODE_POINT) {
+    val value = cpToValue(cp)
+    while (lastValue != value) {
+      indicesBuilder += cp
+      lastValue = (lastValue + 1) % 3
+    }
+  }
+  val indices = indicesBuilder.result()
+
+  val indicesDeltas = indices
+    .zip(0 :: indices.init)
+    .map(tup => tup._1 - tup._2)
+  println("combiningClassNoneOrAboveOrOtherIndices, deltas:")
+  println("    Array(")
+  println(formatLargeArray(indicesDeltas.toArray, "        "))
+  println("    )")
+   */
+  private[this] lazy val combiningClassNoneOrAboveOrOtherIndices: Array[Int] = {
+    val deltas = Array(
+      768, 21, 40, 0, 8, 1, 0, 1, 3, 0, 3, 2, 1, 3, 4, 0, 1, 3, 0, 1, 7, 0,
+      13, 0, 275, 5, 0, 265, 0, 1, 0, 4, 1, 0, 3, 2, 0, 6, 6, 0, 2, 1, 0, 2,
+      2, 0, 1, 14, 1, 0, 1, 1, 0, 2, 1, 1, 1, 1, 0, 1, 72, 8, 3, 48, 0, 8, 0,
+      2, 2, 0, 5, 1, 0, 2, 1, 16, 0, 1, 101, 7, 0, 2, 4, 1, 0, 1, 0, 2, 2, 0,
+      1, 0, 1, 0, 2, 1, 35, 0, 1, 30, 1, 1, 0, 2, 1, 0, 2, 3, 0, 1, 2, 0, 1,
+      1, 0, 3, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 2, 0, 160, 7, 1, 0, 1, 0, 9,
+      0, 1, 24, 4, 0, 1, 9, 0, 1, 3, 0, 1, 5, 0, 43, 0, 3, 119, 0, 1, 0, 14,
+      0, 1, 0, 1, 0, 2, 1, 0, 2, 1, 0, 3, 6, 0, 3, 1, 0, 2, 2, 0, 5, 0, 60,
+      0, 1, 16, 0, 1, 3, 1, 1, 0, 2, 0, 103, 0, 1, 16, 0, 1, 48, 1, 0, 61, 0,
+      1, 16, 0, 1, 110, 0, 1, 16, 0, 1, 110, 0, 1, 16, 0, 1, 127, 0, 1, 127,
+      0, 1, 7, 0, 2, 101, 0, 1, 16, 0, 1, 109, 0, 2, 16, 0, 1, 124, 0, 1,
+      109, 0, 3, 13, 0, 4, 108, 0, 3, 13, 0, 4, 76, 0, 2, 27, 0, 1, 1, 0, 1,
+      1, 0, 1, 55, 0, 2, 1, 0, 1, 5, 0, 4, 2, 0, 1, 1, 2, 1, 1, 2, 0, 62, 0,
+      1, 112, 0, 1, 1, 0, 2, 82, 0, 1, 719, 3, 0, 948, 0, 1, 31, 0, 1, 157,
+      0, 1, 10, 1, 0, 203, 0, 1, 143, 0, 1, 0, 1, 1, 219, 1, 1, 71, 0, 1, 20,
+      8, 0, 2, 0, 1, 48, 5, 6, 0, 2, 1, 1, 0, 2, 115, 0, 1, 15, 0, 1, 38, 1,
+      1, 0, 7, 0, 54, 0, 2, 58, 0, 1, 11, 0, 2, 67, 0, 1, 152, 3, 0, 1, 0, 6,
+      0, 2, 4, 0, 1, 0, 1, 0, 7, 4, 0, 1, 6, 1, 0, 3, 2, 0, 198, 2, 1, 0, 7,
+      1, 0, 2, 4, 0, 37, 4, 1, 1, 2, 0, 1, 1, 720, 2, 2, 0, 4, 3, 0, 2, 0, 4,
+      1, 0, 3, 0, 2, 0, 1, 1, 0, 1, 6, 0, 1, 0, 3070, 3, 0, 141, 0, 1, 96,
+      32, 0, 554, 0, 6, 105, 0, 2, 30164, 1, 0, 4, 10, 0, 32, 2, 0, 80, 2, 0,
+      276, 0, 1, 37, 0, 1, 151, 0, 1, 27, 18, 0, 57, 0, 3, 37, 0, 1, 95, 0,
+      1, 12, 0, 1, 239, 1, 0, 1, 2, 1, 2, 2, 0, 5, 2, 0, 1, 1, 0, 52, 0, 1,
+      246, 0, 1, 20272, 0, 1, 769, 7, 7, 0, 2, 0, 973, 0, 1, 226, 0, 1, 149,
+      5, 0, 1682, 0, 1, 1, 1, 0, 40, 1, 2, 4, 0, 1, 165, 1, 1, 573, 4, 0,
+      387, 2, 0, 153, 0, 2, 0, 3, 1, 0, 1, 4, 245, 0, 1, 56, 0, 1, 57, 0, 2,
+      69, 3, 0, 48, 0, 2, 62, 0, 1, 76, 0, 1, 9, 0, 1, 106, 0, 2, 178, 0, 2,
+      80, 0, 2, 16, 0, 1, 24, 7, 0, 3, 5, 0, 205, 0, 1, 3, 0, 1, 23, 1, 0,
+      99, 0, 2, 251, 0, 2, 126, 0, 1, 118, 0, 2, 115, 0, 1, 269, 0, 2, 258,
+      0, 2, 4, 0, 1, 156, 0, 1, 83, 0, 1, 18, 0, 1, 81, 0, 1, 421, 0, 1, 258,
+      0, 1, 1, 0, 2, 81, 0, 1, 19800, 0, 5, 59, 7, 0, 1209, 0, 2, 19628, 0,
+      1, 5318, 0, 5, 3, 0, 6, 8, 0, 8, 2, 5, 2, 30, 4, 0, 148, 3, 0, 3515, 7,
+      0, 1, 17, 0, 2, 7, 0, 1, 2, 0, 1, 5, 0, 261, 7, 0, 437, 4, 0, 1504, 0,
+      7, 109, 6, 1
+    )
+    uncompressDeltas(deltas)
+  }
+
+  /** Tests whether the given code point's combining class is 0 (None), 230
+   *  (Above) or something else (Other).
+   *
+   *  This is a special-purpose method for use by `String.toLowerCase` and
+   *  `String.toUpperCase`.
+   */
+  private[lang] def combiningClassNoneOrAboveOrOther(cp: Int): Int = {
+    val indexOfRange = findIndexOfRange(
+      combiningClassNoneOrAboveOrOtherIndices, cp, hasEmptyRanges = true)
+    indexOfRange % 3
+  }
   // format: on
 
   @noinline private[this] def uncompressDeltas(
@@ -1196,6 +1307,35 @@ object Character {
     for (i <- 1 until deltas.length)
       deltas(i) += deltas(i - 1)
     deltas
+  }
+
+  private[this] def findIndexOfRange(startOfRangesArray: Array[Int],
+                                     value: Int,
+                                     hasEmptyRanges: scala.Boolean): Int = {
+    val i = Arrays.binarySearch(startOfRangesArray, value)
+    if (i >= 0) {
+      /* `value` is at the start of a range. Its range index is therefore
+       * `i + 1`, since there is an implicit range starting at 0 in the
+       * beginning.
+       *
+       * If the array has empty ranges, we may need to advance further than
+       * `i + 1` until the first index `j > i` where
+       * `startOfRangesArray(j) != value`.
+       */
+      if (hasEmptyRanges) {
+        var j = i + 1
+        while (j < startOfRangesArray.length && startOfRangesArray(j) == value)
+          j += 1
+        j
+      } else {
+        i + 1
+      }
+    } else {
+      /* i is `-p - 1` where `p` is the insertion point. In that case the index
+       * of the range is precisely `p`.
+       */
+      -i - 1
+    }
   }
 
   // Tables to support toUpperCase and toLowerCase transformations

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -831,7 +831,69 @@ final class _String()
     preprocessed.toLowerCase()
   }
 
-  @inline def toLowerCase(): _String = toCase(Character.toLowerCase)
+  @inline def toLowerCase(): _String = {
+    replaceCharsAtIndex { i =>
+      // Test if given character is last cased letter within given word context, that means
+      // given char at index has at least 1 preceding cased letter within word
+      // and is not followed by any cased letter
+      def isFinalCased(idx: Int): Boolean = {
+
+        /* Character is cased when its type matches lowercase, uppercase or title-case type.
+         * Alternatively it can be non standard cased character, eq. modifier or circled letter or roman number
+         */
+        def isCased(c: Char): scala.Boolean = {
+          val charType = Character.getType(c)
+          charType == Character.LOWERCASE_LETTER ||
+          charType == Character.UPPERCASE_LETTER ||
+          charType == Character.TITLECASE_LETTER ||
+          ((c >= 0x02B0) && (c <= 0x02B8)) || // Modifier small letter h..y
+          ((c >= 0x02C0) && (c <= 0x02C1)) || // Modifier letter or reversed letter glottal stop
+          ((c >= 0x02E0) && (c <= 0x02E4)) || // Modifier small or reversed small letter gamma
+          c == '\u0345' ||                    // Combining greek ypogegrammeni
+          c == '\u037A' ||                    // Greek ypogegrammeni
+          ((c >= 0x1D2C) && (c <= 0x1D61)) || // Modifier letter capital A to CHI
+          ((c >= 0x2160) && (c <= 0x217F)) || // Roman capital or small numeral one to one thousand
+          ((c >= 0x24B6) && (c <= 0x24E9))    // Circled latin capital or small letters A to Z
+        }
+
+        @tailrec
+        def followsCased(i: Int): scala.Boolean = {
+          if (i < offset) false // Not found non cased in whole string
+          else {
+            val c = charAt(i)
+            // Outside word boundary and not found cased
+            if (c.isWhitespace) false
+            else if (isCased(c)) true
+            else followsCased(i - Character.charCount(c))
+          }
+        }
+
+        @tailrec
+        def precedesOnlyNonCased(i: Int): scala.Boolean = {
+          if (i >= offset + count) true // At string boundary and no cased found
+          else {
+            val c = charAt(i)
+            if (c.isWhitespace) true // At word boundary and no cased found
+            else if (isCased(c)) false
+            else precedesOnlyNonCased(i + Character.charCount(c))
+          }
+        }
+
+        followsCased(idx - 1) && precedesOnlyNonCased(idx + 1)
+      }
+
+      /* Greek lower letter sigma exists in two forms:
+       * \u03c3 'σ' - is standard lower case variant
+       * \u03c2 'ς' - is used when it's final cased character in given word
+       */
+      (charAt(i): @switch) match {
+        case '\u03A3' if isFinalCased(i) => "\u03C2"
+        case '\u0130'                    => "\u0069\u0307"
+        case _                           => null
+      }
+    }.asInstanceOf[_String]
+      .toCase(Character.toLowerCase)
+  }
 
   override def toString(): String = this
 
@@ -918,7 +980,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
   }
   @inline def toUpperCase(): _String = toCase(Character.toUpperCase)
 
-  private[this] def toCase(convert: Int => Int): _String = {
+  private def toCase(convert: Int => Int): _String = {
     if (count == 0) return this
     val buf = new java.lang.StringBuilder(count)
     var i   = offset

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -969,14 +969,17 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
    */
   @inline
   private def replaceCharsAtIndex(replacementAtIndex: Int => String): String = {
-    var prep           = ""
-    val len            = this.length()
-    var i              = 0
-    var startOfSegment = 0
+    var prep: java.lang.StringBuilder = null
+    val len                           = this.length()
+    var i                             = 0
+    var startOfSegment                = 0
 
     while (i != len) {
       val replacement = replacementAtIndex(i)
       if (replacement != null) {
+        if (prep == null) {
+          prep = new java.lang.StringBuilder(len * 2)
+        }
         prep += this.substring(startOfSegment, i)
         prep += replacement
         startOfSegment = i + 1

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -668,7 +668,7 @@ final class _String()
     buffer
   }
 
-  /*  Ported from Scala.js, commit: ac38a148, dated: 2020-09-25
+  /* Ported from Scala.js, commit: ac38a148, dated: 2020-09-25
    *
    * The overloads without an explicit locale use the default locale, which is
    * the root locale by specification. They are implemented by direct
@@ -831,7 +831,8 @@ final class _String()
     preprocessed.toLowerCase()
   }
 
-  @inline def toLowerCase(): _String = toCase(Character.toLowerCase)
+  @inline
+  def toLowerCase(): _String = toCase(Character.toLowerCase)
 
   override def toString(): String = this
 
@@ -916,7 +917,9 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
 
     preprocessed.toUpperCase()
   }
-  @inline def toUpperCase(): _String = toCase(Character.toUpperCase)
+
+  @inline
+  def toUpperCase(): _String = toCase(Character.toUpperCase)
 
   private[this] def toCase(convert: Int => Int): _String = {
     if (count == 0) return this
@@ -966,7 +969,6 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
    */
   @inline
   private def replaceCharsAtIndex(replacementAtIndex: Int => String): String = {
-
     var prep           = ""
     val len            = this.length()
     var i              = 0

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -10,6 +10,7 @@ import java.util.regex._
 import java.nio._
 import java.nio.charset._
 import java.util.Objects
+import scala.annotation.{switch, tailrec}
 
 final class _String()
     extends Serializable
@@ -667,22 +668,259 @@ final class _String()
     buffer
   }
 
-  def toLowerCase(locale: Locale): _String =
-    toCase(Character.toLowerCase)
+  /*  Ported from Scala.js, commit: ac38a148, dated: 2020-09-25
+   *
+   * The overloads without an explicit locale use the default locale, which is
+   * the root locale by specification. They are implemented by direct
+   * delegation to ECMAScript's `toLowerCase()` and `toUpperCase()`, which are
+   * specified as locale-insensitive, therefore equivalent to the root locale.
+   *
+   * It turns out virtually every locale behaves in the same way as the root
+   * locale for default case algorithms. Only Lithuanian (lt), Turkish (tr)
+   * and Azeri (az) have different behaviors.
+   *
+   * The overloads with a `Locale` specifically test for those three languages
+   * and delegate to dedicated methods to handle them. Those methods start by
+   * handling their respective special cases, then delegate to the locale-
+   * insensitive version. The special cases are specified in the Unicode
+   * reference file at
+   *
+   *   https://unicode.org/Public/13.0.0/ucd/SpecialCasing.txt
+   *
+   * That file first contains a bunch of locale-insensitive special cases,
+   * which we do not need to handle. Only the last two sections about locale-
+   * sensitive special-cases are important for us.
+   *
+   * Some of the rules are further context-sensitive, using predicates that are
+   * defined in Section 3.13 "Default Case Algorithms" of the Unicode Standard,
+   * available at
+   *
+   *   http://www.unicode.org/versions/Unicode13.0.0/
+   *
+   * We based the implementations on Unicode 13.0.0. It is worth noting that
+   * there has been no non-comment changes in the SpecialCasing.txt file
+   * between Unicode 4.1.0 and 13.0.0 (perhaps even earlier; the version 4.1.0
+   * is the earliest that is easily accessible).
+   */
+  def toLowerCase(locale: Locale): String = {
+    locale.getLanguage() match {
+      case "lt"        => toLowerCaseLithuanian()
+      case "tr" | "az" => toLowerCaseTurkishAndAzeri()
+      case _           => toLowerCase()
+    }
+  }
 
-  @inline
-  def toLowerCase(): _String = toCase(Character.toLowerCase)
+  private def toLowerCaseLithuanian(): String = {
+    /* Relevant excerpt from SpecialCasing.txt
+     *
+     * # Lithuanian
+     *
+     * # Lithuanian retains the dot in a lowercase i when followed by accents.
+     *
+     * [...]
+     *
+     * # Introduce an explicit dot above when lowercasing capital I's and J's
+     * # whenever there are more accents above.
+     * # (of the accents used in Lithuanian: grave, acute, tilde above, and ogonek)
+     *
+     * 0049; 0069 0307; 0049; 0049; lt More_Above; # LATIN CAPITAL LETTER I
+     * 004A; 006A 0307; 004A; 004A; lt More_Above; # LATIN CAPITAL LETTER J
+     * 012E; 012F 0307; 012E; 012E; lt More_Above; # LATIN CAPITAL LETTER I WITH OGONEK
+     * 00CC; 0069 0307 0300; 00CC; 00CC; lt; # LATIN CAPITAL LETTER I WITH GRAVE
+     * 00CD; 0069 0307 0301; 00CD; 00CD; lt; # LATIN CAPITAL LETTER I WITH ACUTE
+     * 0128; 0069 0307 0303; 0128; 0128; lt; # LATIN CAPITAL LETTER I WITH TILDE
+     */
+
+    /* Tests whether we are in an `More_Above` context.
+     * From Table 3.17 in the Unicode standard:
+     * - Description: C is followed by a character of combining class
+     *   230 (Above) with no intervening character of combining class 0 or
+     *   230 (Above).
+     * - Regex, after C: [^\p{ccc=230}\p{ccc=0}]*[\p{ccc=230}]
+     */
+    def moreAbove(i: Int): scala.Boolean = {
+      import Character._
+      val len = length()
+
+      @tailrec def loop(j: Int): scala.Boolean = {
+        if (j == len) {
+          false
+        } else {
+          val cp = this.codePointAt(j)
+          combiningClassNoneOrAboveOrOther(cp) match {
+            case CombiningClassIsNone  => false
+            case CombiningClassIsAbove => true
+            case _                     => loop(j + Character.charCount(cp))
+          }
+        }
+      }
+
+      loop(i + 1)
+    }
+    val preprocessed = replaceCharsAtIndex { i =>
+      (this.charAt(i): @switch) match {
+        case '\u0049' if moreAbove(i) => "\u0069\u0307"
+        case '\u004A' if moreAbove(i) => "\u006A\u0307"
+        case '\u012E' if moreAbove(i) => "\u012F\u0307"
+        case '\u00CC'                 => "\u0069\u0307\u0300"
+        case '\u00CD'                 => "\u0069\u0307\u0301"
+        case '\u0128'                 => "\u0069\u0307\u0303"
+        case _                        => null
+      }
+    }
+
+    preprocessed.toLowerCase()
+  }
+
+  private def toLowerCaseTurkishAndAzeri(): String = {
+    /* Relevant excerpt from SpecialCasing.txt
+     *
+     * # Turkish and Azeri
+     *
+     * # I and i-dotless; I-dot and i are case pairs in Turkish and Azeri
+     * # The following rules handle those cases.
+     *
+     * 0130; 0069; 0130; 0130; tr; # LATIN CAPITAL LETTER I WITH DOT ABOVE
+     * 0130; 0069; 0130; 0130; az; # LATIN CAPITAL LETTER I WITH DOT ABOVE
+     *
+     * # When lowercasing, remove dot_above in the sequence I + dot_above, which will turn into i.
+     * # This matches the behavior of the canonically equivalent I-dot_above
+     *
+     * 0307; ; 0307; 0307; tr After_I; # COMBINING DOT ABOVE
+     * 0307; ; 0307; 0307; az After_I; # COMBINING DOT ABOVE
+     *
+     * # When lowercasing, unless an I is before a dot_above, it turns into a dotless i.
+     *
+     * 0049; 0131; 0049; 0049; tr Not_Before_Dot; # LATIN CAPITAL LETTER I
+     * 0049; 0131; 0049; 0049; az Not_Before_Dot; # LATIN CAPITAL LETTER I
+     */
+
+    /* Tests whether we are in an `After_I` context.
+     * From Table 3.17 in the Unicode standard:
+     * - Description: There is an uppercase I before C, and there is no
+     *   intervening combining character class 230 (Above) or 0.
+     * - Regex, before C: [I]([^\p{ccc=230}\p{ccc=0}])*
+     */
+    def afterI(i: Int): scala.Boolean = {
+      val j = skipCharsWithCombiningClassOtherThanNoneOrAboveBackwards(i)
+      j > 0 && charAt(j - 1) == 'I'
+    }
+
+    /* Tests whether we are in an `Before_Dot` context.
+     * From Table 3.17 in the Unicode standard:
+     * - Description: C is followed by combining dot above (U+0307). Any
+     *   sequence of characters with a combining class that is neither 0 nor
+     *   230 may intervene between the current character and the combining dot
+     *   above.
+     * - Regex, after C: ([^\p{ccc=230}\p{ccc=0}])*[\u0307]
+     */
+    def beforeDot(i: Int): scala.Boolean = {
+      val j = skipCharsWithCombiningClassOtherThanNoneOrAboveForwards(i + 1)
+      j != length() && charAt(j) == '\u0307'
+    }
+
+    val preprocessed = replaceCharsAtIndex { i =>
+      (this.charAt(i): @switch) match {
+        case '\u0130'                  => "\u0069"
+        case '\u0307' if afterI(i)     => ""
+        case '\u0049' if !beforeDot(i) => "\u0131"
+        case _                         => null
+      }
+    }
+
+    preprocessed.toLowerCase()
+  }
+
+  @inline def toLowerCase(): _String = toCase(Character.toLowerCase)
 
   override def toString(): String = this
 
-  def toUpperCase(locale: Locale): _String = toCase(Character.toUpperCase)
+  // Ported from Scala.js, commit: ac38a148, dated: 2020-09-25
+  def toUpperCase(locale: Locale): String = {
+    locale.getLanguage() match {
+      case "lt"        => toUpperCaseLithuanian()
+      case "tr" | "az" => toUpperCaseTurkishAndAzeri()
+      case _           => toUpperCase()
+    }
+  }
 
-  @inline
-  def toUpperCase(): _String = toCase(Character.toUpperCase)
+  private def toUpperCaseLithuanian(): String = {
+    /* Relevant excerpt from SpecialCasing.txt
+     *
+     * # Lithuanian
+     *
+     * # Lithuanian retains the dot in a lowercase i when followed by accents.
+     *
+     * # Remove DOT ABOVE after "i" with upper or titlecase
+     *
+     * 0307; 0307; ; ; lt After_Soft_Dotted; # COMBINING DOT ABOVE
+     */
+
+    /* Tests whether we are in an `After_Soft_Dotted` context.
+     * From Table 3.17 in the Unicode standard:
+     * - Description: There is a Soft_Dotted character before C, with no
+     *   intervening character of combining class 0 or 230 (Above).
+     * - Regex, before C: [\p{Soft_Dotted}]([^\p{ccc=230} \p{ccc=0}])*
+     *
+     * According to https://unicode.org/Public/13.0.0/ucd/PropList.txt, there
+     * are 44 code points with the Soft_Dotted property. However,
+     * experimentation on the JVM reveals that the JDK (8 and 14 were tested)
+     * only recognizes 8 code points when deciding whether to remove the 0x0307
+     * code points. The following script reproduces the list:
+
+for (cp <- 0 to Character.MAX_CODE_POINT) {
+  val input = new String(Array(cp, 0x0307, 0x0301), 0, 3)
+  val output = input.toUpperCase(new java.util.Locale("lt"))
+  if (!output.contains('\u0307'))
+    println(cp.toHexString)
+}
+
+     */
+    def afterSoftDotted(i: Int): scala.Boolean = {
+      val j = skipCharsWithCombiningClassOtherThanNoneOrAboveBackwards(i)
+      j > 0 && (codePointBefore(j) match {
+        case 0x0069 | 0x006a | 0x012f | 0x0268 | 0x0456 | 0x0458 | 0x1e2d |
+            0x1ecb =>
+          true
+        case _ => false
+      })
+    }
+
+    val preprocessed = replaceCharsAtIndex { i =>
+      (this.charAt(i): @switch) match {
+        case '\u0307' if afterSoftDotted(i) => ""
+        case _                              => null
+      }
+    }
+
+    preprocessed.toUpperCase()
+  }
+
+  private def toUpperCaseTurkishAndAzeri(): String = {
+    /* Relevant excerpt from SpecialCasing.txt
+     *
+     * # Turkish and Azeri
+     *
+     * # When uppercasing, i turns into a dotted capital I
+     *
+     * 0069; 0069; 0130; 0130; tr; # LATIN SMALL LETTER I
+     * 0069; 0069; 0130; 0130; az; # LATIN SMALL LETTER I
+     */
+
+    val preprocessed = replaceCharsAtIndex { i =>
+      (this.charAt(i): @switch) match {
+        case '\u0069' => "\u0130"
+        case _        => null
+      }
+    }
+
+    preprocessed.toUpperCase()
+  }
+  @inline def toUpperCase(): _String = toCase(Character.toUpperCase)
 
   private[this] def toCase(convert: Int => Int): _String = {
     if (count == 0) return this
-    val buf = new StringBuilder(count)
+    val buf = new java.lang.StringBuilder(count)
     var i   = offset
     while (i < offset + count) {
       val high = value(i)
@@ -709,6 +947,76 @@ final class _String()
       }
     }
     buf.toString
+  }
+
+  /** Replaces special characters in this string (possibly in special contexts)
+   *  by dedicated strings.
+   *
+   *  This method encodes the general pattern of
+   *
+   *  - `toLowerCaseLithuanian()`
+   *  - `toLowerCaseTurkishAndAzeri()`
+   *  - `toUpperCaseLithuanian()`
+   *  - `toUpperCaseTurkishAndAzeri()`
+   *
+   *  @param replacementAtIndex
+   *    A function from index to `String | Null`, which should return a special
+   *    replacement string for the character at the given index, or `null` if
+   *    the character at the given index is not special.
+   */
+  @inline
+  private def replaceCharsAtIndex(replacementAtIndex: Int => String): String = {
+
+    var prep           = ""
+    val len            = this.length()
+    var i              = 0
+    var startOfSegment = 0
+
+    while (i != len) {
+      val replacement = replacementAtIndex(i)
+      if (replacement != null) {
+        prep += this.substring(startOfSegment, i)
+        prep += replacement
+        startOfSegment = i + 1
+      }
+      i += 1
+    }
+
+    if (startOfSegment == 0)
+      this // opt: no character needed replacing, directly return the original string
+    else
+      prep + this.substring(startOfSegment, i)
+  }
+
+  private def skipCharsWithCombiningClassOtherThanNoneOrAboveForwards(
+      i: Int): Int = {
+    // scalastyle:off return
+    import Character._
+    val len = length()
+    var j   = i
+    while (j != len) {
+      val cp = this.codePointAt(j)
+      if (combiningClassNoneOrAboveOrOther(cp) != CombiningClassIsOther)
+        return j
+      j += Character.charCount(cp)
+    }
+    j
+    // scalastyle:on return
+  }
+
+  private def skipCharsWithCombiningClassOtherThanNoneOrAboveBackwards(
+      i: Int): Int = {
+    // scalastyle:off return
+    import Character._
+    var j = i
+    while (j > 0) {
+      val cp = this.codePointBefore(j)
+      if (combiningClassNoneOrAboveOrOther(cp) != CombiningClassIsOther)
+        return j
+      j -= Character.charCount(cp)
+    }
+    0
+    // scalastyle:on return
   }
 
   def trim(): _String = {

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -980,8 +980,8 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
         if (prep == null) {
           prep = new java.lang.StringBuilder(len * 2)
         }
-        prep += this.substring(startOfSegment, i)
-        prep += replacement
+        prep.append(this.substring(startOfSegment, i))
+        prep.append(replacement)
         startOfSegment = i + 1
       }
       i += 1
@@ -990,7 +990,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     if (startOfSegment == 0)
       this // opt: no character needed replacing, directly return the original string
     else
-      prep + this.substring(startOfSegment, i)
+      prep.append(this.substring(startOfSegment, i)).toString
   }
 
   private def skipCharsWithCombiningClassOtherThanNoneOrAboveForwards(

--- a/unit-tests-ext/src/test/scala/java/lang/StringTestExt.scala
+++ b/unit-tests-ext/src/test/scala/java/lang/StringTestExt.scala
@@ -35,9 +35,16 @@ class StringTestEx {
       "PI\u0307JAMALI HASTA, YAĞIZ ŞOFÖRE ÇABUCAK GÜVENDI\u0307.".toLowerCase(
         Turkish))
 
+    println(-1)
+    "IÍÌĨİ".toLowerCase(English).foreach(x => println(Integer.toHexString(x)))
+    println("---")
+    "iíìĩi\u0307".foreach(x => println(Integer.toHexString(x)))
     assertEquals("iíìĩi\u0307", "IÍÌĨİ".toLowerCase(English))
+    println(0)
     assertEquals("ıíìĩi", "IÍÌĨİ".toLowerCase(Turkish))
+    println(1)
     assertEquals("ıíìĩi", "IÍÌĨİ".toLowerCase(Azeri))
+    println(2)
     assertEquals("ii\u0307\u0301i\u0307\u0300i\u0307\u0303i\u0307",
                  "IÍÌĨİ".toLowerCase(Lithuanian))
   }

--- a/unit-tests-ext/src/test/scala/java/lang/StringTestExt.scala
+++ b/unit-tests-ext/src/test/scala/java/lang/StringTestExt.scala
@@ -2,16 +2,17 @@
 package java.lang
 
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Ignore, Test}
 import java.util.Locale
 
 /** Additional tests for java.lang.String that require `java.util.Locale`. */
-class StringTestEx {
+class StringTestExt {
   val English    = new Locale("en")
   val Lithuanian = new Locale("lt")
   val Turkish    = new Locale("tr")
   val Azeri      = new Locale("Az") // randomly test the lowercase normalization
 
+  @Ignore("Handling of special, non-locale-dependant cases not implemented")
   @Test def testToLowerCaseWithLocale(): Unit = {
     assertEquals("title", "TITLE".toLowerCase(English))
     assertEquals("title", "TITLE".toLowerCase(Lithuanian))

--- a/unit-tests-ext/src/test/scala/java/lang/StringTestExt.scala
+++ b/unit-tests-ext/src/test/scala/java/lang/StringTestExt.scala
@@ -35,16 +35,9 @@ class StringTestEx {
       "PI\u0307JAMALI HASTA, YAĞIZ ŞOFÖRE ÇABUCAK GÜVENDI\u0307.".toLowerCase(
         Turkish))
 
-    println(-1)
-    "IÍÌĨİ".toLowerCase(English).foreach(x => println(Integer.toHexString(x)))
-    println("---")
-    "iíìĩi\u0307".foreach(x => println(Integer.toHexString(x)))
     assertEquals("iíìĩi\u0307", "IÍÌĨİ".toLowerCase(English))
-    println(0)
     assertEquals("ıíìĩi", "IÍÌĨİ".toLowerCase(Turkish))
-    println(1)
     assertEquals("ıíìĩi", "IÍÌĨİ".toLowerCase(Azeri))
-    println(2)
     assertEquals("ii\u0307\u0301i\u0307\u0300i\u0307\u0303i\u0307",
                  "IÍÌĨİ".toLowerCase(Lithuanian))
   }

--- a/unit-tests-ext/src/test/scala/java/lang/StringTestExt.scala
+++ b/unit-tests-ext/src/test/scala/java/lang/StringTestExt.scala
@@ -1,0 +1,168 @@
+// Ported from Scala.js, commit: ac38a148, dated: 2020-09-25
+package java.lang
+
+import org.junit.Assert._
+import org.junit.Test
+import java.util.Locale
+
+/** Additional tests for java.lang.String that require `java.util.Locale`. */
+class StringTestEx {
+  val English    = new Locale("en")
+  val Lithuanian = new Locale("lt")
+  val Turkish    = new Locale("tr")
+  val Azeri      = new Locale("Az") // randomly test the lowercase normalization
+
+  @Test def testToLowerCaseWithLocale(): Unit = {
+    assertEquals("title", "TITLE".toLowerCase(English))
+    assertEquals("title", "TITLE".toLowerCase(Lithuanian))
+    assertEquals("tıtle", "TITLE".toLowerCase(Turkish))
+    assertEquals("tıtle", "TITLE".toLowerCase(Azeri))
+
+    // Incurving fencer sword sparkled and perforated a round watermelon
+    assertEquals(
+      "įlinkdama fechtuotojo špaga sublykčiojusi pragręžė apvalų arbūzą",
+      "ĮLINKDAMA FECHTUOTOJO ŠPAGA SUBLYKČIOJUSI PRAGRĘŽĖ APVALŲ ARBŪZĄ"
+        .toLowerCase(Lithuanian)
+    )
+
+    // Patient with pajamas, trusted swarthy driver quickly
+    assertEquals(
+      "pijamalı hasta, yağız şoföre çabucak güvendi.",
+      "PİJAMALI HASTA, YAĞIZ ŞOFÖRE ÇABUCAK GÜVENDİ.".toLowerCase(Turkish))
+    // same, with combining marks for the dotted Is
+    assertEquals(
+      "pijamalı hasta, yağız şoföre çabucak güvendi.",
+      "PI\u0307JAMALI HASTA, YAĞIZ ŞOFÖRE ÇABUCAK GÜVENDI\u0307.".toLowerCase(
+        Turkish))
+
+    println(-1)
+    "IÍÌĨİ".toLowerCase(English).foreach(x => println(Integer.toHexString(x)))
+    println("---")
+    "iíìĩi\u0307".foreach(x => println(Integer.toHexString(x)))
+    assertEquals("iíìĩi\u0307", "IÍÌĨİ".toLowerCase(English))
+    println(0)
+    assertEquals("ıíìĩi", "IÍÌĨİ".toLowerCase(Turkish))
+    println(1)
+    assertEquals("ıíìĩi", "IÍÌĨİ".toLowerCase(Azeri))
+    println(2)
+    assertEquals("ii\u0307\u0301i\u0307\u0300i\u0307\u0303i\u0307",
+                 "IÍÌĨİ".toLowerCase(Lithuanian))
+  }
+
+  @Test def testToLowerCaseWithLocale_CornerCasesFor_Lithuanian(): Unit = {
+    // All the characters with an unconditional special translation
+    assertEquals("i\u0307\u0300 i\u0307\u0300a\u033D",
+                 "\u00CC \u00CCA\u033D".toLowerCase(Lithuanian))
+    assertEquals("i\u0307\u0301 i\u0307\u0301a\u033D",
+                 "\u00CD \u00CDA\u033D".toLowerCase(Lithuanian))
+    assertEquals("i\u0307\u0303 i\u0307\u0303a\u033D",
+                 "\u0128 \u0128A\u033D".toLowerCase(Lithuanian))
+
+    // All the characters with a special translation with More_Above
+    assertEquals("i\u0307\u033D ia\u033D",
+                 "I\u033D IA\u033D".toLowerCase(Lithuanian))
+    assertEquals("j\u0307\u033D ja\u033D",
+                 "J\u033D JA\u033D".toLowerCase(Lithuanian))
+    assertEquals("\u012F\u0307\u033D \u012Fa\u033D",
+                 "\u012E\u033D \u012EA\u033D".toLowerCase(Lithuanian))
+
+    // Can put another combining mark before the Above
+    assertEquals("i\u0307\u0315\u033D i\u0315a\u033D",
+                 "I\u0315\u033D I\u0315A\u033D".toLowerCase(Lithuanian))
+    assertEquals(
+      "i\u0307\uD834\uDD7C\u033D i\uD834\uDD7Ca\u033D",
+      "I\uD834\uDD7C\u033D I\uD834\uDD7CA\u033D".toLowerCase(Lithuanian)
+    ) // 1D17C
+
+    // But combining marks with combining class 0 will cut the link
+    assertEquals("i\u034f\u033D", "I\u034f\u033D".toLowerCase(Lithuanian))
+    assertEquals("i\uD804\uDC00\u033D",
+                 "I\uD804\uDC00\u033D".toLowerCase(Lithuanian)) // 11000
+  }
+
+  @Test def testToLowerCaseWithLocale_CornerCasesFor_TurkishAndAzeri(): Unit = {
+    // Can put another combining mark between I and 0307, as long as its class is not Above
+    assertEquals("i\u0315", "I\u0315\u0307".toLowerCase(Turkish))
+    assertEquals("i\uD834\uDD7C",
+                 "I\uD834\uDD7C\u0307".toLowerCase(Turkish)) // 1D17C
+
+    // But other Above combining marks will cut the link
+    assertEquals("ı\u033D\u0307", "I\u033D\u0307".toLowerCase(Turkish))
+    assertEquals("ı\uD834\uDD85\u0307",
+                 "I\uD834\uDD85\u0307".toLowerCase(Turkish)) // 1D185
+
+    // Even combining marks with combining class 0 will cut the link
+    assertEquals("ı\u034f\u0307", "I\u034f\u0307".toLowerCase(Turkish))
+    assertEquals("ı\uD804\uDC00\u0307",
+                 "I\uD804\uDC00\u0307".toLowerCase(Turkish)) // 11000
+  }
+
+  @Test def testToUpperCaseWithLocale(): Unit = {
+    // Incurving fencer sword sparkled and perforated a round watermelon
+    assertEquals(
+      "ĮLINKDAMA FECHTUOTOJO ŠPAGA SUBLYKČIOJUSI PRAGRĘŽĖ APVALŲ ARBŪZĄ",
+      "įlinkdama fechtuotojo špaga sublykčiojusi pragręžė apvalų arbūzą"
+        .toUpperCase(Lithuanian)
+    )
+
+    // Patient with pajamas, trusted swarthy driver quickly
+    assertEquals(
+      "PİJAMALI HASTA, YAĞIZ ŞOFÖRE ÇABUCAK GÜVENDİ.",
+      "pijamalı hasta, yağız şoföre çabucak güvendi.".toUpperCase(Turkish))
+
+    assertEquals(
+      "IÍÌĨI I\u0307\u0301I\u0307\u0300I\u0307\u0303I\u0307",
+      "iíìĩı i\u0307\u0301i\u0307\u0300i\u0307\u0303i\u0307".toUpperCase(
+        English))
+    assertEquals(
+      "İÍÌĨI İ\u0307\u0301İ\u0307\u0300İ\u0307\u0303İ\u0307",
+      "iíìĩı i\u0307\u0301i\u0307\u0300i\u0307\u0303i\u0307".toUpperCase(
+        Turkish))
+    assertEquals(
+      "İÍÌĨI İ\u0307\u0301İ\u0307\u0300İ\u0307\u0303İ\u0307",
+      "iíìĩı i\u0307\u0301i\u0307\u0300i\u0307\u0303i\u0307".toUpperCase(Azeri))
+    assertEquals(
+      "IÍÌĨI I\u0301I\u0300I\u0303I",
+      "iíìĩı i\u0307\u0301i\u0307\u0300i\u0307\u0303i\u0307".toUpperCase(
+        Lithuanian))
+  }
+
+  @Test def testToUpperCaseWithLocale_CornerCasesFor_Lithuanian(): Unit = {
+    // More characters with the Soft_Dotted property
+    assertEquals(
+      "J\u0301J\u0300J\u0303J",
+      "j\u0307\u0301j\u0307\u0300j\u0307\u0303j\u0307".toUpperCase(Lithuanian))
+    assertEquals(
+      "\u1E2C\u0301\u1E2C\u0300\u1E2C\u0303\u1E2C",
+      "\u1E2D\u0307\u0301\u1E2D\u0307\u0300\u1E2D\u0307\u0303\u1E2D\u0307"
+        .toUpperCase(Lithuanian))
+
+    // This does not seem compliant to the spec to me, but that's what the JVM gives
+    assertEquals(
+      "\u1D96\u0307\u0301\u1D96\u0307\u0300\u1D96\u0307\u0303\u1D96\u0307",
+      "\u1D96\u0307\u0301\u1D96\u0307\u0300\u1D96\u0307\u0303\u1D96\u0307"
+        .toUpperCase(Lithuanian)
+    )
+
+    // Can put another combining mark before the 0307, as long as its class is not Above
+    assertEquals("I\u0315\u0301", "i\u0315\u0307\u0301".toUpperCase(Lithuanian))
+    assertEquals("I\u031A\u0301", "i\u031A\u0307\u0301".toUpperCase(Lithuanian))
+    assertEquals("I\u033C\u0301", "i\u033C\u0307\u0301".toUpperCase(Lithuanian))
+    assertEquals("I\uD834\uDD7C\u0301",
+                 "i\uD834\uDD7C\u0307\u0301".toUpperCase(Lithuanian)) // 1D17C
+
+    // But other Above combining marks will cut the link
+    assertEquals("I\u033D\u0307\u0301",
+                 "i\u033D\u0307\u0301".toUpperCase(Lithuanian))
+    assertEquals("I\u0346\u0307\u0301",
+                 "i\u0346\u0307\u0301".toUpperCase(Lithuanian))
+    assertEquals("I\uD834\uDD85\u0307\u0301",
+                 "i\uD834\uDD85\u0307\u0301".toUpperCase(Lithuanian)) // 1D185
+
+    // Even combining marks with combining class 0 will cut the link
+    assertEquals("I\u034f\u0307\u0301",
+                 "i\u034f\u0307\u0301".toUpperCase(Lithuanian))
+    assertEquals("I\uD804\uDC00\u0307\u0301",
+                 "i\uD804\uDC00\u0307\u0301".toUpperCase(Lithuanian)) // 1D185
+  }
+}

--- a/unit-tests-ext/src/test/scala/java/util/FormatterTestEx.scala
+++ b/unit-tests-ext/src/test/scala/java/util/FormatterTestEx.scala
@@ -3,9 +3,8 @@
 package java.util
 
 import java.math.BigInteger
-import org.junit.{Ignore, Test}
+import org.junit.Test
 import org.junit.Assert._
-import org.junit.Assume._
 
 /** Additional tests for java.lang.String that require `java.util.Locale`
  *  as well as classes in `java.text.*`.
@@ -103,7 +102,6 @@ class FormatterTestEx {
     assertF(HindiWithDevanagariDigits, "-14", "%o", new BigInteger("-12"))
   }
 
-  @Ignore("localized to{Lower, Upper}Case not implemented")
   @Test def testFormatTurkish(): Unit = {
     // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE
     assertF(Turkish, "TİTLE", "%S", "title")

--- a/unit-tests-ext/src/test/scala/java/util/LocaleTest.scala
+++ b/unit-tests-ext/src/test/scala/java/util/LocaleTest.scala
@@ -1,0 +1,43 @@
+// Ported from Scala.js, commit: ac38a148, dated: 2020-09-25
+package java.util
+
+import org.junit.Assert._
+import org.junit.Test
+
+/** Sanity tests for the dummy implemenation of `java.util.Locale`.
+ *
+ *  These tests ensure that our dummy implementation of `java.util.Locale`
+ *  behaves in an appropriate way. We only test specific behaviors that can
+ *  cause tests to "fail to fail" if they are not respected.
+ */
+class LocaleTest {
+  @Test def testLanguageIsNormalizedLowerCase(): Unit = {
+    /* Our implementations of `String.toLowerCase(locale: Locale)` and
+     * `String.toUpperCase(locale: Locale)` assume that the result of
+     * `locale.getLanguage()` is always all-lowercase.
+     * This test makes sure that this is indeed the case.
+     */
+
+    assertEquals("lt", new Locale("lt").getLanguage())
+    assertEquals("lt", new Locale("LT").getLanguage())
+    assertEquals("lt", new Locale("lT").getLanguage())
+    assertEquals("lt", new Locale("Lt").getLanguage())
+
+    assertEquals("tr", new Locale("tr").getLanguage())
+    assertEquals("tr", new Locale("TR").getLanguage())
+    assertEquals("tr", new Locale("tR").getLanguage())
+    assertEquals("tr", new Locale("Tr").getLanguage())
+
+    assertEquals("az", new Locale("az").getLanguage())
+    assertEquals("az", new Locale("AZ").getLanguage())
+    assertEquals("az", new Locale("aZ").getLanguage())
+    assertEquals("az", new Locale("Az").getLanguage())
+
+    // The normalization itself is locale-insensitive
+    // This was locally tested with a JVM configured in Turkish
+    assertEquals("it", new Locale("it").getLanguage())
+    assertEquals("it", new Locale("IT").getLanguage())
+    assertEquals("it", new Locale("iT").getLanguage())
+    assertEquals("it", new Locale("It").getLanguage())
+  }
+}

--- a/unit-tests/src/test/scala/java/lang/StringTest.scala
+++ b/unit-tests/src/test/scala/java/lang/StringTest.scala
@@ -408,7 +408,6 @@ class StringTest {
         .subSequence(4, 16)
         .toString
         .toUpperCase equals "SCALA NATIVE")
-    assertEquals("DΣΣ AΣΣ BΣC", "dσς aσς bσc".toUpperCase)
   }
 
   @Test def toLowerCase(): Unit = {
@@ -424,23 +423,5 @@ class StringTest {
         .subSequence(4, 16)
         .toString
         .toLowerCase equals "scala native")
-  }
-
-  @Test def toLowerCaseSpecialCases(): Unit = {
-    assertEquals("iíìĩi\u0307", "IÍÌĨİ".toLowerCase())
-
-    /* Greek lower letter sigma exists in two forms:
-     * \u03c3 'σ' - is standard lower case variant
-     * \u03c2 'ς' - is used when it's final cased character in given word
-     */
-    assertEquals("dς", "DΣ".toLowerCase())
-    assertEquals("dσς aσς bσc", "DΣΣ AΣΣ BΣC".toLowerCase())
-    assertEquals("dσσa", "DΣΣA".toLowerCase())
-    // \u02B9 is not cased character
-    assertEquals("dσ\u02B9\u02B9ς\u02B9\u02B9",
-                 "DΣ\u02B9\u02B9Σ\u02B9\u02B9".toLowerCase)
-    assertEquals("dσ\u02B9\u02B9σ\u02B9\u02B9z",
-                 "DΣ\u02B9\u02B9Σ\u02B9\u02B9Z".toLowerCase)
-
   }
 }

--- a/unit-tests/src/test/scala/java/lang/StringTest.scala
+++ b/unit-tests/src/test/scala/java/lang/StringTest.scala
@@ -408,6 +408,7 @@ class StringTest {
         .subSequence(4, 16)
         .toString
         .toUpperCase equals "SCALA NATIVE")
+    assertEquals("DΣΣ AΣΣ BΣC", "dσς aσς bσc".toUpperCase)
   }
 
   @Test def toLowerCase(): Unit = {
@@ -423,5 +424,23 @@ class StringTest {
         .subSequence(4, 16)
         .toString
         .toLowerCase equals "scala native")
+  }
+
+  @Test def toLowerCaseSpecialCases(): Unit = {
+    assertEquals("iíìĩi\u0307", "IÍÌĨİ".toLowerCase())
+
+    /* Greek lower letter sigma exists in two forms:
+     * \u03c3 'σ' - is standard lower case variant
+     * \u03c2 'ς' - is used when it's final cased character in given word
+     */
+    assertEquals("dς", "DΣ".toLowerCase())
+    assertEquals("dσς aσς bσc", "DΣΣ AΣΣ BΣC".toLowerCase())
+    assertEquals("dσσa", "DΣΣA".toLowerCase())
+    // \u02B9 is not cased character
+    assertEquals("dσ\u02B9\u02B9ς\u02B9\u02B9",
+                 "DΣ\u02B9\u02B9Σ\u02B9\u02B9".toLowerCase)
+    assertEquals("dσ\u02B9\u02B9σ\u02B9\u02B9z",
+                 "DΣ\u02B9\u02B9Σ\u02B9\u02B9Z".toLowerCase)
+
   }
 }


### PR DESCRIPTION
This PR ports localized methods `String.toLowerCase` and `String.toUpperCase` from Scala.js along with needed changes in `java.lang.Character`. 
It was additionally extended to handle 2 corner cases inside `toLowerCase`: 
* Greek capital letter sigma  &#x03A3; `\u03A3` being last cased letter in word - normally it's mapped to &#x03c3;  `\u03C3`, but if it's last cased letter it should be &#x03c2; `\u03C2`
* Lating capital letter I wth dot above &#x0130;  `\u0130` - it should be mapped to two chars: &#x0069; `\u0069` and  &#x0307;  `\u0307`. 
This handling was needed only in ScalaNative, as it is nativly supported in JS