### PR TITLE
Implement java.io for Windows

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # We need to set proper Pagefile limits in the advance. 
+      # We need to set proper Pagefile limits in advance. 
       - name: Configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.2
         with:

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -86,13 +86,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-2019 ]
-        scala: [ 2.13.6, 2.12.14, 2.11.12 ]
+        os: [windows-2019]
+        scala: [2.13.6, 2.12.14, 2.11.12]
         gc: [none, immix, commix]
     steps:
       - uses: actions/checkout@v2
 
-      # We need to set proper Pagefile limits in advance. 
+      # We need to set proper Pagefile limits in advance.
+      # Github actions default page file size is quite small,
+      # it's not enough to run all tests, especially when using None GC.
+      # We've observed that on Unix memory management is less strict,
+      # you can reserve more memory than it's physically possible.
+      # On Windows however you need to reserve/commit memory in advance -
+      # it does not matter whether it would be used or not, the amount of all
+      # reserved memory cannot exceed the amount of physically available storage.
       - name: Configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.2
         with:

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -133,6 +133,8 @@ jobs:
           set SCALANATIVE &
           sbt ++${{matrix.scala}}
           sandbox/run
-          "tests/testOnly javalib.math.* javalib.security.*"
+          "testsJVM/testOnly javalib.math.* javalib.security.* javalib.io.*"
+          "tests/testOnly javalib.math.* javalib.security.* javalib.io.*"
           testsExt/test
+          testsExtJVM/test
         shell: cmd

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -92,6 +92,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # We need to set proper Pagefile limits in the advance. 
+      - name: Configure Pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+        with:
+          minimum-size: 4GB
+          maximum-size: 16GB
+
       #Prepare environment, clang needs to be installed
       #Compilation on MSVC needs c++14 or higher and expects llvm 11.0.0 or newer
       #Cache commonly used files: Coursier, ivy cache

--- a/javalib/src/main/scala/java/io/ByteArrayOutputStream.scala
+++ b/javalib/src/main/scala/java/io/ByteArrayOutputStream.scala
@@ -1,5 +1,7 @@
 package java.io
 
