### PR TITLE
Fix: Type.isPtrBox always returns false

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -121,7 +121,7 @@ object Type {
 
   def isPtrBox(ty: Type): Boolean = ty match {
     case refty: Type.RefKind =>
-      box.get(Type.Ref(refty.className)).contains(Type.Ptr)
+      unbox.get(Type.Ref(refty.className)).contains(Type.Ptr)
     case _ =>
       false
   }

--- a/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
@@ -417,13 +417,19 @@ trait Combine { self: Interflow =>
 
       // Comparing non-nullable value with null will always
       // yield the same result.
-      case (Ieq, v @ Of(ty: Type.RefKind), Val.Null) if !ty.isNullable =>
+      // This is not true however for ptr boxes, since they
+      // underlying value might be null
+      case (Ieq, v @ Of(ty: Type.RefKind), Val.Null)
+          if !ty.isNullable && !Type.isPtrBox(ty) =>
         Val.False
-      case (Ieq, Val.Null, v @ Of(ty: Type.RefKind)) if !ty.isNullable =>
+      case (Ieq, Val.Null, v @ Of(ty: Type.RefKind))
+          if !ty.isNullable && !Type.isPtrBox(ty) =>
         Val.False
-      case (Ine, v @ Of(ty: Type.RefKind), Val.Null) if !ty.isNullable =>
+      case (Ine, v @ Of(ty: Type.RefKind), Val.Null)
+          if !ty.isNullable && !Type.isPtrBox(ty) =>
         Val.True
-      case (Ine, Val.Null, v @ Of(ty: Type.RefKind)) if !ty.isNullable =>
+      case (Ine, Val.Null, v @ Of(ty: Type.RefKind))
+          if !ty.isNullable && !Type.isPtrBox(ty) =>
         Val.True
 
       // Ptr boxes are null if underlying pointer is null.

--- a/tools/src/test/scala/scala/scalanative/nir/TypesSuite.scala
+++ b/tools/src/test/scala/scala/scalanative/nir/TypesSuite.scala
@@ -1,0 +1,22 @@
+package scala.scalanative.nir
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class TypesSuite extends AnyFunSuite {
+
+  test("Determinate if type boxes pointer for known types") {
+    Type.boxesTo.foreach {
+      case (boxed: Type.Ref, Type.Ptr) =>
+        assert(Type.isPtrBox(boxed), s"$boxed should be Type.Ptr")
+      case (boxed: Type.Ref, _) =>
+        assert(!Type.isPtrBox(boxed), s"$boxed should be primitive type")
+      case (ty, _) =>
+        fail(s"Expected reference boxed type, but got ${ty}")
+    }
+  }
+
+  test("Unknown reference types are not PtrBox") {
+    assert(!Type.isPtrBox(Type.Ref(Global.Top("foo.bar"))))
+  }
+
+}


### PR DESCRIPTION
`Type.isPtrBox` had a bug leading to returning false in any case, caused by using invalid Map of types. 

This method is important in terms of performance, as it used to determine if boxing/unboxing can be delayed or skipped entirely in the optimizer.

As a result of fixing this issue, in my - currently private - branch when I've experimented with CStructs support, it was possible to skip boxing when accessing or assigning a value of struct. 