### PR TITLE
Normalize names in clib and posixlib

### DIFF
--- a/clib/src/main/resources/scala-native/math.c
+++ b/clib/src/main/resources/scala-native/math.c
@@ -1,15 +1,15 @@
 #include <math.h>
 
-float scalanative_libc_huge_valf() { return HUGE_VALF; }
+float scalanative_huge_valf() { return HUGE_VALF; }
 
-double scalanative_libc_huge_val() { return HUGE_VAL; }
+double scalanative_huge_val() { return HUGE_VAL; }
 
-float scalanative_libc_infinity() { return INFINITY; }
+float scalanative_infinity() { return INFINITY; }
 
-float scalanative_libc_nan() { return NAN; }
+float scalanative_nan() { return NAN; }
 
-int scalanative_libc_math_errhandling() { return math_errhandling; }
+int scalanative_math_errhandling() { return math_errhandling; }
 
-int scalanative_libc_math_errno() { return MATH_ERRNO; }
+int scalanative_math_errno() { return MATH_ERRNO; }
 
-int scalanative_libc_math_errexcept() { return MATH_ERREXCEPT; }
+int scalanative_math_errexcept() { return MATH_ERREXCEPT; }

--- a/clib/src/main/resources/scala-native/signal.c
+++ b/clib/src/main/resources/scala-native/signal.c
@@ -2,22 +2,22 @@
 
 typedef void (*sig_handler_t)(int);
 
-sig_handler_t scalanative_libc_sig_dfl() { return SIG_DFL; }
+sig_handler_t scalanative_sig_dfl() { return SIG_DFL; }
 
-sig_handler_t scalanative_libc_sig_ign() { return SIG_IGN; }
+sig_handler_t scalanative_sig_ign() { return SIG_IGN; }
 
-sig_handler_t scalanative_libc_sig_err() { return SIG_ERR; }
+sig_handler_t scalanative_sig_err() { return SIG_ERR; }
 
-int scalanative_libc_sigabrt() { return SIGABRT; }
+int scalanative_sigabrt() { return SIGABRT; }
 
-int scalanative_libc_sigfpe() { return SIGFPE; }
+int scalanative_sigfpe() { return SIGFPE; }
 
-int scalanative_libc_sigill() { return SIGILL; }
+int scalanative_sigill() { return SIGILL; }
 
-int scalanative_libc_sigint() { return SIGINT; }
+int scalanative_sigint() { return SIGINT; }
 
-int scalanative_libc_sigsegv() { return SIGSEGV; }
+int scalanative_sigsegv() { return SIGSEGV; }
 
-int scalanative_libc_sigterm() { return SIGTERM; }
+int scalanative_sigterm() { return SIGTERM; }
 
-int scalanative_libc_sigusr1() { return SIGUSR1; }
+int scalanative_sigusr1() { return SIGUSR1; }

--- a/clib/src/main/resources/scala-native/stdio.c
+++ b/clib/src/main/resources/scala-native/stdio.c
@@ -5,32 +5,32 @@
 // can not expand C macros, and that's the easiest way to
 // get the values out of those in a portable manner.
 
-void *scalanative_libc_stdin() { return stdin; }
+void *scalanative_stdin() { return stdin; }
 
-void *scalanative_libc_stdout() { return stdout; }
+void *scalanative_stdout() { return stdout; }
 
-void *scalanative_libc_stderr() { return stderr; }
+void *scalanative_stderr() { return stderr; }
 
-int scalanative_libc_eof() { return EOF; }
+int scalanative_eof() { return EOF; }
 
-unsigned int scalanative_libc_fopen_max() { return FOPEN_MAX; }
+unsigned int scalanative_fopen_max() { return FOPEN_MAX; }
 
-unsigned int scalanative_libc_filename_max() { return FILENAME_MAX; }
+unsigned int scalanative_filename_max() { return FILENAME_MAX; }
 
-unsigned int scalanative_libc_bufsiz() { return BUFSIZ; }
+unsigned int scalanative_bufsiz() { return BUFSIZ; }
 
-int scalanative_libc_iofbf() { return _IOFBF; }
+int scalanative_iofbf() { return _IOFBF; }
 
-int scalanative_libc_iolbf() { return _IOLBF; }
+int scalanative_iolbf() { return _IOLBF; }
 
-int scalanative_libc_ionbf() { return _IONBF; }
+int scalanative_ionbf() { return _IONBF; }
 
-int scalanative_libc_seek_set() { return SEEK_SET; }
+int scalanative_seek_set() { return SEEK_SET; }
 
-int scalanative_libc_seek_cur() { return SEEK_CUR; }
+int scalanative_seek_cur() { return SEEK_CUR; }
 
-int scalanative_libc_seek_end() { return SEEK_END; }
+int scalanative_seek_end() { return SEEK_END; }
 
-unsigned int scalanative_libc_tmp_max() { return TMP_MAX; }
+unsigned int scalanative_tmp_max() { return TMP_MAX; }
 
-unsigned int scalanative_libc_l_tmpnam() { return L_tmpnam; }
+unsigned int scalanative_l_tmpnam() { return L_tmpnam; }

--- a/clib/src/main/resources/scala-native/stdlib.c
+++ b/clib/src/main/resources/scala-native/stdlib.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 
-int scalanative_libc_exit_success() { return EXIT_SUCCESS; }
+int scalanative_exit_success() { return EXIT_SUCCESS; }
 
-int scalanative_libc_exit_failure() { return EXIT_FAILURE; }
+int scalanative_exit_failure() { return EXIT_FAILURE; }
 
-int scalanative_libc_rand_max() { return RAND_MAX; }
+int scalanative_rand_max() { return RAND_MAX; }

--- a/clib/src/main/scala/scala/scalanative/libc/math.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/math.scala
@@ -145,18 +145,18 @@ object math {
 
   // Macros
 
-  @name("scalanative_libc_huge_valf")
+  @name("scalanative_huge_valf")
   def HUGE_VALF: CFloat = extern
-  @name("scalanative_libc_huge_val")
+  @name("scalanative_huge_val")
   def HUGE_VAL: CDouble = extern
-  @name("scalanative_libc_infinity")
+  @name("scalanative_infinity")
   def INFINITY: CFloat = extern
-  @name("scalanative_libc_nan")
+  @name("scalanative_nan")
   def NAN: CFloat = extern
-  @name("scalanative_libc_math_errhandling")
+  @name("scalanative_math_errhandling")
   def math_errhandling: CInt = extern
-  @name("scalanative_libc_math_errno")
+  @name("scalanative_math_errno")
   def MATH_ERRNO: CInt = extern
-  @name("scalanative_libc_math_errexcept")
+  @name("scalanative_math_errexcept")
   def MATH_ERREXCEPT: CInt = extern
 }

