### PR TITLE
Fix #2286: Remove race condition in ProcessTest

### DIFF
--- a/unit-tests/src/test/scala/java/lang/ProcessTest.scala
+++ b/unit-tests/src/test/scala/java/lang/ProcessTest.scala
@@ -134,11 +134,11 @@ class ProcessTest {
     pb.redirectInput(file)
 
     try {
-      val proc = pb.start()
       val os = new FileOutputStream(file)
       os.write("hello\n".getBytes)
       os.write("quit\n".getBytes)
 
+      val proc = pb.start()
       assertProcessExitOrTimeout(proc)
 
       assertEquals("hello", readInputStream(proc.getInputStream))


### PR DESCRIPTION
The child process will now start after the writing to `FileOutputStream` had been completed. Previously, there was a race condition between read() (in the child process) and write() (in `FileOutputStream`). This would sometimes result in an unexpected failure of the test in the CI.

As it turns out, read and write are not guaranteed to be atomic for different processes in the posix standard, so we cannot rely on that. Additionally, no file locking mechanism is being used in `FileOutputStream`. Because of that, for example, I believe that the read in echo.sh process could potentially read bytes corresponding to "qu" (unfinished quit), return an EOF error, read "it\n", which would not equal "quit\n", so the process would never exit.

I am unsure if the same thing can happen when ran in the JVM. From the few CI tests I ran on my fork, it did not look like it does, but perhaps the errors are much rarer simply due to minor implementation differences. Or maybe a file lock is being used there. I am leaving that for further consideration.