### PR TITLE
j.n.SocketHelpers#ipToHost no longer requests info it does not use.

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
+++ b/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
@@ -213,9 +213,7 @@ object SocketHelpers {
 
   def ipToHost(ip: String, isV6: Boolean): Option[String] =
     Zone { implicit z =>
-      val host    = stackalloc[CChar](MAXHOSTNAMELEN)
-      val service = null.asInstanceOf[Ptr[CChar]]
-
+      val host = stackalloc[CChar](MAXHOSTNAMELEN)
       val addr = stackalloc[sockaddr]
 
       if (!ipStringAddrToSockaddr(ip, isV6, addr)) {
@@ -226,8 +224,8 @@ object SocketHelpers {
                       sizeof[sockaddr].toUInt,
                       host,
                       MAXHOSTNAMELEN,
-                      service,
-                      0.toUInt, // 'service' is never used; do not retrieve
+                      null.asInstanceOf[Ptr[CChar]],
+                      0.toUInt,
                       0)
 
         // Sole caller, Java 8 InetAddress#getHostName(),

--- a/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
+++ b/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
@@ -186,7 +186,8 @@ object SocketHelpers {
   def ipToHost(ip: String, isV6: Boolean): Option[String] =
     Zone { implicit z =>
       val host    = stackalloc[CChar](MAXHOSTNAMELEN)
-      val service = stackalloc[CChar](20.toUInt)
+      val service = null.asInstanceOf[Ptr[CChar]]
+
       val status =
         if (isV6) {
           val addr6 = stackalloc[sockaddr_in6]
@@ -199,7 +200,7 @@ object SocketHelpers {
                       host,
                       MAXHOSTNAMELEN,
                       service,
-                      20.toUInt,
+                      0.toUInt, // 'service' is never used; do not retrieve
                       0)
         } else {
           val addr4 = stackalloc[sockaddr_in]
@@ -210,11 +211,12 @@ object SocketHelpers {
           getnameinfo(addr4.asInstanceOf[Ptr[sockaddr]],
                       sizeof[sockaddr_in].toUInt,
                       host,
-                      1024.toUInt,
+                      MAXHOSTNAMELEN,
                       service,
-                      20.toUInt,
+                      0.toUInt, // 'service' is never used; do not retrieve
                       0)
         }
+
       if (status == 0) Some(fromCString(host)) else None
     }
 }

--- a/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
+++ b/posixlib/src/main/scala/scala/scalanative/runtime/SocketHelpers.scala
@@ -218,6 +218,7 @@ object SocketHelpers {
 
       ipStringAddrToSockaddr(ip, isV6, addr) match {
         case None => None
+
         case Some(sockadr) =>
           val status =
             getnameinfo(sockadr,


### PR DESCRIPTION
We make a small, focused change to specify the 'service' argument
in a way that instructs getnameinfo() to not spend time/cycles retrieving
that information. 

Code is restructured to unify almost identical calls.

For consistency, a hard-coded number is converted to the apparently intended constant.

See Issue #2311 for a discussion of further improvements which could be made.