### PR TITLE
Fix 2209: GitHub action checkout versions are now consistent.

### DIFF
--- a/.github/workflows/check-cla.yml
+++ b/.github/workflows/check-cla.yml
@@ -4,5 +4,5 @@ jobs:
   check-cla:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: ./scripts/check-cla.sh

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -8,7 +8,7 @@ jobs:
   check-lint:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: ./scripts/check-lint.sh
         env:
           CLANG_FORMAT_PATH: "/usr/lib/llvm-6.0/bin/clang-format"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         scala: [2.13.4, 2.12.13, 2.11.12]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8


### PR DESCRIPTION
Workflows now consistently use contemporary `actions/checkout@v2`.