### PR TITLE
WIP: Implement infrastructure to allow CI-only tests.

### DIFF
--- a/unit-tests/src/test/scala/utils/ContinuousIntegrationEnvironment.scala
+++ b/unit-tests/src/test/scala/utils/ContinuousIntegrationEnvironment.scala
@@ -1,0 +1,31 @@
+package org.scalanative.testsuite.utils
+
+import org.junit.Assume._
+
+object ContinuousIntegrationEnvironment {
+  // Some Tests require conditions which may not hold in
+  // developer environments or if CI moves off GitHub_Actions.
+
+  def isGitHubCI(): Boolean =
+    (System.getenv("GITHUB_ACTIONS") != null) && (System.getenv("CI") != null)
+
+  def skipIfNotKnownCIEnv(): Unit = {
+    // Scala Native Windows CI envirionment is not yet defined.
+    val isWindows = scalanative.runtime.Platform.isWindows()
+
+    assumeTrue("Not executing as known GitHub CI, skipping...",
+               (isGitHubCI() && (!isWindows)))
+  }
+
+  // A User Principal name known to exist.
+  def existentUserName(): String = "root"
+
+  // A User Principal name known to not exist.
+  def nonExistentUserName(): String = "gobbledygook"
+
+  // A Group Principal name known to exist.
+  def existentGroupName(): String = "root"
+
+  // A Group Principal name known to not exist.
+  def nonExistentGroupName(): String = "gobbledygook"
+}


### PR DESCRIPTION
This Work In Progress (WIP) PR is presented for discussion
of the concept. The change by itself would be a "dead code"
PR and those are frowned upon.  It will need to be bundled
into either TimeTest or the `java.nio.file.attributes` PR
I have almost ready to submit (but not ready today).

Some tests have preconditions which must hold for the test to
make sense. We allow tests to determine if they are running in
a know Continuous Integration environment.