### PR TITLE
Update junit-runtime to match JUnit 4.13.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -799,14 +799,17 @@ lazy val testRunner =
     .settings(mavenPublishSettings)
     .settings(testInterfaceCommonSourcesSettings)
     .settings(
-      libraryDependencies ++= Seq(
-        "org.scala-sbt" % "test-interface"  % "1.0",
-        "com.novocode"  % "junit-interface" % "0.11" % "test"
-      )
+      libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0",
+      libraryDependencies ++= jUnitJVMDependencies
     )
     .dependsOn(tools, junitAsyncJVM % "test")
 
 // JUnit modules and settings ------------------------------------------------
+
+lazy val jUnitJVMDependencies = Seq(
+  "com.novocode" % "junit-interface" % "0.11"   % "test",
+  "junit"        % "junit"           % "4.13.2" % "test"
+)
 
 lazy val junitRuntime =
   project
@@ -867,9 +870,7 @@ lazy val junitTestOutputsJVM =
     .in(file("junit-test/output-jvm"))
     .settings(
       commonJUnitTestOutputsSettings,
-      libraryDependencies ++= Seq(
-        "com.novocode" % "junit-interface" % "0.11" % "test"
-      )
+      libraryDependencies ++= jUnitJVMDependencies
     )
     .dependsOn(junitAsyncJVM % "test")
 

