### PR TITLE
Implement j.nio.file.PosixException object

### DIFF
--- a/javalib/src/main/scala/java/nio/file/PosixException.scala
+++ b/javalib/src/main/scala/java/nio/file/PosixException.scala
@@ -1,0 +1,17 @@
+package java.nio.file
+
+import java.io.IOException
+
+import scalanative.libc.string
+import scalanative.posix.errno._
+import scalanative.unsafe.{CInt, fromCString}
+
+object PosixException {
+  def apply(file: String, errno: CInt): IOException = errno match {
+    case e if e == ENOTDIR => new NotDirectoryException(file)
+    case e if e == EACCES  => new AccessDeniedException(file)
+    case e if e == ENOENT  => new NoSuchFileException(file)
+    case e if e == EEXIST  => new FileAlreadyExistsException(file)
+    case e                 => new IOException(fromCString(string.strerror(e)))
+  }
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/UnixException.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/UnixException.scala
@@ -1,17 +1,11 @@
 package scala.scalanative.nio.fs
 
-import scala.scalanative.unsafe._
-import scala.scalanative.posix.errno._
 import java.io.IOException
-import java.nio.file._
-import scalanative.libc.string
+import java.nio.file.PosixException
+
+import scala.scalanative.unsafe.CInt
 
 object UnixException {
-  def apply(file: String, errno: CInt): IOException = errno match {
-    case e if e == ENOTDIR => new NotDirectoryException(file)
-    case e if e == EACCES  => new AccessDeniedException(file)
-    case e if e == ENOENT  => new NoSuchFileException(file)
-    case e if e == EEXIST  => new FileAlreadyExistsException(file)
-    case e                 => new IOException(fromCString(string.strerror(e)))
-  }
+  def apply(file: String, errno: CInt): IOException =
+    PosixException(file, errno)
 }


### PR DESCRIPTION
------- Reviewer note:
###### NB:  

  The existing UnixException is an object which return an Exception, not
a proper Exception as one (well, I) would expect from the name.
The new PosixException() object follows prior art.  
      
Suggestions for a name which gives better clues are welcome.
Perhaps `PosixExceptionProvider`??  I tried a few others and they
 all were worse.  

 If you tilt your head just right at exactly local noon on an Equinox day
 of a leap year,  the prior convention makes sense, for some low values
 of sense.

##### Rationale
This PR is the first in a series of PRs related to java.nio. It only makes
sense in that context.
  
1)  It makes `PosixException` available to new code and does not
     disturb existing uses of `UnixException`. In many existing cases 
     `UnixException` is a misnomer. I want to focus on the PRs below
      and not introduce churn, so I did not change those cases.
      If required, they can be changed in a future PR. 

2) A second PR will move and rename the somewhat
    anomalous existing  file `scalanative.nio.fs,NativePosixFileAttributeView.scala` 
    to the more regular `java.nio.file.attribute.PosixFileAttributeViewImpl.scala`. 
    `PosixException` is more appropriate there than `UnixException`.

     This PR is written, tested, and ready to submit as soon as 
      `PosixException` is merged.

3) A third PR introduces the changes which set this series in motion.
    That PR will be a successor to PR #1609 and introduces 
    `PosixUserPrincipalImpl.scala`. 
    Again, `PosixException` is more appropriate.
    
------- Commit message 

`scala.scalanative.nio.fs.UnixException` is currently implemented in
terms of Posix: `scalanative.posix.errno._`. We create PosixExeception
to make this usage visible and implement UnixException in terms of
PosixException. This gives better separation & identification of concepts
and the specifications which can be relied upon.