### PR TITLE
Allow for linktime conditional branching

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -343,10 +343,6 @@ lazy val tools =
       },
       // Running tests in parallel results in `FileSystemAlreadyExistsException`
       Test / parallelExecution := false,
-      Test / envVars ++= Map(
-        "LINKTIME_MSG"              -> "scala-native",
-        "LINKTIME_DECIMALSEPARATOR" -> "_"
-      ),
       mimaSettings
     )
     .dependsOn(nir, util, testingCompilerInterface % Test)

--- a/build.sbt
+++ b/build.sbt
@@ -343,6 +343,10 @@ lazy val tools =
       },
       // Running tests in parallel results in `FileSystemAlreadyExistsException`
       Test / parallelExecution := false,
+      Test / envVars ++= Map(
+        "LINKTIME_MSG"              -> "scala-native",
+        "LINKTIME_DECIMALSEPARATOR" -> "_"
+      ),
       mimaSettings
     )
     .dependsOn(nir, util, testingCompilerInterface % Test)

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/linktimeResolved.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/linktimeResolved.scala
@@ -1,8 +1,0 @@
-package scala.scalanative.unsafe
-
-import scala.annotation.StaticAnnotation
-import scala.annotation.meta.{field, getter}
-import scala.scalanative.runtime.intrinsic
-
-@field @getter
-class linktimeResolved(withName: String = intrinsic) extends StaticAnnotation

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/linktimeResolved.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/linktimeResolved.scala
@@ -5,6 +5,4 @@ import scala.annotation.meta.{field, getter}
 import scala.scalanative.runtime.intrinsic
 
 @field @getter
-class linktimeResolved(fromProperty: String = intrinsic,
-                       fromEnv: String = intrinsic)
-    extends StaticAnnotation
+class linktimeResolved(withName: String = intrinsic) extends StaticAnnotation

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/linktimeResolved.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/linktimeResolved.scala
@@ -1,0 +1,18 @@
+package scala.scalanative.unsafe
+
+import scala.annotation.StaticAnnotation
+import scala.annotation.meta.{field, getter}
+import scala.scalanative.runtime.intrinsic
+import scala.scalanative.unsafe.linktimeResolved.generate
+
+@field @getter
+class linktimeResolved(fromProperty: String = generate,
+                       fromEnv: String = generate)
+    extends StaticAnnotation
+
+object linktimeResolved {
+  def generate: String = intrinsic
+  def disabled: String = null
+}
+
+class resolveAtLinktime() extends StaticAnnotation

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/linktimeResolved.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/linktimeResolved.scala
@@ -3,16 +3,8 @@ package scala.scalanative.unsafe
 import scala.annotation.StaticAnnotation
 import scala.annotation.meta.{field, getter}
 import scala.scalanative.runtime.intrinsic
-import scala.scalanative.unsafe.linktimeResolved.generate
 
 @field @getter
-class linktimeResolved(fromProperty: String = generate,
-                       fromEnv: String = generate)
+class linktimeResolved(fromProperty: String = intrinsic,
+                       fromEnv: String = intrinsic)
     extends StaticAnnotation
