### PR TITLE
Demonstrate conditional dependsOn

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -467,13 +467,25 @@ lazy val javalibCommonSettings = Def.settings(
   exportJars := true
 )
 
+// can be used in aggregate
+lazy val javalibProjectRef = Seq[ProjectReference](posixlib, clib)
+
+lazy val javalibDepends = {
+  val base = Seq(ClasspathDependency(nscplugin, Some("plugin")),
+                 ClasspathDependency(clib, None))
+  if (!Util.isWindows)
+    base :+ ClasspathDependency(posixlib, None)
+  else
+    base
+}
+
 lazy val javalib =
   project
     .in(file("javalib"))
     .enablePlugins(MyScalaNativePlugin)
     .settings(mavenPublishSettings)
     .settings(javalibCommonSettings)
-    .dependsOn(nscplugin % "plugin", posixlib, clib)
+    .dependsOn(javalibDepends: _*)
 
 lazy val javalibExtDummies = project
   .in(file("javalib-ext-dummies"))


### PR DESCRIPTION
I am still thinking about the easiest way to implement Windows support.

Currently, core windows support in `nativelib` uses shared native methods in the Scala code that uses typical C conditional compilation. This code was added during previous attempt for windows support. I suppose that Java does something like this with native methods and JNI. This would work for the entire `javalib` but requires forcing for example POSIX pthreads and Windows threads into the same box, or network or file system code, so it becomes a compatibility layer and is the worst of both worlds.

Originally we thought about separating the various parts of the Java lib and have 2 versions, C/POSIX and C/WIN32. Is this still a viable option? Couldn't the compiler still generate all the NIR for each of these and they could be published as normal? Java is pretty much our only compatibility layer. This means more artifacts but it is more of an implementation detail handled by the build and plugin.

When we go to optimize and link code we need to exclude the classpath for the non-used platform and this would also mean that when we link we would exclude the C code. This is not unlike how we avoid optional components and select Garbage Collectors now.

To me this seems very easy to understand and it also means that the Windows code could move independent of the Unix side of things and also wouldn't affect the stability of the rest of the platform. We also do some of this type of magic for the Scala library versions so it doesn't seem too off the wall.

If we really do need conditional code in Scala for Windows or other reasons maybe we could have some background and some reasons why this is not a workable option. Certainly, the compiler is an area I have not jumped into but it is maybe the least accessible portion of the code base for others as well.