### PR TITLE
Fix warnings for doc generation

### DIFF
--- a/docs/blog/index.rst
+++ b/docs/blog/index.rst
@@ -1,4 +1,4 @@
-.. _tech:
+.. _blog:
 
 Blog
 ====
@@ -7,4 +7,3 @@ Blog
   :maxdepth: 2
 
   interflow
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,22 +29,19 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+# recommonmark provides support for '.md' files
+extensions = ['recommonmark']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-#
-# source_suffix = ['.rst', '.md']
-from recommonmark.parser import CommonMarkParser
-
-source_parsers = {
-  '.md': CommonMarkParser,
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.txt': 'markdown',
+    '.md': 'markdown',
 }
-
-source_suffix = ['.rst', '.md']
 
 # The encoding of source files.
 #
@@ -351,5 +348,3 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #
 # texinfo_no_detailmenu = False
-
-


### PR DESCRIPTION
I also needed to upgrade `recommonmark` to `0.7.1` but I installed it quite some time ago.
```
pip install --upgrade recommonmark
```