### PR TITLE
Fix sbt plugin incompatibilities on Windows

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -84,15 +84,15 @@ object Discover {
    */
   private[scalanative] def checkClangVersion(pathToClangBinary: Path): Unit = {
     def versionMajorFull(clang: String): (Int, String) = {
-      val versionCommand = s"$clang --version"
-      // Pass command as seq of string to handle spaces in path
-      val versionString = Process(Seq(clang, "--version"))
+      val versionCommand = Seq(clang, "--version")
+      val versionString = Process(versionCommand)
         .lineStream_!(silentLogger())
         .headOption
         .getOrElse {
           throw new BuildException(
-            s"""Problem running '$versionCommand'. Please check clang setup.
-                 |Refer to ($docSetup)""".stripMargin)
+            s"""Problem running '${versionCommand
+                 .mkString(" ")}'. Please check clang setup.
+               |Refer to ($docSetup)""".stripMargin)
         }
       // Apple macOS clang is different vs brew installed or Linux
       // Apple LLVM version 10.0.1 (clang-1001.0.46.4)
@@ -136,7 +136,7 @@ object Discover {
                                     envPath: String): Path = {
     val binaryNameOrPath = sys.env.getOrElse(envPath, binaryName)
     val locateCmd        = if (Platform.isWindows) "where" else "which"
-    val path = Process(s"$locateCmd $binaryNameOrPath")
+    val path = Process(Seq(locateCmd, binaryNameOrPath))
       .lineStream_!(silentLogger())
       .map { p => Paths.get(p) }
       .headOption

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -85,7 +85,8 @@ object Discover {
   private[scalanative] def checkClangVersion(pathToClangBinary: Path): Unit = {
     def versionMajorFull(clang: String): (Int, String) = {
       val versionCommand = s"$clang --version"
-      val versionString = Process(versionCommand)
+      // Pass command as seq of string to handle spaces in path
+      val versionString = Process(Seq(clang, "--version"))
         .lineStream_!(silentLogger())
         .headOption
         .getOrElse {
@@ -133,8 +134,9 @@ object Discover {
    */
   private[scalanative] def discover(binaryName: String,
                                     envPath: String): Path = {
-    val binaryNameOrPath = sys.env.get(envPath).getOrElse(binaryName)
-    val path = Process(s"which $binaryNameOrPath")
+    val binaryNameOrPath = sys.env.getOrElse(envPath, binaryName)
+    val locateCmd        = if (Platform.isWindows) "where" else "which"
+    val path = Process(s"$locateCmd $binaryNameOrPath")
       .lineStream_!(silentLogger())
       .map { p => Paths.get(p) }
       .headOption

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -10,7 +10,6 @@ private[scalanative] case class NativeLib(src: Path, dest: Path)
 
 /** Utilities for dealing with native library code */
 private[scalanative] object NativeLib {
-  private val fileSep      = File.separator
   private val jarExtension = ".jar"
 
   /** Object file extension: ".o" */
@@ -34,12 +33,12 @@ private[scalanative] object NativeLib {
   /** Used to find native source files in jar files */
   private val jarSrcRegex: String = {
     val regexExtensions = srcExtensions.mkString("""(\""", """|\""", ")")
-    val escapedFileSep  = if (Platform.isWindows) "/" else raw"\\"
-    s"""^$codeDir$escapedFileSep(.+)$regexExtensions$$"""
+    // Paths in jars always contains '/' separator instead of OS specific one.
+    s"""^$codeDir/(.+)$regexExtensions$$"""
   }
 
   private def srcPathPattern(path: Path): String =
-    s"${path.toString()}${fileSep}${codeDir}${fileSep}"
+    makeDirPath(path, codeDir)
 
   /**
    * Used to create hash of the directory to copy
@@ -60,15 +59,9 @@ private[scalanative] object NativeLib {
    * @return the source pattern
    */
   def destSrcPatterns(workdir: Path, nativelibs: Seq[Path]): String = {
-    val pathPat = destPathPattern(workdir, nativelibs)
-    srcExtensions.mkString(s"glob:${pathPat}**{", ",", "}")
-  }
-
-  private def destPathPattern(workdir: Path, nativelibs: Seq[Path]): String = {
-    val workdirStr = workdir.toString()
-    val nativeDirs = nativelibs.map(_.getFileName().toString())
-    val dirPattern = nativeDirs.mkString("{", ",", "}")
-    s"${workdirStr}${fileSep}${dirPattern}${fileSep}${codeDir}${fileSep}"
+    val dirPattern = nativelibs.map(_.getFileName()).mkString("{", ",", "}")
+    val pathPat    = makeDirPath(workdir, dirPattern, codeDir)
+    srcExtensions.mkString(s"glob:$pathPat**{", ",", "}")
   }
 
   /** To positively identify nativelib */
@@ -81,7 +74,7 @@ private[scalanative] object NativeLib {
    * @return the search file pattern
    */
   private def dirMarkerFilePattern(path: Path): String =
-    s"glob:${path.toString()}${fileSep}${nativeLibMarkerFile}"
+    s"glob:${makeDirPath(path, nativeLibMarkerFile)}"
 
   /** Does this Path point to a jar file */
   def isJar(path: Path): Boolean = path.toString().endsWith(jarExtension)
@@ -185,4 +178,12 @@ private[scalanative] object NativeLib {
       case true  => Some(path)
       case false => None
     }
+
+  private def makeDirPath(path: Path, elems: String*): String = {
+    val pathSep = if (Platform.isWindows) raw"\\" else File.separator
+
+    (path.toString.replace(File.separator, pathSep) +: elems)
+      .mkString("", pathSep, pathSep)
+  }
+
 }

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -34,7 +34,8 @@ private[scalanative] object NativeLib {
   /** Used to find native source files in jar files */
   private val jarSrcRegex: String = {
     val regexExtensions = srcExtensions.mkString("""(\""", """|\""", ")")
-    s"""^${codeDir}${fileSep}(.+)${regexExtensions}$$"""
+    val escapedFileSep  = if (Platform.isWindows) "/" else raw"\\"
+    s"""^$codeDir$escapedFileSep(.+)$regexExtensions$$"""
   }
 
   private def srcPathPattern(path: Path): String =

--- a/tools/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Platform.scala
@@ -1,0 +1,9 @@
+package scala.scalanative.build
+
+object Platform {
+  private lazy val osUsed = System.getProperty("os.name", "unknown").toLowerCase
+
+  lazy val isWindows: Boolean = osUsed.startsWith("windows")
+  lazy val isUnix: Boolean    = osUsed.contains("linux") || osUsed.contains("unix")
+  lazy val isMac: Boolean     = osUsed.contains("mac")
+}

--- a/tools/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Platform.scala
@@ -1,7 +1,10 @@
 package scala.scalanative.build
 
+import java.util.Locale
+
 object Platform {
-  private lazy val osUsed = System.getProperty("os.name", "unknown").toLowerCase
+  private lazy val osUsed =
+    System.getProperty("os.name", "unknown").toLowerCase(Locale.ROOT)
 
   lazy val isWindows: Boolean = osUsed.startsWith("windows")
   lazy val isUnix: Boolean    = osUsed.contains("linux") || osUsed.contains("unix")


### PR DESCRIPTION
This PR fixes fatal errors in the sbt plugin when trying to use it on Windows. Changes include: 
* detection of os used in sbt plugin
* using `where` command instead of `which` 
* passing paths in process commands in sequences, to correctly handle spaces
* fixes to regex and globing filters including usage of the correct path separator

Some methods with single usage were inlined. 

There are still some pending sbt plugin related issues that would need to resolve in the following PRs, e.g.:
* Handling `llvm-config` dependent settings - `llvm-config` is not included in prebuilt binaries targeted for Windows. We don't want to force users to build it locally. Probably for `include` and `lib` dir we can use fixed relative paths based on the location of `clang` or `clang++`.  I have such change prepared, however I decided to not include it now, because of next problem
* Adding proper handling and detection of `include` and `lib` directories, however might finally decide to leave this part for users to configure. 

