### PR TITLE
Fix #2313: Defect in j.n.InetAddress#createIPStringFromByteArray

### DIFF
--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -520,6 +520,9 @@ private[net] trait InetAddressBase {
             buffer.append('0')
           buffer.append(':')
         }
+        if ((i & 1) != 0 && (i + 1) == ipByteArray.length && isFirst) {
+          buffer.append('0')
+        }
       }
       return buffer.toString
     }

--- a/unit-tests/shared/src/test/scala/javalib/net/Inet6AddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/Inet6AddressTest.scala
@@ -113,4 +113,10 @@ class Inet6AddressTest {
     Inet6Address.getByAddress("123", addr2, -1)
   }
 
+  // Issue 2313
+  @Test def trailing0NotLost(): Unit = {
+    val addr = InetAddress.getByName("1c1e::")
+    assertTrue(addr.getHostAddress().endsWith("0"))
+  }
+
 }


### PR DESCRIPTION
Previously, createIPStringFromByteArray would ignore last group if it was equal to 0. A simple test for the issue was added as well. Since JVM uses lowercase characters in String addresses, explicit String comparison would not work here. 