### PR TITLE
Fix to allow 32bit branch to compile and run on Raspberry PI

### DIFF
--- a/nativelib/src/main/resources/scala-native/libunwind/Unwind-EHABI.h
+++ b/nativelib/src/main/resources/scala-native/libunwind/Unwind-EHABI.h
@@ -16,7 +16,9 @@
 #if defined(_LIBUNWIND_ARM_EHABI)
 
 #include <stdint.h>
-#include <unwind.h>
+// #include <unwind.h>
+// Change from original, point to local header file
+#include "include-libunwind/unwind.h"
 
 // Unable to unwind in the ARM index table (section 5 EHABI).
 #define UNW_EXIDX_CANTUNWIND 0x1

--- a/nativelib/src/main/resources/scala-native/libunwind/Unwind-EHABI.h
+++ b/nativelib/src/main/resources/scala-native/libunwind/Unwind-EHABI.h
@@ -16,8 +16,6 @@
 #if defined(_LIBUNWIND_ARM_EHABI)
 
 #include <stdint.h>
-// #include <unwind.h>
-// Change from original, point to local header file
 #include "include-libunwind/unwind.h"
 
 // Unable to unwind in the ARM index table (section 5 EHABI).

--- a/nativelib/src/main/resources/scala-native/libunwind/Unwind_AppleExtras.cpp
+++ b/nativelib/src/main/resources/scala-native/libunwind/Unwind_AppleExtras.cpp
@@ -74,7 +74,8 @@ struct libgcc_object_info {
     __attribute__((visibility("default"))) const char sym##_tmp6 = 0;
 #endif
 
-#if defined(_LIBUNWIND_BUILD_ZERO_COST_APIS)
+// Added __APPLE__ for Rasp PI 32bit
+#if defined(_LIBUNWIND_BUILD_ZERO_COST_APIS) && defined(__APPLE__)
 
 //
 // symbols in libSystem.dylib in 10.6 and later, but are in libgcc_s.dylib in


### PR DESCRIPTION
This change allows the Scala Native `sandbox` to compile and run on 32bit Raspberry Pi OS (Debian variant). The hardware is Raspberry Pi 4 64bit reported as `armv7l` via `uname -mpi` or via `clang-7` as `armv6k-unknown-linux-gnuabihf`.

The changes in this PR are needed just because certain untested paths in the code were not exercised prior to this test/configuration.

These are some additional steps needed to repeat the action.

1. Use the following branch - https://github.com/shadaj/scala-native/tree/32-bit-linker-2
2. Install Boehm GC - `sudo apt install libgc-dev`
3. Edit `build.sbt` add import and then add to `sandbox` settings.
```Scala
import scala.scalanative.build._
lazy val sandbox =
...
.settings(nativeConfig ~= {_.withGC(GC.boehm)})
...
```
4. Add the following to `tools/src/main/scala/scalanative/build/config.scala` on line 85.
```Scala
case "armv6k" => true
```
5. Raspberry Pi 32bit has a maximum process size of 3gb so edit `.sbtopts`. Make max memory 2gb
```
-J-Xmx2G
```
Here is the proof.
```sh
$ file /home/pi/workspace/scala-native/sandbox/target/scala-2.12/sandbox-out
/home/pi/workspace/scala-native/sandbox/target/scala-2.12/sandbox-out: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, BuildID[sha1]=ee72073415a19429103a3ba40aa45ad40bd60378, not stripped
```
And ...
```sh
$ /home/pi/workspace/scala-native/sandbox/target/scala-2.12/sandbox-out
Hello, World!
```
```
