### PR TITLE
Corrects bug in named semaphores length for commix garbage collector

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/commix/Phase.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Phase.c
@@ -8,13 +8,13 @@
 
 void Phase_Init(Heap *heap, uint32_t initialBlockCount) {
     pid_t pid = getpid();
-    // size = static part + 32 bit int as string
-    char startWorkersName[32 + 10];
-    char startMasterName[31 + 10];
-    snprintf(startWorkersName, 32 + 10, "scalanative_commix_startWorkers_%d",
-             pid);
-    snprintf(startMasterName, 31 + 10, "scalanative_commix_startMaster_%d",
-             pid);
+    // size = static part + 10 digits (0xFFFFFFFC as maximum PID) + null char
+    int workerNameSize = 21 + 10 + 1;
+    int masterNameSize = 20 + 10 + 1;
+    char startWorkersName[workerNameSize];
+    char startMasterName[masterNameSize];
+    snprintf(startWorkersName, workerNameSize, "commix_startWorkers_%d", pid);
+    snprintf(startMasterName, masterNameSize, "commix_startMaster_%d", pid);
     // only reason for using named semaphores here is for compatibility with
     // MacOs we do not share them across processes
     heap->gcThreads.startWorkers =

--- a/nativelib/src/main/resources/scala-native/gc/commix/Phase.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Phase.c
@@ -8,13 +8,13 @@
 
 void Phase_Init(Heap *heap, uint32_t initialBlockCount) {
     pid_t pid = getpid();
-    // size = static part + 10 digits (0xFFFFFFFC as maximum PID) + null char
-    int workerNameSize = 21 + 10 + 1;
-    int masterNameSize = 20 + 10 + 1;
+    // size = static part + 20 digits (maximum 64 bit number) + null char
+    int workerNameSize = 11 + 20 + 1;
+    int masterNameSize = 11 + 20 + 1;
     char startWorkersName[workerNameSize];
     char startMasterName[masterNameSize];
-    snprintf(startWorkersName, workerNameSize, "commix_startWorkers_%d", pid);
-    snprintf(startMasterName, masterNameSize, "commix_startMaster_%d", pid);
+    snprintf(startWorkersName, workerNameSize, "commix_mt_%d", pid);
+    snprintf(startMasterName, masterNameSize, "commix_wk_%d", pid);
     // only reason for using named semaphores here is for compatibility with
     // MacOs we do not share them across processes
     heap->gcThreads.startWorkers =


### PR DESCRIPTION
## What

Shortens the names for the commix GC semaphores.

Solves a problem with `_.toDouble` and `_.toFloat` on OSX, for all versions of Scala (see #2200 for context).

## Why
The `commix` garbage collector was polluting `errno` due to the semaphores not being created correctly with `sem_open` (and successive calls trying to manage them), due to the excessive length of their names. And the errno is checked by [other methods](https://github.com/scala-native/scala-native/blob/15ea60eef45c6263cbb7b736c66eec72c3ab51e6/javalib/src/main/scala/java/lang/IEEE754Helpers.scala#L65).

According to the Apple libc [docs](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/sem_open.2.html) for `sem_open`, if the semaphores are more than `SEM_NAME_LEN` characters, the method returns -1 and sets `errno` to `ENAMETOOLONG`.

There are not official sources of documentation for the value for `SEM_NAME_LEN` is OSX, although this StackOverflow [post](https://stackoverflow.com/questions/5288671/sem-open-sets-enametoolong-for-less-than-64-characters-names-on-mac-os-x-10-6-6) answer suggests is 31. [This](https://mail-index.netbsd.org/tech-userlevel/2016/04/23/msg009896.html) other source does also. It holds with the fact that the snippet in #2200 does execute correctly for Scala after the changes.

The GC kicked off after a few iterations in the aforementioned snippet, which explains why it was failing on a given number of loops.

Closes #2200.