### PR TITLE
Fix #1590: Correct j.i.DataInputStream EOF handling & skipBytes

### DIFF
--- a/javalib/src/main/scala/java/io/DataInputStream.scala
+++ b/javalib/src/main/scala/java/io/DataInputStream.scala
@@ -1,8 +1,30 @@
 package java.io
 
+import java.nio.ByteBuffer
+import scalanative.unsafe.sizeof
+
 class DataInputStream(in: InputStream)
     extends FilterInputStream(in)
     with DataInput {
+  // Design notes:
+  //   1) Using ByteBuffer.get* methods results in a slightly longer code
+  //      path than open coding BigEndian byte order, bit shifts, and
+  //      logical Ors. This approach greatly simplifies the code and makes
+  //      it easier to trace; increasing the likelihood of correctness.
+  //
+  //   2) Both the Java 8 and 15 APIs describe the methods of this class
+  //      as only optionally thread-safe and requiring external
+  //      synchronization. A buffer per instance does not introduce a
+  //      concern.
+  private final val inBasket  = new Array[Byte](sizeof[Long].toInt)
+  private final val outBasket = ByteBuffer.wrap(inBasket) // default: BigEndian
+
+  private final def rebuffer(n: Int): ByteBuffer = {
+    if (in.read(inBasket, 0, n) < n)
+      throw new java.io.EOFException
+    outBasket.clear() // tricky here: contents preserved, bookkeeping reset.
+  }
+
   // Notes on End of File (EOF) handling.
   //
   // The Java 8 API describes/defines the first two read routines as returning
@@ -20,35 +42,24 @@ class DataInputStream(in: InputStream)
   override final def readBoolean(): Boolean =
     readByte() != 0
 
-  override final def readByte(): Byte = {
-    val v = in.read()
-
-    if (v == -1)
-      throw new EOFException
-
-    v.toByte
-  }
+  override final def readByte(): Byte =
+    rebuffer(sizeof[Byte].toInt).get()
 
   override final def readChar(): Char =
-    readUnsignedShort().asInstanceOf[Char]
+    rebuffer(sizeof[Char].toInt).getChar()
 
-  override final def readDouble(): Double = {
-    val long = readLong()
-    java.lang.Double.longBitsToDouble(long)
-  }
+  override final def readDouble(): Double =
+    rebuffer(sizeof[Double].toInt).getDouble()
 
-  override final def readFloat(): Float = {
-    val int = readInt()
-    java.lang.Float.intBitsToFloat(int)
-  }
+  override final def readFloat(): Float =
+    rebuffer(sizeof[Float].toInt).getFloat()
 
   override final def readFully(b: Array[Byte]): Unit =
     readFully(b, 0, b.length)
 
   override final def readFully(b: Array[Byte], off: Int, len: Int): Unit = {
-    if (b == null) {
+    if (b == null)
       throw new NullPointerException
-    }
 
     // Use the same message texts as the JVM for all 3 cases. Yes, 3rd differs.
     if ((off < 0) || ((off + len) > b.length)) {
@@ -57,9 +68,8 @@ class DataInputStream(in: InputStream)
       throw new IndexOutOfBoundsException(msg)
     }
 
-    if (len < 0) {
+    if (len < 0)
       throw new IndexOutOfBoundsException()
-    }
 
     var offset = off
     var length = len
@@ -76,10 +86,8 @@ class DataInputStream(in: InputStream)
     }
   }
 
-  override final def readInt(): Int = {
-    val b1, b2, b3, b4 = readUnsignedByte()
-    (b1 << 24) | (b2 << 16) + (b3 << 8) + b4
-  }
+  override final def readInt(): Int =
+    rebuffer(sizeof[Int].toInt).getInt()
 
   @deprecated("BufferedReader.readLine() is preferred", "JDK 1.1")
   override final def readLine(): String = {
@@ -101,31 +109,17 @@ class DataInputStream(in: InputStream)
       builder.toString
     }
   }
+  override final def readLong(): Long =
+    rebuffer(sizeof[Long].toInt).getLong()
 