--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -397,13 +397,13 @@ object Assert {
 
   @noinline
   def assertThrows[T <: Throwable](expectedThrowable: Class[T],
-      runnable: ThrowingRunnable): T = {
+                                   runnable: ThrowingRunnable): T = {
     assertThrows(null, expectedThrowable, runnable)
   }
 
   @noinline
-  def assertThrows[T <: Throwable](message: String, 
-                                   expectedThrowable: Class[T], 
+  def assertThrows[T <: Throwable](message: String,
+                                   expectedThrowable: Class[T],
                                    runnable: ThrowingRunnable): T = {
 
     def buildPrefix: String =
@@ -412,23 +412,24 @@ object Assert {
     try {
       runnable.run()
     } catch {
-      case actualThrown: Throwable if (expectedThrowable.isInstance(actualThrown)) =>
-          return actualThrown.asInstanceOf[T]
+      case actualThrown: Throwable
+          if (expectedThrowable.isInstance(actualThrown)) =>
+        return actualThrown.asInstanceOf[T]
 
       case actualThrown: Throwable =>
-          val expected: String = formatClass(expectedThrowable);
-          val actual: String = formatClass(actualThrown.getClass());
+        val expected: String = formatClass(expectedThrowable);
+        val actual: String   = formatClass(actualThrown.getClass());
 
-          val mismatchMessage = buildPrefix + 
-            format("unexpected exception type thrown;", expected, actual)
+        val mismatchMessage = buildPrefix +
+          format("unexpected exception type thrown;", expected, actual)
 
-          val assertionError = new AssertionError(mismatchMessage)
-          assertionError.initCause(actualThrown)
-          throw assertionError
+        val assertionError = new AssertionError(mismatchMessage)
+        assertionError.initCause(actualThrown)
+        throw assertionError
     }
-    val notThrownMessage = buildPrefix + 
-        s"expected ${formatClass(expectedThrowable)} to be thrown," +
-        " but nothing was thrown"
+    val notThrownMessage = buildPrefix +
+      s"expected ${formatClass(expectedThrowable)} to be thrown," +
+      " but nothing was thrown"
     throw new AssertionError(notThrownMessage)
   }
 }

--- a/junit-runtime/src/main/scala/org/junit/TestCouldNotBeSkippedException.scala
+++ b/junit-runtime/src/main/scala/org/junit/TestCouldNotBeSkippedException.scala
@@ -1,0 +1,10 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+
+package org.junit
+
+class TestCouldNotBeSkippedException(
+    val cause: org.junit.internal.AssumptionViolatedException)
+    extends RuntimeException("Test could not be skipped due to other failures",
+                             cause)

--- a/junit-runtime/src/main/scala/org/junit/function/ThrowingRunnable.scala
+++ b/junit-runtime/src/main/scala/org/junit/function/ThrowingRunnable.scala
@@ -4,5 +4,5 @@
 package org.junit.function
 
 trait ThrowingRunnable {
-    def run(): Unit
+  def run(): Unit
 }

--- a/junit-runtime/src/main/scala/org/junit/function/ThrowingRunnable.scala
+++ b/junit-runtime/src/main/scala/org/junit/function/ThrowingRunnable.scala
@@ -1,0 +1,8 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit.function
+
+trait ThrowingRunnable {
+    def run(): Unit
+}

--- a/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
+++ b/junit-runtime/src/main/scala/scala/scalanative/junit/Reporter.scala
@@ -63,15 +63,15 @@ private[junit] final class Reporter(eventHandler: EventHandler,
     }
   }
 
-  def reportAssumptionViolation(method: String,
+  def reportAssumptionViolation(method: Option[String],
                                 timeInSeconds: Double,
                                 e: Throwable): Unit = {
     logTestException(_.warn,
                      "Test assumption in test ",
-                     Some(method),
+                     method,
                      e,
                      timeInSeconds)
-    emitEvent(Some(method), Status.Skipped)
+    emitEvent(method, Status.Skipped)
   }
 
   private def logTestInfo(level: Reporter.Level,
@@ -89,18 +89,9 @@ private[junit] final class Reporter(eventHandler: EventHandler,
       (settings.logAssert || !ex.isInstanceOf[AssertionError])
     }
 
-    val fmtName = if (logException) {
-      val name = {
-        if (ex.isInstanceOf[AssumptionViolatedException])
-          classOf[internal.AssumptionViolatedException].getName
-        else
-          ex.getClass.getName
-      }
-
-      formatClass(name, Ansi.RED) + ": "
-    } else {
-      ""
-    }
+    val fmtName =
+      if (logException) formatClass(ex.getClass.getName, Ansi.RED) + ": "
+      else ""
 
     val m = formatTest(method, Ansi.RED)
     val msg =

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_.txt
@@ -1,0 +1,7 @@
+ld[34mTest run started[0m
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_a.txt
@@ -1,0 +1,8 @@
+ld[34mTest run started[0m
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_n.txt
@@ -1,0 +1,7 @@
+ldTest run started
+ldTest scala.scalanative.junit.AssertThrows2Test.test started
+leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
+ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_na.txt
@@ -1,0 +1,8 @@
+ldTest run started
+ldTest scala.scalanative.junit.AssertThrows2Test.test started
+leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
+ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nv.txt
@@ -1,0 +1,7 @@
+liTest run started
+liTest scala.scalanative.junit.AssertThrows2Test.test started
+leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
+liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nva.txt
@@ -1,0 +1,8 @@
+liTest run started
+liTest scala.scalanative.junit.AssertThrows2Test.test started
+leTest scala.scalanative.junit.AssertThrows2Test.test failed: java.lang.AssertionError: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
+liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvc.txt
@@ -1,0 +1,7 @@
+liTest run started
+liTest scala.scalanative.junit.AssertThrows2Test.test started
+leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
+liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_nvca.txt
@@ -1,0 +1,8 @@
+liTest run started
+liTest scala.scalanative.junit.AssertThrows2Test.test started
+leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
+liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_v.txt
@@ -1,0 +1,7 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_va.txt
@@ -1,0 +1,8 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+leCaused by: java.lang.IllegalAccessException: Exception message
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vc.txt
@@ -1,0 +1,7 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vs.txt
@@ -1,0 +1,7 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[31mtest[0m failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.[33mAssertThrows2Test[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrows2TestAssertions_vsn.txt
@@ -1,0 +1,7 @@
+liTest run started
+liTest scala.scalanative.junit.AssertThrows2Test.test started
+leTest scala.scalanative.junit.AssertThrows2Test.test failed: This is the message: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalAccessException>, took <TIME>
+e2scala.scalanative.junit.AssertThrows2Test.test
+ldTest scala.scalanative.junit.AssertThrows2Test.test finished, took <TIME>
+liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_.txt
@@ -1,0 +1,7 @@
+ld[34mTest run started[0m
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_a.txt
@@ -1,0 +1,8 @@
+ld[34mTest run started[0m
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
+ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_n.txt
@@ -1,0 +1,7 @@
+ldTest run started
+ldTest scala.scalanative.junit.AssertThrowsTest.test started
+leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
+ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_na.txt
@@ -1,0 +1,8 @@
+ldTest run started
+ldTest scala.scalanative.junit.AssertThrowsTest.test started
+leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
+ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nv.txt
@@ -1,0 +1,7 @@
+liTest run started
+liTest scala.scalanative.junit.AssertThrowsTest.test started
+leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
+liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nva.txt
@@ -1,0 +1,8 @@
+liTest run started
+liTest scala.scalanative.junit.AssertThrowsTest.test started
+leTest scala.scalanative.junit.AssertThrowsTest.test failed: java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
+liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvc.txt
@@ -1,0 +1,7 @@
+liTest run started
+liTest scala.scalanative.junit.AssertThrowsTest.test started
+leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
+liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_nvca.txt
@@ -1,0 +1,8 @@
+liTest run started
+liTest scala.scalanative.junit.AssertThrowsTest.test started
+leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
+liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_v.txt
@@ -1,0 +1,7 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_va.txt
@@ -1,0 +1,8 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+leCaused by: java.lang.IllegalArgumentException: Exception message
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vc.txt
@@ -1,0 +1,7 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vs.txt
@@ -1,0 +1,7 @@
+li[34mTest run started[0m
+liTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m started
+leTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[31mtest[0m failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.[33mAssertThrowsTest[0m.[36mtest[0m finished, took <TIME>
+li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssertThrowsTestAssertions_vsn.txt
@@ -1,0 +1,7 @@
+liTest run started
+liTest scala.scalanative.junit.AssertThrowsTest.test started
+leTest scala.scalanative.junit.AssertThrowsTest.test failed: unexpected exception type thrown; expected:<java.lang.UnsupportedOperationException> but was:<java.lang.IllegalArgumentException>, took <TIME>
+e2scala.scalanative.junit.AssertThrowsTest.test
+ldTest scala.scalanative.junit.AssertThrowsTest.test finished, took <TIME>
+liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
+d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_.txt
@@ -1,8 +1,10 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_a.txt
@@ -1,8 +1,10 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_n.txt
@@ -1,8 +1,10 @@
 ldTest run started
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_na.txt
@@ -1,8 +1,10 @@
 ldTest run started
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nv.txt
@@ -1,8 +1,10 @@
 liTest run started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nva.txt
@@ -1,8 +1,10 @@
 liTest run started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvc.txt
@@ -1,8 +1,10 @@
 liTest run started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_nvca.txt
@@ -1,8 +1,10 @@
 liTest run started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_v.txt
@@ -1,8 +1,10 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_va.txt
@@ -1,8 +1,10 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vc.txt
@@ -1,8 +1,10 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vs.txt
@@ -1,8 +1,10 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterAssumeAssertions_vsn.txt
@@ -1,8 +1,10 @@
 liTest run started
 liTest scala.scalanative.junit.AssumeAfterAssume.assumeFail started
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.AssumeAfterAssume.assumeFail
-leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_.txt
@@ -2,7 +2,7 @@ ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_a.txt
@@ -2,7 +2,7 @@ ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_n.txt
@@ -2,7 +2,7 @@ ldTest run started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.AssumeAfterClassTest ignored
+lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-ldTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_na.txt
@@ -2,7 +2,7 @@ ldTest run started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.AssumeAfterClassTest ignored
+lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-ldTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nv.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.AssumeAfterClassTest ignored
+lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nva.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.AssumeAfterClassTest ignored
+lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvc.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.AssumeAfterClassTest ignored
+lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_nvca.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.AssumeAfterClassTest ignored
+lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_v.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_va.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vc.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vs.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterClassTestAssertions_vsn.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest scala.scalanative.junit.AssumeAfterClassTest.test started
 ldTest scala.scalanative.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0scala.scalanative.junit.AssumeAfterClassTest.test
-liTest scala.scalanative.junit.AssumeAfterClassTest ignored
+lwTest assumption in test scala.scalanative.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_.txt
@@ -2,7 +2,8 @@ ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_a.txt
@@ -2,7 +2,8 @@ ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_n.txt
@@ -2,7 +2,8 @@ ldTest run started
 ldTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_na.txt
@@ -2,7 +2,8 @@ ldTest run started
 ldTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nv.txt
@@ -2,7 +2,8 @@ liTest run started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nva.txt
@@ -2,7 +2,8 @@ liTest run started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvc.txt
@@ -2,7 +2,8 @@ liTest run started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.AssumeAfterException.test failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterException.test failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_nvca.txt
@@ -2,7 +2,8 @@ liTest run started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.AssumeAfterException.test failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterException.test failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_v.txt
@@ -2,7 +2,8 @@ li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_va.txt
@@ -2,7 +2,8 @@ li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vc.txt
@@ -2,7 +2,8 @@ li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vs.txt
@@ -2,7 +2,8 @@ li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeAfterExceptionAssertions_vsn.txt
@@ -2,7 +2,8 @@ liTest run started
 liTest scala.scalanative.junit.AssumeAfterException.test started
 leTest scala.scalanative.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2scala.scalanative.junit.AssumeAfterException.test
-leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest scala.scalanative.junit.AssumeAfterException.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
-lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
-lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest scala.scalanative.junit.AssumeInAfter.test started
-lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest scala.scalanative.junit.AssumeInAfter.test started
-lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.AssumeInAfter.test started
-lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.AssumeInAfter.test started
-lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
-lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
-lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m started
-lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeInAfterAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.AssumeInAfter.test started
-lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeInAfter.test
 ldTest scala.scalanative.junit.AssumeInAfter.test finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
-lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
-lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest scala.scalanative.junit.AssumeTest.assumeFail started
-lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest scala.scalanative.junit.AssumeTest.assumeFail started
-lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
-lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
-lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
-lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
-lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m started
-lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/AssumeTestAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.AssumeTest.assumeFail started
-lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.AssumeTest.assumeFail
 ldTest scala.scalanative.junit.AssumeTest.assumeFail finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
-liTest scala.scalanative.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
-liTest scala.scalanative.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run started
-liTest scala.scalanative.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run started
-liTest scala.scalanative.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest scala.scalanative.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest scala.scalanative.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest scala.scalanative.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest scala.scalanative.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest scala.scalanative.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest scala.scalanative.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest scala.scalanative.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest scala.scalanative.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/BeforeAssumeFailTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest scala.scalanative.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_.txt
@@ -1,6 +1,7 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_a.txt
@@ -1,6 +1,7 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_n.txt
@@ -1,6 +1,7 @@
 ldTest run started
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
-leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_na.txt
@@ -1,6 +1,7 @@
 ldTest run started
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
-leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nv.txt
@@ -1,6 +1,7 @@
 liTest run started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
-leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nva.txt
@@ -1,6 +1,7 @@
 liTest run started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
-leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvc.txt
@@ -1,6 +1,7 @@
 liTest run started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
-leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_nvca.txt
@@ -1,6 +1,7 @@
 liTest run started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
-leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_v.txt
@@ -1,6 +1,7 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_va.txt
@@ -1,6 +1,7 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vc.txt
@@ -1,6 +1,7 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vs.txt
@@ -1,6 +1,7 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/ExceptionAfterAssumeAssertions_vsn.txt
@@ -1,6 +1,7 @@
 liTest run started
 liTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail started
-leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2scala.scalanative.junit.ExceptionAfterAssume.assumeFail
 leTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest scala.scalanative.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail1TestAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail1Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 liTest scala.scalanative.junit.MultiAssumeFail1Test.multiTest2 started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
@@ -10,7 +10,7 @@ ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
@@ -10,7 +10,7 @@ ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
@@ -10,7 +10,7 @@ ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
@@ -10,7 +10,7 @@ ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
@@ -10,7 +10,7 @@ liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
@@ -10,7 +10,7 @@ liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
@@ -10,7 +10,7 @@ liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
@@ -10,7 +10,7 @@ liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
@@ -10,7 +10,7 @@ liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
-lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 liTest scala.scalanative.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started

--- a/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiAssumeFail2TestAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest1
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest2 started
@@ -10,7 +10,7 @@ liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
 e0scala.scalanative.junit.MultiAssumeFail2Test.multiTest3
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 started
-lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiAssumeFail2Test.multiTest4
 ldTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 liTest scala.scalanative.junit.MultiAssumeFail2Test.multiTest5 started

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
-liTest scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_a.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
-liTest scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_n.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run started
-liTest scala.scalanative.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_na.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run started
-liTest scala.scalanative.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nv.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest scala.scalanative.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nva.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest scala.scalanative.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest scala.scalanative.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvca.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest scala.scalanative.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_v.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_va.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vc.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vs.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test scala.scalanative.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vsn.txt
+++ b/junit-test/outputs/scala/scalanative/junit/MultiBeforeAssumeFailTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest scala.scalanative.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test scala.scalanative.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3scala.scalanative.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/AssertThrows2Test.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/AssertThrows2Test.scala
@@ -1,0 +1,20 @@
+package scala.scalanative.junit
+
+import org.junit.Assert._
+import org.junit.function.ThrowingRunnable
+import org.junit.Test
+
+import scala.scalanative.junit.utils.JUnitTest
+
+class AssertThrows2Test {
+  @Test def test(): Unit = {
+    assertThrows("This is the message",
+                 classOf[UnsupportedOperationException],
+                 new ThrowingRunnable {
+                   def run(): Unit =
+                     throw new IllegalAccessException("Exception message")
+                 })
+  }
+}
+
+class AssertThrows2TestAssertions extends JUnitTest

--- a/junit-test/shared/src/test/scala/scala/scalanative/junit/AssertThrowsTest.scala
+++ b/junit-test/shared/src/test/scala/scala/scalanative/junit/AssertThrowsTest.scala
@@ -1,0 +1,17 @@
+package scala.scalanative.junit
+
+import org.junit.Assert._
+import org.junit.function.ThrowingRunnable
+import org.junit.Test
+
+import scala.scalanative.junit.utils.JUnitTest
+
+class AssertThrowsTest {
+  @Test def test(): Unit = {
+    assertThrows(classOf[UnsupportedOperationException], new ThrowingRunnable {
+      def run(): Unit = throw new IllegalArgumentException("Exception message")
+    })
+  }
+}
+
+class AssertThrowsTestAssertions extends JUnitTest

--- a/unit-tests-ext/src/test/scala/java/time/InstantTest.scala
+++ b/unit-tests-ext/src/test/scala/java/time/InstantTest.scala
@@ -4,7 +4,7 @@ package java.time
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 /** Sanity tests for the dummy implemenation of `java.time.Instant`.
  *

--- a/unit-tests-ext/src/test/scala/java/util/FormatterLocaleTest.scala
+++ b/unit-tests-ext/src/test/scala/java/util/FormatterLocaleTest.scala
@@ -20,7 +20,7 @@ import org.junit.Before
 import org.junit.After
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class FormatterLocaleTest {
   private var root: Boolean         = false

--- a/unit-tests-ext/src/test/scala/scala/scalanative/junit/utils/AssertThrows.scala
+++ b/unit-tests-ext/src/test/scala/scala/scalanative/junit/utils/AssertThrows.scala
@@ -5,9 +5,10 @@ import org.junit.function.ThrowingRunnable
 
 // Port of AssertThrows from core unit-tests
 object AssertThrows {
-  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): T = {
+  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T],
+                                      code: => U): T = {
     Assert.assertThrows(expectedThrowable, new ThrowingRunnable {
       def run(): Unit = code
-    } )
+    })
   }
 }

--- a/unit-tests-ext/src/test/scala/scala/scalanative/junit/utils/AssertThrows.scala
+++ b/unit-tests-ext/src/test/scala/scala/scalanative/junit/utils/AssertThrows.scala
@@ -1,73 +1,13 @@
 package scala.scalanative.junit.utils
 
+import org.junit.Assert
+import org.junit.function.ThrowingRunnable
+
 // Port of AssertThrows from core unit-tests
 object AssertThrows {
-
-  /** Backport implementation of Assert.assertThrows to be used until JUnit 4.13 is
-   *  released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private def assertThrowsBackport(expectedThrowable: Class[_ <: Throwable],
-                                   runnable: ThrowingRunnable): Unit = {
-    expectThrowsBackport(expectedThrowable, runnable)
-  }
-
-  /** Backport implementation of Assert.expectThrows to be used until JUnit 4.13 is
-   *  released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private def expectThrowsBackport[T <: Throwable](
-      expectedThrowable: Class[T],
-      runnable: ThrowingRunnable): T = {
-    val result = {
-      try {
-        runnable.run()
-        null.asInstanceOf[T]
-      } catch {
-        case actualThrown: Throwable =>
-          if (expectedThrowable.isInstance(actualThrown)) {
-            actualThrown.asInstanceOf[T]
-          } else {
-            val mismatchMessage = "unexpected exception type thrown;" +
-              expectedThrowable.getSimpleName + " " + actualThrown.getClass.getSimpleName
-
-            val assertionError = new AssertionError(mismatchMessage)
-            assertionError.initCause(actualThrown)
-            throw assertionError
-          }
-      }
-    }
-    if (result == null) {
-      throw new AssertionError(
-        "expected " + expectedThrowable.getSimpleName +
-          " to be thrown, but nothing was thrown")
-    } else {
-      result
-    }
-  }
-
-  /** Backport implementation of Assert.ThrowingRunnable to be used until
-   *  JUnit 4.13 is released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private trait ThrowingRunnable {
-    def run(): Unit
-  }
-
-  private def throwingRunnable(code: => Unit): ThrowingRunnable = {
-    new ThrowingRunnable {
+  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): T = {
+    Assert.assertThrows(expectedThrowable, new ThrowingRunnable {
       def run(): Unit = code
-    }
-  }
-
-  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T],
-                                      code: => U): Unit = {
-    assertThrowsBackport(expectedThrowable, throwingRunnable {
-      code
-    })
-  }
-
-  def expectThrows[T <: Throwable, U](expectedThrowable: Class[T],
-                                      code: => U): T = {
-    expectThrowsBackport(expectedThrowable, throwingRunnable {
-      code
-    })
+    } )
   }
 }

--- a/unit-tests-ext/src/test/scala/scala/scalanative/junit/utils/ThrowsHelper.scala
+++ b/unit-tests-ext/src/test/scala/scala/scalanative/junit/utils/ThrowsHelper.scala
@@ -1,15 +1,15 @@
 package scala.scalanative.junit.utils
 
-import AssertThrows._
+import AssertThrows.assertThrows
 
-// Calls to this should probably be changed to expectThrows.
+// Calls to this should probably be changed to assertThrows.
 // This was added as it was all over the place in the pre
 // JUnit code.
 object ThrowsHelper {
   def assertThrowsAnd[T <: Throwable, U](
       expectedThrowable: Class[T],
       code: => U)(cond: T => Boolean): Unit = {
-    val c = cond(expectThrows(expectedThrowable, code))
+    val c = cond(assertThrows(expectedThrowable, code))
     assert(c)
   }
 }

--- a/unit-tests/src/test/scala/java/io/BufferedInputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/BufferedInputStreamTest.scala
@@ -3,7 +3,7 @@ package java.io
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class BufferedInputStreamTest {
 

--- a/unit-tests/src/test/scala/java/io/BufferedOutputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/BufferedOutputStreamTest.scala
@@ -5,7 +5,7 @@ package java.io
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class BufferedOutputStreamTest {
 

--- a/unit-tests/src/test/scala/java/io/BufferedWriterTest.scala
+++ b/unit-tests/src/test/scala/java/io/BufferedWriterTest.scala
@@ -3,7 +3,7 @@ package java.io
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class BufferedWriterTest {
 

--- a/unit-tests/src/test/scala/java/io/ByteArrayOutputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/ByteArrayOutputStreamTest.scala
@@ -2,7 +2,7 @@ package java.io
 
 import org.junit.Test
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class ByteArrayOutputStreamTest {
 

--- a/unit-tests/src/test/scala/java/io/DataInputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/DataInputStreamTest.scala
@@ -6,7 +6,7 @@
 
 package java.io
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform.executingInJVM
 
 import org.junit._

--- a/unit-tests/src/test/scala/java/io/DataOutputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/DataOutputStreamTest.scala
@@ -5,7 +5,7 @@ package java.io
 import org.junit._
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 object DataOutputStreamTest {
   class DataOutputStreamWrittenAccess(out: OutputStream)

--- a/unit-tests/src/test/scala/java/io/FileDescriptorTest.scala
+++ b/unit-tests/src/test/scala/java/io/FileDescriptorTest.scala
@@ -3,7 +3,7 @@ package java.io
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class FileDescriptorTest {
   val in  = FileDescriptor.in

--- a/unit-tests/src/test/scala/java/io/FileInputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/FileInputStreamTest.scala
@@ -5,7 +5,7 @@ import scala.util.Try
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class FileInputStreamTest {
   @Test def readNull(): Unit = {

--- a/unit-tests/src/test/scala/java/io/FileOutputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/FileOutputStreamTest.scala
@@ -3,7 +3,7 @@ package java.io
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class FileOutputStreamTest {
   def withTempFile(f: File => Unit): Unit = {

--- a/unit-tests/src/test/scala/java/io/FileReaderTest.scala
+++ b/unit-tests/src/test/scala/java/io/FileReaderTest.scala
@@ -2,7 +2,7 @@ package java.io
 
 import org.junit.Test
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class FileReaderTest {
 

--- a/unit-tests/src/test/scala/java/io/FileTest.scala
+++ b/unit-tests/src/test/scala/java/io/FileTest.scala
@@ -5,7 +5,7 @@ import java.net.URI
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class FileTest {
 

--- a/unit-tests/src/test/scala/java/io/InputStreamReaderTest.scala
+++ b/unit-tests/src/test/scala/java/io/InputStreamReaderTest.scala
@@ -5,7 +5,7 @@ import java.nio.charset._
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class InputStreamReaderTest {
   class MockInputStream extends InputStream {

--- a/unit-tests/src/test/scala/java/io/OutputStreamWriterTest.scala
+++ b/unit-tests/src/test/scala/java/io/OutputStreamWriterTest.scala
@@ -4,7 +4,7 @@ import java.nio.charset._
 
 import org.junit.Test
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class OutputStreamWriterTest {
   class MockOutputStream extends OutputStream {

--- a/unit-tests/src/test/scala/java/io/PrintStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/PrintStreamTest.scala
@@ -2,7 +2,7 @@ package java.io
 
 import org.junit.Test
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class PrintStreamTest {
 

--- a/unit-tests/src/test/scala/java/io/PushbackInputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/io/PushbackInputStreamTest.scala
@@ -5,7 +5,7 @@ package java.io
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class PushbackInputStreamTest {
 

--- a/unit-tests/src/test/scala/java/io/RandomAccessFileTest.scala
+++ b/unit-tests/src/test/scala/java/io/RandomAccessFileTest.scala
@@ -7,7 +7,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class RandomAccessFileTest {
 

--- a/unit-tests/src/test/scala/java/lang/CharacterTest.scala
+++ b/unit-tests/src/test/scala/java/lang/CharacterTest.scala
@@ -13,7 +13,7 @@ package java.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class CharacterTest {
   import java.lang.Character._

--- a/unit-tests/src/test/scala/java/lang/DoubleTest.scala
+++ b/unit-tests/src/test/scala/java/lang/DoubleTest.scala
@@ -23,7 +23,7 @@ import java.lang.Double.{
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class DoubleTest {
   @Test def testEquals(): Unit = {

--- a/unit-tests/src/test/scala/java/lang/FloatTest.scala
+++ b/unit-tests/src/test/scala/java/lang/FloatTest.scala
@@ -18,7 +18,7 @@ import java.lang.Float.{floatToIntBits, floatToRawIntBits, intBitsToFloat}
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class FloatTest {
   @Test def testEquals(): Unit = {

--- a/unit-tests/src/test/scala/java/lang/IntegerTest.scala
+++ b/unit-tests/src/test/scala/java/lang/IntegerTest.scala
@@ -3,7 +3,7 @@ package java.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class IntegerTest {
   val signedMaxValue     = Integer.MAX_VALUE
@@ -21,7 +21,7 @@ class IntegerTest {
   def assertThrowsAndMessage[T <: Throwable, U](
       expectedThrowable: Class[T],
       code: => U)(expectedMsg: String): Unit = {
-    val exception = expectThrows(expectedThrowable, code)
+    val exception = assertThrows(expectedThrowable, code)
     assertEquals(expectedMsg, exception.toString)
   }
 

--- a/unit-tests/src/test/scala/java/lang/LongTest.scala
+++ b/unit-tests/src/test/scala/java/lang/LongTest.scala
@@ -3,7 +3,7 @@ package java.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class LongTest {
   val signedMaxValue     = Long.MAX_VALUE
@@ -21,7 +21,7 @@ class LongTest {
   def assertThrowsAndMessage[T <: Throwable, U](
       expectedThrowable: Class[T],
       code: => U)(expectedMsg: String): Unit = {
-    val exception = expectThrows(expectedThrowable, code)
+    val exception = assertThrows(expectedThrowable, code)
     assertEquals(expectedMsg, exception.toString)
   }
 

--- a/unit-tests/src/test/scala/java/lang/ShortTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ShortTest.scala
@@ -3,7 +3,7 @@ package java.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 import scalanative.junit.utils.ThrowsHelper._
 
 class ShortTest {
@@ -18,7 +18,7 @@ class ShortTest {
   def assertThrowsAndMessage[T <: Throwable, U](
       expectedThrowable: Class[T],
       code: => U)(expectedMsg: String): Unit = {
-    val exception = expectThrows(expectedThrowable, code)
+    val exception = assertThrows(expectedThrowable, code)
     assertEquals(expectedMsg, exception.toString)
   }
 

--- a/unit-tests/src/test/scala/java/lang/StringBufferTest.scala
+++ b/unit-tests/src/test/scala/java/lang/StringBufferTest.scala
@@ -5,7 +5,7 @@ package java.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class StringBufferTest {
 
@@ -56,9 +56,9 @@ class StringBufferTest {
       "abcdef",
       initBuf("abef").insert(2, Array('a', 'b', 'c', 'd', 'e'), 2, 2).toString)
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  initBuf("abcd").insert(-1, "whatever"))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  initBuf("abcd").insert(5, "whatever"))
   }
 
@@ -77,9 +77,9 @@ class StringBufferTest {
     assertEquals("023", initBuf("0123").deleteCharAt(1).toString)
     assertEquals("123", initBuf("0123").deleteCharAt(0).toString)
     assertEquals("012", initBuf("0123").deleteCharAt(3).toString)
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  initBuf("0123").deleteCharAt(-1))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  initBuf("0123").deleteCharAt(4))
   }
 
@@ -92,7 +92,7 @@ class StringBufferTest {
     assertEquals("0xxxx123", initBuf("0123").replace(1, 1, "xxxx").toString)
     assertEquals("0123x", initBuf("0123").replace(4, 5, "x").toString)
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  initBuf("0123").replace(-1, 3, "x"))
   }
 
@@ -106,9 +106,9 @@ class StringBufferTest {
     buf.setCharAt(5, 'h')
     assertEquals("foxbah", buf.toString)
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  buf.setCharAt(-1, 'h'))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  buf.setCharAt(6, 'h'))
   }
 
@@ -121,7 +121,7 @@ class StringBufferTest {
     val buf = newBuf
     buf.append("foobar")
 
-    expectThrows(classOf[StringIndexOutOfBoundsException], buf.setLength(-3))
+    assertThrows(classOf[StringIndexOutOfBoundsException], buf.setLength(-3))
 
     assertEquals("foo", { buf.setLength(3); buf.toString })
     assertEquals("foo\u0000\u0000\u0000", { buf.setLength(6); buf.toString })

--- a/unit-tests/src/test/scala/java/lang/StringBuilderTest.scala
+++ b/unit-tests/src/test/scala/java/lang/StringBuilderTest.scala
@@ -5,7 +5,7 @@ package java.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class StringBuilderTest {
 
@@ -61,9 +61,9 @@ class StringBuilderTest {
                    .insert(2, Array('a', 'b', 'c', 'd', 'e'), 2, 2)
                    .toString)
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  initBuilder("abcd").insert(-1, "whatever"))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  initBuilder("abcd").insert(5, "whatever"))
   }
 
@@ -86,9 +86,9 @@ class StringBuilderTest {
     assertEquals("023", initBuilder("0123").deleteCharAt(1).toString)
     assertEquals("123", initBuilder("0123").deleteCharAt(0).toString)
     assertEquals("012", initBuilder("0123").deleteCharAt(3).toString)
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  initBuilder("0123").deleteCharAt(-1))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  initBuilder("0123").deleteCharAt(4))
   }
 
@@ -101,7 +101,7 @@ class StringBuilderTest {
     assertEquals("0xxxx123", initBuilder("0123").replace(1, 1, "xxxx").toString)
     assertEquals("0123x", initBuilder("0123").replace(4, 5, "x").toString)
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
                  initBuilder("0123").replace(-1, 3, "x"))
   }
 
@@ -115,8 +115,8 @@ class StringBuilderTest {
     b.setCharAt(5, 'h')
     assertEquals("foxbah", b.toString)
 
-    expectThrows(classOf[StringIndexOutOfBoundsException], b.setCharAt(-1, 'h'))
-    expectThrows(classOf[StringIndexOutOfBoundsException], b.setCharAt(6, 'h'))
+    assertThrows(classOf[StringIndexOutOfBoundsException], b.setCharAt(-1, 'h'))
+    assertThrows(classOf[StringIndexOutOfBoundsException], b.setCharAt(6, 'h'))
   }
 
   @Test def ensureCapacity(): Unit = {
@@ -128,7 +128,7 @@ class StringBuilderTest {
     val b = newBuilder
     b.append("foobar")
 
-    expectThrows(classOf[StringIndexOutOfBoundsException], b.setLength(-3))
+    assertThrows(classOf[StringIndexOutOfBoundsException], b.setLength(-3))
 
     assertEquals("foo", { b.setLength(3); b.toString })
     assertEquals("foo\u0000\u0000\u0000", { b.setLength(6); b.toString })

--- a/unit-tests/src/test/scala/java/lang/StringTest.scala
+++ b/unit-tests/src/test/scala/java/lang/StringTest.scala
@@ -6,7 +6,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class StringTest {
 

--- a/unit-tests/src/test/scala/java/lang/ThrowablesTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ThrowablesTest.scala
@@ -8,7 +8,7 @@ package java.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class ThrowablesTest {
 

--- a/unit-tests/src/test/scala/java/math/BigDecimalToStringTest.scala
+++ b/unit-tests/src/test/scala/java/math/BigDecimalToStringTest.scala
@@ -71,7 +71,7 @@ class BigDecimalToStringTest {
 
   @Test def testToStringWithRoundingMode(): Unit = {
     import RoundingMode._
-    import scala.scalanative.junit.utils.AssertThrows._
+    import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
     val group1: Seq[RoundingMode] = Seq(UP, CEILING, HALF_UP)
     val group2: Seq[RoundingMode] = Seq(DOWN, FLOOR, HALF_DOWN, HALF_EVEN)

--- a/unit-tests/src/test/scala/java/math/BigIntegerTest.scala
+++ b/unit-tests/src/test/scala/java/math/BigIntegerTest.scala
@@ -3,7 +3,7 @@ package java.math
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class BigIntegerTest {
 // byteValueExact

--- a/unit-tests/src/test/scala/java/net/Inet6AddressTest.scala
+++ b/unit-tests/src/test/scala/java/net/Inet6AddressTest.scala
@@ -5,7 +5,7 @@ package java.net
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class Inet6AddressTest {
 

--- a/unit-tests/src/test/scala/java/net/InetAddressTest.scala
+++ b/unit-tests/src/test/scala/java/net/InetAddressTest.scala
@@ -5,7 +5,7 @@ package java.net
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class InetAddressTest {
 

--- a/unit-tests/src/test/scala/java/net/InetSocketAddressTest.scala
+++ b/unit-tests/src/test/scala/java/net/InetSocketAddressTest.scala
@@ -5,7 +5,7 @@ package java.net
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class InetSocketAddressTest {
 

--- a/unit-tests/src/test/scala/java/net/ServerSocketTest.scala
+++ b/unit-tests/src/test/scala/java/net/ServerSocketTest.scala
@@ -3,7 +3,7 @@ package java.net
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class ServerSocketTest {
 

--- a/unit-tests/src/test/scala/java/net/SocketTest.scala
+++ b/unit-tests/src/test/scala/java/net/SocketTest.scala
@@ -3,7 +3,7 @@ package java.net
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class SocketTest {
 

--- a/unit-tests/src/test/scala/java/net/URITest.scala
+++ b/unit-tests/src/test/scala/java/net/URITest.scala
@@ -5,7 +5,7 @@ package java.net
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class URITest {
 

--- a/unit-tests/src/test/scala/java/net/URLEncoderTest.scala
+++ b/unit-tests/src/test/scala/java/net/URLEncoderTest.scala
@@ -13,7 +13,7 @@ package java.net
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class URLEncoderTest {
   @Test def nullInputString(): Unit = {

--- a/unit-tests/src/test/scala/java/nio/BaseBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/BaseBufferTest.scala
@@ -5,7 +5,7 @@ package java.nio
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 abstract class BaseBufferTest {
 

--- a/unit-tests/src/test/scala/java/nio/ByteBufferTest.scala
+++ b/unit-tests/src/test/scala/java/nio/ByteBufferTest.scala
@@ -7,7 +7,7 @@ import java.nio.BufferFactory.ByteBufferFactory
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 abstract class ByteBufferTest extends BaseBufferTest {
   type Factory = BufferFactory.ByteBufferFactory

--- a/unit-tests/src/test/scala/java/nio/channels/FileChannelTest.scala
+++ b/unit-tests/src/test/scala/java/nio/channels/FileChannelTest.scala
@@ -7,7 +7,7 @@ import java.io.File
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class FileChannelTest {
   @Test def fileChannelCanReadBufferFromFile(): Unit = {

--- a/unit-tests/src/test/scala/java/nio/file/DirectoryStreamTest.scala
+++ b/unit-tests/src/test/scala/java/nio/file/DirectoryStreamTest.scala
@@ -3,7 +3,7 @@ package java.nio.file
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 import FilesTest.withTemporaryDirectory
 

--- a/unit-tests/src/test/scala/java/nio/file/FilesTest.scala
+++ b/unit-tests/src/test/scala/java/nio/file/FilesTest.scala
@@ -11,7 +11,7 @@ import StandardCopyOption._
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 import scala.scalanative.junit.utils.CollectionConverters._
 
 class FilesTest {

--- a/unit-tests/src/test/scala/java/nio/file/PathMatcherTest.scala
+++ b/unit-tests/src/test/scala/java/nio/file/PathMatcherTest.scala
@@ -3,7 +3,7 @@ package java.nio.file
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class PathMatcherTest {
 

--- a/unit-tests/src/test/scala/java/nio/file/PathTest.scala
+++ b/unit-tests/src/test/scala/java/nio/file/PathTest.scala
@@ -3,7 +3,7 @@ package java.nio.file
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class PathTest {
 

--- a/unit-tests/src/test/scala/java/nio/file/PathsTest.scala
+++ b/unit-tests/src/test/scala/java/nio/file/PathsTest.scala
@@ -6,7 +6,7 @@ import java.net.URI
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class PathsTest {
   @Test def pathsGetRelativePathReturnsPathRelativeToCwd(): Unit = {

--- a/unit-tests/src/test/scala/java/nio/file/attribute/UserPrincipalLookupServiceTest.scala
+++ b/unit-tests/src/test/scala/java/nio/file/attribute/UserPrincipalLookupServiceTest.scala
@@ -5,7 +5,7 @@ import java.nio.file.FileSystems
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite
 
 class UserPrincipalLookupServiceTest {

--- a/unit-tests/src/test/scala/java/security/TimestampTest.scala
+++ b/unit-tests/src/test/scala/java/security/TimestampTest.scala
@@ -7,7 +7,7 @@ import java.util.Date
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 /**
  * Tests for [[Timestamp]] class fields and methods

--- a/unit-tests/src/test/scala/java/util/ArrayDequeTest.scala
+++ b/unit-tests/src/test/scala/java/util/ArrayDequeTest.scala
@@ -4,7 +4,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 import scala.scalanative.junit.utils.CollectionConverters._
 
 class ArrayDequeTest {

--- a/unit-tests/src/test/scala/java/util/ArrayListTest.scala
+++ b/unit-tests/src/test/scala/java/util/ArrayListTest.scala
@@ -3,7 +3,7 @@ package java.util
 import org.junit.Test
 import org.junit.Assert._
 import scala.scalanative.junit.utils.CollectionConverters._
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class ArrayListTest {
   @Test def constructor(): Unit = {

--- a/unit-tests/src/test/scala/java/util/ArraysTest.scala
+++ b/unit-tests/src/test/scala/java/util/ArraysTest.scala
@@ -8,7 +8,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform._
 
 import java.util.{Arrays, Comparator}
@@ -146,12 +146,12 @@ class ArraysTest {
     val array = Array(0, 1, 3, 4)
 
     val e1 =
-      expectThrows(classOf[IllegalArgumentException], Arrays.sort(array, 3, 2))
+      assertThrows(classOf[IllegalArgumentException], Arrays.sort(array, 3, 2))
     assertEquals("fromIndex(3) > toIndex(2)", e1.getMessage)
 
     // start/end comparison is made before index ranges checks
     val e2 =
-      expectThrows(classOf[IllegalArgumentException], Arrays.sort(array, 7, 5))
+      assertThrows(classOf[IllegalArgumentException], Arrays.sort(array, 7, 5))
     assertEquals("fromIndex(7) > toIndex(5)", e2.getMessage)
   }
 
@@ -522,12 +522,12 @@ class ArraysTest {
   @Test def binarySearchIllegalArgumentException(): Unit = {
     val array = Array(0, 1, 3, 4)
 
-    val e1 = expectThrows(classOf[IllegalArgumentException],
+    val e1 = assertThrows(classOf[IllegalArgumentException],
                           Arrays.binarySearch(array, 3, 2, 2))
     assertEquals("fromIndex(3) > toIndex(2)", e1.getMessage)
 
     // start/end comparison is made before index ranges checks
-    val e2 = expectThrows(classOf[IllegalArgumentException],
+    val e2 = assertThrows(classOf[IllegalArgumentException],
                           Arrays.binarySearch(array, 7, 5, 2))
     assertEquals("fromIndex(7) > toIndex(5)", e2.getMessage)
   }

--- a/unit-tests/src/test/scala/java/util/Base64Test.scala
+++ b/unit-tests/src/test/scala/java/util/Base64Test.scala
@@ -14,7 +14,7 @@ import java.util.Base64.Decoder
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class Base64Test {
 

--- a/unit-tests/src/test/scala/java/util/CollectionTest.scala
+++ b/unit-tests/src/test/scala/java/util/CollectionTest.scala
@@ -12,7 +12,7 @@ import org.scalanative.testsuite.javalib.lang.IterableTest
 
 import scala.reflect.ClassTag
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 import scala.scalanative.junit.utils.Utils._
 
 trait CollectionTest extends IterableTest {
@@ -172,7 +172,7 @@ trait CollectionTest extends IterableTest {
     if (factory.allowsNullElementQuery) {
       assertFalse(coll.contains(null))
     } else {
-      expectThrows(classOf[Exception], coll.contains(null))
+      assertThrows(classOf[Exception], coll.contains(null))
     }
   }
 

--- a/unit-tests/src/test/scala/java/util/DefaultFormatterTest.scala
+++ b/unit-tests/src/test/scala/java/util/DefaultFormatterTest.scala
@@ -10,7 +10,7 @@ import java.util.Formatter.BigDecimalLayoutForm
 import org.junit.Assert._
 import org.junit.{After, Before, Ignore, Test}
 import org.scalanative.testsuite.utils.Platform.executingInJVM
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class DefaultFormatterTest {
   private var root: Boolean         = false

--- a/unit-tests/src/test/scala/java/util/FormatterTest.scala
+++ b/unit-tests/src/test/scala/java/util/FormatterTest.scala
@@ -6,7 +6,7 @@ import java.math.{BigDecimal, BigInteger}
 import org.junit.Assert._
 import org.junit.Test
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform._
 
 class FormatterTest {
@@ -106,7 +106,7 @@ class FormatterTest {
                                             format: String,
                                             args: Any*): T = {
     val fmt = new Formatter()
-    expectThrows(exeption,
+    assertThrows(exeption,
                  fmt.format(format, args.asInstanceOf[Seq[AnyRef]]: _*))
   }
 

--- a/unit-tests/src/test/scala/java/util/HashtableTest.scala
+++ b/unit-tests/src/test/scala/java/util/HashtableTest.scala
@@ -2,7 +2,7 @@ package java.util
 
 import org.junit.Test
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class HashtableTest {
 

--- a/unit-tests/src/test/scala/java/util/IteratorTest.scala
+++ b/unit-tests/src/test/scala/java/util/IteratorTest.scala
@@ -8,7 +8,7 @@ import org.junit.Assert._
 import java.{util => ju}
 import java.util.function.Consumer
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class IteratorTest {
   @Test def testRemove(): Unit = {

--- a/unit-tests/src/test/scala/java/util/MapTest.scala
+++ b/unit-tests/src/test/scala/java/util/MapTest.scala
@@ -6,7 +6,7 @@ import java.{util => ju}
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 import scala.collection.{immutable => im}
 import scala.collection.{mutable => mu}
 
@@ -148,7 +148,7 @@ trait MapTest {
       assertEquals("one", mp.get(null))
     } else {
       val mp = factory.empty[String, String]
-      expectThrows(classOf[NullPointerException], mp.put(null, "one"))
+      assertThrows(classOf[NullPointerException], mp.put(null, "one"))
     }
   }
 
@@ -159,7 +159,7 @@ trait MapTest {
       assertNull(mp.get("one"))
     } else {
       val mp = factory.empty[String, String]
-      expectThrows(classOf[NullPointerException], mp.put("one", null))
+      assertThrows(classOf[NullPointerException], mp.put("one", null))
     }
   }
 
@@ -182,7 +182,7 @@ trait MapTest {
     if (factory.allowsNullKeysQueries)
       assertFalse(mp.containsKey(null))
     else
-      expectThrows(classOf[Throwable], mp.containsKey(null))
+      assertThrows(classOf[Throwable], mp.containsKey(null))
   }
 
   @Test def shouldCheckContainedValuePresence(): Unit = {
@@ -194,7 +194,7 @@ trait MapTest {
     if (factory.allowsNullValuesQueries)
       assertFalse(mp.containsValue(null))
     else
-      expectThrows(classOf[Throwable], mp.containsValue(null))
+      assertThrows(classOf[Throwable], mp.containsValue(null))
   }
 
   @Test def shouldGiveProperCollectionOverValues(): Unit = {
@@ -254,7 +254,7 @@ trait MapTest {
       assertEquals("y", mp.get(null))
       assertEquals("y", mp.get("X"))
     } else {
-      expectThrows(classOf[NullPointerException],
+      assertThrows(classOf[NullPointerException],
                    mp.putAll(nullMap.toJavaMap[String, String]))
     }
   }
@@ -322,7 +322,7 @@ trait MapTest {
     if (factory.allowsNullValuesQueries)
       assertFalse(values.contains(null))
     else
-      expectThrows(classOf[Throwable], mp.values().contains(null))
+      assertThrows(classOf[Throwable], mp.values().contains(null))
 
     mp.put("THREE", "three")
 
@@ -469,7 +469,7 @@ trait MapTest {
     if (factory.allowsNullKeysQueries)
       assertFalse(keySet.contains(null))
     else
-      expectThrows(classOf[Throwable], mp.keySet().contains(null))
+      assertThrows(classOf[Throwable], mp.keySet().contains(null))
 
     mp.put("THREE", "three")
 

--- a/unit-tests/src/test/scala/java/util/ObjectsTest.scala
+++ b/unit-tests/src/test/scala/java/util/ObjectsTest.scala
@@ -11,7 +11,7 @@ import java.{util => ju}
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class ObjectsTest {
 
@@ -106,7 +106,7 @@ class ObjectsTest {
       }
     }
 
-    val e = expectThrows(classOf[NullPointerException],
+    val e = assertThrows(classOf[NullPointerException],
                          ju.Objects.requireNonNull(null, successSupplier))
     assertEquals(message, e.getMessage())
 

--- a/unit-tests/src/test/scala/java/util/PropertiesTest.scala
+++ b/unit-tests/src/test/scala/java/util/PropertiesTest.scala
@@ -11,7 +11,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 import scala.scalanative.junit.utils.Utils._
 
 import org.scalanative.testsuite.utils.Platform.hasCompliantAsInstanceOfs

--- a/unit-tests/src/test/scala/java/util/StringTokenizerTest.scala
+++ b/unit-tests/src/test/scala/java/util/StringTokenizerTest.scala
@@ -5,7 +5,7 @@ package java.util
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class StringTokenizerTest {
 

--- a/unit-tests/src/test/scala/java/util/function/BiConsumerTest.scala
+++ b/unit-tests/src/test/scala/java/util/function/BiConsumerTest.scala
@@ -7,7 +7,7 @@ import java.util.function.BiConsumer
 import org.junit.Assert._
 import org.junit.Test
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class BiConsumerTest {
   import BiConsumerTest._

--- a/unit-tests/src/test/scala/java/util/function/BiPredicateTest.scala
+++ b/unit-tests/src/test/scala/java/util/function/BiPredicateTest.scala
@@ -7,7 +7,7 @@ import java.util.function.BiPredicate
 import org.junit.Assert._
 import org.junit.Test
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class BiPredicateTest {
   import BiPredicateTest._

--- a/unit-tests/src/test/scala/java/util/function/ConsumerTest.scala
+++ b/unit-tests/src/test/scala/java/util/function/ConsumerTest.scala
@@ -7,7 +7,7 @@ import java.util.function.Consumer
 import org.junit.Assert._
 import org.junit.Test
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class ConsumerTest {
   import ConsumerTest._

--- a/unit-tests/src/test/scala/java/util/function/PredicateTest.scala
+++ b/unit-tests/src/test/scala/java/util/function/PredicateTest.scala
@@ -7,7 +7,7 @@ import java.util.function.Predicate
 import org.junit.Assert._
 import org.junit.Test
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class PredicateTest {
   import PredicateTest._

--- a/unit-tests/src/test/scala/java/util/jar/AttributesNameTest.scala
+++ b/unit-tests/src/test/scala/java/util/jar/AttributesNameTest.scala
@@ -4,7 +4,7 @@ package java.util.jar
 
 import org.junit.Test
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class AttributesNameTest {
 

--- a/unit-tests/src/test/scala/java/util/jar/AttributesTest.scala
+++ b/unit-tests/src/test/scala/java/util/jar/AttributesTest.scala
@@ -8,7 +8,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class AttributesTest {
   private var a: Attributes = null

--- a/unit-tests/src/test/scala/java/util/jar/JarFileTest.scala
+++ b/unit-tests/src/test/scala/java/util/jar/JarFileTest.scala
@@ -10,7 +10,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 import JarBytes._
 

--- a/unit-tests/src/test/scala/java/util/jar/JarInputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/util/jar/JarInputStreamTest.scala
@@ -9,7 +9,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 import JarBytes._
 

--- a/unit-tests/src/test/scala/java/util/jar/JarOutputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/util/jar/JarOutputStreamTest.scala
@@ -7,7 +7,7 @@ import java.util.zip.ZipEntry
 
 import org.junit.Test
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class JarOutputStreamTest {
 

--- a/unit-tests/src/test/scala/java/util/jar/ManifestTest.scala
+++ b/unit-tests/src/test/scala/java/util/jar/ManifestTest.scala
@@ -7,7 +7,7 @@ import java.io._
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 import JarBytes._
 

--- a/unit-tests/src/test/scala/java/util/regex/MatcherTest.scala
+++ b/unit-tests/src/test/scala/java/util/regex/MatcherTest.scala
@@ -9,7 +9,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils._, AssertThrows._, ThrowsHelper._
+import scalanative.junit.utils._, AssertThrows.assertThrows, ThrowsHelper._
 
 class MatcherTest {
 

--- a/unit-tests/src/test/scala/java/util/regex/PatternTest.scala
+++ b/unit-tests/src/test/scala/java/util/regex/PatternTest.scala
@@ -9,7 +9,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.scalanative.junit.utils.CollectionConverters._
-import scalanative.junit.utils._, AssertThrows._, ThrowsHelper._
+import scalanative.junit.utils._, AssertThrows.assertThrows, ThrowsHelper._
 
 class PatternTest {
 

--- a/unit-tests/src/test/scala/java/util/zip/Adler32Test.scala
+++ b/unit-tests/src/test/scala/java/util/zip/Adler32Test.scala
@@ -5,7 +5,7 @@ package java.util.zip
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class Adler32Test {
 

--- a/unit-tests/src/test/scala/java/util/zip/CRC32Test.scala
+++ b/unit-tests/src/test/scala/java/util/zip/CRC32Test.scala
@@ -5,7 +5,7 @@ package java.util.zip
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class CRC32Test {
 

--- a/unit-tests/src/test/scala/java/util/zip/DeflaterOutputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/util/zip/DeflaterOutputStreamTest.scala
@@ -5,7 +5,7 @@ import java.io._
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class DeflaterOutputStreamTest {
 

--- a/unit-tests/src/test/scala/java/util/zip/GZIPInputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/util/zip/GZIPInputStreamTest.scala
@@ -7,7 +7,7 @@ import java.io._
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class GZIPInputStreamTest {
 

--- a/unit-tests/src/test/scala/java/util/zip/GZIPOutputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/util/zip/GZIPOutputStreamTest.scala
@@ -7,7 +7,7 @@ import java.io.{ByteArrayOutputStream, IOException, OutputStream}
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class GZIPOutputStreamTest {
 

--- a/unit-tests/src/test/scala/java/util/zip/InflaterInputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/util/zip/InflaterInputStreamTest.scala
@@ -7,7 +7,7 @@ import java.io._
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class InflaterInputStreamTest {
 

--- a/unit-tests/src/test/scala/java/util/zip/InflaterTest.scala
+++ b/unit-tests/src/test/scala/java/util/zip/InflaterTest.scala
@@ -6,7 +6,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 class InflaterTest {
 

--- a/unit-tests/src/test/scala/java/util/zip/ZipEntryTest.scala
+++ b/unit-tests/src/test/scala/java/util/zip/ZipEntryTest.scala
@@ -6,7 +6,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 import ZipBytes._
 

--- a/unit-tests/src/test/scala/java/util/zip/ZipFileTest.scala
+++ b/unit-tests/src/test/scala/java/util/zip/ZipFileTest.scala
@@ -7,7 +7,7 @@ import java.io.InputStream
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 import ZipBytes._
 

--- a/unit-tests/src/test/scala/java/util/zip/ZipInputStreamTest.scala
+++ b/unit-tests/src/test/scala/java/util/zip/ZipInputStreamTest.scala
@@ -8,7 +8,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.Assert._
 
-import scala.scalanative.junit.utils.AssertThrows._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
 
 import ZipBytes.{brokenManifestBytes, zipFile}
 

--- a/unit-tests/src/test/scala/scala/ArrayDoubleCopyTest.scala
+++ b/unit-tests/src/test/scala/scala/ArrayDoubleCopyTest.scala
@@ -3,7 +3,7 @@ package scala
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class ArrayDoubleCopyTest {
   def init(arr: Array[Double], from: Double = 0.0) = {

--- a/unit-tests/src/test/scala/scala/ArrayIntCopyTest.scala
+++ b/unit-tests/src/test/scala/scala/ArrayIntCopyTest.scala
@@ -3,7 +3,7 @@ package scala
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class ArrayIntCopyTest {
   def init(arr: Array[Int], from: Int = 0) = {

--- a/unit-tests/src/test/scala/scala/ArrayObjectCopyTest.scala
+++ b/unit-tests/src/test/scala/scala/ArrayObjectCopyTest.scala
@@ -3,7 +3,7 @@ package scala
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class ArrayObjectCopyTest {
   class A(_i: Int) {

--- a/unit-tests/src/test/scala/scala/AsInstanceOfTest.scala
+++ b/unit-tests/src/test/scala/scala/AsInstanceOfTest.scala
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 import scala.scalanative.buildinfo.ScalaNativeBuildInfo.scalaVersion
 

--- a/unit-tests/src/test/scala/scala/DivisionByZeroTest.scala
+++ b/unit-tests/src/test/scala/scala/DivisionByZeroTest.scala
@@ -3,7 +3,7 @@ package scala
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class DivisionByZeroTest {
   @noinline def byte1  = 1.toByte

--- a/unit-tests/src/test/scala/scala/NullPointerTest.scala
+++ b/unit-tests/src/test/scala/scala/NullPointerTest.scala
@@ -3,7 +3,7 @@ package scala
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 class NullPointerTest {
   class E extends Exception

--- a/unit-tests/src/test/scala/scala/ReflectiveProxyTest.scala
+++ b/unit-tests/src/test/scala/scala/ReflectiveProxyTest.scala
@@ -5,7 +5,7 @@ package scala
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 import scala.language.reflectiveCalls
 

--- a/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationTest.scala
@@ -6,7 +6,7 @@ package reflect
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 import scala.scalanative.reflect._
 import scala.scalanative.reflect.annotation._
@@ -156,7 +156,7 @@ class ReflectiveInstantiationTest {
       assertTrue(optClassData.isDefined)
       val classData = optClassData.get
 
-      expectThrows(classOf[InstantiationException], {
+      assertThrows(classOf[InstantiationException], {
         classData.newInstance()
       })
     }

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CArrayBoxingTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CArrayBoxingTest.scala
@@ -4,7 +4,7 @@ package unsafe
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 import scalanative.unsafe.Nat._
 import scalanative.unsigned._

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CFuncPtrOpsTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CFuncPtrOpsTest.scala
@@ -3,7 +3,7 @@ package unsafe
 
 import org.junit.Test
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 import scalanative.libc._
 

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/CStructBoxingTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/CStructBoxingTest.scala
@@ -4,7 +4,7 @@ package unsafe
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 import scalanative.unsigned._
 import scalanative.libc.stdlib.malloc

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/PtrBoxingTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/PtrBoxingTest.scala
@@ -4,7 +4,7 @@ package unsafe
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 
 import scalanative.unsigned._
 import scalanative.libc.stdlib.malloc

--- a/unit-tests/src/test/scala/scala/scalanative/unsafe/ZoneTest.scala
+++ b/unit-tests/src/test/scala/scala/scalanative/unsafe/ZoneTest.scala
@@ -4,7 +4,7 @@ package unsafe
 import org.junit.Test
 import org.junit.Assert._
 
-import scalanative.junit.utils.AssertThrows._
+import scalanative.junit.utils.AssertThrows.assertThrows
 import scalanative.unsigned._
 
 class ZoneTest {

--- a/unit-tests/src/test/scala/utils/AssertThrows.scala
+++ b/unit-tests/src/test/scala/utils/AssertThrows.scala
@@ -16,9 +16,10 @@ import org.junit.Assert
 import org.junit.function.ThrowingRunnable
 
 object AssertThrows {
-  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): T = {
+  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T],
+                                      code: => U): T = {
     Assert.assertThrows(expectedThrowable, new ThrowingRunnable {
       def run(): Unit = code
-    } )
+    })
   }
 }

--- a/unit-tests/src/test/scala/utils/AssertThrows.scala
+++ b/unit-tests/src/test/scala/utils/AssertThrows.scala
@@ -12,73 +12,13 @@
 
 package scala.scalanative.junit.utils
 
+import org.junit.Assert
+import org.junit.function.ThrowingRunnable
+
 object AssertThrows {
-
-  /** Backport implementation of Assert.assertThrows to be used until JUnit 4.13 is
-   *  released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private def assertThrowsBackport(expectedThrowable: Class[_ <: Throwable],
-                                   runnable: ThrowingRunnable): Unit = {
-    expectThrowsBackport(expectedThrowable, runnable)
-  }
-
-  /** Backport implementation of Assert.expectThrows to be used until JUnit 4.13 is
-   *  released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private def expectThrowsBackport[T <: Throwable](
-      expectedThrowable: Class[T],
-      runnable: ThrowingRunnable): T = {
-    val result = {
-      try {
-        runnable.run()
-        null.asInstanceOf[T]
-      } catch {
-        case actualThrown: Throwable =>
-          if (expectedThrowable.isInstance(actualThrown)) {
-            actualThrown.asInstanceOf[T]
-          } else {
-            val mismatchMessage = "unexpected exception type thrown;" +
-              expectedThrowable.getSimpleName + " " + actualThrown.getClass.getSimpleName
-
-            val assertionError = new AssertionError(mismatchMessage)
-            assertionError.initCause(actualThrown)
-            throw assertionError
-          }
-      }
-    }
-    if (result == null) {
-      throw new AssertionError(
-        "expected " + expectedThrowable.getSimpleName +
-          " to be thrown, but nothing was thrown")
-    } else {
-      result
-    }
-  }
-
-  /** Backport implementation of Assert.ThrowingRunnable to be used until
-   *  JUnit 4.13 is released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private trait ThrowingRunnable {
-    def run(): Unit
-  }
-
-  private def throwingRunnable(code: => Unit): ThrowingRunnable = {
-    new ThrowingRunnable {
+  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): T = {
+    Assert.assertThrows(expectedThrowable, new ThrowingRunnable {
       def run(): Unit = code
-    }
-  }
-
-  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T],
-                                      code: => U): Unit = {
-    assertThrowsBackport(expectedThrowable, throwingRunnable {
-      code
-    })
-  }
-
-  def expectThrows[T <: Throwable, U](expectedThrowable: Class[T],
-                                      code: => U): T = {
-    expectThrowsBackport(expectedThrowable, throwingRunnable {
-      code
-    })
+    } )
   }
 }

--- a/unit-tests/src/test/scala/utils/ThrowsHelper.scala
+++ b/unit-tests/src/test/scala/utils/ThrowsHelper.scala
@@ -1,15 +1,15 @@
 package scala.scalanative.junit.utils
 
-import AssertThrows._
+import AssertThrows.assertThrows
 
-// Calls to this should probably be changed to expectThrows.
+// Calls to this should probably be changed to assertThrows.
 // This was added as it was all over the place in the pre
 // JUnit code.
 object ThrowsHelper {
   def assertThrowsAnd[T <: Throwable, U](
       expectedThrowable: Class[T],
       code: => U)(cond: T => Boolean): Unit = {
-    val c = cond(expectThrows(expectedThrowable, code))
+    val c = cond(assertThrows(expectedThrowable, code))
     assert(c)
   }
 }


### PR DESCRIPTION
Changes to junit-runtime were ported over from Scala.js. `assertThrows` was merged with `expectThrows` and added to junit-runtime. Generated output logs from junit-runtime were also adjusted to match the ones from JUnit 4.13.2.

I also added two tests to 'junit-tests' concerning newly added `assertThrows`.

As far as I understand (correct me if I'm wrong), the other additions in JUnit 4.13 concern fixes and additions to features which SN does not already support, so this PR should resolve #1881.