### PR TITLE
WIP: Add Scals 2.13.6

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.13.5, 2.12.13, 2.11.12]
+        scala: [2.13.6, 2.12.13, 2.11.12]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
@@ -105,13 +105,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.13.5, 2.12.13, 2.11.12]
+        scala: [2.13.6, 2.12.13, 2.11.12]
         build-mode: [ debug , release-fast ]
         gc: [ boehm, immix, commix ]
         # Create holes in grid to lower number of tests.
         # Excluded entries should have low impact on overall project coverage
         exclude:
-          - scala: 2.13.5
+          - scala: 2.13.6
             build-mode: debug
             gc: immix
           - scala: 2.12.13
@@ -125,6 +125,12 @@ jobs:
             build-mode: debug
             gc: immix
           - scala: 2.13.4
+            build-mode: release-fast
+            gc: commix
+          - scala: 2.13.5
+            build-mode: debug
+            gc: immix
+          - scala: 2.13.5
             build-mode: release-fast
             gc: commix
     steps:
@@ -168,10 +174,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [ 2.13.5, 2.12.13, 2.11.12 ]
+        scala: [ 2.13.6, 2.12.13, 2.11.12 ]
         build-mode: [ debug, release-fast ]
         include:
           - scala: 2.13.4
+            build-mode: release-fast
+          - scala: 2.13.5
             build-mode: release-fast
     steps:
       - uses: actions/checkout@v2

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -1,7 +1,7 @@
 package build
 
 object ScalaVersions {
-  val crossScala213 = Seq("2.13.4", "2.13.5")
+  val crossScala213 = Seq("2.13.4", "2.13.5", "2.13.6")
 
   val scala211: String = "2.11.12"
   val scala212: String = "2.12.13"


### PR DESCRIPTION
--- Reviewer note: --- Delete when promoted to PR.

1) Scala 2.13.6 is not publicly released yet.  This WIP PR is presented
   for review and to enable fast action when that version is released.

2) The matrix of which jobs get run on which version bears review.
   I applied no brain-power and simply made Scala 2.13.5 look like
   the existing 2.13.4.

   I am pretty sure that opportunities exist to more rationally
   configure Scala versions and build options, so that more options
   are tested rather than simply repeating the same options on
   different Scala versions.  I understand that there is a case for
   the latter, but that case is weak for the set of options now
   running for Scala 2.13.4.

   I think there is also room to re-examine if combinations like
   "no-opt release-fast" or even "no-opt" in the first place make
   sense to be run on every CI.   I have some private work to
   run defined tests (MacOS, FreeBSD, "release-fast LTO", etc.)
   periodically. We could discuss moving that work the next steps forward.
   At this point, the impediments are basically administrative:
   to whom (primary person, secondary person) do messages gets
   set to and how are watchdog failures-to-run reported.

--- Commit message ---

Support for Scala 2.13.6 is added to the existing matrix.