-
-object linktimeResolved {
-  def generate: String = intrinsic
-  def disabled: String = null
-}
-
-class resolveAtLinktime() extends StaticAnnotation

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -149,6 +149,9 @@ package object unsafe {
   /** Used as right hand side of external method and field declarations. */
   def extern: Nothing = intrinsic
 
+  /** Used as right hand side of values resolved at link-time. */
+  private[scalanative] def resolved: Nothing = intrinsic
+
   /** C-style string literal. */
   implicit class CQuote(val ctx: StringContext) {
     def c(): CString = intrinsic

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/resolvedAtLinktime.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/resolvedAtLinktime.scala
@@ -5,7 +5,7 @@ import scala.annotation.meta.{field, getter}
 import scala.scalanative.runtime.intrinsic
 
 /** Used to annotate that given value should be resolved at link-time,
- *  based on provided `withName` parameter or on fully-qualified name otherwise */
+ *  based on provided `withName` parameter */
 @field @getter
-private[scalanative] class resolvedAtLinktime(withName: String = intrinsic)
+private[scalanative] class resolvedAtLinktime(withName: String)
     extends StaticAnnotation

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/resolvedAtLinktime.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/resolvedAtLinktime.scala
@@ -1,0 +1,11 @@
+package scala.scalanative.unsafe
+
+import scala.annotation.StaticAnnotation
+import scala.annotation.meta.{field, getter}
+import scala.scalanative.runtime.intrinsic
+
+/** Used to annotate that given value should be resolved at link-time,
+ *  based on provided `withName` parameter or on fully-qualified name otherwise */
+@field @getter
+private[scalanative] class resolvedAtLinktime(withName: String = intrinsic)
+    extends StaticAnnotation

--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -32,6 +32,9 @@ class Buffer(implicit fresh: Fresh) {
   def branch(value: Val, thenp: Next, elsep: Next)(
       implicit pos: Position): Unit =
     this += Inst.If(value, thenp, elsep)
+  def branchLinktime(condition: LinktimeCondition, thenp: Next, elsep: Next)(
+      implicit pos: Position): Unit =
+    this += Inst.LinktimeIf(condition, thenp, elsep)
   def switch(value: Val, default: Next, cases: Seq[Next])(
       implicit pos: Position): Unit =
     this += Inst.Switch(value, default, cases)

--- a/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
@@ -112,6 +112,9 @@ object ControlFlow {
           case Inst.If(_, next1, next2) =>
             edge(node, block(next1.name), next1)
             edge(node, block(next2.name), next2)
+          case Inst.LinktimeIf(_, next1, next2) =>
+            edge(node, block(next1.name), next1)
+            edge(node, block(next2.name), next2)
           case Inst.Switch(_, default, cases) =>
             edge(node, block(default.name), default)
             cases.foreach { case_ => edge(node, block(case_.name), case_) }

--- a/nir/src/main/scala/scala/scalanative/nir/Insts.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Insts.scala
@@ -31,4 +31,9 @@ object Inst {
       extends Cf
   final case class Unreachable(unwind: Next)(implicit val pos: Position)
       extends Cf
+
+  sealed trait LinktimeCf extends Cf
+  final case class LinktimeIf(cond: LinktimeCondition, thenp: Next, elsep: Next)(
+      implicit val pos: Position)
+      extends LinktimeCf
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
@@ -6,7 +6,7 @@ sealed trait LinktimeCondition {
 
 object LinktimeCondition {
 
-  case class SimpleCondition(name: Global, comparison: Comp, value: Val)(
+  case class SimpleCondition(propertyName: String, comparison: Comp, value: Val)(
       implicit val position: Position)
       extends LinktimeCondition
 
@@ -31,19 +31,11 @@ object Linktime {
   // Takes Global for constant struct describing linktime property.
   // Replaced with resolved value at link-time.
   final val PropertyResolveFunctionName: Global.Member =
-    Linktime.member(Sig.Method("resolveProperty", Seq(Type.Ptr, Type.Nothing)))
+    Linktime.member(Sig.Method("resolveProperty", Seq(Rt.String, Type.Nothing)))
 
   final def PropertyResolveFunctionTy(retty: Type): Type.Function =
-    Type.Function(Seq(Type.Ptr), retty)
+    Type.Function(Seq(Rt.String), retty)
 
   final def PropertyResolveFunction(retty: Type): Val.Global =
     Val.Global(PropertyResolveFunctionName, PropertyResolveFunctionTy(retty))
-
-  def nameToLinktimePropertyName(name: Global): Global.Member = {
-    val Global.Member(owner, sig) = name
-    require(sig.isMethod, s"Expected method, but received ${sig.unmangled}")
-
-    val Sig.Method(ident, _, _) = sig.unmangled
-    owner.member(Sig.Generated(s"${ident}_property"))
-  }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
@@ -1,21 +1,26 @@
 package scala.scalanative.nir
 
-sealed trait LinktimeCondition
+sealed trait LinktimeCondition {
+  def position: Position
+}
 
 object LinktimeCondition {
 
-  case class SimpleCondition(name: Global, comparison: Comp, value: Val)
+  case class SimpleCondition(name: Global, comparison: Comp, value: Val)(
+      implicit val position: Position)
       extends LinktimeCondition
 
-  case class ComplexCondition(op: Bin,
-                              left: LinktimeCondition,
-                              right: LinktimeCondition)
+  case class ComplexCondition(
+      op: Bin,
+      left: LinktimeCondition,
+      right: LinktimeCondition)(implicit val position: Position)
       extends LinktimeCondition
 
   object Tag {
     final val SimpleCondition  = 1
     final val ComplexCondition = 2
   }
+
 }
 
 object Linktime {

--- a/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
@@ -1,0 +1,19 @@
+package scala.scalanative.nir
+
+sealed trait LinktimeCondition
+
+object LinktimeCondition {
+
+  case class SimpleCondition(name: Global, comparison: Comp, value: Val)
+      extends LinktimeCondition
+
+  case class ComplexCondition(op: Bin,
+                              left: LinktimeCondition,
+                              right: LinktimeCondition)
+      extends LinktimeCondition
+
+  object Tag {
+    final val SimpleCondition  = 1
+    final val ComplexCondition = 2
+  }
+}

--- a/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Linktime.scala
@@ -17,3 +17,28 @@ object LinktimeCondition {
     final val ComplexCondition = 2
   }
 }
+
+object Linktime {
+
+  final val Linktime = Global.Top("scala.scalanative.linktime")
+
+  // Artificial function, never actually called.
+  // Takes Global for constant struct describing linktime property.
+  // Replaced with resolved value at link-time.
+  final val PropertyResolveFunctionName: Global.Member =
+    Linktime.member(Sig.Method("resolveProperty", Seq(Type.Ptr, Type.Nothing)))
+
+  final def PropertyResolveFunctionTy(retty: Type): Type.Function =
+    Type.Function(Seq(Type.Ptr), retty)
+
+  final def PropertyResolveFunction(retty: Type): Val.Global =
+    Val.Global(PropertyResolveFunctionName, PropertyResolveFunctionTy(retty))
+
+  def nameToLinktimePropertyName(name: Global): Global.Member = {
+    val Global.Member(owner, sig) = name
+    require(sig.isMethod, s"Expected method, but received ${sig.unmangled}")
+
+    val Sig.Method(ident, _, _) = sig.unmangled
+    owner.member(Sig.Generated(s"${ident}_property"))
+  }
+}

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -185,6 +185,7 @@ object Show {
           str(" ")
           next_(unwind)
         }
+      case _ => util.unsupported(s"Show does not support ${inst}")
     }
 
     def op_(op: Op): Unit = op match {

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -51,6 +51,7 @@ trait Transform {
         Inst.Throw(onVal(v), onNext(unwind))
       case Inst.Unreachable(unwind) =>
         Inst.Unreachable(onNext(unwind))
+      case _: Inst.LinktimeCf => util.unreachable
     }
   }
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -302,12 +302,13 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
     case LinktimeCondition.Tag.SimpleCondition =>
       LinktimeCondition.SimpleCondition(name = getGlobal(),
                                         comparison = getComp(),
-                                        value = getVal())
+                                        value = getVal())(getPosition())
 
     case LinktimeCondition.Tag.ComplexCondition =>
-      LinktimeCondition.ComplexCondition(op = getBin(),
-                                         left = getLinktimeCondition(),
-                                         right = getLinktimeCondition())
+      LinktimeCondition.ComplexCondition(
+        op = getBin(),
+        left = getLinktimeCondition(),
+        right = getLinktimeCondition())(getPosition())
 
     case n => util.unsupported(s"Unknown linktime condition tag: ${n}")
   }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -300,7 +300,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
 
   private def getLinktimeCondition(): LinktimeCondition = getInt() match {
     case LinktimeCondition.Tag.SimpleCondition =>
-      LinktimeCondition.SimpleCondition(name = getGlobal(),
+      LinktimeCondition.SimpleCondition(propertyName = getUTF8String(),
                                         comparison = getComp(),
                                         value = getVal())(getPosition())
 

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -162,6 +162,12 @@ final class BinarySerializer {
         putNext(thenp)
         putNext(elsep)
 
+      case Inst.LinktimeIf(v, thenp, elsep) =>
+        putInt(T.LinktimeIfInst)
+        putLinktimeCondition(v)
+        putNext(thenp)
+        putNext(elsep)
+
       case Inst.Switch(v, default, cases) =>
         putInt(T.SwitchInst)
         putVal(v)
@@ -522,6 +528,20 @@ final class BinarySerializer {
       v.foreach(putChar(_))
     case Val.Virtual(v)   => putInt(T.VirtualVal); putLong(v)
     case Val.ClassOf(cls) => putInt(T.ClassOfVal); putGlobal(cls)
+  }
+
+  private def putLinktimeCondition(cond: LinktimeCondition): Unit = cond match {
+    case LinktimeCondition.SimpleCondition(name, comparison, value) =>
+      putInt(LinktimeCondition.Tag.SimpleCondition)
+      putGlobal(name)
+      putComp(comparison)
+      putVal(value)
+
+    case LinktimeCondition.ComplexCondition(op, left, right) =>
+      putInt(LinktimeCondition.Tag.ComplexCondition)
+      putBin(op)
+      putLinktimeCondition(left)
+      putLinktimeCondition(right)
   }
 
   // Ported from Scala.js

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -536,12 +536,14 @@ final class BinarySerializer {
       putGlobal(name)
       putComp(comparison)
       putVal(value)
+      putPosition(cond.position)
 
     case LinktimeCondition.ComplexCondition(op, left, right) =>
       putInt(LinktimeCondition.Tag.ComplexCondition)
       putBin(op)
       putLinktimeCondition(left)
       putLinktimeCondition(right)
+      putPosition(cond.position)
   }
 
   // Ported from Scala.js

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -40,7 +40,7 @@ final class BinarySerializer {
                             Versions.revision,
                             Defn.existsEntryPoint(defns)))
 
-    putSeq(filenames)(putUTF8tring)
+    putSeq(filenames)(putUTF8String)
 
     putSeq(names) { n =>
       putGlobal(n)
@@ -75,7 +75,7 @@ final class BinarySerializer {
 
   private def putInts(ints: Seq[Int]) = putSeq[Int](ints)(putInt)
 
-  private def putUTF8tring(v: String) = putBytes {
+  private def putUTF8String(v: String) = putBytes {
     v.getBytes(StandardCharsets.UTF_8)
   }
 
@@ -98,12 +98,12 @@ final class BinarySerializer {
     case Attr.UnOpt        => putInt(T.UnOptAttr)
     case Attr.NoOpt        => putInt(T.NoOptAttr)
     case Attr.DidOpt       => putInt(T.DidOptAttr)
-    case Attr.BailOpt(msg) => putInt(T.BailOptAttr); putUTF8tring(msg)
+    case Attr.BailOpt(msg) => putInt(T.BailOptAttr); putUTF8String(msg)
 
     case Attr.Dyn      => putInt(T.DynAttr)
     case Attr.Stub     => putInt(T.StubAttr)
     case Attr.Extern   => putInt(T.ExternAttr)
-    case Attr.Link(s)  => putInt(T.LinkAttr); putUTF8tring(s)
+    case Attr.Link(s)  => putInt(T.LinkAttr); putUTF8String(s)
     case Attr.Abstract => putInt(T.AbstractAttr)
   }
 
@@ -281,17 +281,17 @@ final class BinarySerializer {
       putInt(T.NoneGlobal)
     case Global.Top(id) =>
       putInt(T.TopGlobal)
-      putUTF8tring(id)
+      putUTF8String(id)
     case Global.Member(Global.Top(owner), sig) =>
       putInt(T.MemberGlobal)
-      putUTF8tring(owner)
+      putUTF8String(owner)
       putSig(sig)
     case _ =>
       util.unreachable
   }
 
   private def putSig(sig: Sig): Unit =
-    putUTF8tring(sig.mangle)
+    putUTF8String(sig.mangle)
 
   private def putLocal(local: Local): Unit =
     putLong(local.id)
@@ -531,9 +531,9 @@ final class BinarySerializer {
   }
 
   private def putLinktimeCondition(cond: LinktimeCondition): Unit = cond match {
-    case LinktimeCondition.SimpleCondition(name, comparison, value) =>
+    case LinktimeCondition.SimpleCondition(propertyName, comparison, value) =>
       putInt(LinktimeCondition.Tag.SimpleCondition)
-      putGlobal(name)
+      putUTF8String(propertyName)
       putComp(comparison)
       putVal(value)
       putPosition(cond.position)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -115,6 +115,7 @@ object Tags {
   final val SwitchInst      = 1 + IfInst
   final val ThrowInst       = 1 + SwitchInst
   final val UnreachableInst = 1 + ThrowInst
+  final val LinktimeIfInst  = 1 + UnreachableInst
 
   // Globals
 
@@ -229,4 +230,6 @@ object Tags {
   final val StringVal      = 1 + ConstVal
   final val VirtualVal     = 1 + StringVal
   final val ClassOfVal     = 1 + VirtualVal
+
+  final val LinktimeConditionVal = 1 + ClassOfVal
 }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -223,8 +223,8 @@ trait NirDefinitions {
           getMember(module, TermName(s"fromScalaFunction"))
       }
 
-    lazy val LinktimeResolvedClass = getRequiredClass(
-      "scala.scalanative.unsafe.linktimeResolved")
+    lazy val ResolvedAtLinktimeClass = getRequiredClass(
+      "scala.scalanative.unsafe.resolvedAtLinktime")
 
     lazy val RuntimePrimitive: Map[Char, Symbol] = Map(
       'B' -> getRequiredClass("scala.scalanative.runtime.PrimitiveBoolean"),

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -223,6 +223,9 @@ trait NirDefinitions {
           getMember(module, TermName(s"fromScalaFunction"))
       }
 
+    lazy val LinktimeResolvedClass = getRequiredClass(
+      "scala.scalanative.unsafe.linktimeResolved")
+
     lazy val RuntimePrimitive: Map[Char, Symbol] = Map(
       'B' -> getRequiredClass("scala.scalanative.runtime.PrimitiveBoolean"),
       'C' -> getRequiredClass("scala.scalanative.runtime.PrimitiveChar"),

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -225,6 +225,7 @@ trait NirDefinitions {
 
     lazy val ResolvedAtLinktimeClass = getRequiredClass(
       "scala.scalanative.unsafe.resolvedAtLinktime")
+    lazy val ResolvedMethod = getMember(NativeModule, TermName("resolved"))
 
     lazy val RuntimePrimitive: Map[Char, Symbol] = Map(
       'B' -> getRequiredClass("scala.scalanative.runtime.PrimitiveBoolean"),

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -191,8 +191,13 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val thenn, elsen, mergen = fresh()
       val mergev               = Val.Local(fresh(), retty)
 
-      val cond = genExpr(condp)
-      buf.branch(cond, Next(thenn), Next(elsen))(condp.pos)
+      getLinktimeCondition(condp).fold {
+        val cond = genExpr(condp)
+        buf.branch(cond, Next(thenn), Next(elsen))(condp.pos)
+      } { cond =>
+        buf.branchLinktime(cond, Next(thenn), Next(elsen))(condp.pos)
+      }
+
       locally {
         buf.label(thenn)(thenp.pos)
         val thenv = genExpr(thenp)
@@ -1109,6 +1114,66 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     }
 
     private final val ExternForwarderSig = Sig.Generated("$extern$forwarder")
+
+    def getLinktimeCondition(condp: Tree): Option[LinktimeCondition] = {
+      import LinktimeCondition._
+      def genComparsion(name: Name, value: Val): Comp = {
+        def intOrFloatComparison(onInt: Comp, onFloat: Comp)(
+            implicit tpe: nir.Type) =
+          if (tpe.isInstanceOf[Type.F]) onFloat else onInt
+
+        import Comp._
+        implicit val tpe: nir.Type = value.ty
+        name match {
+          case nme.EQ => intOrFloatComparison(Ieq, Feq)
+          case nme.NE => intOrFloatComparison(Ine, Fne)
+          case nme.GT => intOrFloatComparison(Sgt, Fgt)
+          case nme.GE => intOrFloatComparison(Sge, Fge)
+          case nme.LT => intOrFloatComparison(Slt, Flt)
+          case nme.LE => intOrFloatComparison(Sle, Fle)
+          case nme =>
+            globalError(condp.pos, s"Unsupported condition '$nme'"); Comp.Ine
+        }
+      }
+
+      def isLinktimeProperty(tree: Tree): Boolean =
+        tree.hasSymbolWhich(
+          _.annotations.exists(_.symbol == LinktimeResolvedClass))
+
+      condp match {
+        case Apply(reciverp, List()) if isLinktimeProperty(reciverp) =>
+          Some {
+            SimpleCondition(genName(reciverp.symbol), Comp.Ieq, Val.True)
+          }
+
+        case Apply(Select(reciverp, comp), List(arg @ Literal(Constant(_))))
+            if isLinktimeProperty(reciverp) =>
+          Some {
+            val argValue = genLiteralValue(arg)
+            SimpleCondition(genName(reciverp.symbol),
+                            genComparsion(comp, argValue),
+                            argValue)
+          }
+
+        case Apply(Select(cond1, op), List(cond2)) =>
+          (getLinktimeCondition(cond1), getLinktimeCondition(cond2)) match {
+            case (Some(c1), Some(c2)) =>
+              val bin = op match {
+                case nme.ZAND => Bin.And
+                case nme.ZOR  => Bin.Or
+              }
+              Some(ComplexCondition(bin, c1, c2))
+            case (None, None) => None
+            case _ =>
+              globalError(
+                condp.pos,
+                "Mixing link-time and runtime conditions is not allowed")
+              None
+          }
+
+        case _ => None
+      }
+    }
 
     def genFuncExternForwarder(funcName: Global, treeSym: Symbol)(
         implicit pos: nir.Position): Defn = {

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1158,6 +1158,18 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                             argValue)
           }
 
+        // Same as above, but for case when condition is additionally boxed, eg.: `prop != null`
+        case Apply(Select(Apply(_, List(Apply(reciverp, List()))), comp),
+                   List(arg @ Literal(Constant(_))))
+            if isLinktimeProperty(reciverp) =>
+          Some {
+            val argValue = genLiteralValue(arg)
+            val name     = genName(reciverp.symbol)
+            SimpleCondition(Linktime.nameToLinktimePropertyName(name),
+                            genComparsion(comp, argValue),
+                            argValue)
+          }
+
         case Apply(Select(cond1, op), List(cond2)) =>
           (getLinktimeCondition(cond1), getLinktimeCondition(cond2)) match {
             case (Some(c1), Some(c2)) =>

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1140,35 +1140,39 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         tree.hasSymbolWhich(
           _.annotations.exists(_.symbol == LinktimeResolvedClass))
 
+      def someBooleanProperty(reciverp: Tree,
+                              value: Val): Option[LinktimeCondition] = Some {
+        val name         = genName(reciverp.symbol)
+        val propertyName = Linktime.nameToLinktimePropertyName(name)
+        SimpleCondition(propertyName, Comp.Ieq, value)(reciverp.pos)
+      }
+      def someLiteralProperty(reciverp: Tree,
+                              comp: Name,
+                              arg: Literal): Option[LinktimeCondition] = Some {
+        val argValue = genLiteralValue(arg)
+        val name     = genName(reciverp.symbol)
+        SimpleCondition(Linktime.nameToLinktimePropertyName(name),
+                        genComparsion(comp, argValue),
+                        argValue)(reciverp.pos)
+      }
+
       condp match {
         case Apply(reciverp, List()) if isLinktimeProperty(reciverp) =>
-          Some {
-            val name         = genName(reciverp.symbol)
-            val propertyName = Linktime.nameToLinktimePropertyName(name)
-            SimpleCondition(propertyName, Comp.Ieq, Val.True)
-          }
+          someBooleanProperty(reciverp, Val.True)
+
+        case Apply(Select(Apply(reciverp, List()), nme.UNARY_!), List())
+            if isLinktimeProperty(reciverp) =>
+          someBooleanProperty(reciverp, Val.False)
 
         case Apply(Select(reciverp, comp), List(arg @ Literal(Constant(_))))
             if isLinktimeProperty(reciverp) =>
-          Some {
-            val argValue = genLiteralValue(arg)
-            val name     = genName(reciverp.symbol)
-            SimpleCondition(Linktime.nameToLinktimePropertyName(name),
-                            genComparsion(comp, argValue),
-                            argValue)
-          }
+          someLiteralProperty(reciverp, comp, arg)
 
         // Same as above, but for case when condition is additionally boxed, eg.: `prop != null`
         case Apply(Select(Apply(_, List(Apply(reciverp, List()))), comp),
                    List(arg @ Literal(Constant(_))))
             if isLinktimeProperty(reciverp) =>
-          Some {
-            val argValue = genLiteralValue(arg)
-            val name     = genName(reciverp.symbol)
-            SimpleCondition(Linktime.nameToLinktimePropertyName(name),
-                            genComparsion(comp, argValue),
-                            argValue)
-          }
+          someLiteralProperty(reciverp, comp, arg)
 
         case Apply(Select(cond1, op), List(cond2)) =>
           (getLinktimeCondition(cond1), getLinktimeCondition(cond2)) match {
@@ -1177,7 +1181,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
                 case nme.ZAND => Bin.And
                 case nme.ZOR  => Bin.Or
               }
-              Some(ComplexCondition(bin, c1, c2))
+              Some(ComplexCondition(bin, c1, c2)(condp.pos))
             case (None, None) => None
             case _ =>
               globalError(

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1143,14 +1143,17 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       condp match {
         case Apply(reciverp, List()) if isLinktimeProperty(reciverp) =>
           Some {
-            SimpleCondition(genName(reciverp.symbol), Comp.Ieq, Val.True)
+            val name         = genName(reciverp.symbol)
+            val propertyName = Linktime.nameToLinktimePropertyName(name)
+            SimpleCondition(propertyName, Comp.Ieq, Val.True)
           }
 
         case Apply(Select(reciverp, comp), List(arg @ Literal(Constant(_))))
             if isLinktimeProperty(reciverp) =>
           Some {
             val argValue = genLiteralValue(arg)
-            SimpleCondition(genName(reciverp.symbol),
+            val name     = genName(reciverp.symbol)
+            SimpleCondition(Linktime.nameToLinktimePropertyName(name),
                             genComparsion(comp, argValue),
                             argValue)
           }

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1138,7 +1138,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       def isLinktimeProperty(tree: Tree): Boolean =
         tree.hasSymbolWhich(
-          _.annotations.exists(_.symbol == LinktimeResolvedClass))
+          _.annotations.exists(_.symbol == ResolvedAtLinktimeClass))
 
       def someBooleanProperty(reciverp: Tree,
                               value: Val): Option[LinktimeCondition] = Some {

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -653,7 +653,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         dd: DefDef,
         annotationInfo: AnnotationInfo,
         name: Global): (Global.Member, nir.Type) = {
-      require(annotationInfo.symbol == LinktimeResolvedClass)
+      require(annotationInfo.symbol == LinktimeResolvedClass,
+              "Expected linktime property class")
 
       implicit val fresh: Fresh      = Fresh()
       implicit val buf: ExprBuffer   = new ExprBuffer()

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -606,8 +606,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           // Have a concrete method with JavaDefaultMethodAnnotation; a blivet.
           // Do not emit, not even as abstract.
 
-          case _
-              if sym.annotations.exists(_.symbol == ResolvedAtLinktimeClass) =>
+          case _ if sym.hasAnnotation(ResolvedAtLinktimeClass) =>
             genLinktimeResolved(dd, name)
 
           case rhs =>
@@ -854,8 +853,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def unapply(tree: Tree): Option[(String, nir.Position)] = {
       if (tree.symbol == null) None
       else {
-        tree.symbol.annotations
-          .find(_.symbol == ResolvedAtLinktimeClass)
+        tree.symbol
+          .getAnnotation(ResolvedAtLinktimeClass)
           .flatMap(_.args.headOption)
           .flatMap {
             case Literal(Constant(name: String)) => Some((name, tree.pos))

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -574,8 +574,8 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val sig      = genMethodSig(sym)
         val isStatic = owner.isExternModule || isImplClass(owner)
 
-        lazy val linkTimeResolvedAnnotation =
-          sym.annotations.find(_.symbol == LinktimeResolvedClass)
+        lazy val resolvedAtLinktimeAnnotation =
+          sym.annotations.find(_.symbol == ResolvedAtLinktimeClass)
 
         dd.rhs match {
           case EmptyTree
@@ -609,10 +609,10 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           // Have a concrete method with JavaDefaultMethodAnnotation; a blivet.
           // Do not emit, not even as abstract.
 
-          case _ if linkTimeResolvedAnnotation.isDefined =>
+          case _ if resolvedAtLinktimeAnnotation.isDefined =>
             val (propertyName, retty) =
               genLinktimeResolvedProperty(dd,
-                                          linkTimeResolvedAnnotation.get,
+                                          resolvedAtLinktimeAnnotation.get,
                                           name)
             genLinktimeResolvedMethod(retty, propertyName, name)
 
@@ -653,7 +653,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         dd: DefDef,
         annotationInfo: AnnotationInfo,
         name: Global): (Global.Member, nir.Type) = {
-      require(annotationInfo.symbol == LinktimeResolvedClass,
+      require(annotationInfo.symbol == ResolvedAtLinktimeClass,
               "Expected linktime property class")
 
       implicit val fresh: Fresh      = Fresh()

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -682,7 +682,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       val propertyName =
         fromLiteralOrFallback(annotationInfo.args.head,
-                              "Name used to resolve linktime property") {
+                              "Name used to resolve link-time property") {
           case tree if tree.symbol.isParamWithDefault =>
             Val.String(normalizedSymbolName('.'))
         }

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -42,6 +42,9 @@ sealed trait NativeConfig {
   /** Shall we optimize the resulting NIR code? */
   def optimize: Boolean
 
+  /** Map of properties resolved at linktime  */
+  def linktimeProperties: Map[String, Any]
+
   /** Create a new config with given garbage collector. */
   def withGC(value: GC): NativeConfig
 
@@ -80,6 +83,9 @@ sealed trait NativeConfig {
 
   /** Create a new config with given optimize value */
   def withOptimize(value: Boolean): NativeConfig
+
+  /** Create a new config with given linktime properites */
+  def withLinktimeProperties(value: Map[String, Any]): NativeConfig
 }
 
 object NativeConfig {
@@ -98,7 +104,8 @@ object NativeConfig {
       check = false,
       dump = false,
       linkStubs = false,
-      optimize = false
+      optimize = false,
+      linktimeProperties = Map.empty
     )
 
   private final case class Impl(clang: Path,
@@ -112,7 +119,8 @@ object NativeConfig {
                                 linkStubs: Boolean,
                                 check: Boolean,
                                 dump: Boolean,
-                                optimize: Boolean)
+                                optimize: Boolean,
+                                linktimeProperties: Map[String, Any])
       extends NativeConfig {
 
     def withClang(value: Path): NativeConfig =
@@ -155,7 +163,45 @@ object NativeConfig {
     def withOptimize(value: Boolean): NativeConfig =
       copy(optimize = value)
 
-    override def toString: String =
+    override def withLinktimeProperties(v: Map[String, Any]): NativeConfig = {
+      def isNumberOrString(value: Any) = {
+        def isNonUnitPrimitive =
+          value.getClass.isPrimitive && value.isInstanceOf[Unit]
+
+        def isNonEmptyString =
+          value.isInstanceOf[String] && value.toString.nonEmpty
+
+        value != null && (isNonUnitPrimitive || isNonEmptyString)
+      }
+
+      val invalid = linktimeProperties.collect {
+        case (key, value) if !isNumberOrString(value) => key
+      }
+      if (invalid.nonEmpty) {
+        System.err.println(
+          s"Invalid link-time properties: \n ${invalid.mkString(" - ", "\n", "")}")
+        throw new BuildException(
+          "Link-time properties needs to be non-null primitives or string")
+      }
+
+      copy(linktimeProperties = v)
+    }
+
+    override def toString: String = {
+      val listLinktimeProperties = {
+        if (linktimeProperties.isEmpty) ""
+        else {
+          val maxKeyLength = linktimeProperties.keys.map(_.length).max
+          val keyPadSize   = maxKeyLength.min(20)
+          "\n" + linktimeProperties.toSeq
+            .sortBy(_._1)
+            .map {
+              case (key, value) =>
+                s"   * ${key.padTo(keyPadSize, ' ')} : $value"
+            }
+            .mkString("\n")
+        }
+      }
       s"""NativeConfig(
         | - clang:           $clang
         | - clangPP:         $clangPP
@@ -169,7 +215,9 @@ object NativeConfig {
         | - check:           $check
         | - dump:            $dump
         | - optimize         $optimize
+        | - linktimeProperties: $listLinktimeProperties
         |)""".stripMargin
+    }
   }
 
 }

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -165,24 +165,14 @@ object NativeConfig {
 
     override def withLinktimeProperties(v: Map[String, Any]): NativeConfig = {
       def isNumberOrString(value: Any) = {
-        def isNonUnitPrimitive = value match {
-          case _: java.lang.Boolean | Boolean => true
-          case _: java.lang.Byte | Byte       => true
-          case _: java.lang.Character | Char  => true
-          case _: java.lang.Short | Short     => true
-          case _: java.lang.Integer | Int     => true
-          case _: java.lang.Long | Long       => true
-          case _: java.lang.Float | Float     => true
-          case _: java.lang.Double | Double   => true
-          case _                              => false
+        def hasSupportedType = value match {
+          case _: Boolean | _: Byte | _: Char | _: Short | _: Int | _: Long |
+              _: Float | _: Double | _: String =>
+            true
+          case _ => false
         }
 
-        def isNonEmptyString = value match {
-          case s: String => s.nonEmpty
-          case _         => false
-        }
-
-        value != null && (isNonUnitPrimitive || isNonEmptyString)
+        value != null && hasSupportedType
       }
 
       val invalid = v.collect {

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -165,23 +165,34 @@ object NativeConfig {
 
     override def withLinktimeProperties(v: Map[String, Any]): NativeConfig = {
       def isNumberOrString(value: Any) = {
-        def isNonUnitPrimitive =
-          value.getClass.isPrimitive && value.isInstanceOf[Unit]
+        def isNonUnitPrimitive = value match {
+          case _: java.lang.Boolean | Boolean => true
+          case _: java.lang.Byte | Byte       => true
+          case _: java.lang.Character | Char  => true
+          case _: java.lang.Short | Short     => true
+          case _: java.lang.Integer | Int     => true
+          case _: java.lang.Long | Long       => true
+          case _: java.lang.Float | Float     => true
+          case _: java.lang.Double | Double   => true
+          case _                              => false
+        }
 
-        def isNonEmptyString =
-          value.isInstanceOf[String] && value.toString.nonEmpty
+        def isNonEmptyString = value match {
+          case s: String => s.nonEmpty
+          case _         => false
+        }
 
         value != null && (isNonUnitPrimitive || isNonEmptyString)
       }
 
-      val invalid = linktimeProperties.collect {
+      val invalid = v.collect {
         case (key, value) if !isNumberOrString(value) => key
       }
       if (invalid.nonEmpty) {
         System.err.println(
           s"Invalid link-time properties: \n ${invalid.mkString(" - ", "\n", "")}")
         throw new BuildException(
-          "Link-time properties needs to be non-null primitives or string")
+          "Link-time properties needs to be non-null primitives or non-empty string")
       }
 
       copy(linktimeProperties = v)

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -102,6 +102,7 @@ final class Check(implicit linked: linker.Result) {
         enterUnwind(unwind)
       case Inst.Unreachable(unwind) =>
         enterUnwind(unwind)
+      case _: Inst.LinktimeCf => util.unreachable
     }
   }
 
@@ -130,6 +131,7 @@ final class Check(implicit linked: linker.Result) {
       in("unwind")(checkUnwind(unwind))
     case Inst.Unreachable(unwind) =>
       in("unwind")(checkUnwind(unwind))
+    case _: Inst.LinktimeCf => util.unreachable
   }
 
   def checkOp(op: Op): Unit = op match {

--- a/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
@@ -34,6 +34,8 @@ trait NoOpt { self: Interflow =>
       noOptNext(unwind)
     case Inst.Unreachable(unwind) =>
       noOptNext(unwind)
+    case _: Inst.LinktimeCf =>
+      util.unreachable
   }
 
   def noOptNext(next: Next): Unit = next match {

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -218,7 +218,8 @@ final class Result(val infos: mutable.Map[Global, Info],
                    val links: Seq[Attr.Link],
                    val defns: Seq[Defn],
                    val dynsigs: Seq[Sig],
-                   val dynimpls: Seq[Global]) {
+                   val dynimpls: Seq[Global],
+                   val resolvedVals: mutable.Map[Global, Val]) {
   lazy val ObjectClass       = infos(Rt.Object.name).asInstanceOf[Class]
   lazy val StringClass       = infos(Rt.StringName).asInstanceOf[Class]
   lazy val StringValueField  = infos(Rt.StringValueName).asInstanceOf[Field]

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -219,7 +219,7 @@ final class Result(val infos: mutable.Map[Global, Info],
                    val defns: Seq[Defn],
                    val dynsigs: Seq[Sig],
                    val dynimpls: Seq[Global],
-                   val resolvedVals: mutable.Map[Global, Val]) {
+                   val resolvedVals: mutable.Map[String, Val]) {
   lazy val ObjectClass       = infos(Rt.Object.name).asInstanceOf[Class]
   lazy val StringClass       = infos(Rt.StringName).asInstanceOf[Class]
   lazy val StringValueField  = infos(Rt.StringValueName).asInstanceOf[Field]

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -2,13 +2,14 @@ package scala.scalanative.linker
 
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.scalanative.linker.LinktimeValueResolver.ComparableVal.AnyOrderingWithValues
 import scala.scalanative.nir._
 import scala.scalanative.util
 
 trait LinktimeValueResolver { self: Reach =>
   import LinktimeValueResolver._
 
-  val resolvedProperties = mutable.Map.empty[Global, Val]
+  val resolvedValues = mutable.Map.empty[Global, Val]
 
   protected def resolveLinktimeDefine(defn: Defn.Define): Defn.Define = {
     implicit def position: Position = defn.pos
@@ -36,7 +37,7 @@ trait LinktimeValueResolver { self: Reach =>
 
   private def resolveLinktimeProperty(name: Global)(
       implicit pos: Position): Val =
-    resolvedProperties.getOrElseUpdate(name, lookupLinktimeProperty(name))
+    resolvedValues.getOrElseUpdate(name, lookupLinktimeProperty(name))
 
   private def lookupLinktimeProperty(name: Global)(
       implicit pos: Position): Val = {

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -1,0 +1,136 @@
+package scala.scalanative.linker
+
+import scala.collection.mutable
+import scala.scalanative.nir._
+import scala.scalanative.util
+
+trait LinktimeValueResolver { self: Reach =>
+  import LinktimeValueResolver._
+
+  val resolvedProperties = mutable.Map.empty[Global, Val]
+
+  protected def resolveLinktimeDefine(defn: Defn.Define): Defn.Define = {
+    implicit def position: Position = defn.pos
+
+    if (!defn.insts.exists(shouldResolveInst)) defn
+    else {
+      val resolvedInsts = ControlFlow.removeDeadBlocks {
+        defn.insts.map {
+          case inst: Inst.LinktimeIf => resolveLinktimeIf(inst)
+          case inst @ Inst.Let(_, ReferencedPropertyOp(propertyName), _) =>
+            resolveReferencedProperty(inst, propertyName)
+          case inst => inst
+        }
+      }
+
+      defn.copy(insts = resolvedInsts)
+    }
+  }
+
+  protected def shouldResolveInst(inst: Inst): Boolean = inst match {
+    case _: Inst.LinktimeIf                      => true
+    case Inst.Let(_, ReferencedPropertyOp(_), _) => true
+    case _                                       => false
+  }
+
+  private def resolveLinktimeProperty(name: Global)(
+      implicit pos: Position): Val =
+    resolvedProperties.getOrElseUpdate(name, lookupLinktimeProperty(name))
+
+  private def lookupLinktimeProperty(name: Global)(
+      implicit pos: Position): Val = {
+    fieldInfo(name).fold[Val] {
+      addMissing(name, pos)
+      Val.Null
+    } { field =>
+      require(field.isConst, "Linktime property was not const")
+      require(field.ty.isInstanceOf[Type.StructValue],
+              "Linktime property was not struct")
+
+      val Type.StructValue(valType +: _) = field.ty
+      val Val.StructValue(Seq(defaultValue, propertyName, envName)) =
+        field.init
+
+      def stringOrNone(value: Val): Option[String] = value match {
+        case Val.String(str) => Some(str)
+        case _               => None
+      }
+
+      // {property, env}Name can be Val.Null given property should not be
+      // accessible through that channel
+      def propertyValue = stringOrNone(propertyName).flatMap(sys.props.get)
+      def envValue      = stringOrNone(envName).flatMap(sys.env.get)
+
+      propertyValue
+        .orElse(envValue)
+        .map { str =>
+          valType match {
+            case Type.Bool  => Val.Bool(java.lang.Boolean.parseBoolean(str))
+            case Type.Char  => Val.Char(str.head)
+            case Type.Byte  => Val.Byte(java.lang.Byte.parseByte(str))
+            case Type.Short => Val.Short(java.lang.Short.parseShort(str))
+            case Type.Int   => Val.Int(java.lang.Integer.parseInt(str))
+            case Type.Long  => Val.Long(java.lang.Long.parseLong(str))
+            case Type.Float => Val.Float(java.lang.Float.parseFloat(str))
+            case Type.Double =>
+              Val.Double(java.lang.Double.parseDouble(str))
+            case Type.Ref(Rt.StringName, _, _) => Val.String(str)
+            case tpe =>
+              util.unsupported(s"Unsupported type of linktime property: $tpe")
+          }
+        }
+        .getOrElse(defaultValue)
+    }
+  }
+
+  private def resolveCondition(cond: LinktimeCondition)(
+      implicit pos: Position): Boolean = {
+    import LinktimeCondition._
+
+    cond match {
+      case ComplexCondition(Bin.And, left, right) =>
+        resolveCondition(left) && resolveCondition(right)
+
+      case ComplexCondition(Bin.Or, left, right) =>
+        resolveCondition(left) || resolveCondition(right)
+
+      case SimpleCondition(name, comparison, condVal) =>
+        val resolvedValue = resolveLinktimeProperty(name)
+        comparison match {
+          case Comp.Ieq => resolvedValue == condVal
+          case Comp.Ine => resolvedValue != condVal
+          case cmp =>
+            util.unsupported(s"Unsupported linktime comparsion type: $cmp")
+        }
+      case _ => util.unsupported(s"Unknown condition: $cond")
+    }
+  }
+
+  private def resolveLinktimeIf(inst: Inst.LinktimeIf)(
+      implicit pos: Position): Inst = {
+    val Inst.LinktimeIf(cond, thenp, elsep) = inst
+
+    val matchesCondition = resolveCondition(cond)
+    if (matchesCondition) Inst.Jump(thenp)
+    else Inst.Jump(elsep)
+  }
+
+  private def resolveReferencedProperty(inst: Inst.Let, propertyName: Global)(
+      implicit pos: Position): Inst = {
+    reachGlobal(propertyName)
+    inst.copy(op = Op.Copy(resolveLinktimeProperty(propertyName)))
+  }
+
+}
+
+object LinktimeValueResolver {
+  object ReferencedPropertyOp {
+    def unapply(op: Op): Option[Global] = op match {
+      case Op.Call(_,
+                   Val.Global(Linktime.PropertyResolveFunctionName, _),
+                   Seq(Val.Global(propertyName, _))) =>
+        Some(propertyName)
+      case _ => None
+    }
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -48,7 +48,8 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader)
                links.toSeq,
                defns.toSeq,
                dynsigs.toSeq,
-               dynimpls.toSeq)
+               dynimpls.toSeq,
+               resolvedValues)
   }
 
   def cleanup(): Unit = {

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -6,7 +6,9 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scalanative.nir._
 
-class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader)
+class Reach(protected val config: build.Config,
+            entries: Seq[Global],
+            loader: ClassLoader)
     extends LinktimeValueResolver {
   import Reach._
 
@@ -49,7 +51,7 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader)
                defns.toSeq,
                dynsigs.toSeq,
                dynimpls.toSeq,
-               resolvedValues)
+               resolvedNirValues)
   }
 
   def cleanup(): Unit = {

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -282,14 +282,14 @@ class LinktimeConditionsSpec extends LinkerSpec with Matchers {
     )
 
     val cases: List[((Double, String, Long), Int)] = List(
-      (-0.0, "", 1L)              -> 1,
-      (1.5, "2", 2L)              -> 2,
-      (3.0, "tri", -1L)           -> 3,
-      (3.0, "", 3L)               -> 3,
-      (4.0, "four", 4L)           -> 4,
-      (4.0, "three", 4L)          -> 4,
-      (5.0, "", 1234567889L)      -> 5,
-      (654321.0, "", 1234567891L) -> 6
+      (-0.0, "none", 1L)              -> 1,
+      (1.5, "2", 2L)                  -> 2,
+      (3.0, "tri", -1L)               -> 3,
+      (3.0, "None", 3L)               -> 3,
+      (4.0, "four", 4L)               -> 4,
+      (4.0, "three", 4L)              -> 4,
+      (5.0, "None", 1234567889L)      -> 5,
+      (654321.0, "None", 1234567891L) -> 6
     )
 
     for (((doubleValue, stringValue, longValue), pathNumber) <- cases)

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -1,0 +1,363 @@
+package scala.scalanative.linker
+
+import org.scalatest.matchers.should.Matchers
+import scala.scalanative.LinkerSpec
+import scala.util.Properties.{clearProp, envOrNone, setProp}
+import scala.scalanative.nir.{Global, Sig, Val, Type}
+
+class LinktimeConditionsSpec extends LinkerSpec with Matchers {
+  val entry = "Main$"
+  private val props =
+    s"""import scala.scalanative.unsafe.linktimeResolved
+       |
+       |object linktime {
+       |  @linktimeResolved()
+       |  final def int = 1
+       |  
+       |  @linktimeResolved()
+       |  final def bool = true
+       |
+       |  @linktimeResolved(fromProperty = null, fromEnv = "LINKTIME_MSG")
+       |  final def welcomeMessage = "Hello world"
+       |  
+       |  @linktimeResolved()
+       |  def decimalSeparator = ','
+       |  @linktimeResolved()
+       |  def float = -1.0f
+       |  
+       |  object inner{
+       |   @linktimeResolved()
+       |   def countFrom = 2L
+       |   
+       |   @linktimeResolved("secret.performance.multiplier")
+       |   def performanceMultiplier = 1.0
+       |  }
+       |}
+       |""".stripMargin
+
+  def propName(name: String) = Sig.Generated(name + "_property")
+
+  val linktimeModule     = Global.Top("linktime$")
+  val innerModule        = Global.Top("linktime$inner$")
+  val intProp            = linktimeModule.member(propName("int"))
+  val boolProp           = linktimeModule.member(propName("bool"))
+  val welcomeMessageProp = linktimeModule.member(propName("welcomeMessage"))
+  val floatProp          = linktimeModule.member(propName("float"))
+  val decimalSepProp     = linktimeModule.member(propName("decimalSeparator"))
+  val countFromProp      = innerModule.member(propName("countFrom"))
+  val perfMultProp       = innerModule.member(propName("performanceMultiplier"))
+
+  val defaultSep = ','
+  val defaults = Map(
+    intProp            -> Val.Int(1),
+    boolProp           -> Val.True,
+    welcomeMessageProp -> Val.String("Hello world"),
+    floatProp          -> Val.Float(-1.0f),
+    decimalSepProp     -> Val.Char(defaultSep),
+    countFromProp      -> Val.Long(2),
+    perfMultProp       -> Val.Double(1.0)
+  )
+
+  val allProps      = defaults.keySet
+  val allPropsUsage = s"""
+                       |object Main {
+                       |  def main(args: Array[String]): Unit = {
+                       |    linktime.int
+                       |    linktime.bool
+                       |    linktime.welcomeMessage
+                       |    linktime.decimalSeparator
+                       |    linktime.float
+                       |    linktime.inner.countFrom
+                       |    linktime.inner.performanceMultiplier
+                       |  }
+                       |}""".stripMargin
+
+  private val allPropsUsageUnit = Map(
+    "props.scala" -> props,
+    "main.scala"  -> allPropsUsage
+  )
+
+  val defaultPropsOnly =
+    props.replaceAll("@linktimeResolved(.*)", "@linktimeResolved(null, null)")
+
+  "Linktime properties" should "exist in linking results" in {
+    link(entry, allPropsUsageUnit) { (_, result) =>
+      shouldContainAll(allProps, result.resolvedVals.keys)
+    }
+  }
+
+  // Is based on assumption that @linktimeResolved annotation
+  // with from{Property, Env} set to null does block this channel
+  // from resolving value. We test its true by checking that known
+  // system properies and env variables were not used to resolve value
+  it should "resolve default values" in {
+    withProps(
+      "linktime.int"                  -> "10",
+      "secret.performance.multiplier" -> "2.0"
+    ) {
+      val msgOpt = envOrNone("LINKTIME_MSG")
+      msgOpt should not be empty
+      msgOpt shouldNot contain(defaultSep)
+
+      link(entry,
+           Map("props.scala" -> defaultPropsOnly,
+               "main.scala"  -> allPropsUsage)) { (_, result) =>
+        shouldContainAll(defaults, result.resolvedVals)
+      }
+    }
+  }
+
+  it should "resolve values from env variables" in {
+    link(entry, allPropsUsageUnit) { (_, result) =>
+      val vals        = result.resolvedVals
+      val expectedMsg = "scala-native"
+      envOrNone("LINKTIME_MSG") should contain(expectedMsg)
+      vals(welcomeMessageProp) shouldEqual Val.String(expectedMsg)
+
+      val expectedSeperator = '_'
+      envOrNone("LINKTIME_DECIMALSEPARATOR") should contain(
+        expectedSeperator.toString)
+      vals(decimalSepProp) shouldEqual Val.Char(expectedSeperator)
+    }
+  }
+
+  it should "resolve values from system properties" in {
+    case class Entry(propertyName: String,
+                     value: String,
+                     linktimeProp: Global.Member,
+                     lintimeValue: Val)
+
+    val entries = Seq(
+      Entry("linktime.int", "42", intProp, Val.Int(42)),
+      Entry("linktime.bool", "false", boolProp, Val.False),
+      Entry("linktime.welcomeMessage",
+            "Hello native",
+            welcomeMessageProp,
+            Val.String("Hello native")),
+      Entry("linktime.float", "3.14", floatProp, Val.Float(3.14f)),
+      Entry("linktime.decimalSeparator", "-", decimalSepProp, Val.Char('-')),
+      Entry("linktime.inner.countFrom",
+            "123456",
+            countFromProp,
+            Val.Long(123456L)),
+      Entry("secret.performance.multiplier",
+            "9.99",
+            perfMultProp,
+            Val.Double(9.99))
+    )
+
+    val noDisabledProps = Map(
+      "props.scala" -> props
+        .replaceAll("null", "scala.scalanative.runtime.intrinsic"),
+      "main.scala" -> allPropsUsage
+    )
+
+    withProps(entries.map(e => e.propertyName -> e.value): _*) {
+      link(entry, noDisabledProps) { (_, result) =>
+        val expected = for (e <- entries) yield e.linktimeProp -> e.lintimeValue
+        shouldContainAll(expected, result.resolvedVals)
+      }
+    }
+  }
+
+  it should "prefer system property over env variable" in {
+    withProps("linktime.decimalSeparator" -> "p") {
+      envOrNone("LINKTIME_DECIMALSEPARATOR") should contain("_")
+
+      link(entry, allPropsUsageUnit) { (_, result) =>
+        result.resolvedVals(decimalSepProp) shouldEqual Val.Char('p')
+      }
+    }
+  }
+
+  "Linktime conditions" should "resolve simple conditions" in {
+    val pathsRange = 1.to(3)
+    val compilationUnit = Map(
+      "props.scala" -> props,
+      "main.scala"  -> s"""
+                          |object Main {
+                          |  ${pathStrings(pathsRange)}
+                          |  
+                          |  def main(args: Array[String]): Unit = {
+                          |    if(linktime.int == 1) path1()
+                          |    else if (linktime.int == 2) path2()
+                          |    else path3()
+                          |  }
+                          |}""".stripMargin
+    )
+    /* When using normal (runtime) conditions static reachability analysis
+     * would report missing stubs in each branch (in this case 3).
+     * When using linktime conditions only branch that fulfilled condition
+     * would be actually used, others would be discarded and never used/checked.
+     * Based on that only 1 unavailable symbol would be reported (from branch that was taken).
+     */
+    for (n <- pathsRange) withProps("linktime.int" -> n.toString) {
+      link(compilationUnit) { (main, result) =>
+        result.unavailable should contain only pathForNumber(n)
+      }
+    }
+  }
+
+  it should "allow to use inequality comparsion" in {
+    val property   = "linktime.float"
+    val pathsRange = 0.until(6)
+
+    val compilationUnit = Map(
+      "props.scala" -> props,
+      "main.scala"  -> s"""
+                          |object Main {
+                          |  ${pathStrings(pathsRange)}
+                          |  def main(args: Array[String]): Unit = {
+                          |    if($property != 0.0f) {
+                          |       if($property <= 1.0f) path1()
+                          |       else if($property < 2.9f) path2()
+                          |       else if($property > 3.9f) path4()
+                          |       else if($property >= 3.0f) path3()
+                          |       else () // should be unreachable
+                          |    } else path0()
+                          |  }
+                          |}""".stripMargin
+    )
+    for (n <- pathsRange.init)
+      withProps(property -> s"$n.0f") {
+        link(compilationUnit) { (main, result) =>
+          result.unavailable should contain only pathForNumber(n)
+        }
+      }
+  }
+
+  it should "allow to use complex conditions" in {
+    val double     = "linktime.inner.performanceMultiplier"
+    val long       = "linktime.inner.countFrom"
+    val string     = "stringProp"
+    val pathsRange = 1.to(6)
+
+    val cases: List[((Double, String, Long), Int)] = List(
+      (-0.0, "", 1L)              -> 1,
+      (1.5, "2", 2L)              -> 2,
+      (3.0, "tri", -1L)           -> 3,
+      (3.0, "", 3L)               -> 3,
+      (4.0, "four", 4L)           -> 4,
+      (4.0, "three", 4L)          -> 4,
+      (5.0, "", 1234567889L)      -> 5,
+      (654321.0, "", 1234567891L) -> 6
+    )
+
+    val compilationUnit = Map(
+      "props.scala" -> props,
+      "main.scala"  -> s"""
+                          |object Main {
+                          |   @scalanative.unsafe.linktimeResolved(fromProperty = "prop.string")
+                          |   def stringProp: String = "null"
+                          |
+                          |  ${pathStrings(pathsRange)}
+                          |  def main(args: Array[String]): Unit = {
+                          |    if($double == -1.0 || $string == "one" || $long == 1) path1()
+                          |     else if($double >= 1 && $long <= 2 && $string == "2") path2()
+                          |     else if(($double == 3.0 && $long == 3) || $string == "tri") path3()
+                          |     else if(($string != "three" || $long > 3) && $double <= 4.0) path4()
+                          |     else if(($string != null && $long < 1234567890) && ($double >= -12345.789 && $double <= 12345.789)) path5()
+                          |     else path6()
+                          |  }
+                          |}""".stripMargin
+    )
+    for (((double, string, long), pathNumber) <- cases)
+      withProps(
+        "secret.performance.multiplier" -> double.toString,
+        "prop.string"                   -> string,
+        "linktime.inner.countFrom"      -> long.toString
+      ) {
+        link(compilationUnit) { (_, result) =>
+          result.unavailable should contain only pathForNumber(pathNumber)
+        }
+      }
+  }
+
+  it should "handle boolean properties in conditions" in {
+    val bool1      = "boolOne"
+    val bool2      = "bool2"
+    val pathsRange = 1.to(5)
+
+    val cases: List[((Boolean, Boolean), Int)] = List(
+      (true, true)  -> 1,
+      (true, false) -> 2,
+      (false, true) -> 3
+    )
+
+    val compilationUnit = Map(
+      "props.scala" -> props,
+      "main.scala"  -> s"""
+                          |object Main {
+                          |   @scalanative.unsafe.linktimeResolved(fromProperty = "prop.bool.1")
+                          |   def $bool1 = false
+                          |   
+                          |   @scalanative.unsafe.linktimeResolved(fromProperty = "prop.bool.2")
+                          |   def $bool2 = false
+                          |   
+                          |  ${pathStrings(pathsRange)}
+                          |  def main(args: Array[String]): Unit = {
+                          |    if($bool1 && $bool2 == true) path1()
+                          |     else if($bool1 && !$bool2) path2()
+                          |     else if($bool1 == false || $bool2) path3()
+                          |     else path4()
+                          |  }
+                          |}""".stripMargin
+    )
+    for (((bool1, bool2), pathNumber) <- cases)
+      withProps(
+        "prop.bool.1" -> bool1.toString,
+        "prop.bool.2" -> bool2.toString
+      ) {
+        link(compilationUnit) { (_, result) =>
+          result.unavailable should contain only pathForNumber(pathNumber)
+        }
+      }
+  }
+
+  private def shouldContainAll[T](expected: Iterable[T], given: Iterable[T]) = {
+    val left  = given.toSet
+    val right = expected.toSet
+    assert((left -- right).isEmpty, "underapproximation")
+    assert((right -- left).isEmpty, "overapproximation")
+  }
+
+  private def link[T](sources: Map[String, String])(
+      fn: (Method, Result) => T): T = {
+    link(entry, sources) { (_, result) =>
+      implicit val linkerResult: Result = result
+      val mainSig =
+        Sig.Method("main",
+                   Seq(Type.Array(scalanative.nir.Rt.String), Type.Unit))
+      val MethodRef(_, mainMethod) = Global.Member(Global.Top(entry), mainSig)
+      fn(mainMethod, result)
+    }
+  }
+
+  private def pathForNumber(n: Int) = {
+    Global.Member(owner = Global.Top(entry),
+                  sig = Sig.Method(s"path$n", Seq(Type.Unit)))
+  }
+
+  private def pathStrings(range: Range) = {
+    range
+      .map { n =>
+        s"""
+         |@scalanative.annotation.stub
+         |def path$n(): Unit = ???
+         |""".stripMargin
+      }
+      .mkString("\n")
+  }
+
+  private def withProps(props: (String, String)*)(body: => Any): Unit = {
+    props.foreach {
+      case (key, value) =>
+        if (value.isEmpty) ()
+        else setProp(key, value)
+    }
+    try { body }
+    finally props.foreach {
+      case (propName, _) => clearProp(propName)
+    }
+  }
+}

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -25,13 +25,13 @@ class LinktimeConditionsSpec extends LinkerSpec with Matchers {
        |  def decimalSeparator: Char = resolved
        |  @resolvedAtLinktime("float")
        |  def float: Float = resolved
-       |  
+       |
        |  object inner{
-       |   @resolvedAtLinktime("inner.countFrom")
-       |   def countFrom: Long = resolved
+       |    @resolvedAtLinktime("inner.countFrom")
+       |    def countFrom: Long = resolved
        |   
-       |   @resolvedAtLinktime("secret.performance.multiplier")
-       |   def performanceMultiplier: Double = resolved
+       |    @resolvedAtLinktime("secret.performance.multiplier")
+       |    def performanceMultiplier: Double = resolved
        |  }
        |}
        |""".stripMargin

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -112,10 +112,10 @@ class LinktimeConditionsSpec extends LinkerSpec with Matchers {
   }
 
   it should "not allow to define property without `resolved` as rhs value" in {
-    assertThrows[scala.scalanative.api.CompilationFailedException] {
+    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
       linkWithProps(
         "props.scala" ->
-          """pakcage scala.scalanative
+          """package scala.scalanative
             |object props{
             |   @scalanative.unsafe.resolvedAtLinktime(withName = null)
             |   def linktimeProperty: Boolean = true
@@ -129,16 +129,17 @@ class LinktimeConditionsSpec extends LinkerSpec with Matchers {
             |}""".stripMargin
       )() { (_, _) => () }
     }
+    caught.getMessage shouldEqual "Link-time resolved property must have scala.scalanative.unsafe.resolved as body"
   }
 
   it should "not allow to define property with null rhs" in {
-    assertThrows[scala.scalanative.api.CompilationFailedException] {
+    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
       linkWithProps(
         "props.scala" -> """
              |package scala.scalanative
              |object props{
              |   @scalanative.unsafe.resolvedAtLinktime()
-             |   def linktimeProperty: Int = null
+             |   def linktimeProperty: Boolean = null.asInstanceOf[Boolean]
              |}
              |""".stripMargin,
         "main.scala"  -> """
@@ -150,16 +151,17 @@ class LinktimeConditionsSpec extends LinkerSpec with Matchers {
             |}""".stripMargin
       )() { (_, _) => () }
     }
+    caught.getMessage shouldEqual "Link-time resolved property must have scala.scalanative.unsafe.resolved as body"
   }
 
   it should "not allow to define property resolved from property with null name" in {
-    assertThrows[scala.scalanative.api.CompilationFailedException] {
+    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
       linkWithProps(
         "props.scala" ->
-          """pakcage scala.scalanative
+          """package scala.scalanative
             |object props{
-            |   @scalanative.unsafe.resolvedAtLinktime(withName = null)
-            |   def linktimeProperty: Int = scala.scalanative.unsafe.resolved
+            |   @scalanative.unsafe.resolvedAtLinktime(withName = null.asInstanceOf[String])
+            |   def linktimeProperty: Boolean = scala.scalanative.unsafe.resolved
             |}""".stripMargin,
         "main.scala" ->
           """import scala.scalanative.props._
@@ -170,13 +172,14 @@ class LinktimeConditionsSpec extends LinkerSpec with Matchers {
             |}""".stripMargin
       )() { (_, _) => () }
     }
+    caught.getMessage shouldEqual "Name used to resolve link-time property needs to be non-null literal constant"
   }
 
   it should "not allow to define property without explicit return type" in {
-    assertThrows[scala.scalanative.api.CompilationFailedException] {
+    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
       linkWithProps(
         "props.scala" ->
-          """pakcage scala.scalanative
+          """package scala.scalanative
             |object props{
             |   @scalanative.unsafe.resolvedAtLinktime(withName = null)
             |   def linktimeProperty = scala.scalanative.unsafe.resolved
@@ -190,6 +193,7 @@ class LinktimeConditionsSpec extends LinkerSpec with Matchers {
             |}""".stripMargin
       )() { (_, _) => () }
     }
+    caught.getMessage shouldEqual "value resolved at link-time linktimeProperty needs result type"
   }
 
   "Linktime conditions" should "resolve simple conditions" in {
@@ -343,10 +347,10 @@ class LinktimeConditionsSpec extends LinkerSpec with Matchers {
   }
 
   it should "not allow to mix link-time and runtime conditions" in {
-    assertThrows[scala.scalanative.api.CompilationFailedException] {
+    val caught = intercept[scala.scalanative.api.CompilationFailedException] {
       linkWithProps(
         "props.scala" ->
-          """package scala.scalantive
+          """package scala.scalanative
             |
             |object props{
             |   @scalanative.unsafe.resolvedAtLinktime()
@@ -364,6 +368,7 @@ class LinktimeConditionsSpec extends LinkerSpec with Matchers {
            |}""".stripMargin
       )() { (_, _) => () }
     }
+    caught.getMessage shouldEqual "Mixing link-time and runtime conditions is not allowed"
   }
 
   private def shouldContainAll[T](expected: Iterable[T], given: Iterable[T]) = {

--- a/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/StubSpec.scala
@@ -24,7 +24,7 @@ class StubSpec extends LinkerSpec {
                            |}""".stripMargin
 
   "Stub methods" should "be ignored by the linker when `linkStubs = false`" in {
-    link(entry, stubMethodSource, linkStubs = false) { (cfg, result) =>
+    link(entry, stubMethodSource, _.withLinkStubs(false)) { (cfg, result) =>
       assert(!cfg.linkStubs)
       assert(result.unavailable.length == 1)
       assert(
@@ -35,14 +35,14 @@ class StubSpec extends LinkerSpec {
   }
 
   it should "be included when `linkStubs = true`" in {
-    link(entry, stubMethodSource, linkStubs = true) { (cfg, result) =>
+    link(entry, stubMethodSource, _.withLinkStubs(true)) { (cfg, result) =>
       assert(cfg.linkStubs)
       assert(result.unavailable.isEmpty)
     }
   }
 
   "Stub classes" should "be ignored by the linker when `linkStubs = false`" in {
-    link(entry, stubClassSource, linkStubs = false) { (cfg, result) =>
+    link(entry, stubClassSource, _.withLinkStubs(false)) { (cfg, result) =>
       assert(!cfg.linkStubs)
       assert(result.unavailable.length == 1)
       assert(result.unavailable.head == Global.Top("StubClass"))
@@ -50,14 +50,14 @@ class StubSpec extends LinkerSpec {
   }
 
   it should "be included when `linkStubs = true`" in {
-    link(entry, stubClassSource, linkStubs = true) { (cfg, result) =>
+    link(entry, stubClassSource, _.withLinkStubs(true)) { (cfg, result) =>
       assert(cfg.linkStubs)
       assert(result.unavailable.isEmpty)
     }
   }
 
   "Stub modules" should "be ignored by the linker when `linkStubs = false`" in {
-    link(entry, stubModuleSource, linkStubs = false) { (cfg, result) =>
+    link(entry, stubModuleSource, _.withLinkStubs(false)) { (cfg, result) =>
       assert(!cfg.linkStubs)
       assert(result.unavailable.length == 1)
       assert(result.unavailable.head == Global.Top("StubModule$"))
@@ -65,7 +65,7 @@ class StubSpec extends LinkerSpec {
   }
 
   it should "be included when `linkStubs = true`" in {
-    link(entry, stubModuleSource, linkStubs = true) { (cfg, result) =>
+    link(entry, stubModuleSource, _.withLinkStubs(true)) { (cfg, result) =>
       assert(cfg.linkStubs)
       assert(result.unavailable.isEmpty)
     }


### PR DESCRIPTION
This PR adds a new concept to Scala Native by allowing to define values resolved at link-time. Based on that we're able to define link-time conditions allowing us to discard unused execution branches while performing class loading, before performing static reachability analysis.
When performing linking values can be resolved based on values defined in `NativeConfig` in form of `Map[String, Any]` with runtime checks limiting allowed values to non-empty strings and non-null primitives. In case if the property is not defined linking would fail. Link time property needs to be non-null literal. It also needs to define the explicit return type and keep `resolved` at its right-hand side in the same manner as it's done with extern defintions.

Link time conditions are based on `if-else` clauses. Runtime branching is replaced with link-time if the value used in the condition is annotated with `@resolvedAtLinktime` annotation. In the case of usage of mixed runtime and link-time resolved values, a compile-time error is being thrown.

Example of usage:
```
import scalantive.unsafe.{resolvedAtLinktime, resolved}

object Test {

  // linktime value resolved from property `Test.boolProp` 
  @resolvedAtLinktime
  def boolProp: Boolean = resolved

  // linktime value resolved from property `my.string.prop`
  @resolvedAtLinktime(withName = "my.string.prop")
  def stringProp: String = resolved

  @resolvedAtLinktime()
  def intProp: Int = resolved

  def main(args: Array[String]): Unit = {
   val x = if(!boolProp) path1()
    else if(intProp > 2 && intProp <= 10) path2()
    else path3()

    if(stringProp == "") ()
    else println(stringProp)
  }
}
```