### PR TITLE
Pass always to lto config

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -215,10 +215,9 @@ private[scalanative] object LLVM {
       flto(config) ++ Seq("-rdynamic", "-o", outpath.abs) ++ target(config)
     val paths   = objectsPaths.map(_.abs)
     val compile = config.clangPP.abs +: (flags ++ paths ++ linkopts)
-    val ltoName = lto(config).getOrElse("none")
 
     config.logger.time(
-      s"Linking native code (${config.gc.name} gc, $ltoName lto)") {
+      s"Linking native code (${config.gc.name} gc, ${config.LTO.name} lto)") {
       config.logger.running(compile)
       Process(compile, config.workdir.toFile) ! Logger.toProcessLogger(
         config.logger)
@@ -226,17 +225,11 @@ private[scalanative] object LLVM {
     outpath
   }
 
-  private def lto(config: Config): Option[String] =
-    (config.mode, config.LTO) match {
-      case (Mode.Debug, _)             => None
-      case (_: Mode.Release, LTO.None) => None
-      case (_: Mode.Release, lto)      => Some(lto.name)
-    }
-
   private def flto(config: Config): Seq[String] =
-    lto(config).fold[Seq[String]] {
-      Seq()
-    } { name => Seq(s"-flto=$name") }
+    config.compilerConfig.lto match {
+      case LTO.None => Seq.empty
+      case lto      => Seq(s"-flto=${lto.name}")
+    }
 
   private def target(config: Config): Seq[String] =
     config.compilerConfig.targetTriple match {


### PR DESCRIPTION
Currently the LTO setting is passed to the compiler only when the mode is not debug.
This is strange as a user because after setting the LTO in a project, you `nativeLink` 
and read in the logs that the LTO is `none` when you have set `thin`.