### PR TITLE
Introduced a way to construct user's event loop.

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/ExecutionContext.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ExecutionContext.scala
@@ -14,8 +14,8 @@ object ExecutionContext {
 
   private val queue: ListBuffer[Runnable] = new ListBuffer
 
-  private[runtime] def loop(): Unit = {
-    while (queue.nonEmpty) {
+  private[runtime] def once(): Boolean = {
+    if (queue.nonEmpty) {
       val runnable = queue.remove(0)
       try {
         runnable.run()
@@ -24,5 +24,11 @@ object ExecutionContext {
           QueueExecutionContext.reportFailure(t)
       }
     }
+    queue.nonEmpty
   }
+
+  private[runtime] def loop(): Unit =
+    while ({
+      once()
+    }) ()
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -42,6 +42,12 @@ package object runtime {
   @noinline def loop(): Unit =
     ExecutionContext.loop()
 
+  /** Run the runtime's event loop only once. The method is called from the
+   *  generated C-style event loop the application's main method.
+   */
+  @noinline def once(): Boolean =
+    ExecutionContext.once()
+
   /** Called by the generated code in case of division by zero. */
   @noinline def throwDivisionByZero(): Nothing =
     throw new java.lang.ArithmeticException("/ by zero")


### PR DESCRIPTION
Here a tricky commit that allows to enduser to construct his own event loop which can includes `epoll`, `poll`, libuv's `poll` or whatever he would like to use.

Right now such event loop can be constructed via direct access to `queue` inside `scala.scalanative.runtime.ExecutionContext` via magic of pointers because scala-native hasn't got any reflection (yet?).

Thus, after this changes `scala-native-loop` event loop will be something like:
```
  def run(): Unit = {
    while ({
      val hasNext = scala.scalanative.runtime.once()
      if (hasNext) {
        uv_run(loop, UV_RUN_NOWAIT)
      } else {
        uv_run(loop, UV_RUN_ONCE)
      }
      uv_loop_alive(loop) || hasNext
    })()
  }
```