### PR TITLE
WIP: Prepare build.sbt for eventual use by sbt 1.5.n.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,8 +20,7 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
-// Will this build?
-  sources in (Compile, doc) := Nil
+  Compile / doc / sources := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {
@@ -30,8 +29,8 @@ lazy val docsSettings: Seq[Setting[_]] = {
   Def.settings(
     autoAPIMappings := true,
     exportJars := true, // required so ScalaDoc linking works
-    scalacOptions in (Compile, doc) := {
-      val prev = (scalacOptions in (Compile, doc)).value
+    Compile / doc / scalacOptions := {
+      val prev = (Compile / doc / scalacOptions).value
       if (scalaVersion.value.startsWith("2.11."))
         prev.filter(_ != "-Xfatal-warnings")
       else prev
@@ -737,7 +736,7 @@ lazy val testingCompiler =
         "org.scala-lang" % "scala-compiler" % scalaVersion.value,
         "org.scala-lang" % "scala-reflect"  % scalaVersion.value
       ),
-      unmanagedSourceDirectories in Compile ++= {
+      Compile / unmanagedSourceDirectories ++= {
         val oldCompat: File = baseDirectory.value / "src/main/compat-old"
         val newCompat: File = baseDirectory.value / "src/main/compat-new"
         CrossVersion
@@ -761,8 +760,8 @@ lazy val testingCompiler =
     .dependsOn(testingCompilerInterface)
 
 lazy val testInterfaceCommonSourcesSettings: Seq[Setting[_]] = Seq(
-  unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "test-interface-common/src/main/scala",
-  unmanagedSourceDirectories in Test += baseDirectory.value.getParentFile / "test-interface-common/src/test/scala"
+  Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "test-interface-common/src/main/scala",
+  Test / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "test-interface-common/src/test/scala"
 )
 
 lazy val testInterface =

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Seq(
 //  Compile / doc / sources := Nil
-    doc / sources := Nil
+  sources := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
-  Compile / doc / sources := Nil
+  sources in (Compile, doc) := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {
@@ -29,8 +29,8 @@ lazy val docsSettings: Seq[Setting[_]] = {
   Def.settings(
     autoAPIMappings := true,
     exportJars := true, // required so ScalaDoc linking works
-    Compile / doc / scalacOptions := {
-      val prev = (Compile / doc / scalacOptions).value
+    scalacOptions in (Compile, doc) := {
+      val prev = (scalacOptions in (Compile, doc)).value
       if (scalaVersion.value.startsWith("2.11."))
         prev.filter(_ != "-Xfatal-warnings")
       else prev
@@ -736,7 +736,7 @@ lazy val testingCompiler =
         "org.scala-lang" % "scala-compiler" % scalaVersion.value,
         "org.scala-lang" % "scala-reflect"  % scalaVersion.value
       ),
-      Compile / unmanagedSourceDirectories ++= {
+      unmanagedSourceDirectories in Compile ++= {
         val oldCompat: File = baseDirectory.value / "src/main/compat-old"
         val newCompat: File = baseDirectory.value / "src/main/compat-new"
         CrossVersion
@@ -760,8 +760,8 @@ lazy val testingCompiler =
     .dependsOn(testingCompilerInterface)
 
 lazy val testInterfaceCommonSourcesSettings: Seq[Setting[_]] = Seq(
-  Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "test-interface-common/src/main/scala",
-  Test / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "test-interface-common/src/test/scala"
+  unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "test-interface-common/src/main/scala",
+  unmanagedSourceDirectories in Test += baseDirectory.value.getParentFile / "test-interface-common/src/test/scala"
 )
 
 lazy val testInterface =

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
   name := projectName(thisProject.value) // Maven <name>
 )
 
+
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
   sources in (Compile, doc) := Nil
 )

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,8 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Seq(
-  Compile / doc / sources := Nil
+//  Compile / doc / sources := Nil
+    doc / sources := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
-  (Compile / doc / sources) := Nil
+  sources in (Compile, doc) := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {
@@ -29,7 +29,7 @@ lazy val docsSettings: Seq[Setting[_]] = {
   Def.settings(
     autoAPIMappings := true,
     exportJars := true, // required so ScalaDoc linking works
-    scalacOptions in (Compile, doc) := {
+    Compile / doc / scalacOptions := {
       val prev = (scalacOptions in (Compile, doc)).value
       if (scalaVersion.value.startsWith("2.11."))
         prev.filter(_ != "-Xfatal-warnings")

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
-  sources in (Compile, doc) := Nil
+  Compile / doc / sources := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {
@@ -29,8 +29,8 @@ lazy val docsSettings: Seq[Setting[_]] = {
   Def.settings(
     autoAPIMappings := true,
     exportJars := true, // required so ScalaDoc linking works
-    scalacOptions in (Compile, doc) := {
-      val prev = (scalacOptions in (Compile, doc)).value
+    Compile / doc / scalacOptions := {
+      val prev = (Compile / doc / scalacOptions).value
       if (scalaVersion.value.startsWith("2.11."))
         prev.filter(_ != "-Xfatal-warnings")
       else prev
@@ -736,7 +736,7 @@ lazy val testingCompiler =
         "org.scala-lang" % "scala-compiler" % scalaVersion.value,
         "org.scala-lang" % "scala-reflect"  % scalaVersion.value
       ),
-      unmanagedSourceDirectories in Compile ++= {
+      Compile / unmanagedSourceDirectories ++= {
         val oldCompat: File = baseDirectory.value / "src/main/compat-old"
         val newCompat: File = baseDirectory.value / "src/main/compat-new"
         CrossVersion
@@ -760,8 +760,8 @@ lazy val testingCompiler =
     .dependsOn(testingCompilerInterface)
 
 lazy val testInterfaceCommonSourcesSettings: Seq[Setting[_]] = Seq(
-  unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "test-interface-common/src/main/scala",
-  unmanagedSourceDirectories in Test += baseDirectory.value.getParentFile / "test-interface-common/src/test/scala"
+  Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "test-interface-common/src/main/scala",
+  Test / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "test-interface-common/src/test/scala"
 )
 
 lazy val testInterface =

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,8 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
-  Compile / doc / sources := Nil
+// Will this build?
+  sources in (Compile, doc) := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
-  Compile / doc / sources := Nil
+  (Compile / doc / sources) := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
-//  sources in (Compile, doc) := Nil
   sources in (Compile, doc) := Nil
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,8 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
   name := projectName(thisProject.value) // Maven <name>
 )
 
-lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
-  sources in (Compile, doc) := Nil
+lazy val disabledDocsSettings: Seq[Setting[_]] = Seq(
+  Compile / doc / sources := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {
@@ -29,7 +29,7 @@ lazy val docsSettings: Seq[Setting[_]] = {
   Def.settings(
     autoAPIMappings := true,
     exportJars := true, // required so ScalaDoc linking works
-    Compile / doc / scalacOptions := {
+    scalacOptions in (Compile, doc) := {
       val prev = (scalacOptions in (Compile, doc)).value
       if (scalaVersion.value.startsWith("2.11."))
         prev.filter(_ != "-Xfatal-warnings")

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
 //  sources in (Compile, doc) := Nil
+  sources in (Compile, doc) := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {

--- a/build.sbt
+++ b/build.sbt
@@ -19,9 +19,8 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
   name := projectName(thisProject.value) // Maven <name>
 )
 
-lazy val disabledDocsSettings: Seq[Setting[_]] = Seq(
-//  Compile / doc / sources := Nil
-  sources := Nil
+lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
+//  sources in (Compile, doc) := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
   name := projectName(thisProject.value) // Maven <name>
 )
 
-
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
   sources in (Compile, doc) := Nil
 )

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
-  sources in (Compile, doc) := Nil
+  Compile / doc / sources := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -63,7 +63,7 @@ WORKDIR /home/scala-native/scala-native
 # should be only a minimal, and lessening, re-fetch performance hit.
 
 CMD sbt \
-    -ivy /tmp/.ivy2 \
+    -ivy $WORKDIR/.ivy2 \
     -no-colors \
     -J-Xmx5G \
     "++ $SCALA_VERSION -v" \

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -52,6 +52,16 @@ USER scala-native
 
 WORKDIR /home/scala-native/scala-native
 
+# Put on your Personal Protective Equipment (PPE) before proceeding!
+#
+# Using sbt -ivy option is workaround required by sbt +/- 1.5.0
+# to prevent sbt lock file errors in Docker when changing build.sbt.
+# See Scala Native Issue #2260 and Sbt Issue #6634.
+# This appears to be the singular critical intervention point.
+# Other uses of sbt, say in .yml files, seem to work after the change here.
+# Sbt 1.5.n mainly uses Coursier and is moving off using Ivy2, so there
+# should be only a minimal, and lessening, re-fetch performance hit.
+
 CMD sbt \
     -ivy /tmp/.ivy2 \
     -no-colors \

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -52,4 +52,9 @@ USER scala-native
 
 WORKDIR /home/scala-native/scala-native
 
-CMD sbt "++ $SCALA_VERSION -v" -no-colors -J-Xmx5G "set scriptedBufferLog in sbtScalaNative := false" "$TEST_COMMAND"
+CMD sbt -ivy /tmp/.ivy2 \
+    "++ $SCALA_VERSION -v" \
+    -no-colors \
+    -J-Xmx5G \
+    "set sbtScalaNative / scriptedBufferLog := false" \
+    "$TEST_COMMAND"

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -52,9 +52,10 @@ USER scala-native
 
 WORKDIR /home/scala-native/scala-native
 
-CMD sbt -ivy /tmp/.ivy2 \
-    "++ $SCALA_VERSION -v" \
+CMD sbt \
+    -ivy /tmp/.ivy2 \
     -no-colors \
     -J-Xmx5G \
+    "++ $SCALA_VERSION -v" \
     "set sbtScalaNative / scriptedBufferLog := false" \
     "$TEST_COMMAND"

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -63,7 +63,7 @@ WORKDIR /home/scala-native/scala-native
 # should be only a minimal, and lessening, re-fetch performance hit.
 
 CMD sbt \
-    -ivy $WORKDIR/.ivy2 \
+    -ivy /tmp/.ivy2 \
     -no-colors \
     -J-Xmx5G \
     "++ $SCALA_VERSION -v" \

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.7
+sbt.version = 1.5.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.9
+sbt.version = 1.4.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.1
+sbt.version = 1.4.9


### PR DESCRIPTION
While it is still too early to actually use sbt 1.5.0, we prepare for
using the sbt 1.5.n series maturing by uniformly using the sbt slash
syntax required by sbt in that series.