### PR TITLE
Fix #2339/2340 Add a publish-local script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _build/
 _build/
 scripts/.coursier
 scripts/.scalafmt*
+scripts/project/
 sbt-crossproject/
 local.sbt
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ _build/
 _build/
 scripts/.coursier
 scripts/.scalafmt*
-scripts/project/
 sbt-crossproject/
 local.sbt
 

--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -140,11 +140,11 @@ If you need to test your copy of Scala Native in the larger context of a
 separate build, you will need to locally publish all the artifacts of Scala
 Native.
 
-You can do this with:
+Use the special script that publishes all the cross versions:
 
 .. code-block:: text
 
-    > publishLocal
+    $ scripts/publish-local
 
 Afterwards, set the version of `sbt-scala-native` in the target project's
 `project/plugins.sbt` to the current SNAPSHOT version of Scala Native, and use

--- a/scripts/publish-impl
+++ b/scripts/publish-impl
@@ -1,0 +1,31 @@
+#!/bin/bash
+# publishSigned or publishLocal
+publish=$1
+
+set -ex
+
+sbt clean
+
+# lowest versions supported
+for v in 2.11.12 2.12.13 2.13.4; do
+  sbt -Dsbt.supershell=false \
+    ++$v \
+    nscplugin/$publish \
+    junitPlugin/$publish \
+    nativelib/$publish \
+    clib/$publish \
+    posixlib/$publish \
+    javalib/$publish \
+    auxlib/$publish \
+    scalalib/$publish \
+    testInterfaceSbtDefs/$publish \
+    testInterface/$publish \
+    junitRuntime/$publish
+done
+
+sbt -Dsbt.supershell=false \
+  util/$publish \
+  nir/$publish \
+  tools/$publish \
+  testRunner/$publish \
+  sbtScalaNative/$publish

--- a/scripts/publish-impl
+++ b/scripts/publish-impl
@@ -15,6 +15,7 @@ for v in 2.11.12 2.12.13 2.13.4; do
     nativelib/$publish \
     clib/$publish \
     posixlib/$publish \
+    windowslib/$publish \
     javalib/$publish \
     auxlib/$publish \
     scalalib/$publish \

--- a/scripts/publish-impl
+++ b/scripts/publish-impl
@@ -6,8 +6,8 @@ set -ex
 
 sbt clean
 
-# lowest versions supported
-for v in 2.11.12 2.12.13 2.13.4; do
+# use the latest versions
+for v in 2.11.12 2.12.14 2.13.6; do
   sbt -Dsbt.supershell=false \
     ++$v \
     nscplugin/$publish \

--- a/scripts/publish-local
+++ b/scripts/publish-local
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+scripts/publish-impl publishLocal

--- a/scripts/release
+++ b/scripts/release
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+# Locally publishSigned won't work because sbt-pgp isn't in project/build.sbt.
+# It's in the global plugins.sbt of the machine running the publishing.
+
 scripts/publish-impl publishSigned

--- a/scripts/release
+++ b/scripts/release
@@ -1,28 +1,3 @@
 #!/bin/bash
 
-set -ex
-
-sbt clean
-
-for v in 2.11.12 2.12.13 2.13.4; do
-  sbt -Dsbt.supershell=false \
-    ++$v \
-    nscplugin/publishSigned \
-    junitPlugin/publishSigned \
-    nativelib/publishSigned \
-    clib/publishSigned \
-    posixlib/publishSigned \
-    javalib/publishSigned \
-    auxlib/publishSigned \
-    scalalib/publishSigned \
-    testInterfaceSbtDefs/publishSigned \
-    testInterface/publishSigned \
-    junitRuntime/publishSigned
-done
-
-sbt -Dsbt.supershell=false \
-  util/publishSigned \
-  nir/publishSigned \
-  tools/publishSigned \
-  testRunner/publishSigned \
-  sbtScalaNative/publishSigned
+scripts/publish-impl publishSigned


### PR DESCRIPTION
The `publish-local` and `release` scripts now call a `publish-impl` script.

Should publish use the oldest versions in the series or the latest? We can fix this depending on the answer and I added a comment for future maintainers.

I was not able to test release as it calls `publishSigned` which errors. If I call `publish` I get errors that I need keys and such which I expect. Not sure what is going on there.


I didn't add a publish for windows yet. Not sure where it goes in the list yet.