-  override final def readLong(): Long = {
-    val b1, b2, b3, b4, b5, b6, b7, b8 = readUnsignedByte()
-    (b1.toLong << 56) + (b2.toLong << 48) +
-      (b3.toLong << 40) + (b4.toLong << 32) +
-      (b5.toLong << 24) + (b6.toLong << 16) +
-      (b7.toLong << 8) + b8
-  }
+  override final def readShort(): Short =
+    rebuffer(sizeof[Short].toInt).getShort()
 
-  override final def readShort(): Short = {
-    val b1, b2 = readUnsignedByte()
-    ((b1 << 8) | b2).asInstanceOf[Short]
-  }
-
-  // The obvious & wrong implementation using (an implied) toInt does sign
-  // extension: Char 255 wrongly becomes -1, high bytes set.
-  // The bitwise "and" here does the required conversion to Int with high bytes
-  // clear, returning a true char 255.
   override final def readUnsignedByte(): Int =
     readByte() & 0xFF
 
-  override final def readUnsignedShort(): Int = {
-    val b1, b2 = readUnsignedByte()
-    (b1 << 8) | b2
-  }
+  override final def readUnsignedShort(): Int =
+    rebuffer(sizeof[Short].toInt).getShort() & 0xFFFF
 
   override final def readUTF(): String =
     DataInputStream.readUTF(this)

--- a/javalib/src/main/scala/java/io/DataInputStream.scala
+++ b/javalib/src/main/scala/java/io/DataInputStream.scala
@@ -81,7 +81,7 @@ class DataInputStream(in: InputStream)
     (b1 << 24) | (b2 << 16) + (b3 << 8) + b4
   }
 
