### PR TITLE
Provide stubs for POSIX specific implementation on Windows

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
-      
+
       #Prepare environment, clang needs to be installed
       #Compilation on MSVC needs c++14 or higher and expects llvm 11.0.0 or newer
       - name: Cache LLVM
@@ -102,6 +102,8 @@ jobs:
           echo "::set-output name=ProgramFiles::${env:ProgramFiles}"
           echo "::set-output name=LocalAppData::${env:LocalAppData}"
           echo "::set-output name=UserProfile::${env:UserProfile}"
+          echo "::set-output name=VcpkgLibs::${env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows-static"
+
       - name: Cache dependencies
         id: cache-deps
         uses: actions/cache@v2
@@ -121,8 +123,17 @@ jobs:
       - name: Assert clang installed and on path
         run: clang --version
 
+      - name: Install libs
+        run: vcpkg install zlib --triplet=x64-windows-static
+
       - name: Test runtime
-        run: |
-          set SCALANATIVE_GC=${{matrix.gc}}
-          sbt ++${{matrix.scala}};sandbox/run;testsExt/test
+        run: >
+          set SCALANATIVE_GC=${{matrix.gc}}&
+          set SCALANATIVE_INCLUDE_DIRS=${{steps.resolve-env.outputs.VcpkgLibs}}\include&
+          set SCALANATIVE_LIB_DIRS=${{steps.resolve-env.outputs.VcpkgLibs}}\lib&
+          set SCALANATIVE &
+          sbt ++${{matrix.scala}}
+          sandbox/run
+          "tests/testOnly javalib.math.* javalib.security.*"
+          testsExt/test
         shell: cmd

--- a/javalib/src/main/scala/java/lang/ProcessBuilder.scala
+++ b/javalib/src/main/scala/java/lang/ProcessBuilder.scala
@@ -7,7 +7,7 @@ import java.util
 import java.util.Arrays
 import scala.scalanative.unsafe._
 import scala.scalanative.posix.unistd
