### PR TITLE
Allow for cross building tools

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,15 +38,15 @@ jobs:
             ~/.sbt/boot
           key: ${{ runner.os }}-deps-${{ env.binary-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
 
+      - name: Test tools
+        run: sbt "++ ${{ matrix.scala }} -v" "-no-colors" "-J-Xmx3G" test-tools
+
       # Pre-compile and cache results for the most time consuming projects and it dependencies too speed up execution in next phases
       # We cannot use `compile` because sbtScalaNative does not crossCompile
       - name: Compile
         run: sbt "++ ${{ matrix.scala }} -v" "-no-colors" "-J-Xmx3G" \
-          "tools/Test/compile" \
           "tests/Test/compile" "testsExt/Test/compile" \
           "junitTestOutputsNative/Test/compile" "junitTestOutputsJVM/Test/compile"
-      - name: Test tools
-        run: sbt "++ ${{ matrix.scala }} -v" "-no-colors" "-J-Xmx3G" test-tools
 
   # Build testing image that would be used to build and run against different platforms
   # Currently only Linux x64 is tested

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,9 +38,13 @@ jobs:
             ~/.sbt/boot
           key: ${{ runner.os }}-deps-${{ env.binary-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
 
+      # Pre-compile and cache results for the most time consuming projects and it dependencies too speed up execution in next phases
+      # We cannot use `compile` because sbtScalaNative does not crossCompile
       - name: Compile
-        run: sbt "++ ${{ matrix.scala }} -v" "-no-colors" "-J-Xmx3G" compile
-
+        run: sbt "++ ${{ matrix.scala }} -v" "-no-colors" "-J-Xmx3G" \
+          "tools/Test/compile" \
+          "tests/Test/compile" "testsExt/Test/compile" \
+          "junitTestOutputsNative/Test/compile" "junitTestOutputsJVM/Test/compile"
       - name: Test tools
         run: sbt "++ ${{ matrix.scala }} -v" "-no-colors" "-J-Xmx3G" test-tools
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -210,7 +210,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.13.4, 2.12.13, 2.11.12]
+        scala: [2.12.13]
     steps:
       - uses: actions/checkout@v2
       - name: Calculate binary version

--- a/.sbtopts
+++ b/.sbtopts
@@ -2,4 +2,3 @@
 -J-Xms1024M
 # Needed for Scala 2.11 tools compilation. Failing in CI for test-scripted
 -J-Xss2m
-

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,5 @@
 -J-Xmx5G
 -J-Xms1024M
+# Needed for Scala 2.11 tools compilation. Failing in CI for test-scripted
+-J-Xss2m
+

--- a/build.sbt
+++ b/build.sbt
@@ -79,14 +79,6 @@ lazy val mimaSettings: Seq[Setting[_]] = Seq(
   }
 )
 
-// Sbt 1.4.0 introduced mandatory key linting.
-// The val crossSbtVersions is used in toolsSettings below.
-// toolsSettings are used by nir, test-runner, util, etc.
-// but Sbt 1.4.0 still complained about crossSbtVersions.
-// Disable the linting for it, rather than upsetting the apple cart by
-// deleting the probably essential crossSbeVersions. Minimal change.
-Global / excludeLintKeys += crossSbtVersions
-
 // Common start but individual sub-projects may add or remove scalacOptions.
 // project/build.sbt uses a less stringent set to bootstrap.
 inThisBuild(
@@ -242,7 +234,6 @@ lazy val noPublishSettings: Seq[Setting[_]] = Seq(
 lazy val toolSettings: Seq[Setting[_]] =
   Def.settings(
     sbtVersion := sbt10Version,
-    crossSbtVersions := List(sbt10Version),
     crossScalaVersions := Seq(sbt10ScalaVersion),
     javacOptions ++= Seq("-encoding", "utf8")
   )
@@ -363,7 +354,6 @@ lazy val nscplugin =
     .in(file("nscplugin"))
     .settings(mavenPublishSettings)
     .settings(
-      crossScalaVersions := libCrossScalaVersions,
       crossVersion := CrossVersion.full,
       Compile / unmanagedSourceDirectories ++= Seq(
         (nir / Compile / scalaSource).value,

--- a/build.sbt
+++ b/build.sbt
@@ -415,7 +415,7 @@ lazy val sbtScalaNative =
           .value
       }
     )
-    .dependsOn(testRunner, tools)
+    .dependsOn(tools, testRunner)
 
 lazy val nativelib =
   project

--- a/build.sbt
+++ b/build.sbt
@@ -413,16 +413,9 @@ lazy val sbtScalaNative =
             testRunner / publishLocal
           )
           .value
-      },
-      // Depending on projects defining `crossScalaVersion` other then this `scalaVersion` would result in build failure
-      unmanagedSourceDirectories in Compile ++= Seq(
-        (testRunner / Compile / scalaSource).value,
-        (tools / Compile / scalaSource).value,
-        (nir / Compile / scalaSource).value,
-        (util / Compile / scalaSource).value,
-        baseDirectory.value.getParentFile / "test-interface-common/src/main/scala"
-      )
+      }
     )
