### PR TITLE
Update & supersede PR #1609: Implement java.nio UserPrincipal infrastructure.

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -317,6 +317,7 @@ Here is the list of currently available classes:
 * ``java.nio.file.attribute.UserDefinedFileAttributeView``
 * ``java.nio.file.attribute.UserPrincipal``
 * ``java.nio.file.attribute.UserPrincipalLookupService``
+* ``java.nio.file.attribute.UserPrincipalNotFoundException``
 * ``java.nio.file.spi.FileSystemProvider``
 * ``java.rmi.Remote``
 * ``java.rmi.RemoteException``

--- a/javalib/src/main/scala/java/nio/file/FileSystem.scala
+++ b/javalib/src/main/scala/java/nio/file/FileSystem.scala
@@ -7,14 +7,13 @@ import java.nio.file.spi.FileSystemProvider
 import java.util.Set
 
 abstract class FileSystem extends Closeable {
-  // def getUserPrincipalLookupService(): UserPrincipalLookupService
-
   def close(): Unit
   def getFileStores(): Iterable[FileStore]
   def getPath(first: String, more: Array[String]): Path
   def getPathMatcher(syntaxAndPattern: String): PathMatcher
   def getRootDirectories(): Iterable[Path]
   def getSeparator(): String
+  def getUserPrincipalLookupService(): UserPrincipalLookupService
   def isOpen(): Boolean
   def isReadOnly(): Boolean
   def newWatchService(): WatchService

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -1,6 +1,8 @@
 package java.nio.file.attribute
 
+import java.{util => ju}
 import java.util.{HashMap, HashSet, Set}
+
 import java.util.concurrent.TimeUnit
 import java.nio.file.{LinkOption, Path, PosixException}
 import java.nio.file.attribute._
@@ -140,7 +142,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
       override def owner() = PosixUserPrincipal(st_uid)(None)
 
       override def permissions() = {
-        val set = new HashSet[PosixFilePermission]
+        val set = new ju.HashSet[PosixFilePermission]
         PosixFileAttributeViewImpl.permMap.foreach {
           case (flag, value) =>
             if ((st_mode & flag).toInt != 0) set.add(value)
@@ -151,7 +153,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
       override def size() = st_size
     }
 
-  override def asMap: HashMap[String, Object] = {
+  override def asMap: ju.HashMap[String, Object] = {
     val attrs = attributes
     val values =
       List(
@@ -168,7 +170,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
         "group"            -> attrs.group()
       )
 
-    val map = new HashMap[String, Object]()
+    val map = new ju.HashMap[String, Object]()
     values.foreach { case (k, v) => map.put(k, v) }
     map
   }

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -135,9 +135,9 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
       override def creationTime() =
         FileTime.from(st_ctime, TimeUnit.SECONDS)
 
-      override def group = PosixGroupPrincipal(st_gid)(None)
+      override def group() = PosixGroupPrincipal(st_gid)(None)
 
-      override def owner = PosixUserPrincipal(st_uid)(None)
+      override def owner() = PosixUserPrincipal(st_uid)(None)
 
       override def permissions() = {
         val set = new HashSet[PosixFilePermission]

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixUserPrincipalLookupService.scala
@@ -9,14 +9,14 @@ import scala.scalanative.nio.fs.UnixException
 
 final case class PosixUserPrincipal(uid: stat.uid_t)(name: Option[String])
     extends UserPrincipal {
-  override def getName = {
+  override def getName() = {
     name getOrElse PosixUserPrincipalLookupService.getUsername(uid)
   }
 }
 
 final case class PosixGroupPrincipal(gid: stat.gid_t)(name: Option[String])
     extends GroupPrincipal {
-  override def getName: String = {
+  override def getName(): String = {
     name getOrElse PosixUserPrincipalLookupService.getGroupName(gid)
   }
 }

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixUserPrincipalLookupService.scala
@@ -1,0 +1,116 @@
+package java.nio.file.attribute
+
+import scalanative.unsigned._
+import scalanative.unsafe._
+import scalanative.libc._
+import scalanative.posix.{errno => e, grp, pwd, unistd, time, utime}, e._
+import scalanative.posix.sys.stat
+import scala.scalanative.nio.fs.UnixException
+
+final case class PosixUserPrincipal(uid: stat.uid_t)(name: Option[String])
+    extends UserPrincipal {
+  override def getName = {
+    name getOrElse PosixUserPrincipalLookupService.getUsername(uid)
+  }
+}
+
+final case class PosixGroupPrincipal(gid: stat.gid_t)(name: Option[String])
+    extends GroupPrincipal {
+  override def getName: String = {
+    name getOrElse PosixUserPrincipalLookupService.getGroupName(gid)
+  }
+}
+
+object PosixUserPrincipalLookupService extends UserPrincipalLookupService {
+  override def lookupPrincipalByGroupName(group: String): PosixGroupPrincipal =
+    Zone { implicit z =>
+      val gid = getGroup(toCString(group)).fold {
+        try {
+          group.toInt.toUInt
+        } catch {
+          case _: NumberFormatException =>
+            throw new UserPrincipalNotFoundException(group)
+        }
+      }(_._2)
+
+      PosixGroupPrincipal(gid)(Some(group))
+    }
+
+  private[attribute] def getGroupName(gid: stat.gid_t): String = Zone {
+    implicit z =>
+      val buf = alloc[grp.group]
+
+      errno.errno = 0
+      val err = grp.getgrgid(gid, buf)
+
+      if (err == 0) {
+        fromCString(buf._1)
+      } else if (errno.errno == 0) {
+        gid.toString
+      } else {
+        throw UnixException("getgrgid", errno.errno)
+      }
+  }
+
+  private[attribute] def getUsername(uid: stat.uid_t): String = Zone {
+    implicit z =>
+      val buf = alloc[pwd.passwd]
+
+      errno.errno = 0
+      val err = pwd.getpwuid(uid, buf)
+
+      if (err == 0) {
+        fromCString(buf._1)
+      } else if (errno.errno == 0) {
+        uid.toString
+      } else {
+        throw UnixException("getpwuid", errno.errno)
+      }
+  }
+
+  private def getGroup(name: CString)(
+      implicit z: Zone): Option[Ptr[grp.group]] = {
+    val buf = alloc[grp.group]
+
+    errno.errno = 0
+    val err = grp.getgrnam(name, buf)
+
+    if (err == 0) {
+      Some(buf)
+    } else if (errno.errno == 0) {
+      None
+    } else {
+      throw UnixException("getgrnam", errno.errno)
+    }
+  }
+
+  override def lookupPrincipalByName(name: String): PosixUserPrincipal = Zone {
+    implicit z =>
+      val uid = getPasswd(toCString(name)).fold {
+        try {
+          name.toInt.toUInt
+        } catch {
+          case _: NumberFormatException =>
+            throw new UserPrincipalNotFoundException(name)
+        }
+      }(_._2)
+
+      PosixUserPrincipal(uid)(Some(name))
+  }
+
+  private def getPasswd(name: CString)(
+      implicit z: Zone): Option[Ptr[pwd.passwd]] = {
+    val buf = alloc[pwd.passwd]
+
+    errno.errno = 0
+    val err = pwd.getpwnam(name, buf)
+
+    if (err == 0) {
+      Some(buf)
+    } else if (errno.errno == 0) {
+      None
+    } else {
+      throw UnixException("getpwnam", errno.errno)
+    }
+  }
+}

--- a/javalib/src/main/scala/java/nio/file/attribute/UserPrincipalNotFoundException.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/UserPrincipalNotFoundException.scala
@@ -1,0 +1,7 @@
+package java.nio.file.attribute
+
+import java.io.IOException
+
+class UserPrincipalNotFoundException(name: String) extends IOException {
+  def getName(): String = name
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystem.scala
@@ -13,7 +13,7 @@ import java.nio.file.{
 import java.nio.file.spi.FileSystemProvider
 import java.nio.file.attribute.UserPrincipalLookupService
 import java.nio.file.attribute.PosixUserPrincipalLookupService
-import java.util.{LinkedList, Set}
+import java.{util => ju}
 
 import scala.scalanative.unsafe.{
   CUnsignedLong,
@@ -50,7 +50,7 @@ class UnixFileSystem(override val provider: FileSystemProvider,
     PathMatcherImpl(syntaxAndPattern)
 
   override def getRootDirectories(): Iterable[Path] = {
-    val list = new LinkedList[Path]()
+    val list = new ju.LinkedList[Path]()
     list.add(getPath(root, Array.empty))
     list
   }
@@ -76,7 +76,7 @@ class UnixFileSystem(override val provider: FileSystemProvider,
   override def newWatchService(): WatchService =
     throw new UnsupportedOperationException()
 
-  override def supportedFileAttributeViews(): Set[String] = {
+  override def supportedFileAttributeViews(): ju.Set[String] = {
     val set = new java.util.HashSet[String]()
     set.add("basic")
     set.add("posix")

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/UnixFileSystem.scala
@@ -12,6 +12,7 @@ import java.nio.file.{
 }
 import java.nio.file.spi.FileSystemProvider
 import java.nio.file.attribute.UserPrincipalLookupService
+import java.nio.file.attribute.PosixUserPrincipalLookupService
 import java.util.{LinkedList, Set}
 
 import scala.scalanative.unsafe.{
@@ -38,6 +39,9 @@ class UnixFileSystem(override val provider: FileSystemProvider,
 
   @stub
   override def getFileStores(): Iterable[FileStore] = ???
+
+  override def getUserPrincipalLookupService(): UserPrincipalLookupService =
+    PosixUserPrincipalLookupService
 
   override def getPath(first: String, more: Array[String]): Path =
     new UnixPath(this, (first +: more).mkString("/"))

--- a/unit-tests/src/test/scala/java/nio/file/attribute/UserPrincipalLookupServiceTest.scala
+++ b/unit-tests/src/test/scala/java/nio/file/attribute/UserPrincipalLookupServiceTest.scala
@@ -1,0 +1,28 @@
+package java.nio.file.attribute
+
+import java.nio.file.FileSystems
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scalanative.junit.utils.AssertThrows._
+import org.scalanative.testsuite
+
+class UserPrincipalLookupServiceTest {
+
+  val lookupService = FileSystems.getDefault.getUserPrincipalLookupService
+
+  @Test def lookupPrincipalByNameSucceedsForNumeric(): Unit = {
+    val expected = (Int.MaxValue / 2).toString // an arbitrary value
+
+    assertEquals(expected,
+                 lookupService.lookupPrincipalByName(expected).getName)
+  }
+
+  @Test def lookupPrincipalByGroupNameSucceedsForNumeric(): Unit = {
+    val expected = (Int.MaxValue / 3).toString // an arbitrary value
+
+    assertEquals(expected,
+                 lookupService.lookupPrincipalByGroupName(expected).getName)
+  }
+}


### PR DESCRIPTION

##### Intellectual Property Statement:

This PR is an update of original code in PR #1609 by
Claudio Bley (at_avdv) and is used by his kind permission
(see Issue #2128).

##### Commit message
We expand javalib by implementing UserPrincipal infrastructure.
In particular, this allows to lookup UserPricipals by numeric ids.