### PR TITLE
Performs better checks in commix semaphore operations

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/commix/GCThread.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/GCThread.c
@@ -79,7 +79,8 @@ void *GCThread_loop(void *arg) {
     while (true) {
         thread->active = false;
         if (sem_wait(start) != 0) {
-            perror("Acquiring semaphore failed in commix GCThread_loop");
+            fprintf(stderr,
+                    "Acquiring semaphore failed in commix GCThread_loop\n");
             exit(errno);
         }
         // hard fence before proceeding with the next phase
@@ -112,7 +113,9 @@ void *GCThread_loopMaster(void *arg) {
     while (true) {
         thread->active = false;
         if (sem_wait(start) != 0) {
-            perror("Acquiring semaphore failed in commix GCThread_loopMaster");
+            fprintf(
+                stderr,
+                "Acquiring semaphore failed in commix GCThread_loopMaster\n");
             exit(errno);
         }
         // hard fence before proceeding with the next phase
@@ -178,7 +181,8 @@ int GCThread_ActiveCount(Heap *heap) {
 
 INLINE void GCThread_WakeMaster(Heap *heap) {
     if (sem_post(heap->gcThreads.startMaster) != 0) {
-        perror("Releasing semaphore failed in commix GCThread_WakeMaster");
+        fprintf(stderr,
+                "Releasing semaphore failed in commix GCThread_WakeMaster\n");
         exit(errno);
     }
 }
@@ -187,7 +191,9 @@ INLINE void GCThread_WakeWorkers(Heap *heap, int toWake) {
     sem_t *startWorkers = heap->gcThreads.startWorkers;
     for (int i = 0; i < toWake; i++) {
         if (sem_post(startWorkers) != 0) {
-            perror("Releasing semaphore failed in commix GCThread_WakeWorkers");
+            fprintf(
+                stderr,
+                "Releasing semaphore failed in commix GCThread_WakeWorkers\n");
             exit(errno);
         }
     }

--- a/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
@@ -27,7 +27,7 @@
 #define HEAP_MEM_FD_OFFSET 0
 
 void Heap_exitWithOutOfMemory() {
-    printf("Out of heap space\n");
+    fprintf(stderr, "Out of heap space\n");
     StackTrace_PrintStackTrace();
     exit(1);
 }

--- a/nativelib/src/main/resources/scala-native/gc/commix/Phase.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Phase.c
@@ -25,24 +25,28 @@ void Phase_Init(Heap *heap, uint32_t initialBlockCount) {
     heap->gcThreads.startWorkers =
         sem_open(startWorkersName, O_CREAT | O_EXCL, 0644, 0);
     if (heap->gcThreads.startWorkers == SEM_FAILED) {
-        perror("Opening worker semaphore failed in commix Phase_Init");
+        fprintf(stderr,
+                "Opening worker semaphore failed in commix Phase_Init\n");
         exit(errno);
     }
 
     heap->gcThreads.startMaster =
         sem_open(startMasterName, O_CREAT | O_EXCL, 0644, 0);
     if (heap->gcThreads.startMaster == SEM_FAILED) {
-        perror("Opening master semaphore failed in commix Phase_Init");
+        fprintf(stderr,
+                "Opening master semaphore failed in commix Phase_Init\n");
         exit(errno);
     }
     // clean up when process closes
     // also prevents any other process from `sem_open`ing it
     if (sem_unlink(startWorkersName) != 0) {
-        perror("Unlinking worker semaphore failed in commix Phase_Init");
+        fprintf(stderr,
+                "Unlinking worker semaphore failed in commix Phase_Init\n");
         exit(errno);
     }
     if (sem_unlink(startMasterName) != 0) {
-        perror("Unlinking master semaphore failed in commix Phase_Init");
+        fprintf(stderr,
+                "Unlinking master semaphore failed in commix Phase_Init\n");
         exit(errno);
     }
 

--- a/nativelib/src/main/resources/scala-native/gc/commix/Phase.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Phase.c
@@ -18,7 +18,6 @@ void Phase_Init(Heap *heap, uint32_t initialBlockCount) {
     char startMasterName[masterNameSize];
     snprintf(startWorkersName, workerNameSize, "commix_mt_%d", pid);
     snprintf(startMasterName, masterNameSize, "commix_wk_%d", pid);
-
     // only reason for using named semaphores here is for compatibility with
     // MacOs we do not share them across processes
     // We open the semaphores and try to check the call succeeded,

--- a/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
@@ -23,7 +23,7 @@
 #define HEAP_MEM_FD_OFFSET 0
 
 void Heap_exitWithOutOfMemory() {
-    printf("Out of heap space\n");
+    fprintf(stderr, "Out of heap space\n");
     StackTrace_PrintStackTrace();
     exit(1);
 }


### PR DESCRIPTION
The `commix` garbage collector performs operations on semaphores (`sem_open`, `sem_wait` or `sem_post`). This PR adds assertions and prints to the stderr on those, exiting the process with `errno` if they fail.

Uses `fprintf` to `stderr` instead of `perror` for consistency with other checks already done in the garbage collector (see [this](https://github.com/scala-native/scala-native/blob/cda609582a1dfdc119bb85b6cf811918e065c0d6/nativelib/src/main/resources/scala-native/gc/commix/Heap.c#L101) for an example)

Closes #2220