-  @deprecated
+  @deprecated("BufferedReader.readLine() is preferred", "JDK 1.1")
   override final def readLine(): String = {
     var v = in.read()
     if (v == -1) null

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/NativeRPC.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/NativeRPC.scala
@@ -26,13 +26,10 @@ private[testinterface] class NativeRPC(clientSocket: Socket) extends RPCCore {
         inStream.readInt()
       } catch {
         case _: EOFException => 0 // leave loop
-        case throwable: Throwable =>
-          System.err.println(s"NativeRPC loop failed: $throwable")
-          -1
       }
 
     if (msgLength <= 0) {
-      msgLength
+      0 // Always 0, all errors reported by Exception.
     } else {
       val msg = Array.fill(msgLength)(inStream.readChar).mkString
       handleMessage(msg)

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/NativeRPC.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/NativeRPC.scala
@@ -1,6 +1,6 @@
 package scala.scalanative.testinterface
 
-import java.io.{DataInputStream, DataOutputStream}
+import java.io.{DataInputStream, DataOutputStream, EOFException}
 import java.net.Socket
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -21,28 +21,23 @@ private[testinterface] class NativeRPC(clientSocket: Socket) extends RPCCore {
 
   @tailrec
   private[testinterface] final def loop(): Int = {
-    def tryRead: Try[Boolean] = Try {
-      val msgLength = inStream.readInt()
-
-      /**
-       * Current implementation of DataInputStream does not check for EOF,
-       * in this case we need to follow up base `read` behaviour which is returning -1 value to signal EOF
-       * TODO Fix this after merging changes due to #1868
-       */
-      if (msgLength < 0) true
-      else {
-        val msg = Array.fill(msgLength)(inStream.readChar).mkString
-        handleMessage(msg)
-        scalanative.runtime.loop()
-        false
+    val msgLength =
+      try {
+        inStream.readInt()
+      } catch {
+        case _: EOFException => 0 // leave loop
+        case throwable: Throwable =>
+          System.err.println(s"NativeRPC loop failed: $throwable")
+          -1
       }
-    }
 
-    tryRead match {
-      case Success(isEOF) => if (isEOF) 0 else loop()
-      case Failure(exception) =>
-        System.err.println(s"NativeRPC loop failed: $exception")
-        -1
+    if (msgLength <= 0) {
+      msgLength
+    } else {
+      val msg = Array.fill(msgLength)(inStream.readChar).mkString
+      handleMessage(msg)
+      scalanative.runtime.loop()
+      loop()
     }
   }
 }

--- a/unit-tests/src/test/scala/java/io/DataInputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/DataInputStreamTest.scala
@@ -627,7 +627,7 @@ class DataInputStreamTest {
     assertEquals(expected, dis.readShort())
   }
 
-  // readnUsignedShort
+  // readUnsignedShort
   @Test def readUnsignedShortEndOfFile(): Unit = {
     // readUnsignedShort expects to read 2 bytes, cause EOF by providing 1.
     val inputArray = Array[Byte](0x97.toByte)

--- a/unit-tests/src/test/scala/java/io/DataInputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/DataInputStreamTest.scala
@@ -5,12 +5,306 @@ import org.junit.Assert._
 
 import scalanative.junit.utils.AssertThrows._
 
+import scalanative.unsafe.sizeof
+
 class DataInputStreamTest {
+  // read() is inherited from the underlying InputStream. It is not a method
+  // implemented in DIS. Since the internals of DIS use in.read(), test
+  // the method here. Detect defects as close to the cause as feasible.
+
+  @Test def readNoArgEndOfFile(): Unit = {
+    val expected   = 98 // ASCII 'b'
+    val inputArray = Array[Byte](expected.toByte)
+    val iaLength   = 0
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    val buffer = new Array[Byte](inputArray.length)
+
+    assertEquals(-1, dis.read())
+  }
+
+  @Test def readNoArgByte255(): Unit = {
+    val expected   = 255 // ASCII nbsp, particularly troublesome
+    val inputArray = Array[Byte](expected.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    // 255 is ASCII nbsp, a particularly troublesome case.
+    assertEquals(255, dis.read())
+  }
+
+  // read(b)
+
+  @Test def readBufEndOfFile(): Unit = {
+    val expected = 99.toByte // ASCII 'c'
+
+    val inputArray = Array[Byte](expected)
+    val iaLength   = 0
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    val buffer = new Array[Byte](inputArray.length)
+
+    assertEquals(-1, dis.read(buffer))
+  }
+
+  @Test def readBuf(): Unit = {
+    val expected       = "Blue eyes crying in the rain".getBytes
+    val expectedLength = expected.length
+
+    val arrayIn = new ByteArrayInputStream(expected, 0, expectedLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    val buffer = new Array[Byte](expectedLength)
+
+    assertEquals(expectedLength, dis.read(buffer))
+
+    for (i <- 0 until expectedLength) {
+      assertEquals(expected(i), buffer(i))
+    }
+  }
+
+  // read(b, off, len)
+
+  @Test def readBufOffLenEndOfFile(): Unit = {
+    val expected   = 100 // ASCII 'd'
+    val inputArray = Array[Byte](expected.toByte)
+    val iaLength   = 0
+
+    val buffer = new Array[Byte](inputArray.length)
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(-1, dis.read(buffer, 0, 1))
+  }
+
+  @Test def readBufOffLen(): Unit = {
+    val off = 10
+    val len = 3
+
+    val text       = "Fido is a cat, not a goat!"
+    val textBytes  = text.getBytes
+    val textLength = textBytes.length
+
+    val dog       = "dog"
+    val dogBytes  = dog.getBytes
+    val dogLength = dogBytes.length
+
+    val expected       = text.replace("cat", "dog")
+    val expectedBytes  = expected.getBytes
+    val expectedLength = expectedBytes.length
+
+    val arrayIn = new ByteArrayInputStream(dogBytes, 0, dogLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    val buffer = textBytes
+
+    assertEquals(len, dis.read(buffer, off, len))
+
+    for (i <- 0 until expectedLength) {
+      assertEquals(expectedBytes(i), buffer(i))
+    }
+  }
+
+  // readByte
+
+  @Test def readByteEOF(): Unit = {
+    val expected   = 101.toByte // ASCII 'e'
+    val inputArray = Array[Byte](expected)
+    val iaLength   = 0
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], dis.readByte())
+  }
+
+  @Test def readByte(): Unit = {
+    val expected   = 102.toByte // ASCII 'f'
+    val inputArray = Array[Byte](expected)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(expected, dis.readByte())
+  }
+
+  // readBoolean
+
+  @Test def readBooleanEOF(): Unit = {
+    val expected   = 0.toByte
+    val inputArray = Array[Byte](expected)
+    val iaLength   = 0
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], dis.readBoolean())
+  }
+
+  @Test def readBooleanFalse(): Unit = {
+    val inputArray = Array[Byte](0.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(false, dis.readBoolean())
+  }
+
+  @Test def readBooleanTrue(): Unit = {
+    val inputArray = Array[Byte](1.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(true, dis.readBoolean())
+  }
+
+  // readUnsignedByte
+
+  @Test def readUnsignedByteEndOfFile(): Unit = {
+    val expected   = 255.toByte // ASCII nbsp
+    val inputArray = Array[Byte](expected)
+    val iaLength   = 0
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], dis.readUnsignedByte())
+  }
+
+  @Test def readUnsignedByteByte255(): Unit = {
+    // Broken implementations of readUnsignedByte will report character
+    // 255 as -1, high bytes set, not required 255, high bytes clear.
+    val expected   = 255 // ASCII nbsp
+    val inputArray = Array[Byte](expected.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(expected, dis.readUnsignedByte())
+  }
+
+  // readChar
+
+  @Test def readCharEOF(): Unit = {
+    // readChar expects to read 2 bytes, cause EOF by providing only 1.
+    val inputArray = Array[Byte](0x97.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], dis.readChar())
+  }
+
+  @Test def readChar(): Unit = {
+    // Java is reading Big Endian (high byte first) UTF-16.
+    //
+    // Beware: The attractive Character.getBytes apparently returns
+    // modified UTF-8.
+    //
+    // Helpful Unicode URL: https://unicode-table.com/en/03D5/
+
+    // Greek phi symbol U+03D5 is a Java Character which is 2
+    // bytes in modified UTF-8 and has with bits set in both upper &
+    // lower bytes. It is also both non-ASCII & easy to recognize on screen.
+    // UTF-16BE: decimal:   981, hex: 03 D5,  dec bytes:  3 213
+
+    val expected = '\u03d5'
+
+    val inputArray = Array[Byte](0x03.toByte, 0xd5.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(expected, dis.readChar())
+  }
+
+  // readDouble
+
+  @Test def readDoubleEOF(): Unit = {
+    // readDouble expects to read 8 bytes, cause EOF by providing only 3.
+    val inputArray = Array[Byte](0x03.toByte, 0xd5.toByte, 0xFF.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], dis.readDouble())
+  }
+
+  @Test def readDouble(): Unit = {
+    val expected = -0.0 // Negative zero is a common troublemaker.
+
+    var bits = java.lang.Double.doubleToLongBits(expected)
+
+    val nBytes = sizeof[Long].toInt
+    val data   = new Array[Byte](nBytes)
+
+    for (i <- (nBytes - 1) to 0 by -1) {
+      data(i) = bits.toByte
+      bits >>>= 8
+    }
+
+    val inputArray = Array[Byte](data: _*)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(expected, dis.readDouble(), 0.0001)
+  }
+
+  // readFloat
+
+  @Test def readFloatEOF(): Unit = {
+    // readFloat expects to read 4 bytes, cause EOF by providing only 3.
+    val inputArray = Array[Byte](0x03.toByte, 0xd5.toByte, 0xFF.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], dis.readFloat())
+  }
+
+  @Test def readFloat(): Unit = {
+    val expected = Float.MinPositiveValue
+
+    var bits = java.lang.Float.floatToIntBits(expected)
+
+    val nBytes = sizeof[Int].toInt
+    val data   = new Array[Byte](nBytes)
+
+    for (i <- (nBytes - 1) to 0 by -1) {
+      data(i) = bits.toByte
+      bits >>>= 8
+    }
+
+    val inputArray = Array[Byte](data: _*)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(expected, dis.readFloat(), 0.0001)
+  }
 
   // readFully
 
   @Test def readFullyBufOffLenNullBuffer(): Unit = {
-
     val inputArray =
       List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
     val iaLength = inputArray.length
@@ -23,7 +317,6 @@ class DataInputStreamTest {
   }
 
   @Test def readFullyBufOffLenInvalidOffsetArgument(): Unit = {
-
     val inputArray =
       List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
     val iaLength = inputArray.length
@@ -37,7 +330,6 @@ class DataInputStreamTest {
   }
 
   @Test def readFullyBufOffLenInvalidLengthArgument(): Unit = {
-
     val inputArray =
       List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
     val iaLength = inputArray.length
@@ -51,7 +343,6 @@ class DataInputStreamTest {
   }
 
   @Test def readFullyBufOffLenInvalidOffsetPlusLengthArguments(): Unit = {
-
     val inputArray =
       List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
     val iaLength = inputArray.length
@@ -65,7 +356,6 @@ class DataInputStreamTest {
   }
 
   @Test def readFullyBufOffLenMinusLen0(): Unit = {
-
     val inputArray = Array.tabulate[Byte](256)(i => i.toByte)
     val iaLength   = inputArray.length
 
@@ -89,7 +379,6 @@ class DataInputStreamTest {
   }
 
   @Test def readFullyBufOffLenMinusLenEqualsLength(): Unit = {
-
     val inputArray = Array.tabulate[Byte](256)(i => i.toByte)
     val iaLength   = inputArray.length
 
@@ -114,7 +403,6 @@ class DataInputStreamTest {
   }
 
   @Test def readFullyBufOffLenPatchMiddleOfBuffer(): Unit = {
-
     val inputArray = Array.tabulate[Byte](10)(i => (i + 20).toByte)
     val iaLength   = inputArray.length
 
@@ -144,7 +432,6 @@ class DataInputStreamTest {
   }
 
   @Test def readFullyBufOffLenUnexpectedEndOfFile(): Unit = {
-
     val inputArray = Array.tabulate[Byte](128)(i => i.toByte)
     val iaLength   = inputArray.length
 
@@ -158,7 +445,6 @@ class DataInputStreamTest {
   }
 
   @Test def readFullyBufNullBuffer(): Unit = {
-
     val inputArray =
       List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
     val iaLength = inputArray.length
@@ -171,7 +457,6 @@ class DataInputStreamTest {
   }
 
   @Test def readFullyBuf(): Unit = {
-
     val inputArray = Array.tabulate[Byte](256)(i => i.toByte).reverse
     val iaLength   = inputArray.length
 
@@ -194,4 +479,321 @@ class DataInputStreamTest {
     }
   }
 
+  // readInt
+
+  @Test def readIntEndOfFile(): Unit = {
+    // readInt expects to read 4 bytes, cause EOF by providing only 2.
+    val inputArray = Array[Byte](0x03.toByte, 0xFF.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], dis.readInt())
+  }
+
+  @Test def readInt(): Unit = {
+    val expected = -2019
+
+    var bits = expected
+
+    val nBytes = sizeof[Int].toInt
+    val data   = new Array[Byte](nBytes)
+
+    for (i <- (nBytes - 1) to 0 by -1) {
+      data(i) = bits.toByte
+      bits >>>= 8
+    }
+
+    val inputArray = Array[Byte](data: _*)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(expected, dis.readInt())
+  }
+
+  // readLine has been deprecated since Java JDK 1.1.
+  // Test it anyway, help prevent headstrong people from falling into
+  // infinite loops. If it exists, someone if bound to try it.
+
+  // readLine
+
+  @Test def readLineEndOfFile(): Unit = {
+    val inputArray = "These are the times that try people's souls.\n".getBytes
+    val iaLength   = 0
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertNull(dis.readLine())
+  }
+
+  @Test def readLineTermLf(): Unit = {
+    val expected = "These are the times that try people's souls."
+
+    val inputArray = s"${expected}\n".getBytes
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(expected, dis.readLine())
+  }
+
+  @Test def readLineTermNone(): Unit = {
+    val expected = "These are the times that try people's souls."
+
+    val inputArray = expected.getBytes
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(expected, dis.readLine())
+  }
+
+  // readLong
+
+  @Test def readLongEndOfFile(): Unit = {
+    // readLong expects to read 8 bytes, cause EOF by providing only 5.
+    val inputArray = List(0x03, 0xFF, 0x100, 0x101, 0x102)
+      .map(_.toByte)
+      .toArray[Byte]
+
+    val iaLength = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], dis.readLong())
+  }
+
+  @Test def readLong(): Unit = {
+    val expected = Long.MaxValue
+
+    var bits = expected
+
+    val nBytes = sizeof[Long].toInt
+    val data   = new Array[Byte](nBytes)
+
+    for (i <- (nBytes - 1) to 0 by -1) {
+      data(i) = bits.toByte
+      bits >>>= 8
+    }
+
+    val inputArray = Array[Byte](data: _*)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(expected, dis.readLong())
+  }
+
+  // readShort
+
+  @Test def readShortEndOfFile(): Unit = {
+    // readShort expects to read 2 bytes, cause EOF by providing zero.
+    val inputArray = Array[Byte](0x97.toByte)
+    val iaLength   = 0
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], dis.readShort())
+  }
+
+  @Test def readShort(): Unit = {
+    val expected = -1984
+
+    var bits = expected
+
+    val nBytes = sizeof[Short].toInt
+    val data   = new Array[Byte](nBytes)
+
+    for (i <- (nBytes - 1) to 0 by -1) {
+      data(i) = bits.toByte
+      bits >>>= 8
+    }
+
+    val inputArray = Array[Byte](data: _*)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(expected, dis.readShort())
+  }
+
+  // readnUsignedShort
+  @Test def readUnsignedShortEndOfFile(): Unit = {
+    // readUnsignedShort expects to read 2 bytes, cause EOF by providing 1.
+    val inputArray = Array[Byte](0x97.toByte)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], dis.readUnsignedShort())
+  }
+
+  @Test def readUnsignedShort(): Unit = {
+    val expected = 0xFEEB
+
+    var bits = expected
+
+    val nBytes = sizeof[Short].toInt
+    val data   = new Array[Byte](nBytes)
+
+    for (i <- (nBytes - 1) to 0 by -1) {
+      data(i) = bits.toByte
+      bits >>>= 8
+    }
+
+    val inputArray = Array[Byte](data: _*)
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertEquals(expected, dis.readUnsignedShort())
+  }
+
+  // readUTF
+
+  @Test def readUtfEndOfFile(): Unit = {
+    // This is a deliberately mis-configured Java modified UTF-8 file.
+    // A length (first unsigned short, 16 bits) is given, but not
+    // that many following bytes. This is to trigger EOF.
+
+    val expected = 103 // ASCII 'g'
+    val inputArray =
+      List(1, 5, 20, 50).map(_.toByte).toArray[Byte]
+    val iaLength = 0
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], dis.readUTF())
+  }
+
+  @Test def readUtf(): Unit = {
+    // Do not use DataOutputStream#writeUTF to avoid matched and compensating
+    // errors in implementation.
+
+    // Try to break readUTF8:
+    //   Dollar Sign expands to 1 byte in Java modified UTF-8
+    //   Pound Sign (\u00a3) expands to 2 bytes.
+    //   Euro Sign (\u20ac) expands to 2 bytes.
+    //   OxFFFF (valid Unicode but not defined as a character) is three
+    //       bytes of devilry to push high bound & break things.
+
+    val expected       = "$\u00a3\u20ac\uFFFF"
+    val expectedLength = expected.length
+
+    val dataBytes  = expected.getBytes
+    val dataLength = dataBytes.length
+    val highB      = ((dataLength & 0xFFFF0000) >>> 8).toByte
+    val lowB       = dataLength.toByte
+
+    val inputArray = Array(highB, lowB) ++ dataBytes
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    val result = dis.readUTF()
+
+    assertEquals(expectedLength, result.length)
+    assertEquals(expected, result)
+  }
+
+  @Test def readUtfOneArgEndOfFile(): Unit = {
+    // This is deliberately mis-configured Java modified UTF-8 file.
+    // A length (first unsigned short, 16 bits) is given, but not
+    // that many following bytes. This is to trigger EOF.
+
+    val expected = 103 // ASCII 'g'
+    val inputArray =
+      List(44, 0, 43, 12, 87).map(_.toByte).toArray[Byte]
+    val iaLength = 0
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    assertThrows(classOf[EOFException], DataInputStream.readUTF(dis))
+  }
+
+  @Test def readUtfOneArg(): Unit = {
+    // Do not use DataOutputStream#writeUTF to avoid matched and compensating
+    // errors in implementation.
+
+    // Try to break readUTF8:
+    //   Dollar Sign expands to 1 byte in Java modified UTF-8
+    //   Pound Sign (\u00a3) expands to 2 bytes.
+    //   Euro Sign (\u20ac) expands to 2 bytes.
+    //   OxFFFF (valid Unicode but not defined as a character) is three
+    //       bytes of devilry to push high bound & break things.
+
+    val expected       = "$\u00a3\u20ac\uFFFF"
+    val expectedLength = expected.length
+
+    val dataBytes  = expected.getBytes
+    val dataLength = dataBytes.length
+    val highB      = ((dataLength & 0xFFFF0000) >>> 8).toByte
+    val lowB       = dataLength.toByte
+
+    val inputArray = Array(highB, lowB) ++ dataBytes
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    val result = DataInputStream.readUTF(dis)
+
+    assertEquals(expectedLength, result.length)
+    assertEquals(expected, result)
+  }
+
+  // skipBytes
+
+  @Test def skipBytesEndOfFile(): Unit = {
+    val chars = 'b' to 'q'
+
+    val inputArray = chars.map(_.toByte).toArray[Byte]
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    // Do something unusual, start someplace other than 0 and an odd boundary.
+    dis.readLong()
+    dis.readByte()
+
+    val expected = iaLength - (sizeof[Long] + sizeof[Byte]).toInt
+
+    // skipBytes does not throw EOFException, returns short count read instead.
+    assertEquals(expected, dis.skipBytes(iaLength))
+  }
+
+  @Test def skipBytes(): Unit = {
+    val chars = 'a' to 'z'
+
+    val inputArray = chars.map(_.toByte).toArray[Byte]
+    val iaLength   = inputArray.length
+
+    val arrayIn = new ByteArrayInputStream(inputArray, 0, iaLength)
+    val dis     = new DataInputStream(arrayIn)
+
+    // Do something unusual, start someplace other than 0 and an odd boundary.
+    dis.readInt()
+    dis.readByte()
+
+    // Test going up to just before EOF, but not triggering it.
+    val expected = iaLength - (sizeof[Int] + sizeof[Byte]).toInt
+
+    assertEquals(expected, dis.skipBytes(expected))
+  }
 }


### PR DESCRIPTION
We make a number of corrections to DataInputStream (DIS):

1) The  DIS read methods described in the Java 8 API as throwing an
   EOFException when End-of-File on the stream is detected now do so.

2) A workaround in testinterface/NativeRPC.c for the previous non-standard
   behavior of DIS#readInt is removed.

3) To make it clear that the intended read method is actually being called,
   several methods were modified to use the underlying FilterInputStream#read
   method.  To establish/maintain consistency, DIS#skipBytes was
   modified to use the underlying FilterInputStream method.

   An unintended but beneficial consequence of this change is that
   a previously unknown off-by-one error in DIS#skipBytes was fixed.

4)  A number of performance pessimizations vanished as a natural
      consequence of the changes to have  a single-point-of-truth for `EOFException` handling.
