### PR TITLE
Make it explicit that Unix FileAttributeView is provided by Posix calls.

### DIFF
--- a/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystemProvider.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystemProvider.scala
@@ -151,11 +151,10 @@ class UnixFileSystemProvider extends FileSystemProvider {
              (Path, Array[LinkOption]) => FileAttributeView] =
     SMap(
       classOf[BasicFileAttributeView] -> ((p, l) =>
-        new NativePosixFileAttributeView(p, l)),
+        new PosixFileAttributeViewImpl(p, l)),
       classOf[PosixFileAttributeView] -> ((p, l) =>
-        new NativePosixFileAttributeView(p, l)),
+        new PosixFileAttributeViewImpl(p, l)),
       classOf[FileOwnerAttributeView] -> ((p, l) =>
-        new NativePosixFileAttributeView(p, l))
+        new PosixFileAttributeViewImpl(p, l))
     )
-
 }


### PR DESCRIPTION
Use a more accurate file name and location for a class which is private
in Java 8.

This PR is a follow up to and uses recently merged PR #2198. As
explained in that PR, this PR lays the ground work for a successor
to long standing PR #1609.  Fixing the problem addressed by PR #1609
still has value.