### PR TITLE
Incrementally commit memory in GC on Windows

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -121,11 +121,8 @@ jobs:
         run: clang --version
 
       - name: Run sandbox
-        # Set heap limits manually, there seams to be bug in detection of avaiable memory
+        # Set heap limits manually, there seams to be bug in detection of available memory
         # which results in undefined behavior at runtime
-        env:
-          SCALANATIVE_MIN_SIZE: 128M
-          SCALANATIVE_MAX_SIZE: 1G
         run: |
           sbt ++${{matrix.scala}};sandbox/run
         shell: cmd

--- a/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
@@ -308,11 +308,11 @@ void Heap_Grow(Heap *heap, uint32_t incrementInBlocks) {
         incrementInBlocks * LINE_COUNT * LINE_METADATA_SIZE / WORD_SIZE;
 
 #ifdef _WIN32
-    // Windows does not allow for over-committing, because of that we commit
-    // next chunk of memory when growing heap. Without this process might take
-    // over all available memory leading to OutOffMemory errors for other
-    // processes. Also when using UNLIMITED heap size it might try to commit
-    // more memory then it is available.
+    // Windows does not allow for over-committing, therefore we commit the
+    // next chunk of memory when growing the heap. Without this, the process
+    // might take over all available memory leading to OutOfMemory errors for
+    // other processes. Also when using UNLIMITED heap size it might try to
+    // commit more memory than is available.
     if (!memoryCommit(heapEnd, incrementInBytes)) {
         Heap_exitWithOutOfMemory();
     };

--- a/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
@@ -313,9 +313,9 @@ void Heap_Grow(Heap *heap, uint32_t incrementInBlocks) {
     // over all available memory leading to OutOffMemory errors for other
     // processes. Also when using UNLIMITED heap size it might try to commit
     // more memory then it is available.
-        if (!memoryCommit(heapEnd,  incrementInBytes)) {
+    if (!memoryCommit(heapEnd, incrementInBytes)) {
         Heap_exitWithOutOfMemory();
-        };
+    };
 #endif // WIN32
 
 #ifdef DEBUG_ASSERT

--- a/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
@@ -368,11 +368,11 @@ void Heap_Grow(Heap *heap, uint32_t incrementInBlocks) {
         incrementInBlocks * LINE_COUNT * LINE_METADATA_SIZE / WORD_SIZE;
 
 #ifdef _WIN32
-    // Windows does not allow for over-committing, because of that we commit
-    // next chunk of memory when growing heap. Without this process might take
-    // over all available memory leading to OutOffMemory errors for other
-    // processes. Also when using UNLIMITED heap size it might try to commit
-    // more memory then it is available.
+    // Windows does not allow for over-committing, therefore we commit the
+    // next chunk of memory when growing the heap. Without this, the process
+    // might take over all available memory leading to OutOfMemory errors for
+    // other processes. Also when using UNLIMITED heap size it might try to
+    // commit more memory than is available.
     if (!memoryCommit(heapEnd, incrementInBytes)) {
         Heap_exitWithOutOfMemory();
     };

--- a/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
@@ -109,20 +109,36 @@ void Heap_Init(Heap *heap, size_t minHeapSize, size_t maxHeapSize) {
     heap->lineMetaEnd = lineMetaStart + initialBlockCount * LINE_COUNT *
                                             LINE_METADATA_SIZE / WORD_SIZE;
 
-    word_t *heapStart = Heap_mapAndAlign(maxHeapSize, BLOCK_TOTAL_SIZE);
-
-    BlockAllocator_Init(&blockAllocator, blockMetaStart, initialBlockCount);
-
     // reserve space for bytemap
-    Bytemap *bytemap = (Bytemap *)Heap_mapAndAlign(
-        maxHeapSize / ALLOCATION_ALIGNMENT + sizeof(Bytemap),
-        ALLOCATION_ALIGNMENT);
+    size_t bytemapSpaceSize =
+        maxHeapSize / ALLOCATION_ALIGNMENT + sizeof(Bytemap);
+    Bytemap *bytemap =
+        (Bytemap *)Heap_mapAndAlign(bytemapSpaceSize, ALLOCATION_ALIGNMENT);
     heap->bytemap = bytemap;
 
     // Init heap for small objects
+    word_t *heapStart = Heap_mapAndAlign(maxHeapSize, BLOCK_TOTAL_SIZE);
     heap->heapSize = minHeapSize;
     heap->heapStart = heapStart;
     heap->heapEnd = heapStart + minHeapSize / WORD_SIZE;
+
+#ifdef _WIN32
+    // Commit memory chunks reserved using mapMemory
+    bool commitStatus =
+        memoryCommit(blockMetaStart, blockMetaSpaceSize) &&
+        memoryCommit(lineMetaStart, lineMetaSpaceSize) &&
+        memoryCommit(bytemap, bytemapSpaceSize) &&
+        // Due to lack of over-committing on Windows on Heap init reserve memory
+        // chunk equal to maximal size of heap, but commit only minimal needed
+        // chunk of memory. Additional chunks of heap should be committed on
+        // demand when growing the heap.
+        memoryCommit(heapStart, minHeapSize);
+    if (!commitStatus) {
+        Heap_exitWithOutOfMemory();
+    }
+#endif // _WIN32
+
+    BlockAllocator_Init(&blockAllocator, blockMetaStart, initialBlockCount);
     Bytemap_Init(bytemap, heapStart, maxHeapSize);
     Allocator_Init(&allocator, &blockAllocator, bytemap, blockMetaStart,
                    heapStart);
@@ -268,10 +284,10 @@ bool Heap_shouldGrow(Heap *heap) {
         blockCount - (freeBlockCount + recycledBlockCount);
 
 #ifdef DEBUG_PRINT
-    printf("\n\nBlock count: %llu\n", blockCount);
-    printf("Unavailable: %llu\n", unavailableBlockCount);
-    printf("Free: %llu\n", freeBlockCount);
-    printf("Recycled: %llu\n", recycledBlockCount);
+    printf("\n\nBlock count: %u\n", blockCount);
+    printf("Unavailable: %u\n", unavailableBlockCount);
+    printf("Free: %u\n", freeBlockCount);
+    printf("Recycled: %u\n", recycledBlockCount);
     fflush(stdout);
 #endif
 
@@ -334,22 +350,33 @@ void Heap_Grow(Heap *heap, uint32_t incrementInBlocks) {
     if (!Heap_isGrowingPossible(heap, incrementInBlocks)) {
         Heap_exitWithOutOfMemory();
     }
+    size_t incrementInBytes = incrementInBlocks * SPACE_USED_PER_BLOCK;
 
 #ifdef DEBUG_PRINT
-    printf("Growing small heap by %zu bytes, to %zu bytes\n",
-           increment * WORD_SIZE,
-           heap->heapSize + incrementInBlocks * SPACE_USED_PER_BLOCK);
+    printf("Growing small heap by %zu bytes, to %zu bytes\n", incrementInBytes,
+           heap->heapSize + incrementInBytes);
     fflush(stdout);
 #endif
 
     word_t *heapEnd = heap->heapEnd;
     heap->heapEnd = heapEnd + incrementInBlocks * WORDS_IN_BLOCK;
-    heap->heapSize += incrementInBlocks * SPACE_USED_PER_BLOCK;
+    heap->heapSize += incrementInBytes;
     word_t *blockMetaEnd = heap->blockMetaEnd;
     heap->blockMetaEnd =
         (word_t *)(((BlockMeta *)heap->blockMetaEnd) + incrementInBlocks);
     heap->lineMetaEnd +=
         incrementInBlocks * LINE_COUNT * LINE_METADATA_SIZE / WORD_SIZE;
+
+#ifdef _WIN32
+    // Windows does not allow for over-committing, because of that we commit
+    // next chunk of memory when growing heap. Without this process might take
+    // over all available memory leading to OutOffMemory errors for other
+    // processes. Also when using UNLIMITED heap size it might try to commit
+    // more memory then it is available.
+    if (!memoryCommit(heapEnd, incrementInBytes)) {
+        Heap_exitWithOutOfMemory();
+    };
+#endif // WIN32
 
     BlockAllocator_AddFreeBlocks(&blockAllocator, (BlockMeta *)blockMetaEnd,
                                  incrementInBlocks);

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -1,9 +1,17 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include "MemoryMap.h"
 #include "MemoryInfo.h"
 #include "Parsing.h"
 
-// Dummy GC that maps chunks of 4GB and allocates but never frees.
+// Dummy GC that maps chunks of memory and allocates but never frees.
+#ifdef _WIN32
+// On Windows we need to commit memory in relatively small chunks - this way
+// process would not use too much resources.
+#define DEFAULT_CHUNK_SIZE "64M"
+#else
+#define DEFAULT_CHUNK_SIZE "4G"
+#endif
 
 void *current = 0;
 void *end = 0;
@@ -14,6 +22,11 @@ static size_t CHUNK;
 static size_t TO_NORMAL_MMAP = 1L;
 static size_t DO_PREALLOC = 0L; // No Preallocation.
 
+void exitWithOutOfMemory() {
+    fprintf(stderr, "Out of heap space\n");
+    exit(1);
+}
+
 void Prealloc_Or_Default() {
 
     if (TO_NORMAL_MMAP == 1L) { // Check if we have prealloc env varible
@@ -21,7 +34,7 @@ void Prealloc_Or_Default() {
         size_t memorySize = getMemorySize();
 
         DEFAULT_CHUNK = // Default Maximum allocation Map 4GB
-            Choose_IF(Parse_Env_Or_Default_String("GC_MAXIMUM_HEAP_SIZE", "4G"),
+            Choose_IF(Parse_Env_Or_Default_String("GC_MAXIMUM_HEAP_SIZE", DEFAULT_CHUNK_SIZE),
                       Less_OR_Equal, memorySize);
 
         PREALLOC_CHUNK = // Preallocation
@@ -49,7 +62,15 @@ void Prealloc_Or_Default() {
 void scalanative_init() {
     Prealloc_Or_Default();
     current = memoryMapPrealloc(CHUNK, DO_PREALLOC);
+    if (current == NULL) {
+        exitWithOutOfMemory();
+    }
     end = current + CHUNK;
+#ifdef _WIN32
+    if (!memoryCommit(current, CHUNK)) {
+        exitWithOutOfMemory();
+    };
+#endif // _WIN32
 }
 
 void *scalanative_alloc(void *info, size_t size) {

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -34,7 +34,8 @@ void Prealloc_Or_Default() {
         size_t memorySize = getMemorySize();
 
         DEFAULT_CHUNK = // Default Maximum allocation Map 4GB
-            Choose_IF(Parse_Env_Or_Default_String("GC_MAXIMUM_HEAP_SIZE", DEFAULT_CHUNK_SIZE),
+            Choose_IF(Parse_Env_Or_Default_String("GC_MAXIMUM_HEAP_SIZE",
+                                                  DEFAULT_CHUNK_SIZE),
                       Less_OR_Equal, memorySize);
 
         PREALLOC_CHUNK = // Preallocation

--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
@@ -25,8 +25,7 @@
 #endif
 
 // Map private anonymous memory, and prevent from reserving swap
-#define HEAP_MEM_FLAGS
-(MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS)
+#define HEAP_MEM_FLAGS (MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS)
 #define HEAP_MEM_FLAGS_PREALLOC                                                \
     (MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE)
 
@@ -49,17 +48,15 @@ word_t *memoryMap(size_t memorySize) {
 }
 
 word_t *memoryMapPrealloc(size_t memorySize, size_t doPrealloc) {
-    if (!doPrealloc) {
-        return memoryMap(memorySize);
-    }
-
 #ifdef _WIN32
     // No special pre-alloc support on Windows is needed
     return memoryMap(memorySize);
 #else // Unix
-    word_t *res;
-    res = mmap(NULL, memorySize, HEAP_MEM_PROT, HEAP_MEM_FLAGS_PREALLOC,
-               HEAP_MEM_FD, HEAP_MEM_FD_OFFSET);
+    if (!doPrealloc) {
+        return memoryMap(memorySize);
+    }
+    word_t *res = mmap(NULL, memorySize, HEAP_MEM_PROT, HEAP_MEM_FLAGS_PREALLOC,
+                       HEAP_MEM_FD, HEAP_MEM_FD_OFFSET);
 #ifndef __linux__
     // if we are not on linux the next best thing we can do is to mark the pages
     // as MADV_WILLNEED but only if doPrealloc is enabled.

--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
@@ -20,13 +20,13 @@
 #endif
 
 // MAP_POPULATE is linux exclusive. We will use madvice.
-#ifndef  __linux__
+#ifndef __linux__
 #define MAP_POPULATE 0
 #endif
 
 // Map private anonymous memory, and prevent from reserving swap
 #define HEAP_MEM_FLAGS
-    (MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS)
+(MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS)
 #define HEAP_MEM_FLAGS_PREALLOC                                                \
     (MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE)
 
@@ -49,7 +49,7 @@ word_t *memoryMap(size_t memorySize) {
 }
 
 word_t *memoryMapPrealloc(size_t memorySize, size_t doPrealloc) {
-    if(!doPrealloc){
+    if (!doPrealloc) {
         return memoryMap(memorySize);
     }
 

--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.h
@@ -3,8 +3,10 @@
 
 #include "GCTypes.h"
 #include <stddef.h>
+#include <stdbool.h>
 
 word_t *memoryMap(size_t memorySize);
+bool memoryCommit(void *ref, size_t memorySize);
 
 word_t *memoryMapPrealloc(size_t memorySize, size_t doPrealloc);
 

--- a/nativelib/src/main/resources/scala-native/gc/shared/Parsing.h
+++ b/nativelib/src/main/resources/scala-native/gc/shared/Parsing.h
@@ -1,3 +1,10 @@
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+// sscanf and getEnv is deprecated in WinCRT, disable warnings
+#define _CRT_SECURE_NO_WARNINGS
+#include <windows.h>
+#endif
+
 #include <string.h>
 #include <stdio.h>
 


### PR DESCRIPTION
PR #2264 has added support for comping GCs on Windows, however, it contained few bugs. One of them was caused by invalid memory allocation, which behaves differently when compared with Unix. 
In case if Immix/Commix heap is not limited (no ScalaNative_Max_Size env variable) it tries to map memory chunk equal to all physical memory available. On Unix, we can use `mmap` with total size of physical memory and the system will handle the actual handling of committing memory until there is no more left, which would lead to OutOfMemory error
On Windows however we need to make sure that the allocated chunk of memory is less or equal to available memory, otherwise, it would fail at call site (in our case at GC init). This behaviour was described in issue #893. Also in case if we would use all actually available memory resource we would have very little change to start any other process, eg. TestSuite worker node, as there would be no more available memory left. 

To handle this issue strategy for allocating memory was changed for Windows. `memoryMap` helper function now does not automatically commit a given chunk of memory, instead it needs to be explicitly committed. Thanks to this change we're able to commit only a minimal amount of memory at startup, and commit additional chunks every time it is needed (on-call to Heap_grow in Immix/Commix)
Additionally, a method used to allocate memory was changed - instead of the usage of `CreateFileMapping`, we're using now `VirtualAlloc` which is more suitable for this task, and potentially faster.


