### PR TITLE
if Windows, append .exe to binaryName in discover(), to support mingw64 and cygwin compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-# vim
-*.swp
 scalalib/src/
 scala-partest/fetchedSources/
 target/
@@ -34,3 +32,6 @@ bin/
 
 # vscode
 /.vscode/
+
+# vim
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# vim
+*.swp
 scalalib/src/
 scala-partest/fetchedSources/
 target/

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -150,7 +150,7 @@ object Discover {
 
     val command: Seq[String] = {
       if (Platform.isWindows) {
-        val binName = s"$binaryName.exe"
+        val binName = s"${binaryName}.exe"
         val arg = binPath.fold(binName)(p => s"$p:$binName")
         Seq("where", arg)
       } else {

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -150,7 +150,8 @@ object Discover {
 
     val command: Seq[String] = {
       if (Platform.isWindows) {
-        val arg = binPath.fold(binaryName)(p => s"$p:$binaryName")
+        val binName = s"$binaryName.exe"
+        val arg = binPath.fold(binName)(p => s"$p:$binName")
         Seq("where", arg)
       } else {
         val arg = binPath.fold(binaryName) { p =>


### PR DESCRIPTION
This change enables discovery of `clang.exe` and `clang++.exe`,  in these environments:
```
CYGWIN_NT-10.0 d5 3.2.0(0.340/5/3) 2021-03-29 08:42 x86_64 Cygwin
MSYS_NT-10.0-19042 d5 3.2.0-340.x86_64 2021-07-02 08:36 UTC x86_64 Msys
```
Also verified that discovery still works when first `clang` in the PATH is here:
```
C:/Program Files (x86)/Microsoft Visual Studio/2019/Preview/VC/Tools/Llvm/x64
```
