### PR TITLE
Allow to use CommixGC on Windows

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -89,6 +89,7 @@ jobs:
       matrix:
         os: [ windows-2019 ]
         scala: [ 2.13.6, 2.12.14, 2.11.12 ]
+        gc: [none, immix, commix]
     steps:
       - uses: actions/checkout@v2
 
@@ -120,12 +121,8 @@ jobs:
       - name: Assert clang installed and on path
         run: clang --version
 
-      - name: Run sandbox
+      - name: Test runtime
         run: |
-          sbt ++${{matrix.scala}};sandbox/run
-        shell: cmd
-
-      - name: Run testsExt tests
-        run: |
-          sbt ++${{matrix.scala}};testsExt/test
+          set SCALANATIVE_GC=${{matrix.gc}}
+          sbt ++${{matrix.scala}};sandbox/run;testsExt/test
         shell: cmd

--- a/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
@@ -106,7 +106,7 @@ static inline void Marker_giveFullPacket(Heap *heap, Stats *stats,
     assert(packet->type == grey_packet_refrange || packet->size > 0);
     // make all the contents visible to other threads
     atomic_thread_fence(memory_order_acquire);
-    uint32_t greyListSize = UInt24_toUInt32(GreyList_Size(&heap->mark.full));
+    uint32_t greyListSize = GreyList_Size(&heap->mark.full);
     assert(greyListSize <= heap->mark.total);
     Stats_RecordTimeSync(stats, start_ns);
     GreyList_Push(&heap->mark.full, heap->greyPacketsStart, packet);
@@ -411,6 +411,6 @@ void Marker_MarkRoots(Heap *heap, Stats *stats) {
 }
 
 bool Marker_IsMarkDone(Heap *heap) {
-    uint32_t size = UInt24_toUInt32(GreyList_Size(&heap->mark.empty));
+    uint32_t size = GreyList_Size(&heap->mark.empty);
     return size == heap->mark.total;
 }

--- a/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Marker.c
@@ -106,7 +106,8 @@ static inline void Marker_giveFullPacket(Heap *heap, Stats *stats,
     assert(packet->type == grey_packet_refrange || packet->size > 0);
     // make all the contents visible to other threads
     atomic_thread_fence(memory_order_acquire);
-    assert(GreyList_Size(&heap->mark.full) <= heap->mark.total);
+    uint32_t greyListSize = UInt24_toUInt32(GreyList_Size(&heap->mark.full));
+    assert(greyListSize <= heap->mark.total);
     Stats_RecordTimeSync(stats, start_ns);
     GreyList_Push(&heap->mark.full, heap->greyPacketsStart, packet);
     Stats_RecordTimeSync(stats, end_ns);
@@ -332,7 +333,8 @@ void Marker_MarkAndScale(Heap *heap, Stats *stats) {
         GreyPacket *next = Marker_takeFullPacket(heap, stats);
         if (next != NULL) {
             Marker_giveEmptyPacket(heap, stats, in);
-            uint32_t remainingFullPackets = next->next.sep.size;
+            uint32_t remainingFullPackets =
+                UInt24_toUInt32(next->next.sep.size);
             // Make sure than enough worker threads are running
             // given the number of packets available.
             // They will automatically stop if they run out of full packets.
@@ -409,5 +411,6 @@ void Marker_MarkRoots(Heap *heap, Stats *stats) {
 }
 
 bool Marker_IsMarkDone(Heap *heap) {
-    return GreyList_Size(&heap->mark.empty) == heap->mark.total;
+    uint32_t size = UInt24_toUInt32(GreyList_Size(&heap->mark.empty));
+    return size == heap->mark.total;
 }

--- a/nativelib/src/main/resources/scala-native/gc/commix/datastructures/GreyPacket.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/datastructures/GreyPacket.c
@@ -34,10 +34,10 @@ void GreyList_Init(GreyList *list) {
     list->head.atom = GreyPacketRef_Empty();
 }
 
-UInt24 GreyList_Size(GreyList *list) {
+uint32_t GreyList_Size(GreyList *list) {
     GreyPacketRef head;
     head.atom = list->head.atom;
-    return head.sep.size;
+    return UInt24_toUInt32(head.sep.size);
 }
 
 void GreyList_Push(GreyList *list, word_t *greyPacketsStart,

--- a/nativelib/src/main/resources/scala-native/gc/commix/datastructures/GreyPacket.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/datastructures/GreyPacket.h
@@ -16,7 +16,7 @@ typedef Object *Stack_Type;
 // UInt24 used instead of uint_32 bitset for cross-platform compatiblity, mainly
 // due the lack of support for 3-byte alignment in MSVC
 // https://docs.microsoft.com/en-us/cpp/c-language/padding-and-alignment-of-structure-members?redirectedfrom=MSDN&view=msvc-160
-// It would would result in size of 16 bytes on Windows and 8 on Unix
+// It would result in size of 16 bytes on Windows and 8 on Unix
 typedef union {
     struct __attribute__((packed)) {
         UInt24 idx;

--- a/nativelib/src/main/resources/scala-native/gc/commix/datastructures/GreyPacket.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/datastructures/GreyPacket.h
@@ -61,7 +61,7 @@ bool GreyPacket_IsEmpty(GreyPacket *packet);
 void GreyPacket_MoveItems(GreyPacket *src, GreyPacket *dst, int count);
 
 void GreyList_Init(GreyList *list);
-UInt24 GreyList_Size(GreyList *list);
+uint32_t GreyList_Size(GreyList *list);
 void GreyList_Push(GreyList *list, word_t *greyPacketsStart,
                    GreyPacket *packet);
 void GreyList_PushAll(GreyList *list, word_t *greyPacketsStart,
@@ -85,7 +85,7 @@ static inline GreyPacket *GreyPacket_FromIndex(word_t *greyPacketsStart,
 static inline uint64_t GreyPacketRef_Empty() {
     GreyPacketRef initial;
     initial.sep.idx = GREYLIST_LAST;
-    initial.sep.size = (UInt24){0};
+    initial.sep.size = UInt24_fromUInt32(0);
     initial.sep.timesPoped = 0;
     return initial.atom;
 }

--- a/nativelib/src/main/resources/scala-native/gc/commix/datastructures/GreyPacket.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/datastructures/GreyPacket.h
@@ -9,24 +9,31 @@
 #include "BlockRange.h"
 #include "Log.h"
 #include "headers/ObjectHeader.h"
+#include "UInt24.h"
 
 typedef Object *Stack_Type;
 
-// No support for 3-byte alignment in MSVC
+// UInt24 used instead of uint_32 bitset for cross-platform compatiblity, mainly
+// due the lack of support for 3-byte alignment in MSVC
 // https://docs.microsoft.com/en-us/cpp/c-language/padding-and-alignment-of-structure-members?redirectedfrom=MSDN&view=msvc-160
-// Would result in size of 16 bytes on Windows and 8 on Unix
+// It would would result in size of 16 bytes on Windows and 8 on Unix
 typedef union {
     struct __attribute__((packed)) {
-        uint32_t idx : BLOCK_COUNT_BITS;
+        UInt24 idx;
         // Size is kept in the reference it is in sync with the grey list.
         // Otherwise the updates can get reordered causing the number
         // temporarily appearing larger than it is which will trigger
         // Marker_IsMarkDone prematurely.
-        uint32_t size : BLOCK_COUNT_BITS;
+        UInt24 size;
         uint16_t timesPoped; // used to avoid ABA problems when popping
     } sep;
     atomic_uint_least64_t atom;
 } GreyPacketRef;
+
+#define sizeof_field(s, m) (sizeof((((s *)0)->m)))
+static_assert(sizeof_field(GreyPacketRef, sep) ==
+                  sizeof_field(GreyPacketRef, atom),
+              "GreyPacketRef sep and atom value should have the same size");
 
 typedef enum {
     grey_packet_reflist = 0x0,
@@ -41,8 +48,8 @@ typedef struct {
     Stack_Type items[GREY_PACKET_ITEMS];
 } GreyPacket;
 
-#define GREYLIST_NEXT ((uint32_t)0)
-#define GREYLIST_LAST ((uint32_t)1)
+#define GREYLIST_NEXT (UInt24_fromUInt32(0))
+#define GREYLIST_LAST (UInt24_fromUInt32(1))
 
 typedef struct {
     GreyPacketRef head;
@@ -54,30 +61,31 @@ bool GreyPacket_IsEmpty(GreyPacket *packet);
 void GreyPacket_MoveItems(GreyPacket *src, GreyPacket *dst, int count);
 
 void GreyList_Init(GreyList *list);
-uint32_t GreyList_Size(GreyList *list);
+UInt24 GreyList_Size(GreyList *list);
 void GreyList_Push(GreyList *list, word_t *greyPacketsStart,
                    GreyPacket *packet);
 void GreyList_PushAll(GreyList *list, word_t *greyPacketsStart,
                       GreyPacket *first, uint_fast32_t size);
 GreyPacket *GreyList_Pop(GreyList *list, word_t *greyPacketsStart);
 
-static inline uint32_t GreyPacket_IndexOf(word_t *greyPacketsStart,
-                                          GreyPacket *packet) {
+static inline UInt24 GreyPacket_IndexOf(word_t *greyPacketsStart,
+                                        GreyPacket *packet) {
     assert(packet != NULL);
     assert((void *)packet >= (void *)greyPacketsStart);
-    return (uint32_t)(packet - (GreyPacket *)greyPacketsStart) + 2;
+    return UInt24_fromUInt32((packet - (GreyPacket *)greyPacketsStart) + 2);
 }
 
 static inline GreyPacket *GreyPacket_FromIndex(word_t *greyPacketsStart,
-                                               uint32_t idx) {
-    assert(idx >= 2);
-    return (GreyPacket *)greyPacketsStart + (idx - 2);
+                                               UInt24 idx) {
+    uint32_t idxValue = UInt24_toUInt32(idx);
+    assert(idxValue >= 2);
+    return (GreyPacket *)greyPacketsStart + (idxValue - 2);
 }
 
 static inline uint64_t GreyPacketRef_Empty() {
     GreyPacketRef initial;
     initial.sep.idx = GREYLIST_LAST;
-    initial.sep.size = 0;
+    initial.sep.size = (UInt24){0};
     initial.sep.timesPoped = 0;
     return initial.atom;
 }

--- a/nativelib/src/main/resources/scala-native/gc/commix/metadata/BlockMeta.h
+++ b/nativelib/src/main/resources/scala-native/gc/commix/metadata/BlockMeta.h
@@ -9,6 +9,7 @@
 #include "GCTypes.h"
 #include "../Constants.h"
 #include "Log.h"
+#include "UInt24.h"
 
 typedef enum {
     block_free = 0x0,
@@ -26,9 +27,11 @@ typedef struct {
             uint8_t flags;
             int8_t first;
         } simple;
+        // UInt24 type is used for cross-platform compat, due to Windows
+        // problems with aligment of bitfields. See commix/GreyPackets.h
         struct {
             uint8_t flags;
-            int32_t size : BLOCK_COUNT_BITS;
+            UInt24 size;
         } superblock;
     } block;
 #ifdef DEBUG_ASSERT
@@ -38,6 +41,10 @@ typedef struct {
     int32_t nextBlock;
 #endif
 } BlockMeta;
+
+#define sizeof_field(s, m) (sizeof((((s *)0)->m)))
+static_assert(sizeof_field(BlockMeta, block) == sizeof(uint32_t),
+              "BlockMeta block should have size of uint32");
 
 #ifdef DEBUG_ASSERT
 typedef enum {
@@ -75,7 +82,7 @@ static inline bool BlockMeta_IsSuperblockStartMe(BlockMeta *blockMeta) {
 }
 
 static inline uint32_t BlockMeta_SuperblockSize(BlockMeta *blockMeta) {
-    return blockMeta->block.superblock.size;
+    return UInt24_toUInt32(blockMeta->block.superblock.size);
 }
 
 static inline bool BlockMeta_ContainsLargeObjects(BlockMeta *blockMeta) {
@@ -91,10 +98,10 @@ static inline void BlockMeta_SetFlagAndSuperblockSize(BlockMeta *blockMeta,
     assert(blockFlag != block_simple);
     struct {
         uint8_t flags;
-        int32_t size : BLOCK_COUNT_BITS;
+        UInt24 size;
     } combined;
     combined.flags = blockFlag;
-    combined.size = superblockSize;
+    combined.size = UInt24_fromUInt32(superblockSize);
 
     *((int32_t *)&blockMeta->block.superblock) = *((int32_t *)&combined);
 }

--- a/nativelib/src/main/resources/scala-native/gc/immix/metadata/BlockMeta.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/metadata/BlockMeta.h
@@ -8,6 +8,7 @@
 #include "GCTypes.h"
 #include "../Constants.h"
 #include "Log.h"
+#include "UInt24.h"
 
 typedef enum {
     block_free = 0x0,
@@ -23,13 +24,19 @@ typedef struct {
             uint8_t flags;
             int8_t first;
         } simple;
+        // UInt24 type is used for cross-platform compat, due to Windows
+        // problems with aligment of bitfields. See commix/GreyPackets.h
         struct {
             uint8_t flags;
-            int32_t size : BLOCK_COUNT_BITS;
+            UInt24 size;
         } superblock;
     } block;
     int32_t nextBlock;
 } BlockMeta;
+
+#define sizeof_field(s, m) (sizeof((((s *)0)->m)))
+static_assert(sizeof_field(BlockMeta, block) == sizeof(uint32_t),
+              "BlockMeta block should have size of uint32");
 
 static inline bool BlockMeta_IsFree(BlockMeta *blockMeta) {
     return blockMeta->block.simple.flags == block_free;
@@ -45,7 +52,7 @@ static inline bool BlockMeta_IsSuperblockMiddle(BlockMeta *blockMeta) {
 }
 
 static inline uint32_t BlockMeta_SuperblockSize(BlockMeta *blockMeta) {
-    return blockMeta->block.superblock.size;
+    return UInt24_toUInt32(blockMeta->block.superblock.size);
 }
 
 static inline bool BlockMeta_ContainsLargeObjects(BlockMeta *blockMeta) {
@@ -58,7 +65,7 @@ static inline void BlockMeta_SetSuperblockSize(BlockMeta *blockMeta,
     assert(!BlockMeta_IsSuperblockStart(blockMeta) || superblockSize > 0);
     assert(!BlockMeta_IsSimpleBlock(blockMeta));
 
-    blockMeta->block.superblock.size = superblockSize;
+    blockMeta->block.superblock.size = UInt24_fromUInt32(superblockSize);
 }
 
 static inline void BlockMeta_SetFirstFreeLine(BlockMeta *blockMeta,

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/UInt24.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/UInt24.h
@@ -1,0 +1,30 @@
+#ifndef UINT24_H
+#define UINT24_H
+#include <stddef.h>
+
+typedef struct {
+    uint8_t bytes[3];
+} UInt24;
+
+typedef union {
+    UInt24 value;
+    uint32_t bits : 24;
+} UInt24Bits;
+
+static inline UInt24 UInt24_fromUInt32(uint32_t value) {
+    return ((UInt24Bits)(value)).value;
+}
+static inline uint32_t UInt24_toUInt32(UInt24 v) {
+    return ((UInt24Bits)(v)).bits;
+}
+
+static inline UInt24 UInt24_plus(UInt24 value, uint32_t arg) {
+    uint32_t v = UInt24_toUInt32(value);
+    return UInt24_fromUInt32(v + arg);
+}
+
+static inline bool UInt24_equals(UInt24 v1, UInt24 v2) {
+    return UInt24_toUInt32(v1) == UInt24_toUInt32(v2);
+}
+
+#endif // UINT24_H

--- a/nativelib/src/main/resources/scala-native/gc/immix_commix/UInt24.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix_commix/UInt24.h
@@ -18,7 +18,7 @@ static inline uint32_t UInt24_toUInt32(UInt24 v) {
     return ((UInt24Bits)(v)).bits;
 }
 
-static inline UInt24 UInt24_plus(UInt24 value, uint32_t arg) {
+static inline UInt24 UInt24_plus(UInt24 value, int32_t arg) {
     uint32_t v = UInt24_toUInt32(value);
     return UInt24_fromUInt32(v + arg);
 }


### PR DESCRIPTION
Merged PR #2264 allowed for compilation of GCs on Windows however it contained few bugs left. One of them was a problem with an endless loop inside CommixGC. 
It was caused by the difference in sizes of some structs, eg. `GreyPacketsRef` between Unix and Windows and the assumption that this struct should be equal to exactly 8-bytes. Such difference was caused by not portable enough code - MSVC does not support bitfields inside packed structs as expected - it seems that on the whole size of the variable is counted into the size of the struct, or some additional alignment was added.

To handle this issue, usages of 24-bit fields based on `uint32_t` were replaced with a dedicated `UInt24` struct which should fully portable across platforms. 
Additionally, there were added compile-time assertions guarding for the correct size of memory-layout fragile structs.