### PR TITLE
Fix #1646: Implement posixlib sys/resource.scala

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -65,7 +65,7 @@ C Header          Scala Native Module
 `sys/ipc.h`_      N/A
 `sys/mman.h`_     N/A
 `sys/msg.h`_      N/A
-`sys/resource.h`_ N/A
+`sys/resource.h`_ scala.scalanative.posix.sys.resource_
 `sys/select.h`_   scala.scalanative.posix.sys.select_
 `sys/sem.h`_      N/A
 `sys/shm.h`_      N/A
@@ -200,6 +200,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.regex: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/regex.scala
 .. _scala.scalanative.posix.sched: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/sched.scala
 .. _scala.scalanative.posix.stdlib: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
+.. _scala.scalanative.posix.sys.resource: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
 .. _scala.scalanative.posix.sys.select: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
 .. _scala.scalanative.posix.sys.socket: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
 .. _scala.scalanative.posix.sys.stat: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala

--- a/posixlib/src/main/resources/scala-native/sys/resource.c
+++ b/posixlib/src/main/resources/scala-native/sys/resource.c
@@ -1,0 +1,100 @@
+// The Open Group Base Specifications Issue 7, 2018 edition
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs\
+//     /sys_resource.h.html
+
+// XSI
+
+#include <sys/resource.h>
+
+struct scalanative_rlimit {
+    rlim_t rlim_cur;
+    rlim_t rlim_max;
+};
+
+struct scalanative_rusage {
+    struct timeval ru_utime;
+    struct timeval ru_stime;
+};
+
+static void convert_from_scalanative_rlimit(struct scalanative_rlimit *in,
+                                            struct rlimit *out) {
+    out->rlim_cur = in->rlim_cur;
+    out->rlim_max = in->rlim_max;
+}
+
+static void convert_to_scalanative_rlimit(struct rlimit *in,
+                                          struct scalanative_rlimit *out) {
+    out->rlim_cur = in->rlim_cur;
+    out->rlim_max = in->rlim_max;
+}
+
+static void convert_to_scalanative_rusage(struct rusage *in,
+                                          struct scalanative_rusage *out) {
+    out->ru_utime = in->ru_utime;
+    out->ru_stime = in->ru_stime;
+}
+
+int scalanative_getrlimit(int resource, struct scalanative_rlimit *snRlim) {
+    struct rlimit rlim;
+
+    int status = getrlimit(resource, &rlim);
+
+    if (status >= 0) {
+        convert_to_scalanative_rlimit(&rlim, snRlim);
+    } // contents at snRlim undefined on error.
+
+    return status;
+}
+
+int scalanative_getrusage(int who, struct scalanative_rusage *snUsage) {
+    struct rusage usage;
+
+    int status = getrusage(who, &usage);
+
+    if (status >= 0) {
+        convert_to_scalanative_rusage(&usage, snUsage);
+    } // contents at snUsage undefined on error.
+
+    return status;
+}
+
+int scalanative_setrlimit(int resource, struct scalanative_rlimit *snRlim) {
+
+    struct rlimit rlim;
+
+    convert_from_scalanative_rlimit(snRlim, &rlim);
+
+    int status = setrlimit(resource, &rlim);
+
+    return status;
+}
+
+int scalanative_prio_process() { return PRIO_PROCESS; };
+
+int scalanative_prio_pgrp() { return PRIO_PGRP; };
+
+int scalanative_prio_user() { return PRIO_USER; };
+
+rlim_t scalanative_rlim_infinity() { return RLIM_INFINITY; };
+
+rlim_t scalanative_rlim_saved_cur() { return RLIM_SAVED_CUR; };
+
+rlim_t scalanative_rlim_saved_max() { return RLIM_SAVED_MAX; };
+
+int scalanative_rlimit_as() { return RLIMIT_AS; };
+
+int scalanative_rlimit_core() { return RLIMIT_CORE; };
+
+int scalanative_rlimit_cpu() { return RLIMIT_CPU; };
+
+int scalanative_rlimit_data() { return RLIMIT_DATA; };
+
+int scalanative_rlimit_fsize() { return RLIMIT_FSIZE; };
+
+int scalanative_rlimit_nofile() { return RLIMIT_NOFILE; };
+
+int scalanative_rlimit_stack() { return RLIMIT_STACK; };
+
+int scalanative_rusage_children() { return RUSAGE_CHILDREN; };
+
+int scalanative_rusage_self() { return RUSAGE_SELF; };

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
@@ -1,0 +1,107 @@
+package scala.scalanative
+package posix
+package sys
+
+// Reference:
+//   The Open Group Base Specifications Issue 7, 2018 edition
+//   https://pubs.opengroup.org/onlinepubs/9699919799/basedefs\
+//       /sys_resource.h.html
+//
+//   Method argument names come from Ubuntu 19.04 linux man pages.
+//   Open Group seems to no longer suggest them.
+
+import scalanative.unsafe.{CInt, CStruct2, CUnsignedLongInt, Ptr, name, extern}
+
+@extern
+object resource {
+
+  type id_t = sys.types.id_t
+
+  type rlim_t = CUnsignedLongInt
+
+  type timeval = sys.time.timeval
+
+  type rlimit = CStruct2[rlim_t, // rlim_cur
+                         rlim_t] // rlim_max
+
+  type rusage = CStruct2[timeval, // ru_utime
+                         timeval] // ru_stime
+
+  def getpriority(which: CInt, who: id_t): CInt = extern
+
+  @name("scalanative_getrlimit")
+  def getrlimit(resource: CInt, rlim: Ptr[rlimit]): CInt = extern
+
+  @name("scalanative_getrusage")
+  def getrusage(who: CInt, usage: Ptr[rusage]): CInt = extern
+
+  def setpriority(which: CInt, who: id_t, prio: CInt): CInt = extern
+
+  @name("scalanative_setrlimit")
+  def setrlimit(resource: CInt, rlim: Ptr[rlimit]): CInt = extern
+
+  // Constants
+  @name("scalanative_prio_process")
+  def PRIO_PROCESS: CInt = extern
+
+  @name("scalanative_prio_pgrp")
+  def PRIO_PGRP: CInt = extern
+
+  @name("scalanative_prio_user")
+  def PRIO_USER: CInt = extern
+
+  @name("scalanative_rlim_infinity")
+  def RLIM_INFINITY: rlim_t = extern
+
+  @name("scalanative_rlim_saved_cur")
+  def RLIM_SAVED_CUR: rlim_t = extern
+
+  @name("scalanative_rlim_saved_max")
+  def RLIM_SAVED_MAX: rlim_t = extern
+
+  @name("scalanative_rlimit_as")
+  def RLIMIT_AS: CInt = extern
+
+  @name("scalanative_rlimit_core")
+  def RLIMIT_CORE: CInt = extern
+
+  @name("scalanative_rlimit_cpu")
+  def RLIMIT_CPU: CInt = extern
+
+  @name("scalanative_rlimit_data")
+  def RLIMIT_DATA: CInt = extern
+
+  @name("scalanative_rlimit_fsize")
+  def RLIMIT_FSIZE: CInt = extern
+
+  @name("scalanative_rlimit_nofile")
+  def RLIMIT_NOFILE: CInt = extern
+
+  @name("scalanative_rlimit_stack")
+  def RLIMIT_STACK: CInt = extern
+
+  @name("scalanative_rusage_children")
+  def RUSAGE_CHILDREN: CInt = extern
+
+  @name("scalanative_rusage_self")
+  def RUSAGE_SELF: CInt = extern
+}
+
+object resourceOps {
+
+  import resource.{rlimit, rlim_t, rusage, timeval}
+
+  implicit class rlimitOps(val ptr: Ptr[rlimit]) extends AnyVal {
+    def rlim_cur: rlim_t            = ptr._1
+    def rlim_max: rlim_t            = ptr._2
+    def rlim_cur_=(v: rlim_t): Unit = ptr._1 = v
+    def rlim_max_=(v: rlim_t): Unit = ptr._2 = v
+  }
+
+  implicit class rusageOps(val ptr: Ptr[rusage]) extends AnyVal {
+    def ru_utime: timeval            = ptr._1
+    def ru_stime: timeval            = ptr._2
+    def ru_utime_=(v: timeval): Unit = ptr._1 = v
+    def ru_stime_=(v: timeval): Unit = ptr._2 = v
+  }
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/time.scala
@@ -22,4 +22,12 @@ object timeOps {
     def tv_sec_=(v: time_t): Unit       = ptr._1 = v
     def tv_usec_=(v: suseconds_t): Unit = ptr._2 = v
   }
+
+  implicit class timevalValOps(val tv: timeval) extends AnyVal {
+    def tv_sec: time_t                  = tv._1
+    def tv_usec: suseconds_t            = tv._2
+    def tv_sec_=(v: time_t): Unit       = tv._1 = v
+    def tv_usec_=(v: suseconds_t): Unit = tv._2 = v
+  }
+
 }

