### PR TITLE
Homogenises numeric exception messages

### DIFF
--- a/javalib/src/main/scala/java/lang/Short.scala
+++ b/javalib/src/main/scala/java/lang/Short.scala
@@ -201,7 +201,8 @@ object Short {
     if (r == i)
       valueOf(r)
     else
-      throw new NumberFormatException()
+      throw new NumberFormatException(
+        s"""Value $nm out of range from input $nm""")
   }
 
   @inline def hashCode(value: scala.Short): scala.Int =
@@ -213,7 +214,8 @@ object Short {
   @inline def parseShort(s: String, radix: scala.Int): scala.Short = {
     val i = Integer.parseInt(s, radix)
     if (i < MIN_VALUE || i > MAX_VALUE)
-      throw new NumberFormatException(s"""For input string: "$s"""")
+      throw new NumberFormatException(
+        s"""Value out of range. Value:"$s" Radix:$radix""")
     else
       i.toShort
   }

--- a/unit-tests/src/test/scala/java/lang/IntegerTest.scala
+++ b/unit-tests/src/test/scala/java/lang/IntegerTest.scala
@@ -4,7 +4,6 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scalanative.junit.utils.AssertThrows._
-import scalanative.junit.utils.ThrowsHelper._
 
 class IntegerTest {
   val signedMaxValue     = Integer.MAX_VALUE
@@ -18,6 +17,13 @@ class IntegerTest {
   val unsignedMaxValue       = -1
   val unsignedMaxValueText   = "4294967295"
   val unsignedMaxPlusOneText = "4294967296"
+
+  def assertThrowsAndMessage[T <: Throwable, U](
+      expectedThrowable: Class[T],
+      code: => U)(expectedMsg: String): Unit = {
+    val exception = expectThrows(expectedThrowable, code)
+    assertEquals(expectedMsg, exception.toString)
+  }
 
   @Test def decodeTest(): Unit = {
     import Integer.decode

--- a/unit-tests/src/test/scala/java/lang/IntegerTest.scala
+++ b/unit-tests/src/test/scala/java/lang/IntegerTest.scala
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.ThrowsHelper._
 
 class IntegerTest {
   val signedMaxValue     = Integer.MAX_VALUE
@@ -17,6 +18,96 @@ class IntegerTest {
   val unsignedMaxValue       = -1
   val unsignedMaxValueText   = "4294967295"
   val unsignedMaxPlusOneText = "4294967296"
+
+  @Test def decodeTest(): Unit = {
+    import Integer.decode
+
+    assertTrue(decode("-1") == -1)
+    assertTrue(decode("+1") == 1)
+    assertTrue(decode("1") == 1)
+    assertTrue(decode("-123") == -123)
+    assertTrue(decode("+123") == 123)
+    assertTrue(decode("123") == 123)
+    assertTrue(decode("-0") == 0)
+    assertTrue(decode("+0") == 0)
+    assertTrue(decode("00") == 0)
+    assertTrue(decode("-0x1") == -1)
+    assertTrue(decode("+0x1") == 1)
+    assertTrue(decode("0x1") == 1)
+    assertTrue(decode("-0x7b") == -123)
+    assertTrue(decode("+0x7b") == 123)
+    assertTrue(decode("0x7b") == 123)
+    assertTrue(decode("-0x0") == 0)
+    assertTrue(decode("+0x0") == 0)
+    assertTrue(decode("0x0") == 0)
+    assertTrue(decode("-0X1") == -1)
+    assertTrue(decode("+0X1") == 1)
+    assertTrue(decode("0X1") == 1)
+    assertTrue(decode("-0X7B") == -123)
+    assertTrue(decode("+0X7B") == 123)
+    assertTrue(decode("0X7b") == 123)
+    assertTrue(decode("-0X0") == 0)
+    assertTrue(decode("+0X0") == 0)
+    assertTrue(decode("0X0") == 0)
+    assertTrue(decode("-#1") == -1)
+    assertTrue(decode("+#1") == 1)
+    assertTrue(decode("#1") == 1)
+    assertTrue(decode("-#7B") == -123)
+    assertTrue(decode("+#7B") == 123)
+    assertTrue(decode("#7b") == 123)
+    assertTrue(decode("-#0") == 0)
+    assertTrue(decode("+#0") == 0)
+    assertTrue(decode("#0") == 0)
+    assertTrue(decode("-01") == -1)
+    assertTrue(decode("+01") == 1)
+    assertTrue(decode("01") == 1)
+    assertTrue(decode("-0173") == -123)
+    assertTrue(decode("+0173") == 123)
+    assertTrue(decode("0173") == 123)
+    assertTrue(decode("-00") == 0)
+    assertTrue(decode("+00") == 0)
+    assertTrue(decode(signedMaxValueText) == signedMaxValue)
+    assertTrue(decode(signedMinValueText) == signedMinValue)
+
+    assertThrowsAnd(classOf[NumberFormatException], decode(null)) {
+      _.toString == "java.lang.NumberFormatException: null"
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("+")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "+""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("-")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "-""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("")) {
+      _.toString == """java.lang.NumberFormatException: For input string: """""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("0x")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "0x""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("#")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "#""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("0xh")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "0xh""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("0XH")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "0XH""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("09")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "09""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("123a")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    decode(signedMinMinusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    decode(signedMaxPlusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
+    }
+  }
 
   @Test def parseInt(): Unit = {
     import Integer.{parseInt => parse}
@@ -36,17 +127,36 @@ class IntegerTest {
     assertTrue(parse(signedMaxValueText) == signedMaxValue)
     assertTrue(parse(signedMinValueText) == signedMinValue)
 
-    assertThrows(classOf[NumberFormatException], parse(null))
-    assertThrows(classOf[NumberFormatException], parse("+"))
-    assertThrows(classOf[NumberFormatException], parse("-"))
-    assertThrows(classOf[NumberFormatException], parse(""))
-    assertThrows(classOf[NumberFormatException],
-                 parse("123", Character.MIN_RADIX - 1))
-    assertThrows(classOf[NumberFormatException],
-                 parse("123", Character.MAX_RADIX + 1))
-    assertThrows(classOf[NumberFormatException], parse("123a", 10))
-    assertThrows(classOf[NumberFormatException], parse(signedMinMinusOneText))
-    assertThrows(classOf[NumberFormatException], parse(signedMaxPlusOneText))
+    assertThrowsAnd(classOf[NumberFormatException], parse(null)) {
+      _.toString == "java.lang.NumberFormatException: null"
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("+")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "+""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("-")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "-""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("")) {
+      _.toString == """java.lang.NumberFormatException: For input string: """""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse("123", Character.MIN_RADIX - 1)) {
+      _.toString == """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse("123", Character.MAX_RADIX + 1)) {
+      _.toString == """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("123a", 10)) {
+      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse(signedMinMinusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse(signedMaxPlusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
+    }
   }
 
   @Test def parseUnsignedInt(): Unit = {
@@ -60,17 +170,36 @@ class IntegerTest {
     assertTrue(parse("100", 2) == 4)
     assertTrue(parse(unsignedMaxValueText) == unsignedMaxValue)
 
-    assertThrows(classOf[NumberFormatException], parse(null))
-    assertThrows(classOf[NumberFormatException], parse("+"))
-    assertThrows(classOf[NumberFormatException], parse("-"))
-    assertThrows(classOf[NumberFormatException], parse(""))
-    assertThrows(classOf[NumberFormatException], parse("-1"))
-    assertThrows(classOf[NumberFormatException],
-                 parse("123", Character.MIN_RADIX - 1))
-    assertThrows(classOf[NumberFormatException],
-                 parse("123", Character.MAX_RADIX + 1))
-    assertThrows(classOf[NumberFormatException], parse("123a", 10))
-    assertThrows(classOf[NumberFormatException], parse(unsignedMaxPlusOneText))
+    assertThrowsAnd(classOf[NumberFormatException], parse(null)) {
+      _.toString == """java.lang.NumberFormatException: null"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("+")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "+""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("-")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "-""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("")) {
+      _.toString == """java.lang.NumberFormatException: For input string: """""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("-1")) {
+      _.toString == """java.lang.NumberFormatException: Illegal leading minus sign on unsigned string -1."""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse("123", Character.MIN_RADIX - 1)) {
+      _.toString == """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse("123", Character.MAX_RADIX + 1)) {
+      _.toString == """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("123a", 10)) {
+      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse(unsignedMaxPlusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: String value $unsignedMaxPlusOneText exceeds range of unsigned int."""
+    }
 
     val octalMulOverflow = "137777777770"
     // in binary:

--- a/unit-tests/src/test/scala/java/lang/IntegerTest.scala
+++ b/unit-tests/src/test/scala/java/lang/IntegerTest.scala
@@ -22,184 +22,185 @@ class IntegerTest {
   @Test def decodeTest(): Unit = {
     import Integer.decode
 
-    assertTrue(decode("-1") == -1)
-    assertTrue(decode("+1") == 1)
-    assertTrue(decode("1") == 1)
-    assertTrue(decode("-123") == -123)
-    assertTrue(decode("+123") == 123)
-    assertTrue(decode("123") == 123)
-    assertTrue(decode("-0") == 0)
-    assertTrue(decode("+0") == 0)
-    assertTrue(decode("00") == 0)
-    assertTrue(decode("-0x1") == -1)
-    assertTrue(decode("+0x1") == 1)
-    assertTrue(decode("0x1") == 1)
-    assertTrue(decode("-0x7b") == -123)
-    assertTrue(decode("+0x7b") == 123)
-    assertTrue(decode("0x7b") == 123)
-    assertTrue(decode("-0x0") == 0)
-    assertTrue(decode("+0x0") == 0)
-    assertTrue(decode("0x0") == 0)
-    assertTrue(decode("-0X1") == -1)
-    assertTrue(decode("+0X1") == 1)
-    assertTrue(decode("0X1") == 1)
-    assertTrue(decode("-0X7B") == -123)
-    assertTrue(decode("+0X7B") == 123)
-    assertTrue(decode("0X7b") == 123)
-    assertTrue(decode("-0X0") == 0)
-    assertTrue(decode("+0X0") == 0)
-    assertTrue(decode("0X0") == 0)
-    assertTrue(decode("-#1") == -1)
-    assertTrue(decode("+#1") == 1)
-    assertTrue(decode("#1") == 1)
-    assertTrue(decode("-#7B") == -123)
-    assertTrue(decode("+#7B") == 123)
-    assertTrue(decode("#7b") == 123)
-    assertTrue(decode("-#0") == 0)
-    assertTrue(decode("+#0") == 0)
-    assertTrue(decode("#0") == 0)
-    assertTrue(decode("-01") == -1)
-    assertTrue(decode("+01") == 1)
-    assertTrue(decode("01") == 1)
-    assertTrue(decode("-0173") == -123)
-    assertTrue(decode("+0173") == 123)
-    assertTrue(decode("0173") == 123)
-    assertTrue(decode("-00") == 0)
-    assertTrue(decode("+00") == 0)
-    assertTrue(decode(signedMaxValueText) == signedMaxValue)
-    assertTrue(decode(signedMinValueText) == signedMinValue)
+    assertEquals(-1, decode("-1"))
+    assertEquals(1, decode("+1"))
+    assertEquals(1, decode("1"))
+    assertEquals(-123, decode("-123"))
+    assertEquals(123, decode("+123"))
+    assertEquals(123, decode("123"))
+    assertEquals(0, decode("-0"))
+    assertEquals(0, decode("+0"))
+    assertEquals(0, decode("00"))
+    assertEquals(-1, decode("-0x1"))
+    assertEquals(1, decode("+0x1"))
+    assertEquals(1, decode("0x1"))
+    assertEquals(-123, decode("-0x7b"))
+    assertEquals(123, decode("+0x7b"))
+    assertEquals(123, decode("0x7b"))
+    assertEquals(0, decode("-0x0"))
+    assertEquals(0, decode("+0x0"))
+    assertEquals(0, decode("0x0"))
+    assertEquals(-1, decode("-0X1"))
+    assertEquals(1, decode("+0X1"))
+    assertEquals(1, decode("0X1"))
+    assertEquals(-123, decode("-0X7B"))
+    assertEquals(123, decode("+0X7B"))
+    assertEquals(123, decode("0X7b"))
+    assertEquals(0, decode("-0X0"))
+    assertEquals(0, decode("+0X0"))
+    assertEquals(0, decode("0X0"))
+    assertEquals(-1, decode("-#1"))
+    assertEquals(1, decode("+#1"))
+    assertEquals(1, decode("#1"))
+    assertEquals(-123, decode("-#7B"))
+    assertEquals(123, decode("+#7B"))
+    assertEquals(123, decode("#7b"))
+    assertEquals(0, decode("-#0"))
+    assertEquals(0, decode("+#0"))
+    assertEquals(0, decode("#0"))
+    assertEquals(-1, decode("-01"))
+    assertEquals(1, decode("+01"))
+    assertEquals(1, decode("01"))
+    assertEquals(-123, decode("-0173"))
+    assertEquals(123, decode("+0173"))
+    assertEquals(123, decode("0173"))
+    assertEquals(0, decode("-00"))
+    assertEquals(0, decode("+00"))
+    assertEquals(signedMaxValue, decode(signedMaxValueText))
+    assertEquals(signedMinValue, decode(signedMinValueText))
 
-    assertThrowsAnd(classOf[NumberFormatException], decode(null)) {
-      _.toString == "java.lang.NumberFormatException: null"
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("+")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "+""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("-")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "-""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("")) {
-      _.toString == """java.lang.NumberFormatException: For input string: """""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("0x")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "0x""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("#")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "#""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("0xh")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "0xh""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("0XH")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "0XH""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("09")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "09""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("123a")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    decode(signedMinMinusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    decode(signedMaxPlusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
-    }
+    assertThrowsAndMessage(classOf[NumberFormatException], decode(null))(
+      "java.lang.NumberFormatException: null"
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("+"))(
+      """java.lang.NumberFormatException: For input string: "+""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("-"))(
+      """java.lang.NumberFormatException: For input string: "-""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode(""))(
+      """java.lang.NumberFormatException: For input string: """""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("0x"))(
+      """java.lang.NumberFormatException: For input string: "0x""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("#"))(
+      """java.lang.NumberFormatException: For input string: "#""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("0xh"))(
+      """java.lang.NumberFormatException: For input string: "0xh""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("0XH"))(
+      """java.lang.NumberFormatException: For input string: "0XH""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("09"))(
+      """java.lang.NumberFormatException: For input string: "09""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("123a"))(
+      """java.lang.NumberFormatException: For input string: "123a""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           decode(signedMinMinusOneText))(
+      s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           decode(signedMaxPlusOneText))(
+      s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
+    )
   }
 
   @Test def parseInt(): Unit = {
     import Integer.{parseInt => parse}
 
-    assertTrue(parse("-1") == -1)
-    assertTrue(parse("+1") == 1)
-    assertTrue(parse("1") == 1)
-    assertTrue(parse("-123") == -123)
-    assertTrue(parse("+123") == 123)
-    assertTrue(parse("123") == 123)
-    assertTrue(parse("-100", 2) == -4)
-    assertTrue(parse("+100", 2) == 4)
-    assertTrue(parse("100", 2) == 4)
-    assertTrue(parse("-0") == 0)
-    assertTrue(parse("+0") == 0)
-    assertTrue(parse("00") == 0)
-    assertTrue(parse(signedMaxValueText) == signedMaxValue)
-    assertTrue(parse(signedMinValueText) == signedMinValue)
+    assertEquals(-1, parse("-1"))
+    assertEquals(1, parse("+1"))
+    assertEquals(1, parse("1"))
+    assertEquals(-123, parse("-123"))
+    assertEquals(123, parse("+123"))
+    assertEquals(123, parse("123"))
+    assertEquals(-4, parse("-100", 2))
+    assertEquals(4, parse("+100", 2))
+    assertEquals(4, parse("100", 2))
+    assertEquals(0, parse("-0"))
+    assertEquals(0, parse("+0"))
+    assertEquals(0, parse("00"))
+    assertEquals(signedMaxValue, parse(signedMaxValueText))
+    assertEquals(signedMinValue, parse(signedMinValueText))
 
-    assertThrowsAnd(classOf[NumberFormatException], parse(null)) {
-      _.toString == "java.lang.NumberFormatException: null"
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("+")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "+""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("-")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "-""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("")) {
-      _.toString == """java.lang.NumberFormatException: For input string: """""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse("123", Character.MIN_RADIX - 1)) {
-      _.toString == """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse("123", Character.MAX_RADIX + 1)) {
-      _.toString == """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("123a", 10)) {
-      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse(signedMinMinusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse(signedMaxPlusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
-    }
+    assertThrowsAndMessage(classOf[NumberFormatException], parse(null))(
+      "java.lang.NumberFormatException: null"
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("+"))(
+      """java.lang.NumberFormatException: For input string: "+""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("-"))(
+      """java.lang.NumberFormatException: For input string: "-""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse(""))(
+      """java.lang.NumberFormatException: For input string: """""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse("123", Character.MIN_RADIX - 1))(
+      """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse("123", Character.MAX_RADIX + 1))(
+      """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("123a", 10))(
+      """java.lang.NumberFormatException: For input string: "123a""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse(signedMinMinusOneText))(
+      s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse(signedMaxPlusOneText))(
+      s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
+    )
   }
 
   @Test def parseUnsignedInt(): Unit = {
     import Integer.{parseUnsignedInt => parse}
 
-    assertTrue(parse("1") == 1)
-    assertTrue(parse("+1") == 1)
-    assertTrue(parse("0") == 0)
-    assertTrue(parse("00") == 0)
-    assertTrue(parse("+100", 2) == 4)
-    assertTrue(parse("100", 2) == 4)
-    assertTrue(parse(unsignedMaxValueText) == unsignedMaxValue)
+    assertEquals(1, parse("1"))
+    assertEquals(1, parse("+1"))
+    assertEquals(0, parse("0"))
+    assertEquals(0, parse("00"))
+    assertEquals(4, parse("+100", 2))
+    assertEquals(4, parse("100", 2))
+    assertEquals(unsignedMaxValue, parse(unsignedMaxValueText))
 
-    assertThrowsAnd(classOf[NumberFormatException], parse(null)) {
-      _.toString == """java.lang.NumberFormatException: null"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("+")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "+""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("-")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "-""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("")) {
-      _.toString == """java.lang.NumberFormatException: For input string: """""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("-1")) {
-      _.toString == """java.lang.NumberFormatException: Illegal leading minus sign on unsigned string -1."""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse("123", Character.MIN_RADIX - 1)) {
-      _.toString == """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse("123", Character.MAX_RADIX + 1)) {
-      _.toString == """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("123a", 10)) {
-      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse(unsignedMaxPlusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: String value $unsignedMaxPlusOneText exceeds range of unsigned int."""
-    }
+    assertThrowsAndMessage(classOf[NumberFormatException], parse(null))(
+      """java.lang.NumberFormatException: null"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("+"))(
+      """java.lang.NumberFormatException: For input string: "+""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("-"))(
+      """java.lang.NumberFormatException: For input string: "-""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse(""))(
+      """java.lang.NumberFormatException: For input string: """""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("-1"))(
+      """java.lang.NumberFormatException: Illegal leading minus sign on unsigned string -1."""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse("123", Character.MIN_RADIX - 1))(
+      """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse("123", Character.MAX_RADIX + 1))(
+      """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("123a", 10))(
+      """java.lang.NumberFormatException: For input string: "123a""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse(unsignedMaxPlusOneText))(
+      s"""java.lang.NumberFormatException: String value $unsignedMaxPlusOneText exceeds range of unsigned int."""
+    )
 
     val octalMulOverflow = "137777777770"
     // in binary:
@@ -211,65 +212,65 @@ class IntegerTest {
   @Test def testToString(): Unit = {
     import java.lang.Integer.{toString => toStr}
 
-    assertTrue(toStr(0) == "0")
-    assertTrue(toStr(1) == "1")
-    assertTrue(toStr(12) == "12")
-    assertTrue(toStr(123) == "123")
-    assertTrue(toStr(1234) == "1234")
-    assertTrue(toStr(12345) == "12345")
-    assertTrue(toStr(10) == "10")
-    assertTrue(toStr(100) == "100")
-    assertTrue(toStr(1000) == "1000")
-    assertTrue(toStr(10000) == "10000")
-    assertTrue(toStr(100000) == "100000")
-    assertTrue(toStr(101010) == "101010")
-    assertTrue(toStr(111111) == "111111")
-    assertTrue(toStr(-1) == "-1")
-    assertTrue(toStr(-12) == "-12")
-    assertTrue(toStr(-123) == "-123")
-    assertTrue(toStr(-1234) == "-1234")
-    assertTrue(toStr(-12345) == "-12345")
-    assertTrue(toStr(signedMaxValue) == signedMaxValueText)
-    assertTrue(toStr(signedMinValue) == signedMinValueText)
+    assertEquals("0", toStr(0))
+    assertEquals("1", toStr(1))
+    assertEquals("12", toStr(12))
+    assertEquals("123", toStr(123))
+    assertEquals("1234", toStr(1234))
+    assertEquals("12345", toStr(12345))
+    assertEquals("10", toStr(10))
+    assertEquals("100", toStr(100))
+    assertEquals("1000", toStr(1000))
+    assertEquals("10000", toStr(10000))
+    assertEquals("100000", toStr(100000))
+    assertEquals("101010", toStr(101010))
+    assertEquals("111111", toStr(111111))
+    assertEquals("-1", toStr(-1))
+    assertEquals("-12", toStr(-12))
+    assertEquals("-123", toStr(-123))
+    assertEquals("-1234", toStr(-1234))
+    assertEquals("-12345", toStr(-12345))
+    assertEquals(signedMaxValueText, toStr(signedMaxValue))
+    assertEquals(signedMinValueText, toStr(signedMinValue))
   }
 
   @Test def toUnsignedString(): Unit = {
     import java.lang.Integer.{toUnsignedString => toStr}
 
-    assertTrue(toStr(0) == "0")
-    assertTrue(toStr(1) == "1")
-    assertTrue(toStr(12) == "12")
-    assertTrue(toStr(123) == "123")
-    assertTrue(toStr(1234) == "1234")
-    assertTrue(toStr(12345) == "12345")
-    assertTrue(toStr(-1) == "4294967295")
-    assertTrue(toStr(-12) == "4294967284")
-    assertTrue(toStr(-123) == "4294967173")
-    assertTrue(toStr(-1234) == "4294966062")
-    assertTrue(toStr(-12345) == "4294954951")
-    assertTrue(toStr(unsignedMaxValue) == unsignedMaxValueText)
+    assertEquals("0", toStr(0))
+    assertEquals("1", toStr(1))
+    assertEquals("12", toStr(12))
+    assertEquals("123", toStr(123))
+    assertEquals("1234", toStr(1234))
+    assertEquals("12345", toStr(12345))
+    assertEquals("4294967295", toStr(-1))
+    assertEquals("4294967284", toStr(-12))
+    assertEquals("4294967173", toStr(-123))
+    assertEquals("4294966062", toStr(-1234))
+    assertEquals("4294954951", toStr(-12345))
+    assertEquals(unsignedMaxValueText, toStr(unsignedMaxValue))
   }
 
   @Test def testEquals(): Unit = {
-    assertTrue(new Integer(0) == new Integer(0))
-    assertTrue(new Integer(1) == new Integer(1))
-    assertTrue(new Integer(-1) == new Integer(-1))
-    assertTrue(new Integer(123) == new Integer(123))
-    assertTrue(new Integer(Integer.MAX_VALUE) == new Integer(Integer.MAX_VALUE))
-    assertTrue(new Integer(Integer.MIN_VALUE) == new Integer(Integer.MIN_VALUE))
+    assertEquals(new Integer(0), new Integer(0))
+    assertEquals(new Integer(1), new Integer(1))
+    assertEquals(new Integer(-1), new Integer(-1))
+    assertEquals(new Integer(123), new Integer(123))
+    assertEquals(new Integer(Integer.MAX_VALUE), new Integer(Integer.MAX_VALUE))
+    assertEquals(new Integer(Integer.MIN_VALUE), new Integer(Integer.MIN_VALUE))
   }
 
   @Test def highestOneBit(): Unit = {
-    assertTrue(Integer.highestOneBit(1) == 1)
-    assertTrue(Integer.highestOneBit(2) == 2)
-    assertTrue(Integer.highestOneBit(3) == 2)
-    assertTrue(Integer.highestOneBit(4) == 4)
-    assertTrue(Integer.highestOneBit(5) == 4)
-    assertTrue(Integer.highestOneBit(6) == 4)
-    assertTrue(Integer.highestOneBit(7) == 4)
-    assertTrue(Integer.highestOneBit(8) == 8)
-    assertTrue(Integer.highestOneBit(9) == 8)
-    assertTrue(Integer.highestOneBit(63) == 32)
-    assertTrue(Integer.highestOneBit(64) == 64)
+    assertEquals(1, Integer.highestOneBit(1))
+    assertEquals(2, Integer.highestOneBit(2))
+    assertEquals(2, Integer.highestOneBit(3))
+    assertEquals(4, Integer.highestOneBit(4))
+    assertEquals(4, Integer.highestOneBit(5))
+    assertEquals(4, Integer.highestOneBit(6))
+    assertEquals(4, Integer.highestOneBit(7))
+    assertEquals(8, Integer.highestOneBit(8))
+    assertEquals(8, Integer.highestOneBit(9))
+    assertEquals(32, Integer.highestOneBit(63))
+    assertEquals(64, Integer.highestOneBit(64))
   }
 }

--- a/unit-tests/src/test/scala/java/lang/LongTest.scala
+++ b/unit-tests/src/test/scala/java/lang/LongTest.scala
@@ -4,7 +4,6 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scalanative.junit.utils.AssertThrows._
-import scalanative.junit.utils.ThrowsHelper._
 
 class LongTest {
   val signedMaxValue     = Long.MAX_VALUE
@@ -18,6 +17,13 @@ class LongTest {
   val unsignedMaxValue       = -1L
   val unsignedMaxValueText   = "18446744073709551615"
   val unsignedMaxPlusOneText = "18446744073709551616"
+
+  def assertThrowsAndMessage[T <: Throwable, U](
+      expectedThrowable: Class[T],
+      code: => U)(expectedMsg: String): Unit = {
+    val exception = expectThrows(expectedThrowable, code)
+    assertEquals(expectedMsg, exception.toString)
+  }
 
   @Test def decodeTest(): Unit = {
     import Long.decode

--- a/unit-tests/src/test/scala/java/lang/LongTest.scala
+++ b/unit-tests/src/test/scala/java/lang/LongTest.scala
@@ -22,184 +22,185 @@ class LongTest {
   @Test def decodeTest(): Unit = {
     import Long.decode
 
-    assertTrue(decode("-1") == -1)
-    assertTrue(decode("+1") == 1)
-    assertTrue(decode("1") == 1)
-    assertTrue(decode("-123") == -123)
-    assertTrue(decode("+123") == 123)
-    assertTrue(decode("123") == 123)
-    assertTrue(decode("-0") == 0)
-    assertTrue(decode("+0") == 0)
-    assertTrue(decode("00") == 0)
-    assertTrue(decode("-0x1") == -1)
-    assertTrue(decode("+0x1") == 1)
-    assertTrue(decode("0x1") == 1)
-    assertTrue(decode("-0x7b") == -123)
-    assertTrue(decode("+0x7b") == 123)
-    assertTrue(decode("0x7b") == 123)
-    assertTrue(decode("-0x0") == 0)
-    assertTrue(decode("+0x0") == 0)
-    assertTrue(decode("0x0") == 0)
-    assertTrue(decode("-0X1") == -1)
-    assertTrue(decode("+0X1") == 1)
-    assertTrue(decode("0X1") == 1)
-    assertTrue(decode("-0X7B") == -123)
-    assertTrue(decode("+0X7B") == 123)
-    assertTrue(decode("0X7b") == 123)
-    assertTrue(decode("-0X0") == 0)
-    assertTrue(decode("+0X0") == 0)
-    assertTrue(decode("0X0") == 0)
-    assertTrue(decode("-#1") == -1)
-    assertTrue(decode("+#1") == 1)
-    assertTrue(decode("#1") == 1)
-    assertTrue(decode("-#7B") == -123)
-    assertTrue(decode("+#7B") == 123)
-    assertTrue(decode("#7b") == 123)
-    assertTrue(decode("-#0") == 0)
-    assertTrue(decode("+#0") == 0)
-    assertTrue(decode("#0") == 0)
-    assertTrue(decode("-01") == -1)
-    assertTrue(decode("+01") == 1)
-    assertTrue(decode("01") == 1)
-    assertTrue(decode("-0173") == -123)
-    assertTrue(decode("+0173") == 123)
-    assertTrue(decode("0173") == 123)
-    assertTrue(decode("-00") == 0)
-    assertTrue(decode("+00") == 0)
-    assertTrue(decode(signedMaxValueText) == signedMaxValue)
-    assertTrue(decode(signedMinValueText) == signedMinValue)
+    assertEquals(-1L, decode("-1"))
+    assertEquals(1L, decode("+1"))
+    assertEquals(1L, decode("1"))
+    assertEquals(-123L, decode("-123"))
+    assertEquals(123L, decode("+123"))
+    assertEquals(123L, decode("123"))
+    assertEquals(0L, decode("-0"))
+    assertEquals(0L, decode("+0"))
+    assertEquals(0L, decode("00"))
+    assertEquals(-1L, decode("-0x1"))
+    assertEquals(1L, decode("+0x1"))
+    assertEquals(1L, decode("0x1"))
+    assertEquals(-123L, decode("-0x7b"))
+    assertEquals(123L, decode("+0x7b"))
+    assertEquals(123L, decode("0x7b"))
+    assertEquals(0L, decode("-0x0"))
+    assertEquals(0L, decode("+0x0"))
+    assertEquals(0L, decode("0x0"))
+    assertEquals(-1L, decode("-0X1"))
+    assertEquals(1L, decode("+0X1"))
+    assertEquals(1L, decode("0X1"))
+    assertEquals(-123L, decode("-0X7B"))
+    assertEquals(123L, decode("+0X7B"))
+    assertEquals(123L, decode("0X7b"))
+    assertEquals(0L, decode("-0X0"))
+    assertEquals(0L, decode("+0X0"))
+    assertEquals(0L, decode("0X0"))
+    assertEquals(-1L, decode("-#1"))
+    assertEquals(1L, decode("+#1"))
+    assertEquals(1L, decode("#1"))
+    assertEquals(-123L, decode("-#7B"))
+    assertEquals(123L, decode("+#7B"))
+    assertEquals(123L, decode("#7b"))
+    assertEquals(0L, decode("-#0"))
+    assertEquals(0L, decode("+#0"))
+    assertEquals(0L, decode("#0"))
+    assertEquals(-1L, decode("-01"))
+    assertEquals(1L, decode("+01"))
+    assertEquals(1L, decode("01"))
+    assertEquals(-123L, decode("-0173"))
+    assertEquals(123L, decode("+0173"))
+    assertEquals(123L, decode("0173"))
+    assertEquals(0L, decode("-00"))
+    assertEquals(0L, decode("+00"))
+    assertEquals(signedMaxValue, decode(signedMaxValueText))
+    assertEquals(signedMinValue, decode(signedMinValueText))
 
-    assertThrowsAnd(classOf[NumberFormatException], decode(null)) {
-      _.toString == "java.lang.NumberFormatException: null"
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("+")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "+""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("-")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "-""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("")) {
-      _.toString == """java.lang.NumberFormatException: For input string: """""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("0x")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "0x""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("#")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "#""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("0xh")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "0xh""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("0XH")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "0XH""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("09")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "09""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("123a")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    decode(signedMinMinusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    decode(signedMaxPlusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
-    }
+    assertThrowsAndMessage(classOf[NumberFormatException], decode(null))(
+      "java.lang.NumberFormatException: null"
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("+"))(
+      """java.lang.NumberFormatException: For input string: "+""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("-"))(
+      """java.lang.NumberFormatException: For input string: "-""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode(""))(
+      """java.lang.NumberFormatException: For input string: """""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("0x"))(
+      """java.lang.NumberFormatException: For input string: "0x""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("#"))(
+      """java.lang.NumberFormatException: For input string: "#""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("0xh"))(
+      """java.lang.NumberFormatException: For input string: "0xh""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("0XH"))(
+      """java.lang.NumberFormatException: For input string: "0XH""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("09"))(
+      """java.lang.NumberFormatException: For input string: "09""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("123a"))(
+      """java.lang.NumberFormatException: For input string: "123a""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           decode(signedMinMinusOneText))(
+      s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           decode(signedMaxPlusOneText))(
+      s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
+    )
   }
 
   @Test def parseLong(): Unit = {
     import Long.{parseLong => parse}
 
-    assertTrue(parse("-1") == -1L)
-    assertTrue(parse("+1") == 1L)
-    assertTrue(parse("1") == 1L)
-    assertTrue(parse("-123") == -123L)
-    assertTrue(parse("+123") == 123L)
-    assertTrue(parse("123") == 123L)
-    assertTrue(parse("-100", 2) == -4L)
-    assertTrue(parse("+100", 2) == 4L)
-    assertTrue(parse("100", 2) == 4L)
-    assertTrue(parse("-0") == 0L)
-    assertTrue(parse("+0") == 0L)
-    assertTrue(parse("00") == 0L)
-    assertTrue(parse(signedMaxValueText) == signedMaxValue)
-    assertTrue(parse(signedMinValueText) == signedMinValue)
+    assertEquals(-1L, parse("-1"))
+    assertEquals(1L, parse("+1"))
+    assertEquals(1L, parse("1"))
+    assertEquals(-123L, parse("-123"))
+    assertEquals(123L, parse("+123"))
+    assertEquals(123L, parse("123"))
+    assertEquals(-4L, parse("-100", 2))
+    assertEquals(4L, parse("+100", 2))
+    assertEquals(4L, parse("100", 2))
+    assertEquals(0L, parse("-0"))
+    assertEquals(0L, parse("+0"))
+    assertEquals(0L, parse("00"))
+    assertEquals(signedMaxValue, parse(signedMaxValueText))
+    assertEquals(signedMinValue, parse(signedMinValueText))
 
-    assertThrowsAnd(classOf[NumberFormatException], parse(null)) {
-      _.toString == "java.lang.NumberFormatException: null"
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("+")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "+""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("-")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "-""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("")) {
-      _.toString == """java.lang.NumberFormatException: For input string: """""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse("123", Character.MIN_RADIX - 1)) {
-      _.toString == """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse("123", Character.MAX_RADIX + 1)) {
-      _.toString == """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("123a", 10)) {
-      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse(signedMinMinusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse(signedMaxPlusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
-    }
+    assertThrowsAndMessage(classOf[NumberFormatException], parse(null))(
+      "java.lang.NumberFormatException: null"
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("+"))(
+      """java.lang.NumberFormatException: For input string: "+""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("-"))(
+      """java.lang.NumberFormatException: For input string: "-""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse(""))(
+      """java.lang.NumberFormatException: For input string: """""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse("123", Character.MIN_RADIX - 1))(
+      """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse("123", Character.MAX_RADIX + 1))(
+      """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("123a", 10))(
+      """java.lang.NumberFormatException: For input string: "123a""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse(signedMinMinusOneText))(
+      s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse(signedMaxPlusOneText))(
+      s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
+    )
   }
 
   @Test def parseUnsignedLong(): Unit = {
     import Long.{parseUnsignedLong => parse}
 
-    assertTrue(parse("1") == 1)
-    assertTrue(parse("+1") == 1)
-    assertTrue(parse("0") == 0)
-    assertTrue(parse("00") == 0)
-    assertTrue(parse("+100", 2) == 4)
-    assertTrue(parse("100", 2) == 4)
-    assertTrue(parse(unsignedMaxValueText) == unsignedMaxValue)
+    assertEquals(1L, parse("1"))
+    assertEquals(1L, parse("+1"))
+    assertEquals(0L, parse("0"))
+    assertEquals(0L, parse("00"))
+    assertEquals(4L, parse("+100", 2))
+    assertEquals(4L, parse("100", 2))
+    assertEquals(unsignedMaxValue, parse(unsignedMaxValueText))
 
-    assertThrowsAnd(classOf[NumberFormatException], parse(null)) {
-      _.toString == """java.lang.NumberFormatException: null"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("+")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "+""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("-")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "-""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("")) {
-      _.toString == """java.lang.NumberFormatException: For input string: """""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("-1")) {
-      _.toString == """java.lang.NumberFormatException: Illegal leading minus sign on unsigned string -1."""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse("123", Character.MIN_RADIX - 1)) {
-      _.toString == """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse("123", Character.MAX_RADIX + 1)) {
-      _.toString == """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("123a", 10)) {
-      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse(unsignedMaxPlusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: String value $unsignedMaxPlusOneText exceeds range of unsigned long."""
-    }
+    assertThrowsAndMessage(classOf[NumberFormatException], parse(null))(
+      """java.lang.NumberFormatException: null"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("+"))(
+      """java.lang.NumberFormatException: For input string: "+""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("-"))(
+      """java.lang.NumberFormatException: For input string: "-""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse(""))(
+      """java.lang.NumberFormatException: For input string: """""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("-1"))(
+      """java.lang.NumberFormatException: Illegal leading minus sign on unsigned string -1."""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse("123", Character.MIN_RADIX - 1))(
+      """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse("123", Character.MAX_RADIX + 1))(
+      """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("123a", 10))(
+      """java.lang.NumberFormatException: For input string: "123a""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse(unsignedMaxPlusOneText))(
+      s"""java.lang.NumberFormatException: String value $unsignedMaxPlusOneText exceeds range of unsigned long."""
+    )
 
     val octalMulOverflow = "5777777777777777777770"
     // in binary:
@@ -211,67 +212,67 @@ class LongTest {
   @Test def testToString(): Unit = {
     import java.lang.Long.{toString => toStr}
 
-    assertTrue(toStr(0L) == "0")
-    assertTrue(toStr(1L) == "1")
-    assertTrue(toStr(12L) == "12")
-    assertTrue(toStr(123L) == "123")
-    assertTrue(toStr(1234L) == "1234")
-    assertTrue(toStr(12345L) == "12345")
-    assertTrue(toStr(10L) == "10")
-    assertTrue(toStr(100L) == "100")
-    assertTrue(toStr(1000L) == "1000")
-    assertTrue(toStr(10000L) == "10000")
-    assertTrue(toStr(100000L) == "100000")
-    assertTrue(toStr(101010L) == "101010")
-    assertTrue(toStr(111111L) == "111111")
-    assertTrue(toStr(-1L) == "-1")
-    assertTrue(toStr(-12L) == "-12")
-    assertTrue(toStr(-123L) == "-123")
-    assertTrue(toStr(-1234L) == "-1234")
-    assertTrue(toStr(-12345L) == "-12345")
-    assertTrue(toStr(signedMaxValue) == signedMaxValueText)
-    assertTrue(toStr(signedMinValue) == signedMinValueText)
+    assertEquals("0", toStr(0L))
+    assertEquals("1", toStr(1L))
+    assertEquals("12", toStr(12L))
+    assertEquals("123", toStr(123L))
+    assertEquals("1234", toStr(1234L))
+    assertEquals("12345", toStr(12345L))
+    assertEquals("10", toStr(10L))
+    assertEquals("100", toStr(100L))
+    assertEquals("1000", toStr(1000L))
+    assertEquals("10000", toStr(10000L))
+    assertEquals("100000", toStr(100000L))
+    assertEquals("101010", toStr(101010L))
+    assertEquals("111111", toStr(111111L))
+    assertEquals("-1", toStr(-1L))
+    assertEquals("-12", toStr(-12L))
+    assertEquals("-123", toStr(-123L))
+    assertEquals("-1234", toStr(-1234L))
+    assertEquals("-12345", toStr(-12345L))
+    assertEquals(signedMaxValueText, toStr(signedMaxValue))
+    assertEquals(signedMinValueText, toStr(signedMinValue))
   }
 
   @Test def toUnsignedString(): Unit = {
     import java.lang.Long.{toUnsignedString => toStr}
 
-    assertTrue(toStr(0L) == "0")
-    assertTrue(toStr(1L) == "1")
-    assertTrue(toStr(12L) == "12")
-    assertTrue(toStr(123L) == "123")
-    assertTrue(toStr(1234L) == "1234")
-    assertTrue(toStr(12345L) == "12345")
-    assertTrue(toStr(-1L) == "18446744073709551615")
-    assertTrue(toStr(-12L) == "18446744073709551604")
-    assertTrue(toStr(-123L) == "18446744073709551493")
-    assertTrue(toStr(-1234L) == "18446744073709550382")
-    assertTrue(toStr(-12345L) == "18446744073709539271")
-    assertTrue(toStr(unsignedMaxValue) == unsignedMaxValueText)
+    assertEquals("0", toStr(0L))
+    assertEquals("1", toStr(1L))
+    assertEquals("12", toStr(12L))
+    assertEquals("123", toStr(123L))
+    assertEquals("1234", toStr(1234L))
+    assertEquals("12345", toStr(12345L))
+    assertEquals("18446744073709551615", toStr(-1L))
+    assertEquals("18446744073709551604", toStr(-12L))
+    assertEquals("18446744073709551493", toStr(-123L))
+    assertEquals("18446744073709550382", toStr(-1234L))
+    assertEquals("18446744073709539271", toStr(-12345L))
+    assertEquals(unsignedMaxValueText, toStr(unsignedMaxValue))
   }
 
   @Test def testEquals(): Unit = {
-    assertTrue(new Long(0) == new Long(0))
-    assertTrue(new Long(1) == new Long(1))
-    assertTrue(new Long(-1) == new Long(-1))
-    assertTrue(new Long(123) == new Long(123))
-    assertTrue(new Long(Long.MAX_VALUE) == new Long(Long.MAX_VALUE))
-    assertTrue(new Long(Long.MIN_VALUE) == new Long(Long.MIN_VALUE))
+    assertEquals(new Long(0), new Long(0))
+    assertEquals(new Long(1), new Long(1))
+    assertEquals(new Long(-1), new Long(-1))
+    assertEquals(new Long(123), new Long(123))
+    assertEquals(new Long(Long.MAX_VALUE), new Long(Long.MAX_VALUE))
+    assertEquals(new Long(Long.MIN_VALUE), new Long(Long.MIN_VALUE))
   }
 
   @Test def highestOneBit(): Unit = {
-    assertTrue(Long.highestOneBit(1) == 1L)
-    assertTrue(Long.highestOneBit(2) == 2L)
-    assertTrue(Long.highestOneBit(3) == 2L)
-    assertTrue(Long.highestOneBit(4) == 4L)
-    assertTrue(Long.highestOneBit(5) == 4L)
-    assertTrue(Long.highestOneBit(6) == 4L)
-    assertTrue(Long.highestOneBit(7) == 4L)
-    assertTrue(Long.highestOneBit(8) == 8L)
-    assertTrue(Long.highestOneBit(9) == 8L)
-    assertTrue(Long.highestOneBit(63) == 32L)
-    assertTrue(Long.highestOneBit(64) == 64L)
-    assertTrue(Long.highestOneBit(Int.MaxValue) == 1073741824)
-    assertTrue(Long.highestOneBit(Int.MaxValue + 1L) == 2147483648L)
+    assertEquals(1L, Long.highestOneBit(1))
+    assertEquals(2L, Long.highestOneBit(2))
+    assertEquals(2L, Long.highestOneBit(3))
+    assertEquals(4L, Long.highestOneBit(4))
+    assertEquals(4L, Long.highestOneBit(5))
+    assertEquals(4L, Long.highestOneBit(6))
+    assertEquals(4L, Long.highestOneBit(7))
+    assertEquals(8L, Long.highestOneBit(8))
+    assertEquals(8L, Long.highestOneBit(9))
+    assertEquals(32L, Long.highestOneBit(63))
+    assertEquals(64L, Long.highestOneBit(64))
+    assertEquals(1073741824L, Long.highestOneBit(Int.MaxValue))
+    assertEquals(2147483648L, Long.highestOneBit(Int.MaxValue + 1L))
   }
 }

--- a/unit-tests/src/test/scala/java/lang/LongTest.scala
+++ b/unit-tests/src/test/scala/java/lang/LongTest.scala
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.ThrowsHelper._
 
 class LongTest {
   val signedMaxValue     = Long.MAX_VALUE
@@ -17,6 +18,96 @@ class LongTest {
   val unsignedMaxValue       = -1L
   val unsignedMaxValueText   = "18446744073709551615"
   val unsignedMaxPlusOneText = "18446744073709551616"
+
+  @Test def decodeTest(): Unit = {
+    import Long.decode
+
+    assertTrue(decode("-1") == -1)
+    assertTrue(decode("+1") == 1)
+    assertTrue(decode("1") == 1)
+    assertTrue(decode("-123") == -123)
+    assertTrue(decode("+123") == 123)
+    assertTrue(decode("123") == 123)
+    assertTrue(decode("-0") == 0)
+    assertTrue(decode("+0") == 0)
+    assertTrue(decode("00") == 0)
+    assertTrue(decode("-0x1") == -1)
+    assertTrue(decode("+0x1") == 1)
+    assertTrue(decode("0x1") == 1)
+    assertTrue(decode("-0x7b") == -123)
+    assertTrue(decode("+0x7b") == 123)
+    assertTrue(decode("0x7b") == 123)
+    assertTrue(decode("-0x0") == 0)
+    assertTrue(decode("+0x0") == 0)
+    assertTrue(decode("0x0") == 0)
+    assertTrue(decode("-0X1") == -1)
+    assertTrue(decode("+0X1") == 1)
+    assertTrue(decode("0X1") == 1)
+    assertTrue(decode("-0X7B") == -123)
+    assertTrue(decode("+0X7B") == 123)
+    assertTrue(decode("0X7b") == 123)
+    assertTrue(decode("-0X0") == 0)
+    assertTrue(decode("+0X0") == 0)
+    assertTrue(decode("0X0") == 0)
+    assertTrue(decode("-#1") == -1)
+    assertTrue(decode("+#1") == 1)
+    assertTrue(decode("#1") == 1)
+    assertTrue(decode("-#7B") == -123)
+    assertTrue(decode("+#7B") == 123)
+    assertTrue(decode("#7b") == 123)
+    assertTrue(decode("-#0") == 0)
+    assertTrue(decode("+#0") == 0)
+    assertTrue(decode("#0") == 0)
+    assertTrue(decode("-01") == -1)
+    assertTrue(decode("+01") == 1)
+    assertTrue(decode("01") == 1)
+    assertTrue(decode("-0173") == -123)
+    assertTrue(decode("+0173") == 123)
+    assertTrue(decode("0173") == 123)
+    assertTrue(decode("-00") == 0)
+    assertTrue(decode("+00") == 0)
+    assertTrue(decode(signedMaxValueText) == signedMaxValue)
+    assertTrue(decode(signedMinValueText) == signedMinValue)
+
+    assertThrowsAnd(classOf[NumberFormatException], decode(null)) {
+      _.toString == "java.lang.NumberFormatException: null"
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("+")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "+""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("-")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "-""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("")) {
+      _.toString == """java.lang.NumberFormatException: For input string: """""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("0x")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "0x""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("#")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "#""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("0xh")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "0xh""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("0XH")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "0XH""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("09")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "09""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("123a")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    decode(signedMinMinusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    decode(signedMaxPlusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
+    }
+  }
 
   @Test def parseLong(): Unit = {
     import Long.{parseLong => parse}
@@ -36,17 +127,36 @@ class LongTest {
     assertTrue(parse(signedMaxValueText) == signedMaxValue)
     assertTrue(parse(signedMinValueText) == signedMinValue)
 
-    assertThrows(classOf[NumberFormatException], parse(null))
-    assertThrows(classOf[NumberFormatException], parse("+"))
-    assertThrows(classOf[NumberFormatException], parse("-"))
-    assertThrows(classOf[NumberFormatException], parse(""))
-    assertThrows(classOf[NumberFormatException],
-                 parse("123", Character.MIN_RADIX - 1))
-    assertThrows(classOf[NumberFormatException],
-                 parse("123", Character.MAX_RADIX + 1))
-    assertThrows(classOf[NumberFormatException], parse("123a", 10))
-    assertThrows(classOf[NumberFormatException], parse(signedMinMinusOneText))
-    assertThrows(classOf[NumberFormatException], parse(signedMaxPlusOneText))
+    assertThrowsAnd(classOf[NumberFormatException], parse(null)) {
+      _.toString == "java.lang.NumberFormatException: null"
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("+")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "+""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("-")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "-""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("")) {
+      _.toString == """java.lang.NumberFormatException: For input string: """""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse("123", Character.MIN_RADIX - 1)) {
+      _.toString == """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse("123", Character.MAX_RADIX + 1)) {
+      _.toString == """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("123a", 10)) {
+      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse(signedMinMinusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMinMinusOneText""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse(signedMaxPlusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: For input string: "$signedMaxPlusOneText""""
+    }
   }
 
   @Test def parseUnsignedLong(): Unit = {
@@ -60,17 +170,36 @@ class LongTest {
     assertTrue(parse("100", 2) == 4)
     assertTrue(parse(unsignedMaxValueText) == unsignedMaxValue)
 
-    assertThrows(classOf[NumberFormatException], parse(null))
-    assertThrows(classOf[NumberFormatException], parse("+"))
-    assertThrows(classOf[NumberFormatException], parse("-"))
-    assertThrows(classOf[NumberFormatException], parse(""))
-    assertThrows(classOf[NumberFormatException], parse("-1"))
-    assertThrows(classOf[NumberFormatException],
-                 parse("123", Character.MIN_RADIX - 1))
-    assertThrows(classOf[NumberFormatException],
-                 parse("123", Character.MAX_RADIX + 1))
-    assertThrows(classOf[NumberFormatException], parse("123a", 10))
-    assertThrows(classOf[NumberFormatException], parse(unsignedMaxPlusOneText))
+    assertThrowsAnd(classOf[NumberFormatException], parse(null)) {
+      _.toString == """java.lang.NumberFormatException: null"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("+")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "+""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("-")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "-""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("")) {
+      _.toString == """java.lang.NumberFormatException: For input string: """""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("-1")) {
+      _.toString == """java.lang.NumberFormatException: Illegal leading minus sign on unsigned string -1."""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse("123", Character.MIN_RADIX - 1)) {
+      _.toString == """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse("123", Character.MAX_RADIX + 1)) {
+      _.toString == """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("123a", 10)) {
+      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse(unsignedMaxPlusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: String value $unsignedMaxPlusOneText exceeds range of unsigned long."""
+    }
 
     val octalMulOverflow = "5777777777777777777770"
     // in binary:

--- a/unit-tests/src/test/scala/java/lang/ShortTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ShortTest.scala
@@ -15,6 +15,13 @@ class ShortTest {
   val signedMaxPlusOneText  = "32768"
   val signedMinMinusOneText = "-32769"
 
+  def assertThrowsAndMessage[T <: Throwable, U](
+      expectedThrowable: Class[T],
+      code: => U)(expectedMsg: String): Unit = {
+    val exception = expectThrows(expectedThrowable, code)
+    assertEquals(expectedMsg, exception.toString)
+  }
+
   @Test def decodeTest(): Unit = {
     import Short.decode
 

--- a/unit-tests/src/test/scala/java/lang/ShortTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ShortTest.scala
@@ -1,0 +1,188 @@
+package java.lang
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.ThrowsHelper._
+
+class ShortTest {
+  val signedMaxValue     = Short.MAX_VALUE
+  val signedMaxValueText = "32767"
+  val signedMinValue     = Short.MIN_VALUE
+  val signedMinValueText = "-32768"
+
+  val signedMaxPlusOneText  = "32768"
+  val signedMinMinusOneText = "-32769"
+
+  @Test def decodeTest(): Unit = {
+    import Short.decode
+
+    assertTrue(decode("-1") == -1)
+    assertTrue(decode("+1") == 1)
+    assertTrue(decode("1") == 1)
+    assertTrue(decode("-123") == -123)
+    assertTrue(decode("+123") == 123)
+    assertTrue(decode("123") == 123)
+    assertTrue(decode("-0") == 0)
+    assertTrue(decode("+0") == 0)
+    assertTrue(decode("00") == 0)
+    assertTrue(decode("-0x1") == -1)
+    assertTrue(decode("+0x1") == 1)
+    assertTrue(decode("0x1") == 1)
+    assertTrue(decode("-0x7b") == -123)
+    assertTrue(decode("+0x7b") == 123)
+    assertTrue(decode("0x7b") == 123)
+    assertTrue(decode("-0x0") == 0)
+    assertTrue(decode("+0x0") == 0)
+    assertTrue(decode("0x0") == 0)
+    assertTrue(decode("-0X1") == -1)
+    assertTrue(decode("+0X1") == 1)
+    assertTrue(decode("0X1") == 1)
+    assertTrue(decode("-0X7B") == -123)
+    assertTrue(decode("+0X7B") == 123)
+    assertTrue(decode("0X7b") == 123)
+    assertTrue(decode("-0X0") == 0)
+    assertTrue(decode("+0X0") == 0)
+    assertTrue(decode("0X0") == 0)
+    assertTrue(decode("-#1") == -1)
+    assertTrue(decode("+#1") == 1)
+    assertTrue(decode("#1") == 1)
+    assertTrue(decode("-#7B") == -123)
+    assertTrue(decode("+#7B") == 123)
+    assertTrue(decode("#7b") == 123)
+    assertTrue(decode("-#0") == 0)
+    assertTrue(decode("+#0") == 0)
+    assertTrue(decode("#0") == 0)
+    assertTrue(decode("-01") == -1)
+    assertTrue(decode("+01") == 1)
+    assertTrue(decode("01") == 1)
+    assertTrue(decode("-0173") == -123)
+    assertTrue(decode("+0173") == 123)
+    assertTrue(decode("0173") == 123)
+    assertTrue(decode("-00") == 0)
+    assertTrue(decode("+00") == 0)
+    assertTrue(decode(signedMaxValueText) == signedMaxValue)
+    assertTrue(decode(signedMinValueText) == signedMinValue)
+
+    assertThrowsAnd(classOf[NumberFormatException], decode(null)) {
+      _.toString == "java.lang.NumberFormatException: null"
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("+")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "+""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("-")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "-""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("")) {
+      _.toString == """java.lang.NumberFormatException: For input string: """""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("0x")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "0x""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("#")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "#""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("0xh")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "0xh""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("0XH")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "0XH""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("09")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "09""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], decode("123a")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    decode(signedMaxPlusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: Value $signedMaxPlusOneText out of range from input $signedMaxPlusOneText"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    decode(signedMinMinusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: Value $signedMinMinusOneText out of range from input $signedMinMinusOneText"""
+    }
+  }
+
+  @Test def parseShort(): Unit = {
+    import Short.{parseShort => parse}
+
+    assertTrue(parse("-1") == -1)
+    assertTrue(parse("+1") == 1)
+    assertTrue(parse("1") == 1)
+    assertTrue(parse("-123") == -123)
+    assertTrue(parse("+123") == 123)
+    assertTrue(parse("123") == 123)
+    assertTrue(parse("-100", 2) == -4)
+    assertTrue(parse("+100", 2) == 4)
+    assertTrue(parse("100", 2) == 4)
+    assertTrue(parse("-0") == 0)
+    assertTrue(parse("+0") == 0)
+    assertTrue(parse("00") == 0)
+    assertTrue(parse(signedMaxValueText) == signedMaxValue)
+    assertTrue(parse(signedMinValueText) == signedMinValue)
+
+    assertThrowsAnd(classOf[NumberFormatException], parse(null)) {
+      _.toString == "java.lang.NumberFormatException: null"
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("+")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "+""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("-")) {
+      _.toString == """java.lang.NumberFormatException: For input string: "-""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("")) {
+      _.toString == """java.lang.NumberFormatException: For input string: """""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse("123", Character.MIN_RADIX - 1)) {
+      _.toString == """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse("123", Character.MAX_RADIX + 1)) {
+      _.toString == """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse("123a", 10)) {
+      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
+    }
+    assertThrowsAnd(classOf[NumberFormatException], parse(signedMaxPlusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: Value out of range. Value:"$signedMaxPlusOneText" Radix:10"""
+    }
+    assertThrowsAnd(classOf[NumberFormatException],
+                    parse(signedMinMinusOneText)) {
+      _.toString == s"""java.lang.NumberFormatException: Value out of range. Value:"$signedMinMinusOneText" Radix:10"""
+    }
+  }
+
+  @Test def testToString(): Unit = {
+    import java.lang.Short.{toString => toStr}
+
+    assertTrue(toStr(0.toShort) == "0")
+    assertTrue(toStr(1.toShort) == "1")
+    assertTrue(toStr(12.toShort) == "12")
+    assertTrue(toStr(123.toShort) == "123")
+    assertTrue(toStr(1234.toShort) == "1234")
+    assertTrue(toStr(12345.toShort) == "12345")
+    assertTrue(toStr(10.toShort) == "10")
+    assertTrue(toStr(100.toShort) == "100")
+    assertTrue(toStr(1000.toShort) == "1000")
+    assertTrue(toStr(10000.toShort) == "10000")
+    assertTrue(toStr(-1.toShort) == "-1")
+    assertTrue(toStr(-12.toShort) == "-12")
+    assertTrue(toStr(-123.toShort) == "-123")
+    assertTrue(toStr(-1234.toShort) == "-1234")
+    assertTrue(toStr(-12345.toShort) == "-12345")
+    assertTrue(toStr(signedMaxValue) == signedMaxValueText)
+    assertTrue(toStr(signedMinValue) == signedMinValueText)
+  }
+
+  @Test def testEquals(): Unit = {
+    assertTrue(new Short(0.toShort) == new Short(0.toShort))
+    assertTrue(new Short(1.toShort) == new Short(1.toShort))
+    assertTrue(new Short(-1.toShort) == new Short(-1.toShort))
+    assertTrue(new Short(123.toShort) == new Short(123.toShort))
+    assertTrue(new Short(Short.MAX_VALUE) == new Short(Short.MAX_VALUE))
+    assertTrue(new Short(Short.MIN_VALUE) == new Short(Short.MIN_VALUE))
+  }
+}

--- a/unit-tests/src/test/scala/java/lang/ShortTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ShortTest.scala
@@ -18,171 +18,172 @@ class ShortTest {
   @Test def decodeTest(): Unit = {
     import Short.decode
 
-    assertTrue(decode("-1") == -1)
-    assertTrue(decode("+1") == 1)
-    assertTrue(decode("1") == 1)
-    assertTrue(decode("-123") == -123)
-    assertTrue(decode("+123") == 123)
-    assertTrue(decode("123") == 123)
-    assertTrue(decode("-0") == 0)
-    assertTrue(decode("+0") == 0)
-    assertTrue(decode("00") == 0)
-    assertTrue(decode("-0x1") == -1)
-    assertTrue(decode("+0x1") == 1)
-    assertTrue(decode("0x1") == 1)
-    assertTrue(decode("-0x7b") == -123)
-    assertTrue(decode("+0x7b") == 123)
-    assertTrue(decode("0x7b") == 123)
-    assertTrue(decode("-0x0") == 0)
-    assertTrue(decode("+0x0") == 0)
-    assertTrue(decode("0x0") == 0)
-    assertTrue(decode("-0X1") == -1)
-    assertTrue(decode("+0X1") == 1)
-    assertTrue(decode("0X1") == 1)
-    assertTrue(decode("-0X7B") == -123)
-    assertTrue(decode("+0X7B") == 123)
-    assertTrue(decode("0X7b") == 123)
-    assertTrue(decode("-0X0") == 0)
-    assertTrue(decode("+0X0") == 0)
-    assertTrue(decode("0X0") == 0)
-    assertTrue(decode("-#1") == -1)
-    assertTrue(decode("+#1") == 1)
-    assertTrue(decode("#1") == 1)
-    assertTrue(decode("-#7B") == -123)
-    assertTrue(decode("+#7B") == 123)
-    assertTrue(decode("#7b") == 123)
-    assertTrue(decode("-#0") == 0)
-    assertTrue(decode("+#0") == 0)
-    assertTrue(decode("#0") == 0)
-    assertTrue(decode("-01") == -1)
-    assertTrue(decode("+01") == 1)
-    assertTrue(decode("01") == 1)
-    assertTrue(decode("-0173") == -123)
-    assertTrue(decode("+0173") == 123)
-    assertTrue(decode("0173") == 123)
-    assertTrue(decode("-00") == 0)
-    assertTrue(decode("+00") == 0)
-    assertTrue(decode(signedMaxValueText) == signedMaxValue)
-    assertTrue(decode(signedMinValueText) == signedMinValue)
+    assertEquals(-1.toShort, decode("-1"))
+    assertEquals(1.toShort, decode("+1"))
+    assertEquals(1.toShort, decode("1"))
+    assertEquals(-123.toShort, decode("-123"))
+    assertEquals(123.toShort, decode("+123"))
+    assertEquals(123.toShort, decode("123"))
+    assertEquals(0.toShort, decode("-0"))
+    assertEquals(0.toShort, decode("+0"))
+    assertEquals(0.toShort, decode("00"))
+    assertEquals(-1.toShort, decode("-0x1"))
+    assertEquals(1.toShort, decode("+0x1"))
+    assertEquals(1.toShort, decode("0x1"))
+    assertEquals(-123.toShort, decode("-0x7b"))
+    assertEquals(123.toShort, decode("+0x7b"))
+    assertEquals(123.toShort, decode("0x7b"))
+    assertEquals(0.toShort, decode("-0x0"))
+    assertEquals(0.toShort, decode("+0x0"))
+    assertEquals(0.toShort, decode("0x0"))
+    assertEquals(-1.toShort, decode("-0X1"))
+    assertEquals(1.toShort, decode("+0X1"))
+    assertEquals(1.toShort, decode("0X1"))
+    assertEquals(-123.toShort, decode("-0X7B"))
+    assertEquals(123.toShort, decode("+0X7B"))
+    assertEquals(123.toShort, decode("0X7b"))
+    assertEquals(0.toShort, decode("-0X0"))
+    assertEquals(0.toShort, decode("+0X0"))
+    assertEquals(0.toShort, decode("0X0"))
+    assertEquals(-1.toShort, decode("-#1"))
+    assertEquals(1.toShort, decode("+#1"))
+    assertEquals(1.toShort, decode("#1"))
+    assertEquals(-123.toShort, decode("-#7B"))
+    assertEquals(123.toShort, decode("+#7B"))
+    assertEquals(123.toShort, decode("#7b"))
+    assertEquals(0.toShort, decode("-#0"))
+    assertEquals(0.toShort, decode("+#0"))
+    assertEquals(0.toShort, decode("#0"))
+    assertEquals(-1.toShort, decode("-01"))
+    assertEquals(1.toShort, decode("+01"))
+    assertEquals(1.toShort, decode("01"))
+    assertEquals(-123.toShort, decode("-0173"))
+    assertEquals(123.toShort, decode("+0173"))
+    assertEquals(123.toShort, decode("0173"))
+    assertEquals(0.toShort, decode("-00"))
+    assertEquals(0.toShort, decode("+00"))
+    assertEquals(signedMaxValue.toShort, decode(signedMaxValueText))
+    assertEquals(signedMinValue.toShort, decode(signedMinValueText))
 
-    assertThrowsAnd(classOf[NumberFormatException], decode(null)) {
-      _.toString == "java.lang.NumberFormatException: null"
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("+")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "+""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("-")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "-""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("")) {
-      _.toString == """java.lang.NumberFormatException: For input string: """""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("0x")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "0x""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("#")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "#""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("0xh")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "0xh""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("0XH")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "0XH""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("09")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "09""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], decode("123a")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    decode(signedMaxPlusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: Value $signedMaxPlusOneText out of range from input $signedMaxPlusOneText"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    decode(signedMinMinusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: Value $signedMinMinusOneText out of range from input $signedMinMinusOneText"""
-    }
+    assertThrowsAndMessage(classOf[NumberFormatException], decode(null))(
+      "java.lang.NumberFormatException: null"
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("+"))(
+      """java.lang.NumberFormatException: For input string: "+""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("-"))(
+      """java.lang.NumberFormatException: For input string: "-""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode(""))(
+      """java.lang.NumberFormatException: For input string: """""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("0x"))(
+      """java.lang.NumberFormatException: For input string: "0x""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("#"))(
+      """java.lang.NumberFormatException: For input string: "#""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("0xh"))(
+      """java.lang.NumberFormatException: For input string: "0xh""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("0XH"))(
+      """java.lang.NumberFormatException: For input string: "0XH""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("09"))(
+      """java.lang.NumberFormatException: For input string: "09""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], decode("123a"))(
+      """java.lang.NumberFormatException: For input string: "123a""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           decode(signedMaxPlusOneText))(
+      s"""java.lang.NumberFormatException: Value $signedMaxPlusOneText out of range from input $signedMaxPlusOneText"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           decode(signedMinMinusOneText))(
+      s"""java.lang.NumberFormatException: Value $signedMinMinusOneText out of range from input $signedMinMinusOneText"""
+    )
   }
 
   @Test def parseShort(): Unit = {
     import Short.{parseShort => parse}
 
-    assertTrue(parse("-1") == -1)
-    assertTrue(parse("+1") == 1)
-    assertTrue(parse("1") == 1)
-    assertTrue(parse("-123") == -123)
-    assertTrue(parse("+123") == 123)
-    assertTrue(parse("123") == 123)
-    assertTrue(parse("-100", 2) == -4)
-    assertTrue(parse("+100", 2) == 4)
-    assertTrue(parse("100", 2) == 4)
-    assertTrue(parse("-0") == 0)
-    assertTrue(parse("+0") == 0)
-    assertTrue(parse("00") == 0)
-    assertTrue(parse(signedMaxValueText) == signedMaxValue)
-    assertTrue(parse(signedMinValueText) == signedMinValue)
+    assertEquals(-1, parse("-1"))
+    assertEquals(1, parse("+1"))
+    assertEquals(1, parse("1"))
+    assertEquals(-123, parse("-123"))
+    assertEquals(123, parse("+123"))
+    assertEquals(123, parse("123"))
+    assertEquals(-4, parse("-100", 2))
+    assertEquals(4, parse("+100", 2))
+    assertEquals(4, parse("100", 2))
+    assertEquals(0, parse("-0"))
+    assertEquals(0, parse("+0"))
+    assertEquals(0, parse("00"))
+    assertEquals(signedMaxValue, parse(signedMaxValueText))
+    assertEquals(signedMinValue, parse(signedMinValueText))
 
-    assertThrowsAnd(classOf[NumberFormatException], parse(null)) {
-      _.toString == "java.lang.NumberFormatException: null"
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("+")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "+""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("-")) {
-      _.toString == """java.lang.NumberFormatException: For input string: "-""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("")) {
-      _.toString == """java.lang.NumberFormatException: For input string: """""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse("123", Character.MIN_RADIX - 1)) {
-      _.toString == """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse("123", Character.MAX_RADIX + 1)) {
-      _.toString == """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse("123a", 10)) {
-      _.toString == """java.lang.NumberFormatException: For input string: "123a""""
-    }
-    assertThrowsAnd(classOf[NumberFormatException], parse(signedMaxPlusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: Value out of range. Value:"$signedMaxPlusOneText" Radix:10"""
-    }
-    assertThrowsAnd(classOf[NumberFormatException],
-                    parse(signedMinMinusOneText)) {
-      _.toString == s"""java.lang.NumberFormatException: Value out of range. Value:"$signedMinMinusOneText" Radix:10"""
-    }
+    assertThrowsAndMessage(classOf[NumberFormatException], parse(null))(
+      "java.lang.NumberFormatException: null"
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("+"))(
+      """java.lang.NumberFormatException: For input string: "+""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("-"))(
+      """java.lang.NumberFormatException: For input string: "-""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse(""))(
+      """java.lang.NumberFormatException: For input string: """""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse("123", Character.MIN_RADIX - 1))(
+      """java.lang.NumberFormatException: radix 1 less than Character.MIN_RADIX"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse("123", Character.MAX_RADIX + 1))(
+      """java.lang.NumberFormatException: radix 37 greater than Character.MAX_RADIX"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException], parse("123a", 10))(
+      """java.lang.NumberFormatException: For input string: "123a""""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse(signedMaxPlusOneText))(
+      s"""java.lang.NumberFormatException: Value out of range. Value:"$signedMaxPlusOneText" Radix:10"""
+    )
+    assertThrowsAndMessage(classOf[NumberFormatException],
+                           parse(signedMinMinusOneText))(
+      s"""java.lang.NumberFormatException: Value out of range. Value:"$signedMinMinusOneText" Radix:10"""
+    )
   }
 
   @Test def testToString(): Unit = {
     import java.lang.Short.{toString => toStr}
 
-    assertTrue(toStr(0.toShort) == "0")
-    assertTrue(toStr(1.toShort) == "1")
-    assertTrue(toStr(12.toShort) == "12")
-    assertTrue(toStr(123.toShort) == "123")
-    assertTrue(toStr(1234.toShort) == "1234")
-    assertTrue(toStr(12345.toShort) == "12345")
-    assertTrue(toStr(10.toShort) == "10")
-    assertTrue(toStr(100.toShort) == "100")
-    assertTrue(toStr(1000.toShort) == "1000")
-    assertTrue(toStr(10000.toShort) == "10000")
-    assertTrue(toStr(-1.toShort) == "-1")
-    assertTrue(toStr(-12.toShort) == "-12")
-    assertTrue(toStr(-123.toShort) == "-123")
-    assertTrue(toStr(-1234.toShort) == "-1234")
-    assertTrue(toStr(-12345.toShort) == "-12345")
-    assertTrue(toStr(signedMaxValue) == signedMaxValueText)
-    assertTrue(toStr(signedMinValue) == signedMinValueText)
+    assertEquals("0", toStr(0.toShort))
+    assertEquals("1", toStr(1.toShort))
+    assertEquals("12", toStr(12.toShort))
+    assertEquals("123", toStr(123.toShort))
+    assertEquals("1234", toStr(1234.toShort))
+    assertEquals("12345", toStr(12345.toShort))
+    assertEquals("10", toStr(10.toShort))
+    assertEquals("100", toStr(100.toShort))
+    assertEquals("1000", toStr(1000.toShort))
+    assertEquals("10000", toStr(10000.toShort))
+    assertEquals("-1", toStr(-1.toShort))
+    assertEquals("-12", toStr(-12.toShort))
+    assertEquals("-123", toStr(-123.toShort))
+    assertEquals("-1234", toStr(-1234.toShort))
+    assertEquals("-12345", toStr(-12345.toShort))
+    assertEquals(signedMaxValueText, toStr(signedMaxValue))
+    assertEquals(signedMinValueText, toStr(signedMinValue))
   }
 
   @Test def testEquals(): Unit = {
-    assertTrue(new Short(0.toShort) == new Short(0.toShort))
-    assertTrue(new Short(1.toShort) == new Short(1.toShort))
-    assertTrue(new Short(-1.toShort) == new Short(-1.toShort))
-    assertTrue(new Short(123.toShort) == new Short(123.toShort))
-    assertTrue(new Short(Short.MAX_VALUE) == new Short(Short.MAX_VALUE))
-    assertTrue(new Short(Short.MIN_VALUE) == new Short(Short.MIN_VALUE))
+    assertEquals(new Short(0.toShort), new Short(0.toShort))
+    assertEquals(new Short(1.toShort), new Short(1.toShort))
+    assertEquals(new Short(-1.toShort), new Short(-1.toShort))
+    assertEquals(new Short(123.toShort), new Short(123.toShort))
+    assertEquals(new Short(Short.MAX_VALUE), new Short(Short.MAX_VALUE))
+    assertEquals(new Short(Short.MIN_VALUE), new Short(Short.MIN_VALUE))
   }
 }

--- a/unit-tests/src/test/scala/utils/ThrowsHelper.scala
+++ b/unit-tests/src/test/scala/utils/ThrowsHelper.scala
@@ -1,6 +1,7 @@
 package scala.scalanative.junit.utils
 
 import AssertThrows._
+import org.junit.Assert.assertEquals
 
 // Calls to this should probably be changed to expectThrows.
 // This was added as it was all over the place in the pre
@@ -11,5 +12,12 @@ object ThrowsHelper {
       code: => U)(cond: T => Boolean): Unit = {
     val c = cond(expectThrows(expectedThrowable, code))
     assert(c)
+  }
+
+  def assertThrowsAndMessage[T <: Throwable, U](
+      expectedThrowable: Class[T],
+      code: => U)(expectedMsg: String): Unit = {
+    val exception = expectThrows(expectedThrowable, code)
+    assertEquals(expectedMsg, exception.toString)
   }
 }

--- a/unit-tests/src/test/scala/utils/ThrowsHelper.scala
+++ b/unit-tests/src/test/scala/utils/ThrowsHelper.scala
@@ -1,7 +1,6 @@
 package scala.scalanative.junit.utils
 
 import AssertThrows._
-import org.junit.Assert.assertEquals
 
 // Calls to this should probably be changed to expectThrows.
 // This was added as it was all over the place in the pre
@@ -12,12 +11,5 @@ object ThrowsHelper {
       code: => U)(cond: T => Boolean): Unit = {
     val c = cond(expectThrows(expectedThrowable, code))
     assert(c)
-  }
-
-  def assertThrowsAndMessage[T <: Throwable, U](
-      expectedThrowable: Class[T],
-      code: => U)(expectedMsg: String): Unit = {
-    val exception = expectThrows(expectedThrowable, code)
-    assertEquals(expectedMsg, exception.toString)
   }
 }


### PR DESCRIPTION
Closes #2125

Integer, Long and Short parsing / decoding exception messages were a little bit different from the ones JVM gives. I've tried to armonise those with respect to the ones JVM gives.

For example `Integer.parseInt("234.4")` was producing `java.lang.NumberFormatException:` rather than `java.lang.NumberFormatException: For input string: "234.4"`. That has been fixed now.

There are cases where we just would not have the same error message. For example for `Integer.decode("0xh")` we would produce:

```
java.lang.NumberFormatException: For input string: "0xh"
```

rather than

```
java.lang.NumberFormatException: For input string: "h"
```

which raises the question of up to what point do we want exactly equal error messages. 

The intent of this PR is leaving those in a better state than they were before, plus addresses some bugs in the decode methods (see comments below)
