### PR TITLE
Fix #2260: CI - use only coursier cache for extenal dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,13 +40,6 @@ jobs:
       - name: Test tools
         run: sbt "++ ${{ matrix.scala }} -v" "-no-colors" "-J-Xmx3G" test-tools
 
-      # Pre-compile and cache results for the most time consuming projects and it dependencies too speed up execution in next phases
-      # We cannot use `compile` because sbtScalaNative does not crossCompile
-      - name: Compile
-        run: sbt "++ ${{ matrix.scala }} -v" "-no-colors" "-J-Xmx3G" \
-          "tests/Test/compile" "testsExt/Test/compile" \
-          "junitTestOutputsNative/Test/compile" "junitTestOutputsJVM/Test/compile"
-
   # Build testing image that would be used to build and run against different platforms
   # Currently only Linux x64 is tested
   build-image:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           path: |
             ~/.cache/coursier
-            ~/.ivy2/cache
             ~/.sbt/boot
           key: ${{ runner.os }}-deps-${{ env.binary-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
 
@@ -148,7 +147,6 @@ jobs:
         with:
           path: |
             ~/.cache/coursier
-            ~/.ivy2/cache
             ~/.sbt/boot
           key: ${{ runner.os }}-deps-${{ env.binary-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
 
@@ -195,7 +193,6 @@ jobs:
         with:
           path: |
             ~/.cache/coursier
-            ~/.ivy2/cache
             ~/.sbt/boot
           key: ${{ runner.os }}-deps-${{ env.binary-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
 
@@ -238,7 +235,6 @@ jobs:
         with:
           path: |
             ~/.cache/coursier
-            ~/.ivy2/cache
             ~/.sbt/boot
           key: ${{ runner.os }}-deps-${{ env.binary-version }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('**/build.properties') }}
 

--- a/ci-docker/run-test-gha.sh
+++ b/ci-docker/run-test-gha.sh
@@ -42,9 +42,9 @@ if ! docker pull $FULL_IMAGE_NAME;then
 fi
 
 docker run -i "${FULL_IMAGE_NAME}" java -version
-docker run -v $HOME/.ivy2:/home/scala-native/.ivy2 \
-           -v $HOME/.sbt:/home/scala-native/.sbt \
-           -v $PWD:/home/scala-native/scala-native \
+docker run --mount type=bind,source=$HOME/.cache/coursier,target=/home/scala-native/.cache/coursier \
+           --mount type=bind,source=$HOME/.sbt,target=/home/scala-native/.sbt \
+           --mount type=bind,source=$PWD,target=/home/scala-native/scala-native \
            -e SCALANATIVE_MODE="$SCALANATIVE_MODE" \
            -e SCALANATIVE_GC="$SCALANATIVE_GC" \
            -e SCALANATIVE_OPTIMIZE="$SCALANATIVE_OPTIMIZE" \


### PR DESCRIPTION
This PR fixes CI errors existing in #2260. It removes mounting and caching `~/.ivy2` directory to the testing container, which recently leads to CI failures. Logs for local CI have not shown any significant degradation in tests time neither fetching dependencies from external repositories.

* Don't cache or mount `.ivy2` directory to testing container
* Add missing binding to `.cache/coursier` directory used to resolve dependencies
* Mount directories using `--mount` instead `-v` syntax. `--mount` is currently recommended method of adding bindings. It was also possible to observe in private CI that usage of `-v` could lead to another file lock inside `.sbt` directory. Such behaviour was not observed when using `--mount`.  This syntax requires the source directory to actually exist, otherwise, it would finish with an error.
* Remove pre-compilation step for commonly used projects - CI logs prove that it does not speed up actual tests. This step is probably not deleted garbage after local tests. It was not working due to problems with binding `*/target` directories into the testing container. 