### PR TITLE
Add support for @volatile annotation

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -30,6 +30,7 @@ object Attr {
   final case object Extern            extends Attr
   final case class Link(name: String) extends Attr
   final case object Abstract          extends Attr
+  final case object Volatile          extends Attr
 }
 
 final case class Attrs(inlineHint: Inline = MayInline,
@@ -39,6 +40,7 @@ final case class Attrs(inlineHint: Inline = MayInline,
                        isDyn: Boolean = false,
                        isStub: Boolean = false,
                        isAbstract: Boolean = false,
+                       isVolatile: Boolean = false,
                        links: Seq[Attr.Link] = Seq()) {
   def toSeq: Seq[Attr] = {
     val out = Seq.newBuilder[Attr]
@@ -50,6 +52,7 @@ final case class Attrs(inlineHint: Inline = MayInline,
     if (isDyn) out += Dyn
     if (isStub) out += Stub
     if (isAbstract) out += Abstract
+    if (isVolatile) out += Volatile
     out ++= links
 
     out.result()
@@ -66,6 +69,7 @@ object Attrs {
     var isDyn      = false
     var isStub     = false
     var isAbstract = false
+    var isVolatile = false
     val links      = Seq.newBuilder[Attr.Link]
 
     attrs.foreach {
@@ -77,6 +81,7 @@ object Attrs {
       case Stub             => isStub = true
       case link: Attr.Link  => links += link
       case Abstract         => isAbstract = true
+      case Volatile         => isVolatile = true
     }
 
     new Attrs(inline,
@@ -86,6 +91,7 @@ object Attrs {
               isDyn,
               isStub,
               isAbstract,
+              isVolatile,
               links.result())
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -51,11 +51,12 @@ class Buffer(implicit fresh: Fresh) {
   def call(ty: Type, ptr: Val, args: Seq[Val], unwind: Next)(
       implicit pos: Position): Val =
     let(Op.Call(ty, ptr, args), unwind)
-  def load(ty: Type, ptr: Val, unwind: Next)(implicit pos: Position): Val =
-    let(Op.Load(ty, ptr), unwind)
-  def store(ty: Type, ptr: Val, value: Val, unwind: Next)(
+  def load(ty: Type, ptr: Val, unwind: Next, isAtomic: Boolean)(
       implicit pos: Position): Val =
-    let(Op.Store(ty, ptr, value), unwind)
+    let(Op.Load(ty, ptr, isAtomic), unwind)
+  def store(ty: Type, ptr: Val, value: Val, unwind: Next, isAtomic: Boolean)(
+      implicit pos: Position): Val =
+    let(Op.Store(ty, ptr, value, isAtomic), unwind)
   def elem(ty: Type, ptr: Val, indexes: Seq[Val], unwind: Next)(
       implicit pos: Position): Val =
     let(Op.Elem(ty, ptr, indexes), unwind)

--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -11,8 +11,8 @@ sealed abstract class Op {
   final def resty: Type = this match {
     case Op.Call(Type.Function(_, ret), _, _) => ret
     case Op.Call(_, _, _)                     => unreachable
-    case Op.Load(ty, _)                       => ty
-    case Op.Store(_, _, _)                    => Type.Unit
+    case Op.Load(ty, _, _)                    => ty
+    case Op.Store(_, _, _, _)                 => Type.Unit
     case Op.Elem(_, _, _)                     => Type.Ptr
     case Op.Extract(aggr, indexes)            => aggr.ty.elemty(indexes.map(Val.Int(_)))
     case Op.Insert(aggr, _, _)                => aggr.ty
@@ -114,9 +114,10 @@ sealed abstract class Op {
 }
 object Op {
   // low-level
-  final case class Call(ty: Type, ptr: Val, args: Seq[Val])         extends Op
-  final case class Load(ty: Type, ptr: Val)                         extends Op
-  final case class Store(ty: Type, ptr: Val, value: Val)            extends Op
+  final case class Call(ty: Type, ptr: Val, args: Seq[Val])    extends Op
+  final case class Load(ty: Type, ptr: Val, isAtomic: Boolean) extends Op
+  final case class Store(ty: Type, ptr: Val, value: Val, isAtomic: Boolean)
+      extends Op
   final case class Elem(ty: Type, ptr: Val, indexes: Seq[Val])      extends Op
   final case class Extract(aggr: Val, indexes: Seq[Int])            extends Op
   final case class Insert(aggr: Val, value: Val, indexes: Seq[Int]) extends Op

--- a/nir/src/main/scala/scala/scalanative/nir/Prelude.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Prelude.scala
@@ -7,7 +7,9 @@ import java.io.DataOutputStream
 case class Prelude(magic: Int,
                    compat: Int,
                    revision: Int,
-                   hasEntryPoints: Boolean)
+                   hasEntryPoints: Boolean) {
+  final val supportsAtomicOps = compat >= 5 && revision >= 9
+}
 
 object Prelude {
   val length = 13

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -101,6 +101,8 @@ object Show {
         str("\")")
       case Attr.Abstract =>
         str("abstract")
+      case Attr.Volatile =>
+        str("volatile")
     }
 
     def next_(next: Next): Unit = next match {
@@ -197,12 +199,14 @@ object Show {
         str("(")
         rep(args, sep = ", ")(val_)
         str(")")
-      case Op.Load(ty, ptr) =>
+      case Op.Load(ty, ptr, isAtomic) =>
+        if (isAtomic) str("atomic ")
         str("load[")
         type_(ty)
         str("] ")
         val_(ptr)
-      case Op.Store(ty, ptr, value) =>
+      case Op.Store(ty, ptr, value, isAtomic) =>
+        if (isAtomic) str("atomic ")
         str("store[")
         type_(ty)
         str("] ")

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -58,10 +58,10 @@ trait Transform {
   def onOp(op: Op): Op = op match {
     case Op.Call(ty, ptrv, argvs) =>
       Op.Call(onType(ty), onVal(ptrv), argvs.map(onVal))
-    case Op.Load(ty, ptrv) =>
-      Op.Load(onType(ty), onVal(ptrv))
-    case Op.Store(ty, ptrv, v) =>
-      Op.Store(onType(ty), onVal(ptrv), onVal(v))
+    case Op.Load(ty, ptrv, isAtomic) =>
+      Op.Load(onType(ty), onVal(ptrv), isAtomic)
+    case Op.Store(ty, ptrv, v, isAtomic) =>
+      Op.Store(onType(ty), onVal(ptrv), onVal(v), isAtomic)
     case Op.Elem(ty, ptrv, indexvs) =>
       Op.Elem(onType(ty), onVal(ptrv), indexvs.map(onVal))
     case Op.Extract(aggrv, indexvs) =>

--- a/nir/src/main/scala/scala/scalanative/nir/Versions.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Versions.scala
@@ -22,7 +22,7 @@ object Versions {
    * new version of the toolchain.
    */
   final val compat: Int   = 5 // a.k.a. MAJOR version
-  final val revision: Int = 8 // a.k.a. MINOR version
+  final val revision: Int = 9 // a.k.a. MINOR version
 
   /* Current public release version of Scala Native. */
   final val current: String = "0.4.1-SNAPSHOT"

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -105,6 +105,7 @@ final class BinarySerializer {
     case Attr.Extern   => putInt(T.ExternAttr)
     case Attr.Link(s)  => putInt(T.LinkAttr); putUTF8String(s)
     case Attr.Abstract => putInt(T.AbstractAttr)
+    case Attr.Volatile => putInt(T.VolatileAttr)
   }
 
   private def putBin(bin: Bin) = bin match {
@@ -311,16 +312,18 @@ final class BinarySerializer {
       putVal(v)
       putVals(args)
 
-    case Op.Load(ty, ptr) =>
+    case Op.Load(ty, ptr, isAtomic) =>
       putInt(T.LoadOp)
       putType(ty)
       putVal(ptr)
+      putBool(isAtomic)
 
-    case Op.Store(ty, value, ptr) =>
+    case Op.Store(ty, value, ptr, isAtomic) =>
       putInt(T.StoreOp)
       putType(ty)
       putVal(value)
       putVal(ptr)
+      putBool(isAtomic)
 
     case Op.Elem(ty, v, indexes) =>
       putInt(T.ElemOp)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -28,6 +28,7 @@ object Tags {
   final val DynAttr          = 1 + LinkAttr
   final val StubAttr         = 1 + DynAttr
   final val AbstractAttr     = 1 + StubAttr
+  final val VolatileAttr     = 1 + AbstractAttr
 
   // Binary ops
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1693,7 +1693,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case LOAD_OBJECT  => Rt.Object
       }
 
-      buf.load(ty, ptr, unwind)(app.pos)
+      buf.load(ty, ptr, unwind, isAtomic = false)(app.pos)
     }
 
     def genRawPtrStoreOp(app: Apply, code: Int): Val = {
@@ -1715,7 +1715,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         case STORE_OBJECT  => Rt.Object
       }
 
-      buf.store(ty, ptr, value, unwind)(app.pos)
+      buf.store(ty, ptr, value, unwind, isAtomic = false)(app.pos)
     }
 
     def genRawPtrElemOp(app: Apply, code: Int): Val = {
@@ -2157,7 +2157,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
       val name = Val.Global(genName(sym), Type.Ptr)
 
-      fromExtern(ty, buf.load(externTy, name, unwind))
+      fromExtern(ty,
+                 buf.load(externTy, name, unwind, isAtomic = sym.isVolatile))
     }
 
     def genStoreExtern(externTy: nir.Type, sym: Symbol, value: Val)(
@@ -2166,7 +2167,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val name        = Val.Global(genName(sym), Type.Ptr)
       val externValue = toExtern(externTy, value)
 
-      buf.store(externTy, name, externValue, unwind)
+      buf.store(externTy, name, externValue, unwind, isAtomic = sym.isVolatile)
     }
 
     def toExtern(expectedTy: nir.Type, value: Val)(

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -171,8 +171,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val ty                = genType(f.tpe)
         val name              = genFieldName(f)
         val pos: nir.Position = f.pos
+        val fieldAttrs        = attrs.copy(isVolatile = f.isVolatile)
 
-        buf += Defn.Var(attrs, name, ty, Val.Zero(ty))(pos)
+        buf += Defn.Var(fieldAttrs, name, ty, Val.Zero(ty))(pos)
       }
     }
 

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenType.scala
@@ -38,6 +38,8 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
           CFuncPtrNClass.contains(parent.typeSymbol)
         }
       }
+
+    def isVolatile: Boolean = isField && sym.hasAnnotation(VolatileAttr)
   }
 
   object SimpleType {

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -143,9 +143,9 @@ final class Check(implicit linked: linker.Result) {
         case _ =>
           error("call type must be a function type")
       }
-    case Op.Load(ty, ptr) =>
+    case Op.Load(ty, ptr, _) =>
       expect(Type.Ptr, ptr)
-    case Op.Store(ty, ptr, value) =>
+    case Op.Store(ty, ptr, value, _) =>
       expect(Type.Ptr, ptr)
       expect(ty, value)
     case Op.Elem(ty, ptr, indexes) =>

--- a/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/AbstractCodeGen.scala
@@ -626,7 +626,7 @@ private[codegen] abstract class AbstractCodeGen(
         }
         genCall(genBind, callDef, unwind)
 
-      // Special case of load needing additional converstion, since atomic operations do not support i1
+      // Special case of load needing additional conversion, since atomic operations do not support i1
       case Op.Load(Type.Bool, ptr, true) =>
         val pointee = fresh()
         val loaded  = fresh()
@@ -694,7 +694,7 @@ private[codegen] abstract class AbstractCodeGen(
           }
         }
 
-      // Special case of store needing additional converstion, since atomic operations do not support i1
+      // Special case of store needing additional conversion, since atomic operations do not support i1
       case Op.Store(Type.Bool, ptr, value, true) =>
         val pointee  = fresh()
         val extended = fresh()

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -78,7 +78,9 @@ object Generate {
                            meta.hasTraitTables.classHasTraitVal,
                            Seq(Val.Int(0), classid, traitid)),
                    Next.None),
-          Inst.Let(result.name, Op.Load(Type.Bool, boolptr), Next.None),
+          Inst.Let(result.name,
+                   Op.Load(Type.Bool, boolptr, isAtomic = false),
+                   Next.None),
           Inst.Ret(result)
         )
       )
@@ -109,7 +111,9 @@ object Generate {
                            meta.hasTraitTables.traitHasTraitVal,
                            Seq(Val.Int(0), leftid, rightid)),
                    Next.None),
-          Inst.Let(result.name, Op.Load(Type.Bool, boolptr), Next.None),
+          Inst.Let(result.name,
+                   Op.Load(Type.Bool, boolptr, isAtomic = false),
+                   Next.None),
           Inst.Ret(result)
         )
       )
@@ -149,7 +153,8 @@ object Generate {
                    unwind),
           Inst.Let(Op.Store(Type.Ptr,
                             Val.Global(stackBottomName, Type.Ptr),
-                            stackBottom),
+                            stackBottom,
+                            isAtomic = false),
                    unwind),
           Inst.Let(Op.Call(InitSig, Init, Seq()), unwind)
         ) ++ // generate the class initialisers
@@ -232,7 +237,9 @@ object Generate {
                                  Val.Global(moduleArrayName, Type.Ptr),
                                  Seq(Val.Int(meta.moduleArray.index(cls)))),
                          Next.None),
-                Inst.Let(self.name, Op.Load(clsTy, slot), Next.None),
+                Inst.Let(self.name,
+                         Op.Load(clsTy, slot, isAtomic = false),
+                         Next.None),
                 Inst.Let(cond.name,
                          Op.Comp(Comp.Ine, nir.Rt.Object, self, Val.Null),
                          Next.None),
@@ -241,7 +248,8 @@ object Generate {
                 Inst.Ret(self),
                 Inst.Label(initialize, Seq()),
                 Inst.Let(alloc.name, Op.Classalloc(name), Next.None),
-                Inst.Let(Op.Store(clsTy, slot, alloc), Next.None),
+                Inst.Let(Op.Store(clsTy, slot, alloc, isAtomic = false),
+                         Next.None),
                 Inst.Let(Op.Call(initSig, init, Seq(alloc)), Next.None),
                 Inst.Ret(alloc)
               )

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -239,7 +239,8 @@ object Lower {
             val toty = Val.Local(fresh(), Type.Ptr)
 
             buf.label(slowPath, Seq(obj, toty))
-            val fromty = buf.let(Op.Load(Type.Ptr, obj), unwind)
+            val fromty =
+              buf.let(Op.Load(Type.Ptr, obj, isAtomic = false), unwind)
             buf.call(throwClassCastTy,
                      throwClassCastVal,
                      Seq(Val.Null, fromty, toty),
@@ -360,9 +361,14 @@ object Lower {
         case op: Op.Var =>
           ()
         case Op.Varload(Val.Local(slot, Type.Var(ty))) =>
-          buf.let(n, Op.Load(ty, Val.Local(slot, Type.Ptr)), unwind)
+          buf.let(n,
+                  Op.Load(ty, Val.Local(slot, Type.Ptr), isAtomic = false),
+                  unwind)
         case Op.Varstore(Val.Local(slot, Type.Var(ty)), value) =>
-          buf.let(n, Op.Store(ty, Val.Local(slot, Type.Ptr), value), unwind)
+          buf.let(
+            n,
+            Op.Store(ty, Val.Local(slot, Type.Ptr), value, isAtomic = false),
+            unwind)
         case op: Op.Arrayalloc =>
           genArrayallocOp(buf, n, op)
         case op: Op.Arrayload =>
@@ -426,23 +432,31 @@ object Lower {
     def genFieldloadOp(buf: Buffer, n: Local, op: Op.Fieldload)(
         implicit pos: Position) = {
       val Op.Fieldload(ty, obj, name) = op
+      val FieldRef(_, field)          = name
+      val isAtomic                    = field.attrs.isVolatile
 
       val elem = genFieldElemOp(buf, genVal(buf, obj), name)
-      buf.let(n, Op.Load(ty, elem), unwind)
+      buf.let(n, Op.Load(ty, elem, isAtomic = isAtomic), unwind)
     }
 
     def genFieldstoreOp(buf: Buffer, n: Local, op: Op.Fieldstore)(
         implicit pos: Position) = {
       val Op.Fieldstore(ty, obj, name, value) = op
+      val FieldRef(_, field)                  = name
+      val isAtomic                            = field.attrs.isVolatile
 
       val elem = genFieldElemOp(buf, genVal(buf, obj), name)
-      genStoreOp(buf, n, Op.Store(ty, elem, value))
+      genStoreOp(buf, n, Op.Store(ty, elem, value, isAtomic = isAtomic))
     }
 
     def genStoreOp(buf: Buffer, n: Local, op: Op.Store)(
         implicit pos: Position) = {
-      val Op.Store(ty, ptr, value) = op
-      buf.let(n, Op.Store(ty, genVal(buf, ptr), genVal(buf, value)), unwind)
+      val Op.Store(ty, ptr, value, isAtomic) = op
+
+      buf.let(
+        n,
+        Op.Store(ty, genVal(buf, ptr), genVal(buf, value), isAtomic = isAtomic),
+        unwind)
     }
 
     def genCompOp(buf: Buffer, n: Local, op: Op.Comp)(
@@ -475,21 +489,21 @@ object Lower {
         assert(vindex != -1,
                s"The virtual table of ${cls.name} does not contain $sig")
 
-        val typeptr = let(Op.Load(Type.Ptr, obj), unwind)
+        val typeptr = let(Op.Load(Type.Ptr, obj, isAtomic = false), unwind)
         val methptrptr = let(Op.Elem(rtti(cls).struct,
                                      typeptr,
                                      meta.RttiVtableIndex :+ Val.Int(vindex)),
                              unwind)
 
-        let(n, Op.Load(Type.Ptr, methptrptr), unwind)
+        let(n, Op.Load(Type.Ptr, methptrptr, isAtomic = false), unwind)
       }
 
       def genTraitVirtualLookup(trt: Trait): Unit = {
         val sigid   = dispatchTable.traitSigIds(sig)
-        val typeptr = let(Op.Load(Type.Ptr, obj), unwind)
+        val typeptr = let(Op.Load(Type.Ptr, obj, isAtomic = false), unwind)
         val idptr =
           let(Op.Elem(meta.Rtti, typeptr, meta.RttiTraitIdIndex), unwind)
-        val id = let(Op.Load(Type.Int, idptr), unwind)
+        val id = let(Op.Load(Type.Int, idptr, isAtomic = false), unwind)
         val rowptr = let(
           Op.Elem(Type.Ptr,
                   dispatchTable.dispatchVal,
@@ -497,7 +511,7 @@ object Lower {
           unwind)
         val methptrptr =
           let(Op.Elem(Type.Ptr, rowptr, Seq(id)), unwind)
-        let(n, Op.Load(Type.Ptr, methptrptr), unwind)
+        let(n, Op.Load(Type.Ptr, methptrptr, isAtomic = false), unwind)
       }
 
       def genMethodLookup(scope: ScopeInfo): Unit = {
@@ -578,10 +592,10 @@ object Lower {
           meta.linked.dynsigs.zipWithIndex.find(_._1 == sig).get._2
 
         // Load the type information pointer
-        val typeptr = load(Type.Ptr, obj, unwind)
+        val typeptr = load(Type.Ptr, obj, unwind, isAtomic = false)
         // Load the dynamic hash map for given type, make sure it's not null
         val mapelem = elem(classRttiType, typeptr, meta.RttiDynmapIndex, unwind)
-        val mapptr  = load(Type.Ptr, mapelem, unwind)
+        val mapptr  = load(Type.Ptr, mapelem, unwind, isAtomic = false)
         // If hash map is not null, it has to contain at least one entry
         throwIfNull(mapptr)
         // Perform dynamic dispatch via dyndispatch helper
@@ -591,7 +605,7 @@ object Lower {
                               unwind)
         // Hash map lookup can still not contain given signature
         throwIfNull(methptrptr)
-        let(n, Op.Load(Type.Ptr, methptrptr), unwind)
+        let(n, Op.Load(Type.Ptr, methptrptr, isAtomic = false), unwind)
       }
 
       genGuardNotNull(buf, obj)
@@ -634,15 +648,15 @@ object Lower {
 
       ty match {
         case ClassRef(cls) if meta.ranges(cls).length == 1 =>
-          val typeptr = let(Op.Load(Type.Ptr, obj), unwind)
+          val typeptr = let(Op.Load(Type.Ptr, obj, isAtomic = false), unwind)
           let(Op.Comp(Comp.Ieq, Type.Ptr, typeptr, rtti(cls).const), unwind)
 
         case ClassRef(cls) =>
           val range   = meta.ranges(cls)
-          val typeptr = let(Op.Load(Type.Ptr, obj), unwind)
+          val typeptr = let(Op.Load(Type.Ptr, obj, isAtomic = false), unwind)
           val idptr =
             let(Op.Elem(meta.Rtti, typeptr, meta.RttiClassIdIndex), unwind)
-          val id = let(Op.Load(Type.Int, idptr), unwind)
+          val id = let(Op.Load(Type.Int, idptr, isAtomic = false), unwind)
           val ge =
             let(Op.Comp(Comp.Sle, Type.Int, Val.Int(range.start), id), unwind)
           val le =
@@ -650,16 +664,16 @@ object Lower {
           let(Op.Bin(Bin.And, Type.Bool, ge, le), unwind)
 
         case TraitRef(trt) =>
-          val typeptr = let(Op.Load(Type.Ptr, obj), unwind)
+          val typeptr = let(Op.Load(Type.Ptr, obj, isAtomic = false), unwind)
           val idptr =
             let(Op.Elem(meta.Rtti, typeptr, meta.RttiClassIdIndex), unwind)
-          val id = let(Op.Load(Type.Int, idptr), unwind)
+          val id = let(Op.Load(Type.Int, idptr, isAtomic = false), unwind)
           val boolptr = let(
             Op.Elem(hasTraitTables.classHasTraitTy,
                     hasTraitTables.classHasTraitVal,
                     Seq(Val.Int(0), id, Val.Int(meta.ids(trt)))),
             unwind)
-          let(Op.Load(Type.Bool, boolptr), unwind)
+          let(Op.Load(Type.Bool, boolptr, isAtomic = false), unwind)
 
         case _ =>
           util.unsupported(s"is[$ty] $obj")
@@ -1005,7 +1019,7 @@ object Lower {
         Seq(Type.Ptr, Type.Int, Type.Int, Type.ArrayValue(ty, 0)))
       val elemPath = Seq(Val.Int(0), Val.Int(3), idx)
       val elemPtr  = buf.elem(arrTy, arr, elemPath, unwind)
-      buf.let(n, Op.Load(ty, elemPtr), unwind)
+      buf.let(n, Op.Load(ty, elemPtr, isAtomic = false), unwind)
     }
 
     def genArraystoreOp(buf: Buffer, n: Local, op: Op.Arraystore)(
@@ -1021,7 +1035,7 @@ object Lower {
         Seq(Type.Ptr, Type.Int, Type.Int, Type.ArrayValue(ty, 0)))
       val elemPtr =
         buf.elem(arrTy, arr, Seq(Val.Int(0), Val.Int(3), idx), unwind)
-      genStoreOp(buf, n, Op.Store(ty, elemPtr, value))
+      genStoreOp(buf, n, Op.Store(ty, elemPtr, value, isAtomic = false))
     }
 
     def genArraylengthOp(buf: Buffer, n: Local, op: Op.Arraylength)(
@@ -1035,7 +1049,7 @@ object Lower {
       genGuardNotNull(buf, arr)
       val arrTy  = Type.StructValue(Seq(Type.Ptr, Type.Int))
       val lenPtr = buf.elem(arrTy, arr, Seq(Val.Int(0), Val.Int(1)), unwind)
-      buf.let(n, Op.Load(Type.Int, lenPtr), unwind)
+      buf.let(n, Op.Load(Type.Int, lenPtr, isAtomic = false), unwind)
     }
 
     def genStringVal(value: String): Val = {

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -157,10 +157,16 @@ trait Eval { self: Interflow =>
           case _ =>
             nonIntrinsic
         }
-      case Op.Load(ty, ptr) =>
-        emit(Op.Load(ty, materialize(eval(ptr))))
-      case Op.Store(ty, ptr, value) =>
-        emit(Op.Store(ty, materialize(eval(ptr)), materialize(eval(value))))
+      case op @ Op.Load(ty, ptr, isAtomic) =>
+        emit(
+          op.copy(ptr = materialize(eval(ptr)))
+        )
+      case op @ Op.Store(ty, ptr, value, isAtomic) =>
+        emit(
+          op.copy(
+            ptr = materialize(eval(ptr)),
+            value = materialize(eval(value))
+          ))
       case Op.Elem(ty, ptr, indexes) =>
         delay(Op.Elem(ty, eval(ptr), indexes.map(eval)))
       case Op.Extract(aggr, indexes) =>

--- a/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
@@ -49,9 +49,9 @@ trait NoOpt { self: Interflow =>
     case Op.Call(_, ptrv, argvs) =>
       noOptVal(ptrv)
       argvs.foreach(noOptVal)
-    case Op.Load(_, ptrv) =>
+    case Op.Load(_, ptrv, _) =>
       noOptVal(ptrv)
-    case Op.Store(_, ptrv, v) =>
+    case Op.Store(_, ptrv, v, _) =>
       noOptVal(ptrv)
       noOptVal(v)
     case Op.Elem(_, ptrv, indexvs) =>

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -172,16 +172,16 @@ final class State(block: Local) {
     }
 
     def reachOp(op: Op): Unit = op match {
-      case Op.Call(_, v, vs)     => reachVal(v); vs.foreach(reachVal)
-      case Op.Load(_, v)         => reachVal(v)
-      case Op.Store(_, v1, v2)   => reachVal(v1); reachVal(v2)
-      case Op.Elem(_, v, vs)     => reachVal(v); vs.foreach(reachVal)
-      case Op.Extract(v, _)      => reachVal(v)
-      case Op.Insert(v1, v2, _)  => reachVal(v1); reachVal(v2)
-      case Op.Stackalloc(_, v)   => reachVal(v)
-      case Op.Bin(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
-      case Op.Comp(_, _, v1, v2) => reachVal(v1); reachVal(v2)
-      case Op.Conv(_, _, v)      => reachVal(v)
+      case Op.Call(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case Op.Load(_, v, _)       => reachVal(v)
+      case Op.Store(_, v1, v2, _) => reachVal(v1); reachVal(v2)
+      case Op.Elem(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case Op.Extract(v, _)       => reachVal(v)
+      case Op.Insert(v1, v2, _)   => reachVal(v1); reachVal(v2)
+      case Op.Stackalloc(_, v)    => reachVal(v)
+      case Op.Bin(_, _, v1, v2)   => reachVal(v1); reachVal(v2)
+      case Op.Comp(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
+      case Op.Conv(_, _, v)       => reachVal(v)
 
       case _: Op.Classalloc            => ()
       case Op.Fieldload(_, v, _)       => reachVal(v)
@@ -326,16 +326,16 @@ final class State(block: Local) {
     }
 
     def reachOp(op: Op): Unit = op match {
-      case Op.Call(_, v, vs)     => reachVal(v); vs.foreach(reachVal)
-      case Op.Load(_, v)         => reachVal(v)
-      case Op.Store(_, v1, v2)   => reachVal(v1); reachVal(v2)
-      case Op.Elem(_, v, vs)     => reachVal(v); vs.foreach(reachVal)
-      case Op.Extract(v, _)      => reachVal(v)
-      case Op.Insert(v1, v2, _)  => reachVal(v1); reachVal(v2)
-      case Op.Stackalloc(_, v)   => reachVal(v)
-      case Op.Bin(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
-      case Op.Comp(_, _, v1, v2) => reachVal(v1); reachVal(v2)
-      case Op.Conv(_, _, v)      => reachVal(v)
+      case Op.Call(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case Op.Load(_, v, _)       => reachVal(v)
+      case Op.Store(_, v1, v2, _) => reachVal(v1); reachVal(v2)
+      case Op.Elem(_, v, vs)      => reachVal(v); vs.foreach(reachVal)
+      case Op.Extract(v, _)       => reachVal(v)
+      case Op.Insert(v1, v2, _)   => reachVal(v1); reachVal(v2)
+      case Op.Stackalloc(_, v)    => reachVal(v)
+      case Op.Bin(_, _, v1, v2)   => reachVal(v1); reachVal(v2)
+      case Op.Comp(_, _, v1, v2)  => reachVal(v1); reachVal(v2)
+      case Op.Conv(_, _, v)       => reachVal(v)
 
       case _: Op.Classalloc            => ()
       case Op.Fieldload(_, v, _)       => reachVal(v)
@@ -369,10 +369,10 @@ final class State(block: Local) {
     def escapedOp(op: Op): Op = op match {
       case Op.Call(ty, v, vs) =>
         Op.Call(ty, escapedVal(v), vs.map(escapedVal))
-      case Op.Load(ty, v) =>
-        Op.Load(ty, escapedVal(v))
-      case Op.Store(ty, v1, v2) =>
-        Op.Store(ty, escapedVal(v1), escapedVal(v2))
+      case op @ Op.Load(_, v, _) =>
+        op.copy(ptr = escapedVal(v))
+      case op @ Op.Store(_, v1, v2, _) =>
+        op.copy(ptr = escapedVal(v1), value = escapedVal(v2))
       case Op.Elem(ty, v, vs) =>
         Op.Elem(ty, escapedVal(v), vs.map(escapedVal))
       case Op.Extract(v, idxs) =>

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -611,10 +611,10 @@ class Reach(protected val config: build.Config,
       reachType(ty)
       reachVal(ptrv)
       argvs.foreach(reachVal)
-    case Op.Load(ty, ptrv) =>
+    case Op.Load(ty, ptrv, _) =>
       reachType(ty)
       reachVal(ptrv)
-    case Op.Store(ty, ptrv, v) =>
+    case Op.Store(ty, ptrv, v, _) =>
       reachType(ty)
       reachVal(ptrv)
       reachVal(v)

--- a/unit-tests/src/test/scala/scala/VolatileAnnotationTest.scala
+++ b/unit-tests/src/test/scala/scala/VolatileAnnotationTest.scala
@@ -1,0 +1,67 @@
+package scala
+
+import org.junit.Test
+import org.junit.Assert._
+
+class VolatileAnnotationTest {
+  private val initialBool        = true
+  private val initialByte        = 42.toByte
+  private val initialShort       = 43.toShort
+  private val initialInt         = 44
+  private val initialLong        = 45L
+  private val initialFloat       = 1.0f
+  private val initialDouble      = 2.0f
+  private val initialRef: Object = new Object()
+
+  @volatile private var bool        = initialBool
+  @volatile private var byte        = initialByte
+  @volatile private var short       = initialShort
+  @volatile private var int         = initialInt
+  @volatile private var long        = initialLong
+  @volatile private var float       = initialFloat
+  @volatile private var double      = initialDouble
+  @volatile private var ref: Object = initialRef
+
+  @Test def canLoadVolatileFields(): Unit = {
+    assertEquals(initialBool, bool)
+    assertEquals(initialByte, byte)
+    assertEquals(initialShort, short)
+    assertEquals(initialInt, int)
+    assertEquals(initialLong, long)
+    assertEquals(initialFloat, float, 0.0001)
+    assertEquals(initialDouble, double, 0.0001)
+    assertEquals(initialRef, ref)
+  }
+
+  @Test def canMutateVolatileFields(): Unit = {
+    val newBool        = false
+    val newByte        = (initialByte * 2).toByte
+    val newShort       = (initialShort * 2).toShort
+    val newInt         = initialInt * 2
+    val newLong        = initialLong * 2
+    val newFloat       = initialFloat * 2
+    val newDouble      = initialDouble * 2
+    val newRef: Object = new Object()
+
+    bool = newBool
+    byte = newByte
+    short = newShort
+    int = newInt
+    long = newLong
+    float = newFloat
+    double = newDouble
+    ref = newRef
+
+    assertEquals(newBool, bool)
+    assertEquals(newByte, byte)
+    assertEquals(newShort, short)
+    assertEquals(newInt, int)
+    assertEquals(newLong, long)
+    assertEquals(newFloat, float, 0.0001)
+    assertEquals(newDouble, double, 0.0001)
+    assertEquals(newRef, ref)
+  }
+
+  // Todo: Add async test checking for mutual mutation of volatile fields when multithreading would be supported
+
+}


### PR DESCRIPTION
Blocked by #2327 

This PR adds proper support for `@volatile` annotation to match behaviour known from the JVM. For each store/load operation on fields containing this annotation, there would be generated `<op> atomic volatile` using sequential consistent memory order (in the manner as it's done on the JVM). 

Since `Boolean` is represented as `i1` it needed additional handling to allow for atomic operations - atomic operation would be executed on `i8` type, while actual value would be truncated to zero-extended to match type expected by the LLVM. 

This feature also creates changes in the NIR format by introducing a new `Defn` attribute (`Attr.Volatile`) and changing the `Op.Load`/`Op.Store` object by adding the `isAtomic` boolean field. Due to this change, the NIR version was bumped from 5.8 to 5.9. 