### PR TITLE
Fix: #2187 Match with guards does not compile

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -264,7 +264,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       }
 
       def genIfsChain(): Val = {
-        /* Default needs to be generated before any others and though added to
+        /* Default needs to be generated before any others and then added to
          * current MethodEnv. It's label might be referenced in any of them in
          * case of match with guards, eg.:
          *

--- a/unit-tests/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -432,16 +432,16 @@ class IssuesTest {
     val args = List.empty[String]
     // In issue 2187 match with guards would not compile
     val res = "Hello, World!" match {
-      case "Hello" if args.isEmpty => "foo"
+      case "Hello" if args.isEmpty  => "foo"
       case "Hello" if args.nonEmpty => "foo2"
       // With next line it compiled because it was not referencing default case
       // case "Hello" => "foo3"
-      case "World" if args.nonEmpty => "bar"
+      case "World" if args.nonEmpty   => "bar"
       case "World" if args.length > 3 => "bar2"
-      case "World" if args.isEmpty => "bar3"
-      case "World" => "bar4"
-      case _ if args != null => "bar-baz"
-      case _ => "baz-bar"
+      case "World" if args.isEmpty    => "bar3"
+      case "World"                    => "bar4"
+      case _ if args != null          => "bar-baz"
+      case _                          => "baz-bar"
     }
     assertNotNull(res)
   }

--- a/unit-tests/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -428,6 +428,24 @@ class IssuesTest {
       .foreach(assertEquals("hello", _))
   }
 
+  @Test def test_Issue2187(): Unit = {
+    val args = List.empty[String]
+    // In issue 2187 match with guards would not compile
+    val res = "Hello, World!" match {
+      case "Hello" if args.isEmpty => "foo"
+      case "Hello" if args.nonEmpty => "foo2"
+      // With next line it compiled because it was not referencing default case
+      // case "Hello" => "foo3"
+      case "World" if args.nonEmpty => "bar"
+      case "World" if args.length > 3 => "bar2"
+      case "World" if args.isEmpty => "bar3"
+      case "World" => "bar4"
+      case _ if args != null => "bar-baz"
+      case _ => "baz-bar"
+    }
+    assertNotNull(res)
+  }
+
 }
 
 package issue1090 {


### PR DESCRIPTION
This PR fixes #2187. Due to the optimizations done in Scala compiler to pattern matches if the case was successfully matched but non of its guard conditions were fulfilled it would jump to default case without checking for any other intermediate cases.  
When generating such a condition we have not yet generated the default case label, and though not registered it as a local method in `MethodEnv`. Trying to reference the default label in such a case would cause it to fail the whole compilation process.

Fix includes generating default expression before proceeding to generate any of match cases. 