### PR TITLE
Introduced NativeThread

### DIFF
--- a/posixlib/src/main/resources/scala-native/nativethread.c
+++ b/posixlib/src/main/resources/scala-native/nativethread.c
@@ -1,0 +1,66 @@
+#include <sys/types.h>
+#include <stdint.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+pthread_attr_t PTHREAD_DEFAULT_ATTR;
+struct sched_param PTHREAD_DEFAULT_SCHED_PARAM;
+int PTHREAD_DEFAULT_POLICY;
+size_t PTHREAD_DEFAULT_STACK_SIZE;
+int initialized = 0;
+
+void init() {
+    pthread_attr_init(&PTHREAD_DEFAULT_ATTR);
+    pthread_attr_getschedparam(&PTHREAD_DEFAULT_ATTR,
+                               &PTHREAD_DEFAULT_SCHED_PARAM);
+    pthread_attr_getschedpolicy(&PTHREAD_DEFAULT_ATTR, &PTHREAD_DEFAULT_POLICY);
+    pthread_attr_getstacksize(&PTHREAD_DEFAULT_ATTR,
+                              &PTHREAD_DEFAULT_STACK_SIZE);
+
+    initialized = 1;
+}
+
+int get_max_priority() {
+    if (!initialized)
+        init();
+    return sched_get_priority_max(PTHREAD_DEFAULT_POLICY);
+}
+
+int get_min_priority() {
+    if (!initialized)
+        init();
+    return sched_get_priority_min(PTHREAD_DEFAULT_POLICY);
+}
+
+int get_norm_priority() {
+    if (!initialized)
+        init();
+    return PTHREAD_DEFAULT_SCHED_PARAM.sched_priority;
+}
+
+size_t get_stack_size() {
+    if (!initialized)
+        init();
+    return PTHREAD_DEFAULT_STACK_SIZE;
+}
+
+void attr_set_priority(pthread_attr_t *attr, int priority) {
+    struct sched_param param;
+
+    pthread_attr_setschedparam(attr, &param);
+    param.sched_priority = priority;
+
+    pthread_attr_setschedparam(attr, &param);
+}
+
+void set_priority(pthread_t thread, int priority) {
+    struct sched_param param;
+    int policy;
+
+    pthread_getschedparam(thread, &policy, &param);
+    param.sched_priority = priority;
+
+    pthread_setschedparam(thread, policy, &param);
+}

--- a/posixlib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/runtime/NativeThread.scala
@@ -1,0 +1,26 @@
+package scala.scalanative.runtime
+
+import scala.scalanative.posix.sys.types.{pthread_attr_t, pthread_t}
+import scala.scalanative.unsafe.{CInt, CSize, Ptr, extern, name}
+
+@extern
+object NativeThread {
+
+  @name("get_max_priority")
+  def THREAD_MAX_PRIORITY: Int = extern
+
+  @name("get_min_priority")
+  def THREAD_MIN_PRIORITY: Int = extern
+
+  @name("get_norm_priority")
+  def THREAD_NORM_PRIORITY: Int = extern
+
+  @name("get_stack_size")
+  def THREAD_DEFAULT_STACK_SIZE: CSize = extern
+
+  @name("set_priority")
+  def setPriority(thread: pthread_t, priority: CInt): Unit = extern
+
+  @name("attr_set_priority")
+  def attrSetPriority(attr: Ptr[pthread_attr_t], priority: CInt): Unit = extern
+}


### PR DESCRIPTION
This commit introduced `NativeThread` which is a part of #947

This is a step to split https://github.com/catap/scala-native/tree/multithreading
