### PR TITLE
Remove two instances of a hard-coded Scala Native version in documentation.

### DIFF
--- a/docs/user/testing.rst
+++ b/docs/user/testing.rst
@@ -9,10 +9,17 @@ you would do for a Java project.
 
 To enable JUnit support, add the following lines to your `build.sbt` file:
 
-.. code-block:: scala
+.. Note: Using parsed-literal here instead of code-block:: scala
+..       allows this file to reference the Single Point of Truth in
+..       docs/config.py for the Scala Version. That is a big reduction
+..       in the likelihood of version skew.
+..       parsed-literal does not allow scala highlighting, so there is a
+..       slight visual change in the output. Can you even detect it?
 
-    libraryDependencies += "org.scala-native" %%% "junit-runtime" % "0.4.0"
-    addCompilerPlugin("org.scala-native" % "junit-plugin" % "0.4.0" cross CrossVersion.full)
+.. parsed-literal::
+
+    libraryDependencies += "org.scala-native" %%% "junit-runtime" % |release|
+    addCompilerPlugin("org.scala-native" % "junit-plugin" % |release| cross CrossVersion.full)
 
 If you want to get more detailed output from the JUnit runtime, also include the following line:
 

--- a/docs/user/testing.rst
+++ b/docs/user/testing.rst
@@ -13,6 +13,9 @@ To enable JUnit support, add the following lines to your `build.sbt` file:
 ..       allows this file to reference the Single Point of Truth in
 ..       docs/config.py for the Scala Version. That is a big reduction
 ..       in the likelihood of version skew.
+..       A user can "cut & paste" from the output but the SN Release Manager
+..       need not change this source.
+..
 ..       parsed-literal does not allow scala highlighting, so there is a
 ..       slight visual change in the output. Can you even detect it?
 


### PR DESCRIPTION
We remove two instances of a hard-coded Scala Native version if favor of
the documentation Single Point of Truth in `docs/config.py`.