### PR TITLE
Change C compiler standard from gnu11 to c11

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
@@ -7,7 +7,7 @@
 #else // Unix
 // For Linux
 // https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
-#define _BSD_SOURCE
+#define _XOPEN_SOURCE 700
 #include <sys/mman.h>
 // Darwin defines MAP_ANON instead of MAP_ANONYMOUS
 #if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)

--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
@@ -5,6 +5,9 @@
 #define NOMINMAX
 #include <windows.h>
 #else // Unix
+// For Linux
+// https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
+#define _DEFAULT_SOURCE
 #include <sys/mman.h>
 // Darwin defines MAP_ANON instead of MAP_ANONYMOUS
 #if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)

--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
@@ -7,7 +7,7 @@
 #else // Unix
 // For Linux
 // https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
-#define _GNU_SOURCE
+#define _BSD_SOURCE
 #include <sys/mman.h>
 // Darwin defines MAP_ANON instead of MAP_ANONYMOUS
 #if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)

--- a/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
+++ b/nativelib/src/main/resources/scala-native/gc/shared/MemoryMap.c
@@ -7,7 +7,7 @@
 #else // Unix
 // For Linux
 // https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 #include <sys/mman.h>
 // Darwin defines MAP_ANON instead of MAP_ANONYMOUS
 #if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -42,7 +42,7 @@ private[scalanative] object LLVM {
         val stdflag =
           if (isLl) Seq()
           else if (isCpp) Seq("-std=c++11")
-          else Seq("-std=gnu11")
+          else Seq("-std=c11")
         val flags = opt(config) +: stdflag ++: "-fvisibility=hidden" +:
           config.compileOptions
         val compilec =


### PR DESCRIPTION
Please include a release note.

Currently, Scala Native supports clang 6 and uses the `-std=c++11` and `-std=c11` standards while compiling C++ and C respectively. So Scala Native can potentially support more platforms this is quite conservative. This change is because the initial selection of `gnu11` supports GNU extensions beyond `c11` so it is potentially not 100% C standard compliant. See https://gcc.gnu.org/onlinedocs/gcc/Standards.html

>By default, GCC provides some extensions to the C language that, on rare occasions conflict with the C standard. See Extensions to the C Language Family. Some features that are part of the C99 standard are accepted as extensions in C90 mode, and some features that are part of the C11 standard are accepted as extensions in C90 and C99 modes. Use of the -std options listed above disables these extensions where they conflict with the C standard version selected. You may also select an extended version of the C language explicitly with -std=gnu90 (for C90 with GNU extensions), -std=gnu99 (for C99 with GNU extensions) or -std=gnu11 (for C11 with GNU extensions). 