### PR TITLE
Ensure testing image is accessible in CI

### DIFF
--- a/ci-docker/run-test-gha.sh
+++ b/ci-docker/run-test-gha.sh
@@ -11,12 +11,35 @@ IMAGE_NAME=$1
 FULL_IMAGE_NAME="localhost:5000/${IMAGE_NAME}"
 sudo chmod a+rwx -R "$HOME"
 
+# Start registry containing images built in previous CI steps
 docker run -d -p 5000:5000 \
   --restart=always \
   --name registry \
   -v /tmp/docker-registry:/var/lib/registry \
   registry:2 && \
   npx wait-on tcp:5000
+
+# Pull cached image or build locally if image is missing
+# In most cases image should exist, however in the past we have observed single
+# CI jobs failing due to missing image.
+if ! docker pull $FULL_IMAGE_NAME;then
+  echo "Image not found found in cache, building locally"
+  imageNamePattern="scala-native-testing:linux-(.*)"
+
+  if [[ "$IMAGE_NAME" =~ $imageNamePattern ]];then
+    arch=${BASH_REMATCH[1]}
+
+    docker build \
+    -t ${FULL_IMAGE_NAME} \
+    --build-arg TARGET_DOCKER_PLATFORM=library \
+    --build-arg HOST_ARCHITECTURE=${arch}  \
+    --cpuset-cpus=0 \
+    ci-docker
+  else
+    >&2 echo "$IMAGE_NAME is not regular testing image name"
+    exit 1
+  fi
+fi
 
 docker run -i "${FULL_IMAGE_NAME}" java -version
 docker run -v $HOME/.ivy2:/home/scala-native/.ivy2 \


### PR DESCRIPTION
In the past, we could have observed numerous failures of CI due to missing image. To save upcycles we build them only once in a dedicated CI job and share them with the next ones. However, it might happen that cache/results from building images are not accessible in the runner. In such a case, it was failing due to a missing image. 

This PR fixes this issue, by checking if the image is accessible or builds it locally otherwise. Since we cannot restart a single failed job, this approach will allow us to save a significant amount of time in case of a random failure due to CI infrastructure problems. 