### PR TITLE
Fix #2178: j.l.{Double,Float}#isFinite now handles NaN as specified.

### DIFF
--- a/javalib/src/main/scala/java/lang/Double.scala
+++ b/javalib/src/main/scala/java/lang/Double.scala
@@ -225,8 +225,9 @@ object Double {
     (v ^ (v >>> 32)).toInt
   }
 
+  // Ported from Scala.js commit: 217f3a3 dated: 2021-02-19
   @inline def isFinite(d: scala.Double): scala.Boolean =
-    !isInfinite(d)
+    !isNaN(d) && !isInfinite(d)
 
   @inline def isInfinite(v: scala.Double): scala.Boolean =
     v == POSITIVE_INFINITY || v == NEGATIVE_INFINITY

--- a/javalib/src/main/scala/java/lang/Float.scala
+++ b/javalib/src/main/scala/java/lang/Float.scala
@@ -222,8 +222,9 @@ object Float {
   @inline def intBitsToFloat(value: scala.Int): scala.Float =
     Intrinsics.castIntToFloat(value)
 
+  // Ported from Scala.js commit: 217f3a3 dated: 2021-02-19
   @inline def isFinite(f: scala.Float): scala.Boolean =
-    !isInfinite(f)
+    !isNaN(f) && !isInfinite(f)
 
   @inline def isInfinite(v: scala.Float): scala.Boolean =
     v == POSITIVE_INFINITY || v == NEGATIVE_INFINITY

--- a/unit-tests/src/test/scala/java/lang/DoubleTest.scala
+++ b/unit-tests/src/test/scala/java/lang/DoubleTest.scala
@@ -1,5 +1,18 @@
 package java.lang
 
+// Three tests ported from Scala.js javalib/lang/DoubleTest.scala
+// commit: 0f25c8c dated: 2021-02-17
+//   isFinite()
+//   isInfinite()
+//   isNanTest()
+
+// Because this test is the java.lang package, an unqualified Double
+// is a java.lang.Double. Prior art used unqualified Double freely,
+// with that intent. Scala.js JDouble is introduced to minimize changes
+// in ported Scala.js tests. Existing usages of unqualified Double
+// are not changed. Joys of blending code bases.
+import java.lang.{Double => JDouble}
+
 import java.lang.Double.{
   doubleToLongBits,
   doubleToRawLongBits,
@@ -322,4 +335,44 @@ class DoubleTest {
     assertTrue(java.lang.Double.toHexString(-31.0).equals("-0x1.fp4"))
   }
 
+  @Test def isFinite(): Unit = {
+    assertFalse(JDouble.isFinite(scala.Double.PositiveInfinity))
+    assertFalse(JDouble.isFinite(scala.Double.NegativeInfinity))
+    assertFalse(JDouble.isFinite(scala.Double.NaN))
+    assertFalse(JDouble.isFinite(1d / 0))
+    assertFalse(JDouble.isFinite(-1d / 0))
+
+    assertTrue(JDouble.isFinite(0d))
+    assertTrue(JDouble.isFinite(1d))
+    assertTrue(JDouble.isFinite(123456d))
+    assertTrue(JDouble.isFinite(scala.Double.MinValue))
+    assertTrue(JDouble.isFinite(scala.Double.MaxValue))
+    assertTrue(JDouble.isFinite(scala.Double.MinPositiveValue))
+  }
+
+  // Scala.js Issue 515
+  @Test def isInfinite(): Unit = {
+    assertTrue(scala.Double.PositiveInfinity.isInfinite)
+    assertTrue(scala.Double.NegativeInfinity.isInfinite)
+    assertTrue((1.0 / 0).isInfinite)
+    assertTrue((-1.0 / 0).isInfinite)
+    assertFalse((0.0).isInfinite)
+  }
+
+  @Test def isNaNTest(): Unit = {
+    def f(v: Double): Boolean = {
+      var v2 = v // do not inline
+      v2.isNaN
+    }
+
+    assertTrue(f(Double.NaN))
+
+    assertFalse(f(scala.Double.PositiveInfinity))
+    assertFalse(f(scala.Double.NegativeInfinity))
+    assertFalse(f(1.0 / 0))
+    assertFalse(f(-1.0 / 0))
+    assertFalse(f(0.0))
+    assertFalse(f(3.0))
+    assertFalse(f(-1.5))
+  }
 }

--- a/unit-tests/src/test/scala/java/lang/FloatTest.scala
+++ b/unit-tests/src/test/scala/java/lang/FloatTest.scala
@@ -1,5 +1,18 @@
 package java.lang
 
+// Three tests ported from Scala.js javalib/lang/FloatTest.scala
+// commit: 217f3a3 dated: 2021-02-19
+//   isFinite()
+//   isInfinite()
+//   isNanTest()
+
+// Because this test is the java.lang package, an unqualified Float
+// is a java.lang.Float. Prior art used unqualified Float freely,
+// with that intent.  Scala.js JFloat is introduced to minimize changes
+// in ported Scala.js tests. Existing usages of unqualified Double
+// are not changed. Joys of blending code bases.
+import java.lang.{Float => JFloat}
+
 import java.lang.Float.{floatToIntBits, floatToRawIntBits, intBitsToFloat}
 
 import org.junit.Test
@@ -296,5 +309,45 @@ class FloatTest {
     assertF2sEquals("3.1415926E7", (math.Pi * 1.0E+7).toFloat)
     assertF2sEquals("0.0031415927", (math.Pi * 1.0E-3).toFloat)
     assertF2sEquals("3.1415926E-4", (math.Pi * 1.0E-4).toFloat)
+  }
+
+  @Test def isFinite(): Unit = {
+    assertFalse(JFloat.isFinite(scala.Float.PositiveInfinity))
+    assertFalse(JFloat.isFinite(scala.Float.NegativeInfinity))
+    assertFalse(JFloat.isFinite(scala.Float.NaN))
+    assertFalse(JFloat.isFinite(1f / 0))
+    assertFalse(JFloat.isFinite(-1f / 0))
+
+    assertTrue(JFloat.isFinite(0f))
+    assertTrue(JFloat.isFinite(1f))
+    assertTrue(JFloat.isFinite(123456f))
+    assertTrue(JFloat.isFinite(scala.Float.MinValue))
+    assertTrue(JFloat.isFinite(scala.Float.MaxValue))
+    assertTrue(JFloat.isFinite(scala.Float.MinPositiveValue))
+  }
+
+  @Test def isInfinite_Issue515(): Unit = {
+    assertTrue(scala.Float.PositiveInfinity.isInfinite)
+    assertTrue(scala.Float.NegativeInfinity.isInfinite)
+    assertTrue((1f / 0).isInfinite)
+    assertTrue((-1f / 0).isInfinite)
+    assertFalse(0f.isInfinite)
+  }
+
+  @Test def isNaNTest(): Unit = {
+    def f(v: Float): Boolean = {
+      var v2 = v // do not inline
+      v2.isNaN
+    }
+
+    assertTrue(f(Float.NaN))
+
+    assertFalse(f(scala.Float.PositiveInfinity))
+    assertFalse(f(scala.Float.NegativeInfinity))
+    assertFalse(f(1f / 0))
+    assertFalse(f(-1f / 0))
+    assertFalse(f(0f))
+    assertFalse(f(3f))
+    assertFalse(f(-1.5f))
   }
 }


### PR DESCRIPTION
Reported & co-authored by Timothy McCarthy (at_tmccarthy).

We port the implementation of the isFinite method and associated
tests from Scala.js.