### PR TITLE
Fix #2063: Modify j.u.Date#toString to be Java 8 compliant.

### DIFF
--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -2,9 +2,14 @@ package java.util
 
 import java.time.Instant
 
+import scalanative.posix.time._
+import scalanative.posix.sys.types.size_t
+import scalanative.unsafe._
+import scalanative.unsigned._
+
 /** Ported from Scala JS and Apache Harmony
  * - omits deprecated methods
- * - toString not jdk compatible
+ * - toString code created ab ovo for Scala Native.
  */
 class Date(var milliseconds: Long)
     extends Object
@@ -35,12 +40,44 @@ class Date(var milliseconds: Long)
   def setTime(time: Long): Unit =
     milliseconds = time
 
-  override def toString(): String = s"Date($milliseconds)"
-
   def toInstant(): Instant = Instant.ofEpochMilli(getTime())
+
+  override def toString(): String = {
+    val seconds = milliseconds / 1000L
+    val default = s"Date($milliseconds)"
+    Date.secondsToString(seconds, default)
+  }
 }
 
 object Date {
+  // Provide prerequisite for localtime_r calls.
+  // Applications which must track timezone changes over their lifetime
+  // must do timely subsequent tzset() calls, either directly or through
+  // an occasional localtime().
+
+  tzset()
+
+  private def secondsToString(seconds: Long, default: String): String = Zone {
+    implicit z =>
+      val ttPtr = alloc[time_t]
+      !ttPtr = seconds
+
+      val tmPtr = alloc[tm]
+
+      if (localtime_r(ttPtr, tmPtr) == null) {
+        default
+      } else {
+        // 40 is over-provisioning.
+        // Most result strings should be about 28 + 1 for terminal NULL
+        // + 2 because some IANA timezone abbreviation can have 5 characters.
+        val bufSize = 40.toULong // no toSize_t() yet
+        val buf     = alloc[Byte](bufSize)
+        val n       = strftime(buf, bufSize, c"%a %b %d %T %Z %Y", tmPtr)
+
+        if (n == 0) default else fromCString(buf)
+      }
+  }
+
   def from(instant: Instant): Date = {
     try {
       new Date(instant.toEpochMilli())

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -44,7 +44,7 @@ class Date(var milliseconds: Long)
 
   override def toString(): String = {
     val seconds = milliseconds / 1000L
-    val default = s"Date($milliseconds)"
+    def default = s"Date($milliseconds)"
     Date.secondsToString(seconds, default)
   }
 }
@@ -57,8 +57,8 @@ object Date {
 
   tzset()
 
-  private def secondsToString(seconds: Long, default: String): String = Zone {
-    implicit z =>
+  private def secondsToString(seconds: Long, default: => String): String =
+    Zone { implicit z =>
       val ttPtr = alloc[time_t]
       !ttPtr = seconds
 
@@ -76,7 +76,7 @@ object Date {
 
         if (n == 0) default else fromCString(buf)
       }
-  }
+    }
 
   def from(instant: Instant): Date = {
     try {

--- a/unit-tests/src/test/scala/java/util/DateTest.scala
+++ b/unit-tests/src/test/scala/java/util/DateTest.scala
@@ -51,10 +51,11 @@ class DateTest {
   }
 
   @Test def testToString(): Unit = {
-    val result = now.toString
-    // regex should match: "Fri Mar 31 14:47:44 EDT 2017"
+    val result = new Date().toString // actual time this test is run.
+    // regex should match, but not be: "Fri Mar 31 14:47:44 EDT 2020"
+    // Two decade year range in regex is coarse sanity check.
     val expected = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
-      "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{2,5} 20[1-3]\\d"
+      "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{2,5} 20[2-3]\\d"
 
     assertTrue(s"""Result "${result}" does not match regex "${expected}"""",
                result.matches(expected))

--- a/unit-tests/src/test/scala/java/util/DateTest.scala
+++ b/unit-tests/src/test/scala/java/util/DateTest.scala
@@ -51,6 +51,12 @@ class DateTest {
   }
 
   @Test def testToString(): Unit = {
-    assertTrue(now.toString equals "Date(1490986064740)")
+    val result = now.toString
+    // regex should match: "Fri Mar 31 14:47:44 EDT 2017"
+    val expected = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
+      "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{2,5} 20[1-3]\\d"
+
+    assertTrue(s"""Result "${result}" does not match regex "${expected}"""",
+               result.matches(expected))
   }
 }


### PR DESCRIPTION
We modify the toString method to match the results of at least Java 8
and earlier.