### PR TITLE
Fix #2211: NIR warnings from incorrect subtyping resolution 

### DIFF
--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -18,8 +18,8 @@ object MyScalaNativePlugin extends AutoPlugin {
     },
     nativeConfig ~= {
       _.withCheck(true)
+        .withCheckFatalWarnings(true)
         .withDump(true)
-        .withNirWarnsAsErrors(true)
     }
   )
 }

--- a/project/MyScalaNativePlugin.scala
+++ b/project/MyScalaNativePlugin.scala
@@ -19,6 +19,7 @@ object MyScalaNativePlugin extends AutoPlugin {
     nativeConfig ~= {
       _.withCheck(true)
         .withDump(true)
+        .withNirWarnsAsErrors(true)
     }
   )
 }

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -74,6 +74,8 @@ sealed trait Config {
   /** Shall linker dump intermediate NIR after every phase? */
   def dump: Boolean = compilerConfig.dump
 
+  def nirWarnsAsErrors: Boolean = compilerConfig.nirWarnsAsErrors
+
   private[scalanative] def targetsWindows: Boolean = {
     compilerConfig.targetTriple.fold(Platform.isWindows) { customTriple =>
       customTriple.contains("win32") ||

--- a/tools/src/main/scala/scala/scalanative/build/Config.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Config.scala
@@ -74,8 +74,6 @@ sealed trait Config {
   /** Shall linker dump intermediate NIR after every phase? */
   def dump: Boolean = compilerConfig.dump
 
-  def nirWarnsAsErrors: Boolean = compilerConfig.nirWarnsAsErrors
-
   private[scalanative] def targetsWindows: Boolean = {
     compilerConfig.targetTriple.fold(Platform.isWindows) { customTriple =>
       customTriple.contains("win32") ||

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -37,11 +37,11 @@ sealed trait NativeConfig {
   /** Shall linker check that NIR is well-formed after every phase? */
   def check: Boolean
 
+  /** Shall linker throw NIR check treat warnings as errors? */
+  def checkFatalWarnings: Boolean
+
   /** Shall linker dump intermediate NIR after every phase? */
   def dump: Boolean
-
-  /** Shall linker throw Nir warnings as errors? */
-  def nirWarnsAsErrors: Boolean
 
   /** Shall we optimize the resulting NIR code? */
   def optimize: Boolean
@@ -82,11 +82,11 @@ sealed trait NativeConfig {
   /** Create a new config with given check value. */
   def withCheck(value: Boolean): NativeConfig
 
+  /** Create a new config with given checkFatalWarnings value. */
+  def withCheckFatalWarnings(value: Boolean): NativeConfig
+
   /** Create a new config with given dump value. */
   def withDump(value: Boolean): NativeConfig
-
-  /** Create a new config with given errorNirWarns value. */
-  def withNirWarnsAsErrors(value: Boolean): NativeConfig
 
   /** Create a new config with given optimize value */
   def withOptimize(value: Boolean): NativeConfig
@@ -109,8 +109,8 @@ object NativeConfig {
       lto = LTO.default,
       mode = Mode.default,
       check = false,
+      checkFatalWarnings = false,
       dump = false,
-      nirWarnsAsErrors = false,
       linkStubs = false,
       optimize = false,
       linktimeProperties = Map.empty
@@ -127,8 +127,8 @@ object NativeConfig {
       lto: LTO,
       linkStubs: Boolean,
       check: Boolean,
+      checkFatalWarnings: Boolean,
       dump: Boolean,
-      nirWarnsAsErrors: Boolean,
       optimize: Boolean,
       linktimeProperties: Map[String, Any]
   ) extends NativeConfig {
@@ -167,11 +167,11 @@ object NativeConfig {
     def withCheck(value: Boolean): NativeConfig =
       copy(check = value)
 
+    def withCheckFatalWarnings(value: Boolean): NativeConfig =
+      copy(checkFatalWarnings = value)
+
     def withDump(value: Boolean): NativeConfig =
       copy(dump = value)
-
-    def withNirWarnsAsErrors(value: Boolean): NativeConfig =
-      copy(nirWarnsAsErrors = value)
 
     def withOptimize(value: Boolean): NativeConfig =
       copy(optimize = value)
@@ -219,19 +219,19 @@ object NativeConfig {
         }
       }
       s"""NativeConfig(
-        | - clang:            $clang
-        | - clangPP:          $clangPP
-        | - linkingOptions:   $linkingOptions
-        | - compileOptions:   $compileOptions
-        | - targetTriple:     $targetTriple
-        | - GC:               $gc
-        | - mode:             $mode
-        | - LTO:              $lto
-        | - linkStubs:        $linkStubs
-        | - check:            $check
-        | - dump:             $dump
-        | - nirWarnsAsErrors: $nirWarnsAsErrors
-        | - optimize          $optimize
+        | - clang:              $clang
+        | - clangPP:            $clangPP
+        | - linkingOptions:     $linkingOptions
+        | - compileOptions:     $compileOptions
+        | - targetTriple:       $targetTriple
+        | - GC:                 $gc
+        | - mode:               $mode
+        | - LTO:                $lto
+        | - linkStubs:          $linkStubs
+        | - check:              $check
+        | - checkFatalWarnings: $checkFatalWarnings
+        | - dump:               $dump
+        | - optimize            $optimize
         | - linktimeProperties: $listLinktimeProperties
         |)""".stripMargin
     }

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -40,6 +40,9 @@ sealed trait NativeConfig {
   /** Shall linker dump intermediate NIR after every phase? */
   def dump: Boolean
 
+  /** Shall linker throw Nir warnings as errors? */
+  def nirWarnsAsErrors: Boolean
+
   /** Shall we optimize the resulting NIR code? */
   def optimize: Boolean
 
@@ -82,6 +85,9 @@ sealed trait NativeConfig {
   /** Create a new config with given dump value. */
   def withDump(value: Boolean): NativeConfig
 
+  /** Create a new config with given errorNirWarns value. */
+  def withNirWarnsAsErrors(value: Boolean): NativeConfig
+
   /** Create a new config with given optimize value */
   def withOptimize(value: Boolean): NativeConfig
 
@@ -104,6 +110,7 @@ object NativeConfig {
       mode = Mode.default,
       check = false,
       dump = false,
+      nirWarnsAsErrors = false,
       linkStubs = false,
       optimize = false,
       linktimeProperties = Map.empty
@@ -121,6 +128,7 @@ object NativeConfig {
       linkStubs: Boolean,
       check: Boolean,
       dump: Boolean,
+      nirWarnsAsErrors: Boolean,
       optimize: Boolean,
       linktimeProperties: Map[String, Any]
   ) extends NativeConfig {
@@ -161,6 +169,9 @@ object NativeConfig {
 
     def withDump(value: Boolean): NativeConfig =
       copy(dump = value)
+
+    def withNirWarnsAsErrors(value: Boolean): NativeConfig =
+      copy(nirWarnsAsErrors = value)
 
     def withOptimize(value: Boolean): NativeConfig =
       copy(optimize = value)
@@ -208,18 +219,19 @@ object NativeConfig {
         }
       }
       s"""NativeConfig(
-        | - clang:           $clang
-        | - clangPP:         $clangPP
-        | - linkingOptions:  $linkingOptions
-        | - compileOptions:  $compileOptions
-        | - targetTriple:    $targetTriple
-        | - GC:              $gc
-        | - mode:            $mode
-        | - LTO:             $lto
-        | - linkStubs:       $linkStubs
-        | - check:           $check
-        | - dump:            $dump
-        | - optimize         $optimize
+        | - clang:            $clang
+        | - clangPP:          $clangPP
+        | - linkingOptions:   $linkingOptions
+        | - compileOptions:   $compileOptions
+        | - targetTriple:     $targetTriple
+        | - GC:               $gc
+        | - mode:             $mode
+        | - LTO:              $lto
+        | - linkStubs:        $linkStubs
+        | - check:            $check
+        | - dump:             $dump
+        | - nirWarnsAsErrors: $nirWarnsAsErrors
+        | - optimize          $optimize
         | - linktimeProperties: $listLinktimeProperties
         |)""".stripMargin
     }

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -37,7 +37,7 @@ sealed trait NativeConfig {
   /** Shall linker check that NIR is well-formed after every phase? */
   def check: Boolean
 
-  /** Shall linker throw NIR check treat warnings as errors? */
+  /** Shall linker NIR check treat warnings as errors? */
   def checkFatalWarnings: Boolean
 
   /** Shall linker dump intermediate NIR after every phase? */

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -104,7 +104,9 @@ private[scalanative] object ScalaNative {
   )(linked: scalanative.linker.Result): scalanative.linker.Result = {
     if (config.check) {
       config.logger.time("Checking intermediate code") {
-        def warn(s: String) = config.logger.warn(s)
+        def warn(s: String) =
+          if (config.nirWarnsAsErrors) config.logger.error(s)
+          else config.logger.warn(s)
         val errors = Check(linked)
         if (errors.nonEmpty) {
           val grouped =

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -105,7 +105,7 @@ private[scalanative] object ScalaNative {
     if (config.check) {
       config.logger.time("Checking intermediate code") {
         def warn(s: String) =
-          if (config.nirWarnsAsErrors) config.logger.error(s)
+          if (config.compilerConfig.checkFatalWarnings) config.logger.error(s)
           else config.logger.warn(s)
         val errors = Check(linked)
         if (errors.nonEmpty) {

--- a/tools/src/main/scala/scala/scalanative/linker/Sub.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Sub.scala
@@ -121,12 +121,14 @@ object Sub {
       // it should be ignored. Otherwise java.lang.Object
       // would be returned, which may not be correct
       val correctedBoundInfo = boundInfo.flatMap { bound =>
-        if(linfo.is(bound) && rinfo.is(bound)) Some(bound)
-        else None 
+        if (linfo.is(bound) && rinfo.is(bound)) Some(bound)
+        else None
       }
-      
+
       val candidates =
-        linfo.linearized.filter { i => rinfo.is(i) && correctedBoundInfo.forall(i.is) }
+        linfo.linearized.filter { i =>
+          rinfo.is(i) && correctedBoundInfo.forall(i.is)
+        }
 
       candidates match {
         case Seq() =>

--- a/tools/src/main/scala/scala/scalanative/linker/Sub.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Sub.scala
@@ -120,9 +120,8 @@ object Sub {
       // If bound is not a type of linfo or rinfo
       // it should be ignored. Otherwise java.lang.Object
       // would be returned, which may not be correct
-      val correctedBoundInfo = boundInfo.flatMap { bound =>
-        if (linfo.is(bound) && rinfo.is(bound)) Some(bound)
-        else None
+      val correctedBoundInfo = boundInfo.filterNot { bound =>
+        (!linfo.is(bound) || !rinfo.is(bound))
       }
 
       val candidates =

--- a/tools/src/main/scala/scala/scalanative/linker/Sub.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Sub.scala
@@ -117,8 +117,16 @@ object Sub {
     } else if (rinfo.is(linfo)) {
       linfo
     } else {
+      // If bound is not a type of linfo or rinfo
+      // it should be ignored. Otherwise java.lang.Object
+      // would be returned, which may not be correct
+      val correctedBoundInfo = boundInfo.flatMap { bound =>
+        if(linfo.is(bound) && rinfo.is(bound)) Some(bound)
+        else None 
+      }
+      
       val candidates =
-        linfo.linearized.filter { i => rinfo.is(i) && boundInfo.forall(i.is) }
+        linfo.linearized.filter { i => rinfo.is(i) && correctedBoundInfo.forall(i.is) }
 
       candidates match {
         case Seq() =>


### PR DESCRIPTION
Previously, if bound value in `Sub.lub` was not a supertype of either resolved value (`linfo` or `rinfo`), the type would always be resolved as `java.lang.Object`, which would result in NIR warnings. Now, the bound value is being checked and ignored if found to be incorrect. Additionally, as discussed in #2021, a new option is added to native build which decides whether to interpret NIR warnings as errors. In our build, it is turned on by default so that one can easily identify NIR errors in the CI. If contentious, I can always remove that feature, but I thought it would be useful to have this option implemented and turned on for this fix.

Fixes #2211