+    .dependsOn(testRunner, tools)
 
 lazy val nativelib =
   project

--- a/build.sbt
+++ b/build.sbt
@@ -328,6 +328,14 @@ lazy val tools =
             allCoreLibsCp.map(_.getAbsolutePath).mkString(pathSeparator)
         )
       },
+      libraryDependencies ++= {
+        CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, 11 | 12)) => Nil
+          case _ =>
+            List(
+              "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.0")
+        }
+      },
       // Running tests in parallel results in `FileSystemAlreadyExistsException`
       Test / parallelExecution := false,
       mimaSettings

--- a/build.sbt
+++ b/build.sbt
@@ -233,8 +233,6 @@ lazy val noPublishSettings: Seq[Setting[_]] = Seq(
 
 lazy val toolSettings: Seq[Setting[_]] =
   Def.settings(
-    sbtVersion := sbt10Version,
-    crossScalaVersions := Seq(sbt10ScalaVersion),
     javacOptions ++= Seq("-encoding", "utf8")
   )
 
@@ -414,9 +412,16 @@ lazy val sbtScalaNative =
             testRunner / publishLocal
           )
           .value
-      }
+      },
+      // Depending on projects defining `crossScalaVersion` other then this `scalaVersion` would result in build failure
+      unmanagedSourceDirectories in Compile ++= Seq(
+        (testRunner / Compile / scalaSource).value,
+        (tools / Compile / scalaSource).value,
+        (nir / Compile / scalaSource).value,
+        (util / Compile / scalaSource).value,
+        baseDirectory.value.getParentFile / "test-interface-common/src/main/scala"
+      )
     )
-    .dependsOn(tools, testRunner)
 
 lazy val nativelib =
   project

