### PR TITLE
Fix #I2283 - j.nio.file.Files.copy() now sets lastModified time correctly

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -96,12 +96,16 @@ object Files {
     if (options.contains(COPY_ATTRIBUTES)) {
       val newAttrView =
         getFileAttributeView(target, classOf[PosixFileAttributeView], linkOpts)
-      newAttrView.setTimes(attrs.lastModifiedTime(),
-                           attrs.lastAccessTime(),
-                           attrs.creationTime())
+
+      // Re-read attrs, copy() above may have changed lastModifiedTime.
+      val attrs =
+        Files.readAttributes(source, classOf[PosixFileAttributes], linkOpts)
       newAttrView.setGroup(attrs.group())
       newAttrView.setOwner(attrs.owner())
       newAttrView.setPermissions(attrs.permissions())
+      newAttrView.setTimes(attrs.lastModifiedTime(),
+                           attrs.lastAccessTime(),
+                           attrs.creationTime())
     }
     target
   }


### PR DESCRIPTION
Improve/correct the way `java.nio.file.Files.copy() sets lastModified time
of the destination file.

See referenced issue for design discussion and details.
