### PR TITLE
Fix #2277: Expunge redundant memset calls

### DIFF
--- a/javalib/src/main/scala/java/net/PlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/PlainSocketImpl.scala
@@ -74,14 +74,14 @@ private[net] class PlainSocketImpl extends SocketImpl {
   }
 
   override def bind(addr: InetAddress, port: Int): Unit = {
-    val hints = stackalloc[addrinfo]
-    val ret   = stackalloc[Ptr[addrinfo]]
-    string.memset(hints.asInstanceOf[Ptr[Byte]], 0, sizeof[addrinfo])
-    hints.ai_family = socket.AF_UNSPEC
-    hints.ai_flags = AI_NUMERICHOST
-    hints.ai_socktype = socket.SOCK_STREAM
+    val ret = stackalloc[Ptr[addrinfo]]
 
     Zone { implicit z =>
+      val hints = alloc[addrinfo] // alloc is documented to clear memory
+      hints.ai_family = socket.AF_UNSPEC
+      hints.ai_flags = AI_NUMERICHOST
+      hints.ai_socktype = socket.SOCK_STREAM
+
       val cIP = toCString(addr.getHostAddress())
       if (getaddrinfo(cIP, toCString(port.toString), hints, ret) != 0) {
         throw new BindException(
@@ -269,16 +269,16 @@ private[net] class PlainSocketImpl extends SocketImpl {
 
     throwIfClosed(fd.fd, "connect") // Do not send negative fd.fd to poll()
 
-    val inetAddr = address.asInstanceOf[InetSocketAddress]
-    val hints    = stackalloc[addrinfo]
-    val ret      = stackalloc[Ptr[addrinfo]]
-    string.memset(hints.asInstanceOf[Ptr[Byte]], 0, sizeof[addrinfo])
-    hints.ai_family = socket.AF_UNSPEC
-    hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV
-    hints.ai_socktype = socket.SOCK_STREAM
+    val inetAddr      = address.asInstanceOf[InetSocketAddress]
+    val ret           = stackalloc[Ptr[addrinfo]]
     val remoteAddress = inetAddr.getAddress.getHostAddress()
 
     Zone { implicit z =>
+      val hints = alloc[addrinfo] // alloc is documented to clear memory
+      hints.ai_family = socket.AF_UNSPEC
+      hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV
+      hints.ai_socktype = socket.SOCK_STREAM
+
       val cIP   = toCString(remoteAddress)
       val cPort = toCString(inetAddr.getPort.toString)
 

--- a/javalib/src/main/scala/java/net/PlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/PlainSocketImpl.scala
@@ -77,8 +77,7 @@ private[net] class PlainSocketImpl extends SocketImpl {
     val ret = stackalloc[Ptr[addrinfo]]
 
     Zone { implicit z =>
-      val hints = stackalloc[addrinfo]
-      string.memset(hints.asInstanceOf[Ptr[Byte]], 0, sizeof[addrinfo])
+      val hints = stackalloc[addrinfo] // As of PR #1426, stackalloc clears.
       hints.ai_family = socket.AF_UNSPEC
       hints.ai_flags = AI_NUMERICHOST
       hints.ai_socktype = socket.SOCK_STREAM

--- a/javalib/src/main/scala/java/net/PlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/PlainSocketImpl.scala
@@ -125,7 +125,7 @@ private[net] class PlainSocketImpl extends SocketImpl {
 
       pollFdPtr.fd = fd.fd
       pollFdPtr.events = POLLIN
-      pollFdPtr.revents = 0
+      // pollFdPtr.revents already zero, stackalloc cleared.
 
       val pollRes = poll(pollFdPtr, nAlloc, timeout)
 
@@ -238,7 +238,7 @@ private[net] class PlainSocketImpl extends SocketImpl {
 
     pollFdPtr.fd = fd.fd
     pollFdPtr.events = POLLIN | POLLOUT
-    pollFdPtr.revents = 0
+    // pollFdPtr.revents already zero, stackalloc cleared.
 
     val pollRes = poll(pollFdPtr, nAlloc.toUInt, timeout)
 

--- a/javalib/src/main/scala/java/net/PlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/PlainSocketImpl.scala
@@ -74,14 +74,14 @@ private[net] class PlainSocketImpl extends SocketImpl {
   }
 
   override def bind(addr: InetAddress, port: Int): Unit = {
+    val hints = stackalloc[addrinfo] // As of PR #1426, stackalloc clears.
+    hints.ai_family = socket.AF_UNSPEC
+    hints.ai_flags = AI_NUMERICHOST
+    hints.ai_socktype = socket.SOCK_STREAM
+
     val ret = stackalloc[Ptr[addrinfo]]
 
     Zone { implicit z =>
-      val hints = stackalloc[addrinfo] // As of PR #1426, stackalloc clears.
-      hints.ai_family = socket.AF_UNSPEC
-      hints.ai_flags = AI_NUMERICHOST
-      hints.ai_socktype = socket.SOCK_STREAM
-
       val cIP = toCString(addr.getHostAddress())
       if (getaddrinfo(cIP, toCString(port.toString), hints, ret) != 0) {
         throw new BindException(
@@ -269,16 +269,18 @@ private[net] class PlainSocketImpl extends SocketImpl {
 
     throwIfClosed(fd.fd, "connect") // Do not send negative fd.fd to poll()
 
-    val inetAddr      = address.asInstanceOf[InetSocketAddress]
-    val ret           = stackalloc[Ptr[addrinfo]]
+    val inetAddr = address.asInstanceOf[InetSocketAddress]
+
+    val hints = stackalloc[addrinfo] // As of PR #1426, stackalloc clears.
+    hints.ai_family = socket.AF_UNSPEC
+    hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV
+    hints.ai_socktype = socket.SOCK_STREAM
+
+    val ret = stackalloc[Ptr[addrinfo]]
+
     val remoteAddress = inetAddr.getAddress.getHostAddress()
 
     Zone { implicit z =>
-      val hints = alloc[addrinfo] // alloc is documented to clear memory
-      hints.ai_family = socket.AF_UNSPEC
-      hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV
-      hints.ai_socktype = socket.SOCK_STREAM
-
       val cIP   = toCString(remoteAddress)
       val cPort = toCString(inetAddr.getPort.toString)
 

--- a/javalib/src/main/scala/java/net/PlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/PlainSocketImpl.scala
@@ -77,7 +77,8 @@ private[net] class PlainSocketImpl extends SocketImpl {
     val ret = stackalloc[Ptr[addrinfo]]
 
     Zone { implicit z =>
-      val hints = alloc[addrinfo] // alloc is documented to clear memory
+      val hints = stackalloc[addrinfo]
+      string.memset(hints.asInstanceOf[Ptr[Byte]], 0, sizeof[addrinfo])
       hints.ai_family = socket.AF_UNSPEC
       hints.ai_flags = AI_NUMERICHOST
       hints.ai_socktype = socket.SOCK_STREAM

--- a/javalib/src/main/scala/java/util/zip/Deflater.scala
+++ b/javalib/src/main/scala/java/util/zip/Deflater.scala
@@ -221,11 +221,6 @@ object Deflater {
   private def createStream(level: Int,
                            strategy: Int,
                            noHeader: Boolean): zlib.z_streamp = {
-    /*
-    val stream =
-      stdlib.malloc(sizeof[zlib.z_stream]).asInstanceOf[zlib.z_streamp]
-    string.memset(stream.asInstanceOf[Ptr[Byte]], 0, sizeof[zlib.z_stream])
-     */
     val stream = stdlib
       .calloc(1.toULong, sizeof[zlib.z_stream])
       .asInstanceOf[zlib.z_streamp]

--- a/javalib/src/main/scala/java/util/zip/Deflater.scala
+++ b/javalib/src/main/scala/java/util/zip/Deflater.scala
@@ -221,9 +221,15 @@ object Deflater {
   private def createStream(level: Int,
                            strategy: Int,
                            noHeader: Boolean): zlib.z_streamp = {
+    /*
     val stream =
       stdlib.malloc(sizeof[zlib.z_stream]).asInstanceOf[zlib.z_streamp]
     string.memset(stream.asInstanceOf[Ptr[Byte]], 0, sizeof[zlib.z_stream])
+     */
+    val stream = stdlib
+      .calloc(1.toULong, sizeof[zlib.z_stream])
+      .asInstanceOf[zlib.z_streamp]
+
     val wbits =
       if (noHeader) 15 / -1
       else 15

--- a/javalib/src/main/scala/java/util/zip/Inflater.scala
+++ b/javalib/src/main/scala/java/util/zip/Inflater.scala
@@ -195,9 +195,10 @@ private object Inflater {
   val empty = new Array[Byte](1)
 
   def createStream(noHeader: Boolean): zlib.z_streamp = {
-    val stream =
-      stdlib.malloc(sizeof[zlib.z_stream]).asInstanceOf[zlib.z_streamp]
-    string.memset(stream.asInstanceOf[Ptr[Byte]], 0, sizeof[zlib.z_stream])
+    val stream = stdlib
+      .calloc(1.toULong, sizeof[zlib.z_stream])
+      .asInstanceOf[zlib.z_streamp]
+
     val wbits: Int =
       if (noHeader) 15 / -1
       else 15

--- a/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
+++ b/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
@@ -20,10 +20,9 @@ object SocketHelpers {
   def isReachableByEcho(ip: String, timeout: Int, port: Int): Boolean = {
     Zone { implicit z =>
       val cIP   = toCString(ip)
-      var hints = alloc[addrinfo]
+      var hints = alloc[addrinfo] // alloc documented to clear retured memory
       var ret   = alloc[Ptr[addrinfo]]
 
-      libc.memset(hints.rawptr, 0, sizeof[addrinfo])
       hints.ai_family = AF_UNSPEC
       hints.ai_protocol = 0
       hints.ai_addr = null

--- a/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
+++ b/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
@@ -21,6 +21,12 @@ object SocketHelpers {
     Zone { implicit z =>
       val cIP = toCString(ip)
 
+      // Design note:
+      // For historical reasons, this file uses heap alloc
+      // extensively. All but two of those allocations are "small".
+      // With care for cumulative stack size, those small allocations
+      // could be replaced by stackalloc.
+
       val hints = alloc[addrinfo] // alloc documented to clear retured memory
       hints.ai_family = AF_UNSPEC
       hints.ai_flags = 4 // AI_NUMERICHOST

--- a/unit-tests/src/test/scala/java/net/InetAddressTest.scala
+++ b/unit-tests/src/test/scala/java/net/InetAddressTest.scala
@@ -107,11 +107,11 @@ class InetAddressTest {
 
   @Test def isLoopbackAddress(): Unit = {
     val ia1 = InetAddress.getByName("239.255.255.255")
-    assertFalse(ia1.isLoopbackAddress())
+    assertFalse("239.n.n.n", ia1.isLoopbackAddress())
     val ia2 = InetAddress.getByName("localhost")
-    assertTrue(ia2.isLoopbackAddress())
+    assertTrue("localhost", ia2.isLoopbackAddress())
     val ia3 = InetAddress.getByName("127.0.0.2")
-    assertTrue(ia3.isLoopbackAddress())
+    assertTrue("127.0.0.2", ia3.isLoopbackAddress())
   }
 
   @Test def isSiteLocalAddress(): Unit = {

--- a/unit-tests/src/test/scala/java/net/InetAddressTest.scala
+++ b/unit-tests/src/test/scala/java/net/InetAddressTest.scala
@@ -106,12 +106,17 @@ class InetAddressTest {
   }
 
   @Test def isLoopbackAddress(): Unit = {
-    val ia1 = InetAddress.getByName("239.255.255.255")
-    assertFalse("239.n.n.n", ia1.isLoopbackAddress())
-    val ia2 = InetAddress.getByName("localhost")
-    assertTrue("localhost", ia2.isLoopbackAddress())
-    val ia3 = InetAddress.getByName("127.0.0.2")
-    assertTrue("127.0.0.2", ia3.isLoopbackAddress())
+    val a1  = "239.255.255.255"
+    val ia1 = InetAddress.getByName(a1)
+    assertFalse(a1, ia1.isLoopbackAddress())
+
+    val a2  = "localhost"
+    val ia2 = InetAddress.getByName(a2)
+    assertTrue(a2, ia2.isLoopbackAddress())
+
+    val a3  = "127.0.0.2"
+    val ia3 = InetAddress.getByName(a3)
+    assertTrue(a3, ia3.isLoopbackAddress())
   }
 
   @Test def isSiteLocalAddress(): Unit = {

--- a/unit-tests/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -151,8 +151,7 @@ class TimeTest {
 
         // grossly over-provision rather than chase fencepost bugs.
         val bufSize = 70.toULong
-        val buf     = alloc[Byte](bufSize)
-        string.memset(buf, 0, bufSize)
+        val buf     = alloc[Byte](bufSize) // unsafe.alloc will cle
 
         val n = strftime(buf, bufSize, c"%a %b %d %T %Z %Y", tmPtr)
 
@@ -275,8 +274,7 @@ class TimeTest {
                    36.toULong)
 
       val tmBufSize = 56.toULong
-      val tmBuf     = alloc[Byte](tmBufSize)
-      string.memset(tmBuf, 0, tmBufSize)
+      val tmBuf     = alloc[Byte](tmBufSize) // unsafe.alloc will cle
 
       val tmPtr = tmBuf.asInstanceOf[Ptr[tm]]
 

--- a/unit-tests/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -136,11 +136,7 @@ class TimeTest {
       // Scala Native tm, so the linux 56 byte form is necessary here.
       val tmBufCount = 7.toULong
 
-      val tmBuf = alloc[Ptr[Byte]](tmBufCount)
-      string.memset(tmBuf.asInstanceOf[Ptr[Byte]],
-                    0,
-                    tmBufCount * sizeof[Ptr[Byte]])
-
+      val tmBuf = alloc[Ptr[Byte]](tmBufCount) // alloc documented to clear all
       val tmPtr = tmBuf.asInstanceOf[Ptr[tm]]
 
       if (localtime_r(ttPtr, tmPtr) == null) {


### PR DESCRIPTION
Remove memset calls to zero memory that unsafe.package alloc has
already zeroed.  Use calloc() instead of malloc/memset where possible.

See Issue #2277 for a short description of why two stackalloc[] calls were
converted to an equivalent but slightly slower Zone.alloc.