### PR TITLE
Add a configurable env flag that controls memory preallocation when G…

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -1,16 +1,54 @@
 #include <stdlib.h>
 #include "MemoryMap.h"
+#include "MemoryInfo.h"
+#include "Parsing.h"
 
 // Dummy GC that maps chunks of 4GB and allocates but never frees.
-
-// Map 4GB
-#define CHUNK (4 * 1024 * 1024 * 1024L)
 
 void *current = 0;
 void *end = 0;
 
+static size_t DEFAULT_CHUNK;
+static size_t PREALLOC_CHUNK;
+static size_t CHUNK;
+static size_t TO_NORMAL_MMAP = 1L;
+static size_t DO_PREALLOC = 0L; // No Preallocation.
+
+void Prealloc_Or_Default() {
+
+    if (TO_NORMAL_MMAP == 1L) { // Check if we have prealloc env varible
+                                // or execute default mmap settings
+        size_t memorySize = getMemorySize();
+
+        DEFAULT_CHUNK = // Default Maximum allocation Map 4GB
+            Choose_IF(Parse_Env_Or_Default_String("GC_MAXIMUM_HEAP_SIZE", "4G"),
+                      Less_OR_Equal, memorySize);
+
+        PREALLOC_CHUNK = // Preallocation
+            Choose_IF(Parse_Env_Or_Default("GC_INITIAL_HEAP_SIZE", 0L),
+                      Less_OR_Equal, DEFAULT_CHUNK);
+
+        if (PREALLOC_CHUNK == 0L) { // no prealloc settings.
+            CHUNK = DEFAULT_CHUNK;
+            TO_NORMAL_MMAP = 0L;
+
+        } else { // config prealloc settings and the flag to reset the
+                 // mmap settings the next iteration.
+            CHUNK = PREALLOC_CHUNK;
+            DO_PREALLOC = 1L;    // Do Preallocate.
+            TO_NORMAL_MMAP = 2L; // Return settings to normal on next iteration.
+        }
+    } else if (TO_NORMAL_MMAP == 2L) {
+        DO_PREALLOC = 0L;
+        CHUNK = DEFAULT_CHUNK;
+        TO_NORMAL_MMAP = 0L; // break the cycle and return to normal mmap alloc
+    } else {
+    }
+}
+
 void scalanative_init() {
-    current = memoryMap(CHUNK);
+    Prealloc_Or_Default();
+    current = memoryMapPrealloc(CHUNK, DO_PREALLOC);
     end = current + CHUNK;
 }
 

--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
@@ -25,6 +25,25 @@
 #define HEAP_MEM_FLAGS (MAP_PRIVATE | MAP_ANONYMOUS)
 #endif
 
+#ifdef MAP_NORESERVE
+#ifndef __linux__
+// MAP_POPULATE is linux exclusive. We will use madvice.
+#define HEAP_MEM_FLAGS_PREALLOC (MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS)
+#else
+#define HEAP_MEM_FLAGS_PREALLOC                                                \
+    (MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE)
+#endif
+
+#else
+#ifndef __linux__
+// MAP_POPULATE is linux exclusive. We will use madvice.
+#define HEAP_MEM_FLAGS_PREALLOC (MAP_PRIVATE | MAP_ANONYMOUS)
+#else
+#define HEAP_MEM_FLAGS_PREALLOC (MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE)
+#endif
+
+#endif
+
 // Map anonymous memory (not a file)
 #define HEAP_MEM_FD -1
 #define HEAP_MEM_FD_OFFSET 0
@@ -52,5 +71,44 @@ word_t *memoryMap(size_t memorySize) {
 #else // Unix
     return mmap(NULL, memorySize, HEAP_MEM_PROT, HEAP_MEM_FLAGS, HEAP_MEM_FD,
                 HEAP_MEM_FD_OFFSET);
+#endif
+}
+
+word_t *memoryMapPrealloc(size_t memorySize, size_t doPrealloc) {
+#ifdef _WIN32
+    HANDLE hMapFile;
+    ULARGE_INTEGER memSize;
+    memSize.QuadPart = memorySize;
+
+    hMapFile = CreateFileMappingW(
+        INVALID_HANDLE_VALUE, // use paging file
+        NULL,                 // default security
+        PAGE_READWRITE,       // read/write access
+        memSize.u.HighPart,   // maximum object size (high-order DWORD)
+        memSize.u.LowPart,    // maximum object size (low-order DWORD)
+        NULL);                // name of mapping object
+
+    if (hMapFile == NULL) {
+        return NULL;
+    }
+    return (word_t *)(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0,
+                                    memorySize));
+#else // Unix
+    word_t res;
+    if (doPrealloc) {
+        res = mmap(NULL, memorySize, HEAP_MEM_PROT, HEAP_MEM_FLAGS_PREALLOC,
+                   HEAP_MEM_FD, HEAP_MEM_FD_OFFSET);
+    } else {
+        res = mmap(NULL, memorySize, HEAP_MEM_PROT, HEAP_MEM_FLAGS, HEAP_MEM_FD,
+                   HEAP_MEM_FD_OFFSET);
+    }
+
+#ifndef __linux__
+    // if we are not on linux the next best thing we can do is to mark the pages
+    // as MADV_WILLNEED.
+    madvise(res, memorySize, MADV_WILLNEED);
+#endif
+
+    return res;
 #endif
 }

