### PR TITLE
Use LLVM 11 in the CI for Windows 

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -13,17 +13,17 @@ jobs:
       - uses: actions/checkout@v2
       
       #Prepare environment, clang needs to be installed
-      #Compilation on MSVC needs c++14 or higher and expects llvm 10.0.0 or newer
+      #Compilation on MSVC needs c++14 or higher and expects llvm 11.0.0 or newer
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v2
         with:
           path: |
             C:\Program Files\LLVM\
-          key: ${{ runner.os }}-llvm-10
+          key: ${{ runner.os }}-llvm-11
       - name: Install LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: choco install llvm --version=10.0.0
+        run: choco install llvm --version=11.0.0
 
       - name: Add LLVM on Path
         run: echo "${env:ProgramFiles}\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v2
 
       #Prepare environment, clang needs to be installed
-      #Compilation on MSVC needs c++14 or higher and expects llvm 10.0.0 or newer
+      #Compilation on MSVC needs c++14 or higher and expects llvm 11.0.0 or newer
       #Cache commonly used files: Coursier, ivy cache
       - name: Resolve env variables
         id: resolve-env
@@ -113,7 +113,7 @@ jobs:
       # Install LLVM in case if cache is missing
       - name: Install LLVM
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: choco install llvm --version=10.0.0
+        run: choco install llvm --version=11.0.0
 
       - name: Add LLVM on Path
         run: echo "${env:ProgramFiles}\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append


### PR DESCRIPTION
(Probably) after the latest update of GitHub actions, Windows environments new minimal LLVM version was changed from 10.0.0 to 11.0.0, as to indicate logs of the failed jobs
```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30037\include\yvals_core.h:537:2: error: STL1000: Unexpected compiler version, expected Clang 11.0.0 or newer.
#error STL1000: Unexpected compiler version, expected Clang 11.0.0 or newer.
```

The failing to compile files are automatically included by `Windows.h` so we don't have any other way to workaround this issue. 