### PR TITLE
Fix #2249: Improve inet_ntoa() ease-of-use.

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -10,7 +10,7 @@ Scala Native provides bindings for a core subset of the
 C Header          Scala Native Module
 ================= ==================================
 `aio.h`_          N/A - *indicates binding not available*
-`arpa/inet.h`_    scala.scalanative.posix.arpa.inet_
+`arpa/inet.h`_    scala.scalanative.posix.arpa.inet_ [#inet_ntoa]_
 `assert.h`_       N/A
 `complex.h`_      scala.scalanative.libc.complex_
 `cpio.h`_         scala.scalanative.posix.cpio_
@@ -214,5 +214,11 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.time: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/time.scala
 .. _scala.scalanative.posix.unistd: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
 .. _scala.scalanative.posix.utime: https://github.com/scala-native/scala-native/blob/master/posixlib/src/main/scala/scala/scalanative/posix/utime.scala
+
+.. rubric Footnotes
+.. [#inet_ntoa] The argument to inet_ntoa() differs from the POSIX
+                specification because Scala Native supports only
+                passing structures by reference.  See code for details
+		and usage.
 
 Continue to :ref:`communitylib`.

--- a/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
@@ -22,6 +22,19 @@ object inet {
   @name("scalanative_ntohs")
   def ntohs(arg: uint16_t): uint16_t = extern
 
+  /* The argument for inet_ntoa() differs from the POSIX specification
+   * because Scala Native supports only passing structures by reference,
+   * not value.
+   *
+   * It is hard to obtain a in_addr structure without a pointer being
+   * involved.  If a Ptr[in_addr] is not immediately available, a
+   * Ptr[sockaddr_in] or Ptr[sockaddr_in6] may be.  In that case, try
+   * ptr.at3, for sockaddr_in or ptr.at1 for sockaddr_in6 (
+   * (casting of the resultant in6_addr will be needed).
+   *
+   * The standard compliant inet_ntop() may be more useful.
+   */
+
   @name("scalanative_inet_ntoa")
   def inet_ntoa(in: Ptr[in_addr]): CString = extern
 


### PR DESCRIPTION
Make it easier for a developer to understand that the argument
of posixlib `inet_ntoa()` is non-standard. Provide rationale
and possible adaptation.