### PR TITLE
Update clangfmt script to address flaws

### DIFF
--- a/scripts/clangfmt
+++ b/scripts/clangfmt
@@ -10,7 +10,6 @@
 # Set CLANG_FORMAT_PATH to configure path to clang-format.
 
 set -euo pipefail
-IFS=$'\n\t'
 
 # The required version of clang-format (matches minimum clang version) for CI
 CLANG_FORMAT_VERSION=6
@@ -27,15 +26,26 @@ version=
 
 check_clang_format_version() {
   cmd="$1"
-  [ -e "$(type -P "$cmd")" ] && \
-    version=$("$cmd" --version 2> /dev/null | cut -d" " -f3)
-    major=$(echo $version | cut -d. -f1)
-    [ $major -eq $CLANG_FORMAT_VERSION ]
+  # version can be in 3rd or 4th position
+  cv=$("$cmd" --version 2> /dev/null | cut -d" " -f1-4)
+  sel=1
+  for w in $cv; do
+    if [ $sel -eq 0 ]; then
+      version=$w
+      sel=1
+    fi
+    if [ "$w" == "version" ]; then
+      sel=0
+    fi
+  done
+  major=$(echo $version | cut -d. -f1)
+  [ $major -eq $CLANG_FORMAT_VERSION ]
 }
 
 clang_format=
 
 if [ -n "${CLANG_FORMAT_PATH:-}" ]; then
+  # original used: -e "$(type -P "$cmd")"
   if [ ! -x "$(command -v ${CLANG_FORMAT_PATH})" ]; then
     echo "CLANG_FORMAT_PATH='$CLANG_FORMAT_PATH' does not exist or is not executable" >&2
   else

--- a/scripts/clangfmt
+++ b/scripts/clangfmt
@@ -38,7 +38,7 @@ if [ -n "${CLANG_FORMAT_PATH:-}" ]; then
         "CLANG_FORMAT_PATH points to $CLANG_FORMAT_PATH"
   clang_format="$CLANG_FORMAT_PATH"
 else
-  if check_clang_format_version clang-format; then
+  if [ check_clang_format_version clang-format ]; then
     clang_format=clang-format
   fi
 fi

--- a/scripts/clangfmt
+++ b/scripts/clangfmt
@@ -26,27 +26,19 @@ version=
 
 check_clang_format_version() {
   cmd="$1"
-  # version can be in 3rd or 4th position
-  cv=$("$cmd" --version 2> /dev/null | cut -d" " -f1-4)
-  sel=1
-  for w in $cv; do
-    if [ $sel -eq 0 ]; then
-      version=$w
-      sel=1
-    fi
-    if [ "$w" == "version" ]; then
-      sel=0
-    fi
-  done
-  major=$(echo $version | cut -d. -f1)
+  # version can be in 3rd or 4th position after the word "version"
+  version=$("$cmd" --version \
+    | grep -E -i -o " version [0-9]+.[0-9]+" \
+    | grep -E -i -o "[0-9]+.[0-9]+")
+
+  major=${version%%.*}
   [ $major -eq $CLANG_FORMAT_VERSION ]
 }
 
 clang_format=
 
 if [ -n "${CLANG_FORMAT_PATH:-}" ]; then
-  # original used: -e "$(type -P "$cmd")"
-  if [ ! -x "$(command -v ${CLANG_FORMAT_PATH})" ]; then
+  if [ ! -e "$(type -P "${CLANG_FORMAT_PATH}")" ]; then
     echo "CLANG_FORMAT_PATH='$CLANG_FORMAT_PATH' does not exist or is not executable" >&2
   else
     if check_clang_format_version "$CLANG_FORMAT_PATH"; then
@@ -56,7 +48,7 @@ if [ -n "${CLANG_FORMAT_PATH:-}" ]; then
     fi
   fi
 else
-  if [ ! -x "$(command -v clang-format)" ]; then
+  if [ ! -e "$(type -P clang-format)" ]; then
     echo "clang-format is not installed or not in the PATH." >&2
   else
     check_clang_format_version "clang-format" && \

--- a/scripts/clangfmt
+++ b/scripts/clangfmt
@@ -22,10 +22,13 @@ die() {
   exit 1
 }
 
+# avoid unbound var
+version=
+
 check_clang_format_version() {
   cmd="$1"
   [ -e "$(type -P "$cmd")" ] && \
-    version=$("$cmd" --version | cut -d" " -f3)
+    version=$("$cmd" --version 2> /dev/null | cut -d" " -f3)
     major=$(echo $version | cut -d. -f1)
     [ $major -eq $CLANG_FORMAT_VERSION ]
 }
@@ -33,20 +36,28 @@ check_clang_format_version() {
 clang_format=
 
 if [ -n "${CLANG_FORMAT_PATH:-}" ]; then
-  check_clang_format_version "$CLANG_FORMAT_PATH" || \
-    die "CLANG_FORMAT_PATH must point to version $CLANG_FORMAT_VERSION" \
-        "CLANG_FORMAT_PATH points to $CLANG_FORMAT_PATH"
-  clang_format="$CLANG_FORMAT_PATH"
+  if [ ! -x "$(command -v ${CLANG_FORMAT_PATH})" ]; then
+    echo "CLANG_FORMAT_PATH='$CLANG_FORMAT_PATH' does not exist or is not executable" >&2
+  else
+    if check_clang_format_version "$CLANG_FORMAT_PATH"; then
+      clang_format="$CLANG_FORMAT_PATH"
+    else
+      echo "CLANG_FORMAT_PATH='$CLANG_FORMAT_PATH'" >&2
+    fi
+  fi
 else
-  if [ check_clang_format_version clang-format ]; then
-    clang_format=clang-format
+  if [ ! -x "$(command -v clang-format)" ]; then
+    echo "clang-format is not installed or not in the PATH." >&2
+  else
+    check_clang_format_version "clang-format" && \
+      clang_format=clang-format
   fi
 fi
 
 if [ -z "$clang_format" ]; then
-  die "clang-format version $CLANG_FORMAT_VERSION expected, but version $version found." \
-      "Install LLVM version $CLANG_FORMAT_VERSION and rerun." \
-      "Hint: export CLANG_FORMAT_PATH=/path/to/clang-format"
+  die "clang-format version '$CLANG_FORMAT_VERSION' expected, but version '$version' found." \
+      "Install LLVM version '$CLANG_FORMAT_VERSION' and rerun." \
+      "Hint: export CLANG_FORMAT_PATH='/path/to/clang-format'"
 fi
 
 test_mode=


### PR DESCRIPTION
Now the script does the following checks.
1. Existence of the `CLANG_FORMAT_PATH` and it being an executable - this was the CI error.
2. Checks for `clang-format` on the path and rejects if it is not there. This code was in the script but didn't work.
3. Checks both the above cases for the `CLANG_FORMAT_VERSION` currently `6`.

It also adds Lee Tibbert's changes in PR https://github.com/scala-native/scala-native/pull/2184 that uses `grep` instead of `cut` to find the version and a shell built-in to find the major version. He found that bleeding edge Ubuntu had a version string as follows:

```script
Ubuntu clang-version version x.y.z
# vs
clang-version version x.y.z
```