### PR TITLE
Fix #1665: posixlib localtime() now ensures tzset() has been called.

### DIFF
--- a/posixlib/src/main/resources/scala-native/time.c
+++ b/posixlib/src/main/resources/scala-native/time.c
@@ -19,8 +19,7 @@ struct scalanative_tm {
     int tm_isdst;
 };
 
-static struct scalanative_tm scalanative_gmtime_buf;
-static struct scalanative_tm scalanative_localtime_buf;
+static struct scalanative_tm scalanative_shared_tm_buf;
 
 static void scalanative_tm_init(struct scalanative_tm *scala_tm,
                                 struct tm *tm) {
@@ -72,7 +71,7 @@ struct scalanative_tm *scalanative_gmtime_r(const time_t *clock,
 }
 
 struct scalanative_tm *scalanative_gmtime(const time_t *clock) {
-    return scalanative_gmtime_r(clock, &scalanative_gmtime_buf);
+    return scalanative_gmtime_r(clock, &scalanative_shared_tm_buf);
 }
 
 struct scalanative_tm *scalanative_localtime_r(const time_t *clock,
@@ -84,7 +83,9 @@ struct scalanative_tm *scalanative_localtime_r(const time_t *clock,
 }
 
 struct scalanative_tm *scalanative_localtime(const time_t *clock) {
-    return scalanative_localtime_r(clock, &scalanative_localtime_buf);
+    // Calling localtime() ensures that tzset() has been called.
+    scalanative_tm_init(&scalanative_shared_tm_buf, localtime(clock));
+    return &scalanative_shared_tm_buf;
 }
 
 time_t scalanative_mktime(struct scalanative_tm *result) {


### PR DESCRIPTION
Change the implementation of posixlib localtime() to complies with the
relevant Posix specification.

Scala Native posixlib localtime() now calls C localtime(), not localtime_r().
C localtime() is required to act as though tzset() had been called, the
previously used localtime_r() does not have that requirement.