### PR TITLE
Improve POSIX pthread code quality

### DIFF
--- a/posixlib/src/main/resources/scala-native/pthread.c
+++ b/posixlib/src/main/resources/scala-native/pthread.c
@@ -4,22 +4,6 @@
 #include <sys/types.h>
 #include <string.h>
 
-size_t scalanative_pthread_t_size() { return sizeof(pthread_t); }
-
-size_t scalanative_pthread_attr_t_size() { return sizeof(pthread_attr_t); }
-
-size_t scalanative_pthread_cond_t_size() { return sizeof(pthread_cond_t); }
-
-size_t scalanative_pthread_condattr_t_size() {
-    return sizeof(pthread_condattr_t);
-}
-
-size_t scalanative_pthread_mutex_t_size() { return sizeof(pthread_mutex_t); }
-
-size_t scalanative_pthread_mutexattr_t_size() {
-    return sizeof(pthread_mutexattr_t);
-}
-
 int scalanative_pthread_cancel_asynchronous() {
     return PTHREAD_CANCEL_ASYNCHRONOUS;
 }
@@ -67,5 +51,23 @@ int scalanative_pthread_process_private() { return PTHREAD_PROCESS_PRIVATE; }
 int scalanative_pthread_scope_process() { return PTHREAD_SCOPE_PROCESS; }
 
 int scalanative_pthread_scope_system() { return PTHREAD_SCOPE_SYSTEM; }
+
+// The following are not part of the POSIX spec
+
+size_t scalanative_pthread_t_size() { return sizeof(pthread_t); }
+
+size_t scalanative_pthread_attr_t_size() { return sizeof(pthread_attr_t); }
+
+size_t scalanative_pthread_cond_t_size() { return sizeof(pthread_cond_t); }
+
+size_t scalanative_pthread_condattr_t_size() {
+    return sizeof(pthread_condattr_t);
+}
+
+size_t scalanative_pthread_mutex_t_size() { return sizeof(pthread_mutex_t); }
+
+size_t scalanative_pthread_mutexattr_t_size() {
+    return sizeof(pthread_mutexattr_t);
+}
 
 #endif // Unix or Mac OS

--- a/posixlib/src/main/resources/scala-native/pthread.c
+++ b/posixlib/src/main/resources/scala-native/pthread.c
@@ -4,19 +4,19 @@
 #include <sys/types.h>
 #include <string.h>
 
-size_t scalanative_size_of_pthread_t() { return sizeof(pthread_t); }
+size_t scalanative_pthread_t_size() { return sizeof(pthread_t); }
 
-size_t scalanative_pthread_attr_t() { return sizeof(pthread_attr_t); }
+size_t scalanative_pthread_attr_t_size() { return sizeof(pthread_attr_t); }
 
-size_t scalanative_size_of_pthread_cond_t() { return sizeof(pthread_cond_t); }
+size_t scalanative_pthread_cond_t_size() { return sizeof(pthread_cond_t); }
 
