### PR TITLE
Scalanative now uses a scala object rather than an extern object for GC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ bin/
 /.bloop/
 /.metals/
 /project/**/metals.sbt
+/project/**/.bloop
 
 # Build Server Protocol, used by sbt
 /.bsp/

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -2,6 +2,7 @@ package scala.scalanative
 package runtime
 
 import scalanative.unsafe._
+import scalanative.unsigned._
 
 /**
  * The Boehm GC conservative garbage collector
@@ -9,11 +10,34 @@ import scalanative.unsafe._
  * @see [[http://hboehm.info/gc/gcinterface.html C Interface]]
  */
 @extern
-object GC {
+object GCExtern {
+
+  @name("scalanative_init")
+  def init(): Unit = extern
   @name("scalanative_alloc")
   def alloc(rawty: RawPtr, size: CSize): RawPtr = extern
+  @name("scalanative_alloc_small")
+  def alloc_small(rawty: RawPtr, size: Long): RawPtr = extern
+  @name("scalanative_alloc_large")
+  def alloc_large(rawty: RawPtr, size: Long): RawPtr = extern
   @name("scalanative_alloc_atomic")
   def alloc_atomic(rawty: RawPtr, size: CSize): RawPtr = extern
   @name("scalanative_collect")
   def collect(): Unit = extern
+}
+
+object GC {
+  def init(): Unit = {
+    GCExtern.init()
+  }
+  def alloc(rawty: RawPtr, size: CSize): RawPtr = GCExtern.alloc(rawty, size)
+  def alloc_small(rawty: RawPtr, size: CLong): RawPtr = {
+    GCExtern.alloc_small(rawty, size)
+  }
+  def alloc_large(rawty: RawPtr, size: CLong): RawPtr = {
+    GCExtern.alloc_large(rawty, size)
+  }
+  def alloc_atomic(rawty: RawPtr, size: CSize): RawPtr =
+    GCExtern.alloc_atomic(rawty, size)
+  def collect(): Unit = GCExtern.collect()
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -359,8 +359,10 @@ object Generate {
     val PrintStackTrace =
       Val.Global(PrintStackTraceName, Type.Ptr)
 
-    val InitSig  = Type.Function(Seq(), Type.Unit)
-    val Init     = Val.Global(extern("scalanative_init"), Type.Ptr)
+    val InitSig = Type.Function(Seq(), Type.Unit)
+    val GCInit = Global.Member(Global.Top("scala.scalanative.runtime.GC$"),
+                               Sig.Method("init", Seq(Type.Unit)))
+    val Init     = Val.Global(GCInit, Type.Ptr)
     val InitDecl = Defn.Declare(Attrs.None, Init.name, InitSig)
 
     val stackBottomName     = extern("__stack_bottom")

--- a/tools/src/main/scala/scala/scalanative/interflow/Whitelist.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Whitelist.scala
@@ -33,6 +33,7 @@ object Whitelist {
     out += Global.Top("scala.scalanative.unsafe.Tag$Nat7$")
     out += Global.Top("scala.scalanative.unsafe.Tag$Nat8$")
     out += Global.Top("scala.scalanative.unsafe.Tag$Nat9$")
+    out += Global.Top("scala.scalanative.runtime.GC$")
     out += Global.Top("java.lang.Math$")
     out
   }


### PR DESCRIPTION
This PR is the first in a set I'm wanting to do to port the GC code from C to scala. That is, my plan is to eventually have immix, commix, and none implemented as scalanative code instead of C. 

Likewise, I would like to change the design of the GC so that nativelib depends on a provided GC lib so that users can switch GC through a `libraryDependencies +=` rather than a special GC flag that in scala native.