### PR TITLE
Add support for Scala 2.13.6

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.13.5, 2.12.13, 2.11.12]
+        scala: [2.13.6, 2.12.13, 2.11.12]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
@@ -105,13 +105,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.13.5, 2.12.13, 2.11.12]
+        scala: [2.13.6, 2.12.13, 2.11.12]
         build-mode: [ debug , release-fast ]
         gc: [ boehm, immix, commix ]
         # Create holes in grid to lower number of tests.
         # Excluded entries should have low impact on overall project coverage
         exclude:
-          - scala: 2.13.5
+          - scala: 2.13.6
             build-mode: debug
             gc: immix
           - scala: 2.12.13
@@ -125,6 +125,12 @@ jobs:
             build-mode: debug
             gc: immix
           - scala: 2.13.4
+            build-mode: release-fast
+            gc: commix
+          - scala: 2.13.5
+            build-mode: debug
+            gc: immix
+          - scala: 2.13.5
             build-mode: release-fast
             gc: commix
     steps:
@@ -168,10 +174,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [ 2.13.5, 2.12.13, 2.11.12 ]
+        scala: [ 2.13.6, 2.12.13, 2.11.12 ]
         build-mode: [ debug, release-fast ]
         include:
           - scala: 2.13.4
+            build-mode: release-fast
+          - scala: 2.13.5
             build-mode: release-fast
     steps:
       - uses: actions/checkout@v2

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -1,7 +1,7 @@
 package build
 
 object ScalaVersions {
-  val crossScala213 = Seq("2.13.4", "2.13.5")
+  val crossScala213 = Seq("2.13.4", "2.13.5", "2.13.6")
 
   val scala211: String = "2.11.12"
   val scala212: String = "2.12.13"


### PR DESCRIPTION
This PR updates the default Scala 2.13 version to 2.13.6 and uses it in the CI. 
No additional changes were needed when upgrading from 2.13.5