### PR TITLE
Fix #2117: Don't include scalalib overrides in sources-jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -658,14 +658,8 @@ lazy val scalalib =
             !path.endsWith(".class")
         }
       },
-      Compile / packageSrc / mappings := {
-        // Filter out overrides with duplicate names, mappings should include only used sources
-        val previous    = (Compile / packageSrc / mappings).value
-        val usedSources = (Compile / sources).value
-        previous.filter {
-          case (file, _) => usedSources.contains(file)
-        }
-      },
+      // Sources in scalalib are only internal overrides, we don't include them in the resulting sources jar
+      Compile / packageSrc / mappings := Seq.empty,
       exportJars := true
     )
     .dependsOn(nscplugin % "plugin", auxlib, nativelib, javalib)

--- a/build.sbt
+++ b/build.sbt
@@ -658,6 +658,14 @@ lazy val scalalib =
             !path.endsWith(".class")
         }
       },
+      Compile / packageSrc / mappings := {
+        // Filter out overrides with duplicate names, mappings should include only used sources
+        val previous    = (Compile / packageSrc / mappings).value
+        val usedSources = (Compile / sources).value
+        previous.filter {
+          case (file, _) => usedSources.contains(file)
+        }
+      },
       exportJars := true
     )
     .dependsOn(nscplugin % "plugin", auxlib, nativelib, javalib)


### PR DESCRIPTION
This PR stops overridden scalalib sources from being included in sources-jar. We don't publish `*.class` files in scalalib and though actual sources are not needed. 