### PR TITLE
Improve, but not perfect, Posix pthread code quality.

### DIFF
--- a/posixlib/src/main/resources/scala-native/pthread.c
+++ b/posixlib/src/main/resources/scala-native/pthread.c
@@ -48,28 +48,22 @@ int scalanative_pthread_scope_process() { return PTHREAD_SCOPE_PROCESS; }
 
 int scalanative_pthread_scope_system() { return PTHREAD_SCOPE_SYSTEM; }
 
-// BEWARE: scalanative_pthread_size_of*_t functions do not follow
+// BEWARE: scalanative_pthread_*_t_size functions do not follow
 // Posix 2018 specification.  See discussion in "BEWARE" note in pthread.scala.
 
-size_t scalanative_pthread_size_of_pthread_t() { return sizeof(pthread_t); }
+size_t scalanative_pthread_t_size() { return sizeof(pthread_t); }
 
-size_t scalanative_pthread_size_of_pthread_attr_t() {
-    return sizeof(pthread_attr_t);
-}
+size_t scalanative_pthread_attr_t_size() { return sizeof(pthread_attr_t); }
 
-size_t scalanative_pthread_size_of_pthread_cond_t() {
-    return sizeof(pthread_cond_t);
-}
+size_t scalanative_pthread_cond_t_size() { return sizeof(pthread_cond_t); }
 