-size_t scalanative_size_of_pthread_condattr_t() {
+size_t scalanative_pthread_condattr_t_size() {
     return sizeof(pthread_condattr_t);
 }
 
-size_t scalanative_size_of_pthread_mutex_t() { return sizeof(pthread_mutex_t); }
+size_t scalanative_pthread_mutex_t_size() { return sizeof(pthread_mutex_t); }
 
-size_t scalanative_size_of_pthread_mutexattr_t() {
+size_t scalanative_pthread_mutexattr_t_size() {
     return sizeof(pthread_mutexattr_t);
 }
 
@@ -26,21 +26,21 @@ int scalanative_pthread_cancel_asynchronous() {
 
 int scalanative_pthread_cancel_enable() { return PTHREAD_CANCEL_ENABLE; }
 
-int scalanative_pthread_cancel_ered() { return PTHREAD_CANCEL_DEFERRED; }
+int scalanative_pthread_cancel_deferred() { return PTHREAD_CANCEL_DEFERRED; }
 
 int scalanative_pthread_cancel_disable() { return PTHREAD_CANCEL_DISABLE; }
 
 void *scalanative_pthread_canceled() { return PTHREAD_CANCELED; }
 
-int scalanative_pthread_create_deteached() { return PTHREAD_CREATE_DETACHED; }
+int scalanative_pthread_create_detached() { return PTHREAD_CREATE_DETACHED; }
 
-int scalanative_pthread_create_joinale() { return PTHREAD_CREATE_JOINABLE; }
+int scalanative_pthread_create_joinable() { return PTHREAD_CREATE_JOINABLE; }
 
 int scalanative_pthread_explicit_sched() { return PTHREAD_EXPLICIT_SCHED; }
 
 int scalanative_pthread_inherit_sched() { return PTHREAD_INHERIT_SCHED; }
 
-int scalanative_pthread_mutex_ault() { return PTHREAD_MUTEX_DEFAULT; }
+int scalanative_pthread_mutex_default() { return PTHREAD_MUTEX_DEFAULT; }
 
 int scalanative_pthread_mutex_errorcheck() { return PTHREAD_MUTEX_ERRORCHECK; }
 
@@ -49,6 +49,7 @@ int scalanative_pthread_mutex_normal() { return PTHREAD_MUTEX_NORMAL; }
 int scalanative_pthread_mutex_recursive() { return PTHREAD_MUTEX_RECURSIVE; }
 
 pthread_once_t scalanative_pthread_once_init() {
+    // On macOS, PTHREAD_ONCE_INIT is defined as an expression
     pthread_once_t once_block = PTHREAD_ONCE_INIT;
     return once_block;
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -13,6 +13,11 @@ import scala.scalanative.posix.sys.types._
 @extern
 object pthread {
 
+  // simpify definitions - not in spec
+  type routine = CFuncPtr0[Unit]
+
+  // functions
+
   def pthread_atfork(prepare: routine, parent: routine, child: routine): CInt =
     extern
 
@@ -211,10 +216,8 @@ object pthread {
 
   def pthread_testcancel(): Unit = extern
 
-  // Types
-  type routine = CFuncPtr0[Unit]
+  // symbolic constants
 
-  // Macros
   @name("scalanative_pthread_cancel_asynchronous")
   def PTHREAD_CANCEL_ASYNCHRONOUS: CInt = extern
 
@@ -279,6 +282,7 @@ object pthread {
   def PTHREAD_SCOPE_SYSTEM: CInt = extern
 
   // The following are not part of the POSIX spec
+  // and therefore could be subject to removal
 
   @name("scalanative_pthread_t_size")
   def pthread_t_size: CSize = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pthread.scala
@@ -1,15 +1,7 @@
 package scala.scalanative
 package posix
 
-import scala.scalanative.unsafe.{
-  CFuncPtr0,
-  CFuncPtr1,
-  CInt,
-  CSize,
-  Ptr,
-  extern,
-  name
-}
+import scala.scalanative.unsafe._
 import scala.scalanative.posix.sched.sched_param
 import scala.scalanative.posix.time.timespec
 import scala.scalanative.posix.sys.types._
@@ -17,6 +9,7 @@ import scala.scalanative.posix.sys.types._
 // SUSv2 version is used for compatibility
 // see http://pubs.opengroup.org/onlinepubs/007908799/xsh/threads.html
 
+@link("pthread")
 @extern
 object pthread {
 
@@ -72,7 +65,6 @@ object pthread {
   def pthread_attr_setstacksize(attr: Ptr[pthread_attr_t],
                                 stacksize: CSize): CInt = extern
 
-  @name("scalanative_pthread_cancel")
   def pthread_cancel(thread: pthread_t): CInt = extern
 
   def pthread_cond_broadcast(cond: Ptr[pthread_cond_t]): CInt = extern
@@ -106,12 +98,10 @@ object pthread {
                      startroutine: CFuncPtr1[Ptr[Byte], Ptr[Byte]],
                      args: Ptr[Byte]): CInt = extern
 
-  @name("scalanative_pthread_detach")
   def pthread_detach(thread: pthread_t): CInt = extern
 
   def pthread_equal(thread1: pthread_t, thread2: pthread_t): CInt = extern
 
-  @name("scalanative_pthread_exit")
   def pthread_exit(retval: Ptr[Byte]): Unit = extern
 
   def pthread_getconcurrency(): CInt = extern
@@ -122,12 +112,10 @@ object pthread {
 
   def pthread_getspecific(key: pthread_key_t): Ptr[Byte] = extern
 
-  @name("scalanative_pthread_join")
   def pthread_join(thread: pthread_t, value_ptr: Ptr[Ptr[Byte]]): CInt = extern
 
   def pthread_key_create(key: Ptr[pthread_key_t],
-                         destructor: CFuncPtr1[Ptr[Byte], Unit]): CInt =
-    extern
+                         destructor: CFuncPtr1[Ptr[Byte], Unit]): CInt = extern
 
   def pthread_key_delete(key: pthread_key_t): CInt = extern
 
@@ -197,8 +185,7 @@ object pthread {
 
   def pthread_rwlock_wrlock(rwlock: Ptr[pthread_rwlock_t]): CInt = extern
 
-  def pthread_rwlockattr_destroy(attr: Ptr[pthread_rwlockattr_t]): CInt =
-    extern
+  def pthread_rwlockattr_destroy(attr: Ptr[pthread_rwlockattr_t]): CInt = extern
 
   def pthread_rwlockattr_getpshared(attr: Ptr[pthread_rwlockattr_t],
                                     pshared: Ptr[CInt]): CInt = extern
@@ -234,7 +221,7 @@ object pthread {
   @name("scalanative_pthread_cancel_enable")
   def PTHREAD_CANCEL_ENABLE: CInt = extern
 
-  @name("scalanative_pthread_cancel_defered")
+  @name("scalanative_pthread_cancel_deferred")
   def PTHREAD_CANCEL_DEFERRED: CInt = extern
 
   @name("scalanative_pthread_cancel_disable")
@@ -243,10 +230,10 @@ object pthread {
   @name("scalanative_pthread_canceled")
   def PTHREAD_CANCELED: Ptr[Byte] = extern
 
-  @name("scalanative_pthread_create_deteached")
+  @name("scalanative_pthread_create_detached")
   def PTHREAD_CREATE_DETACHED: CInt = extern
 
-  @name("scalanative_pthread_create_joinale")
+  @name("scalanative_pthread_create_joinable")
   def PTHREAD_CREATE_JOINABLE: CInt = extern
 
   @name("scalanative_pthread_explicit_sched")
@@ -291,22 +278,24 @@ object pthread {
   @name("scalanative_pthread_scope_system")
   def PTHREAD_SCOPE_SYSTEM: CInt = extern
 
-  @name("scalanative_size_of_pthread_t")
+  // The following are not part of the POSIX spec
+
+  @name("scalanative_pthread_t_size")
   def pthread_t_size: CSize = extern
 
-  @name("scalanative_pthread_attr_t")
+  @name("scalanative_pthread_attr_t_size")
   def pthread_attr_t_size: CSize = extern
 
-  @name("scalanative_size_of_pthread_cond_t")
+  @name("scalanative_pthread_cond_t_size")
   def pthread_cond_t_size: CSize = extern
 
-  @name("scalanative_size_of_pthread_condattr_t")
+  @name("scalanative_pthread_condattr_t_size")
   def pthread_condattr_t_size: CSize = extern
 
-  @name("scalanative_size_of_pthread_mutex_t")
+  @name("scalanative_pthread_mutex_t_size")
   def pthread_mutex_t_size: CSize = extern
 
-  @name("scalanative_size_of_pthread_mutexattr_t")
+  @name("scalanative_pthread_mutexattr_t_size")
   def pthread_mutexattr_t_size: CSize = extern
 
 }


### PR DESCRIPTION
This was originally initiated by @LeeTibbert here. https://github.com/scala-native/scala-native/pull/2301/

This is almost the same as the original with just a few naming by convention changes and spelling corrections to make things match exactly. I also moved a type definition to the top as was recommended by Lee and made a few comment changes to match the spec.

The constants in the spec are first but after the functions here - those can be moved to the top of the spec if desired to match the spec more directly. The constants and functions are verified to be in spec order within their group.
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/pthread.h.html