### PR TITLE
Speedup Interflow

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -20,17 +20,17 @@ trait Inline { self: Interflow =>
       .fold[Boolean] {
         false
       } { defn =>
-        val isCtor = originalName(name) match {
+        lazy val isCtor = originalName(name) match {
           case Global.Member(_, sig) if sig.isCtor || sig.isImplCtor =>
             true
           case _ =>
             false
         }
-        val isSmall =
+        lazy val isSmall =
           defn.insts.size <= 8
         val isExtern =
           defn.attrs.isExtern
-        val hasVirtualArgs =
+        lazy val hasVirtualArgs =
           args.exists(_.isInstanceOf[Val.Virtual])
         val noOpt =
           defn.attrs.opt == Attr.NoOpt
@@ -40,15 +40,15 @@ trait Inline { self: Interflow =>
           defn.attrs.inlineHint == Attr.AlwaysInline
         val hintInline =
           defn.attrs.inlineHint == Attr.InlineHint
-        val isRecursive =
+        lazy val isRecursive =
           hasContext(s"inlining ${name.show}")
-        val isBlacklisted =
+        lazy val isBlacklisted =
           this.isBlacklisted(name)
-        val calleeTooBig =
+        lazy val calleeTooBig =
           defn.insts.size > 8192
-        val callerTooBig =
+        lazy val callerTooBig =
           mergeProcessor.currentSize() > 8192
-        val hasUnwind = defn.insts.exists {
+        lazy val hasUnwind = defn.insts.exists {
           case Inst.Let(_, _, unwind)   => unwind ne Next.None
           case Inst.Throw(_, unwind)    => unwind ne Next.None
           case Inst.Unreachable(unwind) => unwind ne Next.None
@@ -57,37 +57,38 @@ trait Inline { self: Interflow =>
 
         val shall = mode match {
           case build.Mode.Debug =>
-            isCtor || alwaysInline
+            alwaysInline || isCtor
           case build.Mode.ReleaseFast =>
-            isCtor || alwaysInline || hintInline || isSmall
+            alwaysInline || hintInline || isSmall || isCtor
           case build.Mode.ReleaseFull =>
-            isCtor || alwaysInline || hintInline || isSmall || hasVirtualArgs
+            alwaysInline || hintInline || isSmall || isCtor || hasVirtualArgs
         }
-        val shallNot =
+        lazy val shallNot =
           noOpt || noInline || isRecursive || isBlacklisted || calleeTooBig || callerTooBig || isExtern || hasUnwind
-
-        if (shall) {
-          if (shallNot) {
-            log(s"not inlining ${name.show}, because:")
-            if (noInline) {
-              log("* has noinline attr")
+        withLogger { logger =>
+          if (shall) {
+            if (shallNot) {
+              logger(s"not inlining ${name.show}, because:")
+              if (noInline) {
+                logger("* has noinline attr")
+              }
+              if (isRecursive) {
+                logger("* is recursive")
+              }
+              if (isBlacklisted) {
+                logger("* is blacklisted")
+              }
+              if (callerTooBig) {
+                logger("* caller is too big")
+              }
+              if (calleeTooBig) {
+                logger("* callee is too big")
+              }
             }
-            if (isRecursive) {
-              log("* is recursive")
-            }
-            if (isBlacklisted) {
-              log("* is blacklisted")
-            }
-            if (callerTooBig) {
-              log("* caller is too big")
-            }
-            if (calleeTooBig) {
-              log("* callee is too big")
-            }
+          } else {
+            logger(
+              s"no reason to inline ${name.show}(${args.map(_.show).mkString(",")})")
           }
-        } else {
-          log(
-            s"no reason to inline ${name.show}(${args.map(_.show).mkString(",")})")
         }
 
         shall && !shallNot

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -20,17 +20,17 @@ trait Inline { self: Interflow =>
       .fold[Boolean] {
         false
       } { defn =>
-        lazy val isCtor = originalName(name) match {
+        def isCtor = originalName(name) match {
           case Global.Member(_, sig) if sig.isCtor || sig.isImplCtor =>
             true
           case _ =>
             false
         }
-        lazy val isSmall =
+        def isSmall =
           defn.insts.size <= 8
         val isExtern =
           defn.attrs.isExtern
-        lazy val hasVirtualArgs =
+        def hasVirtualArgs =
           args.exists(_.isInstanceOf[Val.Virtual])
         val noOpt =
           defn.attrs.opt == Attr.NoOpt
@@ -40,15 +40,15 @@ trait Inline { self: Interflow =>
           defn.attrs.inlineHint == Attr.AlwaysInline
         val hintInline =
           defn.attrs.inlineHint == Attr.InlineHint
-        lazy val isRecursive =
+        def isRecursive =
           hasContext(s"inlining ${name.show}")
-        lazy val isBlacklisted =
+        def isBlacklisted =
           this.isBlacklisted(name)
-        lazy val calleeTooBig =
+        def calleeTooBig =
           defn.insts.size > 8192
-        lazy val callerTooBig =
+        def callerTooBig =
           mergeProcessor.currentSize() > 8192
-        lazy val hasUnwind = defn.insts.exists {
+        def hasUnwind = defn.insts.exists {
           case Inst.Let(_, _, unwind)   => unwind ne Next.None
           case Inst.Throw(_, unwind)    => unwind ne Next.None
           case Inst.Unreachable(unwind) => unwind ne Next.None

--- a/tools/src/main/scala/scala/scalanative/interflow/Log.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Log.scala
@@ -6,18 +6,17 @@ trait Log { self: Interflow =>
     false
 
   def in[T](msg: String)(f: => T): T = {
-    if (show) {
-      log(msg)
-    }
+    log(msg)
     pushContext(msg)
     try {
-      val start = System.nanoTime
-      val res   = f
-      val end   = System.nanoTime
       if (show) {
+        val start = System.nanoTime
+        val res   = f
+        val end   = System.nanoTime
         log(s"done $msg (${(end - start) / 1000000D})")
+        res
       }
-      res
+      else f
     } catch {
       case e: Throwable =>
         log("unwinding " + msg + " due to: " + e.toString)
@@ -27,7 +26,7 @@ trait Log { self: Interflow =>
     }
   }
 
-  def log(msg: String): Unit =
+  def log(msg: => String): Unit =
     if (show) {
       println(("  " * contextDepth()) + msg)
     }

--- a/tools/src/main/scala/scala/scalanative/interflow/Log.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Log.scala
@@ -31,6 +31,11 @@ trait Log { self: Interflow =>
       println(("  " * contextDepth()) + msg)
     }
 
+  def withLogger(f: (String => Unit) => Unit): Unit =
+    if (show) {
+      f(x => log(x))
+    }
+
   def debug[T](msg: String)(f: => T): T = {
     log(s"computing $msg")
     val res = f

--- a/tools/src/main/scala/scala/scalanative/interflow/Log.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Log.scala
@@ -31,6 +31,8 @@ trait Log { self: Interflow =>
       println(("  " * contextDepth()) + msg)
     }
 
+  /* Performance Note: Useful to wrap large functions that are used only for
+   * logging, as the code is not executed when show is false. */
   def withLogger(f: (String => Unit) => Unit): Unit =
     if (show) {
       f(x => log(x))

--- a/tools/src/main/scala/scala/scalanative/interflow/Log.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Log.scala
@@ -15,8 +15,7 @@ trait Log { self: Interflow =>
         val end   = System.nanoTime
         log(s"done $msg (${(end - start) / 1000000D})")
         res
-      }
-      else f
+      } else f
     } catch {
       case e: Throwable =>
         log("unwinding " + msg + " due to: " + e.toString)

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -68,7 +68,7 @@ final class MergeProcessor(insts: Array[Inst],
         val headState = states.head
 
         var mergeFresh   = Fresh(merge.id)
-        val mergeLocals  = mutable.Map.empty[Local, Val]
+        val mergeLocals  = mutable.OpenHashMap.empty[Local, Val]
         val mergeHeap    = mutable.LongMap.empty[Instance]
         val mergePhis    = mutable.UnrolledBuffer.empty[MergePhi]
         val mergeDelayed = mutable.AnyRefMap.empty[Op, Val]

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -101,9 +101,7 @@ final class MergeProcessor(insts: Array[Inst],
           def mergeLocal(local: Local, value: Val): Unit = {
             val values = mutable.UnrolledBuffer.empty[Val]
             states.foreach { s =>
-              s.locals.get(local).foreach { l =>
-                values += l
-              }
+              s.locals.get(local).foreach(values += _ )
             }
             if (states.size == values.size) {
               mergeLocals(local) = mergePhi(values, Some(value.ty))

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -69,10 +69,10 @@ final class MergeProcessor(insts: Array[Inst],
 
         var mergeFresh   = Fresh(merge.id)
         val mergeLocals  = mutable.Map.empty[Local, Val]
-        val mergeHeap    = mutable.Map.empty[Addr, Instance]
+        val mergeHeap    = mutable.LongMap.empty[Instance]
         val mergePhis    = mutable.UnrolledBuffer.empty[MergePhi]
-        val mergeDelayed = mutable.Map.empty[Op, Val]
-        val mergeEmitted = mutable.Map.empty[Op, Val]
+        val mergeDelayed = mutable.AnyRefMap.empty[Op, Val]
+        val mergeEmitted = mutable.AnyRefMap.empty[Op, Val]
         val newEscapes   = mutable.Set.empty[Addr]
 
         def mergePhi(values: Seq[Val], bound: Option[Type]): Val = {

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -101,8 +101,8 @@ final class MergeProcessor(insts: Array[Inst],
           def mergeLocal(local: Local, value: Val): Unit = {
             val values = mutable.UnrolledBuffer.empty[Val]
             states.foreach { s =>
-              if (s.locals.contains(local)) {
-                values += s.locals(local)
+              s.locals.get(local).foreach { l =>
+                values += l
               }
             }
             if (states.size == values.size) {

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -100,9 +100,7 @@ final class MergeProcessor(insts: Array[Inst],
 
           def mergeLocal(local: Local, value: Val): Unit = {
             val values = mutable.UnrolledBuffer.empty[Val]
-            states.foreach { s =>
-              s.locals.get(local).foreach(values += _ )
-            }
+            states.foreach { s => s.locals.get(local).foreach(values += _) }
             if (states.size == values.size) {
               mergeLocals(local) = mergePhi(values, Some(value.ty))
             }

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -9,10 +9,10 @@ import scalanative.codegen.Lower
 
 final class State(block: Local) {
   var fresh   = Fresh(block.id)
-  var heap    = mutable.Map.empty[Addr, Instance]
+  var heap    = mutable.LongMap.empty[Instance]
   var locals  = mutable.Map.empty[Local, Val]
-  var delayed = mutable.Map.empty[Op, Val]
-  var emitted = mutable.Map.empty[Op, Val]
+  var delayed = mutable.AnyRefMap.empty[Op, Val]
+  var emitted = mutable.AnyRefMap.empty[Op, Val]
   var emit    = new nir.Buffer()(fresh)
 
   private def alloc(kind: Kind, cls: Class, values: Array[Val]): Addr = {
@@ -209,7 +209,7 @@ final class State(block: Local) {
   }
   def fullClone(block: Local): State = {
     val newstate = new State(block)
-    newstate.heap = heap.map { case (k, v) => (k, v.clone()) }
+    newstate.heap = heap.mapValuesNow(_.clone())
     newstate.locals = locals.clone()
     newstate.delayed = delayed.clone()
     newstate.emitted = emitted.clone()

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -9,6 +9,8 @@ import scalanative.codegen.Lower
 
 final class State(block: Local) {
   var fresh   = Fresh(block.id)
+  /* Performance Note: OpenHashMap/LongMap/AnyRefMap have a faster clone()
+   * operation. This really makes a difference on fullClone() */
   var heap    = mutable.LongMap.empty[Instance]
   var locals  = mutable.OpenHashMap.empty[Local, Val]
   var delayed = mutable.AnyRefMap.empty[Op, Val]

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -8,7 +8,7 @@ import scalanative.linker._
 import scalanative.codegen.Lower
 
 final class State(block: Local) {
-  var fresh   = Fresh(block.id)
+  var fresh = Fresh(block.id)
   /* Performance Note: OpenHashMap/LongMap/AnyRefMap have a faster clone()
    * operation. This really makes a difference on fullClone() */
   var heap    = mutable.LongMap.empty[Instance]

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -10,7 +10,7 @@ import scalanative.codegen.Lower
 final class State(block: Local) {
   var fresh   = Fresh(block.id)
   var heap    = mutable.LongMap.empty[Instance]
-  var locals  = mutable.Map.empty[Local, Val]
+  var locals  = mutable.OpenHashMap.empty[Local, Val]
   var delayed = mutable.AnyRefMap.empty[Op, Val]
   var emitted = mutable.AnyRefMap.empty[Op, Val]
   var emit    = new nir.Buffer()(fresh)


### PR DESCRIPTION
Adds some performance optimizations to Interflow, mainly regarding hash map cloning and avoiding unnecessary operations when logging is disabled.

I ran this on a [small codebase](https://github.com/JD557/minart/blob/06ecc9edbe99ffaa221f6e239895085e81bf71fa/examples/colorsquare/shared/src/main/scala/eu/joaocosta/minart/examples/ColorSquare.scala) and got some nice performance improvements on `release-full`.

|  | Optimization (Avg) | Total (Avg) |
|-|-|-|
| 0.4.0 | 170934ms | 226639ms |
| This Branch | 90806ms | 156839ms |

It might be nice to also try this on a large codebase. Any ideas?

-----

Full times of the 3 runs (SBT was not restarted between runs to keep the JIT warm, it was restarted between tests):

# 0.4.0

## Run 1

```
[info] Linking (2373 ms)
[info] Discovered 1083 classes and 9147 methods
[info] Optimizing (release-full mode) (173719 ms)
[info] Generating intermediate code (7042 ms)
[info] Produced 8 files
[info] Compiling to native code (15208 ms)
[info] Linking native code (immix gc, thin lto) (33952 ms)
[info] Total (232533 ms)
```

## Run 2

```
[info] Linking (1116 ms)
[info] Discovered 1083 classes and 9147 methods
[info] Optimizing (release-full mode) (169880 ms)
[info] Generating intermediate code (5002 ms)
[info] Produced 8 files
[info] Compiling to native code (13307 ms)
[info] Linking native code (immix gc, thin lto) (34893 ms)
[info] Total (224436 ms)
```

## Run 3

```
[info] Linking (1167 ms)
[info] Discovered 1083 classes and 9147 methods
[info] Optimizing (release-full mode) (169202 ms)
[info] Generating intermediate code (4851 ms)
[info] Produced 8 files
[info] Compiling to native code (13107 ms)
[info] Linking native code (immix gc, thin lto) (34634 ms)
[info] Total (223112 ms)
```

# New Branch

## Run 1

```
[info] Linking (2868 ms)
[info] Discovered 1083 classes and 9147 methods
[info] Optimizing (release-full mode) (94776 ms)
[info] Generating intermediate code (8554 ms)
[info] Produced 8 files
[info] Compiling to native code (13660 ms)
[info] Linking native code (immix gc, thin lto) (45077 ms)
[info] Total (165277 ms)
```

## Run 2

```
[info] Linking (1186 ms)
[info] Discovered 1083 classes and 9147 methods
[info] Optimizing (release-full mode) (89203 ms)
[info] Generating intermediate code (5405 ms)
[info] Produced 8 files
[info] Compiling to native code (13693 ms)
[info] Linking native code (immix gc, thin lto) (45296 ms)
[info] Total (154986 ms)
```

## Run 3

```
[info] Linking (971 ms)
[info] Discovered 1083 classes and 9147 methods
[info] Optimizing (release-full mode) (88440 ms)
[info] Generating intermediate code (4288 ms)
[info] Produced 8 files
[info] Compiling to native code (12454 ms)
[info] Linking native code (immix gc, thin lto) (44035 ms)
[info] Total (150305 ms)
```