### PR TITLE
Fix #2181: Use strict OS version control in GitHub workflows

### DIFF
--- a/.github/workflows/check-cla.yml
+++ b/.github/workflows/check-cla.yml
@@ -2,7 +2,7 @@ name: Check CLA
 on: [pull_request]
 jobs:
   check-cla:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: ./scripts/check-cla.sh

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
   # Test tools, if any of them fails, further tests will not start.
   tests-tools:
     name: Compile & test tools
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
   # Currently only Linux x64 is tested
   build-image:
     name: Build image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       image-name: ${{ steps.build-image.outputs.image-base-name }}
     strategy:
@@ -108,7 +108,7 @@ jobs:
   #It can be extended to test against different OS and Arch settings
   test-runtime:
     name: Test runtime
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: [tests-tools, build-image]
     strategy:
       fail-fast: false
@@ -165,7 +165,7 @@ jobs:
   # Main difference is disabled optimization and fixed Immix GC
   test-runtime-no-opt:
     name: Test runtime no-opt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: [tests-tools, build-image]
     strategy:
       fail-fast: false
@@ -209,7 +209,7 @@ jobs:
   # Scripted tests take a long time to run, ~30 minutes, and should be limited and absolute minimum.
   test-scripted:
     name: Test scripted
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: [tests-tools, build-image]
     strategy:
       fail-fast: false


### PR DESCRIPTION
We modify two github workflow actions to use explicit & strict
configuration of the operating system major.minor in GitHub work flows.
Distribution patch level (M.m.p) still floats.

This PR restores the OS versions to that in use before the end of
February, 2021 "ubuntu-latest" change by GitHub.

See referenced Issue for a discussion of OS version specified.