### PR TITLE
Fix wrong positions of class fields

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -360,8 +360,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                           Seq(_1, _2))
       }
 
-      def genClassConstructorsInfo(exprBuf: ExprBuffer,
-                                   ctors: Seq[global.Symbol]): Val = {
+      def genClassConstructorsInfo(
+          exprBuf: ExprBuffer,
+          ctors: Seq[global.Symbol])(implicit pos: nir.Position): Val = {
         val applyMethodSig =
           Sig.Method("apply", Seq(jlObjectRef, jlObjectRef))
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -176,6 +176,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           cd.find(_.symbol == f)
             .map(_.pos)
             .filter(_ != NoPosition)
+            .map(toNirPosition)
             .getOrElse(f.pos)
         }
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -114,7 +114,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       implicit val pos: nir.Position = cd.pos
       genReflectiveInstantiation(cd)
-      genClassFields(sym)
+      genClassFields(cd)
       genMethods(cd)
 
       buf += {
@@ -162,15 +162,22 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         genTypeName(psym)
       }
 
-    def genClassFields(sym: Symbol)(implicit pos: nir.Position): Unit = {
+    def genClassFields(cd: ClassDef): Unit = {
+      val sym   = cd.symbol
       val attrs = nir.Attrs(isExtern = sym.isExternModule)
 
       for (f <- sym.info.decls
            if !f.isMethod && f.isTerm && !f.isModule) {
         val ty   = genType(f.tpe)
         val name = genFieldName(f)
+        val pos: nir.Position = {
+          // ValDef containing field f should always be contained in ClassDef cd even if it is defined in other class/file
+          cd.find(_.symbol == f)
+            .map(_.pos)
+            .get
+        }
 
-        buf += Defn.Var(attrs, name, ty, Val.Zero(ty))
+        buf += Defn.Var(attrs, name, ty, Val.Zero(ty))(pos)
       }
     }
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -360,9 +360,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                           Seq(_1, _2))
       }
 
-      def genClassConstructorsInfo(
-          exprBuf: ExprBuffer,
-          ctors: Seq[global.Symbol])(implicit pos: nir.Position): Val = {
+      def genClassConstructorsInfo(exprBuf: ExprBuffer,
+                                   ctors: Seq[global.Symbol]): Val = {
         val applyMethodSig =
           Sig.Method("apply", Seq(jlObjectRef, jlObjectRef))
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -171,10 +171,12 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val ty   = genType(f.tpe)
         val name = genFieldName(f)
         val pos: nir.Position = {
-          // ValDef containing field f should always be contained in ClassDef cd even if it is defined in other class/file
+          // In 2.12+ ValDef containing field f would always be contained in ClassDef even if it is defined in other class/file
+          // In 2.11 we use field symbol position
           cd.find(_.symbol == f)
             .map(_.pos)
-            .get
+            .filter(_ != NoPosition)
+            .getOrElse(f.pos)
         }
 
         buf += Defn.Var(attrs, name, ty, Val.Zero(ty))(pos)

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -168,17 +168,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       for (f <- sym.info.decls
            if !f.isMethod && f.isTerm && !f.isModule) {
-        val ty   = genType(f.tpe)
-        val name = genFieldName(f)
-        val pos: nir.Position = {
-          // In 2.12+ ValDef containing field f would always be contained in ClassDef even if it is defined in other class/file
-          // In 2.11 we use field symbol position
-          cd.find(_.symbol == f)
-            .map(_.pos)
-            .filter(_ != NoPosition)
-            .map(toNirPosition)
-            .getOrElse(f.pos)
-        }
+        val ty                = genType(f.tpe)
+        val name              = genFieldName(f)
+        val pos: nir.Position = f.pos
 
         buf += Defn.Var(attrs, name, ty, Val.Zero(ty))(pos)
       }


### PR DESCRIPTION
This PR fixes bug occouring when generating position metadata for Class fields. Currently position of fields would always point to owner `ClassDef` position. 

After this fix position of created `nir.Defn.Var` would be based on position of `Tree` within `ClassDef` by finding `ValDef` such that its symbol matches symbol known form list of class decls. 