### PR TITLE
Correct BufferedInputStream mark() and  close() behaviour

### DIFF
--- a/javalib/src/main/scala/java/io/BufferedInputStream.scala
+++ b/javalib/src/main/scala/java/io/BufferedInputStream.scala
@@ -1,132 +1,273 @@
 package java.io
 
-class BufferedInputStream(_in: InputStream, size: Int)
+/* The protected fields combined with the expectation that close is not synchronized with read
+ * requires some care.
+ *
+ * References:
+ *
+ * - https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4225348
+ * - https://issues.apache.org/jira/browse/HARMONY-6014
+ *
+ * Mark support makes lenient use of the "might" and "may"s in the spec.
+ */
+class BufferedInputStream(_in: InputStream, initialSize: Int)
     extends FilterInputStream(_in)
     with Closeable
     with AutoCloseable {
 
-  if (size <= 0) throw new IllegalArgumentException("Buffer size <= 0")
+  if (initialSize <= 0) throw new IllegalArgumentException("Buffer size <= 0")
 
   def this(in: InputStream) = this(in, 8192)
 
+  // per spec close will release system resources. This implies buf should be set to null
+  // post close to ensure GC can release this resource
   /** The internal buffer array where the data is stored. */
-  protected[this] var buf = new Array[Byte](size)
+  protected[this] var buf = new Array[Byte](initialSize)
 
-  /** The index one greater than the index of the last valid byte in the buffer.
-   */
-  protected[this] var count = 0
+  /** The index one greater than the index of the last valid byte in the buffer. */
+  protected[this] var count: Int = 0
 
-  /** The maximum read ahead allowed after a call to the mark method before
-   *  subsequent calls to the reset method fail..
+  private[this] var closed: Boolean = false
+
+  /** The maximum read ahead allowed after a call to the mark method before subsequent calls to the
+   *  reset method fail.
    */
-  private[this] var markLimit = 0
+  protected[this] var marklimit: Int = 0
 
   /** The value of the pos field at the time the last mark method was called. */
-  private[this] var markpos = -1
+  protected[this] var markpos: Int = -1
 
   /** The current position in the buffer. */
-  protected[this] var pos = 0
-
-  private[this] var closed = false
-
-  /** The position of the last element in the buffer excluded */
-  private[this] var end = 0
+  protected[this] var pos: Int = 0
 
   override def available(): Int = {
-    if (closed) throw new IOException()
-    end - pos + in.available()
-  }
-
-  override def close(): Unit = {
-    closed = true
-  }
-
-  override def mark(readLimit: Int): Unit = {
-    if (!closed) {
-      val srcBuf = buf
-      if (buf.size < readLimit)
-        buf = new Array[Byte](readLimit)
-
-      // Move data to beginning of buffer
-      if (pos != 0 || (buf ne srcBuf))
-        System.arraycopy(srcBuf, pos, buf, 0, end - pos)
-
-      // Update internal state
-      end -= pos
-      pos = 0
-      markpos = 0
+    val (_, in) = ensureOpen()
+    synchronized {
+      in.available() + count - pos
     }
+  }
+
+  // from spec: "closing a previously closed stream has no effect"
+  override def close(): Unit = {
+    if (!closed) {
+      closed = true
+      val in = this.in
+      if (in != null)
+        in.close()
+      // from spec "releases any system resources associated".
+      // implies
+      this.in = null
+      buf = null
+    }
+  }
+
+  // https://github.com/scala-native/scala-native/pull/1767#discussion_r423120768
+  private def ensureOpen(): (Array[Byte], InputStream) = {
+    /* First read `in` and `buf`, then `closed`. Since `closed` is the first thing
+     *  that is set to `true` in `close()`, we know that if `closed` is false, the
+     *  `in` and `buf` are non-null.
+     */
+    val in  = this.in
+    val buf = this.buf
+    if (closed)
+      throw new IOException("Operation on closed stream")
+    (buf, in)
+  }
+
+  override def mark(readLimit: Int): Unit = synchronized {
+    marklimit = readLimit
+    markpos = pos
   }
 
   override def markSupported(): Boolean = true
 
-  override def read(): Int = {
-    ensureOpen()
+  /* Reads up to sourceBuffer.length bytes from the source input stream.
+   * This will also replace `buf` if a larger buffer is required to handle mark.
+   *
+   * postcondition: markpos invalidated if pos - markpos exceeds marklimit. Not exactly at the
+   * boundary tho as this is only a "may" in spec.
+   *
+   * @returns buf
+   */
+  private def fillBuffer(sourceBuffer: Array[Byte],
+                         source: InputStream): Option[Array[Byte]] = {
+    if (markpos != -1 && (pos - markpos <= marklimit))
+      fillMarkedBuffer(sourceBuffer, source)
+    else
+      fillUnmarkedBuffer(sourceBuffer, source)
+  }
 
-    if (prepareRead()) {
-      val res = buf(pos).toInt & 0xff
-      pos += 1
-      res
-    } else -1
+  private def fillUnmarkedBuffer(sourceBuffer: Array[Byte],
+                                 source: InputStream): Option[Array[Byte]] = {
+    // mark is always invalidated in this case
+    marklimit = 0
+    markpos = -1
+
+    val bytesRead = source.read(sourceBuffer)
+
+    if (bytesRead == -1) {
+      pos = 0
+      count = 0
+      None
+    } else {
+      pos = 0
+      count = bytesRead
+      Some(sourceBuffer)
+    }
+  }
+
+  /* For mark (markpos == -1) the logic is:
+   * If there is space in the current buffer: read into buffer starting at `count`
+   *
+   * If there is no space in the current buffer: create a larger buffer, copy old, read into larger
+   * buffer starting at `count`.
+   *
+   * The mark is not invalidated in this method: Per spec there is no requirement to invalidate mark
+   * *exactly* when pos - markpos exceeds marklimit. This is "generous" and migh permit a reset
+   * beyond marklimit.
+   */
+  private def fillMarkedBuffer(sourceBuffer: Array[Byte],
+                               source: InputStream): Option[Array[Byte]] = {
+    val buffer = if (count < sourceBuffer.length) {
+      sourceBuffer
+    } else {
+      val newBuffer = new Array[Byte](sourceBuffer.length * 2)
+      sourceBuffer.copyToArray(newBuffer)
+      buf = newBuffer
+      if (closed)
+        buf = null
+      newBuffer
+    }
+
+    val bytesRead = source.read(buffer, count, buffer.length - count)
+    if (bytesRead == -1)
+      None
+    else {
+      count += bytesRead
+      Some(buffer)
+    }
+  }
+
+  // can block
+  // returns -1 on end of stream
+  // otherwise returns next byte of data
+  // or throws IOException
+  override def read(): Int = {
+    val (buf, in) = ensureOpen()
+
+    synchronized {
+      if (pos < count) {
+        val res = buf(pos).toInt
+        pos += 1
+        res
+      } else {
+        fillBuffer(buf, in) match {
+          case None => -1
+          case Some(nextBuffer) => {
+            val res = nextBuffer(pos).toInt
+            pos += 1
+            res
+          }
+        }
+      }
+    }
   }
 
   override def read(b: Array[Byte], off: Int, len: Int): Int = {
-    ensureOpen()
+    val (buf, in) = ensureOpen()
 
     if (off < 0 || len < 0 || len > b.length - off)
       throw new IndexOutOfBoundsException
 
     if (len == 0) 0
-    else if (prepareRead()) {
-      val count = Math.min(len, end - pos)
-      System.arraycopy(this.buf, pos, b, off, count)
-      pos += count
-      count
-    } else -1
+    else {
+      synchronized {
+        unsafeRead(b, off, len, buf, in)
+      }
+    }
+  }
+
+  private def unsafeRead(targetBuffer: Array[Byte],
+                         initialOffset: Int,
+                         requested: Int,
+                         initialBuffer: Array[Byte],
+                         source: InputStream): Int = {
+    var sourceBuffer: Array[Byte] = initialBuffer
+    var remaining: Int            = requested
+    var targetOffset: Int         = initialOffset
+    var bytesRead: Int            = 0
+
+    while (remaining > 0) {
+      if (pos + remaining <= count) {
+        // all remaining can be read from the source buffer
+        System.arraycopy(sourceBuffer,
+                         pos,
+                         targetBuffer,
+                         targetOffset,
+                         remaining)
+        pos += remaining
+        bytesRead += remaining
+        remaining = 0
+      } else {
+        val available = count - pos
+        if (available > 0) {
+          System.arraycopy(sourceBuffer,
+                           pos,
+                           targetBuffer,
+                           targetOffset,
+                           available)
+        }
+
+        // fill source buffer from source stream
+        fillBuffer(sourceBuffer, source) match {
+          // end of source stream
+          case None => {
+            if (available == 0)
+              bytesRead = -1
+            else
+              bytesRead += available
+
+            remaining = 0
+          }
+          // source read into nextBuffer
+          case Some(nextBuffer) => {
+            sourceBuffer = nextBuffer
+            targetOffset += available
+            bytesRead += available
+
+            remaining -= available
+          }
+        }
+      }
+    }
+
+    bytesRead
   }
 
   override def reset(): Unit = {
     ensureOpen()
 
-    if (markpos == -1) throw new IOException("Mark invalid")
-    pos = 0
-  }
+    synchronized {
+      if (markpos == -1) throw new IOException("Mark invalid")
 
-  override def skip(n: Long): Long = {
-    if (n < 0) throw new IllegalArgumentException("n negative")
-    else if (pos < end) {
-      val count = Math.min(n, end - pos).toInt
-      pos += count
-      count.toLong
-    } else {
-      markpos = -1
-      in.skip(n)
+      pos = markpos
     }
   }
 
-  /** Prepare the buffer for reading. Returns false if EOF */
-  private def prepareRead(): Boolean =
-    pos < end || fillBuffer()
-
-  /** Tries to fill the buffer. Returns false if EOF */
-  private def fillBuffer(): Boolean = {
-    if (markpos >= 0 && end < buf.length) {
-      // we may not do a full re-read, since we'll damage the mark.
-      val read = in.read(buf, end, buf.length - end)
-      if (read > 0) // protect from adding -1
-        end += read
-      read > 0
-    } else {
-      // Full re-read
-      markpos = -1
-      end = in.read(buf)
-      pos = 0
-      end > 0
+  // TODO: inefficient
+  // per spec: if n is < 0 then no bytes are skipped and the return value is 0
+  override def skip(n: Long): Long =
+    if (n <= 0) 0
+    else {
+      var actual = 0
+      var eos    = false
+      while (!eos && actual < n) {
+        if (read() == -1) {
+          eos = true
+        } else {
+          actual += 1
+        }
+      }
+      actual
     }
-  }
-
-  private def ensureOpen(): Unit = {
-    if (closed)
-      throw new IOException("Operation on closed stream")
-  }
 }

--- a/unit-tests/shared/src/test/scala/javalib/io/BufferedInputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/BufferedInputStreamTest.scala
@@ -8,22 +8,20 @@ import org.junit.Assert._
 import scalanative.junit.utils.AssertThrows.assertThrows
 
 class BufferedInputStreamTest {
+  private val exampleBytes0 =
+    List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
 
   @Test def bufferOfNegativeSizeThrowsIllegalArgumentException(): Unit = {
     assertThrows(
       classOf[IllegalArgumentException], {
-        val inputArray =
-          List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
-        val arrayIn = new ByteArrayInputStream(inputArray, 0, 10)
+        val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
         val in = new BufferedInputStream(arrayIn, -1)
       }
     )
   }
 
   @Test def simpleReads(): Unit = {
-    val inputArray =
-      List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
-    val arrayIn = new ByteArrayInputStream(inputArray, 0, 10)
+    val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
     val in = new BufferedInputStream(arrayIn)
     assertTrue(in.read() == 0)
     assertTrue(in.read() == 1)
@@ -35,6 +33,23 @@ class BufferedInputStreamTest {
       a(0) == 3 && a(1) == 4 && a(2) == 5 &&
         a(3) == 6 && a(4) == 7 && a(5) == 8 && a(6) == 9
     )
+  }
+
+  @Test def simpleArrayRead(): Unit = {
+    val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
+    val in = new BufferedInputStream(arrayIn)
+    val a = new Array[Byte](7)
+
+    assertEquals(3, in.skip(3))
+    assertEquals(7, in.read(a, 0, 7))
+
+    assertEquals(3, a(0))
+    assertEquals(4, a(1))
+    assertEquals(5, a(2))
+    assertEquals(6, a(3))
+    assertEquals(7, a(4))
+    assertEquals(8, a(5))
+    assertEquals(9, a(6))
   }
 
   @Test def readValueBiggerThan0x7f(): Unit = {
@@ -57,9 +72,7 @@ class BufferedInputStreamTest {
   }
 
   @Test def readIntoArrayWithBadIndexOrLengthThrowsException(): Unit = {
-    val inputArray =
-      List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
-    val arrayIn = new ByteArrayInputStream(inputArray, 0, 10)
+    val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
     val in = new BufferedInputStream(arrayIn)
     val a = new Array[Byte](10)
     assertThrows(classOf[java.lang.IndexOutOfBoundsException], in.read(a, 8, 7))
@@ -71,48 +84,95 @@ class BufferedInputStreamTest {
       classOf[java.lang.IndexOutOfBoundsException],
       in.read(a, -1, 7)
     )
-  }
-
-  @Test def readArrayBehavesCorrectlyWhenAskingForElementsInBuffer(): Unit = {
-    val inputArray =
-      List(0, 1, 2).map(_.toByte).toArray[Byte]
-    val arrayIn = new ByteArrayInputStream(inputArray, 0, 10)
-    val in = new BufferedInputStream(arrayIn)
-    val a = new Array[Byte](10)
     assertThrows(
       classOf[java.lang.IndexOutOfBoundsException],
-      in.read(a, 0, 10)
+      in.read(a, 0, 11)
     )
   }
 
-  @Test def markAndResetBehaveCorrectly(): Unit = {
-    val inputArray =
-      List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte).toArray[Byte]
-    val arrayIn = new ByteArrayInputStream(inputArray, 0, 10)
+  @Test def readArrayBehavesCorrectlyWhenAskingForElementsInBuffer(): Unit = {
+    val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
+    // start with buffer of size 2 to force multiple refills of the buffer
+    val in = new BufferedInputStream(arrayIn, 2)
+    val a = new Array[Byte](10)
+    in.read(a, 0, 10)
+    assertArrayEquals(exampleBytes0, a)
+  }
+
+  /* interestingly... failing is not technically required according to the
+   * InputStream or BufferedInputStream spec.
+   */
+  @Test def resetThrowsIOExceptionIfNoPriorMark(): Unit = {
+    val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
     val in = new BufferedInputStream(arrayIn)
     in.read()
     in.read()
     in.read()
-    assertThrows(classOf[IOException], in.reset())
 
-    in.mark(3)
-    assertTrue(in.read() == 3)
-    assertTrue(in.read() == 4)
-    assertTrue(in.read() == 5)
+    assertThrows(classOf[IOException], in.reset())
+  }
+
+  @Test def resetMovesPositionToMark_NoBufferResize(): Unit = {
+    val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
+    val in = new BufferedInputStream(arrayIn, 10)
+    in.mark(Int.MaxValue)
+
+    assertEquals(0, in.read())
+    assertEquals(1, in.read())
+    assertEquals(2, in.read())
 
     in.reset()
-    assertTrue(in.read() == 3)
-    assertTrue(in.read() == 4)
-    assertTrue(in.read() == 5)
-    assertTrue(in.read() == 6)
-    assertTrue(in.read() == 7)
-    assertTrue(in.read() == 8)
-    assertTrue(in.read() == 9)
+
+    assertEquals(0, in.read())
+    assertEquals(1, in.read())
+    assertEquals(2, in.read())
+  }
+
+  @Test def resetMovesPositionToMark_WithBufferResize(): Unit = {
+    val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
+    val in = new BufferedInputStream(arrayIn, 2)
+    in.mark(Int.MaxValue)
+
+    assertEquals(0, in.read())
+    assertEquals(1, in.read())
+    assertEquals(2, in.read())
+
+    in.reset()
+
+    assertEquals(0, in.read())
+    assertEquals(1, in.read())
+    assertEquals(2, in.read())
+  }
+
+  // there is no requirement in the spec that the mark is invalidated
+  // exactly when read limit bytes exceeded: the exception "might be thrown"
+  @Test def markIsInvalidatedAfterReadLimitBytesAndBufferExceeded(): Unit = {
+    val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
+    val in = new BufferedInputStream(arrayIn, 2)
+
+    in.mark(2)
+
+    assertEquals(0, in.read())
+    assertEquals(1, in.read())
+
+    in.reset()
+
+    // read enough to definitely invalidate mark
+    for (_ <- 0 until 5) in.read()
+
+    assertThrows(classOf[IOException], in.reset())
+  }
+
+  @Test def availableAfterCloseThrowsIOException(): Unit = {
+    val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
+    val in = new BufferedInputStream(arrayIn)
+
+    in.close()
+    assertThrows(classOf[IOException], in.available())
   }
 
   @Test def availableBehaveCorrectly(): Unit = {
-    val inputArray = Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).map(_.toByte)
-    val in = new BufferedInputStream(new ByteArrayInputStream(inputArray))
+    val in = new BufferedInputStream(new ByteArrayInputStream(exampleBytes0))
     assertTrue(in.available() > 0)
 
     val tmp = new Array[Byte](10)


### PR DESCRIPTION
This is a rebased PR fixing re-implementing BufferedInputStream, originally published by @coreyoconnor #1767 

Original PR was rebased onto the current HEAD and adjusted to the new test suites layout.