--- a/clib/src/main/scala/scala/scalanative/libc/signal.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/signal.scala
@@ -15,24 +15,24 @@ object signal {
 
   // Macros
 
-  @name("scalanative_libc_sig_dfl")
+  @name("scalanative_sig_dfl")
   def SIG_DFL: CFuncPtr1[CInt, Unit] = extern
-  @name("scalanative_libc_sig_ign")
+  @name("scalanative_sig_ign")
   def SIG_IGN: CFuncPtr1[CInt, Unit] = extern
-  @name("scalanative_libc_sig_err")
+  @name("scalanative_sig_err")
   def SIG_ERR: CFuncPtr1[CInt, Unit] = extern
-  @name("scalanative_libc_sigabrt")
+  @name("scalanative_sigabrt")
   def SIGABRT: CInt = extern
-  @name("scalanative_libc_sigfpe")
+  @name("scalanative_sigfpe")
   def SIGFPE: CInt = extern
-  @name("scalanative_libc_sigill")
+  @name("scalanative_sigill")
   def SIGILL: CInt = extern
-  @name("scalanative_libc_sigint")
+  @name("scalanative_sigint")
   def SIGINT: CInt = extern
-  @name("scalanative_libc_sigsegv")
+  @name("scalanative_sigsegv")
   def SIGSEGV: CInt = extern
-  @name("scalanative_libc_sigterm")
+  @name("scalanative_sigterm")
   def SIGTERM: CInt = extern
-  @name("scalanative_libc_sigusr1")
+  @name("scalanative_sigusr1")
   def SIGUSR1: CInt = extern
 }

--- a/clib/src/main/scala/scala/scalanative/libc/stdio.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdio.scala
@@ -93,34 +93,34 @@ object stdio {
 
   // Macros
 
-  @name("scalanative_libc_stdin")
+  @name("scalanative_stdin")
   def stdin: Ptr[FILE] = extern
-  @name("scalanative_libc_stdout")
+  @name("scalanative_stdout")
   def stdout: Ptr[FILE] = extern
-  @name("scalanative_libc_stderr")
+  @name("scalanative_stderr")
   def stderr: Ptr[FILE] = extern
-  @name("scalanative_libc_eof")
+  @name("scalanative_eof")
   def EOF: CInt = extern
-  @name("scalanative_libc_fopen_max")
+  @name("scalanative_fopen_max")
   def FOPEN_MAX: CUnsignedInt = extern
-  @name("scalanative_libc_filename_max")
+  @name("scalanative_filename_max")
   def FILENAME_MAX: CUnsignedInt = extern
-  @name("scalanative_libc_bufsiz")
+  @name("scalanative_bufsiz")
   def BUFSIZ: CUnsignedInt = extern
-  @name("scalanative_libc_iofbf")
+  @name("scalanative_iofbf")
   def _IOFBF: CInt = extern
-  @name("scalanative_libc_iolbf")
+  @name("scalanative_iolbf")
   def _IOLBF: CInt = extern
-  @name("scalanative_libc_ionbf")
+  @name("scalanative_ionbf")
   def _IONBF: CInt = extern
-  @name("scalanative_libc_seek_set")
+  @name("scalanative_seek_set")
   def SEEK_SET: CInt = extern
-  @name("scalanative_libc_seek_cur")
+  @name("scalanative_seek_cur")
   def SEEK_CUR: CInt = extern
-  @name("scalanative_libc_seek_end")
+  @name("scalanative_seek_end")
   def SEEK_END: CInt = extern
-  @name("scalanative_libc_tmp_max")
+  @name("scalanative_tmp_max")
   def TMP_MAX: CUnsignedInt = extern
-  @name("scalanative_libc_l_tmpnam")
+  @name("scalanative_l_tmpnam")
   def L_tmpnam: CUnsignedInt = extern
 }

--- a/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
+++ b/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
@@ -70,10 +70,10 @@ object stdlib {
 
   // Macros
 
-  @name("scalanative_libc_exit_success")
+  @name("scalanative_exit_success")
   def EXIT_SUCCESS: CInt = extern
-  @name("scalanative_libc_exit_failure")
+  @name("scalanative_exit_failure")
   def EXIT_FAILURE: CInt = extern
-  @name("scalanative_libc_rand_max")
+  @name("scalanative_rand_max")
   def RAND_MAX: CInt = extern
 }

--- a/docs/contrib/contributing.rst
+++ b/docs/contrib/contributing.rst
@@ -65,6 +65,42 @@ the environment variable to your shell startup file for convenience:
 The script `./scripts/clangfmt` will use the `.clang-format` file
 at the root of the project for settings used in formatting.
 