--- a/unit-tests/src/test/scala/scala/scalanative/posix/ResourceTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/ResourceTest.scala
@@ -1,0 +1,182 @@
+package scala.scalanative
+package posix
+package sys
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scalanative.libc.errno
+import scalanative.posix.errno._
+import scalanative.unsafe.{CInt, Ptr, Zone, alloc}
+import scalanative.unsigned._
+
+import resource._, resourceOps._
+import timeOps._
+
+// Design notes:
+//
+//   * The two methods setpriority() & setrlimit() make changes to the
+//     process execution environment. For that reason they are not tested
+//     here.
+//
+//     unit-tests run sequentially in the same process, so a change caused
+//     by either of those methods could affect later tests in ways that are
+//     hard to trace.
+//
+//     A save/restore approach is possible, but works only with _exquisite_
+//     care that the restore is _always_executed, even on error. Too fragile
+//     for now.
+//
+//   * The intent here is not to be exhaustive but rather to exercise
+//     expected common sucess & failure paths for each method.
+
+class ResourceTest {
+
+  case class TestInfo(name: String, value: CInt)
+
+  @Test def getpriorityInvalidArgWhich {
+    errno.errno = 0
+    val invalidWhich = -1
+
+    getpriority(invalidWhich, 0.toUInt)
+
+    assertEquals("unexpected errno", EINVAL, errno.errno)
+  }
+
+  @Test def getpriorityInvalidArgWho {
+    errno.errno = 0
+
+    getpriority(PRIO_PROCESS, -1.toUInt)
+
+    assertEquals("unexpected errno", ESRCH, errno.errno)
+  }
+
+  @Test def testGetpriority {
+    // format: off
+    val cases = Array(TestInfo("PRIO_PROCESS", PRIO_PROCESS),
+                      TestInfo("PRIO_PGRP",    PRIO_PGRP),
+                      TestInfo("PRIO_USER",    PRIO_USER)
+                     )
+    // format: on
+
+    for (c <- cases) {
+      errno.errno = 0
+
+      val result = getpriority(c.value, 0.toUInt)
+
+      assertEquals("unexpected errno", 0, errno.errno)
+
+      // Beware: these are linux un-nice "nice" priorities,
+      // where -20 is least "nice", so highest priority.
+      assertTrue(
+        s"${c.name} result: ${result} not in inclusive range [-20, 19]",
+        ((result >= -20) && (result <= 19)))
+    }
+  }
+
+  @Test def getrlimitInvalidArgResource {
+    Zone { implicit z =>
+      errno.errno = 0
+      val rlimPtr = alloc[rlimit]
+
+      getrlimit(Integer.MAX_VALUE, rlimPtr)
+
+      assertEquals("unexpected errno", EINVAL, errno.errno)
+    }
+  }
+
+  @Test def testGetrlimit {
+    Zone { implicit z =>
+      // format: off
+      val cases = Array(TestInfo("RLIMIT_AS",     RLIMIT_AS),
+                        TestInfo("RLIMIT_CORE",   RLIMIT_CORE),
+                        TestInfo("RLIMIT_CPU",    RLIMIT_CPU),
+                        TestInfo("RLIMIT_DATA",   RLIMIT_DATA),
+                        TestInfo("RLIMIT_FSIZE",  RLIMIT_FSIZE),
+                        TestInfo("RLIMIT_NOFILE", RLIMIT_NOFILE),
+                        TestInfo("RLIMIT_STACK",  RLIMIT_STACK)
+                        )
+      // format: on
+
+      for (c <- cases) {
+        errno.errno = 0
+        val rlimPtr = alloc[rlimit] // start each pass with all bytes 0.
+
+        val result = getrlimit(c.value, rlimPtr)
+
+        assertEquals(s"${c.name} unexpected failure, errno: ${errno.errno}",
+                     0,
+                     result)
+
+        // Coarse grain sanity checks. Do better someday.
+        assertTrue(s"${c.name} rlim_cur: ${rlimPtr.rlim_cur} < 0",
+                   rlimPtr.rlim_cur >= 0.toUInt)
+
+        assertTrue(s"${c.name} rlim_max: ${rlimPtr.rlim_max} < 0",
+                   rlimPtr.rlim_max >= 0.toUInt)
+
+        assertTrue(s"${c.name} rlim_cur > rlim_max",
+                   rlimPtr.rlim_cur <= rlimPtr.rlim_max)
+      }
+    }
+  }
+
+  @Test def getrusageInvalidArgWho {
+    Zone { implicit z =>
+      errno.errno = 0
+      val rusagePtr = alloc[rusage]
+
+      getrusage(Integer.MIN_VALUE, rusagePtr)
+
+      assertEquals("unexpected errno", EINVAL, errno.errno)
+    }
+  }
+
+  @Test def getrusageSelf {
+    Zone { implicit z =>
+      errno.errno = 0
+      val rusagePtr = alloc[rusage]
+
+      val result = getrusage(RUSAGE_SELF, rusagePtr)
+
+      assertEquals(s"unexpected failure, errno: ${errno.errno}", 0, result)
+
+      assertTrue(
+        s"unexpected ru_utime.tv_sec: ${rusagePtr.ru_utime.tv_sec} < 0",
+        rusagePtr.ru_utime.tv_sec >= 0)
+
+      val MICROS_PER_SECOND = 1000 * 1000
+
+      val utUsec = rusagePtr.ru_utime.tv_usec
+      assertTrue(s"unexpected ru_utime: ${rusagePtr.ru_utime.tv_sec} " +
+                   s"${rusagePtr.ru_utime.tv_usec}",
+                 (utUsec >= 0) && (utUsec < MICROS_PER_SECOND))
+
+      val stUsec = rusagePtr.ru_stime.tv_usec
+      assertTrue(s"unexpected ru_stime: ${rusagePtr.ru_utime.tv_sec} " +
+                   s"${rusagePtr.ru_utime.tv_usec}",
+                 (stUsec >= 0) && (stUsec < MICROS_PER_SECOND))
+    }
+  }
+
+  @Test def getrusageChildren {
+    Zone { implicit z =>
+      errno.errno = 0
+      val rusagePtr = alloc[rusage]
+
+      val result = getrusage(RUSAGE_CHILDREN, rusagePtr)
+
+      assertEquals(s"unexpected failure, errno: ${errno.errno}", 0, result)
+
+      // tv_sec could validly be 0 if either no descendents
+      // have been created or descendents were created but
+      // all completed quickly.
+
+      assertTrue(s"unexpected ru_utime.tv_sec < 0",
+                 rusagePtr.ru_utime.tv_sec >= 0)
+
+      assertTrue(s"unexpected ru_stime.tv_sec < 0",
+                 rusagePtr.ru_stime.tv_sec >= 0)
+    }
+  }
+}


### PR DESCRIPTION
We implement & test posix sys/resource.scala. This
provides infrastructure for both scalafmt and Scala Native.

scalafmt may need to raise the maximum number of open files.

See Issue #1645. Scala Native may want to raise the maximum
number of open files at the beginning of execution.