### PR TITLE
Makes dirent.c more readable and returns -1 only on empty dir

### DIFF
--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -35,12 +35,10 @@ object FileHelpers {
             }
           }
           closedir(dir)
-          res match {
-            case e if e == -1 =>
-              buffer.toArray
-            case _ =>
-              throw UnixException(path, res)
-          }
+          if (res == -1)
+            buffer.toArray
+          else
+            throw UnixException(path, res)
         }
       }
   }

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -36,9 +36,10 @@ object FileHelpers {
           }
           closedir(dir)
           res match {
-            case e if e == EBADF || e == EFAULT || e == EIO =>
+            case e if e == -1 =>
+              buffer.toArray
+            case _ =>
               throw UnixException(path, res)
-            case _ => buffer.toArray
           }
         }
       }

--- a/posixlib/src/main/resources/scala-native/dirent.c
+++ b/posixlib/src/main/resources/scala-native/dirent.c
@@ -31,6 +31,7 @@ void scalanative_dirent_init(struct dirent *dirent,
     my_dirent->d_type = dirent->d_type;
 }
 
+// returns 0 in case of success, -1 in case of empty dir, errno otherwise
 int scalanative_readdir(DIR *dirp, struct scalanative_dirent *buf) {
     errno = 0;
     struct dirent *orig_buf = readdir(dirp);

--- a/posixlib/src/main/resources/scala-native/dirent.c
+++ b/posixlib/src/main/resources/scala-native/dirent.c
@@ -34,20 +34,16 @@ void scalanative_dirent_init(struct dirent *dirent,
 int scalanative_readdir(DIR *dirp, struct scalanative_dirent *buf) {
     errno = 0;
     struct dirent *orig_buf = readdir(dirp);
-    if (orig_buf != NULL) {
+    int result = 0;
+
+    if (orig_buf != NULL)
         scalanative_dirent_init(orig_buf, buf);
-        return 0;
-    } else {
-        switch (errno) {
-        case EBADF:
-            return EBADF;
-        case EFAULT:
-            return EFAULT;
-        case EIO:
-            return EIO;
-        }
-        return -1;
-    }
+    else if (errno == 0)
+        result = -1;
+    else
+        result = errno;
+
+    return result;
 }
 
 int scalanative_closedir(DIR *dirp) { return closedir(dirp); }


### PR DESCRIPTION
Makes the native implementation for readdir return -1 only if the directory is empty, otherwise `errno`. Simplifies the code a bit to avoid early returns.

Closes #2001