### PR TITLE
Upgrade build to sbt 1.4.9

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.7
+sbt.version = 1.4.9


### PR DESCRIPTION
Sbt 1.4.9 [Release Notes](https://github.com/sbt/sbt/releases/tag/v1.4.9).

A week after release, no issues in sbt gitter, no issues with moderate
personal use developing Scala Native.