### PR TITLE
Remove explicit versions for items in .g8 template.

### DIFF
--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -13,16 +13,30 @@ template.  In an empty working directory, execute::
 
     sbt new scala-native/scala-native.g8
 
-This generates a basic project containing the following files:
+This will start sbt, prompt for a project name, and then
+use the `.g8 template
+<https://github.com/scala-native/scala-native.g8/tree/master/src/main/g8>`_.
+to generate a basic project.
+First a sub-directory with the project name will be created.
+Then the contents at these template links will be copied to
+the corresponding location in this new project.
 
-* ``project/plugins.sbt`` to add a plugin dependency and version.
+* `project/plugins.sbt
+  <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/project/plugins.sbt>`_
+  adds the Scala Native plugin dependency and its version.
 
-* ``project/build.properties`` to specify the sbt version.
+* `project/build.properties
+  <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/project/build.properties>`_
+  specifies the sbt version.
 
-* ``build.sbt`` to enable the plugin and specify Scala version.
+* `build.sbt
+  <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/build.sbt>`_
+  enables the plugin and specifies the Scala version.
 
-* ``src/main/scala/Main.scala`` with minimal application::
-
+* `src/main/scala/Main.scala
+  <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/src/main/scala/Main.scala>`_
+  is a minimal application::
+  
     object Main {
       def main(args: Array[String]): Unit =
         println("Hello, world!")

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -8,25 +8,18 @@ If you have reached this section you probably have a system that is now able to 
 Minimal sbt project
 -------------------
 
-The easiest way to make a fresh project is to use our official gitter8 template::
+The easiest way to make a fresh project is to use our official gitter8
+template.  In an empty working directory, execute::
 
     sbt new scala-native/scala-native.g8
 
-This generates the following files:
+This generates a basic project containing the following files:
 
-* ``project/plugins.sbt`` to add a plugin dependency::
+* ``project/plugins.sbt`` to add a plugin dependency and version.
 
-    addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0-M2")
+* ``project/build.properties`` to specify the sbt version.
 
-* ``project/build.properties`` to specify the sbt version::
-
-    sbt.version = 1.4.1
-
-* ``build.sbt`` to enable the plugin and specify Scala version::
-
-    enablePlugins(ScalaNativePlugin)
-
-    scalaVersion := "2.11.12"
+* ``build.sbt`` to enable the plugin and specify Scala version.
 
 * ``src/main/scala/Main.scala`` with minimal application::
 
@@ -35,8 +28,12 @@ This generates the following files:
         println("Hello, world!")
     }
 
-Now, simply run ``sbt run`` to get everything compiled and have the expected
+Now, run ``sbt run`` to get everything compiled and have the expected
 output! Please refer to the :ref:`faq` if you encounter any problems.
+
+The generated project is an easy starting point. After the first run, you
+should review the software versions in the generated files and, possibly,
+update or customize them.
 
 Scala versions
 --------------

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -33,7 +33,8 @@ output! Please refer to the :ref:`faq` if you encounter any problems.
 
 The generated project is an easy starting point. After the first run, you
 should review the software versions in the generated files and, possibly,
-update or customize them.
+update or customize them. `Scaladex <https://index.scala-lang.org/>`_
+is a useful resource for software versions.
 
 Scala versions
 --------------

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -13,40 +13,58 @@ template.  In an empty working directory, execute::
 
     sbt new scala-native/scala-native.g8
 
-This will start sbt, prompt for a project name, and then
-use the `.g8 template
-<https://github.com/scala-native/scala-native.g8/tree/master/src/main/g8>`_.
-to generate a basic project.
-First a sub-directory with the project name will be created.
-Then the contents at these template links will be copied to
-the corresponding location in this new project.
+This will:
 
-* `project/plugins.sbt
-  <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/project/plugins.sbt>`_
-  adds the Scala Native plugin dependency and its version.
+* start sbt.
 
-* `project/build.properties
-  <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/project/build.properties>`_
-  specifies the sbt version.
+* prompt for a project name
 
-* `build.sbt
-  <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/build.sbt>`_
-  enables the plugin and specifies the Scala version.
+* use the `.g8 template
+  <https://github.com/scala-native/scala-native.g8/tree/master/src/main/g8>`_.
+  to generate a basic project with that name.
 
-* `src/main/scala/Main.scala
-  <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/src/main/scala/Main.scala>`_
-  is a minimal application.
-  ::
+* create a project sub-directory with the project name.
+
+* copy the contents at these template links to the corresponding location
+  in this new project sub-directory.
+
+  * `project/plugins.sbt
+    <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/project/plugins.sbt>`_
+    adds the Scala Native plugin dependency and its version.
+
+  * `project/build.properties
+    <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/project/build.properties>`_
+    specifies the sbt version.
+
+  * `build.sbt
+    <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/build.sbt>`_
+    enables the plugin and specifies the Scala version.
+
+  * `src/main/scala/Main.scala
+    <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/src/main/scala/Main.scala>`_
+    is a minimal application.
+    ::
      
-    object Main {
-      def main(args: Array[String]): Unit =
-        println("Hello, world!")
-    }
+      object Main {
+        def main(args: Array[String]): Unit =
+          println("Hello, world!")
+      }
+      
 
-Now, run ``sbt run`` to get everything compiled and have the expected
-output! Please refer to the :ref:`faq` if you encounter any problems.
+To use the new project:
 
-The generated project is an easy starting point. After the first run, you
+* Change the current working directory to the new project directory.
+
+   - For example, on linux with a project named AnswerToProjectNamePrompt,
+     type ``cd AnswerToProjectNamePrompt``.
+
+* Type ``sbt run``.
+
+This will get everything compiled and should have the expected output!
+
+Please refer to the :ref:`faq` if you encounter any problems.
+
+The generated project is a starting point. After the first run, you
 should review the software versions in the generated files and, possibly,
 update or customize them. `Scaladex <https://index.scala-lang.org/>`_
 is a useful resource for software versions.

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -35,8 +35,9 @@ the corresponding location in this new project.
 
 * `src/main/scala/Main.scala
   <https://github.com/scala-native/scala-native.g8/blob/master/src/main/g8/src/main/scala/Main.scala>`_
-  is a minimal application::
-  
+  is a minimal application.
+  ::
+     
     object Main {
       def main(args: Array[String]): Unit =
         println("Hello, world!")


### PR DESCRIPTION
co-authored-by: bjorn regnell, first time contributor

We remove the explicit mention of software versions which are generated by the .g8.
Links to the files in the template are provided instead.  

The .g8 template is the This Single Point of Truth. This eliminates the possibility of version skew due
to double bookkeeping yet preserves the usefulness and intent of that section of documentation.