### PR TITLE
Fix #2305 compile error on macro using Scala 2.11.12

### DIFF
--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -624,6 +624,11 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           case EmptyTree =>
             buf += Defn.Declare(attrs, name, sig)
 
+          case Apply(TypeApply(Select(retBlock, _), _), _)
+              if retBlock.tpe == NoType && isScala211 =>
+            // Fix issue #2305 Compile error on macro using Scala 2.11.12
+            buf += Defn.Declare(attrs, name, sig)
+
           case _ if dd.name == nme.CONSTRUCTOR && owner.isExternModule =>
             validateExternCtor(dd.rhs)
             ()

--- a/unit-tests/src/test/scala-2.11/scala/Issue2305.scala
+++ b/unit-tests/src/test/scala-2.11/scala/Issue2305.scala
@@ -1,0 +1,22 @@
+package scala
+
+import org.junit.Test
+import org.junit.Assert._
+import scala.reflect.macros.blackbox.Context
+import scala.reflect.runtime.universe._
+import scala.language.experimental.macros
+
+/* Dummy test used determinate if a trait of macro can compile to nir.
+ * If it does compile, it passes
+ */
+class Issue2305 {
+
+  trait Foo {
+    def fooImpl(c: Context)(input: c.Tree): c.Tree
+  }
+
+  @Test def macroTraitCanCompile(): Unit = {
+    assertTrue(true)
+  }
+
+}


### PR DESCRIPTION
The solution, while simple, requires a quick explanation.
In Scala 2.12, the generated AST for the method foo of the example trait looks like this:
```scala
def foo(c: scala.reflect.macros.blackbox.Context, input: reflect.api.Trees$TreeApi): reflect.api.Trees$TreeApi
```
While in Scala 2.11, it looks like this:
```scala
def foo(c: scala.reflect.macros.blackbox.Context, input: reflect.api.Trees$TreeApi): reflect.api.Trees$TreeApi = {
  <synthetic> val input$1: reflect.api.Trees$TreeApi = input;
  <empty>
}.$asInstanceOf[reflect.api.Trees$TreeApi]()
```

In Scala 2.11 a body of the method is being generated, which is a block of `NoType`, while in later versions the body is an `EmptyTree`. The compiler tries to cast the type of the body (`NoType`) to `SimpleType` (in `SimpleType.fromType`), but that case is not being handled, resulting in the error.
The solution relies on standardizing the behavior between different versions of Scala - now we ignore the body, like in later versions. An alternative would be trying to generate that body in NIR, but my fear is that it would result in more errors (perhaps connected to returning values we were not meant to return) down the line.