### PR TITLE
Improve speed of release-full compilation

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -1,9 +1,13 @@
 package scala.scalanative
 package nir
 
+import scala.util.hashing.MurmurHash3
 import util.unreachable
 
 sealed abstract class Op {
+  self: Product =>
+  override lazy val hashCode = MurmurHash3.productHash(self)
+
   final def resty: Type = this match {
     case Op.Call(Type.Function(_, ret), _, _) => ret
     case Op.Call(_, _, _)                     => unreachable

--- a/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/PolyInline.scala
@@ -34,7 +34,9 @@ trait PolyInline { self: Interflow =>
         Seq.empty
     }
 
-    res.sortBy(_._1.name)
+    // the only case when result won't be empty or one element seq is reading from `scop.implementors`
+    // scop.implementors are prestorted by the same way => I don't need sort here.
+    res
   }
 
   def shallPolyInline(op: Op.Method, args: Seq[Val])(

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -18,7 +18,7 @@ sealed abstract class ScopeInfo extends Info {
   def isTrait: Boolean = this.isInstanceOf[Trait]
   def is(info: ScopeInfo): Boolean
   def targets(sig: Sig): mutable.Set[Global]
-  def implementors: mutable.Set[Class]
+  def implementors: mutable.SortedSet[Class]
 
   lazy val linearized: Seq[ScopeInfo] = {
     val out = mutable.UnrolledBuffer.empty[ScopeInfo]
@@ -65,7 +65,7 @@ final class Unavailable(val name: Global) extends Info {
 final class Trait(val attrs: Attrs, val name: Global, val traits: Seq[Trait])(
     implicit val position: Position)
     extends ScopeInfo {
-  val implementors = mutable.Set.empty[Class]
+  val implementors = mutable.SortedSet.empty[Class]
   val subtraits    = mutable.Set.empty[Trait]
   val responds     = mutable.Map.empty[Sig, Global]
 
@@ -100,7 +100,7 @@ final class Class(val attrs: Attrs,
                   val traits: Seq[Trait],
                   val isModule: Boolean)(implicit val position: Position)
     extends ScopeInfo {
-  val implementors    = mutable.Set[Class](this)
+  val implementors    = mutable.SortedSet[Class](this)
   val subclasses      = mutable.Set.empty[Class]
   val responds        = mutable.Map.empty[Sig, Global]
   val defaultResponds = mutable.Map.empty[Sig, Global]
@@ -174,6 +174,13 @@ final class Class(val attrs: Attrs,
           false
       }
     }
+  }
+}
+
+object Class {
+  implicit val classOrdering: Ordering[Class] = new Ordering[Class] {
+    override def compare(x: Class, y: Class): Int =
+      Global.globalOrdering.compare(x.name, y.name)
   }
 }
 


### PR DESCRIPTION
This PR contains two changes that allows me to improve SN-related time of building unit tests with `release-full` from about 20 minutes to near of 11 minutes on my machine.

`release-full` on real-life project which is contains a lot of classes consume significant time with compare with `release-fast` and huge fraction of this time is spent during `Optimizing (release-full mode)`.

This time is bigger than `clang` when it needs to compile huge `.ll` file. Do you know that `out.ll` for unit tests on `release-full` is near of 1.1Gb? Now you know.

So, that I did:
 - caching inside NIR's `Ops` that save something like 10% of wall clock time,
 - removing one sort inside `polyTargets` by using pre-sorted strucutres that allows to save something like 40%

Results:

Base line 24e0983e3c478325dacad44d5a7e4a7146c5cbe5:
```
% env SCALANATIVE_MODE=release-full sbt tests/test:nativeLink
...
[info] Linking (2634 ms)
[info] Checking intermediate code (937 ms)
[info] Dumping intermediate code (linked) (2896 ms)
[info] Discovered 4817 classes and 30666 methods
[info] Optimizing (release-full mode) (1232678 ms)
[info] Checking intermediate code (1938 ms)
[info] Dumping intermediate code (optimized) (12983 ms)
[info] Dumping intermediate code (lowered) (22404 ms)
[info] Generating intermediate code (91978 ms)
[info] Produced 1 files
[info] Compiling to native code (915988 ms)
[info] Linking native code (immix gc, none lto) (16751 ms)
[info] Total (2281215 ms)
...
```
with cached `hashCode` only:
```
% env SCALANATIVE_MODE=release-full sbt tests/test:nativeLink
...
[info] Linking (3903 ms)
[info] Checking intermediate code (490 ms)
[info] Dumping intermediate code (linked) (3094 ms)
[info] Discovered 4817 classes and 30666 methods
[info] Optimizing (release-full mode) (1118378 ms)
[info] Checking intermediate code (2302 ms)
[info] Dumping intermediate code (optimized) (15484 ms)
[info] Dumping intermediate code (lowered) (26133 ms)
[info] Generating intermediate code (102145 ms)
[info] Produced 1 files
[info] Compiling to native code (936460 ms)
[info] Linking native code (immix gc, none lto) (17370 ms)
[info] Total (2200063 ms)
...
```
and with presorted set:
```
...
[info] Linking (2848 ms)
[info] Checking intermediate code (604 ms)
[info] Dumping intermediate code (linked) (2610 ms)
[info] Discovered 4817 classes and 30666 methods
[info] Optimizing (release-full mode) (693704 ms)
[info] Checking intermediate code (1838 ms)
[info] Dumping intermediate code (optimized) (15642 ms)
[info] Dumping intermediate code (lowered) (24563 ms)
[info] Generating intermediate code (98017 ms)
[info] Produced 1 files
[info] Compiling to native code (890735 ms)
[info] Linking native code (immix gc, none lto) (18106 ms)
[info] Total (1724876 ms)
...
```

The target stage was reduced as `1232678 ms` -> `1118378 ms` -> `693704  ms`.
