### PR TITLE
Implement nativelib Platform.isLinux method.

### DIFF
--- a/nativelib/src/main/resources/scala-native/platform.c
+++ b/nativelib/src/main/resources/scala-native/platform.c
@@ -4,6 +4,14 @@
 #include <sys/utsname.h>
 #endif
 
+int scalanative_platform_is_linux() {
+#ifdef __linux__
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 int scalanative_platform_is_mac() {
 #ifdef __APPLE__
     return 1;

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
@@ -5,6 +5,9 @@ import scala.scalanative.unsafe.{CInt, CString, CFuncPtr2, Ptr, extern, name}
 
 @extern
 object Platform {
+  @name("scalanative_platform_is_linux")
+  def isLinux(): Boolean = extern
+
   @name("scalanative_platform_is_mac")
   def isMac(): Boolean = extern
 


### PR DESCRIPTION
Platform.isLinux is added to extend the existing isMac and
isWindows methods. scala.util.Properties.isLinux is not
available in Scala 2.11.

This PR is required in order to fix Issue #2217,  a macOS-only defect in
ResourceTest.scala. 