--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
@@ -94,7 +94,7 @@ word_t *memoryMapPrealloc(size_t memorySize, size_t doPrealloc) {
     return (word_t *)(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0,
                                     memorySize));
 #else // Unix
-    word_t res;
+    word_t *res;
     if (doPrealloc) {
         res = mmap(NULL, memorySize, HEAP_MEM_PROT, HEAP_MEM_FLAGS_PREALLOC,
                    HEAP_MEM_FD, HEAP_MEM_FD_OFFSET);

--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.h
@@ -6,4 +6,6 @@
 
 word_t *memoryMap(size_t memorySize);
 
+word_t *memoryMapPrealloc(size_t memorySize, size_t doPrealloc);
+
 #endif // MEMORYMAP_H

--- a/nativelib/src/main/resources/scala-native/gc/shared/Parsing.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/Parsing.h
@@ -1,0 +1,97 @@
+#include <string.h>
+#include <stdio.h>
+
+size_t Parse_Size_Or_Default(const char *str, size_t defaultSizeInBytes) {
+    if (str == NULL) {
+        return defaultSizeInBytes;
+    } else {
+        int length = strlen(str);
+        size_t size;
+        sscanf(str, "%zu", &size);
+        char possibleSuffix = str[length - 1];
+        switch (possibleSuffix) {
+        case 'k':
+        case 'K':
+            if (size < (1ULL << (8 * sizeof(size_t) - 10))) {
+                size <<= 10;
+            } else {
+                size = defaultSizeInBytes;
+            }
+            break;
+        case 'm':
+        case 'M':
+            if (size < (1ULL << (8 * sizeof(size_t) - 20))) {
+                size <<= 20;
+            } else {
+                size = defaultSizeInBytes;
+            }
+            break;
+        case 'g':
+        case 'G':
+            if (size < (1ULL << (8 * sizeof(size_t) - 30))) {
+                size <<= 30;
+            } else {
+                size = defaultSizeInBytes;
+            }
+        }
+        return size;
+    }
+    return defaultSizeInBytes;
+}
+
+size_t Parse_Env_Or_Default(const char *envName, size_t defaultSizeInBytes) {
+    return Parse_Size_Or_Default(getenv(envName), defaultSizeInBytes);
+}
+
+size_t Parse_Env_Or_Default_String(const char *envName,
+                                   const char *defaultSizeString) {
+    if (envName == NULL)
+        return Parse_Size_Or_Default(defaultSizeString, 0L);
+    else
+        return Parse_Size_Or_Default(
+            getenv(envName), Parse_Size_Or_Default(defaultSizeString, 0L));
+}
+
+typedef enum {
+    Greater_Than,
+    Less_Than,
+    Equal_To,
+    Greater_OR_Equal,
+    Less_OR_Equal
+} qualifier;
+
+size_t Choose_IF(size_t left, qualifier qualifier, size_t right) {
+    switch (qualifier) {
+    case Greater_Than:
+        if (left > right) {
+            return left;
+        } else {
+            return right;
+        }
+
+    case Less_Than:
+        if (left < right) {
+            return left;
+        } else {
+            return right;
+        }
+    case Equal_To:
+        if (left == right) {
+            return left;
+        } else {
+            return right;
+        }
+    case Greater_OR_Equal:
+        if (left >= right) {
+            return left;
+        } else {
+            return right;
+        }
+    case Less_OR_Equal:
+        if (left <= right) {
+            return left;
+        } else {
+            return right;
+        }
+    }
+}


### PR DESCRIPTION
…C.none is selected.
Motivated by https://github.com/scala-native/scala-native/issues/2202, we add a configurable flag to adjust the behavior of mmap. An example will be 
```bash 
export GC_NONE_PREALLOC_SIZE=1500M
``` 
which will preallocate 1500 megabytes of memory. If no GC_NONE_PREALLOC_SIZE is provided the default allocation policy of 4GB  chunks will be used. This preallocation lasts only 1 cycle. If the specified preallocation is not enough for the application the next time Scala-Native asks for memory it will be allocated by the default policy - incremental chunks of the os page size. 