+import java.nio.charset.Charset
+
 class ByteArrayOutputStream(initBufSize: Int) extends OutputStream {
 
   protected var buf: Array[Byte] = new Array(initBufSize)
@@ -45,6 +47,9 @@ class ByteArrayOutputStream(initBufSize: Int) extends OutputStream {
 
   def toString(charsetName: String): String =
     new String(buf, 0, count, charsetName)
+
+  def toString(charset: Charset): String =
+    new String(buf, 0, count, charset)
 
   private def growBuf(minIncrement: Int): Unit = {
     val newSize = Math.max(count + minIncrement, buf.length * 2)

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -906,7 +906,7 @@ object File {
    *  Otherwise, returns `None`.
    */
   private def readLink(link: CString)(implicit z: Zone): CString = {
-    val bufferSize =
+    val bufferSize: CSize =
       if (isWindows) FileApiExt.MAX_PATH
       else limits.PATH_MAX - `1U`
     val buffer: CString = alloc[Byte](bufferSize)
@@ -923,7 +923,7 @@ object File {
         def pathLength = GetFinalPathNameByHandleA(
           fileHandle,
           buffer = buffer,
-          bufferSize = bufferSize,
+          bufferSize = bufferSize.toUInt,
           flags = finalPathFlags
         )
 

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -87,7 +87,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
 
   def setExecutable(executable: Boolean, ownerOnly: Boolean): Boolean = {
     if (isWindows) {
-      // Windows (JVM) does not allow for setting setting as not executable
+      // Windows (JVM) does not allow for setting a file as not executable
       if (!executable) false
       else {
         val accessRights = FILE_GENERIC_EXECUTE

--- a/javalib/src/main/scala/java/io/FileDescriptor.scala
+++ b/javalib/src/main/scala/java/io/FileDescriptor.scala
@@ -54,9 +54,9 @@ final class FileDescriptor private[java] (
     def isStdOrInvalidFileDescriptor: Boolean = {
       if (isWindows) {
         handle == INVALID_HANDLE_VALUE ||
-          this == FileDescriptor.in ||
-          this == FileDescriptor.out ||
-          this == FileDescriptor.err
+        this == FileDescriptor.in ||
+        this == FileDescriptor.out ||
+        this == FileDescriptor.err
 
       } else fd <= 2
     }

--- a/javalib/src/main/scala/java/io/FileDescriptor.scala
+++ b/javalib/src/main/scala/java/io/FileDescriptor.scala
@@ -50,15 +50,18 @@ final class FileDescriptor private[java] (
     def throwSyncFailed(): Unit = {
       throw new SyncFailedException("sync failed")
     }
-    def isStdFileDescriptor: Boolean = {
+
+    def isStdOrInvalidFileDescriptor: Boolean = {
       if (isWindows) {
-        this == FileDescriptor.in ||
-        this == FileDescriptor.out ||
-        this == FileDescriptor.err
+        handle == INVALID_HANDLE_VALUE ||
+          this == FileDescriptor.in ||
+          this == FileDescriptor.out ||
+          this == FileDescriptor.err
+
       } else fd <= 2
     }
 
-    if (isStdFileDescriptor) throwSyncFailed()
+    if (isStdOrInvalidFileDescriptor) throwSyncFailed()
     else {
       if (!readOnly) {
         val hasSucceded =

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -82,7 +82,7 @@ object FileOutputStream {
       if (isWindows) {
         val handle = CreateFileW(
           toCWideStringUTF16LE(file.getPath()),
-          desiredAccess = FILE_GENERIC_WRITE,
+          desiredAccess = if (append) FILE_APPEND_DATA else FILE_GENERIC_WRITE,
           shareMode = FILE_SHARE_READ | FILE_SHARE_WRITE,
           securityAttributes = null,
           creationDisposition =
@@ -91,8 +91,9 @@ object FileOutputStream {
           flagsAndAttributes = 0.toUInt,
           templateFile = null
         )
+
         if (handle == INVALID_HANDLE_VALUE) {
-          throw new FileNotFoundException(s"$file (${GetLastError()})")
+          throw new FileNotFoundException(file.toString())
         }
         new FileDescriptor(FileDescriptor.FileHandle(handle), readOnly = false)
       } else {

--- a/javalib/src/main/scala/java/io/PrintStream.scala
+++ b/javalib/src/main/scala/java/io/PrintStream.scala
@@ -178,7 +178,7 @@ class PrintStream private (
   }
 
   def println(): Unit = ensureOpenAndTrapIOExceptions {
-    encoder.write('\n') // In Scala.js the line separator is always LF
+    encoder.write(System.lineSeparator())
     encoder.flushBuffer()
     if (autoFlush)
       flush()

--- a/javalib/src/main/scala/java/io/PrintWriter.scala
+++ b/javalib/src/main/scala/java/io/PrintWriter.scala
@@ -1,14 +1,18 @@
 package java.io
 
 import java.util.Formatter
+import java.nio.charset.Charset
 
 class PrintWriter(protected[io] var out: Writer, autoFlush: Boolean)
     extends Writer {
 
   def this(out: Writer) = this(out, false)
 
+  def this(out: OutputStream, autoFlush: Boolean, charset: Charset) =
+    this(new OutputStreamWriter(out, charset), autoFlush)
+
   def this(out: OutputStream, autoFlush: Boolean) =
-    this(new OutputStreamWriter(out), autoFlush)
+    this(out, autoFlush, Charset.defaultCharset())
 
   def this(out: OutputStream) =
     this(out, false)
@@ -29,15 +33,20 @@ class PrintWriter(protected[io] var out: Writer, autoFlush: Boolean)
   def this(file: File) =
     this(new BufferedOutputStream(new FileOutputStream(file)))
 
-  def this(file: File, csn: String) =
+  def this(file: File, charset: Charset) =
     this(
       new OutputStreamWriter(
         new BufferedOutputStream(new FileOutputStream(file)),
-        csn
+        charset
       )
     )
 
+  def this(file: File, csn: String) = this(file, Charset.forName(csn))
+
   def this(fileName: String) = this(new File(fileName))
+
+  def this(fileName: String, charset: Charset) =
+    this(new File(fileName), charset)
 
   def this(fileName: String, csn: String) = this(new File(fileName), csn)
 
@@ -105,7 +114,7 @@ class PrintWriter(protected[io] var out: Writer, autoFlush: Boolean)
   def print(obj: AnyRef): Unit = write(String.valueOf(obj))
 
   def println(): Unit = {
-    write('\n') // In Scala.js the line separator is always LF
+    write(System.lineSeparator())
     if (autoFlush)
       flush()
   }

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -13,7 +13,7 @@ import scala.scalanative.windows.FileApi._
 import scala.scalanative.windows.FileApiExt.MAX_PATH
 import scala.scalanative.windows.UserEnvApi._
 import scala.scalanative.windows.WinBaseApi._
-import scala.scalanative.windows.ProcessEnv._
+import scala.scalanative.windows.ProcessEnvApi._
 import scala.scalanative.windows.winnt.AccessToken
 
 final class System private ()

--- a/javalib/src/main/scala/java/nio/file/WindowsException.scala
+++ b/javalib/src/main/scala/java/nio/file/WindowsException.scala
@@ -1,25 +1,29 @@
 package java.nio.file
 
-import java.io.IOException
-import java.nio.charset.StandardCharsets
-import scala.scalanative.libc.{errno => stdErrno}
-import scala.scalanative.posix.errno._
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
+import scalanative.libc.{string, errno => stdErrno}
+import scalanative.posix.errno.ENOTDIR
+import java.io.IOException
+import java.nio.charset.StandardCharsets
 import scala.scalanative.windows._
 import scala.scalanative.windows.ErrorHandlingApi._
-import scala.scalanative.windows.ErrorCodes._
+import scala.scalanative.windows.ErrorHandlingApiOps.errorMessage
 import scala.scalanative.windows.WinBaseApi._
-import scala.scalanative.windows.WinBaseApiExt._
 
 private[java] trait WindowsException extends Exception
 private[java] object WindowsException {
   def apply(msg: String): WindowsException = {
-    val err = GetLastError()
-    new IOException(s"$msg - ${errorMessage(err)} ($err)") with WindowsException
+    WindowsException(msg, GetLastError())
+  }
+
+  def apply(msg: String, errorCode: DWord): WindowsException = {
+    new IOException(s"$msg - ${errorMessage(errorCode)} ($errorCode)")
+      with WindowsException
   }
 
   def onPath(file: String): IOException = {
+    import ErrorCodes._
     lazy val e = stdErrno.errno
     val winError = GetLastError()
     winError match {
@@ -33,20 +37,4 @@ private[java] object WindowsException {
     }
   }
 
-  private def errorMessage(errCode: DWord): String = Zone { implicit z =>
-    val msgBuffer = stackalloc[CWString]
-    FormatMessageW(
-      flags = FORMAT_MESSAGE_ALLOCATE_BUFFER |
-        FORMAT_MESSAGE_FROM_SYSTEM |
-        FORMAT_MESSAGE_IGNORE_INSERTS,
-      source = null,
-      messageId = errCode,
-      languageId = DefaultLanguageId,
-      buffer = msgBuffer,
-      size = 0.toUInt,
-      arguments = null
-    )
-    fromCWideString(!msgBuffer, StandardCharsets.UTF_16LE)
-      .stripSuffix(System.lineSeparator())
-  }
 }

--- a/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
+++ b/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
@@ -1,12 +1,18 @@
 package java.util
 
 import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
 import java.io.IOException
 import scala.scalanative.windows.ProcessThreadsApi._
 import scala.scalanative.windows.HandleApi._
 import scala.scalanative.windows.HandleApiExt._
 import scala.scalanative.windows.FileApiExt._
+import scala.scalanative.windows.ErrorHandlingApi._
 import scala.scalanative.windows._
+import scala.scalanative.windows.winnt._
+import winnt.AccessToken._
+import scala.scalanative.windows.SecurityBaseApi._
+import java.nio.file.WindowsException
 
 private[java] object WindowsHelperMethods {
   def withUserToken[T](desiredAccess: DWord)(fn: Handle => T): T = {
@@ -31,6 +37,65 @@ private[java] object WindowsHelperMethods {
     }
   }
 
+  def withImpersonatedToken[T](fn: Handle => T): T = {
+    withUserToken(
+      TOKEN_IMPERSONATE | TOKEN_READ | TOKEN_DUPLICATE
+    ) { tokenHandle =>
+      val impersonatedToken = stackalloc[Handle]
+      if (!DuplicateToken(
+            tokenHandle,
+            SecurityImpersonation,
+            impersonatedToken
+          )) {
+        throw new RuntimeException("Cannot impersonate access token")
+      }
+
+      try {
+        fn(!impersonatedToken)
+      } finally HandleApi.CloseHandle(!impersonatedToken)
+    }
+  }
+
+  def withTokenInformation[T, R](
+      token: Handle,
+      informationClass: TokenInformationClass
+  )(fn: Ptr[T] => R)(implicit z: Zone): R = {
+    val dataSize = alloc[DWord]
+    !dataSize = 0.toUInt
+
+    if (!GetTokenInformation(
+          token,
+          informationClass,
+          information = null,
+          informationLength = !dataSize,
+          returnLength = dataSize
+        )) {
+      GetLastError() match {
+        case ErrorCodes.ERROR_INSUFFICIENT_BUFFER => ()
+        case errCode =>
+          throw WindowsException(
+            s"Cannot determinate size for token informaiton $informationClass",
+            errCode
+          )
+      }
+    }
+
+    val data = alloc[Byte](!dataSize)
+    if (!GetTokenInformation(
+          token,
+          informationClass,
+          information = data,
+          informationLength = !dataSize,
+          returnLength = dataSize
+        )) {
+      throw WindowsException(
+        s"Failed to get data for token informaiton $informationClass"
+      )
+    }
+
+    fn(data.asInstanceOf[Ptr[T]])
+  }
+
   def withFileOpen[T](
       path: String,
       access: DWord,
@@ -52,9 +117,7 @@ private[java] object WindowsHelperMethods {
       try { fn(handle) }
       finally CloseHandle(handle)
     } else {
-      throw new IOException(
-        s"Cannot open file ${path}: ${ErrorHandlingApi.GetLastError()}"
-      )
+      throw WindowsException(s"Cannot open file ${path}")
     }
   }
 }

--- a/unit-tests/jvm/src/test/resources/BlacklistedTests.txt
+++ b/unit-tests/jvm/src/test/resources/BlacklistedTests.txt
@@ -2,11 +2,6 @@
 # In most cases, both javalib implementation 
 # and tests need to be changed
 
-scala/javalib/io/FileDescriptorTest.scala
-scala/javalib/io/FileInputStreamTest.scala
-scala/javalib/io/BufferedInputStreamTest.scala
-scala/javalib/io/BufferedOutputStreamTest.scala
-
 scala/javalib/lang/RuntimeTest.scala
 scala/javalib/lang/CharacterTest.scala
 scala/javalib/lang/IntegerTest.scala

--- a/unit-tests/jvm/src/test/scala/utils/Platform.scala
+++ b/unit-tests/jvm/src/test/scala/utils/Platform.scala
@@ -22,5 +22,7 @@ object Platform {
 
   final val hasCompliantAsInstanceOfs = true
 
-  final val isFreeBSD = System.getProperty("os.name").equals("FreeBSD")
+  private val osNameProp = System.getProperty("os.name")
+  final val isFreeBSD = osNameProp.equals("FreeBSD")
+  final val isWindows = osNameProp.toLowerCase.startsWith("windows")
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/ResourceTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/ResourceTest.scala
@@ -66,9 +66,9 @@ class ResourceTest {
   @Test def testGetpriority() = if (!isWindows) {
     val cases = Array(
       TestInfo("PRIO_PROCESS", PRIO_PROCESS),
-                      TestInfo("PRIO_PGRP",    PRIO_PGRP),
-                      TestInfo("PRIO_USER",    PRIO_USER)
-                     )
+      TestInfo("PRIO_PGRP", PRIO_PGRP),
+      TestInfo("PRIO_USER", PRIO_USER)
+    )
 
     for (c <- cases) {
       errno.errno = 0
@@ -101,13 +101,13 @@ class ResourceTest {
     Zone { implicit z =>
       val cases = Array(
         TestInfo("RLIMIT_AS", RLIMIT_AS),
-                        TestInfo("RLIMIT_CORE",   RLIMIT_CORE),
-                        TestInfo("RLIMIT_CPU",    RLIMIT_CPU),
-                        TestInfo("RLIMIT_DATA",   RLIMIT_DATA),
-                        TestInfo("RLIMIT_FSIZE",  RLIMIT_FSIZE),
-                        TestInfo("RLIMIT_NOFILE", RLIMIT_NOFILE),
-                        TestInfo("RLIMIT_STACK",  RLIMIT_STACK)
-                        )
+        TestInfo("RLIMIT_CORE", RLIMIT_CORE),
+        TestInfo("RLIMIT_CPU", RLIMIT_CPU),
+        TestInfo("RLIMIT_DATA", RLIMIT_DATA),
+        TestInfo("RLIMIT_FSIZE", RLIMIT_FSIZE),
+        TestInfo("RLIMIT_NOFILE", RLIMIT_NOFILE),
+        TestInfo("RLIMIT_STACK", RLIMIT_STACK)
+      )
 
       for (c <- cases) {
         errno.errno = 0

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/ResourceTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/ResourceTest.scala
@@ -66,9 +66,9 @@ class ResourceTest {
   @Test def testGetpriority() = if (!isWindows) {
     val cases = Array(
       TestInfo("PRIO_PROCESS", PRIO_PROCESS),
-      TestInfo("PRIO_PGRP",    PRIO_PGRP),
-      TestInfo("PRIO_USER",    PRIO_USER)
-    )
+                      TestInfo("PRIO_PGRP",    PRIO_PGRP),
+                      TestInfo("PRIO_USER",    PRIO_USER)
+                     )
 
     for (c <- cases) {
       errno.errno = 0
@@ -101,13 +101,13 @@ class ResourceTest {
     Zone { implicit z =>
       val cases = Array(
         TestInfo("RLIMIT_AS", RLIMIT_AS),
-        TestInfo("RLIMIT_CORE",   RLIMIT_CORE),
-        TestInfo("RLIMIT_CPU",    RLIMIT_CPU),
-        TestInfo("RLIMIT_DATA",   RLIMIT_DATA),
-        TestInfo("RLIMIT_FSIZE",  RLIMIT_FSIZE),
-        TestInfo("RLIMIT_NOFILE", RLIMIT_NOFILE),
-        TestInfo("RLIMIT_STACK",  RLIMIT_STACK)
-      )
+                        TestInfo("RLIMIT_CORE",   RLIMIT_CORE),
+                        TestInfo("RLIMIT_CPU",    RLIMIT_CPU),
+                        TestInfo("RLIMIT_DATA",   RLIMIT_DATA),
+                        TestInfo("RLIMIT_FSIZE",  RLIMIT_FSIZE),
+                        TestInfo("RLIMIT_NOFILE", RLIMIT_NOFILE),
+                        TestInfo("RLIMIT_STACK",  RLIMIT_STACK)
+                        )
 
       for (c <- cases) {
         errno.errno = 0

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/ResourceTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/ResourceTest.scala
@@ -66,8 +66,8 @@ class ResourceTest {
   @Test def testGetpriority() = if (!isWindows) {
     val cases = Array(
       TestInfo("PRIO_PROCESS", PRIO_PROCESS),
-      TestInfo("PRIO_PGRP", PRIO_PGRP),
-      TestInfo("PRIO_USER", PRIO_USER)
+      TestInfo("PRIO_PGRP",    PRIO_PGRP),
+      TestInfo("PRIO_USER",    PRIO_USER)
     )
 
     for (c <- cases) {
@@ -101,12 +101,12 @@ class ResourceTest {
     Zone { implicit z =>
       val cases = Array(
         TestInfo("RLIMIT_AS", RLIMIT_AS),
-        TestInfo("RLIMIT_CORE", RLIMIT_CORE),
-        TestInfo("RLIMIT_CPU", RLIMIT_CPU),
-        TestInfo("RLIMIT_DATA", RLIMIT_DATA),
-        TestInfo("RLIMIT_FSIZE", RLIMIT_FSIZE),
+        TestInfo("RLIMIT_CORE",   RLIMIT_CORE),
+        TestInfo("RLIMIT_CPU",    RLIMIT_CPU),
+        TestInfo("RLIMIT_DATA",   RLIMIT_DATA),
+        TestInfo("RLIMIT_FSIZE",  RLIMIT_FSIZE),
         TestInfo("RLIMIT_NOFILE", RLIMIT_NOFILE),
-        TestInfo("RLIMIT_STACK", RLIMIT_STACK)
+        TestInfo("RLIMIT_STACK",  RLIMIT_STACK)
       )
 
       for (c <- cases) {

--- a/unit-tests/native/src/test/scala/utils/Platform.scala
+++ b/unit-tests/native/src/test/scala/utils/Platform.scala
@@ -20,5 +20,7 @@ object Platform {
 
   final val hasCompliantAsInstanceOfs = true
 
-  final val isFreeBSD = System.getProperty("os.name").equals("FreeBSD")
+  private val osNameProp = System.getProperty("os.name")
+  final val isFreeBSD = osNameProp.equals("FreeBSD")
+  final val isWindows = osNameProp.toLowerCase.startsWith("windows")
 }

--- a/unit-tests/shared/src/test/scala/javalib/io/BufferedInputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/BufferedInputStreamTest.scala
@@ -4,8 +4,10 @@ import java.io._
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform.executingInJVM
 
 class BufferedInputStreamTest {
   private val exampleBytes0 =
@@ -91,6 +93,7 @@ class BufferedInputStreamTest {
   }
 
   @Test def readArrayBehavesCorrectlyWhenAskingForElementsInBuffer(): Unit = {
+    assumeFalse("Not complient with JDK", executingInJVM)
     val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
     // start with buffer of size 2 to force multiple refills of the buffer
     val in = new BufferedInputStream(arrayIn, 2)

--- a/unit-tests/shared/src/test/scala/javalib/io/BufferedInputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/BufferedInputStreamTest.scala
@@ -7,7 +7,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
-import org.scalanative.testsuite.utils.Platform.executingInJVM
+import scalanative.junit.utils.AssumesHelper._
 
 class BufferedInputStreamTest {
   private val exampleBytes0 =
@@ -93,7 +93,7 @@ class BufferedInputStreamTest {
   }
 
   @Test def readArrayBehavesCorrectlyWhenAskingForElementsInBuffer(): Unit = {
-    assumeFalse("Not complient with JDK", executingInJVM)
+    assumeNotJVMCompliant()
     val arrayIn = new ByteArrayInputStream(exampleBytes0, 0, 10)
     // start with buffer of size 2 to force multiple refills of the buffer
     val in = new BufferedInputStream(arrayIn, 2)

--- a/unit-tests/shared/src/test/scala/javalib/io/BufferedOutputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/BufferedOutputStreamTest.scala
@@ -9,7 +9,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
-import org.scalanative.testsuite.utils.Platform.executingInJVM
+import scalanative.junit.utils.AssumesHelper._
 
 class BufferedOutputStreamTest {
 
@@ -348,7 +348,7 @@ class BufferedOutputStreamTest {
   }
 
   @Test def writeToClosedBufferThrowsIOException(): Unit = {
-    assumeFalse("Not complient with JDK", executingInJVM)
+    assumeNotJVMCompliant()
     val out = new BufferedOutputStream(new ByteArrayOutputStream())
     out.close()
     assertThrows(classOf[java.io.IOException], out.write(1))

--- a/unit-tests/shared/src/test/scala/javalib/io/BufferedOutputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/BufferedOutputStreamTest.scala
@@ -6,8 +6,10 @@ import java.io._
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform.executingInJVM
 
 class BufferedOutputStreamTest {
 
@@ -346,6 +348,7 @@ class BufferedOutputStreamTest {
   }
 
   @Test def writeToClosedBufferThrowsIOException(): Unit = {
+    assumeFalse("Not complient with JDK", executingInJVM)
     val out = new BufferedOutputStream(new ByteArrayOutputStream())
     out.close()
     assertThrows(classOf[java.io.IOException], out.write(1))

--- a/unit-tests/shared/src/test/scala/javalib/io/DataInputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/DataInputStreamTest.scala
@@ -9,7 +9,7 @@ package javalib.io
 import java.io._
 
 import scala.scalanative.junit.utils.AssertThrows.assertThrows
-import org.scalanative.testsuite.utils.Platform.executingInJVM
+import scala.scalanative.junit.utils.AssumesHelper._
 
 import org.junit._
 import org.junit.Assert._
@@ -301,7 +301,7 @@ trait DataInputStreamTest {
   }
 
   @Test def markReadLinePushBack(): Unit = {
-    assumeFalse("Not supported on JDK", executingInJVM)
+    assumeNotJVMCompliant()
 
     val stream = newStream(
       "Hello World\nUNIX\nWindows\r\nMac (old)\rStuff".map(_.toInt): _*

--- a/unit-tests/shared/src/test/scala/javalib/io/FileDescriptorTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/FileDescriptorTest.scala
@@ -7,7 +7,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
-import org.scalanative.testsuite.utils.Platform.executingInJVM
+import scalanative.junit.utils.AssumesHelper._
 
 class FileDescriptorTest {
   val in = FileDescriptor.in
@@ -26,17 +26,17 @@ class FileDescriptorTest {
   }
 
   @Test def syncShouldThrowSyncFailedExceptionForStdin(): Unit = {
-    assumeFalse("Not complient with JDK", executingInJVM)
+    assumeNotJVMCompliant()
     assertThrows(classOf[SyncFailedException], in.sync())
   }
 
   @Test def syncShouldThrowSyncFailedExceptionForStdout(): Unit = {
-    assumeFalse("Not complient with JDK", executingInJVM)
+    assumeNotJVMCompliant()
     assertThrows(classOf[SyncFailedException], out.sync())
   }
 
   @Test def syncShouldThrowSyncFailedExceptionForStderr(): Unit = {
-    assumeFalse("Not complient with JDK", executingInJVM)
+    assumeNotJVMCompliant()
     assertThrows(classOf[SyncFailedException], err.sync())
   }
 

--- a/unit-tests/shared/src/test/scala/javalib/io/FileDescriptorTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/FileDescriptorTest.scala
@@ -4,8 +4,10 @@ import java.io._
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform.executingInJVM
 
 class FileDescriptorTest {
   val in = FileDescriptor.in
@@ -24,14 +26,17 @@ class FileDescriptorTest {
   }
 
   @Test def syncShouldThrowSyncFailedExceptionForStdin(): Unit = {
+    assumeFalse("Not complient with JDK", executingInJVM)
     assertThrows(classOf[SyncFailedException], in.sync())
   }
 
   @Test def syncShouldThrowSyncFailedExceptionForStdout(): Unit = {
+    assumeFalse("Not complient with JDK", executingInJVM)
     assertThrows(classOf[SyncFailedException], out.sync())
   }
 
   @Test def syncShouldThrowSyncFailedExceptionForStderr(): Unit = {
+    assumeFalse("Not complient with JDK", executingInJVM)
     assertThrows(classOf[SyncFailedException], err.sync())
   }
 

--- a/unit-tests/shared/src/test/scala/javalib/io/FileInputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/FileInputStreamTest.scala
@@ -7,32 +7,34 @@ import scala.util.Try
 import org.junit.Test
 import org.junit.Assert._
 
+import org.scalanative.testsuite.utils.Platform.isWindows
 import scalanative.junit.utils.AssertThrows.assertThrows
 
 class FileInputStreamTest {
+  // On Windows new File(".") is not valid input file
+  val file =
+    if (isWindows) new File("NUL")
+    else new File(".")
+
   @Test def readNull(): Unit = {
-    val file = new File(".")
     val fis = new FileInputStream(file)
     assertThrows(classOf[NullPointerException], fis.read(null))
     assertThrows(classOf[NullPointerException], fis.read(null, 0, 0))
   }
 
   @Test def readOutOfBoundsNegativeCount(): Unit = {
-    val file = new File(".")
     val fis = new FileInputStream(file)
     val arr = new Array[Byte](8)
     assertThrows(classOf[IndexOutOfBoundsException], fis.read(arr, 0, -1))
   }
 
   @Test def readOutOfBoundsNegativeOffset(): Unit = {
-    val file = new File(".")
     val fis = new FileInputStream(file)
     val arr = new Array[Byte](8)
     assertThrows(classOf[IndexOutOfBoundsException], fis.read(arr, -1, 0))
   }
 
   @Test def readOutOfBoundsArrayTooSmall(): Unit = {
-    val file = new File(".")
     val fis = new FileInputStream(file)
     val arr = new Array[Byte](8)
     assertThrows(classOf[IndexOutOfBoundsException], fis.read(arr, 0, 16))

--- a/unit-tests/shared/src/test/scala/javalib/io/FileInputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/FileInputStreamTest.scala
@@ -11,10 +11,10 @@ import org.scalanative.testsuite.utils.Platform.isWindows
 import scalanative.junit.utils.AssertThrows.assertThrows
 
 class FileInputStreamTest {
-  // On Windows new File(".") is not valid input file
+  // On JVM new File(".") is not valid input file
   val file =
     if (isWindows) new File("NUL")
-    else new File(".")
+    else new File("/dev/null")
 
   @Test def readNull(): Unit = {
     val fis = new FileInputStream(file)

--- a/unit-tests/shared/src/test/scala/javalib/io/FileOutputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/FileOutputStreamTest.scala
@@ -4,6 +4,8 @@ import java.io._
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
+import org.scalanative.testsuite.utils.Platform.isWindows
 
 import scalanative.junit.utils.AssertThrows.assertThrows
 
@@ -97,6 +99,10 @@ class FileOutputStreamTest {
   }
 
   @Test def attemptToCreateFileInReadonlyDirectory(): Unit = {
+    assumeFalse(
+      "Setting directory read only in Windows does not have affect on creating new files",
+      isWindows
+    )
     withTempDirectory { ro =>
       ro.setReadOnly()
       assertThrows(

--- a/unit-tests/shared/src/test/scala/javalib/io/FileOutputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/FileOutputStreamTest.scala
@@ -5,7 +5,7 @@ import java.io._
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import org.scalanative.testsuite.utils.Platform.isWindows
+import org.scalanative.testsuite.utils.Platform._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
 
@@ -93,6 +93,10 @@ class FileOutputStreamTest {
   }
 
   @Test def attemptToOpenDirectory(): Unit = {
+    assumeTrue(
+      "Uses not yet implemented java.nio methods",
+      !isWindows || executingInJVM
+    )
     withTempDirectory { dir =>
       assertThrows(classOf[FileNotFoundException], new FileOutputStream(dir))
     }

--- a/unit-tests/shared/src/test/scala/javalib/io/FileTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/FileTest.scala
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform.isWindows
 
 class FileTest {
 
@@ -29,13 +30,19 @@ class FileTest {
   @Test def getUriFromFile(): Unit = {
     val u1 = new File("path").toURI
     assertNotNull(u1)
-    assertTrue(u1.getScheme == "file")
+    assertEquals("file", u1.getScheme)
     assertTrue(u1.getPath.endsWith("path"))
 
-    val u2 = new File("/path/to/file.txt").toURI
+    val absPathString =
+      if (isWindows) raw"C:\path\to\file.txt"
+      else "/path/to/file.txt"
+    val expectedPath =
+      if (isWindows) "/C:/path/to/file.txt"
+      else absPathString
+    val u2 = new File(absPathString).toURI
     assertNotNull(u2)
-    assertTrue(u2.getScheme == "file")
-    assertTrue(u2.getPath.endsWith("file.txt"))
-    assertTrue(u2.toString == "file:/path/to/file.txt")
+    assertEquals("file", u2.getScheme)
+    assertEquals(expectedPath, u2.getPath())
+    assertEquals(s"file:$expectedPath", u2.toString)
   }
 }

--- a/unit-tests/shared/src/test/scala/javalib/io/FileWriterTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/FileWriterTest.scala
@@ -8,7 +8,10 @@ import org.junit.Assert._
 class FileWriterTest {
 
   @Test def writeToNewFile(): Unit = {
-    val path = "/tmp/new.file"
+    val tmpDir = System.getProperty("java.io.tmpdir")
+    assertNotEquals("Not set sys tmp directory property", null, tmpDir)
+
+    val path = s"$tmpDir/new.file"
     val toWrite = "something"
 
     val fw = new FileWriter(path)

--- a/unit-tests/shared/src/test/scala/javalib/io/PrintStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/PrintStreamTest.scala
@@ -5,13 +5,17 @@ import java.io._
 import org.junit.Test
 
 import scalanative.junit.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform.isWindows
 
 class PrintStreamTest {
 
   @Test def printStreamOutputStreamStringWithUnsupportedEncoding(): Unit = {
+    // Make sure to not use /dev/null on Windows leading to FileNotFoundException
+    // On JVM charset check happens before file exists checks
+    val devNull = if (isWindows) "NUL" else "/dev/null"
     assertThrows(
       classOf[java.io.UnsupportedEncodingException],
-      new PrintStream(new File("/dev/null"), "unsupported encoding")
+      new PrintStream(new File(devNull), "unsupported encoding")
     )
   }
 

--- a/unit-tests/shared/src/test/scala/javalib/io/RandomAccessFileTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/RandomAccessFileTest.scala
@@ -52,8 +52,8 @@ class RandomAccessFileTest {
     // assign to var for @After to close
     raf = new RandomAccessFile(file, "r")
     val fd = raf.getFD
-    assertTrue(fd.valid())
-    assertTrue(Try(fd.sync()).isSuccess)
+    assertTrue("Invalid FD", fd.valid())
+    assertTrue("Failed to sync", Try(fd.sync()).isSuccess)
   }
 
   @Test def canWriteAndReadBoolean(): Unit = {

--- a/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
@@ -14,7 +14,6 @@ import scala.collection.{mutable => mu}
 
 import scala.reflect.ClassTag
 import scala.scalanative.junit.utils.CollectionConverters._
-import org.scalanative.testsuite.utils.Platform.executingInJVM
 
 trait MapTest {
   import MapTest._
@@ -23,11 +22,17 @@ trait MapTest {
 
   def testObj(i: Int): TestObj = TestObj(i)
 
+  // temporary until Platform is introduced
+  val executingInJVM = false
+
+  // replace when new IdentityHashMap from Scala.js
+  // private def assumeNotIdentityHashMapOnJVM(): Unit =
+  //   assumeFalse("JVM vs Native cache differences",
+  //               executingInJVM && factory.isIdentityBased)
+
+  // temp implementation
   private def assumeNotIdentityHashMapOnJVM(): Unit =
-    assumeFalse(
-      "JVM vs Native cache differences",
-      executingInJVM && factory.isIdentityBased
-    )
+    assumeFalse("JVM vs Native cache differences", factory.isIdentityBased)
 
   @Test def shouldStoreStrings(): Unit = {
     val mp = factory.empty[String, String]

--- a/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
@@ -14,6 +14,7 @@ import scala.collection.{mutable => mu}
 
 import scala.reflect.ClassTag
 import scala.scalanative.junit.utils.CollectionConverters._
+import org.scalanative.testsuite.utils.Platform.executingInJVM
 
 trait MapTest {
   import MapTest._
@@ -22,17 +23,11 @@ trait MapTest {
 
   def testObj(i: Int): TestObj = TestObj(i)
 
-  // temporary until Platform is introduced
-  val executingInJVM = false
-
-  // replace when new IdentityHashMap from Scala.js
-  // private def assumeNotIdentityHashMapOnJVM(): Unit =
-  //   assumeFalse("JVM vs Native cache differences",
-  //               executingInJVM && factory.isIdentityBased)
-
-  // temp implementation
   private def assumeNotIdentityHashMapOnJVM(): Unit =
-    assumeFalse("JVM vs Native cache differences", factory.isIdentityBased)
+    assumeFalse(
+      "JVM vs Native cache differences",
+      executingInJVM && factory.isIdentityBased
+    )
 
   @Test def shouldStoreStrings(): Unit = {
     val mp = factory.empty[String, String]

--- a/unit-tests/shared/src/test/scala/utils/AssumesHelper.scala
+++ b/unit-tests/shared/src/test/scala/utils/AssumesHelper.scala
@@ -1,0 +1,9 @@
+package scala.scalanative.junit.utils
+
+import org.junit.Assume
+import org.scalanative.testsuite.utils.Platform
+
+object AssumesHelper {
+  def assumeNotJVMCompliant(): Unit =
+    Assume.assumeFalse("Not compliant with JDK", Platform.executingInJVM)
+}

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/securityObjectType.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/securityObjectType.c
@@ -1,0 +1,36 @@
+#if defined(_WIN32) || defined(WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <AccCtrl.h>
+
+int scalanative_win32_se_object_type_unknown_object_type() {
+    return SE_UNKNOWN_OBJECT_TYPE;
+}
+int scalanative_win32_se_object_type_file_object() { return SE_FILE_OBJECT; }
+int scalanative_win32_se_object_type_service() { return SE_SERVICE; }
+int scalanative_win32_se_object_type_printer() { return SE_PRINTER; }
+int scalanative_win32_se_object_type_registry_key() { return SE_REGISTRY_KEY; }
+int scalanative_win32_se_object_type_lmshare() { return SE_LMSHARE; }
+int scalanative_win32_se_object_type_kernel_object() {
+    return SE_KERNEL_OBJECT;
+}
+int scalanative_win32_se_object_type_window_object() {
+    return SE_WINDOW_OBJECT;
+}
+int scalanative_win32_se_object_type_ds_object() { return SE_DS_OBJECT; }
+int scalanative_win32_se_object_type_ds_object_all() {
+    return SE_DS_OBJECT_ALL;
+}
+int scalanative_win32_se_object_type_provider_defined_object() {
+    return SE_PROVIDER_DEFINED_OBJECT;
+}
+int scalanative_win32_se_object_type_wmiguid_object() {
+    return SE_WMIGUID_OBJECT;
+}
+int scalanative_win32_se_object_type_registry_wow64_32key() {
+    return SE_REGISTRY_WOW64_32KEY;
+}
+int scalanative_win32_se_object_type_registry_wow64_64key() {
+    return SE_REGISTRY_WOW64_64KEY;
+}
+
+#endif // defined(_WIN32)

--- a/windowslib/src/main/resources/scala-native/windows/constants.c
+++ b/windowslib/src/main/resources/scala-native/windows/constants.c
@@ -5,7 +5,6 @@
 // Needed to find symbols from UCRT - Windows Universal C Runtime
 #pragma comment(lib, "legacy_stdio_definitions.lib")
 
-
 size_t scalanative_win32_winnt_empty_priviliges_size() {
     PRIVILEGE_SET privileges = {0};
     return sizeof(privileges);

--- a/windowslib/src/main/resources/scala-native/windows/constants.c
+++ b/windowslib/src/main/resources/scala-native/windows/constants.c
@@ -5,6 +5,12 @@
 // Needed to find symbols from UCRT - Windows Universal C Runtime
 #pragma comment(lib, "legacy_stdio_definitions.lib")
 
+
+size_t scalanative_win32_winnt_empty_priviliges_size() {
+    PRIVILEGE_SET privileges = {0};
+    return sizeof(privileges);
+}
+
 LANGID scalanative_win32_default_language() { return LANG_USER_DEFAULT; }
 
 #endif // defined(Win32)

--- a/windowslib/src/main/resources/scala-native/windows/securityImpersonation.c
+++ b/windowslib/src/main/resources/scala-native/windows/securityImpersonation.c
@@ -1,0 +1,18 @@
+#if defined(_WIN32) || defined(WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+DWORD scalanative_win32_security_impersonation_anonymous() {
+    return SecurityAnonymous;
+}
+DWORD scalanative_win32_security_impersonation_identification() {
+    return SecurityIdentification;
+}
+DWORD scalanative_win32_security_impersonation_impersonation() {
+    return SecurityImpersonation;
+}
+DWORD scalanative_win32_security_impersonation_delegation() {
+    return SecurityDelegation;
+}
+
+#endif // defined(_WIN32)

--- a/windowslib/src/main/scala/scala/scalanative/windows/AclApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/AclApi.scala
@@ -1,0 +1,91 @@
+package scala.scalanative.windows
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+@extern()
+object AclApi {
+  import SecurityBaseApi._
+  import WinBaseApi._
+  import accctrl._
+
+  type SecurityObjectType = CInt
+
+  def SetEntriesInAclW(
+      countOfExplicitEntries: ULong,
+      listOfExplicitEntries: Ptr[ExplicitAccessW],
+      oldAcl: ACLPtr,
+      newAcl: Ptr[ACLPtr]
+  ): DWord = extern
+  def GetNamedSecurityInfoA(
+      objectName: CString,
+      objectType: SecurityObjectType,
+      securityInfo: SecurityInformation,
+      sidOwner: Ptr[SIDPtr],
+      sidGroup: Ptr[SIDPtr],
+      dacl: Ptr[ACLPtr],
+      sacl: Ptr[ACLPtr],
+      securityDescriptor: Ptr[Ptr[SecurityDescriptor]]
+  ): DWord = extern
+
+  def GetNamedSecurityInfoW(
+      objectName: CWString,
+      objectType: SecurityObjectType,
+      securityInfo: SecurityInformation,
+      sidOwner: Ptr[SIDPtr],
+      sidGroup: Ptr[SIDPtr],
+      dacl: Ptr[ACLPtr],
+      sacl: Ptr[ACLPtr],
+      securityDescriptor: Ptr[Ptr[SecurityDescriptor]]
+  ): DWord = extern
+
+  def SetNamedSecurityInfoA(
+      objectName: CString,
+      objectType: SecurityObjectType,
+      securityInfo: SecurityInformation,
+      sidOwner: SIDPtr,
+      sidGroup: SIDPtr,
+      dacl: ACLPtr,
+      sacl: ACLPtr
+  ): DWord = extern
+
+  def SetNamedSecurityInfoW(
+      objectName: CWString,
+      objectType: SecurityObjectType,
+      securityInfo: SecurityInformation,
+      sidOwner: SIDPtr,
+      sidGroup: SIDPtr,
+      dacl: ACLPtr,
+      sacl: ACLPtr
+  ): DWord = extern
+
+  // SecurityObjectType enum
+  @name("scalanative_win32_se_object_type_unknown_object_type")
+  def SE_UNKNOWN_OBJECT_TYPE: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_file_object")
+  def SE_FILE_OBJECT: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_service")
+  def SE_SERVICE: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_printer")
+  def SE_PRINTER: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_registry_key")
+  def SE_REGISTRY_KEY: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_lmshare")
+  def SE_LMSHARE: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_kernel_object")
+  def SE_KERNEL_OBJECT: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_window_object")
+  def SE_WINDOW_OBJECT: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_ds_object")
+  def SE_DS_OBJECT: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_ds_object_all")
+  def SE_DS_OBJECT_ALL: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_provider_defined_object")
+  def SE_PROVIDER_DEFINED_OBJECT: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_wmiguid_object")
+  def SE_WMIGUID_OBJECT: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_registry_wow64_32key")
+  def SE_REGISTRY_WOW64_32KEY: SecurityObjectType = extern
+  @name("scalanative_win32_se_object_type_registry_wow64_64key")
+  def SE_REGISTRY_WOW64_64KEY: SecurityObjectType = extern
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
@@ -1,13 +1,16 @@
 package scala.scalanative.windows
 
 import scala.language.implicitConversions
-import scala.scalanative.libc.wchar.wcscpy
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 import scala.scalanative.windows.HandleApi.Handle
+import MinWinBaseApi._
+import WinBaseApi.SecurityAttributes
 
 @extern
 object FileApi {
+  private[windows] type PathMax = Nat.Digit3[Nat._2, Nat._6, Nat._0]
+
   def CreateFileA(
       filename: CString,
       desiredAccess: DWord,
@@ -27,11 +30,37 @@ object FileApi {
       flagsAndAttributes: UInt,
       templateFile: Handle
   ): Handle = extern
+
+  def CreateDirectoryA(
+      filename: CString,
+      securityAttributes: Ptr[SecurityAttributes]
+  ): Boolean =
+    extern
+  def CreateDirectoryW(
+      filename: CWString,
+      securityAttributes: Ptr[SecurityAttributes]
+  ): Boolean =
+    extern
   def DeleteFileA(filename: CString): Boolean = extern
   def DeleteFileW(filename: CWString): Boolean = extern
   def FlushFileBuffers(handle: Handle): Boolean = extern
   def GetFileAttributesA(filename: CString): DWord = extern
   def GetFileAttributesW(filename: CWString): DWord = extern
+
+  def GetFinalPathNameByHandleA(
+      handle: Handle,
+      buffer: CString,
+      bufferSize: DWord,
+      flags: DWord
+  ): DWord = extern
+
+  def GetFinalPathNameByHandleW(
+      handle: Handle,
+      buffer: CWString,
+      bufferSize: DWord,
+      flags: DWord
+  ): DWord = extern
+
   def GetFullPathNameA(
       filename: CString,
       bufferLength: DWord,
@@ -46,6 +75,12 @@ object FileApi {
       filePart: Ptr[CWString]
   ): DWord = extern
   def GetFileSizeEx(file: Handle, fileSize: Ptr[LargeInteger]): Boolean = extern
+  def GetFileTime(
+      file: Handle,
+      creationTime: Ptr[FileTime],
+      lastAccessTime: Ptr[FileTime],
+      lastWriteTime: Ptr[FileTime]
+  ): Boolean = extern
   def GetTempPathA(bufferLength: DWord, buffer: CString): DWord = extern
   def GetTempPathW(bufferLength: DWord, buffer: CWString): DWord = extern
   def ReadFile(
@@ -55,6 +90,9 @@ object FileApi {
       bytesReadPtr: Ptr[DWord],
       overlapped: Ptr[Byte]
   ): Boolean = extern
+
+  def RemoveDirectoryW(filename: CWString): Boolean = extern
+  def SetEndOfFile(file: Handle): Boolean = extern
   def SetFileAttributesA(filename: CString, fileAttributes: DWord): Boolean =
     extern
   def SetFileAttributesW(filename: CWString, fileAttributes: DWord): Boolean =
@@ -64,6 +102,13 @@ object FileApi {
       distanceToMove: LargeInteger,
       newFilePointer: Ptr[LargeInteger],
       moveMethod: DWord
+  ): Boolean = extern
+
+  def SetFileTime(
+      file: Handle,
+      creationTime: Ptr[FileTime],
+      lastAccessTime: Ptr[FileTime],
+      lastWriteTime: Ptr[FileTime]
   ): Boolean = extern
 
   def WriteFile(
@@ -135,4 +180,13 @@ object FileApiExt {
   final val FILE_FLAG_SESSION_AWARE = 0x00800000.toUInt
   final val FILE_FLAG_SEQUENTIAL_SCAN = 0x08000000.toUInt
   final val FILE_FLAG_WRITE_THROUGH = 0x80000000.toUInt
+
+  // Final path flags
+  final val FILE_NAME_NORMALIZED = 0.toUInt
+  final val FILE_NAME_OPENED = 0x8.toUInt
+
+  final val VOLUME_NAME_DOS = 0.toUInt
+  final val VOLUME_NAME_GUID = 0x01.toUInt
+  final val VOLUME_NAME_NT = 0x02.toUInt
+  final val VOLUME_NAME_NONE = 0x04.toUInt
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/MinWinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/MinWinBaseApi.scala
@@ -1,0 +1,80 @@
+package scala.scalanative.windows
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+import scala.language.implicitConversions
+import scala.scalanative.windows.util.Conversion
+
+object MinWinBaseApi {
+  type FileTime = ULargeInteger
+  type FileTimeStruct = CStruct2[DWord, DWord]
+  type SystemTime = CStruct8[Word, Word, Word, Word, Word, Word, Word, Word]
+}
+
+object MinWinBaseApiOps {
+  import MinWinBaseApi._
+  implicit class FileTimeStructOps(ref: Ptr[FileTimeStruct]) {
+    def lowFileTime: DWord = ref._1
+    def highFileTime: DWord = ref._2
+    def fileTime: FileTime = {
+      Conversion.dwordPairToULargeInteger(
+        high = highFileTime,
+        low = lowFileTime
+      )
+    }
+    def lowFileTime_=(v: DWord): Unit = ref._1
+    def highFileTime_=(v: DWord): Unit = ref._2
+    def fileTime_=(v: FileTime): Unit = {
+      Conversion.uLargeIntegerToDWordPair(v, high = ref.at1, low = ref.at2)
+    }
+  }
+
+  object FileTimeOps {
+    private final val EpochPerSecond = 10000000L.toULong
+    private final val EpochPerMilis = 10000L.toULong
+    final val EpochInterval = 100L //ns
+    final val UnixEpochDifference = 116444736000000000L
+    final val UnixEpochDifferenceMillis = 11644473600000L
+    final val UnixEpochDifferenceSeconds = 11644473600L
+
+    def toUnixEpochSeconds(filetime: FileTime): Long = {
+      val windowsSeconds = filetime / EpochPerSecond
+      windowsSeconds.toLong - UnixEpochDifferenceSeconds
+    }
+
+    def toUnixEpochMillis(filetime: FileTime): Long = {
+      val windowsMillis = filetime / EpochPerMilis
+      windowsMillis.toLong - UnixEpochDifferenceMillis
+    }
+
+    def fromUnixEpoch(epoch: Long): FileTime = {
+      val windowsSeconds = (epoch + UnixEpochDifferenceSeconds).toULong
+      windowsSeconds * EpochPerSecond
+    }
+
+    def fromUnixEpochMillis(epochMillis: Long): FileTime = {
+      val windowsMillis = (epochMillis + UnixEpochDifferenceMillis).toULong
+      windowsMillis * EpochPerMilis
+    }
+  }
+
+  implicit class SystemTimeOps(val ref: Ptr[SystemTime]) extends AnyVal {
+    def year: Word = ref._1
+    def month: Word = ref._2
+    def dayOfWeek: Word = ref._3
+    def day: Word = ref._4
+    def hour: Word = ref._5
+    def minute: Word = ref._6
+    def second: Word = ref._7
+    def milliseconds: Word = ref._8
+
+    def year_=(v: Word): Unit = ref._1
+    def month_=(v: Word): Unit = ref._2
+    def dayOfWeek_=(v: Word): Unit = ref._3
+    def day_=(v: Word): Unit = ref._4
+    def hour_=(v: Word): Unit = ref._5
+    def minute_=(v: Word): Unit = ref._6
+    def second_=(v: Word): Unit = ref._7
+    def milliseconds_=(v: Word): Unit = ref._8
+  }
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/ProcessEnvApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/ProcessEnvApi.scala
@@ -3,7 +3,7 @@ package scala.scalanative.windows
 import scala.scalanative.unsafe._
 
 @extern()
-object ProcessEnv {
+object ProcessEnvApi {
   def GetEnvironmentStringsW(): CWString = extern
   def FreeEnvironmentStringsW(envBlockPtr: CWString): Boolean = extern
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
@@ -1,12 +1,115 @@
 package scala.scalanative.windows
 
 import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
 import scala.scalanative.windows.HandleApi.Handle
 
 @link("Advapi32")
 @extern()
 object SecurityBaseApi {
+  import winnt.TokenInformationClass
+
+  type AccessMask = DWord
+  type SecurityDescriptorControl = Word
+  type SecurityImpersonationLevel = CInt
+
+  type SecurityDescriptor = CStruct7[
+    Byte,
+    Byte,
+    SecurityDescriptorControl,
+    SIDPtr,
+    SIDPtr,
+    ACLPtr,
+    ACLPtr
+  ]
+  type GenericMapping = CStruct4[AccessMask, AccessMask, AccessMask, AccessMask]
+
   // Internal Windows structures, might have variable size and should not be modifed by the user
   type SIDPtr = Ptr[Byte]
   type ACLPtr = Ptr[Byte]
+  type PrivilegeSetPtr = Ptr[Byte]
+
+  def AccessCheck(
+      securityDescriptor: Ptr[SecurityDescriptor],
+      clientToken: Handle,
+      desiredAccess: DWord,
+      genericMapping: Ptr[GenericMapping],
+      privilegeSet: PrivilegeSetPtr,
+      privilegeSetLength: Ptr[DWord],
+      grantedAccess: Ptr[DWord],
+      accessStatus: Ptr[Boolean]
+  ): DWord =
+    extern
+
+  def DuplicateToken(
+      existingToken: Handle,
+      impersonationLevel: CInt,
+      duplicateTokenHandle: Ptr[Handle]
+  ): Boolean = extern
+
+  def FreeSid(sid: SIDPtr): Ptr[Byte] = extern
+  def GetTokenInformation(
+      handle: Handle,
+      informationClass: TokenInformationClass,
+      information: Ptr[Byte],
+      informationLength: DWord,
+      returnLength: Ptr[DWord]
+  ): Boolean = extern
+
+  def MapGenericMask(
+      accessMask: Ptr[DWord],
+      genericMapping: Ptr[GenericMapping]
+  ): Unit = extern
+
+  // SecurityImpersonationLevel enum
+  @name("scalanative_win32_security_impersonation_anonymous")
+  def SecurityAnonymous: SecurityImpersonationLevel = extern
+
+  @name("scalanative_win32_security_impersonation_identification")
+  def SecurityIdentification: SecurityImpersonationLevel = extern
+
+  @name("scalanative_win32_security_impersonation_impersonation")
+  def SecurityImpersonation: SecurityImpersonationLevel = extern
+
+  @name("scalanative_win32_security_impersonation_delegation")
+  def SecurityDelegation: SecurityImpersonationLevel = extern
+
+  // utils
+  @name("scalanative_win32_winnt_empty_priviliges_size")
+  def emptyPriviligesSize: CSize = extern
+
+}
+
+object SecurityBaseApiOps {
+  import SecurityBaseApi._
+  implicit class SecurityDescriptorOps(ref: Ptr[SecurityDescriptor]) {
+    def revision: Byte = ref._1
+    def sbz1: Byte = ref._2
+    def control: SecurityDescriptorControl = ref._3
+    def owner: SIDPtr = ref._4
+    def group: SIDPtr = ref._5
+    def sAcl: ACLPtr = ref._6
+    def dAcl: ACLPtr = ref._7
+
+    def revision_=(v: Byte): Unit = ref._1 = v
+    def sbz1_=(v: Byte): Unit = ref._2 = v
+    def control_=(v: SecurityDescriptorControl): Unit = ref._3 = v
+    def owner_=(v: SIDPtr): Unit = ref._4 = v
+    def group_=(v: SIDPtr): Unit = ref._5 = v
+    def sAcl_=(v: ACLPtr): Unit = ref._6 = v
+    def dAcl_=(v: ACLPtr): Unit = ref._7 = v
+  }
+
+  implicit class GenericMappingOps(ref: Ptr[GenericMapping]) {
+    def genericRead: AccessMask = ref._1
+    def genericWrite: AccessMask = ref._2
+    def genericExecute: AccessMask = ref._3
+    def genericAll: AccessMask = ref._4
+
+    def genericRead_=(v: AccessMask): Unit = ref._1 = v
+    def genericWrite_=(v: AccessMask): Unit = ref._2 = v
+    def genericExecute_=(v: AccessMask): Unit = ref._3 = v
+    def genericAll_=(v: AccessMask): Unit = ref._4 = v
+  }
+
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
@@ -63,7 +63,7 @@ object WinBaseApiExt {
   final val WT_EXECUTELONGFUNCTION = 0x00000010.toUInt
   final val WT_EXECUTEONLYONCE = 0x00000008.toUInt
   final val WT_TRANSFER_IMPERSONATION = 0x00000100.toUInt
-    
+
   final val MOVEFILE_REPLACE_EXISTING = 0x1.toUInt
   final val MOVEFILE_COPY_ALLOWED = 0x2.toUInt
   final val MOVEFILE_DELAY_UNTIL_REBOOT = 0x4.toUInt

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
@@ -10,10 +10,23 @@ import scala.scalanative.windows.winnt._
 object WinBaseApi {
   import SecurityBaseApi._
 
+  type SecurityInformation = DWord
+  type SecurityAttributes = CStruct3[DWord, Ptr[Byte], Boolean]
   type CallbackContext = Ptr[Byte]
   type WaitOrTimerCallback = CFuncPtr2[CallbackContext, Boolean, Unit]
   type LocalHandle = Ptr[_]
 
+  def CreateHardLinkW(
+      linkFileName: CWString,
+      existingFileName: CWString,
+      securityAttributes: SecurityAttributes
+  ): Boolean = extern
+
+  def CreateSymbolicLinkW(
+      symlinkFileName: CWString,
+      targetFileName: CWString,
+      flags: DWord
+  ): Boolean = extern
   def FormatMessageA(
       flags: DWord,
       source: Ptr[Byte],
@@ -36,6 +49,7 @@ object WinBaseApi {
   def GetCurrentDirectoryA(bufferLength: DWord, buffer: CString): DWord = extern
   def GetCurrentDirectoryW(bufferLength: DWord, buffer: CWString): DWord =
     extern
+  def LocalFree(ref: LocalHandle): LocalHandle = extern
 
   @name("scalanative_win32_default_language")
   final def DefaultLanguageId: DWord = extern
@@ -49,7 +63,7 @@ object WinBaseApiExt {
   final val WT_EXECUTELONGFUNCTION = 0x00000010.toUInt
   final val WT_EXECUTEONLYONCE = 0x00000008.toUInt
   final val WT_TRANSFER_IMPERSONATION = 0x00000100.toUInt
-
+    
   final val MOVEFILE_REPLACE_EXISTING = 0x1.toUInt
   final val MOVEFILE_COPY_ALLOWED = 0x2.toUInt
   final val MOVEFILE_DELAY_UNTIL_REBOOT = 0x4.toUInt
@@ -61,11 +75,39 @@ object WinBaseApiExt {
   final val SYMBOLIC_LINK_FLAG_DIRECTORY = 0x01.toUInt
   final val SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE = 0x02.toUInt
 
-  final val FORMAT_MESSAGE_ALLOCATE_BUFFER: DWord = 0x00000100.toUInt
-  final val FORMAT_MESSAGE_IGNORE_INSERTS: DWord = 0x00000200.toUInt
-  final val FORMAT_MESSAGE_FROM_STRING: DWord = 0x00000400.toUInt
-  final val FORMAT_MESSAGE_FROM_HMODULE: DWord = 0x00000800.toUInt
-  final val FORMAT_MESSAGE_FROM_SYSTEM: DWord = 0x00001000.toUInt
-  final val FORMAT_MESSAGE_ARGUMENT_ARRAY: DWord = 0x00002000.toUInt
+  final val FORMAT_MESSAGE_ALLOCATE_BUFFER = 0x00000100.toUInt
+  final val FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200.toUInt
+  final val FORMAT_MESSAGE_FROM_STRING = 0x00000400.toUInt
+  final val FORMAT_MESSAGE_FROM_HMODULE = 0x00000800.toUInt
+  final val FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000.toUInt
+  final val FORMAT_MESSAGE_ARGUMENT_ARRAY = 0x00002000.toUInt
 
+  final val OWNER_SECURITY_INFORMATION = 0x00000001L.toUInt
+  final val GROUP_SECURITY_INFORMATION = 0x00000002L.toUInt
+  final val DACL_SECURITY_INFORMATION = 0x00000004L.toUInt
+  final val SACL_SECURITY_INFORMATION = 0x00000008L.toUInt
+  final val LABEL_SECURITY_INFORMATION = 0x00000010L.toUInt
+  final val ATTRIBUTE_SECURITY_INFORMATION = 0x00000020L.toUInt
+  final val SCOPE_SECURITY_INFORMATION = 0x00000040L.toUInt
+  final val PROCESS_TRUST_LABEL_SECURITY_INFORMATION = 0x00000080L.toUInt
+  final val ACCESS_FILTER_SECURITY_INFORMATION = 0x00000100L.toUInt
+  final val BACKUP_SECURITY_INFORMATION = 0x00010000L.toUInt
+  final val PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000L.toUInt
+  final val PROTECTED_SACL_SECURITY_INFORMATION = 0x40000000L.toUInt
+  final val UNPROTECTED_DACL_SECURITY_INFORMATION = 0x20000000L.toUInt
+  final val UNPROTECTED_SACL_SECURITY_INFORMATION = 0x10000000L.toUInt
+}
+
+object WinBaseApiOps {
+  import WinBaseApi._
+  implicit class SecurityAttributesOps(val ref: Ptr[SecurityAttributes])
+      extends AnyVal {
+    def length: DWord = ref._1
+    def securityDescriptor: Ptr[Byte] = ref._2
+    def inheritHandle: Boolean = ref._3
+
+    def length_=(v: DWord): Unit = ref._1 = v
+    def securityDescriptor_=(v: Ptr[Byte]): Unit = ref._2 = v
+    def inheritHandle_=(v: Boolean): Unit = ref._3 = v
+  }
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/AccessMode.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/AccessMode.scala
@@ -1,0 +1,21 @@
+package scala.scalanative.windows.accctrl
+
+import scala.scalanative.unsafe._
+
+@extern
+object AccessMode {
+  @name("scalanative_win32_accctrl_not_used_access")
+  def NOT_USED_ACCESS: AccessMode = extern
+  @name("scalanative_win32_accctrl_grant_access")
+  def GRANT_ACCESS: AccessMode = extern
+  @name("scalanative_win32_accctrl_set_access")
+  def SET_ACCESS: AccessMode = extern
+  @name("scalanative_win32_accctrl_deny_access")
+  def DENY_ACCESS: AccessMode = extern
+  @name("scalanative_win32_accctrl_revoke_access")
+  def REVOKE_ACCESS: AccessMode = extern
+  @name("scalanative_win32_accctrl_set_audit_success")
+  def SET_AUDIT_SUCCESS: AccessMode = extern
+  @name("scalanative_win32_accctrl_set_audit_failure")
+  def SET_AUDIT_FAILURE: AccessMode = extern
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/MultipleTrusteeOperation.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/MultipleTrusteeOperation.scala
@@ -1,0 +1,11 @@
+package scala.scalanative.windows.accctrl
+
+import scala.scalanative.unsafe._
+
+@extern
+object MultipleTrusteeOperation {
+  @name("scalanative_win32_accctrl_no_multiple_trustee")
+  def NO_MULTIPLE_TRUSTEE: MultipleTruteeOperation = extern
+  @name("scalanative_win32_accctrl_trustee_is_impersonate")
+  def TRUSTEE_IS_IMPERSONATE: MultipleTruteeOperation = extern
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/TrusteeForm.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/TrusteeForm.scala
@@ -1,0 +1,17 @@
+package scala.scalanative.windows.accctrl
+
+import scala.scalanative.unsafe._
+
+@extern
+object TrusteeForm {
+  @name("scalanative_win32_accctrl_trustee_is_sid")
+  def TRUSTEE_IS_SID: TrusteeForm = extern
+  @name("scalanative_win32_accctrl_trustee_is_name")
+  def TRUSTEE_IS_NAME: TrusteeForm = extern
+  @name("scalanative_win32_accctrl_trustee_bad_form")
+  def TRUSTEE_BAD_FORM: TrusteeForm = extern
+  @name("scalanative_win32_accctrl_trustee_is_objects_and_sid")
+  def TRUSTEE_IS_OBJECTS_AND_SID: TrusteeForm = extern
+  @name("scalanative_win32_accctrl_trustee_is_objects_and_name")
+  def TRUSTEE_IS_OBJECTS_AND_NAME: TrusteeForm = extern
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/TrusteeType.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/TrusteeType.scala
@@ -1,0 +1,25 @@
+package scala.scalanative.windows.accctrl
+
+import scala.scalanative.unsafe._
+
+@extern
+object TrusteeType {
+  @name("scalanative_win32_accctrl_trustee_is_unknown")
+  def TRUSTEE_IS_UNKNOWN: TrusteeType = extern
+  @name("scalanative_win32_accctrl_trustee_is_user")
+  def TRUSTEE_IS_USER: TrusteeType = extern
+  @name("scalanative_win32_accctrl_trustee_is_group")
+  def TRUSTEE_IS_GROUP: TrusteeType = extern
+  @name("scalanative_win32_accctrl_trustee_is_domain")
+  def TRUSTEE_IS_DOMAIN: TrusteeType = extern
+  @name("scalanative_win32_accctrl_trustee_is_alias")
+  def TRUSTEE_IS_ALIAS: TrusteeType = extern
+  @name("scalanative_win32_accctrl_trustee_is_well_known_group")
+  def TRUSTEE_IS_WELL_KNOWN_GROUP: TrusteeType = extern
+  @name("scalanative_win32_accctrl_trustee_is_deleted")
+  def TRUSTEE_IS_DELETED: TrusteeType = extern
+  @name("scalanative_win32_accctrl_trustee_is_invalid")
+  def TRUSTEE_IS_INVALID: TrusteeType = extern
+  @name("scalanative_win32_accctrl_trustee_is_computer")
+  def TRUSTEE_IS_COMPUTER: TrusteeType = extern
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/ops.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/ops.scala
@@ -1,0 +1,80 @@
+package scala.scalanative.windows.accctrl
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+import scala.scalanative.windows._
+
+import AclApi._
+import SecurityBaseApi._
+import WinBaseApi._
+
+object ops {
+  implicit class ExplicitAccessOps(ref: Ptr[ExplicitAccessW]) {
+    def accessPermisions: DWord = ref._1
+    def accessMode: AccessMode = ref._2
+    def inheritence: DWord = ref._3
+    def trustee: Ptr[TrusteeW] = ref.at4
+
+    def accessPermisions_=(v: DWord): Unit = ref._1 = v
+    def accessMode_=(v: AccessMode): Unit = ref._2 = v
+    def inheritence_=(v: DWord): Unit = ref._3 = v
+    def trustee_=(v: Ptr[TrusteeW]): Unit = !ref.at4 = v
+  }
+
+  implicit class TrusteeWOps(ref: Ptr[TrusteeW]) {
+    def multipleTrustee: Ptr[TrusteeW] = ref._1.asInstanceOf[Ptr[TrusteeW]]
+    def multipleTrusteeOperation: MultipleTruteeOperation = ref._2
+    def trusteeForm: TrusteeForm = ref._3
+    def trusteeType: TrusteeType = ref._4
+    // union type
+    def strName: CWString = ref._5.asInstanceOf[CWString]
+    def sid: SIDPtr = ref._5.asInstanceOf[SIDPtr]
+    def objectsAndSid: Ptr[ObjectsAndSid] =
+      ref._5.asInstanceOf[Ptr[ObjectsAndSid]]
+    def objectsAndName: Ptr[ObjectsAndNameW] =
+      ref._5.asInstanceOf[Ptr[ObjectsAndNameW]]
+
+    def multipleTrustee_=(v: Ptr[TrusteeW]): Unit = {
+      ref._1 = v.asInstanceOf[Ptr[Byte]]
+    }
+    def multipleTrusteeOperation_=(v: MultipleTruteeOperation): Unit = {
+      ref._2 = v
+    }
+    def trusteeForm_=(v: TrusteeForm): Unit = { ref._3 = v }
+    def trusteeType_=(v: TrusteeType): Unit = { ref._4 = v }
+    def strName_=(v: CWString): Unit = { ref._5 = v.asInstanceOf[Ptr[Byte]] }
+    def sid_=(v: SIDPtr): Unit = { ref._5 = v.asInstanceOf[Ptr[Byte]] }
+    def objectsAndSid_=(v: Ptr[ObjectsAndSid]): Unit = {
+      ref._5 = v.asInstanceOf[Ptr[Byte]]
+    }
+    def objectsAndName_=(v: Ptr[ObjectsAndNameW]): Unit = {
+      ref._5 = v.asInstanceOf[Ptr[Byte]]
+    }
+  }
+
+  implicit class ObjectsAndSidOps(ref: Ptr[ObjectsAndSid]) {
+    def objectsPresent: ObjectsPresent = ref._1
+    def objectTypeGuid: Ptr[GUID] = ref.at2
+    def inheritedObjectTypeGuid: Ptr[GUID] = ref.at3
+    def sid: SIDPtr = ref._4
+
+    def objectsPresent_=(v: ObjectsPresent): Unit = ref._1 = v
+    def objectTypeGuid_=(v: Ptr[GUID]): Unit = !ref.at2 = v
+    def inheritedObjectTypeGuid_=(v: Ptr[GUID]): Unit = !ref.at3 = v
+    def sid_=(v: SIDPtr): Unit = ref._4 = v
+  }
+
+  implicit class ObjectsAndNameWOps(ref: Ptr[ObjectsAndNameW]) {
+    def objectsPresent: ObjectsPresent = ref._1
+    def objectType: SecurityObjectType = ref._2
+    def objectTypeName: CWString = ref._3
+    def inheritedObjectTypeName: CWString = ref._4
+    def strName: CWString = ref._5
+
+    def objectsPresent_=(v: ObjectsPresent): Unit = ref._1 = v
+    def objectType_=(v: SecurityObjectType): Unit = ref._2 = v
+    def objectTypeName_=(v: CWString): Unit = ref._3 = v
+    def inheritedObjectTypeName_=(v: CWString): Unit = ref._4 = v
+    def strName_=(v: CWString): Unit = ref._5 = v
+  }
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/package.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/package.scala
@@ -1,0 +1,42 @@
+package scala.scalanative.windows
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+import scala.scalanative.windows._
+
+import AclApi._
+import SecurityBaseApi._
+import WinBaseApi._
+
+package object accctrl {
+  type AccessMode = CInt
+  type MultipleTruteeOperation = CInt
+  type TrusteeForm = CInt
+  type TrusteeType = CInt
+  type ObjectsPresent = DWord
+  type ExplicitAccessW = CStruct4[DWord, AccessMode, DWord, TrusteeW]
+  type TrusteeW = CStruct6[
+    Ptr[Byte],
+    MultipleTruteeOperation,
+    TrusteeForm,
+    TrusteeType,
+    Ptr[Byte],
+    CWString
+  ]
+  type GUID = CStruct4[UInt, UShort, UShort, CArray[UByte, Nat._8]]
+  type ObjectsAndSid = CStruct4[ObjectsPresent, GUID, GUID, SIDPtr]
+  type ObjectsAndNameW =
+    CStruct5[ObjectsPresent, SecurityObjectType, CWString, CWString, CWString]
+
+  // ObjectsPresents
+  final val ACE_OBJECT_TYPE_PRESENT = 0x01.toUInt
+  final val ACE_INHERITED_OBJECT_TYPE_PRESENT = 0x02.toUInt
+
+  // InheritFlags
+  final val OBJECT_INHERIT_ACE = 0x01.toUInt
+  final val CONTAINER_INHERIT_ACE = 0x02.toUInt
+  final val NO_PROPAGATE_INHERIT_ACE = 0x04.toUInt
+  final val INHERIT_ONLY_ACE = 0x08.toUInt
+  final val INHERITED_ACE = 0x10.toUInt
+  final val VALID_INHERIT_FLAGS = 0x1f.toUInt
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/package.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/package.scala
@@ -19,17 +19,4 @@ package object windows {
     Ptr[WChar] // In Windows wide string are always encoded using UTF-16LE
   type CTString =
     CWString // if UNICODE is defined equals to CWString, otherwise its CString
-
-  type SecurityAttributes = CStruct3[DWord, Ptr[Byte], Boolean]
-  implicit class SecurityAttributesOps(val ref: Ptr[SecurityAttributes])
-      extends AnyVal {
-    def length: DWord = ref._1
-    def securityDescriptor: Ptr[Byte] = ref._2
-    def inheritHandle: Boolean = ref._3
-
-    def length_=(v: DWord): Unit = ref._1 = v
-    def securityDescriptor_=(v: Ptr[Byte]): Unit = ref._2 = v
-    def inheritHandle_=(v: Boolean): Unit = ref._3 = v
-  }
-
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/util/Conversion.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/util/Conversion.scala
@@ -1,7 +1,8 @@
 package scala.scalanative.windows.util
 
+import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
-import scala.scalanative.windows.{Word => WinWord}
+import scala.scalanative.windows.{Word => WinWord, _}
 
 private[windows] object Conversion {
   def wordToBytes(word: WinWord): (Byte, Byte) = {
@@ -12,5 +13,20 @@ private[windows] object Conversion {
 
   def wordFromBytes(low: Byte, high: Byte): WinWord = {
     ((low & 0xff) | ((high & 0xff) << 8)).toUShort
+  }
+
+  def dwordPairToULargeInteger(high: DWord, low: DWord): ULargeInteger = {
+    if (high == 0.toUInt) low
+    else (high.toULong << 32) | low
+  }
+
+  def uLargeIntegerToDWordPair(
+      v: ULargeInteger,
+      high: Ptr[DWord],
+      low: Ptr[DWord]
+  ): Unit = {
+    val mask = 0xffffffff.toUInt
+    !high = ((v >> 32) & mask).toUInt
+    !low = (v & mask).toUInt
   }
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/util/Conversion.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/util/Conversion.scala
@@ -25,8 +25,7 @@ private[windows] object Conversion {
       high: Ptr[DWord],
       low: Ptr[DWord]
   ): Unit = {
-    val mask = 0xffffffff.toUInt
-    !high = ((v >> 32) & mask).toUInt
-    !low = (v & mask).toUInt
+    !high = (v >> 32).toUInt
+    !low = v.toUInt
   }
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/HelperMethods.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/HelperMethods.scala
@@ -1,0 +1,13 @@
+package scala.scalanative.windows.winnt
+
+import scala.scalanative.unsafe.extern
+import scala.scalanative.unsafe._
+
+import scala.scalanative.windows.SecurityBaseApi._
+
+@link("Advapi32")
+@extern
+object HelperMethods {
+  @name("scalanative_win32_winnt_setupUsersGroupSid")
+  def setupUserGroupSid(ref: Ptr[SIDPtr]): Boolean = extern
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/TokenInformationClass.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/TokenInformationClass.scala
@@ -1,0 +1,160 @@
+package scala.scalanative.windows.winnt
+
+import scalanative.unsafe._
+import scalanative.windows.DWord
+
+@link("Advapi32")
+@extern
+object TokenInformationClass {
+  @name("scalanative_win32_winnt_token_info_class_user")
+  def TokenUser: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_groups")
+  def TokenGroups: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_privileges")
+  def TokenPrivileges: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_owner")
+  def TokenOwner: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_primarygroup")
+  def TokenPrimaryGroup: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_defaultdacl")
+  def TokenDefaultDacl: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_source")
+  def TokenSource: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_type")
+  def TokenTokenInformationClass: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_impersonationlevel")
+  def TokenImpersonationLevel: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_statistics")
+  def TokenStatistics: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_restrictedsids")
+  def TokenRestrictedSids: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_sessionid")
+  def TokenSessionId: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_groupsandprivileges")
+  def TokenGroupsAndPrivileges: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_sessionreference")
+  def TokenSessionReference: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_sandboxinert")
+  def TokenSandBoxInert: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_auditpolicy")
+  def TokenAuditPolicy: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_origin")
+  def TokenOrigin: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_elevationtype")
+  def TokenElevationTokenInformationClass: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_linkedtoken")
+  def TokenLinkedToken: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_elevation")
+  def TokenElevation: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_hasrestrictions")
+  def TokenHasRestrictions: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_accessinformation")
+  def TokenAccessInformation: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_virtualizationallowed")
+  def TokenVirtualizationAllowed: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_virtualizationenabled")
+  def TokenVirtualizationEnabled: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_integritylevel")
+  def TokenIntegrityLevel: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_uiaccess")
+  def TokenUIAccess: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_mandatorypolicy")
+  def TokenMandatoryPolicy: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_logonsid")
+  def TokenLogonSid: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_isappcontainer")
+  def TokenIsAppContainer: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_capabilities")
+  def TokenCapabilities: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_appcontainersid")
+  def TokenAppContainerSid: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_appcontainernumber")
+  def TokenAppContainerNumber: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_userclaimattributes")
+  def TokenUserClaimAttributes: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_deviceclaimattributes")
+  def TokenDeviceClaimAttributes: TokenInformationClass = extern
+
+  @name(
+    "scalanative_win32_winnt_token_info_class_restricteduserclaimattributes"
+  )
+  def TokenRestrictedUserClaimAttributes: TokenInformationClass = extern
+
+  @name(
+    "scalanative_win32_winnt_token_info_class_restricteddeviceclaimattributes"
+  )
+  def TokenRestrictedDeviceClaimAttributes: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_devicegroups")
+  def TokenDeviceGroups: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_restricteddevicegroups")
+  def TokenRestrictedDeviceGroups: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_securityattributes")
+  def TokenSecurityAttributes: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_isrestricted")
+  def TokenIsRestricted: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_processtrustlevel")
+  def TokenProcessTrustLevel: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_privatenamespace")
+  def TokenPrivateNameSpace: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_singletonattributes")
+  def TokenSingletonAttributes: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_bnoisolation")
+  def TokenBnoIsolation: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_childprocessflags")
+  def TokenChildProcessFlags: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_islessprivilegedappcontainer")
+  def TokenIsLessPrivilegedAppContainer: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_issandboxed")
+  def TokenIsSandboxed: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_originatingprocesstrustlevel")
+  def TokenOriginatingProcessTrustLevel: TokenInformationClass = extern
+
+  @name("scalanative_win32_winnt_token_info_class_infoclass_max")
+  def MaxTokenInfoClass: TokenInformationClass = extern
+
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/package.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/package.scala
@@ -1,6 +1,21 @@
 package scala.scalanative.windows
 
+import scala.scalanative.unsafe._
+import scala.scalanative.windows.SecurityBaseApi._
+
 package object winnt {
   type AccessRights = DWord
   type AccessToken = DWord
+  type TokenInformationClass = DWord
+  type SidAndAttributes = CStruct2[SIDPtr, DWord]
+  type SidNameUse = CInt
+
+  implicit class SidAndAttributesOps(ref: Ptr[SidAndAttributes]) {
+    def sid: SIDPtr = ref._1
+    def attributes: DWord = ref._2
+
+    def size_=(v: SIDPtr) = ref._1 = v
+    def attributes_=(v: DWord) = ref._2 = v
+  }
+
 }


### PR DESCRIPTION
This PR continues series of Windows support changes, it adds proper implementation for `java.io` package. 

Changes include: 
* Implement stubs in `java.io` package to support all currently available methods/classes with Unix. 
* Add bindings and native sources for Windows API for functions used in `java.io`
* Align names of `windowslib` classes 
* Adjust `java.io` unit tests based on JVM compliance on Windows
* Adjust CI to run tests in `java.io`  and check compliance with JVM
* Added missing `toString(Charset)` method in `ByteArrayOutputStream`
* Added missing constructors in `PrintWriter` (added in Java 9+)