### PR TITLE
Fix reporting undefined symbols not marked with stub

### DIFF
--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -23,8 +23,8 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
   val dynsigs       = mutable.Set.empty[Sig]
   val dynimpls      = mutable.Set.empty[Global]
 
-  private case class DeleyedMethod(owner: Global.Top, sig: Sig, pos: Position)
-  private val delayedMethods = mutable.Set.empty[DeleyedMethod]
+  private case class DelayedMethod(owner: Global.Top, sig: Sig, pos: Position)
+  private val delayedMethods = mutable.Set.empty[DelayedMethod]
 
   entries.foreach(reachEntry)
   loader.classesWithEntryPoints.foreach(reachClinit)
@@ -107,7 +107,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
      *  At this stage they should define at least 1 target, or should be marked as a missing symbol.
      */
     delayedMethods.foreach {
-      case DeleyedMethod(top, sig, position) =>
+      case DelayedMethod(top, sig, position) =>
         scopeInfo(top).foreach { info =>
           val wasAllocated = info match {
             case value: Trait => value.implementors.exists(_.allocated)
@@ -706,7 +706,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
             else {
               // At this stage we cannot tell if method target is not defined or not yet reached
               // We're delaying resolving targets to the end of Reach phase to check if this method is never defined in NIR
-              delayedMethods += DeleyedMethod(name.top, sig, pos)
+              delayedMethods += DelayedMethod(name.top, sig, pos)
             }
           }
         }

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -101,7 +101,11 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
         reachDefn(name)
       }
     }
+
   def processDelayed(): Unit = {
+    /*  Check methods that were marked to not have any defined targets yet when processing loop.
+     *  At this stage they should define at least 1 target, or should be marked as a missing symbol.
+     */
     delayedMethods.foreach {
       case DeleyedMethod(top, sig, position) =>
         scopeInfo(top).foreach { info =>
@@ -777,7 +781,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
       log.error(s"Found ${missing.size} missing definitions while linking")
       missing.foreach {
         case (global, positions) =>
-          log.error(s"Not found ${global.mangle}")
+          log.error(s"Not found $global")
           positions.toList
             .sortBy(p => (p.path, p.line))
             .foreach { pos =>


### PR DESCRIPTION
Recently it could have been possible to observe multiple runtime exceptions that should actually fail when linking. 
These problems could have been spotted when enabling `nativeCheck`, although they would be reported as warnings. Additionally by default checks are disabled, so users in multiple cases were unaware of an existing problem. 

An example of the mentioned problem can be using Java standard library methods not defined in the `javalib` and not marked with `@stub` annotation, eg. `String::repeat`. In such case, the method targets list was always empty, but there was no special handling for such cases. 

This PR adds additional handling to `Reach` adding an additional list with a method whose targets should be checked again at the very end of the `Reach` pipeline. This way we can be sure that all needed classes were already loaded. If the method still does not contain any targets we can be sure that the method should be treated as a missing symbol and reported accordingly. 

Since missing symbols found using this approach were never contained in the scala-native code (they may come from dependencies not compiled with SN) they would always be leading to breaking the build, even if `linkStubs` is enabled. The only way to mitigate this problem is to explicitly define the method stub by the user. 