### PR TITLE
Respect doPrealloc if we are not on linux.

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
@@ -105,8 +105,10 @@ word_t *memoryMapPrealloc(size_t memorySize, size_t doPrealloc) {
 
 #ifndef __linux__
     // if we are not on linux the next best thing we can do is to mark the pages
-    // as MADV_WILLNEED.
-    madvise(res, memorySize, MADV_WILLNEED);
+    // as MADV_WILLNEED but only if doPrealloc is enabled.
+    if (doPrealloc) {
+        madvise(res, memorySize, MADV_WILLNEED);
+    }
 #endif
 
     return res;


### PR DESCRIPTION
i have made small fix and a test for the gc preallocation:
https://github.com/teodimoff/scala-native/tree/gc-prealloc-test/staging/gc-prealloc
My first question is where the test should go? If in scripted test i will need some help with the yml file. The test need to run two times(be it either the result binary or sbt run). Before the second run we need to export the export GC_INITIAL_HEAP_SIZE=700M to see the difference. Also the results is printing the execution time for both runs if preallocation works the second the will take less time. Is this enough or we want to actually compare both execution times to see if the second is actually less? If so how?
