### PR TITLE
Use Ubuntu to 18.04 which includes clang 6.0.0

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -6,7 +6,7 @@ on:
       - master
 jobs:
   check-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: ./scripts/check-lint.sh


### PR DESCRIPTION
The `clangfmt` script is failing in CI. The script is not super robust so it probably needs fixing but it did work in the past.