### PR TITLE
Prepare build.sbt for eventual use by sbt 1.5.n.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val nameSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val disabledDocsSettings: Seq[Setting[_]] = Def.settings(
-  sources in (Compile, doc) := Nil
+  Compile / doc / sources := Nil
 )
 
 lazy val docsSettings: Seq[Setting[_]] = {
@@ -29,8 +29,8 @@ lazy val docsSettings: Seq[Setting[_]] = {
   Def.settings(
     autoAPIMappings := true,
     exportJars := true, // required so ScalaDoc linking works
-    scalacOptions in (Compile, doc) := {
-      val prev = (scalacOptions in (Compile, doc)).value
+    Compile / doc / scalacOptions := {
+      val prev = (Compile / doc / scalacOptions).value
       if (scalaVersion.value.startsWith("2.11."))
         prev.filter(_ != "-Xfatal-warnings")
       else prev
@@ -736,7 +736,7 @@ lazy val testingCompiler =
         "org.scala-lang" % "scala-compiler" % scalaVersion.value,
         "org.scala-lang" % "scala-reflect"  % scalaVersion.value
       ),
-      unmanagedSourceDirectories in Compile ++= {
+      Compile / unmanagedSourceDirectories ++= {
         val oldCompat: File = baseDirectory.value / "src/main/compat-old"
         val newCompat: File = baseDirectory.value / "src/main/compat-new"
         CrossVersion
@@ -760,8 +760,8 @@ lazy val testingCompiler =
     .dependsOn(testingCompilerInterface)
 
 lazy val testInterfaceCommonSourcesSettings: Seq[Setting[_]] = Seq(
-  unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "test-interface-common/src/main/scala",
-  unmanagedSourceDirectories in Test += baseDirectory.value.getParentFile / "test-interface-common/src/test/scala"
+  Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "test-interface-common/src/main/scala",
+  Test / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "test-interface-common/src/test/scala"
 )
 
 lazy val testInterface =


### PR DESCRIPTION
PR #2058 introduced a regression in the consistent use of
the slash syntax recommended, but not enforced, by sbt at
the time of that PR & now.

As of sbt 1.5.0, sbt now gives a deprecation message for
the old "in (foo, bar)" style.  As of this PR, build.sbt
once again consistently uses sbt slash style so that
sbt 1.5.n can be used without that complication.