### PR TITLE
Make corresponding Scala Native version evident in documentation.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,8 @@
 Scala Native
 ============
 
+Version |release| 
+
 Scala Native is an optimizing ahead-of-time compiler and lightweight managed
 runtime designed specifically for Scala. It features:
 


### PR DESCRIPTION
Reviewer Note -- to be removed before merge.

The presenting problem solved by this PR is both the Scala JVM
and Scala.js web sites make it relatively easy to determing
the software version under discussin but that it is hard to
determine this information for Scala Native.

Someday -SNAPSHOT versions will have, at least in my dreams, a
date or commit tag -SNAPSHOT-2021-01-17.

This PR is a step on the road towards having a "Single-Point-of-Truth"
for the Scala Native version.  As a minimal change, it uses the
existing `docs/conf.py` Scala Native version.  However, it is written
in such a way that when `docs/conf.py` changes to use
`nir/mumble/Versions.scala`, or a better solution, the solution will
be used the next time the documentation is generated without requiring
a change to `index.rst`.

Someday, I would like to see the SN version in a footer on each page
but that was more than I could accomplish today.

Commit message:
We provide a clue on the landing page as to which Scala Native version
is being described by the documentation.

The current commit is an immediate, better-than-before, and
"least-effort" change, rather than a paragon of good design.