-import scala.scalanative.runtime.Platform
+import scala.scalanative.meta.LinktimeInfo.isWindows
 import ProcessBuilder.Redirect
 
 final class ProcessBuilder(private var _command: List[String]) {
@@ -106,7 +106,7 @@ final class ProcessBuilder(private var _command: List[String]) {
   def start(): Process = {
     if (_command.isEmpty()) throw new IndexOutOfBoundsException()
     if (_command.contains(null)) throw new NullPointerException()
-    if (Platform.isWindows()) {
+    if (isWindows) {
       val msg = "No windows implementation of java.lang.Process"
       throw new UnsupportedOperationException(msg)
     } else {

--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -236,7 +236,8 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
 
   override def close(): Unit = {
     if (!isClosed) {
-      fd.close()
+      if (isWindows) ???
+      else fd.close()
       fd = InvalidSocketDescriptor
       isClosed = true
     }
@@ -478,10 +479,11 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
 }
 
 private[net] object AbstractPlainSocketImpl {
-  final val InvalidSocketDescriptor = new FileDescriptor
+  final val InvalidSocketDescriptor = new FileDescriptor()
 
   def apply(): AbstractPlainSocketImpl = {
-    if (isWindows) new WindowsPlainSocketImpl()
+    if (isWindows)
+      new WindowsPlainSocketImpl()
     else
       new UnixPlainSocketImpl()
   }

--- a/javalib/src/main/scala/java/nio/file/FileSystems.scala
+++ b/javalib/src/main/scala/java/nio/file/FileSystems.scala
@@ -6,10 +6,15 @@ import java.net.URI
 import java.util.{HashMap, Map}
 
 import scala.scalanative.nio.fs.{UnixFileSystem, UnixFileSystemProvider}
+import scala.scalanative.meta.LinktimeInfo.isWindows
 
 object FileSystems {
-  private lazy val fs =
-    (new UnixFileSystemProvider).getFileSystem(
+  private lazy val fs = {
+    val provider =
+      if (isWindows) ???
+      else new UnixFileSystemProvider()
+
+    provider.getFileSystem(
       new URI(
         scheme = "file",
         userInfo = null,
@@ -20,8 +25,9 @@ object FileSystems {
         fragment = null
       )
     )
-  def getDefault(): FileSystem =
-    fs
+  }
+
+  def getDefault(): FileSystem = fs
 
   def getFileSystem(uri: URI): FileSystem = {
     val provider = findProvider(uri)

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -30,6 +30,7 @@ import java.util.{
 }
 import java.util.stream.{Stream, WrappedScalaStream}
 
+import scalanative.meta.LinktimeInfo.isWindows
 import scalanative.unsigned._
 import scalanative.unsafe._
 import scalanative.libc._
@@ -161,38 +162,48 @@ object Files {
       throw new IOException()
     }
 
-  def createLink(link: Path, existing: Path): Path =
-    Zone { implicit z =>
-      if (exists(link, Array.empty)) {
-        throw new FileAlreadyExistsException(link.toString)
-      } else if (unistd.link(
-            toCString(existing.toString),
-            toCString(link.toString)
-          ) == 0) {
-        link
-      } else {
-        throw new IOException()
-      }
+  def createLink(link: Path, existing: Path): Path = {
+    def tryCreateHardLink() = Zone { implicit z =>
+      if (isWindows) ???
+      else
+        unistd.link(
+          toCString(existing.toString()),
+          toCString(link.toString())
+        ) == 0
     }
+    if (exists(link, Array.empty)) {
+      throw new FileAlreadyExistsException(link.toString)
+    } else if (tryCreateHardLink()) {
+      link
+    } else {
+      throw new IOException("Cannot create link")
+    }
+  }
 
   def createSymbolicLink(
       link: Path,
       target: Path,
       attrs: Array[FileAttribute[_]]
-  ): Path =
-    Zone { implicit z =>
-      if (exists(link, Array.empty)) {
-        throw new FileAlreadyExistsException(target.toString)
-      } else if (unistd.symlink(
-            toCString(target.toString),
-            toCString(link.toString)
-          ) == 0) {
-        setAttributes(link, attrs)
-        link
-      } else {
-        throw new IOException()
+  ): Path = {
+
+    def tryCreateLink() = Zone { implicit z =>
+      if (isWindows) ???
+      else {
+        val targetFilename = toCString(target.toString())
+        val linkFilename = toCString(link.toString())
+        unistd.symlink(targetFilename, linkFilename) == 0
       }
     }
+
+    if (exists(link, Array.empty)) {
+      throw new FileAlreadyExistsException(target.toString)
+    } else if (tryCreateLink()) {
+      setAttributes(link, attrs)
+      link
+    } else {
+      throw new IOException("Cannot create symbolic link")
+    }
+  }
 
   private def createTempDirectory(
       dir: File,
@@ -251,13 +262,14 @@ object Files {
   ): Path =
     createTempFile(null: File, prefix, suffix, attrs)
 
-  def delete(path: Path): Unit =
+  def delete(path: Path): Unit = {
     if (!exists(path, Array.empty)) {
       throw new NoSuchFileException(path.toString)
     } else {
       if (path.toFile().delete()) ()
-      else throw new IOException()
+      else throw new IOException(s"Failed to remove $path")
     }
+  }
 
   def deleteIfExists(path: Path): Boolean =
     try {
@@ -337,7 +349,7 @@ object Files {
       .asInstanceOf[Set[PosixFilePermission]]
 
   def isDirectory(path: Path, options: Array[LinkOption]): Boolean = {
-    val notALink =
+    def notALink =
       if (options.contains(LinkOption.NOFOLLOW_LINKS)) !isSymbolicLink(path)
       else true
     exists(path, options) && notALink && path.toFile().isDirectory()
@@ -352,24 +364,28 @@ object Files {
   def isReadable(path: Path): Boolean =
     path.toFile().canRead()
 
-  def isRegularFile(path: Path, options: Array[LinkOption]): Boolean =
-    Zone { implicit z =>
-      val buf = alloc[stat.stat]
-      val err =
-        if (options.contains(LinkOption.NOFOLLOW_LINKS)) {
-          stat.lstat(toCString(path.toFile().getPath()), buf)
-        } else {
-          stat.stat(toCString(path.toFile().getPath()), buf)
-        }
-      if (err == 0) stat.S_ISREG(buf._13) == 1
-      else false
-    }
+  def isRegularFile(path: Path, options: Array[LinkOption]): Boolean = {
+    if (isWindows) ???
+    else
+      Zone { implicit z =>
+        val buf = alloc[stat.stat]
+        val err =
+          if (options.contains(LinkOption.NOFOLLOW_LINKS)) {
+            stat.lstat(toCString(path.toFile().getPath()), buf)
+          } else {
+            stat.stat(toCString(path.toFile().getPath()), buf)
+          }
+        if (err == 0) stat.S_ISREG(buf._13) == 1
+        else false
+      }
+  }
 
   def isSameFile(path: Path, path2: Path): Boolean =
     path.toFile().getCanonicalPath() == path2.toFile().getCanonicalPath()
 
-  def isSymbolicLink(path: Path): Boolean =
-    Zone { implicit z =>
+  def isSymbolicLink(path: Path): Boolean = Zone { implicit z =>
+    if (isWindows) ???
+    else {
       val buf = alloc[stat.stat]
       if (stat.lstat(toCString(path.toFile().getPath()), buf) == 0) {
         stat.S_ISLNK(buf._13) == 1
@@ -377,6 +393,7 @@ object Files {
         false
       }
     }
+  }
 
   def isWritable(path: Path): Boolean =
     path.toFile().canWrite()
@@ -394,23 +411,38 @@ object Files {
     )
 
   def move(source: Path, target: Path, options: Array[CopyOption]): Path = {
+    lazy val replaceExisting = options.contains(REPLACE_EXISTING)
+
     if (!exists(source.toAbsolutePath(), Array.empty)) {
       throw new NoSuchFileException(source.toString)
-    } else if (!exists(target.toAbsolutePath(), Array.empty) ||
-        options.contains(REPLACE_EXISTING)) {
-      Zone { implicit z =>
-        if (stdio.rename(
-              toCString(source.toAbsolutePath().toString),
-              toCString(target.toAbsolutePath().toString)
-            ) != 0) {
-          throw UnixException(target.toString, errno.errno)
-        }
-      }
+    } else if (!exists(
+          target.toAbsolutePath(),
+          Array.empty
+        ) || replaceExisting) {
+      moveImpl(source, target, replaceExisting)
     } else {
       throw new FileAlreadyExistsException(target.toString)
     }
     target
   }
+
+  private def moveImpl(
+      source: Path,
+      target: Path,
+      replaceExisting: => Boolean
+  ) =
+    Zone { implicit z =>
+      val sourceAbs = source.toAbsolutePath().toString
+      val targetAbs = target.toAbsolutePath().toString
+      if (isWindows) ???
+      else {
+        val sourceCString = toCString(sourceAbs)
+        val targetCString = toCString(targetAbs)
+        if (stdio.rename(sourceCString, targetCString) != 0) {
+          throw UnixException(target.toString, errno.errno)
+        }
+      }
+    }
 
   def newBufferedReader(path: Path): BufferedReader =
     newBufferedReader(path, StandardCharsets.UTF_8)
@@ -490,21 +522,26 @@ object Files {
     }
     val len = pathSize.toInt
     val bytes = scala.scalanative.runtime.ByteArray.alloc(len)
-    val fd = fcntl.open(toCString(path.toString), fcntl.O_RDONLY, 0.toUInt)
-    try {
-      var offset = 0
-      var read = 0
-      while ({
-        read = unistd.read(fd, bytes.at(offset), (len - offset).toUInt);
-        read != -1 && (offset + read) < len
-      }) {
-        offset += read
+
+    if (isWindows) ???
+    else {
+      val pathCString = toCString(path.toString)
+      val fd = fcntl.open(pathCString, fcntl.O_RDONLY, 0.toUInt)
+      try {
+        var offset = 0
+        var read = 0
+        while ({
+          read = unistd.read(fd, bytes.at(offset), (len - offset).toUInt);
+          read != -1 && (offset + read) < len
+        }) {
+          offset += read
+        }
+        if (read == -1) throw UnixException(path.toString, errno.errno)
+      } finally {
+        unistd.close(fd)
       }
-      if (read == -1) throw UnixException(path.toString, errno.errno)
-      bytes.asInstanceOf[Array[Byte]]
-    } finally {
-      unistd.close(fd)
     }
+    bytes.asInstanceOf[Array[Byte]]
   }
 
   def readAllLines(path: Path): List[String] =
@@ -564,16 +601,20 @@ object Files {
       throw new NotLinkException(link.toString)
     } else
       Zone { implicit z =>
-        val buf: CString = alloc[Byte](limits.PATH_MAX.toUInt)
-        if (unistd.readlink(
-              toCString(link.toString),
-              buf,
-              limits.PATH_MAX.toUInt
-            ) == -1) {
-          throw UnixException(link.toString, errno.errno)
-        } else {
-          Paths.get(fromCString(buf), Array.empty)
-        }
+        val name =
+          if (isWindows) ???
+          else {
+            val buf: CString = alloc[Byte](limits.PATH_MAX.toUInt)
+            if (unistd.readlink(
+                  toCString(link.toString),
+                  buf,
+                  limits.PATH_MAX.toUInt
+                ) == -1) {
+              throw UnixException(link.toString, errno.errno)
+            }
+            fromCString(buf)
+          }
+        Paths.get(name, Array.empty)
       }
 
   def setAttribute(
@@ -649,23 +690,24 @@ object Files {
           .list(start.toString, (n, t) => (n, t))
           .toScalaStream
           .flatMap {
-            case (name, tpe)
-                if tpe == DT_LNK() && options.contains(
-                  FileVisitOption.FOLLOW_LINKS
-                ) =>
+            case (name, FileHelpers.FileType.Link)
+                if options.contains(FileVisitOption.FOLLOW_LINKS) =>
               val path = start.resolve(name)
               val newVisited = visited + path
               val target = readSymbolicLink(path)
               if (newVisited.contains(target))
                 throw new FileSystemLoopException(path.toString)
               else walk(path, maxDepth, currentDepth + 1, options, newVisited)
-            case (name, tpe) if tpe == DT_DIR() && currentDepth < maxDepth =>
+
+            case (name, FileHelpers.FileType.Directory)
+                if currentDepth < maxDepth =>
               val path = start.resolve(name)
               val newVisited =
                 if (options.contains(FileVisitOption.FOLLOW_LINKS))
                   visited + path
                 else visited
               walk(path, maxDepth, currentDepth + 1, options, newVisited)
+
             case (name, _) =>
               start.resolve(name) #:: SStream.empty
           }

--- a/javalib/src/main/scala/java/nio/file/spi/FileSystemProvider.scala
+++ b/javalib/src/main/scala/java/nio/file/spi/FileSystemProvider.scala
@@ -19,6 +19,7 @@ import java.nio.channels.{
   SeekableByteChannel
 }
 
+import scala.scalanative.meta.LinktimeInfo.isWindows
 import scala.scalanative.nio.fs.UnixFileSystemProvider
 
 abstract class FileSystemProvider protected () {
@@ -172,7 +173,8 @@ abstract class FileSystemProvider protected () {
 object FileSystemProvider {
   def installedProviders: List[FileSystemProvider] = {
     val list = new LinkedList[FileSystemProvider]
-    list.add(new UnixFileSystemProvider())
+    if (isWindows) ???
+    else list.add(new UnixFileSystemProvider())
     list
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -5,6 +5,7 @@ import java.nio.file.{Files, Path, Paths}
 import scala.sys.process._
 import scalanative.build.IO.RichPath
 import scalanative.compat.CompatParColls.Converters._
+import scalanative.nir.Attr.Link
 
 /** Internal utilities to interact with LLVM command-line tools. */
 private[scalanative] object LLVM {
@@ -93,7 +94,10 @@ private[scalanative] object LLVM {
       outpath: Path
   ): Path = {
     val links = {
-      val srclinks = linkerResult.links.map(_.name)
+      val srclinks = linkerResult.links.collect {
+        case Link("z") if config.targetsWindows => "zlib"
+        case Link(name)                         => name
+      }
       val gclinks = config.gc.links
       // We need extra linking dependencies for:
       // * libdl for our vendored libunwind implementation.

--- a/unit-tests/native/src/test/scala/java/lang/ProcessInheritTest.scala
+++ b/unit-tests/native/src/test/scala/java/lang/ProcessInheritTest.scala
@@ -7,6 +7,8 @@ import java.util.concurrent.TimeUnit
 import scala.scalanative.unsigned._
 import scala.scalanative.unsafe._
 import scala.scalanative.posix.{fcntl, unistd}
+import scala.scalanative.meta.LinktimeInfo.isWindows
+
 import scala.io.Source
 
 import org.junit.Test
@@ -16,14 +18,14 @@ class ProcessInheritTest {
   import javalib.lang.ProcessUtils._
 
   @Test def inherit(): Unit = {
-    val f = Files.createTempFile("/tmp", "out")
-    val savedFD = unistd.dup(unistd.STDOUT_FILENO)
-    val flags = fcntl.O_RDWR | fcntl.O_TRUNC | fcntl.O_CREAT
-    val fd = Zone { implicit z =>
-      fcntl.open(toCString(f.toAbsolutePath.toString), flags, 0.toUInt)
-    }
+    def unixImpl() = {
+      val f = Files.createTempFile("/tmp", "out")
+      val savedFD = unistd.dup(unistd.STDOUT_FILENO)
+      val flags = fcntl.O_RDWR | fcntl.O_TRUNC | fcntl.O_CREAT
+      val fd = Zone { implicit z =>
+        fcntl.open(toCString(f.toAbsolutePath.toString), flags, 0.toUInt)
+      }
 
-    val out =
       try {
         unistd.dup2(fd, unistd.STDOUT_FILENO)
         unistd.close(fd)
@@ -34,7 +36,14 @@ class ProcessInheritTest {
         unistd.dup2(savedFD, unistd.STDOUT_FILENO)
         unistd.close(savedFD)
       }
+    }
 
-    assertEquals(scripts, out.split("\n").toSet)
+    def windowsImpl() = ???
+
+    val out =
+      if (isWindows) windowsImpl()
+      else unixImpl()
+
+    assertEquals(scripts, out.split(System.lineSeparator()).toSet)
   }
 }

--- a/unit-tests/native/src/test/scala/java/lang/SystemWithPosixTest.scala
+++ b/unit-tests/native/src/test/scala/java/lang/SystemWithPosixTest.scala
@@ -4,8 +4,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 class SystemWithPosixTest {
-  @Test def systemCurrentTimeMillisSecondsShouldApproximatePosixTime()()
-      : Unit = {
+  @Test def systemCurrentTimeMillisSecondsShouldApproximatePosixTime(): Unit = {
     // This is a coarse-grain sanity check, primarily to ensure that 64 bit
     // math is being done on 32 bit systems. Only seconds are considered.
 
@@ -26,8 +25,6 @@ class SystemWithPosixTest {
     // Truncate down to keep math simple & reduce number of bits in play.
     val ctmSeconds = ctmMillis / 1000
 
-    val delta = Math.abs(ctmSeconds - cSeconds)
-
-    assert(delta <= tolerance)
+    assertEquals(cSeconds, ctmSeconds, tolerance)
   }
 }

--- a/unit-tests/native/src/test/scala/java/net/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/java/net/UdpSocketTest.scala
@@ -7,22 +7,50 @@ import scalanative.posix.netinet.in._
 import scalanative.posix.netinet.inOps._
 import scalanative.posix.sys.socket._
 import scalanative.posix.sys.socketOps._
-import scalanative.posix.unistd.close
+import scalanative.posix.unistd
 import scalanative.unsafe._
 import scalanative.unsigned._
+import scalanative.meta.LinktimeInfo.isWindows
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 class UdpSocketTest {
   // All tests in this class assume that an IPv4 network is up & running.
+
+  // For some unknown reason inlining content of this method leads to failures
+  // on Unix, probably due to bug in linktime conditions.
+  private def setSocketBlocking(socket: CInt): Unit = {
+    if (isWindows) ???
+    else {
+      assertNotEquals(
+        s"fcntl set blocking",
+        -1,
+        fcntl.fcntl(socket, F_SETFL, O_NONBLOCK)
+      )
+    }
+  }
+
+  private def createAndCheckUdpSocket(): CInt = {
+    if (isWindows) ???
+    else {
+      val sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+      assertNotEquals("socket create", -1, sock)
+      sock
+    }
+  }
+
+  private def closeSocket(socket: CInt): Unit = {
+    if (isWindows) ???
+    else unistd.close(socket)
+  }
 
   @Test def sendtoRecvfrom(): Unit = Zone { implicit z =>
     val localhost = c"127.0.0.1"
     val localhostInetAddr = inet_addr(localhost)
 
-    val inSocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
-    assertNotEquals("socket_1", -1, inSocket)
+    val inSocket: CInt = createAndCheckUdpSocket()
 
     try {
       val inAddr = alloc[sockaddr]
@@ -32,8 +60,7 @@ class UdpSocketTest {
       inAddrInPtr.sin_addr.s_addr = localhostInetAddr
       // inAddrInPtr.sin_port is already the desired 0; "find a free port".
 
-      val fcntlStatus = fcntl.fcntl(inSocket, F_SETFL, O_NONBLOCK)
-      assertNotEquals("fcntl", -1, fcntlStatus)
+      setSocketBlocking(inSocket)
 
       // Get port for sendto() to use.
       val bindStatus = bind(inSocket, inAddr, sizeof[sockaddr].toUInt)
@@ -47,8 +74,7 @@ class UdpSocketTest {
       assertNotEquals("getsockname", -1, gsnStatus)
 
       // Now use port.
-      val outSocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
-      assertNotEquals("socket_2", -1, outSocket)
+      val outSocket = createAndCheckUdpSocket()
 
       try {
         val outAddr = alloc[sockaddr]
@@ -133,13 +159,12 @@ class UdpSocketTest {
 
         // Contents are good.
         assertEquals("recvfrom content", outData, fromCString(inData))
-
       } finally {
-        close(outSocket)
+        closeSocket(outSocket)
       }
 
     } finally {
-      close(inSocket)
+      closeSocket(inSocket)
     }
   }
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/FcntlTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/FcntlTest.scala
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.scalanative.unsafe._
+import scalanative.meta.LinktimeInfo.isWindows
 
 import scalanative.libc.{errno => Cerrno}
 
@@ -11,7 +12,7 @@ import scalanative.posix.sys.stat
 
 class FcntlTest {
 
-  @Test def openPathnameFlagsExistingFile(): Unit = {
+  @Test def openPathnameFlagsExistingFile(): Unit = if (!isWindows) {
 
     Cerrno.errno = 0
     val fileName = c"/dev/null"
@@ -22,7 +23,7 @@ class FcntlTest {
     assertTrue(s"fd == -1 errno: ${Cerrno.errno}", fd != -1)
   }
 
-  @Test def openPathnameFlagsModeExistingFile(): Unit = {
+  @Test def openPathnameFlagsModeExistingFile(): Unit = if (!isWindows) {
 
     Cerrno.errno = 0
     val fileName = c"/dev/null"

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/ResourceTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/ResourceTest.scala
@@ -8,6 +8,7 @@ import org.junit.Assert._
 import scalanative.libc.errno
 import scalanative.posix.errno._
 import scalanative.runtime.Platform
+import scalanative.meta.LinktimeInfo.isWindows
 import scalanative.unsafe.{CInt, Ptr, Zone, alloc}
 import scalanative.unsigned._
 
@@ -35,7 +36,7 @@ class ResourceTest {
 
   case class TestInfo(name: String, value: CInt)
 
-  @Test def getpriorityInvalidArgWhich {
+  @Test def getpriorityInvalidArgWhich() = if (!isWindows) {
     errno.errno = 0
     val invalidWhich = -1
 
@@ -44,7 +45,7 @@ class ResourceTest {
     assertEquals("unexpected errno", EINVAL, errno.errno)
   }
 
-  @Test def getpriorityInvalidArgWho {
+  @Test def getpriorityInvalidArgWho() = if (!isWindows) {
     errno.errno = 0
 
     getpriority(PRIO_PROCESS, UInt.MaxValue)
@@ -62,12 +63,12 @@ class ResourceTest {
     }
   }
 
-  @Test def testGetpriority {
+  @Test def testGetpriority() = if (!isWindows) {
     // format: off
     val cases = Array(TestInfo("PRIO_PROCESS", PRIO_PROCESS),
-                      TestInfo("PRIO_PGRP",    PRIO_PGRP),
-                      TestInfo("PRIO_USER",    PRIO_USER)
-                     )
+      TestInfo("PRIO_PGRP",    PRIO_PGRP),
+      TestInfo("PRIO_USER",    PRIO_USER)
+    )
     // format: on
 
     for (c <- cases) {
@@ -86,7 +87,7 @@ class ResourceTest {
     }
   }
 
-  @Test def getrlimitInvalidArgResource {
+  @Test def getrlimitInvalidArgResource() = if (!isWindows) {
     Zone { implicit z =>
       errno.errno = 0
       val rlimPtr = alloc[rlimit]
@@ -97,17 +98,17 @@ class ResourceTest {
     }
   }
 
-  @Test def testGetrlimit {
+  @Test def testGetrlimit() = if (!isWindows) {
     Zone { implicit z =>
       // format: off
       val cases = Array(TestInfo("RLIMIT_AS",     RLIMIT_AS),
-                        TestInfo("RLIMIT_CORE",   RLIMIT_CORE),
-                        TestInfo("RLIMIT_CPU",    RLIMIT_CPU),
-                        TestInfo("RLIMIT_DATA",   RLIMIT_DATA),
-                        TestInfo("RLIMIT_FSIZE",  RLIMIT_FSIZE),
-                        TestInfo("RLIMIT_NOFILE", RLIMIT_NOFILE),
-                        TestInfo("RLIMIT_STACK",  RLIMIT_STACK)
-                        )
+        TestInfo("RLIMIT_CORE",   RLIMIT_CORE),
+        TestInfo("RLIMIT_CPU",    RLIMIT_CPU),
+        TestInfo("RLIMIT_DATA",   RLIMIT_DATA),
+        TestInfo("RLIMIT_FSIZE",  RLIMIT_FSIZE),
+        TestInfo("RLIMIT_NOFILE", RLIMIT_NOFILE),
+        TestInfo("RLIMIT_STACK",  RLIMIT_STACK)
+      )
       // format: on
 
       for (c <- cases) {
@@ -141,7 +142,7 @@ class ResourceTest {
     }
   }
 
-  @Test def getrusageInvalidArgWho {
+  @Test def getrusageInvalidArgWho() = if (!isWindows) {
     Zone { implicit z =>
       errno.errno = 0
       val rusagePtr = alloc[rusage]
@@ -152,7 +153,7 @@ class ResourceTest {
     }
   }
 
-  @Test def getrusageSelf {
+  @Test def getrusageSelf() = if (!isWindows) {
     Zone { implicit z =>
       errno.errno = 0
       val rusagePtr = alloc[rusage]
@@ -184,7 +185,7 @@ class ResourceTest {
     }
   }
 
-  @Test def getrusageChildren {
+  @Test def getrusageChildren() = if (!isWindows) {
     Zone { implicit z =>
       errno.errno = 0
       val rusagePtr = alloc[rusage]

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
@@ -4,9 +4,11 @@ package unsafe
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import scalanative.unsafe._
 import scalanative.unsigned._
+import scalanative.meta.LinktimeInfo.isWindows
 
 object ExternTest {
   /* These can be nested inside an object but not a class - see #897
@@ -40,6 +42,12 @@ object ExternTest {
 class ExternTest {
 
   @Test def externVariableReadAndAssign(): Unit = {
+    assumeFalse("No getOpt in Windows", isWindows)
+    if (isWindows) ??? //unsupported extern methods
+    else externVariableReadAndAssignUnix()
+  }
+
+  def externVariableReadAndAssignUnix(): Unit = {
     import scala.scalanative.posix.getopt
 
     val args = Seq("skipped", "skipped", "skipped", "-b", "-f", "farg")


### PR DESCRIPTION
This PR continues topic of Windows support in Scala Native, by providing stubs for future, Windows-specific implementation inside `javalib` and `unit-tests` projects. It now allows to compile and run `unit-tests`, by making sure that none of POSIX specific functions would be used on Windows. 
Proper implementation for these stubs would be added in the follow-up PRs. 
By providing stubs, we would be able to run a subset of `unit-tests` and to provide missing implementations in chunks allowing for the better review process. 
This PR also does perform manual mapping of `zlib` library name, which name differs across Unix and Windows platforms. 
CI was updated to provide zlib library and to run subset of `unit-tests` tests. 