### PR TITLE
Fix #2271: Download sbt from its documented download site.

### DIFF
--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get install -y curl
 
 # Install sbt
 RUN \
-  curl -L -o sbt-$SBT_LAUNCHER_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_LAUNCHER_VERSION.deb && \
+  curl -L -o sbt-$SBT_LAUNCHER_VERSION.deb \
+      https://repo.scala-sbt.org/scalasbt/debian/sbt-1.3.7.deb && \
   dpkg -i sbt-$SBT_LAUNCHER_VERSION.deb && \
   rm sbt-$SBT_LAUNCHER_VERSION.deb && \
   apt-get update && \

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -25,15 +25,16 @@ ENV PATH "/usr/lib/jvm/java-8-openjdk-$HOST_ARCHITECTURE/bin:$PATH"
 
 ENV SBT_LAUNCHER_VERSION 1.3.7
 ENV SBT_INSTALL_FILE sbt-$SBT_LAUNCHER_VERSION.deb
-ENV SBT_INSTALL_URL https://repo.scala-sbt.org/scalasbt/debian/SBT_INSTALL_FILE
+ENV SBT_INSTALL_URL \
+        https://repo.scala-sbt.org/scalasbt/debian/$SBT_INSTALL_FILE
 
 RUN apt-get install -y curl
 
 # Install sbt
 RUN \
-  curl -L -O SBT_INSTALL_URL && \
-  dpkg -i SBT_INSTALL_FILE && \
-  rm SBT_INSTALL_FILE && \
+  curl -L -O $SBT_INSTALL_URL && \
+  dpkg -i $SBT_INSTALL_FILE && \
+  rm $SBT_INSTALL_FILE && \
   apt-get update && \
   apt-get install -y sbt
 

--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -24,15 +24,16 @@ RUN apt-get update && apt-get install -y openjdk-8-jdk-headless:$HOST_ARCHITECTU
 ENV PATH "/usr/lib/jvm/java-8-openjdk-$HOST_ARCHITECTURE/bin:$PATH"
 
 ENV SBT_LAUNCHER_VERSION 1.3.7
+ENV SBT_INSTALL_FILE sbt-$SBT_LAUNCHER_VERSION.deb
+ENV SBT_INSTALL_URL https://repo.scala-sbt.org/scalasbt/debian/SBT_INSTALL_FILE
 
 RUN apt-get install -y curl
 
 # Install sbt
 RUN \
-  curl -L -o sbt-$SBT_LAUNCHER_VERSION.deb \
-      https://repo.scala-sbt.org/scalasbt/debian/sbt-1.3.7.deb && \
-  dpkg -i sbt-$SBT_LAUNCHER_VERSION.deb && \
-  rm sbt-$SBT_LAUNCHER_VERSION.deb && \
+  curl -L -O SBT_INSTALL_URL && \
+  dpkg -i SBT_INSTALL_FILE && \
+  rm SBT_INSTALL_FILE && \
   apt-get update && \
   apt-get install -y sbt
 


### PR DESCRIPTION
Use sbt's [documented](https://eed3si9n.com/bintray-to-jfrog-artifactory-migration-status-and-sbt-1.5.1) download site so that  Scala Native build continues to operate
 after Bintray fades into the sunset.
