### PR TITLE
Fix 1664: Correct two memory access flaws in POSIX time

### DIFF
--- a/posixlib/src/main/resources/scala-native/time.c
+++ b/posixlib/src/main/resources/scala-native/time.c
@@ -1,4 +1,9 @@
-#include <stdio.h>
+// X/Open System Interfaces (XSI), also sets _POSIX_C_SOURCE.
+// Partial, but useful, implementation of X/Open 7, incorporating Posix 2008.
+
+#define _XOPEN_SOURCE 700
+
+#include <string.h>
 #include <sys/time.h>
 #include <time.h>
 
@@ -40,6 +45,22 @@ static void tm_init(struct tm *tm, struct scalanative_tm *scala_tm) {
     tm->tm_wday = scala_tm->tm_wday;
     tm->tm_yday = scala_tm->tm_yday;
     tm->tm_isdst = scala_tm->tm_isdst;
+
+    if (sizeof(struct tm) > sizeof(struct scalanative_tm)) {
+        // The operating system struct tm can be larger than
+        // the scalanative tm.  On 64 bit GNU or _BSD_SOURCE Linux this
+        // usually is true and beyond easy control.
+        //
+        // Clear any fields not known to scalanative, such as tm_zone,
+        // so they are zero/NULL, not J-Random garbage.
+        // strftime() in Scala Native release mode is particularly sensitive
+        // to garbage beyond the end of the scalanative tm.
+        // Assume all excess size is at bottom of C tm, not internal padding.
+
+        char *start = (char *)tm + sizeof(struct scalanative_tm);
+        size_t count = sizeof(struct tm) - sizeof(struct scalanative_tm);
+        memset(start, 0, count);
+    }
 }
 
 char *scalanative_asctime_r(struct scalanative_tm *scala_tm, char *buf) {
@@ -91,8 +112,24 @@ size_t scalanative_strftime(char *buf, size_t maxsize, const char *format,
     return strftime(buf, maxsize, format, &tm);
 }
 
+// XSI
+char *scalanative_strptime(const char *s, const char *format,
+                           struct scalanative_tm *scala_tm) {
+    // strptime is known to not set is_dst field for %Z format.
+    // Take runtime hit of clearing entire structure to be robust
+    // to that and undiscovered corner cases where strptime does not fill
+    // a field under some condition.
+    struct tm tm = {0};
+
+    char *result = strptime(s, format, &tm);
+    scalanative_tm_init(scala_tm, &tm);
+    return result;
+}
+
 char **scalanative_tzname() { return tzname; }
 
+// XSI
 long scalanative_timezone() { return timezone; }
 
+// XSI
 int scalanative_daylight() { return daylight; }

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -4,6 +4,9 @@ package posix
 import scala.scalanative.unsafe._
 import scala.scalanative.posix.sys.types, types._
 
+// XSI comment before method indicates it is defined in
+// extended POSIX X/Open System Interfaces, not base POSIX.
+
 @extern
 object time {
 
@@ -12,36 +15,67 @@ object time {
   type timespec = CStruct2[time_t, CLong]
   type tm       = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
 
+  // Some methods here have a @name annotation and some do not.
+  // Methods where a @name extern "glue" layer would simply pass through
+  // the arguments or return value do not need that layer & its
+  // annotation.
+  //
+  // time_t is a simple type, not a structure, so it does not need to be
+  // transformed.
+  //
+  // Structures, such as timespec or tm, are subject to differing total
+  // sizes(tail padding), ordering of elements, and intervening padding.
+  // Expect an @name annotation and "glue" layer implementation to handle
+  // them.
+
   @name("scalanative_asctime")
   def asctime(time_ptr: Ptr[tm]): CString = extern
+
   @name("scalanative_asctime_r")
   def asctime_r(time_ptr: Ptr[tm], buf: Ptr[CChar]): CString = extern
-  def clock(): clock_t                                       = extern
-  def ctime(time: Ptr[time_t]): CString                      = extern
-  def ctime_r(time: Ptr[time_t], buf: Ptr[CChar]): CString   = extern
-  def difftime(time_end: CLong, time_beg: CLong): CDouble    = extern
+
+  def clock(): clock_t                                     = extern
+  def ctime(time: Ptr[time_t]): CString                    = extern
+  def ctime_r(time: Ptr[time_t], buf: Ptr[CChar]): CString = extern
+  def difftime(time_end: CLong, time_beg: CLong): CDouble  = extern
+
   @name("scalanative_gmtime")
   def gmtime(time: Ptr[time_t]): Ptr[tm] = extern
+
   @name("scalanative_gmtime_r")
   def gmtime_r(time: Ptr[time_t], tm: Ptr[tm]): Ptr[tm] = extern
+
   @name("scalanative_localtime")
   def localtime(time: Ptr[time_t]): Ptr[tm] = extern
+
   @name("scalanative_localtime_r")
   def localtime_r(time: Ptr[time_t], tm: Ptr[tm]): Ptr[tm] = extern
+
   @name("scalanative_mktime")
   def mktime(time: Ptr[tm]): time_t = extern
+
+  @name("scalanative_strftime")
   def strftime(str: Ptr[CChar],
                count: CSize,
                format: CString,
                time: Ptr[tm]): CSize = extern
+
+  // XSI
+  @name("scalanative_strptime")
   def strptime(str: Ptr[CChar], format: CString, time: Ptr[tm]): CString =
     extern
+
   def time(arg: Ptr[time_t]): time_t = extern
   def tzset(): Unit                  = extern
+
   @name("scalanative_daylight")
   def daylight(): CInt = extern
+
+  // XSI
   @name("scalanative_timezone")
   def timezone(): CLong = extern
+
+  // XSI
   @name("scalanative_tzname")
   def tzname(): Ptr[CStruct2[CString, CString]] = extern
 }

--- a/unit-tests/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -3,6 +3,9 @@ package scala.scalanative.posix
 import org.junit.Test
 import org.junit.Assert._
 
+import java.io.IOException
+
+import scalanative.libc.{errno => libcErrno, string}
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 
@@ -11,7 +14,9 @@ import timeOps.tmOps
 
 class TimeTest {
   tzset()
-  //In 2.11/2.12 time was resolved to posix.time.type, in 2.13 to posix.time.time method
+
+  // In 2.11/2.12 time was resolved to posix.time.type, in 2.13 to
+  // posix.time.time method.
   val now_time_t: time_t = scala.scalanative.posix.time.time(null)
   val epoch: time_t      = 0L
 
@@ -67,6 +72,54 @@ class TimeTest {
   @Test def timeNowGreaterThanTimestampWhenCodeWasWritten(): Unit = {
     // arbitrary date set at the time when I was writing this.
     assertTrue(now_time_t > 1502752688)
+  }
+
+  @Test def strftimeDoesNotReadMemoryOutsideStructTm(): Unit = {
+    Zone { implicit z =>
+      if (sizeof[tm] < 56.toULong) {
+        val ttPtr = alloc[time_t]
+        !ttPtr = 1490986064740L / 1000L // Fri Mar 31 14:47:44 EDT 2017
+
+        // This code is testing for reading past the end of a "short"
+        // Scala Native tm, so the linux 56 byte form is necessary here.
+        val tmBufCount = 7.toULong
+
+        // alloc will zero/clear all bytes
+        val tmBuf = alloc[Ptr[Byte]](tmBufCount)
+        val tmPtr = tmBuf.asInstanceOf[Ptr[tm]]
+
+        if (localtime_r(ttPtr, tmPtr) == null) {
+          throw new IOException(fromCString(string.strerror(libcErrno.errno)))
+        } else {
+          val unexpected = "BOGUS"
+
+          // With the "short" 36 byte SN struct tm tmBuf(6) is
+          // is BSD linux tm_zone, and outside the posix minimal required
+          // range. strftime() should not read it.
+
+          tmBuf(6) = toCString(unexpected)
+
+          // grossly over-provision rather than chase fencepost bugs.
+          val bufSize = 70.toULong
+          val buf     = alloc[Byte](bufSize) // will zero/clear all bytes
+          val n       = strftime(buf, bufSize, c"%a %b %d %T %Z %Y", tmPtr)
+
+          // strftime does not set errno on error
+          assertNotEquals("unexpected zero from strftime", n, 0)
+
+          val result = fromCString(buf)
+          val len    = "Fri Mar 31 14:47:44 ".length
+
+          assertEquals("strftime failed", result.indexOf(unexpected, len), -1)
+
+          val regex = "[A-Z][a-z]{2} [A-Z][a-z]{2} " +
+            "\\d\\d \\d{2}:\\d{2}:\\d{2} [A-Z]{2,5} 20[1-3]\\d"
+
+          assertTrue(s"result: '${result}' does not match regex: '${regex}'",
+                     result.matches(regex))
+        }
+      }
+    }
   }
 
   @Test def strftimeForJanOne1900ZeroZulu(): Unit = {
@@ -131,6 +184,81 @@ class TimeTest {
         strptime(c"December 32, 2016 23:59", c"%B %d, %Y %T", tmPtr)
 
       assertTrue(s"expected null result, got pointer", result == null)
+    }
+  }
+
+  @Test def strptimeDoesNotWriteMemoryOutsideStructTm(): Unit = {
+    Zone { implicit z =>
+      // Key to magic numbers 56 & 36.
+      // Linux _BSD_Source uses at least 56 Bytes.
+      // Posix specifies 36 but allows more.
+      val tmBufSize = 56.toULong
+      val tmBuf     = alloc[Byte](tmBufSize) // will zero/clear all bytes
+      val tmPtr     = tmBuf.asInstanceOf[Ptr[tm]]
+
+      // C strptime() parses %Z but does not set corresponding field.
+      // Initialize tm_isdate to something other than 0 to ensure
+      // Scala Native strptime() is clearing it.
+      // Change in this initial condition is checked in a test below.
+      tmPtr.tm_isdst = Int.MinValue
+
+      val gmtIndex = 36.toULong
+
+      // To detect the case where strptime() is writing tm_gmtoff
+      // use a value outside the known range of valid values.
+      val expectedGmtOff = Long.MaxValue
+      (tmBuf + gmtIndex).asInstanceOf[Ptr[CLong]](0) = expectedGmtOff
+
+      val cp =
+        strptime(c"Fri Mar 31 14:47:44 EDT 2017", c"%a %b %d %T %Z %Y", tmPtr)
+
+      assertNotNull(s"strptime() returned unexpected null pointer", cp)
+
+      val ch = cp(0) // last character not processed by strptime().
+      assertEquals("strptime() result is not NUL terminated", ch, '\u0000')
+
+      // tm_gmtoff & tm_zone are outside the posix defined range.
+      // Scala Native strftime() should never write to them.
+      // Assume no leading or interior padding.
+
+      val tm_gmtoff = (tmBuf + gmtIndex).asInstanceOf[Ptr[CLong]](0)
+      assertEquals("tm_gmtoff", expectedGmtOff, tm_gmtoff)
+
+      val tmZoneIndex = (gmtIndex + sizeof[CLong])
+      val tm_zone     = (tmBuf + tmZoneIndex).asInstanceOf[CString]
+      assertNull("tm_zone", null)
+
+      // Major concerning conditions passed. Sanity check the tm proper.
+
+      val expectedSec = 44
+      assertEquals("tm_sec", expectedSec, tmPtr.tm_sec)
+
+      val expectedMin = 47
+      assertEquals("tm_min", expectedMin, tmPtr.tm_min)
+
+      val expectedHour = 14
+      assertEquals("tm_hour", expectedHour, tmPtr.tm_hour)
+
+      val expectedMday = 31
+      assertEquals("tm_mday", expectedMday, tmPtr.tm_mday)
+
+      val expectedMonth = 2
+      assertEquals("tm_mon", expectedMonth, tmPtr.tm_mon)
+
+      val expectedYear = 117
+      assertEquals("tm_year", expectedYear, tmPtr.tm_year)
+
+      val expectedWday = 5
+      assertEquals("tm_wday", expectedWday, tmPtr.tm_wday)
+
+      val expectedYday = 89
+      assertEquals("tm_yday", expectedYday, tmPtr.tm_yday)
+
+      // C strptime() parses %Z but does not set corresponding field.
+      // This and the initializaton at beginning of test
+      // ensures that Scala Native strptime() initializes that field to zero.
+      val expectedIsDst = 0
+      assertEquals("tm_isdst", expectedIsDst, tmPtr.tm_isdst)
     }
   }
 


### PR DESCRIPTION
We correct two classes of defects in POSIX time.h handling.

The "@name" changes in time.scala cause Scala strftime() & strptime()
to use the code which handles translations of structure sizes.
Previously strftime() could read memory it did not own. More seriously,
strptime could write memory it did not own: memory spray!

Changes in time.c give the newly licit memory a defined, sensible
value when used by strftime().


This PR supersedes declined PR #2093. See that PR and the chain
it supersedes for discussion.