### PR TITLE
WIP Re-enables some tests that were ignored for identity based maps

### DIFF
--- a/unit-tests/src/test/scala/java/util/MapTest.scala
+++ b/unit-tests/src/test/scala/java/util/MapTest.scala
@@ -23,14 +23,9 @@ trait MapTest {
   // temporary until Platform is introduced
   val executingInJVM = false
 
-  // replace when new IdentityHashMap from Scala.js
-  // private def assumeNotIdentityHashMapOnJVM(): Unit =
-  //   assumeFalse("JVM vs Native cache differences",
-  //               executingInJVM && factory.isIdentityBased)
-
-  // temp implementation
   private def assumeNotIdentityHashMapOnJVM(): Unit =
-    assumeFalse("JVM vs Native cache differences", factory.isIdentityBased)
+    assumeFalse("JVM vs Native cache differences",
+                executingInJVM && factory.isIdentityBased)
 
   @Test def shouldStoreStrings(): Unit = {
     val mp = factory.empty[String, String]


### PR DESCRIPTION
## What

Re-enables tests that were producing these warns (because they were disabled):

```
[warn] Test assumption in test java.util.IdentityHashMapTest.shouldRemoveStoredElementsInDoubleCornerCases failed: org.junit.internal.AssumptionViolatedException: JVM vs Native cache differences, took 0.001 sec
[warn] Test assumption in test java.util.IdentityHashMapTest.shouldStoreDoublesAlsoInCornerCases failed: org.junit.internal.AssumptionViolatedException: JVM vs Native cache differences, took 0.000 sec
[warn] Test assumption in test java.util.IdentityHashMapTest.shouldStoreIntegers failed: org.junit.internal.AssumptionViolatedException: JVM vs Native cache differences, took 0.000 sec
```

## Why

There seemed to be a comment that was never addressed, because those maps were in fact changed to scalajs similar implementations? Probably @ekrich can clarify that better?

Addressed #2233 partly.
