### PR TITLE
Ignore no longer existing objects when inheriting Interflow state

### DIFF
--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -137,8 +137,12 @@ final class State(block: Local) {
   def inherit(other: State, roots: Seq[Val]): Unit = {
     val closure = heapClosure(roots) ++ other.heapClosure(roots)
 
-    closure.foreach { addr =>
-      val clone = other.heap(addr).clone()
+    for {
+      addr <- closure
+      // Ignore keys no longer existing in other state
+      obj <- other.heap.get(addr)
+      clone = obj.clone
+    } {
       clone match {
         case DelayedInstance(op) =>
           delayed(op) = Val.Virtual(addr)

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -141,8 +141,8 @@ final class State(block: Local) {
       addr <- closure
       // Ignore keys no longer existing in other state
       obj <- other.heap.get(addr)
-      clone = obj.clone
     } {
+      val clone = obj.clone()
       clone match {
         case DelayedInstance(op) =>
           delayed(op) = Val.Virtual(addr)

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -809,7 +809,7 @@ class Reach(
   protected def addMissing(global: Global, pos: Position): Unit = {
     val prev = missing.getOrElse(global, Set.empty)
     val position = NonReachablePosition(
-      path = Paths.get(pos.source.getPath),
+      path = Paths.get(pos.source),
       line = pos.line + 1
     )
     missing(global) = prev + position

--- a/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
@@ -1,6 +1,6 @@
 package scala.scalanative
 
-import build.{ScalaNative, Config, Mode}
+import build.{ScalaNative, Config, NativeConfig, Mode}
 
 /** Base class to test the optimizer */
 abstract class OptimizerSpec extends LinkerSpec {
@@ -18,10 +18,14 @@ abstract class OptimizerSpec extends LinkerSpec {
    *  @return
    *    The result of applying `fn` to the resulting definitions.
    */
-  def optimize[T](entry: String, sources: Map[String, String])(
+  def optimize[T](
+      entry: String,
+      sources: Map[String, String],
+      setupConfig: NativeConfig => NativeConfig = identity
+  )(
       fn: (Config, linker.Result) => T
   ): T =
-    link(entry, sources) {
+    link(entry, sources, setupConfig) {
       case (config, linked) =>
         val optimized = ScalaNative.optimize(config, linked)
         fn(config, optimized)


### PR DESCRIPTION
This PR fixes issue leading to failures of `release` builds when using linktime resolved properties. 
When resolving link-time property call to synthesised method is replaced with `Op.Copy` returning a resolved value. 
When inlining such a call, the owner in which given property is defined (eg. `scalanative.LinktimeInfo$`) is never used and might be removed from the given block state. However, we don't check if a given instance is defined in both current and inherited state. This might lead to unhandled NullPointerException and failure of the build.

This PR does also contain fixes for other issues leading to build failure. `Reach.addMissing` now creates `Path` using the dedicated method for URIs, instead of passing String from `URI.getPath`, on Windows such usage will lead to an Invalid Argument exception. 