-size_t scalanative_pthread_size_of_pthread_condattr_t() {
+size_t scalanative_pthread_condattr_t_size() {
     return sizeof(pthread_condattr_t);
 }
 
-size_t scalanative_pthread_size_of_pthread_mutex_t() {
-    return sizeof(pthread_mutex_t);
-}
+size_t scalanative_pthread_mutex_t_size { return sizeof(pthread_mutex_t); }
 
-size_t scalanative_pthread_size_of_pthread_mutexattr_t() {
+size_t scalanative_pthread_mutexattr_t_size() {
     return sizeof(pthread_mutexattr_t);
 }
 

--- a/posixlib/src/main/resources/scala-native/pthread.c
+++ b/posixlib/src/main/resources/scala-native/pthread.c
@@ -61,7 +61,7 @@ size_t scalanative_pthread_condattr_t_size() {
     return sizeof(pthread_condattr_t);
 }
 
-size_t scalanative_pthread_mutex_t_size { return sizeof(pthread_mutex_t); }
+size_t scalanative_pthread_mutex_t_size() { return sizeof(pthread_mutex_t); }
 
 size_t scalanative_pthread_mutexattr_t_size() {
     return sizeof(pthread_mutexattr_t);

--- a/posixlib/src/main/resources/scala-native/pthread.c
+++ b/posixlib/src/main/resources/scala-native/pthread.c
@@ -4,22 +4,6 @@
 #include <sys/types.h>
 #include <string.h>
 
-size_t scalanative_size_of_pthread_t() { return sizeof(pthread_t); }
-
-size_t scalanative_size_of_pthread_attr_t() { return sizeof(pthread_attr_t); }
-
-size_t scalanative_size_of_pthread_cond_t() { return sizeof(pthread_cond_t); }
-
-size_t scalanative_size_of_pthread_condattr_t() {
-    return sizeof(pthread_condattr_t);
-}
-
-size_t scalanative_size_of_pthread_mutex_t() { return sizeof(pthread_mutex_t); }
-
-size_t scalanative_size_of_pthread_mutexattr_t() {
-    return sizeof(pthread_mutexattr_t);
-}
-
 int scalanative_pthread_cancel_asynchronous() {
     return PTHREAD_CANCEL_ASYNCHRONOUS;
 }
@@ -63,5 +47,30 @@ int scalanative_pthread_process_private() { return PTHREAD_PROCESS_PRIVATE; }
 int scalanative_pthread_scope_process() { return PTHREAD_SCOPE_PROCESS; }
 
 int scalanative_pthread_scope_system() { return PTHREAD_SCOPE_SYSTEM; }
+
+// BEWARE: scalanative_pthread_size_of*_t functions do not follow
+// Posix 2018 specification.  See discussion in "BEWARE" note in pthread.scala.
+
+size_t scalanative_pthread_size_of_pthread_t() { return sizeof(pthread_t); }
+
+size_t scalanative_pthread_size_of_pthread_attr_t() {
+    return sizeof(pthread_attr_t);
+}
+
+size_t scalanative_pthread_size_of_pthread_cond_t() {
+    return sizeof(pthread_cond_t);
+}
+
+size_t scalanative_pthread_size_of_pthread_condattr_t() {
+    return sizeof(pthread_condattr_t);
+}
+
+size_t scalanative_pthread_size_of_pthread_mutex_t() {
+    return sizeof(pthread_mutex_t);
+}
+
+size_t scalanative_pthread_size_of_pthread_mutexattr_t() {
+    return sizeof(pthread_mutexattr_t);
+}
 
 #endif // Unix or Mac OS

--- a/posixlib/src/main/resources/scala-native/pthread.c
+++ b/posixlib/src/main/resources/scala-native/pthread.c
@@ -6,7 +6,7 @@
 
 size_t scalanative_size_of_pthread_t() { return sizeof(pthread_t); }
 
-size_t scalanative_pthread_attr_t() { return sizeof(pthread_attr_t); }
+size_t scalanative_size_of_pthread_attr_t() { return sizeof(pthread_attr_t); }
 
 size_t scalanative_size_of_pthread_cond_t() { return sizeof(pthread_cond_t); }
 
@@ -48,10 +48,7 @@ int scalanative_pthread_mutex_normal() { return PTHREAD_MUTEX_NORMAL; }
 
 int scalanative_pthread_mutex_recursive() { return PTHREAD_MUTEX_RECURSIVE; }
 
-pthread_once_t scalanative_pthread_once_init() {
-    pthread_once_t once_block = PTHREAD_ONCE_INIT;
-    return once_block;
-}
+pthread_once_t scalanative_pthread_once_init() { return PTHREAD_ONCE_INIT; }
 
 int scalanative_pthread_prio_inherit() { return PTHREAD_PRIO_INHERIT; }
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -288,7 +288,7 @@ object pthread {
   def PTHREAD_SCOPE_SYSTEM: CInt = extern
 
   // BEWARE:
-  // The pthread_*t_size methods and corresponding
+  // The six scalanative_pthread_*t_size methods below and corresponding
   // scalanative_pthread_*size_of_*_t C functions
   // are not part of the specification:
   //   The Open Group Base Specifications Issue 7, 2018 edition
@@ -296,21 +296,15 @@ object pthread {
   // Someday they should be removed and, iff useful, moved to another
   // file, say pthread_helpers.*, and given new names.
 
-  @name("scalanative_pthread_size_of_pthread_t")
-  def pthread_t_size: CSize = extern
+  def scalanative_pthread_t_size: CSize = extern
 
-  @name("scalanative_pthread_size_of_pthread_attr_t")
-  def pthread_attr_t_size: CSize = extern
+  def scalanative_pthread_attr_t_size: CSize = extern
 
-  @name("scalanative_pthread_size_of_pthread_cond_t")
-  def pthread_cond_t_size: CSize = extern
+  def scalanative_pthread_cond_t_size: CSize = extern
 
-  @name("scalanative_pthread_size_of_pthread_condattr_t")
-  def pthread_condattr_t_size: CSize = extern
+  def scalanative_pthread_condattr_t_size: CSize = extern
 
-  @name("scalanative_pthread_size_of_pthread_mutex_t")
-  def pthread_mutex_t_size: CSize = extern
+  def scalanative_pthread_mutex_t_size: CSize = extern
 
-  @name("scalanative_pthread_size_of_pthread_mutexattr_t")
-  def pthread_mutexattr_t_size: CSize = extern
+  def scalanative_pthread_mutexattr_t_size: CSize = extern
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -8,6 +8,7 @@ import scala.scalanative.unsafe.{
   CSize,
   Ptr,
   extern,
+  link,
   name
 }
 import scala.scalanative.posix.sched.sched_param
@@ -17,9 +18,9 @@ import scala.scalanative.posix.sys.types._
 // SUSv2 version is used for compatibility
 // see http://pubs.opengroup.org/onlinepubs/007908799/xsh/threads.html
 
+@link("pthread")
 @extern
 object pthread {
-
   def pthread_atfork(prepare: routine, parent: routine, child: routine): CInt =
     extern
 
@@ -72,7 +73,6 @@ object pthread {
   def pthread_attr_setstacksize(attr: Ptr[pthread_attr_t],
                                 stacksize: CSize): CInt = extern
 
-  @name("scalanative_pthread_cancel")
   def pthread_cancel(thread: pthread_t): CInt = extern
 
   def pthread_cond_broadcast(cond: Ptr[pthread_cond_t]): CInt = extern
@@ -106,12 +106,10 @@ object pthread {
                      startroutine: CFuncPtr1[Ptr[Byte], Ptr[Byte]],
                      args: Ptr[Byte]): CInt = extern
 
-  @name("scalanative_pthread_detach")
   def pthread_detach(thread: pthread_t): CInt = extern
 
   def pthread_equal(thread1: pthread_t, thread2: pthread_t): CInt = extern
 
-  @name("scalanative_pthread_exit")
   def pthread_exit(retval: Ptr[Byte]): Unit = extern
 
   def pthread_getconcurrency(): CInt = extern
@@ -122,12 +120,10 @@ object pthread {
 
   def pthread_getspecific(key: pthread_key_t): Ptr[Byte] = extern
 
-  @name("scalanative_pthread_join")
   def pthread_join(thread: pthread_t, value_ptr: Ptr[Ptr[Byte]]): CInt = extern
 
   def pthread_key_create(key: Ptr[pthread_key_t],
-                         destructor: CFuncPtr1[Ptr[Byte], Unit]): CInt =
-    extern
+                         destructor: CFuncPtr1[Ptr[Byte], Unit]): CInt = extern
 
   def pthread_key_delete(key: pthread_key_t): CInt = extern
 
@@ -294,7 +290,7 @@ object pthread {
   @name("scalanative_size_of_pthread_t")
   def pthread_t_size: CSize = extern
 
-  @name("scalanative_pthread_attr_t")
+  @name("scalanative_size_of_pthread_attr_t")
   def pthread_attr_t_size: CSize = extern
 
   @name("scalanative_size_of_pthread_cond_t")
@@ -308,5 +304,4 @@ object pthread {
 
   @name("scalanative_size_of_pthread_mutexattr_t")
   def pthread_mutexattr_t_size: CSize = extern
-
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -287,21 +287,30 @@ object pthread {
   @name("scalanative_pthread_scope_system")
   def PTHREAD_SCOPE_SYSTEM: CInt = extern
 
-  @name("scalanative_size_of_pthread_t")
+  // BEWARE:
+  // The pthread_*t_size methods and corresponding
+  // scalanative_pthread_*size_of_*_t C functions
+  // are not part of the specification:
+  //   The Open Group Base Specifications Issue 7, 2018 edition
+  //
+  // Someday they should be removed and, iff useful, moved to another
+  // file, say pthread_helpers.*, and given new names.
+
+  @name("scalanative_pthread_size_of_pthread_t")
   def pthread_t_size: CSize = extern
 
-  @name("scalanative_size_of_pthread_attr_t")
+  @name("scalanative_pthread_size_of_pthread_attr_t")
   def pthread_attr_t_size: CSize = extern
 
-  @name("scalanative_size_of_pthread_cond_t")
+  @name("scalanative_pthread_size_of_pthread_cond_t")
   def pthread_cond_t_size: CSize = extern
 
-  @name("scalanative_size_of_pthread_condattr_t")
+  @name("scalanative_pthread_size_of_pthread_condattr_t")
   def pthread_condattr_t_size: CSize = extern
 
-  @name("scalanative_size_of_pthread_mutex_t")
+  @name("scalanative_pthread_size_of_pthread_mutex_t")
   def pthread_mutex_t_size: CSize = extern
 
-  @name("scalanative_size_of_pthread_mutexattr_t")
+  @name("scalanative_pthread_size_of_pthread_mutexattr_t")
   def pthread_mutexattr_t_size: CSize = extern
 }


### PR DESCRIPTION
We ameliorate Posix pathread code quality by removing `@name`
annotations in pthread.scala which are both unnecessary and have
not corresponding code in pthread.c.

A name is changed in both pthread.scala & pthread.c to make it parallel
similar names.

Lastly, `scalanative_pthread_once_init()` in pthread.c is simplified
to make it parallel other constant declarations, to show that it is
exactly similar to those, and to make it easier to trace & understand.