### PR TITLE
Fix #2143: j.i.DataOutputStream now does bulk writes where possible.

### DIFF
--- a/javalib/src/main/scala/java/io/DataOutputStream.scala
+++ b/javalib/src/main/scala/java/io/DataOutputStream.scala
@@ -1,8 +1,14 @@
 package java.io
 
+import java.nio.charset.StandardCharsets
+
 class DataOutputStream(out: OutputStream)
     extends FilterOutputStream(out)
     with DataOutput {
+  // Capacity is a guess: Balance memory use & execution speed.
+  // Allow small to moderate sized Strings to be written as Chars in one shot.
+  private val bufferCapacity = 1024 * 2
+  private val buffer         = new Array[Byte](bufferCapacity)
 
   protected var written: Int = 0
 
@@ -18,7 +24,7 @@ class DataOutputStream(out: OutputStream)
   }
 
   override def write(b: Int): Unit = {
-    out.write(b)
+    out.write(b) // underlying stream will convert to byte.
     written += 1
   }
 
@@ -26,18 +32,48 @@ class DataOutputStream(out: OutputStream)
     write(if (v) 1 else 0)
 
   override final def writeByte(v: Int): Unit =
-    write(v.toByte)
+    write(v)
 
-  override final def writeBytes(s: String): Unit =
-    write(s.toArray.map(_.toByte))
+  override final def writeBytes(s: String): Unit = {
+    var index = 0
 
-  override final def writeChar(v: Int): Unit = {
-    write((v >> 8) & 0xFF)
-    write(v & 0xFF)
+    for (ch <- s) {
+      if (index == bufferCapacity) {
+        write(buffer, 0, bufferCapacity)
+        index = 0
+      }
+
+      buffer(index) = ch.toByte
+      index += 1
+    }
+
+    if (index > 0)
+      write(buffer, 0, index)
   }
 
-  override final def writeChars(s: String): Unit =
-    s.toCharArray.foreach(c => writeChar(c.toInt))
+  override final def writeChar(v: Int): Unit = {
+    buffer(0) = (v >> 8).toByte
+    buffer(1) = v.toByte
+    write(buffer, 0, 2)
+  }
+
+  override final def writeChars(s: String): Unit = {
+    var index = 0
+
+    for (ch <- s) {
+      if (index == bufferCapacity) {
+        write(buffer, 0, bufferCapacity)
+        index = 0
+      }
+
+      buffer(index) = (ch >> 8).toByte
+      buffer(index + 1) = ch.toByte
+      index += 2
+    }
+
+    if (index > 0)
+      write(buffer, 0, index)
+  }
 
   override final def writeDouble(v: Double): Unit =
     writeLong(java.lang.Double.doubleToLongBits(v))
@@ -46,49 +82,62 @@ class DataOutputStream(out: OutputStream)
     writeInt(java.lang.Float.floatToIntBits(v))
 
   override final def writeInt(v: Int): Unit = {
-    write((v >> 24) & 0xFF)
-    write((v >> 16) & 0xFF)
-    write((v >> 8) & 0xFF)
-    write(v & 0xFF)
+    buffer(0) = (v >> 24).toByte
+    buffer(1) = (v >> 16).toByte
+    buffer(2) = (v >> 8).toByte
+    buffer(3) = v.toByte
+    write(buffer, 0, 4)
   }
 
   override final def writeLong(v: Long): Unit = {
-    write(((v >> 56) & 0xFF).toInt)
-    write(((v >> 48) & 0xFF).toInt)
-    write(((v >> 40) & 0xFF).toInt)
-    write(((v >> 32) & 0xFF).toInt)
-    write(((v >> 24) & 0xFF).toInt)
-    write(((v >> 16) & 0xFF).toInt)
-    write(((v >> 8) & 0xFF).toInt)
-    write((v & 0xFF).toInt)
+    buffer(0) = (v >> 56).toByte
+    buffer(1) = (v >> 48).toByte
+    buffer(2) = (v >> 40).toByte
+    buffer(3) = (v >> 32).toByte
+    buffer(4) = (v >> 24).toByte
+    buffer(5) = (v >> 16).toByte
+    buffer(6) = (v >> 8).toByte
+    buffer(7) = v.toByte
+    write(buffer, 0, 8)
   }
 
   override final def writeShort(v: Int): Unit = {
-    write((v >> 8) & 0xFF)
-    write(v & 0xFF)
+    buffer(0) = (v >> 8).toByte
+    buffer(1) = v.toByte
+    write(buffer, 0, 2)
   }
 
-  override final def writeUTF(str: String): Unit = {
-    val utfBytes = toModifiedUTF(str)
-    writeShort(utfBytes.length)
-    write(utfBytes)
-  }
+  // Ported from Scala.js commit: f700b9f dated: Sep 12, 2019
 
-  private def toModifiedUTF(str: String): Array[Byte] =
-    str.toArray.flatMap(c => toModifiedUTF(c))
+  final def writeUTF(s: String): Unit = {
+    val buffer = new Array[Byte](2 + 3 * s.length)
 
-  private def toModifiedUTF(c: Char): Array[Byte] = {
-    if (c >= '\u0001' && c <= '\u007F') {
-      Array(c.toByte)
-    } else if (c == '\u0000' || (c >= '\u0080' && c <= '\u07FF')) {
-      val b1 = 0xC0 | (c >>> 6)
-      val b2 = 0x80 | (c & 0x3F)
-      Array(b1.toByte, b2.toByte)
-    } else {
-      val b1 = 0xE0 | (c >>> 12)
-      val b2 = 0x80 | ((c >>> 6) & 0x3F)
-      val b3 = 0x80 | (c & 0x3F)
-      Array(b1.toByte, b2.toByte, b3.toByte)
+    var idx = 2
+    for (i <- 0 until s.length()) {
+      val c = s.charAt(i)
+      if (c <= 0x7f && c >= 0x01) {
+        buffer(idx) = c.toByte
+        idx += 1
+      } else if (c < 0x0800) {
+        buffer(idx) = ((c >> 6) | 0xc0).toByte
+        buffer(idx + 1) = ((c & 0x3f) | 0x80).toByte
+        idx += 2
+      } else {
+        buffer(idx) = ((c >> 12) | 0xe0).toByte
+        buffer(idx + 1) = (((c >> 6) & 0x3f) | 0x80).toByte
+        buffer(idx + 2) = ((c & 0x3f) | 0x80).toByte
+        idx += 3
+      }
     }
+
+    val len = idx - 2
+
+    if (len >= 0x10000)
+      throw new UTFDataFormatException(s"encoded string too long: $len bytes")
+
+    buffer(0) = (len >> 8).toByte
+    buffer(1) = len.toByte
+
+    write(buffer, 0, idx)
   }
 }

--- a/unit-tests/src/test/scala/java/io/DataOutputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/DataOutputStreamTest.scala
@@ -1,0 +1,270 @@
+// Ported from Scala.js commit: 9dc4d5b dated: 2018-10-11
+
+package java.io
+
+import org.junit._
+import org.junit.Assert._
+
+import scala.scalanative.junit.utils.AssertThrows._
+
+object DataOutputStreamTest {
+  class DataOutputStreamWrittenAccess(out: OutputStream)
+      extends DataOutputStream(out) {
+    def getWritten(): Int        = written
+    def setWritten(v: Int): Unit = written = v
+  }
+
+  class CheckerOutputStream extends ByteArrayOutputStream {
+    val dataOutputStream = new DataOutputStreamWrittenAccess(this)
+
+    assertEquals(0, dataOutputStream.getWritten())
+
+    /* Artificially skew `written` to make sure `size()` uses `written` as
+     * its implementation.
+     */
+    dataOutputStream.setWritten(100)
+
+    def check(expectedBytes: Int*): Unit = {
+      val expectedWritten = 100 + expectedBytes.size
+      assertEquals(expectedWritten, dataOutputStream.getWritten())
+      assertEquals(expectedWritten, dataOutputStream.size())
+      assertArrayEquals(expectedBytes.map(_.toByte).toArray, toByteArray())
+    }
+  }
+}
+
+class DataOutputStreamTest {
+  import DataOutputStreamTest._
+
+  private def newStream(): (DataOutputStream, CheckerOutputStream) = {
+    val checker = new CheckerOutputStream
+    (checker.dataOutputStream, checker)
+  }
+
+  @Test def construct(): Unit = {
+    val (stream, checker) = newStream()
+    checker.check()
+  }
+
+  @Test def writePrimitiveByte(): Unit = {
+    val (stream, checker) = newStream()
+    stream.write(42)
+    checker.check(42)
+  }
+
+  @Test def writePrimitiveBytes(): Unit = {
+    val (stream, checker) = newStream()
+    stream.write(Array[Byte](5, 3, 1, 43, 6, 12, 2), 1, 4)
+    checker.check(3, 1, 43, 6)
+  }
+
+  @Test def writeBoolean(): Unit = {
+    val (stream, checker) = newStream()
+
+    stream.writeBoolean(true)
+    stream.writeBoolean(true)
+    stream.writeBoolean(false)
+
+    checker.check(1, 1, 0)
+  }
+
+  @Test def writeByte(): Unit = {
+    val (stream, checker) = newStream()
+
+    stream.writeByte(0)
+    stream.writeByte(1)
+    stream.writeByte(-15)
+    stream.writeByte(125)
+    stream.writeByte(53)
+
+    checker.check(0, 1, -15, 125, 53)
+  }
+
+  @Test def writeShort(): Unit = {
+    val (stream, checker) = newStream()
+
+    stream.writeShort(453)
+    stream.writeShort(-43)
+    stream.writeShort(Short.MaxValue)
+    stream.writeShort(6320)
+    stream.writeShort(0)
+    stream.writeShort(Short.MinValue)
+    stream.writeShort(-346)
+    stream.writeShort(34)
+
+    checker.check(
+      0x01, 0xc5, 0xff, 0xd5, 0x7f, 0xff, 0x18, 0xb0, 0x00, 0x00, 0x80, 0x00,
+      0xfe, 0xa6, 0x00, 0x22
+    )
+  }
+
+  @Test def writeChar(): Unit = {
+    val (stream, checker) = newStream()
+
+    for (c <- "Höllö Wărȴđ")
+      stream.writeChar(c)
+
+    checker.check(
+      0x00, 0x48, // H
+      0x00, 0xF6, // ö
+      0x00, 0x6C, // l
+      0x00, 0x6C, // l
+      0x00, 0xF6, // ö
+      0x00, 0x20, // [space]
+      0x00, 0x57, // W
+      0x01, 0x03, // ă
+      0x00, 0x72, // r
+      0x02, 0x34, // ȴ
+      0x01, 0x11  // đ
+    )
+  }
+
+  @Test def writeInt(): Unit = {
+    val (stream, checker) = newStream()
+
+    stream.writeInt(0)
+    stream.writeInt(Int.MaxValue)
+    stream.writeInt(-4)
+    stream.writeInt(83)
+    stream.writeInt(35234)
+    stream.writeInt(-97539)
+    stream.writeInt(Int.MinValue)
+    stream.writeInt(1)
+
+    checker.check(
+      0x00, 0x00, 0x00, 0x00, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfc,
+      0x00, 0x00, 0x00, 0x53, 0x00, 0x00, 0x89, 0xa2, 0xff, 0xfe, 0x82, 0xfd,
+      0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+    )
+  }
+
+  @Test def writeLong(): Unit = {
+    val (stream, checker) = newStream()
+
+    stream.writeLong(546372873646234L)
+    stream.writeLong(-32451234L)
+    stream.writeLong(Long.MaxValue)
+    stream.writeLong(0L)
+    stream.writeLong(-1L)
+    stream.writeLong(Long.MinValue)
+    stream.writeLong(-34524L)
+    stream.writeLong(47L)
+
+    checker.check(
+      0x00, 0x01, 0xf0, 0xec, 0x59, 0x0c, 0x70, 0x9a, 0xff, 0xff, 0xff, 0xff,
+      0xfe, 0x10, 0xd5, 0x5e, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+      0xff, 0xff, 0xff, 0xff, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x79, 0x24, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x2f
+    )
+  }
+
+  @Test def writeFloat(): Unit = {
+    val (stream, checker) = newStream()
+
+    stream.writeFloat(-1.0f)
+    stream.writeFloat(4563.564f)
+    stream.writeFloat(-0.0f)
+    stream.writeFloat(0.0f)
+    stream.writeFloat(Float.NaN)
+    stream.writeFloat(Float.PositiveInfinity)
+    stream.writeFloat(-0.002f)
+    stream.writeFloat(Float.NegativeInfinity)
+
+    checker.check(
+      0xbf, 0x80, 0x00, 0x00, 0x45, 0x8e, 0x9c, 0x83, 0x80, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x7f, 0xc0, 0x00, 0x00, 0x7f, 0x80, 0x00, 0x00,
+      0xbb, 0x03, 0x12, 0x6f, 0xff, 0x80, 0x00, 0x00
+    )
+  }
+
+  @Test def writeDouble(): Unit = {
+    val (stream, checker) = newStream()
+
+    stream.writeDouble(0.7)
+    stream.writeDouble(345672.067923)
+    stream.writeDouble(-3472.0673)
+    stream.writeDouble(Double.NaN)
+    stream.writeDouble(Double.PositiveInfinity)
+    stream.writeDouble(-7.0134674)
+    stream.writeDouble(Double.NegativeInfinity)
+    stream.writeDouble(0.0)
+
+    checker.check(
+      0x3f, 0xe6, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x41, 0x15, 0x19, 0x20,
+      0x45, 0x8d, 0x9b, 0x5f, 0xc0, 0xab, 0x20, 0x22, 0x75, 0x25, 0x46, 0x0b,
+      0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7f, 0xf0, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0xc0, 0x1c, 0x0d, 0xca, 0x65, 0xea, 0x3f, 0xa4,
+      0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00
+    )
+  }
+
+  @Test def writeBytesOfString(): Unit = {
+    val (stream, checker) = newStream()
+
+    stream.writeBytes("Höllö Wărȴđ")
+
+    checker.check(
+      0x48, // H
+      0xF6, // ö
+      0x6C, // l
+      0x6C, // l
+      0xF6, // ö
+      0x20, // [space]
+      0x57, // W
+      0x03, // ă
+      0x72, // r
+      0x34, // ȴ
+      0x11  // đ
+    )
+  }
+
+  @Test def writeCharsOfString(): Unit = {
+    val (stream, checker) = newStream()
+
+    stream.writeChars("Höllö Wărȴđ")
+
+    checker.check(
+      0x00, 0x48, // H
+      0x00, 0xF6, // ö
+      0x00, 0x6C, // l
+      0x00, 0x6C, // l
+      0x00, 0xF6, // ö
+      0x00, 0x20, // [space]
+      0x00, 0x57, // W
+      0x01, 0x03, // ă
+      0x00, 0x72, // r
+      0x02, 0x34, // ȴ
+      0x01, 0x11  // đ
+    )
+  }
+
+  @Test def writeUTF(): Unit = {
+    val (stream, checker) = newStream()
+
+    stream.writeUTF("Höllö Wărȴđ")
+    stream.writeUTF("poo -> 💩")
+    stream.writeUTF("愛")
+
+    checker.check(
+      0x00, 0x10, 0x48, 0xc3, 0xb6, 0x6c, 0x6c, 0xc3, 0xb6, 0x20, 0x57, 0xc4,
+      0x83, 0x72, 0xc8, 0xb4, 0xc4, 0x91, 0x00, 0x0d, 0x70, 0x6f, 0x6f, 0x20,
+      0x2d, 0x3e, 0x20, 0xed, 0xa0, 0xbd, 0xed, 0xb2, 0xa9, 0x00, 0x03, 0xe6,
+      0x84, 0x9b
+    )
+  }
+
+  @Test def writeUTFTooLong(): Unit = {
+    val (stream, checker) = newStream()
+
+    var longString = "aaa"
+    while (longString.length < 0x10000)
+      longString = longString + longString
+
+    assertThrows(classOf[UTFDataFormatException], {
+      stream.writeUTF(longString)
+    })
+  }
+}


### PR DESCRIPTION
We now use multi-byte writes to the underlying stream in java.io.DataOutputStream
where possible. This reduces the number of I/O calls. 
  
`DataOutputStream#writeUTF` and `DataOutputStreamTest` are newly ported from Scala.js.

See the referenced issue for more extensive design discussion.