+C / POSIX Libraries
+-------------------
+
+Both the `clib` and `posixlib` have coding styles that are unique
+compared to normal Scala coding style. Normal C code is written in
+lowercase snake case for function names and uppercase snake case for
+macro or pre-processor constants. Here is an example for Scala:
+
+.. code-block:: scala
+
+    @extern
+    object cpio {
+      @name("scalanative_c_issock")
+      def C_ISSOCK: CUnsignedShort = extern
+
+      @name("scalanative_c_islnk")
+      def C_ISLNK: CUnsignedShort = extern
+
+The following is the corresponding C file:
+
+.. code-block:: C
+
+    #include <cpio.h>
+
+    unsigned short scalanative_c_issock() { return C_ISSOCK; }
+    unsigned short scalanative_c_islnk() { return C_ISLNK; }
+
+Since C has a flat namespace most libraries have prefixes and
+in general cannot use the same symbol names so there is no
+need to add additional prefixes. For Scala Native we use
+`scalanative_` as a prefix for functions.
+
+This is the reason C++ added namespaces so that library designer
+could have a bit more freedom. The developer, however, still has to
+de-conflict duplicate symbols by using the defined namespaces.
+
 General workflow
 ----------------
 

--- a/nativelib/src/main/resources/scala-native/optional/z.c
+++ b/nativelib/src/main/resources/scala-native/optional/z.c
@@ -1,66 +1,66 @@
 #include <zlib.h>
 
-int scalanative_Z_NO_FLUSH() { return Z_NO_FLUSH; }
+int scalanative_z_no_flush() { return Z_NO_FLUSH; }
 
-int scalanative_Z_PARTIAL_FLUSH() { return Z_PARTIAL_FLUSH; }
+int scalanative_z_partial_flush() { return Z_PARTIAL_FLUSH; }
 
-int scalanative_Z_SYNC_FLUSH() { return Z_SYNC_FLUSH; }
+int scalanative_z_sync_flush() { return Z_SYNC_FLUSH; }
 
-int scalanative_Z_FULL_FLUSH() { return Z_FULL_FLUSH; }
+int scalanative_z_full_flush() { return Z_FULL_FLUSH; }
 
-int scalanative_Z_FINISH() { return Z_FINISH; }
+int scalanative_z_finish() { return Z_FINISH; }
 
-int scalanative_Z_BLOCK() { return Z_BLOCK; }
+int scalanative_z_block() { return Z_BLOCK; }
 
-int scalanative_Z_TREES() { return Z_TREES; }
+int scalanative_z_trees() { return Z_TREES; }
 
-int scalanative_Z_OK() { return Z_OK; }
+int scalanative_z_ok() { return Z_OK; }
 
-int scalanative_Z_STREAM_END() { return Z_STREAM_END; }
+int scalanative_z_stream_end() { return Z_STREAM_END; }
 
-int scalanative_Z_NEED_DICT() { return Z_NEED_DICT; }
+int scalanative_z_need_dict() { return Z_NEED_DICT; }
 
-int scalanative_Z_ERRNO() { return Z_ERRNO; }
+int scalanative_z_errno() { return Z_ERRNO; }
 
-int scalanative_Z_STREAM_ERROR() { return Z_STREAM_ERROR; }
+int scalanative_z_stream_error() { return Z_STREAM_ERROR; }
 
-int scalanative_Z_DATA_ERROR() { return Z_DATA_ERROR; }
+int scalanative_z_data_error() { return Z_DATA_ERROR; }
 
-int scalanative_Z_MEM_ERROR() { return Z_MEM_ERROR; }
+int scalanative_z_mem_error() { return Z_MEM_ERROR; }
 
-int scalanative_Z_BUF_ERROR() { return Z_BUF_ERROR; }
+int scalanative_z_buf_error() { return Z_BUF_ERROR; }
 
-int scalanative_Z_VERSION_ERROR() { return Z_VERSION_ERROR; }
+int scalanative_z_version_error() { return Z_VERSION_ERROR; }
 
-int scalanative_Z_NO_COMPRESSION() { return Z_NO_COMPRESSION; }
+int scalanative_z_no_compression() { return Z_NO_COMPRESSION; }
 
-int scalanative_Z_BEST_SPEED() { return Z_BEST_SPEED; }
+int scalanative_z_best_speed() { return Z_BEST_SPEED; }
 
-int scalanative_Z_BEST_COMPRESSION() { return Z_BEST_COMPRESSION; }
+int scalanative_z_best_compression() { return Z_BEST_COMPRESSION; }
 
-int scalanative_Z_DEFAULT_COMPRESSION() { return Z_DEFAULT_COMPRESSION; }
+int scalanative_z_default_compression() { return Z_DEFAULT_COMPRESSION; }
 
-int scalanative_Z_FILTERED() { return Z_FILTERED; }
+int scalanative_z_filtered() { return Z_FILTERED; }
 
-int scalanative_Z_HUFFMAN_ONLY() { return Z_HUFFMAN_ONLY; }
+int scalanative_z_huffman_only() { return Z_HUFFMAN_ONLY; }
 
-int scalanative_Z_RLE() { return Z_RLE; }
+int scalanative_z_rle() { return Z_RLE; }
 
-int scalanative_Z_FIXED() { return Z_FIXED; }
+int scalanative_z_fixed() { return Z_FIXED; }
 
-int scalanative_Z_DEFAULT_STRATEGY() { return Z_DEFAULT_STRATEGY; }
+int scalanative_z_default_strategy() { return Z_DEFAULT_STRATEGY; }
 
-int scalanative_Z_BINARY() { return Z_BINARY; }
+int scalanative_z_binary() { return Z_BINARY; }
 
-int scalanative_Z_TEXT() { return Z_TEXT; }
+int scalanative_z_text() { return Z_TEXT; }
 
-int scalanative_Z_ASCII() { return Z_ASCII; }
+int scalanative_z_ascii() { return Z_ASCII; }
 
-int scalanative_Z_UNKNOWN() { return Z_UNKNOWN; }
+int scalanative_z_unknown() { return Z_UNKNOWN; }
 
-int scalanative_Z_DEFLATED() { return Z_DEFLATED; }
+int scalanative_z_deflated() { return Z_DEFLATED; }
 
-int scalanative_Z_NULL() { return Z_NULL; }
+int scalanative_z_null() { return Z_NULL; }
 
 const char *scalanative_zlibVersion() { return zlibVersion(); }
 

--- a/nativelib/src/main/resources/scala-native/unwind.c
+++ b/nativelib/src/main/resources/scala-native/unwind.c
@@ -23,4 +23,4 @@ int scalanative_unwind_get_reg(void *cursor, int regnum,
     return unw_get_reg((unw_cursor_t *)cursor, regnum, (unw_word_t *)valp);
 }
 
-int scalanative_UNW_REG_IP() { return UNW_REG_IP; }
+int scalanative_unw_reg_ip() { return UNW_REG_IP; }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/unwind.scala
@@ -21,6 +21,6 @@ object unwind {
               reg: CInt,
               valp: Ptr[CUnsignedLongLong]): CInt = extern
 
-  @name("scalanative_UNW_REG_IP")
+  @name("scalanative_unw_reg_ip")
   def UNW_REG_IP: CInt = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/zlib.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/zlib.scala
@@ -56,97 +56,97 @@ object zlib {
     CFuncPtr3[Ptr[Byte], Ptr[CUnsignedChar], CUnsignedInt, CInt]
   type gzFile = Ptr[Byte]
 
-  @name("scalanative_Z_NO_FLUSH")
+  @name("scalanative_z_no_flush")
   def Z_NO_FLUSH: CInt = extern
 
-  @name("scalanative_Z_PARTIAL_FLUSH")
+  @name("scalanative_z_partial_flush")
   def Z_PARTIAL_FLUSH: CInt = extern
 
-  @name("scalanative_Z_SYNC_FLUSH")
+  @name("scalanative_z_sync_flush")
   def Z_SYNC_FLUSH: CInt = extern
 
-  @name("scalanative_Z_FULL_FLUSH")
+  @name("scalanative_z_full_flush")
   def Z_FULL_FLUSH: CInt = extern
 
-  @name("scalanative_Z_FINISH")
+  @name("scalanative_z_finish")
   def Z_FINISH: CInt = extern
 
-  @name("scalanative_Z_BLOCK")
+  @name("scalanative_z_block")
   def Z_BLOCK: CInt = extern
 
-  @name("scalanative_Z_TREES")
+  @name("scalanative_z_trees")
   def Z_TREES: CInt = extern
 
-  @name("scalanative_Z_OK")
+  @name("scalanative_z_ok")
   def Z_OK: CInt = extern
 
-  @name("scalanative_Z_STREAM_END")
+  @name("scalanative_z_stream_end")
   def Z_STREAM_END: CInt = extern
 
-  @name("scalanative_Z_NEED_DICT")
+  @name("scalanative_z_need_dict")
   def Z_NEED_DICT: CInt = extern
 
-  @name("scalanative_Z_ERRNO")
+  @name("scalanative_z_errno")
   def Z_ERRNO: CInt = extern
 
-  @name("scalanative_Z_STREAM_ERROR")
+  @name("scalanative_z_stream_error")
   def Z_STREAM_ERROR: CInt = extern
 
-  @name("scalanative_Z_DATA_ERROR")
+  @name("scalanative_z_data_error")
   def Z_DATA_ERROR: CInt = extern
 
-  @name("scalanative_Z_MEM_ERROR")
+  @name("scalanative_z_mem_error")
   def Z_MEM_ERROR: CInt = extern
 
-  @name("scalanative_Z_BUF_ERROR")
+  @name("scalanative_z_buf_error")
   def Z_BUF_ERROR: CInt = extern
 
-  @name("scalanative_Z_VERSION_ERROR")
+  @name("scalanative_z_version_error")
   def Z_VERSION_ERROR: CInt = extern
 
-  @name("scalanative_Z_NO_COMPRESSION")
+  @name("scalanative_z_no_compression")
   def Z_NO_COMPRESSION: CInt = extern
 
-  @name("scalanative_Z_BEST_SPEED")
+  @name("scalanative_z_best_speed")
   def Z_BEST_SPEED: CInt = extern
 
-  @name("scalanative_Z_BEST_COMPRESSION")
+  @name("scalanative_z_best_compression")
   def Z_BEST_COMPRESSION: CInt = extern
 
-  @name("scalanative_Z_DEFAULT_COMPRESSION")
+  @name("scalanative_z_default_compression")
   def Z_DEFAULT_COMPRESSION: CInt = extern
 
-  @name("scalanative_Z_FILTERED")
+  @name("scalanative_z_filtered")
   def Z_FILTERED: CInt = extern
 
-  @name("scalanative_Z_HUFFMAN_ONLY")
+  @name("scalanative_z_huffman_only")
   def Z_HUFFMAN_ONLY: CInt = extern
 
-  @name("scalanative_Z_RLE")
+  @name("scalanative_z_rle")
   def Z_RLE: CInt = extern
 
-  @name("scalanative_Z_FIXED")
+  @name("scalanative_z_fixed")
   def Z_FIXED: CInt = extern
 
-  @name("scalanative_Z_DEFAULT_STRATEGY")
+  @name("scalanative_z_default_strategy")
   def Z_DEFAULT_STRATEGY: CInt = extern
 
-  @name("scalanative_Z_BINARY")
+  @name("scalanative_z_binary")
   def Z_BINARY: CInt = extern
 
-  @name("scalanative_Z_TEXT")
+  @name("scalanative_z_text")
   def Z_TEXT: CInt = extern
 
-  @name("scalanative_Z_ASCII")
+  @name("scalanative_z_ascii")
   def Z_ASCII: CInt = extern
 
-  @name("scalanative_Z_UNKNOWN")
+  @name("scalanative_z_unknown")
   def Z_UNKNOWN: CInt = extern
 
-  @name("scalanative_Z_DEFLATED")
+  @name("scalanative_z_deflated")
   def Z_DEFLATED: CInt = extern
 
-  @name("scalanative_Z_NULL")
+  @name("scalanative_z_null")
   def Z_NULL: CInt = extern
 
   // Basic Functions

--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -104,14 +104,14 @@ int scalanative_getaddrinfo(char *name, char *service,
     return status;
 }
 
-int scalanative_AI_NUMERICHOST() { return AI_NUMERICHOST; }
+int scalanative_ai_numerichost() { return AI_NUMERICHOST; }
 
-int scalanative_AI_PASSIVE() { return AI_PASSIVE; }
+int scalanative_ai_passive() { return AI_PASSIVE; }
 
-int scalanative_AI_NUMERICSERV() { return AI_NUMERICSERV; }
+int scalanative_ai_numericserv() { return AI_NUMERICSERV; }
 
-int scalanative_AI_ADDRCONFIG() { return AI_ADDRCONFIG; }
+int scalanative_ai_addrconfig() { return AI_ADDRCONFIG; }
 
-int scalanative_AI_V4MAPPED() { return AI_V4MAPPED; }
+int scalanative_ai_v4mapped() { return AI_V4MAPPED; }
 
-int scalanative_AI_CANONNAME() { return AI_CANONNAME; }
+int scalanative_ai_canonname() { return AI_CANONNAME; }

--- a/posixlib/src/main/resources/scala-native/netinet/in.c
+++ b/posixlib/src/main/resources/scala-native/netinet/in.c
@@ -22,113 +22,113 @@ void scalanative_convert_scalanative_in6_addr(
     void *ignored = memcpy(out->_s6_addr, in->s6_addr, 16);
 }
 
-int scalanative_IPPROTO_IP() { return IPPROTO_IP; }
+int scalanative_ipproto_ip() { return IPPROTO_IP; }
 
-int scalanative_IPPROTO_IPV6() { return IPPROTO_IPV6; }
+int scalanative_ipproto_ipv6() { return IPPROTO_IPV6; }
 
-int scalanative_IPPROTO_ICMP() { return IPPROTO_ICMP; }
+int scalanative_ipproto_icmp() { return IPPROTO_ICMP; }
 
-int scalanative_IPPROTO_RAW() { return IPPROTO_RAW; }
+int scalanative_ipproto_raw() { return IPPROTO_RAW; }
 
-int scalanative_IPPROTO_TCP() { return IPPROTO_TCP; }
+int scalanative_ipproto_tcp() { return IPPROTO_TCP; }
 
-int scalanative_IPPROTO_UDP() { return IPPROTO_UDP; }
+int scalanative_ipproto_udp() { return IPPROTO_UDP; }
 
-uint32_t scalanative_INADDR_ANY() { return INADDR_ANY; }
+uint32_t scalanative_inaddr_any() { return INADDR_ANY; }
 
-uint32_t scalanative_INADDR_BROADCAST() { return INADDR_BROADCAST; }
+uint32_t scalanative_inaddr_broadcast() { return INADDR_BROADCAST; }
 
-int scalanative_INET6_ADDRSTRLEN() { return INET6_ADDRSTRLEN; }
+int scalanative_inet6_addrstrlen() { return INET6_ADDRSTRLEN; }
 
-int scalanative_INET_ADDRSTRLEN() { return INET_ADDRSTRLEN; }
+int scalanative_inet_addrstrlen() { return INET_ADDRSTRLEN; }
 
-int scalanative_IPV6_JOIN_GROUP() { return IPV6_JOIN_GROUP; }
+int scalanative_ipv6_join_group() { return IPV6_JOIN_GROUP; }
 
-int scalanative_IPV6_LEAVE_GROUP() { return IPV6_LEAVE_GROUP; }
+int scalanative_ipv6_leave_group() { return IPV6_LEAVE_GROUP; }
 
-int scalanative_IPV6_MULTICAST_HOPS() { return IPV6_MULTICAST_HOPS; }
+int scalanative_ipv6_multicast_hops() { return IPV6_MULTICAST_HOPS; }
 
-int scalanative_IPV6_MULTICAST_IF() { return IPV6_MULTICAST_IF; }
+int scalanative_ipv6_multicast_if() { return IPV6_MULTICAST_IF; }
 
-int scalanative_IPV6_MULTICAST_LOOP() { return IPV6_MULTICAST_LOOP; }
+int scalanative_ipv6_multicast_loop() { return IPV6_MULTICAST_LOOP; }
 
-int scalanative_IPV6_UNICAST_HOPS() { return IPV6_UNICAST_HOPS; }
+int scalanative_ipv6_unicast_hops() { return IPV6_UNICAST_HOPS; }
 
-int scalanative_IPV6_V6ONLY() { return IPV6_V6ONLY; }
+int scalanative_ipv6_v6only() { return IPV6_V6ONLY; }
 
-int scalanative_IP_MULTICAST_IF() { return IP_MULTICAST_IF; }
+int scalanative_ip_multicast_if() { return IP_MULTICAST_IF; }
 
-int scalanative_IP_MULTICAST_LOOP() { return IP_MULTICAST_LOOP; }
+int scalanative_ip_multicast_loop() { return IP_MULTICAST_LOOP; }
 
-int scalanative_IP_TOS() { return IP_TOS; }
+int scalanative_ip_tos() { return IP_TOS; }
 
-int scalanative_IN6_IS_ADDR_UNSPECIFIED(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_unspecified(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_UNSPECIFIED(&converted);
 }
 
-int scalanative_IN6_IS_ADDR_LOOPBACK(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_loopback(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_LOOPBACK(&converted);
 }
 
-int scalanative_IN6_IS_ADDR_MULTICAST(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_multicast(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_MULTICAST(&converted);
 }
 
-int scalanative_IN6_IS_ADDR_LINKLOCAL(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_linklocal(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_LINKLOCAL(&converted);
 }
 
-int scalanative_IN6_IS_ADDR_SITELOCAL(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_sitelocal(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_SITELOCAL(&converted);
 }
 
-int scalanative_IN6_IS_ADDR_V4MAPPED(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_v4mapped(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_V4MAPPED(&converted);
 }
 
-int scalanative_IN6_IS_ADDR_V4COMPAT(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_v4compat(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_V4COMPAT(&converted);
 }
 
-int scalanative_IN6_IS_ADDR_MC_NODELOCAL(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_mc_nodelocal(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_MC_NODELOCAL(&converted);
 }
 
-int scalanative_IN6_IS_ADDR_MC_LINKLOCAL(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_mc_linklocal(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_MC_LINKLOCAL(&converted);
 }
 
-int scalanative_IN6_IS_ADDR_MC_SITELOCAL(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_mc_sitelocal(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_MC_SITELOCAL(&converted);
 }
 
-int scalanative_IN6_IS_ADDR_MC_ORGLOCAL(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_mc_orglocal(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_MC_ORGLOCAL(&converted);
 }
 
-int scalanative_IN6_IS_ADDR_MC_GLOBAL(struct scalanative_in6_addr *arg) {
+int scalanative_in6_is_addr_mc_global(struct scalanative_in6_addr *arg) {
     struct in6_addr converted;
     scalanative_convert_in6_addr(arg, &converted);
     return IN6_IS_ADDR_MC_GLOBAL(&converted);

--- a/posixlib/src/main/resources/scala-native/netinet/tcp.c
+++ b/posixlib/src/main/resources/scala-native/netinet/tcp.c
@@ -1,3 +1,3 @@
 #include <netinet/tcp.h>
 
-int scalanative_TCP_NODELAY() { return TCP_NODELAY; }
+int scalanative_tcp_nodelay() { return TCP_NODELAY; }

--- a/posixlib/src/main/resources/scala-native/sys/ioctl.c
+++ b/posixlib/src/main/resources/scala-native/sys/ioctl.c
@@ -4,4 +4,4 @@ int scalanative_ioctl(int fd, long int request, void *argp) {
     return ioctl(fd, request, argp);
 }
 
-long int scalanative_FIONREAD() { return FIONREAD; }
+long int scalanative_fionread() { return FIONREAD; }

--- a/posixlib/src/main/resources/scala-native/sys/select.c
+++ b/posixlib/src/main/resources/scala-native/sys/select.c
@@ -34,7 +34,7 @@ struct scalanative_fd_set {
     long fd_bits[FD_SETSIZE / FDBITS];
 };
 
-int scalanative_FD_SETSIZE() { return FD_SETSIZE; }
+int scalanative_fd_setsize() { return FD_SETSIZE; }
 
 void convert_scalanative_timeval(struct scalanative_timeval *in,
                                  struct timeval *out) {
@@ -42,19 +42,19 @@ void convert_scalanative_timeval(struct scalanative_timeval *in,
     out->tv_usec = in->tv_usec;
 }
 
-void scalanative_FD_ZERO(struct scalanative_fd_set *set) {
+void scalanative_fd_zero(struct scalanative_fd_set *set) {
     FD_ZERO((fd_set *)set);
 }
 
-void scalanative_FD_CLR(int fd, struct scalanative_fd_set *set) {
+void scalanative_fd_clr(int fd, struct scalanative_fd_set *set) {
     FD_CLR(fd, (fd_set *)set);
 }
 
-void scalanative_FD_SET(int fd, struct scalanative_fd_set *set) {
+void scalanative_fd_set(int fd, struct scalanative_fd_set *set) {
     FD_SET(fd, (fd_set *)set);
 }
 
-int scalanative_FD_ISSET(int fd, struct scalanative_fd_set *set) {
+int scalanative_fd_isset(int fd, struct scalanative_fd_set *set) {
     return FD_ISSET(fd, (fd_set *)set);
 }
 

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -8,61 +8,61 @@
 #include "socket_conversions.h"
 #include "socket.h"
 
-int scalanative_SCM_RIGHTS() { return SCM_RIGHTS; }
+int scalanative_scm_rights() { return SCM_RIGHTS; }
 
-int scalanative_SOCK_DGRAM() { return SOCK_DGRAM; }
+int scalanative_sock_dgram() { return SOCK_DGRAM; }
 
-int scalanative_SOCK_RAW() { return SOCK_RAW; }
+int scalanative_sock_raw() { return SOCK_RAW; }
 
-int scalanative_SOCK_SEQPACKET() { return SOCK_SEQPACKET; }
+int scalanative_sock_seqpacket() { return SOCK_SEQPACKET; }
 
-int scalanative_SOCK_STREAM() { return SOCK_STREAM; }
+int scalanative_sock_stream() { return SOCK_STREAM; }
 
-int scalanative_SOL_SOCKET() { return SOL_SOCKET; }
+int scalanative_sol_socket() { return SOL_SOCKET; }
 
-int scalanative_SO_ACCEPTCONN() { return SO_ACCEPTCONN; }
+int scalanative_so_acceptconn() { return SO_ACCEPTCONN; }
 
-int scalanative_SO_BROADCAST() { return SO_BROADCAST; }
+int scalanative_so_broadcast() { return SO_BROADCAST; }
 
-int scalanative_SO_DEBUG() { return SO_DEBUG; }
+int scalanative_so_debug() { return SO_DEBUG; }
 
-int scalanative_SO_DONTROUTE() { return SO_DONTROUTE; }
+int scalanative_so_dontroute() { return SO_DONTROUTE; }
 
-int scalanative_SO_ERROR() { return SO_ERROR; }
+int scalanative_so_error() { return SO_ERROR; }
 
-int scalanative_SO_KEEPALIVE() { return SO_KEEPALIVE; }
+int scalanative_so_keepalive() { return SO_KEEPALIVE; }
 
-int scalanative_SO_LINGER() { return SO_LINGER; }
+int scalanative_so_linger() { return SO_LINGER; }
 
-int scalanative_SO_OOBINLINE() { return SO_OOBINLINE; }
+int scalanative_so_oobinline() { return SO_OOBINLINE; }
 
-int scalanative_SO_RCVBUF() { return SO_RCVBUF; }
+int scalanative_so_rcvbuf() { return SO_RCVBUF; }
 
-int scalanative_SO_RCVLOWAT() { return SO_RCVLOWAT; }
+int scalanative_so_rcvlowat() { return SO_RCVLOWAT; }
 
-int scalanative_SO_RCVTIMEO() { return SO_RCVTIMEO; }
+int scalanative_so_rcvtimeo() { return SO_RCVTIMEO; }
 
-int scalanative_SO_REUSEADDR() { return SO_REUSEADDR; }
+int scalanative_so_reuseaddr() { return SO_REUSEADDR; }
 
-int scalanative_SO_SNDBUF() { return SO_SNDBUF; }
+int scalanative_so_sndbuf() { return SO_SNDBUF; }
 
-int scalanative_SO_SNDLOWAT() { return SO_SNDLOWAT; }
+int scalanative_so_sndlowat() { return SO_SNDLOWAT; }
 
-int scalanative_SO_SNDTIMEO() { return SO_SNDTIMEO; }
+int scalanative_so_sndtimeo() { return SO_SNDTIMEO; }
 
-int scalanative_SO_TYPE() { return SO_TYPE; }
+int scalanative_so_type() { return SO_TYPE; }
 
-int scalanative_SOMAXCONN() { return SOMAXCONN; }
+int scalanative_somaxconn() { return SOMAXCONN; }
 
-int scalanative_MSG_CTRUNC() { return MSG_CTRUNC; }
+int scalanative_msg_ctrunc() { return MSG_CTRUNC; }
 
-int scalanative_MSG_DONTROUTE() { return MSG_DONTROUTE; }
+int scalanative_msg_dontroute() { return MSG_DONTROUTE; }
 
-int scalanative_MSG_EOR() { return MSG_EOR; }
+int scalanative_msg_eor() { return MSG_EOR; }
 
-int scalanative_MSG_OOB() { return MSG_OOB; }
+int scalanative_msg_oob() { return MSG_OOB; }
 
-int scalanative_MSG_NOSIGNAL() {
+int scalanative_msg_nosignal() {
 #ifdef MSG_NOSIGNAL
     return MSG_NOSIGNAL;
 #endif
@@ -71,19 +71,19 @@ int scalanative_MSG_NOSIGNAL() {
 #endif
 }
 
-int scalanative_MSG_PEEK() { return MSG_PEEK; }
+int scalanative_msg_peek() { return MSG_PEEK; }
 
-int scalanative_MSG_TRUNC() { return MSG_TRUNC; }
+int scalanative_msg_trunc() { return MSG_TRUNC; }
 
-int scalanative_MSG_WAITALL() { return MSG_WAITALL; }
+int scalanative_msg_waitall() { return MSG_WAITALL; }
 
-int scalanative_AF_INET() { return AF_INET; }
+int scalanative_af_inet() { return AF_INET; }
 
-int scalanative_AF_INET6() { return AF_INET6; }
+int scalanative_af_inet6() { return AF_INET6; }
 
-int scalanative_AF_UNIX() { return AF_UNIX; }
+int scalanative_af_unix() { return AF_UNIX; }
 
-int scalanative_AF_UNSPEC() { return AF_UNSPEC; }
+int scalanative_af_unspec() { return AF_UNSPEC; }
 
 int scalanative_getsockname(int socket, struct scalanative_sockaddr *address,
                             socklen_t *address_len) {

--- a/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
@@ -33,22 +33,22 @@ object netdb {
                   servlen: socket.socklen_t,
                   flags: CInt): CInt = extern
 
-  @name("scalanative_AI_NUMERICHOST")
+  @name("scalanative_ai_numerichost")
   def AI_NUMERICHOST: CInt = extern
 
-  @name("scalanative_AI_PASSIVE")
+  @name("scalanative_ai_passive")
   def AI_PASSIVE: CInt = extern
 
-  @name("scalanative_AI_NUMERICSERV")
+  @name("scalanative_ai_numericserv")
   def AI_NUMERICSERV: CInt = extern
 
-  @name("scalanative_AI_ADDRCONFIG")
+  @name("scalanative_ai_addrconfig")
   def AI_ADDRCONFIG: CInt = extern
 
-  @name("scalanative_AI_V4MAPPED")
+  @name("scalanative_ai_v4mapped")
   def AI_V4MAPPED: CInt = extern
 
-  @name("scalanative_AI_CANONNAME")
+  @name("scalanative_ai_canonname")
   def AI_CANONNAME: CInt = extern
 }
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
@@ -27,100 +27,100 @@ object in {
   type ipv6_mreq = CStruct2[in6_addr, // ipv6mr_multiaddr
                             CUnsignedInt] // ipv6mr_interface
 
-  @name("scalanative_IPPROTO_IP")
+  @name("scalanative_ipproto_ip")
   def IPPROTO_IP: CInt = extern
 
-  @name("scalanative_IPPROTO_IPV6")
+  @name("scalanative_ipproto_ipv6")
   def IPPROTO_IPV6: CInt = extern
 
-  @name("scalanative_IPPROTO_ICMP")
+  @name("scalanative_ipproto_icmp")
   def IPPROTO_ICMP: CInt = extern
 
-  @name("scalanative_IPPROTO_RAW")
+  @name("scalanative_ipproto_raw")
   def IPPROTO_RAW: CInt = extern
 
-  @name("scalanative_IPPROTO_TCP")
+  @name("scalanative_ipproto_tcp")
   def IPPROTO_TCP: CInt = extern
 
-  @name("scalanative_IPPROTO_UDP")
+  @name("scalanative_ipproto_udp")
   def IPPROTO_UDP: CInt = extern
 
-  @name("scalanative_INADDR_ANY")
+  @name("scalanative_inaddr_any")
   def INADDR_ANY: uint32_t = extern
 
-  @name("scalanative_INADDR_BROADCAST")
+  @name("scalanative_inaddr_broadcast")
   def INADDR_BROADCAST: uint32_t = extern
 
-  @name("scalanative_INET6_ADDRSTRLEN")
+  @name("scalanative_inet6_addrstrlen")
   def INET6_ADDRSTRLEN: CInt = extern
 
-  @name("scalanative_INET_ADDRSTRLEN")
+  @name("scalanative_inet_addrstrlen")
   def INET_ADDRSTRLEN: CInt = extern
 
-  @name("scalanative_IPV6_JOIN_GROUP")
+  @name("scalanative_ipv6_join_group")
   def IPV6_JOIN_GROUP: CInt = extern
 
-  @name("scalanative_IPV6_LEAVE_GROUP")
+  @name("scalanative_ipv6_leave_group")
   def IPV6_LEAVE_GROUP: CInt = extern
 
-  @name("scalanative_IPV6_MULTICAST_HOPS")
+  @name("scalanative_ipv6_multicast_hops")
   def IPV6_MULTICAST_HOPS: CInt = extern
 
-  @name("scalanative_IPV6_MULTICAST_IF")
+  @name("scalanative_ipv6_multicast_if")
   def IPV6_MULTICAST_IF: CInt = extern
 
-  @name("scalanative_IPV6_MULTICAST_LOOP")
+  @name("scalanative_ipv6_multicast_loop")
   def IPV6_MULTICAST_LOOP: CInt = extern
 
-  @name("scalanative_IPV6_UNICAST_HOPS")
+  @name("scalanative_ipv6_unicast_hops")
   def IPV6_UNICAST_HOPS: CInt = extern
 
-  @name("scalanative_IPV6_V6ONLY")
+  @name("scalanative_ipv6_v6only")
   def IPV6_V6ONLY: CInt = extern
 
-  @name("scalanative_IP_MULTICAST_IF")
+  @name("scalanative_ip_multicast_if")
   def IP_MULTICAST_IF: CInt = extern
 
-  @name("scalanative_IP_MULTICAST_LOOP")
+  @name("scalanative_ip_multicast_loop")
   def IP_MULTICAST_LOOP: CInt = extern
 
-  @name("scalanative_IP_TOS")
+  @name("scalanative_ip_tos")
   def IP_TOS: CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_UNSPECIFIED")
+  @name("scalanative_in6_is_addr_unspecified")
   def IN6_IS_ADDR_UNSPECIFIED(arg: Ptr[in6_addr]): CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_LOOPBACK")
+  @name("scalanative_in6_is_addr_loopback")
   def IN6_IS_ADDR_LOOPBACK(arg: Ptr[in6_addr]): CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_MULTICAST")
+  @name("scalanative_in6_is_addr_multicast")
   def IN6_IS_ADDR_MULTICAST(arg: Ptr[in6_addr]): CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_LINKLOCAL")
+  @name("scalanative_in6_is_addr_linklocal")
   def IN6_IS_ADDR_LINKLOCAL(arg: Ptr[in6_addr]): CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_SITELOCAL")
+  @name("scalanative_in6_is_addr_sitelocal")
   def IN6_IS_ADDR_SITELOCAL(arg: Ptr[in6_addr]): CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_V4MAPPED")
+  @name("scalanative_in6_is_addr_v4mapped")
   def IN6_IS_ADDR_V4MAPPED(arg: Ptr[in6_addr]): CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_V4COMPAT")
+  @name("scalanative_in6_is_addr_v4compat")
   def IN6_IS_ADDR_V4COMPAT(arg: Ptr[in6_addr]): CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_MC_NODELOCAL")
+  @name("scalanative_in6_is_addr_mc_nodelocal")
   def IN6_IS_ADDR_MC_NODELOCAL(arg: Ptr[in6_addr]): CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_MC_LINKLOCAL")
+  @name("scalanative_in6_is_addr_mc_linklocal")
   def IN6_IS_ADDR_MC_LINKLOCAL(arg: Ptr[in6_addr]): CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_MC_SITELOCAL")
+  @name("scalanative_in6_is_addr_mc_sitelocal")
   def IN6_IS_ADDR_MC_SITELOCAL(arg: Ptr[in6_addr]): CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_MC_ORGLOCAL")
+  @name("scalanative_in6_is_addr_mc_orglocal")
   def IN6_IS_ADDR_MC_ORGLOCAL(arg: Ptr[in6_addr]): CInt = extern
 
-  @name("scalanative_IN6_IS_ADDR_MC_GLOBAL")
+  @name("scalanative_in6_is_addr_mc_global")
   def IN6_IS_ADDR_MC_GLOBAL(arg: Ptr[in6_addr]): CInt = extern
 
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/netinet/tcp.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netinet/tcp.scala
@@ -5,6 +5,6 @@ import scalanative.unsafe._
 @extern
 object tcp {
 
-  @name("scalanative_TCP_NODELAY")
+  @name("scalanative_tcp_nodelay")
   def TCP_NODELAY: CInt = extern
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/ioctl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/ioctl.scala
@@ -8,6 +8,6 @@ object ioctl {
   @name("scalanative_ioctl")
   def ioctl(fd: CInt, request: CLongInt, argp: Ptr[Byte]): CInt = extern
 
-  @name("scalanative_FIONREAD")
+  @name("scalanative_fionread")
   def FIONREAD: CLongInt = extern
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
@@ -55,19 +55,19 @@ object select {
              exceptfds: Ptr[fd_set],
              timeout: Ptr[time.timeval]): CInt = extern
 
-  @name("scalanative_FD_SETSIZE")
+  @name("scalanative_fd_setsize")
   def FD_SETSIZE: CInt = extern
 
-  @name("scalanative_FD_CLR")
+  @name("scalanative_fd_clr")
   def FD_CLR(fd: CInt, set: Ptr[fd_set]): Unit = extern
 
-  @name("scalanative_FD_ISSET")
+  @name("scalanative_fd_isset")
   def FD_ISSET(fd: CInt, set: Ptr[fd_set]): CInt = extern
 
-  @name("scalanative_FD_SET")
+  @name("scalanative_fd_set")
   def FD_SET(fd: CInt, set: Ptr[fd_set]): Unit = extern
 
-  @name("scalanative_FD_ZERO")
+  @name("scalanative_fd_zero")
   def FD_ZERO(set: Ptr[fd_set]): Unit = extern
 
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -27,109 +27,109 @@ object socket {
   type linger = CStruct2[CInt, // l_onoff
                          CInt] // l_linger
 
-  @name("scalanative_SCM_RIGHTS")
+  @name("scalanative_scm_rights")
   def SCM_RIGHTS: CInt = extern
 
-  @name("scalanative_SOCK_DGRAM")
+  @name("scalanative_sock_dgram")
   def SOCK_DGRAM: CInt = extern
 
-  @name("scalanative_SOCK_RAW")
+  @name("scalanative_sock_raw")
   def SOCK_RAW: CInt = extern
 
-  @name("scalanative_SOCK_SEQPACKET")
+  @name("scalanative_sock_seqpacket")
   def SOCK_SEQPACKET: CInt = extern
 
-  @name("scalanative_SOCK_STREAM")
+  @name("scalanative_sock_stream")
   def SOCK_STREAM: CInt = extern
 
-  @name("scalanative_SOL_SOCKET")
+  @name("scalanative_sol_socket")
   def SOL_SOCKET: CInt = extern
 
-  @name("scalanative_SO_ACCEPTCONN")
+  @name("scalanative_so_acceptconn")
   def SO_ACCEPTCONN: CInt = extern
 
-  @name("scalanative_SO_BROADCAST")
+  @name("scalanative_so_broadcast")
   def SO_BROADCAST: CInt = extern
 
-  @name("scalanative_SO_DEBUG")
+  @name("scalanative_so_debug")
   def SO_DEBUG: CInt = extern
 
-  @name("scalanative_SO_DONTROUTE")
+  @name("scalanative_so_dontroute")
   def SO_DONTROUTE: CInt = extern
 
-  @name("scalanative_SO_ERROR")
+  @name("scalanative_so_error")
   def SO_ERROR: CInt = extern
 
-  @name("scalanative_SO_KEEPALIVE")
+  @name("scalanative_so_keepalive")
   def SO_KEEPALIVE: CInt = extern
 
-  @name("scalanative_SO_LINGER")
+  @name("scalanative_so_linger")
   def SO_LINGER: CInt = extern
 
-  @name("scalanative_SO_OOBINLINE")
+  @name("scalanative_so_oobinline")
   def SO_OOBINLINE: CInt = extern
 
-  @name("scalanative_SO_RCVBUF")
+  @name("scalanative_so_rcvbuf")
   def SO_RCVBUF: CInt = extern
 
-  @name("scalanative_SO_RCVLOWAT")
+  @name("scalanative_so_rcvlowat")
   def SO_RCVLOWAT: CInt = extern
 
-  @name("scalanative_SO_RCVTIMEO")
+  @name("scalanative_so_rcvtimeo")
   def SO_RCVTIMEO: CInt = extern
 
-  @name("scalanative_SO_REUSEADDR")
+  @name("scalanative_so_reuseaddr")
   def SO_REUSEADDR: CInt = extern
 
-  @name("scalanative_SO_SNDBUF")
+  @name("scalanative_so_sndbuf")
   def SO_SNDBUF: CInt = extern
 
-  @name("scalanative_SO_SNDLOWAT")
+  @name("scalanative_so_sndlowat")
   def SO_SNDLOWAT: CInt = extern
 
-  @name("scalanative_SO_SNDTIMEO")
+  @name("scalanative_so_sndtimeo")
   def SO_SNDTIMEO: CInt = extern
 
-  @name("scalanative_SO_TYPE")
+  @name("scalanative_so_type")
   def SO_TYPE: CInt = extern
 
-  @name("scalanative_SOMAXCONN")
+  @name("scalanative_somaxconn")
   def SOMAXCONN: CInt = extern
 
-  @name("scalanative_MSG_CTRUNC")
+  @name("scalanative_msg_ctrunc")
   def MSG_CTRUNC: CInt = extern
 
-  @name("scalanative_MSG_DONTROUTE")
+  @name("scalanative_msg_dontroute")
   def MSG_DONTROUTE: CInt = extern
 
-  @name("scalanative_MSG_EOR")
+  @name("scalanative_msg_eor")
   def MSG_EOR: CInt = extern
 
-  @name("scalanative_MSG_OOB")
+  @name("scalanative_msg_oob")
   def MSG_OOB: CInt = extern
 
-  @name("scalanative_MSG_NOSIGNAL")
+  @name("scalanative_msg_nosignal")
   def MSG_NOSIGNAL: CInt = extern // returns 0 on macOS
 
-  @name("scalanative_MSG_PEEK")
+  @name("scalanative_msg_peek")
   def MSG_PEEK: CInt = extern
 
-  @name("scalanative_MSG_TRUNC")
+  @name("scalanative_msg_trunc")
   def MSG_TRUNC: CInt = extern
 
-  @name("scalanative_MSG_WAITALL")
+  @name("scalanative_msg_waitall")
   def MSG_WAITALL: CInt = extern
 
-  @name("scalanative_AF_INET")
+  @name("scalanative_af_inet")
   def AF_INET: CInt = extern
 
-  @name("scalanative_AF_INET6")
+  @name("scalanative_af_inet6")
   def AF_INET6: CInt = extern
 
-  @name("scalanative_AF_UNIX")
+  @name("scalanative_af_unix")
   def AF_UNIX: CInt = extern
 
-  @name("scalanative_AF_UNSPEC")
+  @name("scalanative_af_unspec")
   def AF_UNSPEC: CInt = extern
 
   @name("scalanative_getsockname")


### PR DESCRIPTION
The have been previous discussions about naming and this PR brings the code in line with the styles and standards of those past discussion. Documentation has been added.

Hopefully, much of this glue code will become a thing of the past when C interopt improves. None of the code changes should change the external APIs.