### PR TITLE
Fix #1623: Fix an infinite loop in j.i.RandomAccessFile#readLine

### DIFF
--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -1,5 +1,7 @@
 package java.io
 
+import java.{lang => jl}
+
 import scalanative.unsafe.{toCString, Zone}
 import scalanative.libc.stdio
 import scalanative.posix.{fcntl, unistd}
@@ -83,7 +85,7 @@ class RandomAccessFile private (file: File,
     if (pos >= end) {
       null // JDK 8 specification requires null here.
     } else {
-      val builder = new StringBuilder
+      val builder = new jl.StringBuilder
       var done    = false
 
       while (!done && (pos < end)) {

--- a/unit-tests/src/test/scala/java/io/RandomAccessFileTest.scala
+++ b/unit-tests/src/test/scala/java/io/RandomAccessFileTest.scala
@@ -102,23 +102,23 @@ class RandomAccessFileTest {
 
   @Test def canWriteAndReadLineWithTerminatorLf(): Unit = {
     val line = "Hello, world!"
-    raf.writeChars(line + '\n')
+    raf.writeBytes(line + '\n')
     raf.seek(0)
-    assertTrue(raf.readLine() == line)
+    assertEquals(line, raf.readLine())
   }
 
   @Test def canWriteAndReadLineWithTerminatorCr(): Unit = {
     val line = "Hello, world!"
-    raf.writeChars(line + '\r')
+    raf.writeBytes(line + '\r')
     raf.seek(0)
-    assertTrue(raf.readLine() == line)
+    assertEquals(line, raf.readLine())
   }
 
   @Test def canWriteAndReadLineWithTerminatorCrLf(): Unit = {
     val line = "Hello, world!"
-    raf.writeChars(line + "\r\n")
+    raf.writeBytes(line + "\r\n")
     raf.seek(0)
-    assertTrue(raf.readLine() == line)
+    assertEquals(line, raf.readLine())
   }
 
   @Test def canWriteAndReadLong(): Unit = {


### PR DESCRIPTION
We correct the condition which lead to an infinite loop. 
Previously, two-byte Chars were being used where 1-byte Bytes
should have been.

This PR updates and supersedes now closed PR #1624. The latter
has extensive notes which may aid future developers.