### PR TITLE
Source compatibility with Scala 3 for tools

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -10,26 +10,26 @@ sealed abstract class Attr {
 
 object Attr {
   sealed abstract class Inline extends Attr
-  final case object MayInline extends Inline // no information
-  final case object InlineHint extends Inline // user hinted at inlining
-  final case object NoInline extends Inline // should never inline
-  final case object AlwaysInline extends Inline // should always inline
+  case object MayInline extends Inline // no information
+  case object InlineHint extends Inline // user hinted at inlining
+  case object NoInline extends Inline // should never inline
+  case object AlwaysInline extends Inline // should always inline
 
   sealed abstract class Specialize extends Attr
-  final case object MaySpecialize extends Specialize
-  final case object NoSpecialize extends Specialize
+  case object MaySpecialize extends Specialize
+  case object NoSpecialize extends Specialize
 
   sealed abstract class Opt extends Attr
-  final case object UnOpt extends Opt
-  final case object NoOpt extends Opt
-  final case object DidOpt extends Opt
+  case object UnOpt extends Opt
+  case object NoOpt extends Opt
+  case object DidOpt extends Opt
   final case class BailOpt(msg: String) extends Opt
 
-  final case object Dyn extends Attr
-  final case object Stub extends Attr
-  final case object Extern extends Attr
+  case object Dyn extends Attr
+  case object Stub extends Attr
+  case object Extern extends Attr
   final case class Link(name: String) extends Attr
-  final case object Abstract extends Attr
+  case object Abstract extends Attr
 }
 
 final case class Attrs(

--- a/nir/src/main/scala/scala/scalanative/nir/Bins.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Bins.scala
@@ -6,22 +6,22 @@ sealed abstract class Bin {
 }
 
 object Bin {
-  final case object Iadd extends Bin
-  final case object Fadd extends Bin
-  final case object Isub extends Bin
-  final case object Fsub extends Bin
-  final case object Imul extends Bin
-  final case object Fmul extends Bin
-  final case object Sdiv extends Bin
-  final case object Udiv extends Bin
-  final case object Fdiv extends Bin
-  final case object Srem extends Bin
-  final case object Urem extends Bin
-  final case object Frem extends Bin
-  final case object Shl extends Bin
-  final case object Lshr extends Bin
-  final case object Ashr extends Bin
-  final case object And extends Bin
-  final case object Or extends Bin
-  final case object Xor extends Bin
+  case object Iadd extends Bin
+  case object Fadd extends Bin
+  case object Isub extends Bin
+  case object Fsub extends Bin
+  case object Imul extends Bin
+  case object Fmul extends Bin
+  case object Sdiv extends Bin
+  case object Udiv extends Bin
+  case object Fdiv extends Bin
+  case object Srem extends Bin
+  case object Urem extends Bin
+  case object Frem extends Bin
+  case object Shl extends Bin
+  case object Lshr extends Bin
+  case object Ashr extends Bin
+  case object And extends Bin
+  case object Or extends Bin
+  case object Xor extends Bin
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Comps.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Comps.scala
@@ -7,22 +7,22 @@ sealed abstract class Comp {
 
 object Comp {
   sealed abstract class Icmp extends Comp
-  final case object Ieq extends Icmp
-  final case object Ine extends Icmp
-  final case object Ugt extends Icmp
-  final case object Uge extends Icmp
-  final case object Ult extends Icmp
-  final case object Ule extends Icmp
-  final case object Sgt extends Icmp
-  final case object Sge extends Icmp
-  final case object Slt extends Icmp
-  final case object Sle extends Icmp
+  case object Ieq extends Icmp
+  case object Ine extends Icmp
+  case object Ugt extends Icmp
+  case object Uge extends Icmp
+  case object Ult extends Icmp
+  case object Ule extends Icmp
+  case object Sgt extends Icmp
+  case object Sge extends Icmp
+  case object Slt extends Icmp
+  case object Sle extends Icmp
 
   sealed abstract class Fcmp extends Comp
-  final case object Feq extends Fcmp
-  final case object Fne extends Fcmp
-  final case object Fgt extends Fcmp
-  final case object Fge extends Fcmp
-  final case object Flt extends Fcmp
-  final case object Fle extends Fcmp
+  case object Feq extends Fcmp
+  case object Fne extends Fcmp
+  case object Fgt extends Fcmp
+  case object Fge extends Fcmp
+  case object Flt extends Fcmp
+  case object Fle extends Fcmp
 }

--- a/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
@@ -86,7 +86,7 @@ object ControlFlow {
             // first control-flow instruction after the label
             val body = mutable.UnrolledBuffer.empty[Inst]
             var i = k
-            while({
+            while ({
               i += 1
               body += insts(i)
               !insts(i).isInstanceOf[Inst.Cf]

--- a/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/ControlFlow.scala
@@ -86,10 +86,11 @@ object ControlFlow {
             // first control-flow instruction after the label
             val body = mutable.UnrolledBuffer.empty[Inst]
             var i = k
-            do {
+            while({
               i += 1
               body += insts(i)
-            } while (!insts(i).isInstanceOf[Inst.Cf])
+              !insts(i).isInstanceOf[Inst.Cf]
+            }) ()
 
             val block = Block(n, params, body.toSeq, isEntry = k == 0)
             blocks(local) = block

--- a/nir/src/main/scala/scala/scalanative/nir/Convs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Convs.scala
@@ -6,16 +6,16 @@ sealed abstract class Conv {
 }
 
 object Conv {
-  final case object Trunc extends Conv
-  final case object Zext extends Conv
-  final case object Sext extends Conv
-  final case object Fptrunc extends Conv
-  final case object Fpext extends Conv
-  final case object Fptoui extends Conv
-  final case object Fptosi extends Conv
-  final case object Uitofp extends Conv
-  final case object Sitofp extends Conv
-  final case object Ptrtoint extends Conv
-  final case object Inttoptr extends Conv
-  final case object Bitcast extends Conv
+  case object Trunc extends Conv
+  case object Zext extends Conv
+  case object Sext extends Conv
+  case object Fptrunc extends Conv
+  case object Fpext extends Conv
+  case object Fptoui extends Conv
+  case object Fptosi extends Conv
+  case object Uitofp extends Conv
+  case object Sitofp extends Conv
+  case object Ptrtoint extends Conv
+  case object Inttoptr extends Conv
+  case object Bitcast extends Conv
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Global.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Global.scala
@@ -14,7 +14,7 @@ sealed abstract class Global {
     Mangle(this)
 }
 object Global {
-  final case object None extends Global {
+  case object None extends Global {
     override def top: Global.Top =
       throw new Exception("None doesn't have a top.")
     override def member(sig: Sig) =

--- a/nir/src/main/scala/scala/scalanative/nir/Next.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Next.scala
@@ -7,7 +7,7 @@ sealed abstract class Next {
   final def show: String = nir.Show(this)
 }
 object Next {
-  final case object None extends Next {
+  case object None extends Next {
     def name: Local =
       throw new UnsupportedOperationException
   }

--- a/nir/src/main/scala/scala/scalanative/nir/Types.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Types.scala
@@ -27,24 +27,24 @@ object Type {
 
   /** Primitive value types. */
   sealed abstract class PrimitiveKind(val width: Int) extends ValueKind
-  final case object Bool extends PrimitiveKind(1)
-  final case object Ptr extends PrimitiveKind(64)
+  case object Bool extends PrimitiveKind(1)
+  case object Ptr extends PrimitiveKind(64)
 
   sealed abstract class I(width: Int, val signed: Boolean)
       extends PrimitiveKind(width)
   object I {
     def unapply(i: I): Some[(Int, Boolean)] = Some((i.width, i.signed))
   }
-  final case object Char extends I(16, signed = false)
-  final case object Byte extends I(8, signed = true)
-  final case object Short extends I(16, signed = true)
-  final case object Int extends I(32, signed = true)
-  final case object Long extends I(64, signed = true)
+  case object Char extends I(16, signed = false)
+  case object Byte extends I(8, signed = true)
+  case object Short extends I(16, signed = true)
+  case object Int extends I(32, signed = true)
+  case object Long extends I(64, signed = true)
 
   sealed abstract class F(width: Int) extends PrimitiveKind(width)
   object F { def unapply(f: F): Some[Int] = Some(f.width) }
-  final case object Float extends F(32)
-  final case object Double extends F(64)
+  case object Float extends F(32)
+  case object Double extends F(64)
 
   /** Aggregate value types. */
   sealed abstract class AggregateKind extends ValueKind
@@ -72,8 +72,8 @@ object Type {
       case Type.Ref(_, _, n) => n
     }
   }
-  final case object Null extends RefKind
-  final case object Unit extends RefKind
+  case object Null extends RefKind
+  case object Unit extends RefKind
   final case class Array(ty: Type, nullable: Boolean = true) extends RefKind
   final case class Ref(
       name: Global,
@@ -83,9 +83,9 @@ object Type {
 
   /** Second-class types. */
   sealed abstract class SpecialKind extends Type
-  final case object Vararg extends SpecialKind
-  final case object Nothing extends SpecialKind
-  final case object Virtual extends SpecialKind
+  case object Vararg extends SpecialKind
+  case object Nothing extends SpecialKind
+  case object Virtual extends SpecialKind
   final case class Var(ty: Type) extends SpecialKind
   final case class Function(args: Seq[Type], ret: Type) extends SpecialKind
 

--- a/nir/src/main/scala/scala/scalanative/nir/Vals.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Vals.scala
@@ -136,8 +136,8 @@ sealed abstract class Val {
 }
 object Val {
   // low-level
-  final case object True extends Val
-  final case object False extends Val
+  case object True extends Val
+  case object False extends Val
   object Bool extends (Boolean => Val) {
     def apply(value: Boolean): Val =
       if (value) True else False
@@ -147,7 +147,7 @@ object Val {
       case _     => scala.None
     }
   }
-  final case object Null extends Val
+  case object Null extends Val
   final case class Zero(of: nir.Type) extends Val
   final case class Char(value: scala.Char) extends Val
   final case class Byte(value: scala.Byte) extends Val
@@ -182,7 +182,7 @@ object Val {
   final case class Global(name: nir.Global, valty: nir.Type) extends Val
 
   // high-level
-  final case object Unit extends Val
+  case object Unit extends Val
   final case class Const(value: Val) extends Val
   final case class String(value: java.lang.String) extends Val
   final case class Virtual(key: scala.Long) extends Val

--- a/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
+++ b/test-runner/src/main/scala/scala/scalanative/testinterface/ComRunner.scala
@@ -199,7 +199,7 @@ private[testinterface] object ComRunner {
       native2jvm: DataInputStream
   ) extends State
 
-  private final case object Closing extends State
+  private case object Closing extends State
 
   private def writeMsg(s: DataOutputStream, msg: String): Unit = {
     s.writeInt(msg.length)

--- a/tools/src/main/scala/scala/scalanative/build/GC.scala
+++ b/tools/src/main/scala/scala/scalanative/build/GC.scala
@@ -27,15 +27,15 @@ sealed abstract class GC private (
   override def toString: String = name
 }
 object GC {
-  private[scalanative] final case object None
+  private[scalanative] case object None
       extends GC("none", Seq(), Seq("shared"))
-  private[scalanative] final case object Boehm
+  private[scalanative] case object Boehm
       extends GC("boehm", Seq("gc"), Seq())
-  private[scalanative] final case object Immix
+  private[scalanative] case object Immix
       extends GC("immix", Seq(), Seq("shared", "immix_commix"))
-  private[scalanative] final case object Commix
+  private[scalanative] case object Commix
       extends GC("commix", Seq(), Seq("shared", "immix_commix"))
-  private[scalanative] final case object Experimental
+  private[scalanative] case object Experimental
       extends GC("experimental", Seq(), Seq())
 
   /** Non-freeing garbage collector. */

--- a/tools/src/main/scala/scala/scalanative/build/GC.scala
+++ b/tools/src/main/scala/scala/scalanative/build/GC.scala
@@ -27,10 +27,8 @@ sealed abstract class GC private (
   override def toString: String = name
 }
 object GC {
-  private[scalanative] case object None
-      extends GC("none", Seq(), Seq("shared"))
-  private[scalanative] case object Boehm
-      extends GC("boehm", Seq("gc"), Seq())
+  private[scalanative] case object None extends GC("none", Seq(), Seq("shared"))
+  private[scalanative] case object Boehm extends GC("boehm", Seq("gc"), Seq())
   private[scalanative] case object Immix
       extends GC("immix", Seq(), Seq("shared", "immix_commix"))
   private[scalanative] case object Commix

--- a/tools/src/main/scala/scala/scalanative/build/LTO.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LTO.scala
@@ -9,13 +9,13 @@ sealed abstract class LTO private (val name: String) {
 object LTO {
 
   /** LTO disabled */
-  private[scalanative] final case object None extends LTO("none")
+  private[scalanative] case object None extends LTO("none")
 
   /** LTO mode uses ThinLTO */
-  private[scalanative] final case object Thin extends LTO("thin")
+  private[scalanative] case object Thin extends LTO("thin")
 
   /** LTO mode uses standard LTO compilation */
-  private[scalanative] final case object Full extends LTO("full")
+  private[scalanative] case object Full extends LTO("full")
 
   def none: LTO = None
   def thin: LTO = Thin

--- a/tools/src/main/scala/scala/scalanative/build/Mode.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Mode.scala
@@ -17,12 +17,12 @@ sealed abstract class Mode private (val name: String) {
   override def toString: String = name
 }
 object Mode {
-  private[scalanative] final case object Debug extends Mode("debug")
+  private[scalanative] case object Debug extends Mode("debug")
   private[scalanative] sealed trait Release
-  private[scalanative] final case object ReleaseFast
+  private[scalanative] case object ReleaseFast
       extends Mode("release-fast")
       with Release
-  private[scalanative] final case object ReleaseFull
+  private[scalanative] case object ReleaseFull
       extends Mode("release-full")
       with Release
 

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -154,14 +154,14 @@ final class Check(implicit linked: linker.Result) {
     case Op.Extract(aggr, indexes) =>
       aggr.ty match {
         case ty: Type.AggregateKind =>
-          checkAggregateOp(ty, indexes.map(Val.Int), None)
+          checkAggregateOp(ty, indexes.map(Val.Int(_)), None)
         case _ =>
           error(s"extract is only defined on aggregate types, not ${aggr.ty}")
       }
     case Op.Insert(aggr, value, indexes) =>
       aggr.ty match {
         case ty: Type.AggregateKind =>
-          checkAggregateOp(ty, indexes.map(Val.Int), Some(value.ty))
+          checkAggregateOp(ty, indexes.map(Val.Int(_)), Some(value.ty))
         case _ =>
           error(s"insert is only defined on aggregate types, not ${aggr.ty}")
       }

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -85,7 +85,7 @@ object CodeGen {
     ): AbstractCodeGen = {
       new AbstractCodeGen(config, env, defns) {
         override val os: OsCompat = {
-          if (config.targetsWindows) new WindowsCompat(this)
+          if (this.config.targetsWindows) new WindowsCompat(this)
           else new UnixCompat(this)
         }
       }

--- a/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 /** Created by lukaskellenberger on 17.12.16.
  */
 object GenerateReflectiveProxies {
-  implicit val fresh = Fresh()
+  implicit val fresh: Fresh = Fresh()
 
   private def genReflProxy(defn: Defn.Define): Defn.Define = {
     val Global.Member(owner, sig) = defn.name

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -12,7 +12,8 @@ import scalanative.linker.{
   ClassRef,
   TraitRef,
   FieldRef,
-  MethodRef
+  MethodRef,
+  Result
 }
 import scalanative.interflow.UseDef.eliminateDeadCode
 
@@ -24,7 +25,7 @@ object Lower {
   private final class Impl(implicit meta: Metadata) extends Transform {
     import meta._
 
-    implicit val linked = meta.linked
+    implicit val linked: Result = meta.linked
 
     val Object = linked.infos(Rt.Object.name).asInstanceOf[Class]
 
@@ -1125,7 +1126,7 @@ object Lower {
             rtti(CharArrayCls).const,
             charsLength,
             Val.Int(0), // padding to get next field aligned properly
-            Val.ArrayValue(Type.Char, chars.toSeq.map(Val.Char))
+            Val.ArrayValue(Type.Char, chars.toSeq.map(Val.Char(_)))
           )
         )
       )

--- a/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/PerfectHashMap.scala
@@ -193,7 +193,7 @@ object DynmethodPerfectHashMap {
           List(
             Val.Int(perfectHashMap.size),
             Val.Const(
-              Val.ArrayValue(Type.Int, perfectHashMap.keys.map(Val.Int))
+              Val.ArrayValue(Type.Int, perfectHashMap.keys.map(Val.Int(_)))
             ),
             Val.Const(Val.ArrayValue(Type.Int, keys)),
             Val.Const(Val.ArrayValue(Type.Ptr, values))

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -146,7 +146,7 @@ trait Eval { self: Interflow =>
 
           dtarget match {
             case Val.Global(name, _) if shallInline(name, eargs) =>
-             `inline`(name, eargs)
+              `inline`(name, eargs)
             case DelayedRef(op: Op.Method) if shallPolyInline(op, eargs) =>
               polyInline(op, eargs)
             case _ =>

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -146,7 +146,7 @@ trait Eval { self: Interflow =>
 
           dtarget match {
             case Val.Global(name, _) if shallInline(name, eargs) =>
-              inline(name, eargs)
+             `inline`(name, eargs)
             case DelayedRef(op: Op.Method) if shallPolyInline(op, eargs) =>
               polyInline(op, eargs)
             case _ =>

--- a/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Inline.scala
@@ -131,7 +131,7 @@ trait Inline { self: Interflow =>
     }
   }
 
-  def inline(name: Global, args: Seq[Val])(implicit
+  def `inline`(name: Global, args: Seq[Val])(implicit
       state: State,
       linked: linker.Result,
       origPos: Position

--- a/tools/src/main/scala/scala/scalanative/interflow/Kind.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Kind.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package interflow
 
 sealed abstract class Kind
-final object ClassKind extends Kind
-final object ArrayKind extends Kind
-final object BoxKind extends Kind
-final object StringKind extends Kind
+object ClassKind extends Kind
+object ArrayKind extends Kind
+object BoxKind extends Kind
+object StringKind extends Kind

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -205,7 +205,7 @@ final class MergeProcessor(
         // Retry until no new escapes are found
 
         var retries = 0
-        do {
+        while( {
           retries += 1
           mergeFresh = Fresh(merge.id)
           mergeLocals.clear()
@@ -223,7 +223,8 @@ final class MergeProcessor(
           if (retries > 128) {
             throw BailOut("too many state merge retries")
           }
-        } while (newEscapes.nonEmpty)
+          newEscapes.nonEmpty
+        })()
 
         // Wrap up anre rturn a new merge state
 

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -205,7 +205,7 @@ final class MergeProcessor(
         // Retry until no new escapes are found
 
         var retries = 0
-        while( {
+        while ({
           retries += 1
           mergeFresh = Fresh(merge.id)
           mergeLocals.clear()
@@ -224,7 +224,7 @@ final class MergeProcessor(
             throw BailOut("too many state merge retries")
           }
           newEscapes.nonEmpty
-        })()
+        }) ()
 
         // Wrap up anre rturn a new merge state
 
@@ -467,9 +467,7 @@ final class MergeProcessor(
 }
 
 object MergeProcessor {
-  case object Restart
-      extends Exception
-      with scala.util.control.NoStackTrace
+  case object Restart extends Exception with scala.util.control.NoStackTrace
 
   def fromEntry(
       insts: Array[Inst],

--- a/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/MergeProcessor.scala
@@ -466,7 +466,7 @@ final class MergeProcessor(
 }
 
 object MergeProcessor {
-  final case object Restart
+  case object Restart
       extends Exception
       with scala.util.control.NoStackTrace
 

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -172,7 +172,8 @@ final class Class(
           info.implementors.contains(this)
         case info: Class =>
           info.subclasses.contains(this)
-        case null => false
+        case _ =>
+          false
       }
     }
   }

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -172,8 +172,7 @@ final class Class(
           info.implementors.contains(this)
         case info: Class =>
           info.subclasses.contains(this)
-        case _ =>
-          false
+        case null => false
       }
     }
   }

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -193,7 +193,7 @@ private[linker] object LinktimeValueResolver {
             )
           }
 
-        case null => None
+        case _ => None
       }
     }.map(_.asInstanceOf[ComparableTupleType])
   }

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -193,7 +193,7 @@ private[linker] object LinktimeValueResolver {
             )
           }
 
-        case _ => None
+        case null => None
       }
     }.map(_.asInstanceOf[ComparableTupleType])
   }

--- a/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
+++ b/util/src/main/scala/scala/scalanative/io/VirtualDirectory.scala
@@ -178,7 +178,7 @@ object VirtualDirectory {
     }
   }
 
-  private final object EmptyDirectory extends VirtualDirectory {
+  private object EmptyDirectory extends VirtualDirectory {
 
     val uri: URI = URI.create("")
 

--- a/util/src/main/scala/scala/scalanative/util/UnreachableException.scala
+++ b/util/src/main/scala/scala/scalanative/util/UnreachableException.scala
@@ -1,4 +1,4 @@
 package scala.scalanative
 package util
 
-final case object UnreachableException extends Exception
+case object UnreachableException extends Exception


### PR DESCRIPTION
This PR introduces changes allowing for compilation of sources in `tools`, `nir` and `util` projects allowing for cross-compilation with Scala 3. Changes include: 
* removal of `final` modifier for `object`s - redundant in Scala 2, syntax warning in Scala 3
* quoted used of `inline` method as it's a keyword in Scala 3
* fixed some ambiguous definitions - when `config` is both member of a newly created class instance and argument of the function. 
* added missing type definitions of implicit parameters
* removal of do-while loops, as they're deprecated in Scala 3
