### PR TITLE
Fix #2164: Return `-1` at first `EOF` at `Base64.DecodingInputStream`

### DIFF
--- a/javalib/src/main/scala/java/util/Base64.scala
+++ b/javalib/src/main/scala/java/util/Base64.scala
@@ -358,7 +358,8 @@ object Base64 {
         -1
       } else {
         iterate()
-        written
+        if (written == 0 && eof) -1
+        else written
       }
     }
 

--- a/unit-tests/src/test/scala/java/util/Base64Test.scala
+++ b/unit-tests/src/test/scala/java/util/Base64Test.scala
@@ -2,11 +2,15 @@ package java.util
 
 // Ported from Scala.js
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, IOException}
+import java.io.{
+  ByteArrayInputStream,
+  ByteArrayOutputStream,
+  IOException,
+  InputStream
+}
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.ISO_8859_1
 import java.util.Base64.Decoder
-
 import org.junit.Test
 import org.junit.Assert._
 
@@ -230,6 +234,13 @@ class Base64Test {
       val bb = Base64.getMimeDecoder.decode(ByteBuffer.wrap(input.getBytes))
       assertEquals(0, bb.limit())
     }
+  }
+
+  @Test def decodeInputStreamFirstEOF(): Unit = {
+    val emptyInputStream = new InputStream {
+      override def read(): Int = -1
+    }
+    assertEquals(-1, Base64.getDecoder.wrap(emptyInputStream).read())
   }
 
   private def decodeInputStream(decoder: Decoder,


### PR DESCRIPTION
When InputStream is used as source for Base64.DecodingInputStream returns -1 (aka EOF) at the first read, the `Base64.DecodingInputStream.read` returns 0 that broke contract for this method.

The root cause of the issue that `eof` flag doesn't check after iterate.