### PR TITLE
Remove link to pthread_create missing C helper function

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -101,7 +101,6 @@ object pthread {
   def pthread_condattr_setpshared(attr: Ptr[pthread_condattr_t],
                                   pshared: CInt): CInt = extern
 
-  @name("scalanative_pthread_create")
   def pthread_create(thread: Ptr[pthread_t],
                      attr: Ptr[pthread_attr_t],
                      startroutine: CFuncPtr1[Ptr[Byte], Ptr[Byte]],


### PR DESCRIPTION
As reported by @errikos, `pthread_create` didn't have a helper method causing a link error. The POSIX function should work without helper functions.