### PR TITLE
Refactor build to compile each project and ll separately

### DIFF
--- a/nativelib/src/main/resources/org_scala-native_nativelib.txt
+++ b/nativelib/src/main/resources/org_scala-native_nativelib.txt
@@ -1,1 +1,0 @@
-Marker file to guarantee we can find the nativelib

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -79,9 +79,10 @@ object Build {
 
         // compile nativelib
         val nativelibObjectPaths = {
-          val nativelibPath = LLVM.unpackNativeCode(nativelib)
+          val destPath = LLVM.unpackNativeCode(nativelib)
+          val paths = NativeLib.findNativePaths(workdir, destPath)
           val nativelibPaths =
-            LLVM.filterNativelib(fconfig, linked, nativelibPath)
+            LLVM.filterNativelib(fconfig, linked, destPath, paths)
           LLVM.compile(fconfig, nativelibPaths)
         }
 

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -75,7 +75,7 @@ object Build {
         val libObjectPaths = otherlibs
           .map(nl => LLVM.unpackNativeCode(nl))
           .map(destPath => NativeLib.findNativePaths(workdir, destPath))
-          .map(paths => LLVM.compile(fconfig, paths.map(_.abs)))
+          .map(paths => LLVM.compile(fconfig, paths))
           .flatten
 
         // compile nativelib
@@ -83,11 +83,11 @@ object Build {
           val nativelibPath = LLVM.unpackNativeCode(nativelib)
           val nativelibPaths =
             LLVM.filterNativelib(fconfig, linked, nativelibPath)
-          LLVM.compile(fconfig, nativelibPaths.map(_.abs))
+          LLVM.compile(fconfig, nativelibPaths)
         }
 
         // compile generated ll
-        val llObjectPaths = LLVM.compile(fconfig, generated.map(_.abs))
+        val llObjectPaths = LLVM.compile(fconfig, generated)
 
         libObjectPaths ++ nativelibObjectPaths ++ llObjectPaths
       }

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -72,9 +72,10 @@ object Build {
           .map(nl => NativeLib.unpackNativeCode(nl))
           .map(destPath => {
             val paths = NativeLib.findNativePaths(workdir, destPath)
-            Filter.filterNativelib(fconfig, linked, destPath, paths)
+            val (projPaths, projConfig) =
+              Filter.filterNativelib(fconfig, linked, destPath, paths)
+            LLVM.compile(projConfig, projPaths)
           })
-          .map(filteredPaths => LLVM.compile(fconfig, filteredPaths))
           .flatten
 
         // compile generated ll

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -69,7 +69,7 @@ object Build {
 
         // compile all libs
         val libObjectPaths = nativelibs
-          .map(nl => LLVM.unpackNativeCode(nl))
+          .map(nl => NativeLib.unpackNativeCode(nl))
           .map(destPath => {
             val paths = NativeLib.findNativePaths(workdir, destPath)
             LLVM.filterNativelib(fconfig, linked, destPath, paths)

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -80,7 +80,7 @@ object Build {
         // compile nativelib
         val nativelibObjectPaths = {
           val destPath = LLVM.unpackNativeCode(nativelib)
-          val paths = NativeLib.findNativePaths(workdir, destPath)
+          val paths    = NativeLib.findNativePaths(workdir, destPath)
           val nativelibPaths =
             LLVM.filterNativelib(fconfig, linked, destPath, paths)
           LLVM.compile(fconfig, nativelibPaths)

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -69,13 +69,13 @@ object Build {
 
         // compile all libs
         val libObjectPaths = nativelibs
-          .map(nl => NativeLib.unpackNativeCode(nl))
-          .map(destPath => {
+          .map { NativeLib.unpackNativeCode }
+          .map { destPath =>
             val paths = NativeLib.findNativePaths(workdir, destPath)
             val (projPaths, projConfig) =
               Filter.filterNativelib(fconfig, linked, destPath, paths)
             LLVM.compile(projConfig, projPaths)
-          })
+          }
           .flatten
 
         // compile generated ll

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -72,7 +72,7 @@ object Build {
           .map(nl => NativeLib.unpackNativeCode(nl))
           .map(destPath => {
             val paths = NativeLib.findNativePaths(workdir, destPath)
-            LLVM.filterNativelib(fconfig, linked, destPath, paths)
+            Filter.filterNativelib(fconfig, linked, destPath, paths)
           })
           .map(filteredPaths => LLVM.compile(fconfig, filteredPaths))
           .flatten

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -3,7 +3,6 @@ package build
 
 import java.nio.file.{Files, Path}
 import scala.scalanative.util.Scope
-import scalanative.build.IO.RichPath // until reverted to Path
 
 /** Utility methods for building code using Scala Native. */
 object Build {

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -72,7 +72,7 @@ private[scalanative] object Filter {
    * Check for a filtering properties file in destination
    * native code directory.
    *
-   * @param codePath The native code directory
+   * @param nativeCodePath The native code directory
    * @return The optional path to the file or none
    */
   private def findFilterProperties(nativeCodePath: Path): Option[Path] = {

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -1,0 +1,79 @@
+package scala.scalanative
+package build
+
+import java.nio.file.{Files, Path, Paths}
+import scalanative.build.IO.RichPath
+
+object Filter {
+
+  /** To find filter file */
+  private val filterProperties = s"${NativeLib.codeDir}-filter.properties"
+
+  /**
+   * Filter the `nativelib` source files with special logic
+   * to select GC and optional components.
+   *
+   * @param config The configuration of the toolchain.
+   * @param linkerResult The results from the linker.
+   * @param destPath The unpacked location of the Scala Native nativelib.
+   * @param allPaths The native paths found for this library
+   * @return The paths filtered to be included in the compile.
+   */
+  def filterNativelib(config: Config,
+                      linkerResult: linker.Result,
+                      destPath: Path,
+                      allPaths: Seq[Path]): Seq[Path] = {
+    val codePath = destPath.resolve(NativeLib.codeDir)
+    // check if filtering is needed, o.w. return all paths
+    findFilterProperties(codePath) match {
+      case None => allPaths
+      case Some(file) =>
+        val paths = allPaths.map(_.abs)
+
+        // predicate to check if given file path shall be compiled
+        // we only include sources of the current gc and exclude
+        // all optional dependencies if they are not necessary
+        val optPath = codePath.resolve("optional").abs
+        val (gcPath, gcSelPath) = {
+          val gcPath    = codePath.resolve("gc")
+          val gcSelPath = gcPath.resolve(config.gc.name)
+          (gcPath.abs, gcSelPath.abs)
+        }
+
+        def include(path: String) = {
+          if (path.contains(optPath)) {
+            val name = Paths.get(path).toFile.getName.split("\\.").head
+            linkerResult.links.map(_.name).contains(name)
+          } else if (path.contains(gcPath)) {
+            path.contains(gcSelPath)
+          } else {
+            true
+          }
+        }
+
+        val (includePaths, excludePaths) = paths.partition(include(_))
+
+        // delete .o files for all excluded source files
+        excludePaths.foreach { path =>
+          val opath = Paths.get(path + oExt) // path.resolve
+          if (Files.exists(opath))
+            Files.delete(opath)
+        }
+
+        includePaths.map(Paths.get(_))
+    }
+  }
+
+  /**
+   * Check for a filtering properties file in destination
+   * native code directory.
+   *
+   * @param codePath The native code directory
+   * @return The optional path to the file or none
+   */
+  private def findFilterProperties(codePath: Path): Option[Path] = {
+    val file = codePath.resolve(filterProperties)
+    if (Files.exists(file)) Some(file)
+    else None
+  }
+}

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -27,8 +27,6 @@ object Filter {
     val codePath = destPath.resolve(codeDir)
     // check if filtering is needed, o.w. return all paths
     findFilterProperties(codePath).fold(allPaths) { file =>
-      val paths = allPaths.map(_.abs)
-
       // predicate to check if given file path shall be compiled
       // we only include sources of the current gc and exclude
       // all optional dependencies if they are not necessary
@@ -41,7 +39,7 @@ object Filter {
 
       def include(path: String) = {
         if (path.contains(optPath)) {
-          val name = Paths.get(path).toFile.getName.split("\\.").head
+          val name = Paths.get(path).toFile.getName.split(".").head
           linkerResult.links.map(_.name).contains(name)
         } else if (path.contains(gcPath)) {
           path.contains(gcSelPath)
@@ -50,13 +48,13 @@ object Filter {
         }
       }
 
-      val (includePaths, excludePaths) = paths.partition(include(_))
+      val (includePaths, excludePaths) =
+        allPaths.map(_.abs).partition(include(_))
 
       // delete .o files for all excluded source files
       excludePaths.foreach { path =>
-        val opath = Paths.get(path + oExt) // path.resolve
-        if (Files.exists(opath))
-          Files.delete(opath)
+        val opath = Paths.get(path + oExt)
+        Files.deleteIfExists(opath)
       }
 
       includePaths.map(Paths.get(_))

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -62,7 +62,8 @@ private[scalanative] object Filter {
         Files.deleteIfExists(opath)
       }
       val projectConfig = config.withCompilerConfig(
-        _.withCompileOptions(config.compileOptions ++ gcIncludePaths.map("-I" + _)))
+        _.withCompileOptions(
+          config.compileOptions ++ gcIncludePaths.map("-I" + _)))
       val projectPaths = includePaths.map(Paths.get(_))
       (projectPaths, projectConfig)
     }

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -26,42 +26,40 @@ object Filter {
                       allPaths: Seq[Path]): Seq[Path] = {
     val codePath = destPath.resolve(codeDir)
     // check if filtering is needed, o.w. return all paths
-    findFilterProperties(codePath) match {
-      case None => allPaths
-      case Some(file) =>
-        val paths = allPaths.map(_.abs)
+    findFilterProperties(codePath).fold(allPaths) { file =>
+      val paths = allPaths.map(_.abs)
 
-        // predicate to check if given file path shall be compiled
-        // we only include sources of the current gc and exclude
-        // all optional dependencies if they are not necessary
-        val optPath = codePath.resolve("optional").abs
-        val (gcPath, gcSelPath) = {
-          val gcPath    = codePath.resolve("gc")
-          val gcSelPath = gcPath.resolve(config.gc.name)
-          (gcPath.abs, gcSelPath.abs)
+      // predicate to check if given file path shall be compiled
+      // we only include sources of the current gc and exclude
+      // all optional dependencies if they are not necessary
+      val optPath = codePath.resolve("optional").abs
+      val (gcPath, gcSelPath) = {
+        val gcPath    = codePath.resolve("gc")
+        val gcSelPath = gcPath.resolve(config.gc.name)
+        (gcPath.abs, gcSelPath.abs)
+      }
+
+      def include(path: String) = {
+        if (path.contains(optPath)) {
+          val name = Paths.get(path).toFile.getName.split("\\.").head
+          linkerResult.links.map(_.name).contains(name)
+        } else if (path.contains(gcPath)) {
+          path.contains(gcSelPath)
+        } else {
+          true
         }
+      }
 
-        def include(path: String) = {
-          if (path.contains(optPath)) {
-            val name = Paths.get(path).toFile.getName.split("\\.").head
-            linkerResult.links.map(_.name).contains(name)
-          } else if (path.contains(gcPath)) {
-            path.contains(gcSelPath)
-          } else {
-            true
-          }
-        }
+      val (includePaths, excludePaths) = paths.partition(include(_))
 
-        val (includePaths, excludePaths) = paths.partition(include(_))
+      // delete .o files for all excluded source files
+      excludePaths.foreach { path =>
+        val opath = Paths.get(path + oExt) // path.resolve
+        if (Files.exists(opath))
+          Files.delete(opath)
+      }
 
-        // delete .o files for all excluded source files
-        excludePaths.foreach { path =>
-          val opath = Paths.get(path + oExt) // path.resolve
-          if (Files.exists(opath))
-            Files.delete(opath)
-        }
-
-        includePaths.map(Paths.get(_))
+      includePaths.map(Paths.get(_))
     }
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -3,11 +3,12 @@ package build
 
 import java.nio.file.{Files, Path, Paths}
 import scalanative.build.IO.RichPath
+import scalanative.build.NativeLib._
 
 object Filter {
 
   /** To find filter file */
-  private val filterProperties = s"${NativeLib.codeDir}-filter.properties"
+  private val filterProperties = s"${codeDir}-filter.properties"
 
   /**
    * Filter the `nativelib` source files with special logic
@@ -23,7 +24,7 @@ object Filter {
                       linkerResult: linker.Result,
                       destPath: Path,
                       allPaths: Seq[Path]): Seq[Path] = {
-    val codePath = destPath.resolve(NativeLib.codeDir)
+    val codePath = destPath.resolve(codeDir)
     // check if filtering is needed, o.w. return all paths
     findFilterProperties(codePath) match {
       case None => allPaths

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -10,7 +10,7 @@ import scalanative.build.LLVM._
 private[scalanative] object Filter {
 
   /** To find filter file */
-  private val filterProperties = s"${codeDir}-filter.properties"
+  private val filterProperties = s"${codeDir}.properties"
 
   /**
    * Filter the `nativelib` source files with special logic

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -62,7 +62,7 @@ private[scalanative] object Filter {
         Files.deleteIfExists(opath)
       }
       val projectConfig = config.withCompilerConfig(
-        _.withCompileOptions(gcIncludePaths.map("-I" + _)))
+        _.withCompileOptions(config.compileOptions ++ gcIncludePaths.map("-I" + _)))
       val projectPaths = includePaths.map(Paths.get(_))
       (projectPaths, projectConfig)
     }

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -2,10 +2,12 @@ package scala.scalanative
 package build
 
 import java.nio.file.{Files, Path, Paths}
+
 import scalanative.build.IO.RichPath
 import scalanative.build.NativeLib._
+import scalanative.build.LLVM._
 
-object Filter {
+private[scalanative] object Filter {
 
   /** To find filter file */
   private val filterProperties = s"${codeDir}-filter.properties"

--- a/tools/src/main/scala/scala/scalanative/build/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Filter.scala
@@ -39,7 +39,7 @@ object Filter {
 
       def include(path: String) = {
         if (path.contains(optPath)) {
-          val name = Paths.get(path).toFile.getName.split(".").head
+          val name = Paths.get(path).toFile.getName.split("\\.").head
           linkerResult.links.map(_.name).contains(name)
         } else if (path.contains(gcPath)) {
           path.contains(gcSelPath)

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -25,7 +25,7 @@ private[scalanative] object LLVM {
       val isCpp   = inpath.endsWith(cppExt)
       val isLl    = inpath.endsWith(llExt)
       val objPath = Paths.get(outpath)
-      // scripted tests fail if LL not rebuilt
+      // LL is generated so always rebuild
       if (isLl || !Files.exists(objPath)) {
         val compiler = if (isCpp) config.clangPP.abs else config.clang.abs
         val stdflag =

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -140,7 +140,7 @@ private[scalanative] object LLVM {
    * @param paths The directory paths containing native files to compile.
    * @return The paths of the `.o` files.
    */
-  def compile(config: Config, paths: Seq[String]): Seq[Path] = {
+  def compile(config: Config, paths: Seq[Path]): Seq[Path] = {
     val optimizationOpt =
       config.mode match {
         case Mode.Debug       => "-O0"
@@ -150,11 +150,12 @@ private[scalanative] object LLVM {
 
     // generate .o files for all included source files in parallel
     paths.par.map { path =>
-      val opath   = path + oExt
-      val objPath = Paths.get(opath)
+      val inpath  = path.abs
+      val outpath = inpath + oExt
+      val isCpp   = inpath.endsWith(cppExt)
+      val isLl    = inpath.endsWith(llExt)
+      val objPath = Paths.get(outpath)
       if (!Files.exists(objPath)) {
-        val isCpp    = path.endsWith(cppExt)
-        val isLl     = path.endsWith(llExt)
         val compiler = if (isCpp) config.clangPP.abs else config.clang.abs
         val stdflag =
           if (isLl) "" else if (isCpp) "-std=c++11" else "-std=gnu11"

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -4,7 +4,6 @@ package build
 import java.nio.file.{Files, Path, Paths}
 import scala.sys.process._
 import scalanative.build.IO.RichPath
-import scalanative.build.NativeLib._
 import scalanative.compat.CompatParColls.Converters._
 
 /** Internal utilities to interact with LLVM command-line tools. */

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -148,7 +148,8 @@ private[scalanative] object LLVM {
       val isCpp   = inpath.endsWith(cppExt)
       val isLl    = inpath.endsWith(llExt)
       val objPath = Paths.get(outpath)
-      if (!Files.exists(objPath)) {
+      // always rebuild ll
+      if (isLl || !Files.exists(objPath)) {
         val compiler = if (isCpp) config.clangPP.abs else config.clang.abs
         val stdflag =
           if (isLl) "" else if (isCpp) "-std=c++11" else "-std=gnu11"

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -10,6 +10,18 @@ import scalanative.compat.CompatParColls.Converters._
 /** Internal utilities to interact with LLVM command-line tools. */
 private[scalanative] object LLVM {
 
+  /** Object file extension: ".o" */
+  val oExt = ".o"
+
+  /** C++ file extension: ".cpp" */
+  val cppExt = ".cpp"
+
+  /** LLVM intermediate file extension: ".ll" */
+  val llExt = ".ll"
+
+  /** List of source patterns used: ".c, .cpp, .S" */
+  val srcExtensions = Seq(".c", cppExt, ".S")
+
   /**
    * Compile the given files to object files
    *

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -40,7 +40,7 @@ private[scalanative] object LLVM {
         val result = Process(compilec, config.workdir.toFile) ! Logger
           .toProcessLogger(config.logger)
         if (result != 0) {
-          sys.error("Failed to compile ll or native code.")
+          sys.error(s"Failed to compile ${inpath}")
         }
       }
       objPath

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -41,8 +41,10 @@ private[scalanative] object LLVM {
       if (isLl || !Files.exists(objPath)) {
         val compiler = if (isCpp) config.clangPP.abs else config.clang.abs
         val stdflag =
-          if (isLl) "" else if (isCpp) "-std=c++11" else "-std=gnu11"
-        val flags = opt(config) +: stdflag +: "-fvisibility=hidden" +:
+          if (isLl) Seq()
+          else if (isCpp) Seq("-std=c++11")
+          else Seq("-std=gnu11")
+        val flags = opt(config) +: stdflag ++: "-fvisibility=hidden" +:
           config.compileOptions
         val compilec =
           Seq(compiler) ++ flto(config) ++ flags ++ target(config) ++

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -148,7 +148,7 @@ private[scalanative] object LLVM {
       val isCpp   = inpath.endsWith(cppExt)
       val isLl    = inpath.endsWith(llExt)
       val objPath = Paths.get(outpath)
-      // always rebuild ll
+      // scripted tests fail if LL not rebuilt
       if (isLl || !Files.exists(objPath)) {
         val compiler = if (isCpp) config.clangPP.abs else config.clang.abs
         val stdflag =

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -45,8 +45,8 @@ private[scalanative] object LLVM {
         val flags = opt(config) +: stdflag +: "-fvisibility=hidden" +:
           config.compileOptions
         val compilec =
-          Seq(compiler) ++ flto(config) ++ flags ++ target(config) ++ includeOpt ++
-            Seq("-c", path, "-o", opath)
+          Seq(compiler) ++ flto(config) ++ flags ++ target(config) ++
+            Seq("-c", inpath, "-o", outpath)
 
         config.logger.running(compilec)
         val result = Process(compilec, config.workdir.toFile) ! Logger

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -11,68 +11,6 @@ import scalanative.compat.CompatParColls.Converters._
 private[scalanative] object LLVM {
 
   /**
-   * Filter the `nativelib` source files with special logic
-   * to select GC and optional components.
-   *
-   * @param config The configuration of the toolchain.
-   * @param linkerResult The results from the linker.
-   * @param destPath The unpacked location of the Scala Native nativelib.
-   * @param allPaths The native paths found for this library
-   * @return The paths filtered to be included in the compile.
-   */
-  def filterNativelib(config: Config,
-                      destPath: Path,
-                      allPaths: Seq[Path]): Seq[Path] = {
-    val codePath = destPath.resolve(NativeLib.codeDir)
-    // check if filtering is needed, o.w. return all paths
-    NativeLib.findFilterProperties(codePath) match {
-      case None => allPaths
-      case Some(file) =>
-        val paths = allPaths.map(_.abs)
-
-        // predicate to check if given file path shall be compiled
-        // we only include sources of the current gc and exclude
-        // all optional dependencies if they are not necessary
-        val optPath = codePath.resolve("optional").abs
-        val (gcPath, gcIncludePaths, gcSelectedPaths) = {
-          val gcPath         = codePath.resolve("gc")
-          val gcIncludePaths = config.gc.include.map(gcPath.resolve(_).abs)
-          val selectedGC     = gcPath.resolve(config.gc.name).abs
-          val selectedGCPath = selectedGC +: gcIncludePaths
-          (gcPath.abs, gcIncludePaths, selectedGCPath)
-        }
-
-        def include(path: String) = {
-          if (path.contains(optPath)) {
-            val name = Paths.get(path).toFile.getName.split("\\.").head
-            linkerResult.links.map(_.name).contains(name)
-          } else if (path.contains(gcPath)) {
-            gcSelectedPaths.exists(path.contains)
-          } else {
-            true
-          }
-        }
-
-        val (includePaths, excludePaths) = paths.partition(include(_))
-
-        // delete .o files for all excluded source files
-        // avoids deleting .o files except when changing
-        // optional or garbage collectors
-        excludePaths.foreach { path =>
-          val opath = Paths.get(path + oExt)
-          if (Files.exists(opath)) {
-            Files.delete(opath)
-          }
-        }
-
-        val fltoOpt    = flto(config)
-        val targetOpt  = target(config)
-        val includeOpt = gcIncludePaths.map("-I" + _)
-        includePaths.map(Paths.get(_))
-    }
-  }
-
-  /**
    * Compile the given files to object files
    *
    * @param config The configuration of the toolchain.

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -84,13 +84,14 @@ private[scalanative] object LLVM {
    * @param config The configuration of the toolchain.
    * @param linkerResult The results from the linker.
    * @param destPath The unpacked location of the Scala Native nativelib.
-   * @return The paths included to be compiled.
+   * @param allPaths The native paths found for this library
+   * @return The paths filtered to be included in the compile.
    */
   def filterNativelib(config: Config,
                       destPath: Path,
                       allPaths: Seq[Path]): Seq[Path] = {
     val codePath = destPath.resolve(NativeLib.codeDir)
-    // check if filtering is needed, o.w. return paths
+    // check if filtering is needed, o.w. return all paths
     NativeLib.findFilterProperties(codePath) match {
       case None => allPaths
       case Some(file) =>

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -70,6 +70,9 @@ private[scalanative] object NativeLib {
   /** To positively identify nativelib */
   private val nativeLibMarkerFile = "org_scala-native_nativelib.txt"
 
+  /** To find filter file */
+  private val filterProperties = s"${codeDir}-filter.properties"
+
   /**
    * Find the marker file in the directory.
    *
@@ -117,6 +120,19 @@ private[scalanative] object NativeLib {
         s"No Scala Native libraries were found: $classpath")
     else
       extractPaths
+  }
+
+  /**
+    * Check for a filtering properties file in destination
+    * native code directory.
+    *
+    * @param codePath The native code directory
+    * @return The optional path to the file or none
+    */
+  def findFilterProperties(codePath: Path): Option[Path] = {
+    val file = codePath.resolve(filterProperties)
+    if(Files.exists(file)) Some(file)
+    else None
   }
 
   /**

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -20,7 +20,7 @@ private[scalanative] object NativeLib {
   /**
    * Name of directory that contains native code: "scala-native"
    */
-  val codeDir = "scala-native"
+  val nativeCodeDir = "scala-native"
 
   /** Used to find native source files in directories */
   private def srcPatterns(path: Path): String =
@@ -30,11 +30,11 @@ private[scalanative] object NativeLib {
   private val jarSrcRegex: String = {
     val regexExtensions = srcExtensions.mkString("""(\""", """|\""", ")")
     // Paths in jars always contains '/' separator instead of OS specific one.
-    s"""^$codeDir/(.+)$regexExtensions$$"""
+    s"""^$nativeCodeDir/(.+)$regexExtensions$$"""
   }
 
   private def srcPathPattern(path: Path): String =
-    makeDirPath(path, codeDir)
+    makeDirPath(path, nativeCodeDir)
 
   /**
    * Used to create hash of the directory to copy
@@ -56,7 +56,7 @@ private[scalanative] object NativeLib {
    */
   private def destSrcPattern(workdir: Path, destPath: Path): String = {
     val dirPattern = s"{${destPath.getFileName()}}"
-    val pathPat    = makeDirPath(workdir, dirPattern, codeDir)
+    val pathPat    = makeDirPath(workdir, dirPattern, nativeCodeDir)
     srcExtensions.mkString(s"glob:$pathPat**{", ",", "}")
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -6,6 +6,8 @@ import java.nio.file.{Files, Path}
 import java.util.Arrays
 import java.util.regex._
 
+import scalanative.build.LLVM._
+
 /** Original jar or dir path and generated dir path for native code */
 private[scalanative] case class NativeLib(src: Path, dest: Path)
 
@@ -14,18 +16,6 @@ private[scalanative] object NativeLib {
 
   /** Java Archive extension: ".jar" */
   val jarExt = ".jar"
-
-  /** Object file extension: ".o" */
-  val oExt = ".o"
-
-  /** C++ file extension: ".cpp" */
-  val cppExt = ".cpp"
-
-  /** LLVM intermediate file extension: ".ll" */
-  val llExt = ".ll"
-
-  /** List of source patterns used: ".c, .cpp, .S" */
-  val srcExtensions = Seq(".c", cppExt, ".S")
 
   /**
    * Name of directory that contains native code: "scala-native"

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -67,20 +67,8 @@ private[scalanative] object NativeLib {
     srcExtensions.mkString(s"glob:$pathPat**{", ",", "}")
   }
 
-  /** To positively identify nativelib */
-  private val nativeLibMarkerFile = "org_scala-native_nativelib.txt"
-
   /** To find filter file */
   private val filterProperties = s"${codeDir}-filter.properties"
-
-  /**
-   * Find the marker file in the directory.
-   *
-   * @param path The path we are searching
-   * @return the search file pattern
-   */
-  private def dirMarkerFilePattern(path: Path): String =
-    s"glob:${makeDirPath(path, nativeLibMarkerFile)}"
 
   /** Does this Path point to a jar file */
   def isJar(path: Path): Boolean = path.toString().endsWith(jarExtension)
@@ -136,29 +124,6 @@ private[scalanative] object NativeLib {
   }
 
   /**
-   * Find the Scala Native `nativelib` from within all the
-   * other libraries with native code.
-   *
-   * @param nativeLibs The Seq of discovered native libs
-   * @return The Scala Native `nativelib`
-   */
-  def findNativeLib(nativelibs: Seq[NativeLib]): NativeLib = {
-    val nativelib = nativelibs.find { nl =>
-      val srcPath = nl.src
-      if (isJar(srcPath))
-        IO.existsInJar(srcPath, hasMarkerFileInJar)
-      else
-        IO.existsInDir(srcPath, dirMarkerFilePattern(srcPath))
-    }
-    nativelib match {
-      case Some(nl) => nl
-      case None =>
-        throw new BuildException(
-          s"Native Library 'nativelib' not found: $nativelibs")
-    }
-  }
-
-  /**
    * Find the native file paths for this native library
    *
    * @param destPath The native lib dest path
@@ -193,9 +158,6 @@ private[scalanative] object NativeLib {
 
   private def isNativeFile(name: String): Boolean =
     jarPattern.matcher(name).matches()
-
-  private def hasMarkerFileInJar(name: String): Boolean =
-    name.equals(nativeLibMarkerFile)
 
   private def readDir(path: Path): Option[Path] =
     IO.existsInDir(path, srcPatterns(path)) match {

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -123,15 +123,15 @@ private[scalanative] object NativeLib {
   }
 
   /**
-    * Check for a filtering properties file in destination
-    * native code directory.
-    *
-    * @param codePath The native code directory
-    * @return The optional path to the file or none
-    */
+   * Check for a filtering properties file in destination
+   * native code directory.
+   *
+   * @param codePath The native code directory
+   * @return The optional path to the file or none
+   */
   def findFilterProperties(codePath: Path): Option[Path] = {
     val file = codePath.resolve(filterProperties)
-    if(Files.exists(file)) Some(file)
+    if (Files.exists(file)) Some(file)
     else None
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeLib.scala
@@ -70,9 +70,6 @@ private[scalanative] object NativeLib {
     srcExtensions.mkString(s"glob:$pathPat**{", ",", "}")
   }
 
-  /** To find filter file */
-  private val filterProperties = s"${codeDir}-filter.properties"
-
   /** Does this Path point to a jar file */
   private def isJar(path: Path): Boolean =
     path.toString().endsWith(jarExt)
@@ -112,19 +109,6 @@ private[scalanative] object NativeLib {
         s"No Scala Native libraries were found: $classpath")
     else
       extractPaths
-  }
-
-  /**
-   * Check for a filtering properties file in destination
-   * native code directory.
-   *
-   * @param codePath The native code directory
-   * @return The optional path to the file or none
-   */
-  def findFilterProperties(codePath: Path): Option[Path] = {
-    val file = codePath.resolve(filterProperties)
-    if (Files.exists(file)) Some(file)
-    else None
   }
 
   /**

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -87,7 +87,7 @@ private[scalanative] object ScalaNative {
   /** Given low-level assembly, emit LLVM IR for it to the buildDirectory. */
   def codegen(config: Config, linked: linker.Result): Seq[Path] = {
     val llPaths = config.logger.time("Generating intermediate code") {
-      // blindly clean ll files
+      // currently, always clean ll files
       IO.getAll(config.workdir, "glob:**.ll").foreach(Files.delete)
       CodeGen(config, linked)
     }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -1,7 +1,7 @@
 package scala.scalanative
 package build
 
-import java.nio.file.Path
+import java.nio.file.{Path, Files}
 import scala.collection.mutable
 import scala.scalanative.checker.Check
 import scala.scalanative.codegen.CodeGen
@@ -87,6 +87,8 @@ private[scalanative] object ScalaNative {
   /** Given low-level assembly, emit LLVM IR for it to the buildDirectory. */
   def codegen(config: Config, linked: linker.Result): Seq[Path] = {
     val llPaths = config.logger.time("Generating intermediate code") {
+      // blindly clean ll files
+      IO.getAll(config.workdir, "glob:**.ll").foreach(Files.delete)
       CodeGen(config, linked)
     }
     config.logger.info(s"Produced ${llPaths.length} files")


### PR DESCRIPTION
This PR is designed to simplify the build by compiling each project as a unit and using the same code for projects and the generated LL. Some benefits are as follow:

1. Ensure the same optimization level is applied to all files compiled.
2. Prior to this PR compiling code was duplicated once for `ll` and once for everything else.
3. Native lib specific code only filters files to compile and removes previous objects. This is now more conducive to logic for platform selection
4. We could output the project being compiled which might make it easier to debug.
5. Makes the code more accessible and easier for future improvement.

The only potential down side I can see is that the files for each project are found individually rather than in one huge directory traversal. The upside here is that the glob pattern is simpler. The intuition here is there is little impact on performance.

Done - Right now the code converts paths to strings unnecessarily which needs to get resolved. 

FYI - In debug mode `-g` or `--debug` is not added.