--- a/build.sbt
+++ b/build.sbt
@@ -369,6 +369,7 @@ lazy val sbtPluginSettings: Seq[Setting[_]] =
   toolSettings ++
     bintrayPublishSettings ++
     Seq(
+      sbtVersion := sbt10Version,
       scriptedLaunchOpts := {
         scriptedLaunchOpts.value ++
           Seq("-Xmx1024M",

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -5,8 +5,6 @@ import java.nio.charset.StandardCharsets
 import scala.collection.mutable
 import scala.scalanative.util.ShowBuilder.InMemoryShowBuilder
 import scalanative.util.{ShowBuilder, unreachable}
-import java.util.stream.{Stream => JStream}
-import java.util.function.{Function => JFunction, Consumer => JConsumer}
 
 object Show {
   def newBuilder: NirShowBuilder = new NirShowBuilder(new InMemoryShowBuilder)
@@ -123,6 +121,7 @@ object Show {
         str("(")
         rep(args, sep = ", ")(val_)
         str(")")
+      case Next.None => ()
     }
 
     def inst_(inst: Inst): Unit = inst match {

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -2,7 +2,8 @@ package scala.scalanative
 package build
 
 import java.io.File
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Path, Paths}
+import scala.annotation.nowarn
 import scala.util.Try
 import scala.sys.process._
 import scalanative.build.IO.RichPath
@@ -10,6 +11,7 @@ import scalanative.build.IO.RichPath
 /** Utilities for discovery of command-line tools and settings required
  *  to build Scala Native applications.
  */
+@nowarn("msg=method lineStream_!")
 object Discover {
 
   /** Compilation mode name from SCALANATIVE_MODE env var or default. */

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -3,7 +3,6 @@ package build
 
 import java.io.File
 import java.nio.file.{Path, Paths}
-import scala.annotation.nowarn
 import scala.util.Try
 import scala.sys.process._
 import scalanative.build.IO.RichPath

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -11,7 +11,6 @@ import scalanative.build.IO.RichPath
 /** Utilities for discovery of command-line tools and settings required
  *  to build Scala Native applications.
  */
-@nowarn("msg=method lineStream_!")
 object Discover {
 
   /** Compilation mode name from SCALANATIVE_MODE env var or default. */

--- a/tools/src/main/scala/scala/scalanative/build/IO.scala
+++ b/tools/src/main/scala/scala/scalanative/build/IO.scala
@@ -58,7 +58,7 @@ private[scalanative] object IO {
                        EnumSet.of(FileVisitOption.FOLLOW_LINKS),
                        Int.MaxValue,
                        visitor)
-    out
+    out.toSeq
   }
 
   /** Does a `pattern` match starting at base */

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -1,11 +1,12 @@
 package scala.scalanative
 package build
 
-import java.nio.file.{Files, Path, Paths, StandardCopyOption}
+import java.nio.file.{Files, Path, Paths}
 import java.util.Arrays
 import scala.sys.process._
 import scalanative.build.IO.RichPath
 import scalanative.build.NativeLib._
+import scalanative.compat.CompatParColls.Converters._
 
 /** Internal utilities to interact with LLVM command-line tools. */
 private[scalanative] object LLVM {

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -5,6 +5,7 @@ import scala.collection.mutable
 import scalanative.nir._
 import scalanative.linker._
 import scalanative.util.partitionBy
+import scalanative.compat.CompatParColls.Converters._
 
 final class Check(implicit linked: linker.Result) {
   val errors = mutable.UnrolledBuffer.empty[Check.Error]

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -8,9 +8,10 @@ import scala.scalanative.util.ShowBuilder.FileShowBuilder
 import scalanative.util.{Scope, ShowBuilder, partitionBy, procs, unsupported}
 import scalanative.io.VirtualDirectory
 import scalanative.nir._
-import scalanative.nir.ControlFlow.{Block, Edge, Graph => CFG}
+import scalanative.nir.ControlFlow.{Block, Graph => CFG}
 import scalanative.util.unreachable
 import scalanative.build.ScalaNative.dumpDefns
+import scalanative.compat.CompatParColls.Converters._
 
 object CodeGen {
 

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -38,7 +38,7 @@ object CodeGen {
       .seq
       .foreach { defns => buf ++= defns }
 
-    buf
+    buf.toSeq
   }
 
   /** Generate code for given assembly. */
@@ -373,7 +373,7 @@ object CodeGen {
             str(" = phi ")
             genType(ty)
             str(" ")
-            rep(block.inEdges, sep = ", ") { edge =>
+            rep(block.inEdges.toSeq, sep = ", ") { edge =>
               def genRegularEdge(next: Next.Label): Unit = {
                 val Next.Label(_, vals) = next
                 genJustVal(vals(n))
@@ -1062,6 +1062,6 @@ object CodeGen {
     buf += Rt.Object.name member Rt.ScalaHashCodeSig
     buf += Rt.Object.name member Rt.JavaEqualsSig
     buf += Rt.Object.name member Rt.JavaHashCodeSig
-    buf
+    buf.toSeq
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -36,7 +36,7 @@ object Generate {
       genArrayIds()
       genStackBottom()
 
-      buf
+      buf.toSeq
     }
 
     def genDefnsExcludingGenerated(): Unit = {

--- a/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
@@ -127,6 +127,6 @@ object GenerateReflectiveProxies {
       case _ =>
         ()
     }
-    result
+    result.toSeq
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/HasTraitTables.scala
@@ -35,7 +35,7 @@ class HasTraitTables(meta: Metadata) {
     val columns = meta.classes.map { cls =>
       val row = new Array[Boolean](meta.traits.length)
       markTraits(row, cls)
-      Val.ArrayValue(Type.Bool, row.map(Val.Bool))
+      Val.ArrayValue(Type.Bool, row.toSeq.map(Val.Bool))
     }
     val table =
       Val.ArrayValue(Type.ArrayValue(Type.Bool, meta.traits.length), columns)
@@ -50,7 +50,7 @@ class HasTraitTables(meta: Metadata) {
       val row = new Array[Boolean](meta.traits.length)
       markTraits(row, left)
       row(meta.ids(left)) = true
-      Val.ArrayValue(Type.Bool, row.map(Val.Bool))
+      Val.ArrayValue(Type.Bool, row.toSeq.map(Val.Bool))
     }
     val table =
       Val.ArrayValue(Type.ArrayValue(Type.Bool, meta.traits.length), columns)

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -71,7 +71,7 @@ object Lower {
           buf += onDefn(defn)
       }
 
-      buf
+      buf.toSeq
     }
 
     override def onDefn(defn: Defn): Defn = defn match {
@@ -521,6 +521,7 @@ object Lower {
                 genClassVirtualLookup(Object)
               case TraitRef(trt) =>
                 genTraitVirtualLookup(trt)
+              case _ => util.unreachable
             }
         }
       }
@@ -996,6 +997,7 @@ object Lower {
             n,
             Op.Call(sig, Val.Global(func, Type.Ptr), Seq(module, len, init)),
             unwind)
+        case _ => util.unreachable
       }
     }
 
@@ -1293,7 +1295,7 @@ object Lower {
     buf += Defn.Declare(Attrs.None, largeAllocName, allocSig)
     buf += Defn.Declare(Attrs.None, dyndispatchName, dyndispatchSig)
     buf += Defn.Declare(Attrs.None, throwName, throwSig)
-    buf
+    buf.toSeq
   }
 
   val depends: Seq[Global] = {
@@ -1325,6 +1327,6 @@ object Lower {
     buf += RuntimeNull.name
     buf += RuntimeNothing.name
     buf += toClassVal.name
-    buf
+    buf.toSeq
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -1060,7 +1060,7 @@ object Lower {
             rtti(CharArrayCls).const,
             charsLength,
             Val.Int(0), // padding to get next field aligned properly
-            Val.ArrayValue(Type.Char, chars.map(Val.Char))
+            Val.ArrayValue(Type.Char, chars.toSeq.map(Val.Char))
           )
         ))
 

--- a/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/MemoryLayout.scala
@@ -74,6 +74,6 @@ object MemoryLayout {
 
     val alignment = if (tys.isEmpty) 1 else tys.map(alignmentOf).max
 
-    MemoryLayout(align(offset, alignment), pos)
+    MemoryLayout(align(offset, alignment), pos.toSeq)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -56,7 +56,7 @@ class Metadata(val linked: linker.Result, proxies: Seq[Defn]) {
 
     loop(linked.infos(Rt.Object.name).asInstanceOf[Class])
 
-    out
+    out.toSeq
   }
 
   def initClassMetadata(): Unit = {

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -29,7 +29,7 @@ class Metadata(val linked: linker.Result, proxies: Seq[Defn]) {
     val traits =
       linked.infos.valuesIterator
         .collect { case info: Trait => info }
-        .toArray
+        .toIndexedSeq
         .sortBy(_.name.show)
     traits.zipWithIndex.foreach {
       case (node, id) =>

--- a/tools/src/main/scala/scala/scalanative/codegen/ModuleArray.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ModuleArray.scala
@@ -16,5 +16,5 @@ class ModuleArray(meta: Metadata) {
   }
   val size: Int = modules.size
   val value: Val =
-    Val.ArrayValue(Type.Ptr, Array.fill[Val](modules.length)(Val.Null))
+    Val.ArrayValue(Type.Ptr, Seq.fill[Val](modules.length)(Val.Null))
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/TraitDispatchTable.scala
@@ -88,7 +88,7 @@ class TraitDispatchTable(meta: Metadata) {
 
     val (compressed, offsets) = compressTable(table, mins, sizes)
 
-    val value = Val.ArrayValue(Type.Ptr, compressed)
+    val value = Val.ArrayValue(Type.Ptr, compressed.toSeq)
 
     dispatchOffset = offsets
     dispatchTy = Type.Ptr

--- a/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/VirtualTable.scala
@@ -34,7 +34,7 @@ class VirtualTable(meta: Metadata, cls: linker.Class) {
     }
   }
   val value: Val =
-    Val.ArrayValue(Type.Ptr, slots.map(impls))
+    Val.ArrayValue(Type.Ptr, slots.map(impls).toSeq)
   val ty =
     value.ty
   def index(sig: Sig): Int =

--- a/tools/src/main/scala/scala/scalanative/compat/CompatParColls.scala
+++ b/tools/src/main/scala/scala/scalanative/compat/CompatParColls.scala
@@ -1,0 +1,15 @@
+package scala.scalanative.compat
+
+private[scalanative] object CompatParColls {
+  val Converters = {
+    import Compat._
+    {
+      import scala.collection.parallel._
+      CollectionConverters
+    }
+  }
+
+  object Compat {
+    object CollectionConverters
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -423,6 +423,7 @@ trait Eval { self: Interflow =>
         val Val.Local(local, _) = eval(slot)
         state.storeVar(local, eval(value))
         Val.Unit
+      case _ => util.unreachable
     }
   }
 

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -176,7 +176,7 @@ trait Inline { self: Interflow =>
           }
 
         case first +: rest =>
-          emit ++= first.toInsts.tail
+          emit ++= first.toInsts().tail
 
           rest.foreach { block =>
             block.cf match {
@@ -184,10 +184,10 @@ trait Inline { self: Interflow =>
                 ()
               case Inst.Throw(value, unwind) =>
                 val excv = block.end.materialize(value)
-                emit ++= block.toInsts.init
+                emit ++= block.toInsts().init
                 emit.raise(excv, unwind)
               case _ =>
-                emit ++= block.toInsts
+                emit ++= block.toInsts()
             }
           }
 
@@ -195,7 +195,7 @@ trait Inline { self: Interflow =>
             .collectFirst {
               case block if block.cf.isInstanceOf[Inst.Ret] =>
                 val Inst.Ret(value) = block.cf
-                emit ++= block.toInsts.init
+                emit ++= block.toInsts().init
                 (value, block.end)
             }
             .getOrElse {

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -102,7 +102,7 @@ final class MergeProcessor(insts: Array[Inst],
             val values = mutable.UnrolledBuffer.empty[Val]
             states.foreach { s => s.locals.get(local).foreach(values += _) }
             if (states.size == values.size) {
-              mergeLocals(local) = mergePhi(values, Some(value.ty))
+              mergeLocals(local) = mergePhi(values.toSeq, Some(value.ty))
             }
           }
           headState.locals.foreach((mergeLocal _).tupled)
@@ -150,6 +150,7 @@ final class MergeProcessor(insts: Array[Inst],
                   assert(
                     states.forall(s => s.derefDelayed(addr).delayedOp == op))
                   mergeHeap(addr) = DelayedInstance(op)
+                case _ => util.unreachable
               }
             }
             out
@@ -227,7 +228,7 @@ final class MergeProcessor(insts: Array[Inst],
         mergeState.delayed = mergeDelayed
         mergeState.emitted = mergeEmitted
 
-        (mergePhis, mergeState)
+        (mergePhis.toSeq, mergeState)
     }
   }
 
@@ -450,7 +451,7 @@ final class MergeProcessor(insts: Array[Inst],
     }
 
     orderedBlocks ++= sortedBlocks.filter(isExceptional)
-    orderedBlocks
+    orderedBlocks.toSeq
   }
 }
 

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -419,7 +419,7 @@ final class MergeProcessor(insts: Array[Inst],
       // Create synthetic label and block where all returning blocks
       // are going tojump to. Synthetics names must be fresh relative
       // to the source instructions, not relative to generated ones.
-      val syntheticFresh = Fresh(insts)
+      val syntheticFresh = Fresh(insts.toSeq)
       val syntheticParam =
         Val.Local(syntheticFresh(), Sub.lub(tys, Some(retTy)))
       val syntheticLabel =

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -29,7 +29,7 @@ trait PolyInline { self: Interflow =>
             cls.resolve(sig).foreach { g => targets += ((cls, g)) }
           }
         }
-        targets
+        targets.toSeq
       case _ =>
         Seq.empty
     }
@@ -118,7 +118,7 @@ trait PolyInline { self: Interflow =>
         emit.jump(Next.Label(mergeLabel, Seq(res)))
     }
 
-    val result = Val.Local(fresh(), Sub.lub(rettys, Some(op.resty)))
+    val result = Val.Local(fresh(), Sub.lub(rettys.toSeq, Some(op.resty)))
     emit.label(mergeLabel, Seq(result))
 
     result

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -245,7 +245,7 @@ final class State(block: Local) {
             && values.exists(v => !v.isZero))
         val init =
           if (canConstantInit) {
-            Val.ArrayValue(elemty, values)
+            Val.ArrayValue(elemty, values.toSeq)
           } else {
             Val.Int(values.length)
           }

--- a/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
@@ -52,7 +52,7 @@ object UseDef {
   private def collect(inst: Inst): Seq[Local] = {
     val collector = new CollectLocalValDeps
     collector.onInst(inst)
-    collector.deps.distinct
+    collector.deps.distinct.toSeq
   }
 
   private def isPure(inst: Inst) = inst match {

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -3,6 +3,7 @@ package interflow
 
 import scalanative.nir._
 import scalanative.linker._
+import scalanative.compat.CompatParColls.Converters._
 
 trait Visit { self: Interflow =>
   def shallVisit(name: Global): Boolean = {

--- a/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Visit.scala
@@ -3,7 +3,6 @@ package interflow
 
 import scalanative.nir._
 import scalanative.linker._
-import scalanative.interflow.UseDef.eliminateDeadCode
 
 trait Visit { self: Interflow =>
   def shallVisit(name: Global): Boolean = {

--- a/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/ClassLoader.scala
@@ -49,11 +49,11 @@ object ClassLoader {
 
     lazy val classesWithEntryPoints: Iterable[Global] = {
       scopes.filter {
-        case (_, defns) => Defn.existsEntryPoint(defns)
+        case (_, defns) => Defn.existsEntryPoint(defns.toSeq)
       }.keySet
     }
 
     def load(global: Global): Option[Seq[Defn]] =
-      scopes.get(global)
+      scopes.get(global).map(_.toSeq)
   }
 }

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -46,7 +46,7 @@ sealed abstract class ScopeInfo extends Info {
     }
 
     loop(this)
-    overwrite(out)
+    overwrite(out.toSeq)
   }
 }
 
@@ -116,7 +116,7 @@ final class Class(val attrs: Attrs,
       }
     }
     add(this)
-    out
+    out.toSeq
   }
 
   val ty: Type =

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -41,7 +41,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
                unavailable.toSeq,
                from,
                links.toSeq,
-               defns,
+               defns.toSeq,
                dynsigs.toSeq,
                dynimpls.toSeq)
   }

--- a/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
@@ -53,7 +53,7 @@ abstract class LinkerSpec extends AnyFlatSpec {
     val classpath = makeClasspath(outDir)
     Config.empty
       .withWorkdir(outDir)
-      .withClassPath(classpath)
+      .withClassPath(classpath.toSeq)
       .withMainClass(entry)
       .withCompilerConfig(_.withLinkStubs(linkStubs))
   }

--- a/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
@@ -70,6 +70,6 @@ trait ReachabilitySuite extends AnyFunSuite {
     val paths = makeClasspath(outDir)
     build.Config.empty
       .withWorkdir(outDir)
-      .withClassPath(paths)
+      .withClassPath(paths.toSeq)
   }
 }


### PR DESCRIPTION
This PR adopts our codebase to be compatible with Scala 2.13 and cross builts most of the remaining projects with 2 exclusions:
 - `nirParser` which is not published or used by any other of our components
 - `sbtScalaNative` is sbt plugin project
 
Currently, tools are only used within sbt plugin, which can only be published in Scala 2.12 and therefore not cross-built.  
Incoming support for Scala partests (#2154) needs `tools` to run tests against Scala 2.11 and 2.13. 