### PR TITLE
clangfmt can now extract version on both Ubuntu 18.04 & 20.04.

### DIFF
--- a/scripts/clangfmt
+++ b/scripts/clangfmt
@@ -22,12 +22,29 @@ die() {
   exit 1
 }
 
+## As a side effect, intentionally sets bash variable "version"
 check_clang_format_version() {
   cmd="$1"
-  [ -e "$(type -P "$cmd")" ] && \
-    version=$("$cmd" --version | cut -d" " -f3)
-    major=$(echo $version | cut -d. -f1)
+
+  if [ ! -e "$(type -P "$cmd")" ]; then
+    version="Unknown"
+    echo "Setting version to UNKNOWN"
+    return 0
+  else
+    # More elegant ways of extracting version exist, such as grep -P perl.
+    # This way has the minimal requirement of standard "grep" which is
+    # highly likely to be on any system actively used for development.  
+    version=$("$cmd" --version \
+      | grep -E -i -o " version [0-9]+.[0-9]+" \
+      | grep -E -i -o "[0-9]+.[0-9]+")
+
+    major=${version%%.*}
+    echo "Debug - major is ${major}"
+    ls -l $CLANG_FORMAT_PATH
+    echo "Debug "
+
     [ $major -eq $CLANG_FORMAT_VERSION ]
+  fi
 }
 
 clang_format=


### PR DESCRIPTION
We harden the steps used to extract the clang-format version so
that it will now work on both Ubuntu 18.04 and 20.04.

PR #2177 removed a failure when GitHub changed "ubuntu-latest" to
20.04 by reverting the build version to 18.04. This PR is the next
evolution of that work.  It remove a hidden, lurking, & time wasting
 "gotcha" arising when the build version advances past 18.04.
Far easier to fix it now when we have characterized the problem than
to re-establish that knowledge later.

Parsing output strings is always fraught with peril, fragile, and subject to change. This
PR is no exception.