### PR TITLE
Fix #2253: Two Posix socket functions now return correct type.

### DIFF
--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -192,11 +192,11 @@ int scalanative_getsockopt(int socket, int level, int option_name,
     return getsockopt(socket, level, option_name, option_value, option_len);
 }
 
-int scalanative_recv(int socket, void *buffer, size_t length, int flags) {
+ssize_t scalanative_recv(int socket, void *buffer, size_t length, int flags) {
     return recv(socket, buffer, length, flags);
 }
 
-int scalanative_send(int socket, void *buffer, size_t length, int flags) {
+ssize_t scalanative_send(int socket, void *buffer, size_t length, int flags) {
     return send(socket, buffer, length, flags);
 }
 


### PR DESCRIPTION
Implement a 'least change' correction of the reported defect.
See referenced issue for details.