### PR TITLE
Fix #1921, #2250: Evolve hacktoberfest Posix socket sendto() & recvfrom()

### DIFF
--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -235,7 +235,7 @@ ssize_t scalanative_recv(int socket, void *buffer, size_t length, int flags) {
     return recv(socket, buffer, length, flags);
 }
 
-int scalanative_send(int socket, void *buffer, size_t length, int flags) {
+ssize_t scalanative_send(int socket, void *buffer, size_t length, int flags) {
     return send(socket, buffer, length, flags);
 }
 

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -3,9 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-// #include "../netinet/in.h"
 #include "socket_conversions.h"
-// #include "socket.h"
 
 #ifdef _WIN32
 #include <WinSock2.h>

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -19,9 +19,13 @@ typedef SSIZE_T ssize_t;
 #warning "Size and order of C structures are not checked when -std < c11."
 #endif
 #else
-// Posix defines the order of required fields.
-// The first field in C has had size 2 and no padding after it
-// since time immemorial. Verify that the Scala Native has the same.
+// Posix defines the order and type of required fields. Size of fields
+// and any internal or tail padding are left unspecified. This section
+// verifies that the C and Scala Native definitons match in each compilation
+// environment.
+//
+// The first sockaddr field in C has had size 2 and no padding after it
+// since time immemorial. Chedk that the Scala Native has the same.
 
 _Static_assert(offsetof(struct scalanative_sockaddr, sa_data) == 2,
                "Unexpected size: scalanative_sockaddr sa_family");
@@ -231,28 +235,8 @@ ssize_t scalanative_recv(int socket, void *buffer, size_t length, int flags) {
     return recv(socket, buffer, length, flags);
 }
 
-ssize_t scalanative_recvfrom(int socket, void *buffer, size_t length, int flags,
-                             struct scalanative_sockaddr *address,
-                             socklen_t *address_len) {
-    // Using this function rather than a direct call in socket.scala allows
-    // _Static_asserts at the top of this file to check structure requirements.
-
-    return recvfrom(socket, buffer, length, flags, (struct sockaddr *)address,
-                    address_len);
-}
-
 int scalanative_send(int socket, void *buffer, size_t length, int flags) {
     return send(socket, buffer, length, flags);
-}
-
-ssize_t scalanative_sendto(int socket, void *buffer, size_t length, int flags,
-                           struct scalanative_sockaddr *address,
-                           socklen_t address_len) {
-    // Using this function rather than a direct call in socket.scala allows
-    // _Static_asserts at the top of this file to check structure requirements.
-
-    return sendto(socket, buffer, length, flags, (struct sockaddr *)address,
-                  address_len);
 }
 
 int scalanative_shutdown(int socket, int how) { return shutdown(socket, how); }

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -19,11 +19,11 @@ typedef SSIZE_T ssize_t;
 #else
 // Posix defines the order and type of required fields. Size of fields
 // and any internal or tail padding are left unspecified. This section
-// verifies that the C and Scala Native definitons match in each compilation
+// verifies that the C and Scala Native definitions match in each compilation
 // environment.
 //
 // The first sockaddr field in C has had size 2 and no padding after it
-// since time immemorial. Chedk that the Scala Native has the same.
+// since time immemorial. Verify that the Scala Native field has the same.
 
 _Static_assert(offsetof(struct scalanative_sockaddr, sa_data) == 2,
                "Unexpected size: scalanative_sockaddr sa_family");

--- a/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
@@ -139,6 +139,11 @@ object inOps {
     def sin_addr_=(v: in_addr): Unit              = ptr._3 = v
   }
 
+  implicit class sockaddr_inAddrOps(val value: in_addr) extends AnyVal {
+    def s_addr: in_addr_t            = value._1
+    def s_addr_=(v: in_addr_t): Unit = value._1 = v
+  }
+
   implicit class sockaddr_in6Ops(val ptr: Ptr[sockaddr_in6]) extends AnyVal {
     def sin6_addr: in6_addr                        = ptr._1
     def sin6_family: socket.sa_family_t            = ptr._2

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -177,11 +177,27 @@ object socket {
            length: CSize,
            flags: CInt): CSSize = extern
 
+  @name("scalanative_recvfrom")
+  def recvfrom(socket: CInt,
+               buffer: Ptr[Byte],
+               length: CSize,
+               flags: CInt,
+               dest_addr: Ptr[sockaddr],
+               address_len: Ptr[socklen_t]): CSSize = extern
+
   @name("scalanative_send")
   def send(socket: CInt,
            buffer: Ptr[Byte],
            length: CSize,
            flags: CInt): CSSize = extern
+
+  @name("scalanative_sendto")
+  def sendto(socket: CInt,
+             buffer: Ptr[Byte],
+             length: CSize,
+             flags: CInt,
+             dest_addr: Ptr[sockaddr],
+             address_len: socklen_t): CSSize = extern
 
   @name("scalanative_shutdown")
   def shutdown(socket: CInt, how: CInt): CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -177,7 +177,7 @@ object socket {
            length: CSize,
            flags: CInt): CSSize = extern
 
-  @name("scalanative_recvfrom")
+  // direct call to C, _Static_assert in socket.c validates structures.
   def recvfrom(socket: CInt,
                buffer: Ptr[Byte],
                length: CSize,
@@ -191,7 +191,7 @@ object socket {
            length: CSize,
            flags: CInt): CSSize = extern
 
-  @name("scalanative_sendto")
+  // direct call to C, _Static_assert in socket.c validates structures.
   def sendto(socket: CInt,
              buffer: Ptr[Byte],
              length: CSize,

--- a/unit-tests/src/test/scala/java/net/UdpSocketTest.scala
+++ b/unit-tests/src/test/scala/java/net/UdpSocketTest.scala
@@ -1,0 +1,139 @@
+package java.net
+
+import scalanative.posix.arpa.inet._
+import scalanative.posix.fcntl
+import scalanative.posix.fcntl.{F_SETFL, O_NONBLOCK}
+import scalanative.posix.netinet.in._
+import scalanative.posix.netinet.inOps._
+import scalanative.posix.sys.socket._
+import scalanative.posix.sys.socketOps._
+import scalanative.posix.unistd.close
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+import org.junit.Test
+import org.junit.Assert._
+
+class UdpSocketTest {
+  // All tests in this class assume that an IPv4 network is up & running.
+
+  @Test def sendtoRecvfrom(): Unit = Zone { implicit z =>
+    val localhost         = c"127.0.0.1"
+    val localhostInetAddr = inet_addr(localhost)
+
+    val inSocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+    assertNotEquals("socket", -1, inSocket)
+
+    try {
+      val inAddr      = alloc[sockaddr]
+      val inAddrInPtr = inAddr.asInstanceOf[Ptr[sockaddr_in]]
+
+      inAddrInPtr.sin_family = AF_INET.toUShort
+      inAddrInPtr.sin_addr.s_addr = localhostInetAddr
+      // inAddrInPtr.sin_port is already the desired 0; "find a free port".
+
+      val fcntlStatus = fcntl.fcntl(inSocket, F_SETFL, O_NONBLOCK)
+      assertNotEquals("fcntl", -1, fcntlStatus)
+
+      // Get port for sendto() to use.
+      val bindStatus = bind(inSocket, inAddr, sizeof[sockaddr].toUInt)
+      assertNotEquals("bind", -1, bindStatus)
+
+      val inAddrInfo = alloc[sockaddr]
+      val gsnAddrLen = alloc[socklen_t]
+      !gsnAddrLen = sizeof[sockaddr].toUInt
+
+      val gsnStatus = getsockname(inSocket, inAddrInfo, gsnAddrLen)
+      assertNotEquals("getsockname", -1, gsnStatus)
+
+      // Now use port.
+      val outSocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+      assertNotEquals("socket", -1, outSocket)
+
+      try {
+        val outAddr      = alloc[sockaddr]
+        val outAddrInPtr = outAddr.asInstanceOf[Ptr[sockaddr_in]]
+        outAddrInPtr.sin_family = AF_INET.toUShort
+        outAddrInPtr.sin_addr.s_addr = localhostInetAddr
+        outAddrInPtr.sin_port =
+          inAddrInfo.asInstanceOf[Ptr[sockaddr_in]].sin_port
+
+        val outData =
+          """
+          |Four Freedoms -
+          |   Freedom of speech
+          |   Freedom of worship
+          |   Freedom from want
+          |   Freedom from fear
+          """.stripMargin
+
+        val nBytesSent = sendto(outSocket,
+                                toCString(outData),
+                                outData.length.toULong,
+                                0,
+                                outAddr,
+                                sizeof[sockaddr].toUInt)
+        assertEquals("sendto", outData.size, nBytesSent)
+
+        // There is a "pick your poison" design choice here.
+        // inSocket is set O_NONBLOCK to eliminate the possibility
+        // that a bad sendto() or readfrom() implemenation would hang
+        // for a long time.
+        //
+        // This introduces the theoretical possiblity the sendto() above
+        // does not complete before recvfrom() looks for data, causing
+        // failure. Since this is send/recv pair is explicitly loopback,
+        // that is highly unlikely.
+        //
+        // If this race condition becomes bothersome, a Thead.sleep() can
+        // be inserted here.
+
+        /// Two tests using one inbound packet, save test duplication.
+
+        // Provide extra room to allow detecting extra junk being sent.
+        val maxInData = 2 * outData.length
+        val inData    = alloc[Byte](maxInData)
+
+        // Test not fetching remote address. Exercise last two arguments.
+        val nBytesPeekedAt =
+          recvfrom(inSocket,
+                   inData,
+                   maxInData.toUInt,
+                   MSG_PEEK,
+                   null.asInstanceOf[Ptr[sockaddr]],
+                   null.asInstanceOf[Ptr[socklen_t]])
+
+        // Friendlier code here and after the next recvfrom() would loop
+        // on partial reads rather than fail.
+        // Punt to a future generation. Since this is loopback and
+        // writes are small, if any bytes are ready, all should be.
+        assertEquals("recvfrom length", nBytesSent, nBytesPeekedAt)
+
+        // Test retrieving remote address.
+        val srcAddr    = alloc[sockaddr]
+        val srcAddrLen = alloc[socklen_t]
+        !srcAddrLen = sizeof[sockaddr].toUInt
+        val nBytesRecvd =
+          recvfrom(inSocket, inData, maxInData.toUInt, 0, srcAddr, srcAddrLen)
+
+        assertEquals("recvfrom length", nBytesSent, nBytesRecvd)
+
+        // Packet came from where we expected, and not Mars.
+        assertEquals("unexpected remote address",
+                     localhostInetAddr,
+                     srcAddr.asInstanceOf[Ptr[sockaddr_in]].sin_addr.s_addr)
+
+        assertEquals("inData NUL termination", 0, inData(nBytesRecvd))
+
+        // Contents are good.
+        assertEquals("recvfrom content", outData, fromCString(inData))
+
+      } finally {
+        close(outSocket)
+      }
+
+    } finally {
+      close(inSocket)
+    }
+  }
+}

--- a/unit-tests/src/test/scala/java/net/UdpSocketTest.scala
+++ b/unit-tests/src/test/scala/java/net/UdpSocketTest.scala
@@ -22,7 +22,7 @@ class UdpSocketTest {
     val localhostInetAddr = inet_addr(localhost)
 
     val inSocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
-    assertNotEquals("socket", -1, inSocket)
+    assertNotEquals("socket_1", -1, inSocket)
 
     try {
       val inAddr      = alloc[sockaddr]
@@ -48,7 +48,7 @@ class UdpSocketTest {
 
       // Now use port.
       val outSocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
-      assertNotEquals("socket", -1, outSocket)
+      assertNotEquals("socket_2", -1, outSocket)
 
       try {
         val outAddr      = alloc[sockaddr]
@@ -107,7 +107,7 @@ class UdpSocketTest {
         // on partial reads rather than fail.
         // Punt to a future generation. Since this is loopback and
         // writes are small, if any bytes are ready, all should be.
-        assertEquals("recvfrom length", nBytesSent, nBytesPeekedAt)
+        assertEquals("recvfrom_1 length", nBytesSent, nBytesPeekedAt)
 
         // Test retrieving remote address.
         val srcAddr    = alloc[sockaddr]
@@ -116,7 +116,7 @@ class UdpSocketTest {
         val nBytesRecvd =
           recvfrom(inSocket, inData, maxInData.toUInt, 0, srcAddr, srcAddrLen)
 
-        assertEquals("recvfrom length", nBytesSent, nBytesRecvd)
+        assertEquals("recvfrom_2 length", nBytesSent, nBytesRecvd)
 
         // Packet came from where we expected, and not Mars.
         assertEquals("unexpected remote address",


### PR DESCRIPTION
PR #1921 provided an initial implementation of two Posix socket routines
usually used for UDP transport: sendto() & recvfrom().  We bring
recvfrom() into closer compliance with the posix standard, superseding
that PR.

We also fix Issue #2250 in order to improve the readability and
maintainability of the UdpSocketTest.scala used to verify the
named methods.