### PR TITLE
Setup MiMa checks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,13 +73,17 @@ lazy val docsSettings: Seq[Setting[_]] = {
 
 // The previous releases of Scala Native with which this version is binary compatible.
 val binCompatVersions = Set("0.4.0")
+lazy val neverPublishedProjects = Set(windowslib).map(_.id)
 
 lazy val mimaSettings = Seq(
+  mimaFailOnNoPrevious := false,
   mimaBinaryIssueFilters ++= BinaryIncompatibilities.moduleFilters(name.value),
-  mimaPreviousArtifacts ++= binCompatVersions.map { version =>
-    ModuleID(organization.value, moduleName.value, version)
-      .cross(crossVersion.value)
-  }
+  mimaPreviousArtifacts ++= binCompatVersions
+    .filter(_ => !neverPublishedProjects.contains(thisProject.value.id))
+    .map { version =>
+      ModuleID(organization.value, moduleName.value, version)
+        .cross(crossVersion.value)
+    }
 )
 
 // Common start but individual sub-projects may add or remove scalacOptions.
@@ -138,10 +142,11 @@ addCommandAlias(
 
 addCommandAlias(
   "test-mima", {
-    Seq("util", "nir", "tools", "nscplugin") ++
+    Seq("util", "nir", "tools") ++
       Seq("testRunner", "testInterface", "testInterfaceSbtDefs") ++
-      Seq("junitPlugin", "junitRuntime") ++
-      Seq("clib", "posixlib", "nativelib", "auxlib", "javalib")
+      Seq("junitRuntime") ++
+      Seq("nativelib", "clib", "posixlib", "windowslib") ++
+      Seq("auxlib", "javalib", "scalalib")
   }.map(_ + "/mimaReportBinaryIssues")
     .mkString(";")
 )

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -13,11 +13,14 @@ object GC {
   @deprecated("Marked for removal, use alloc(Class[_], CSize) instead", "0.4.1")
   @name("scalanative_alloc")
   def alloc(rawty: RawPtr, size: CSize): RawPtr = extern
-  
-  @deprecated("Marked for removal, use alloc_atomic(Class[_], CSize) instead", "0.4.1")
+
+  @deprecated(
+    "Marked for removal, use alloc_atomic(Class[_], CSize) instead",
+    "0.4.1"
+  )
   @name("scalanative_alloc_atomic")
   def alloc_atomic(rawty: RawPtr, size: CSize): RawPtr = extern
- 
+
   @name("scalanative_alloc")
   def alloc(cls: Class[_], size: CSize): RawPtr = extern
   @name("scalanative_alloc_atomic")

--- a/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/GC.scala
@@ -10,6 +10,14 @@ import scalanative.unsafe._
  */
 @extern
 object GC {
+  @deprecated("Marked for removal, use alloc(Class[_], CSize) instead", "0.4.1")
+  @name("scalanative_alloc")
+  def alloc(rawty: RawPtr, size: CSize): RawPtr = extern
+  
+  @deprecated("Marked for removal, use alloc_atomic(Class[_], CSize) instead", "0.4.1")
+  @name("scalanative_alloc_atomic")
+  def alloc_atomic(rawty: RawPtr, size: CSize): RawPtr = extern
+ 
   @name("scalanative_alloc")
   def alloc(cls: Class[_], size: CSize): RawPtr = extern
   @name("scalanative_alloc_atomic")

--- a/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/package.scala
@@ -6,6 +6,22 @@ import scalanative.runtime.Intrinsics._
 
 package object runtime {
 
+  @deprecated("Internal API, deprecated for removal", "0.4.1")
+  def toClass(rtti: RawPtr): _Class[_] = {
+    castRawPtrToObject(rtti).getClass().asInstanceOf[_Class[_]]
+  }
+
+  @deprecated("Internal API, deprecated for removal", "0.4.1")
+  @alwaysinline def toRawType(cls: Class[_]): RawPtr = {
+    castObjectToRawPtr(cls)
+  }
+
+  /** Read type information of given object. */
+  @deprecated("Internal API, deprecated for removal", "0.4.1")
+  @alwaysinline def getRawType(obj: Object): RawPtr = {
+    Intrinsics.castObjectToRawPtr(obj.getClass())
+  }
+
   /** Used as a stub right hand of intrinsified methods. */
   def intrinsic: Nothing = throwUndefined()
 

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -4,11 +4,65 @@ import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.core.ProblemFilters._
 
 object BinaryIncompatibilities {
+  type Filters = Seq[ProblemFilter]
+  final val Util: Filters = Nil
+  final val Nir: Filters = Seq(
+    exclude[DirectMissingMethodProblem]("scala.scalanative.nir.Rt.*")
+  )
+
+  final val Tools: Filters = Seq(
+    exclude[Problem]("scala.scalanative.codegen.*"),
+    exclude[Problem]("scala.scalanative.checker.*"),
+    exclude[Problem]("scala.scalanative.interflow.*"),
+    exclude[Problem]("scala.scalanative.linker.*"),
+    exclude[Problem]("scala.scalanative.build.NativeLib.*"),
+    exclude[Problem]("scala.scalanative.build.LLVM.*"),
+    exclude[Problem]("scala.scalanative.build.NativeConfig*Impl*"),
+    exclude[Problem]("scala.scalanative.build.GC.this")
+  )
+
+  final val CLib, PosixLib, WindowsLib: Filters = Seq(
+    exclude[IncompatibleResultTypeProblem](
+      "scala.scalanative.posix.limits.PATH_MAX"
+    )
+  )
   final val NativeLib = Seq(
-    // Since 0.4.1
     // Internal usage
-    exclude[Problem]("scala.scalanative.runtime.package*TypeOps*"),
+    exclude[DirectMissingMethodProblem]("java.lang._Class.rawty"),
+    exclude[DirectMissingMethodProblem]("java.lang._Class.this"),
+    // moved to auxlib
+    exclude[MissingClassProblem]("scala.runtime.BoxesRunTime*"),
+    // moved to javalib
+    exclude[MissingClassProblem]("scala.scalanative.runtime.DeleteOnExit*"),
+    // package-private
+    exclude[MissingClassProblem]("scala.scalanative.runtime.*Shutdown*"),
     exclude[Problem]("scala.scalanative.runtime.ClassInstancesRegistry*"),
-    exclude[IncompatibleMethTypeProblem]("scala.scalanative.runtime.GC.alloc*")
+    exclude[Problem]("scala.scalanative.runtime.package*TypeOps*")
+  )
+
+  final val AuxLib, JavaLib, ScalaLib: Filters = Nil
+  final val TestRunner: Filters = Nil
+  final val TestInterface: Filters = Nil
+  final val TestInterfaceSbtDefs: Filters = Nil
+  final val JUnitRuntime: Filters = Seq(
+    // Internal method, package-private
+    exclude[IncompatibleMethTypeProblem]("scala.scalanative.junit.Reporter.*")
+  )
+
+  val moduleFilters = Map(
+    "util" -> Util,
+    "nir" -> Nir,
+    "tools" -> Tools,
+    "clib" -> CLib,
+    "posixlib" -> PosixLib,
+    "windowslib" -> WindowsLib,
+    "nativelib" -> NativeLib,
+    "auxlib" -> AuxLib,
+    "javalib" -> JavaLib,
+    "scalalib" -> ScalaLib,
+    "test-runner" -> TestRunner,
+    "test-interface" -> TestInterface,
+    "test-interface-sbt-defs" -> TestInterfaceSbtDefs,
+    "junit-runtime" -> JUnitRuntime
   )
 }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -35,11 +35,6 @@ object BinaryIncompatibilities {
     )
   )
 
-  final val CLib, PosixLib, WindowsLib: Filters = Seq(
-    exclude[IncompatibleResultTypeProblem](
-      "scala.scalanative.posix.limits.PATH_MAX"
-    )
-  )
   final val NativeLib = Seq(
     // Internal usage
     exclude[DirectMissingMethodProblem]("java.lang._Class.rawty"),
@@ -53,6 +48,13 @@ object BinaryIncompatibilities {
     exclude[Problem]("scala.scalanative.runtime.ClassInstancesRegistry*"),
     exclude[Problem]("scala.scalanative.runtime.package*TypeOps*")
   )
+  final val CLib: Filters = Nil
+  final val PosixLib: Filters = Seq(
+    exclude[IncompatibleResultTypeProblem](
+      "scala.scalanative.posix.limits.PATH_MAX"
+    )
+  )
+  final val WindowsLib: Filters = Nil
 
   final val AuxLib, JavaLib, ScalaLib: Filters = Nil
   final val TestRunner: Filters = Nil
@@ -67,7 +69,6 @@ object BinaryIncompatibilities {
     "util" -> Util,
     "nir" -> Nir,
     "tools" -> Tools,
-    "nscplugin" -> NscPlugin,
     "clib" -> CLib,
     "posixlib" -> PosixLib,
     "windowslib" -> WindowsLib,
@@ -78,7 +79,6 @@ object BinaryIncompatibilities {
     "test-runner" -> TestRunner,
     "test-interface" -> TestInterface,
     "test-interface-sbt-defs" -> TestInterfaceSbtDefs,
-    "junit-plugin" -> JUnitPlugin,
     "junit-runtime" -> JUnitRuntime
   )
 }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -1,0 +1,14 @@
+package build
+
+import com.typesafe.tools.mima.core._
+import com.typesafe.tools.mima.core.ProblemFilters._
+
+object BinaryIncompatibilities {
+  final val NativeLib = Seq(
+    // Since 0.4.1
+    // Internal usage
+    exclude[Problem]("scala.scalanative.runtime.package*TypeOps*"),
+    exclude[Problem]("scala.scalanative.runtime.ClassInstancesRegistry*"),
+    exclude[IncompatibleMethTypeProblem]("scala.scalanative.runtime.GC.alloc*")
+  )
+}

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -10,6 +10,17 @@ object BinaryIncompatibilities {
     exclude[DirectMissingMethodProblem]("scala.scalanative.nir.Rt.*")
   )
 
+  final val NscPlugin = Seq(
+    exclude[DirectMissingMethodProblem]("scala.scalanative.nir.Rt.*"),
+    exclude[IncompatibleMethTypeProblem](
+      "scala.scalanative.nscplugin.NirCompat*"
+    ),
+    exclude[ReversedMissingMethodProblem](
+      "scala.scalanative.nscplugin.NirGenStat.LinktimeProperty"
+    )
+  )
+  final val JUnitPlugin: Filters = Nil
+
   final val Tools: Filters = Seq(
     exclude[Problem]("scala.scalanative.codegen.*"),
     exclude[Problem]("scala.scalanative.checker.*"),
@@ -18,7 +29,10 @@ object BinaryIncompatibilities {
     exclude[Problem]("scala.scalanative.build.NativeLib.*"),
     exclude[Problem]("scala.scalanative.build.LLVM.*"),
     exclude[Problem]("scala.scalanative.build.NativeConfig*Impl*"),
-    exclude[Problem]("scala.scalanative.build.GC.this")
+    exclude[Problem]("scala.scalanative.build.GC.this"),
+    exclude[ReversedMissingMethodProblem](
+      "scala.scalanative.build.NativeConfig*"
+    )
   )
 
   final val CLib, PosixLib, WindowsLib: Filters = Seq(
@@ -53,6 +67,7 @@ object BinaryIncompatibilities {
     "util" -> Util,
     "nir" -> Nir,
     "tools" -> Tools,
+    "nscplugin" -> NscPlugin,
     "clib" -> CLib,
     "posixlib" -> PosixLib,
     "windowslib" -> WindowsLib,
@@ -63,6 +78,7 @@ object BinaryIncompatibilities {
     "test-runner" -> TestRunner,
     "test-interface" -> TestInterface,
     "test-interface-sbt-defs" -> TestInterfaceSbtDefs,
+    "junit-plugin" -> JUnitPlugin,
     "junit-runtime" -> JUnitRuntime
   )
 }

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -12,9 +12,9 @@ Compile / unmanagedSourceDirectories ++= {
 }
 
 addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
-addSbtPlugin("org.foundweekends"  % "sbt-bintray"       % "0.5.4")
-addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"   % "0.8.1")
-addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"     % "0.9.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "5.10.0.202012080955-r"
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -12,9 +12,9 @@ Compile / unmanagedSourceDirectories ++= {
 }
 
 addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("org.foundweekends"  % "sbt-bintray"       % "0.5.4")
+addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"   % "0.8.1")
+addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"     % "0.9.0")
 
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "5.10.0.202012080955-r"
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativeCrossVersion.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativeCrossVersion.scala
@@ -7,6 +7,8 @@ import sbt._
 import scala.scalanative.nir.Versions
 
 object ScalaNativeCrossVersion {
+  val currentBinaryVersion = CrossVersion.binaryScalaVersion(Versions.current)
+
   private[this] def crossVersionAddPlatformPart(
       cross: CrossVersion,
       part: String

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativeCrossVersion.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativeCrossVersion.scala
@@ -7,7 +7,15 @@ import sbt._
 import scala.scalanative.nir.Versions
 
 object ScalaNativeCrossVersion {
-  val currentBinaryVersion = CrossVersion.binaryScalaVersion(Versions.current)
+  private final val ReleaseVersion =
+    raw"""(\d+)\.(\d+)\.(\d+)""".r
+
+  val currentBinaryVersion = binaryVersion(Versions.current)
+
+  def binaryVersion(full: String): String = full match {
+    case ReleaseVersion(major, minor, _) => s"$major.$minor"
+    case _                               => full
+  }
 
   private[this] def crossVersionAddPlatformPart(
       cross: CrossVersion,


### PR DESCRIPTION
This PR adds checks proper setup for MiMa binary incompatibilities checks, based on Scala.js. 

Needs to be rebased onto #2207 due to a bug in the binary version resolving mechanism. 

 * Binary compatibility checks were enabled in all published projects.
 * Added filters for known incompatibilities inside package-private classes and classes treated as internal
 * Fixed some binary incompatibilities in public API