### PR TITLE
Implement `java.nio` on Windows

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -147,8 +147,8 @@ jobs:
           set SCALANATIVE &
           sbt ++${{matrix.scala}}
           sandbox/run
-          "testsJVM/testOnly javalib.math.* javalib.security.* javalib.io.*"
-          "tests/testOnly javalib.math.* javalib.security.* javalib.io.*"
+          "testsJVM/testOnly javalib.math.* javalib.security.* javalib.io.* javalib.nio.*"
+          "tests/testOnly javalib.math.* javalib.security.* javalib.io.* javalib.nio.*"
           testsExt/test
           testsExtJVM/test
         shell: cmd

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -7,7 +7,7 @@ import scala.scalanative.libc.stdio._
 import scala.scalanative.meta.LinktimeInfo.isWindows
 import scala.scalanative.posix.unistd
 import scala.scalanative.posix.unistd.lseek
-import scala.scalanative.nio.fs.UnixException
+import scala.scalanative.nio.fs.unix.UnixException
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 import scala.scalanative.{runtime, windows}

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -1,7 +1,7 @@
 package java.io
 
 import java.nio.file.WindowsException
-import scala.scalanative.nio.fs.UnixException
+import scala.scalanative.nio.fs.unix.UnixException
 import scala.scalanative.libc._
 import scala.scalanative.meta.LinktimeInfo.isWindows
 import scala.scalanative.posix.unistd

--- a/javalib/src/main/scala/java/nio/file/FileSystemException.scala
+++ b/javalib/src/main/scala/java/nio/file/FileSystemException.scala
@@ -19,12 +19,12 @@ class FileSystemException(file: String, other: String, reason: String)
         case (f1, null)   => s"$f1"
         case (f1, f2)     => s"$f1 -> $f2"
       }
-      (files, reason) match {
-        case (null, null) => null
-        case (null, reason) => reason
-        case (files, null) => files
-        case (files, reason) => s"$files: $reason"
-      }
+    (files, reason) match {
+      case (null, null)    => null
+      case (null, reason)  => reason
+      case (files, null)   => files
+      case (files, reason) => s"$files: $reason"
+    }
   }
 
   def getOtherFile(): String =

--- a/javalib/src/main/scala/java/nio/file/FileSystemException.scala
+++ b/javalib/src/main/scala/java/nio/file/FileSystemException.scala
@@ -11,17 +11,20 @@ class FileSystemException(file: String, other: String, reason: String)
     file
 
   override def getMessage(): String = {
-    val message =
-      if (reason == null) ""
-      else s": $reason"
+
     val files =
       (file, other) match {
-        case (null, null) => ""
+        case (null, null) => null
         case (null, f2)   => s" -> $f2"
         case (f1, null)   => s"$f1"
         case (f1, f2)     => s"$f1 -> $f2"
       }
-    s"$files$message"
+      (files, reason) match {
+        case (null, null) => null
+        case (null, reason) => reason
+        case (files, null) => files
+        case (files, reason) => s"$files: $reason"
+      }
   }
 
   def getOtherFile(): String =

--- a/javalib/src/main/scala/java/nio/file/FileSystems.scala
+++ b/javalib/src/main/scala/java/nio/file/FileSystems.scala
@@ -5,13 +5,17 @@ import java.nio.file.spi.FileSystemProvider
 import java.net.URI
 import java.util.{HashMap, Map}
 
-import scala.scalanative.nio.fs.{UnixFileSystem, UnixFileSystemProvider}
+import scala.scalanative.nio.fs.unix.{UnixFileSystem, UnixFileSystemProvider}
+import scala.scalanative.nio.fs.windows.{
+  WindowsFileSystem,
+  WindowsFileSystemProvider
+}
 import scala.scalanative.meta.LinktimeInfo.isWindows
 
 object FileSystems {
   private lazy val fs = {
     val provider =
-      if (isWindows) ???
+      if (isWindows) new WindowsFileSystemProvider()
       else new UnixFileSystemProvider()
 
     provider.getFileSystem(
@@ -26,7 +30,6 @@ object FileSystems {
       )
     )
   }
-
   def getDefault(): FileSystem = fs
 
   def getFileSystem(uri: URI): FileSystem = {

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -650,11 +650,14 @@ object Files {
   def readAllLines(path: Path, cs: Charset): List[String] = {
     val list = new LinkedList[String]()
     val reader = newBufferedReader(path, cs)
-    val lines = reader.lines().iterator()
-    while (lines.hasNext()) {
-      list.add(lines.next())
+    try {
+      val lines = reader.lines().iterator()
+      while (lines.hasNext()) {
+        list.add(lines.next())
+      }
+    } finally {
+      reader.close()
     }
-    reader.close()
     list
   }
 

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -728,7 +728,7 @@ object Files {
           if (unistd.readlink(
                 toCString(link.toString),
                 buf,
-                  limits.PATH_MAX - `1U`
+                limits.PATH_MAX - `1U`
               ) == -1) {
             throw UnixException(link.toString, errno.errno)
           }

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -6,17 +6,15 @@ import java.io.{
   BufferedWriter,
   File,
   FileOutputStream,
+  IOException,
   InputStream,
   InputStreamReader,
-  IOException,
   OutputStream,
   OutputStreamWriter
 }
-
 import java.nio.file.attribute._
 import java.nio.charset.{Charset, StandardCharsets}
 import java.nio.channels.{FileChannel, SeekableByteChannel}
-
 import java.util.function.BiPredicate
 import java.util.{
   EnumSet,
@@ -29,18 +27,25 @@ import java.util.{
   Set
 }
 import java.util.stream.{Stream, WrappedScalaStream}
-
-import scalanative.meta.LinktimeInfo.isWindows
 import scalanative.unsigned._
 import scalanative.unsafe._
 import scalanative.libc._
-import scalanative.posix.{dirent, fcntl, limits, unistd}, dirent._
+import scalanative.posix.{dirent, fcntl, limits, unistd}
+import dirent._
+import java.nio.file.StandardCopyOption.{COPY_ATTRIBUTES, REPLACE_EXISTING}
+import scalanative.nio.fs.unix.UnixException
 import scalanative.posix.sys.stat
-import scalanative.nio.fs.{FileHelpers, UnixException}
+import scalanative.windows._
+import scalanative.windows.WinBaseApi._
+import scalanative.windows.WinBaseApiExt._
+import scalanative.windows.FileApiExt._
+import scalanative.windows.ErrorHandlingApi._
+import scalanative.windows.winnt.AccessRights._
+import java.util.WindowsHelperMethods._
+import scalanative.nio.fs.FileHelpers
 import scalanative.compat.StreamsCompat._
-
+import scalanative.meta.LinktimeInfo.isWindows
 import scala.collection.immutable.{Map => SMap, Set => SSet}
-import StandardCopyOption._
 
 object Files {
 
@@ -81,15 +86,20 @@ object Files {
 
   def copy(source: Path, target: Path, options: Array[CopyOption]): Path = {
     val linkOpts = Array(LinkOption.NOFOLLOW_LINKS)
-    val attrs =
-      Files.readAttributes(source, classOf[PosixFileAttributes], linkOpts)
+    val attrsCls =
+      if (isWindows) classOf[DosFileAttributes]
+      else classOf[PosixFileAttributes]
+
+    val attrs = Files.readAttributes(source, attrsCls, linkOpts)
     if (attrs.isSymbolicLink())
       throw new IOException(
         s"Unsupported operation: copy symbolic link $source to $target"
       )
+
     val targetExists = exists(target, linkOpts)
     if (targetExists && !options.contains(REPLACE_EXISTING))
       throw new FileAlreadyExistsException(target.toString)
+
     if (isDirectory(source, Array.empty)) {
       createDirectory(target, Array.empty)
     } else {
@@ -97,16 +107,27 @@ object Files {
       try copy(in, target, options.filter(_ == REPLACE_EXISTING))
       finally in.close()
     }
-    if (options.contains(COPY_ATTRIBUTES)) {
-      val newAttrView =
-        getFileAttributeView(target, classOf[PosixFileAttributeView], linkOpts)
 
-      // Re-read attrs, copy() above may have changed lastModifiedTime.
-      val attrs =
-        Files.readAttributes(source, classOf[PosixFileAttributes], linkOpts)
-      newAttrView.setGroup(attrs.group())
-      newAttrView.setOwner(attrs.owner())
-      newAttrView.setPermissions(attrs.permissions())
+    if (options.contains(COPY_ATTRIBUTES)) {
+      val attrViewCls =
+        if (isWindows) classOf[DosFileAttributeView]
+        else classOf[PosixFileAttributeView]
+      val newAttrView = getFileAttributeView(target, attrViewCls, linkOpts)
+
+      (attrs, newAttrView) match {
+        case (
+              attrs: PosixFileAttributes,
+              newAttrView: PosixFileAttributeView
+            ) =>
+          newAttrView.setGroup(attrs.group())
+          newAttrView.setOwner(attrs.owner())
+          newAttrView.setPermissions(attrs.permissions())
+        case (attrs: DosFileAttributes, newAttrView: DosFileAttributeView) =>
+          newAttrView.setArchive(attrs.isArchive())
+          newAttrView.setHidden(attrs.isHidden())
+          newAttrView.setReadOnly(attrs.isReadOnly())
+          newAttrView.setSystem(attrs.isSystem())
+      }
       newAttrView.setTimes(
         attrs.lastModifiedTime(),
         attrs.lastAccessTime(),
@@ -166,7 +187,12 @@ object Files {
 
   def createLink(link: Path, existing: Path): Path = {
     def tryCreateHardLink() = Zone { implicit z =>
-      if (isWindows) ???
+      if (isWindows)
+        CreateHardLinkW(
+          toCWideStringUTF16LE(link.toString),
+          toCWideStringUTF16LE(existing.toString),
+          securityAttributes = null
+        )
       else
         unistd.link(
           toCString(existing.toString()),
@@ -189,8 +215,35 @@ object Files {
   ): Path = {
 
     def tryCreateLink() = Zone { implicit z =>
-      if (isWindows) ???
-      else {
+      if (isWindows) {
+        import WinBaseApiExt._
+        val targetFilename = toCWideStringUTF16LE(target.toString())
+        val linkFilename = toCWideStringUTF16LE(link.toString())
+        val flags =
+          if (target.toFile().isFile()) SYMBOLIC_LINK_FLAG_FILE
+          else SYMBOLIC_LINK_FLAG_DIRECTORY
+        val created =
+          CreateSymbolicLinkW(
+            symlinkFileName = linkFilename,
+            targetFileName = targetFilename,
+            flags = flags
+          )
+        val ERROR_PRIVILEGE_NOT_HELD = 1314.toUInt
+        // On Windows creating soft link is possible only with admin privileges
+        if (!created &&
+            GetLastError() == ERROR_PRIVILEGE_NOT_HELD) {
+          // If develop mode is enabled we can create unprivileged symlinks
+          CreateSymbolicLinkW(
+            symlinkFileName = linkFilename,
+            targetFileName = targetFilename,
+            flags = flags | SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+          ) || {
+            throw new SecurityException(
+              "Creating symbolic link requires admin privileges"
+            )
+          }
+        } else created
+      } else {
         val targetFilename = toCString(target.toString())
         val linkFilename = toCString(link.toString())
         unistd.symlink(targetFilename, linkFilename) == 0
@@ -278,12 +331,12 @@ object Files {
       delete(path); true
     } catch { case _: NoSuchFileException => false }
 
-  def exists(path: Path, options: Array[LinkOption]): Boolean =
-    if (options.contains(LinkOption.NOFOLLOW_LINKS)) {
-      path.toFile().exists() || isSymbolicLink(path)
-    } else {
-      path.toFile().exists()
-    }
+  def exists(path: Path, options: Array[LinkOption]): Boolean = {
+    def fileExists = path.toFile().exists()
+    def noFollowLinks = options.contains(LinkOption.NOFOLLOW_LINKS)
+
+    fileExists || (noFollowLinks && isSymbolicLink(path))
+  }
 
   def find(
       start: Path,
@@ -367,8 +420,9 @@ object Files {
     path.toFile().canRead()
 
   def isRegularFile(path: Path, options: Array[LinkOption]): Boolean = {
-    if (isWindows) ???
-    else
+    if (isWindows) {
+      getAttribute(path, "basic:isRegularFile", options).asInstanceOf[Boolean]
+    } else
       Zone { implicit z =>
         val buf = alloc[stat.stat]
         val err =
@@ -386,10 +440,16 @@ object Files {
     path.toFile().getCanonicalPath() == path2.toFile().getCanonicalPath()
 
   def isSymbolicLink(path: Path): Boolean = Zone { implicit z =>
-    if (isWindows) ???
-    else {
+    if (isWindows) {
+      val filename = toCWideStringUTF16LE(path.toFile().getPath())
+      val attrs = FileApi.GetFileAttributesW(filename)
+      val exists = attrs != INVALID_FILE_ATTRIBUTES
+      def isReparsePoint = (attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0.toUInt
+      exists & isReparsePoint
+    } else {
+      val filename = toCString(path.toFile().getPath())
       val buf = alloc[stat.stat]
-      if (stat.lstat(toCString(path.toFile().getPath()), buf) == 0) {
+      if (stat.lstat(filename, buf) == 0) {
         stat.S_ISLNK(buf._13) == 1
       } else {
         false
@@ -436,8 +496,29 @@ object Files {
     Zone { implicit z =>
       val sourceAbs = source.toAbsolutePath().toString
       val targetAbs = target.toAbsolutePath().toString
-      if (isWindows) ???
-      else {
+      if (isWindows) {
+        val sourceCString = toCWideStringUTF16LE(sourceAbs)
+        val targetCString = toCWideStringUTF16LE(targetAbs)
+        // We cannot replace directory, it needs to be removed first
+        if (replaceExisting && target.toFile().isDirectory()) {
+          //todo delete children
+          Files.delete(target)
+        }
+        // stdio.rename on Windows does not replace existing file
+        val flags = {
+          val replace =
+            if (replaceExisting) MOVEFILE_REPLACE_EXISTING else 0.toUInt
+          MOVEFILE_COPY_ALLOWED | //Allow coping betwen volumes
+            MOVEFILE_WRITE_THROUGH | //Block until actually moved
+            replace
+        }
+        if (!MoveFileExW(sourceCString, targetCString, flags)) {
+          GetLastError() match {
+            case ErrorCodes.ERROR_SUCCESS => ()
+            case _ => throw WindowsException.onPath(target.toString())
+          }
+        }
+      } else {
         val sourceCString = toCString(sourceAbs)
         val targetCString = toCString(targetAbs)
         if (stdio.rename(sourceCString, targetCString) != 0) {
@@ -525,8 +606,25 @@ object Files {
     val len = pathSize.toInt
     val bytes = scala.scalanative.runtime.ByteArray.alloc(len)
 
-    if (isWindows) ???
-    else {
+    if (isWindows) {
+      val bytesRead = stackalloc[DWord]
+
+      withFileOpen(
+        path.toString,
+        access = FILE_GENERIC_READ,
+        shareMode = FILE_SHARE_READ
+      ) { handle =>
+        if (!FileApi.ReadFile(
+              handle,
+              bytes.at(0),
+              pathSize.toUInt,
+              bytesRead,
+              null
+            )) {
+          throw WindowsException.onPath(path.toString())
+        }
+      }
+    } else {
       val pathCString = toCString(path.toString)
       val fd = fcntl.open(pathCString, fcntl.O_RDONLY, 0.toUInt)
       try {
@@ -556,6 +654,7 @@ object Files {
     while (lines.hasNext()) {
       list.add(lines.next())
     }
+    reader.close()
     list
   }
 
@@ -603,19 +702,38 @@ object Files {
       throw new NotLinkException(link.toString)
     } else
       Zone { implicit z =>
-        val name =
-          if (isWindows) ???
-          else {
-            val buf: CString = alloc[Byte](limits.PATH_MAX.toUInt)
-            if (unistd.readlink(
-                  toCString(link.toString),
-                  buf,
-                  limits.PATH_MAX - `1U`
-                ) == -1) {
-              throw UnixException(link.toString, errno.errno)
+        val name = if (isWindows) {
+          withFileOpen(
+            link.toString,
+            access = FILE_GENERIC_READ
+          ) { handle =>
+            val bufferSize = FileApiExt.MAX_PATH
+            val buffer = alloc[WChar](bufferSize)
+            val pathSize =
+              FileApi.GetFinalPathNameByHandleW(
+                handle,
+                buffer,
+                bufferSize,
+                FileApiExt.FILE_NAME_NORMALIZED
+              )
+            if (pathSize > bufferSize) {
+              throw WindowsException(
+                "Target path size of link was greater then max allowed size"
+              )
             }
-            fromCString(buf)
+            fromCWideString(buffer, StandardCharsets.UTF_16LE)
           }
+        } else {
+          val buf: CString = alloc[Byte](limits.PATH_MAX.toUInt)
+          if (unistd.readlink(
+                toCString(link.toString),
+                buf,
+                  limits.PATH_MAX - `1U`
+              ) == -1) {
+            throw UnixException(link.toString, errno.errno)
+          }
+          fromCString(buf)
+        }
         Paths.get(name, Array.empty)
       }
 
@@ -865,10 +983,9 @@ object Files {
         setAttribute(path, name, value.asInstanceOf[AnyRef], Array.empty)
     }
 
-  private val attributesClassesToViews: SMap[
-    Class[_ <: BasicFileAttributes],
-    Class[_ <: BasicFileAttributeView]
-  ] =
+  private val attributesClassesToViews: SMap[Class[
+    _ <: BasicFileAttributes
+  ], Class[_ <: BasicFileAttributeView]] =
     SMap(
       classOf[BasicFileAttributes] -> classOf[BasicFileAttributeView],
       classOf[DosFileAttributes] -> classOf[DosFileAttributeView],

--- a/javalib/src/main/scala/java/nio/file/InvalidPathException.scala
+++ b/javalib/src/main/scala/java/nio/file/InvalidPathException.scala
@@ -1,0 +1,17 @@
+package java.nio.file
+
+class InvalidPathException(input: String, reason: String, index: Int)
+    extends IllegalArgumentException(reason) {
+  def this(input: String, reason: String) = this(input, reason, -1)
+
+  def getInput(): String = input
+  def getReason() = reason
+  def getIndex(): Int = index
+
+  override def getMessage() = {
+    val location =
+      if (index >= 0) s"at index $index"
+      else ""
+    s"${this.getClass().getName()}: $reason $location: $input"
+  }
+}

--- a/javalib/src/main/scala/java/nio/file/WindowsException.scala
+++ b/javalib/src/main/scala/java/nio/file/WindowsException.scala
@@ -2,17 +2,18 @@ package java.nio.file
 
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
-import scalanative.libc.{string, errno => stdErrno}
-import scalanative.posix.errno.ENOTDIR
+import scala.scalanative.posix.errno._
+import scala.scalanative.windows._
 import java.io.IOException
 import java.nio.charset.StandardCharsets
-import scala.scalanative.windows._
 import scala.scalanative.windows.ErrorHandlingApi._
 import scala.scalanative.windows.ErrorHandlingApiOps.errorMessage
 import scala.scalanative.windows.WinBaseApi._
+import java.nio.file._
+import scalanative.libc.{string, errno => stdErrno}
 
-private[java] trait WindowsException extends Exception
-private[java] object WindowsException {
+trait WindowsException extends Exception
+object WindowsException {
   def apply(msg: String): WindowsException = {
     WindowsException(msg, GetLastError())
   }

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -2,7 +2,6 @@ package java.nio.file.attribute
 
 import java.{util => ju}
 import java.util.{HashMap, HashSet, Set}
-
 import java.util.concurrent.TimeUnit
 import java.nio.file.{LinkOption, Path, PosixException}
 import java.nio.file.attribute._

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixUserPrincipalLookupService.scala
@@ -5,7 +5,7 @@ import scalanative.unsafe._
 import scalanative.libc._
 import scalanative.posix.{errno => e, grp, pwd, unistd, time, utime}, e._
 import scalanative.posix.sys.stat
-import scala.scalanative.nio.fs.UnixException
+import scala.scalanative.nio.fs.unix.UnixException
 
 final case class PosixUserPrincipal(uid: stat.uid_t)(name: Option[String])
     extends UserPrincipal {

--- a/javalib/src/main/scala/java/nio/file/spi/FileSystemProvider.scala
+++ b/javalib/src/main/scala/java/nio/file/spi/FileSystemProvider.scala
@@ -19,8 +19,9 @@ import java.nio.channels.{
   SeekableByteChannel
 }
 
+import scala.scalanative.nio.fs.unix.UnixFileSystemProvider
+import scala.scalanative.nio.fs.windows.WindowsFileSystemProvider
 import scala.scalanative.meta.LinktimeInfo.isWindows
-import scala.scalanative.nio.fs.UnixFileSystemProvider
 
 abstract class FileSystemProvider protected () {
 
@@ -173,8 +174,10 @@ abstract class FileSystemProvider protected () {
 object FileSystemProvider {
   def installedProviders: List[FileSystemProvider] = {
     val list = new LinkedList[FileSystemProvider]
-    if (isWindows) ???
-    else list.add(new UnixFileSystemProvider())
+    if (isWindows)
+      list.add(new WindowsFileSystemProvider())
+    else
+      list.add(new UnixFileSystemProvider())
     list
   }
 

--- a/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
+++ b/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
@@ -14,7 +14,11 @@ import winnt.AccessToken._
 import scala.scalanative.windows.SecurityBaseApi._
 import java.nio.file.WindowsException
 
-private[java] object WindowsHelperMethods {
+/** Windows implementation specific helper methods, not available in public API
+ *  (javalib does not contain them in published jar) Not made `java` package
+ *  private only because of usage inside `scala.scalanative.nio.fs`
+ */
+object WindowsHelperMethods {
   def withUserToken[T](desiredAccess: DWord)(fn: Handle => T): T = {
     val tokenHandle = stackalloc[Handle]
     def getProcessToken =

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -88,7 +88,7 @@ object FileHelpers {
     }
 
     def listWindows() = Zone { implicit z =>
-      val searchPath = path + raw"\*"
+      val searchPath = raw"$path\*"
       if (searchPath.length.toUInt > FileApiExt.MAX_PATH)
         throw new IOException("File name to long")
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -11,12 +11,17 @@ import scala.collection.mutable.UnrolledBuffer
 import scala.reflect.ClassTag
 import java.io.{File, IOException}
 import java.nio.charset.StandardCharsets
-import scala.scalanative.windows.ErrorHandlingApi._
+import scala.scalanative.windows._
+import scala.scalanative.windows.HandleApiExt.INVALID_HANDLE_VALUE
 import scala.scalanative.windows.FileApi._
 import scala.scalanative.windows.FileApiExt._
-import scala.scalanative.windows.HandleApiExt._
+import scala.scalanative.windows.FileApiOps._
+import scala.scalanative.windows.ErrorHandlingApi._
 import scala.scalanative.windows.winnt.AccessRights._
-import scala.scalanative.windows._
+
+import java.nio.file.WindowsException
+import scala.scalanative.nio.fs.unix.UnixException
+import java.nio.file.attribute.FileAttribute
 
 object FileHelpers {
   sealed trait FileType
@@ -82,7 +87,36 @@ object FileHelpers {
       }
     }
 
-    def listWindows() = ???
+    def listWindows() = Zone { implicit z =>
+      val searchPath = path + raw"\*"
+      if (searchPath.length.toUInt > FileApiExt.MAX_PATH)
+        throw new IOException("File name to long")
+
+      val fileData = stackalloc[Win32FindDataW]
+      val searchHandle =
+        FindFirstFileW(toCWideStringUTF16LE(searchPath), fileData)
+      if (searchHandle == INVALID_HANDLE_VALUE) {
+        if (allowEmpty) Array.empty[T]
+        else throw WindowsException.onPath(path)
+      } else {
+        try {
+          while ({
+            collectFile(
+              fromCWideString(fileData.fileName, StandardCharsets.UTF_16LE),
+              FileType.windowsFileType(fileData.fileAttributes)
+            )
+            FileApi.FindNextFileW(searchHandle, fileData)
+          }) ()
+        } finally {
+          FileApi.FindClose(searchHandle)
+        }
+
+        GetLastError() match {
+          case ErrorCodes.ERROR_NO_MORE_FILES => buffer.toArray
+          case err => throw WindowsException.onPath(path)
+        }
+      }
+    }
 
     if (isWindows) listWindows()
     else listUnix()
@@ -101,14 +135,21 @@ object FileHelpers {
             desiredAccess = FILE_GENERIC_WRITE,
             shareMode = FILE_SHARE_ALL,
             securityAttributes = null,
-            creationDisposition = CREATE_NEW,
+            creationDisposition = CREATE_ALWAYS,
             flagsAndAttributes = FILE_ATTRIBUTE_NORMAL,
             templateFile = null
           )
           HandleApi.CloseHandle(handle)
           GetLastError() match {
             case ErrorCodes.ERROR_FILE_EXISTS => false
-            case _                            => handle != INVALID_HANDLE_VALUE
+            case errCode =>
+              if (handle != INVALID_HANDLE_VALUE) true
+              else if (throwOnError)
+                throw WindowsException(
+                  s"Cannot create new file $path",
+                  errorCode = errCode
+                )
+              else false
           }
         } else {
           fopen(toCString(path), c"w") match {

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixException.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixException.scala
@@ -1,9 +1,9 @@
-package scala.scalanative.nio.fs
+package scala.scalanative.nio.fs.unix
 
 import java.io.IOException
 import java.nio.file.PosixException
 
-import scala.scalanative.unsafe.CInt
+import scala.scalanative.unsafe._
 
 object UnixException {
   def apply(file: String, errno: CInt): IOException =

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
@@ -1,4 +1,4 @@
-package scala.scalanative.nio.fs
+package scala.scalanative.nio.fs.unix
 
 import java.io.IOException
 import java.lang.Iterable

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystemProvider.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystemProvider.scala
@@ -1,0 +1,36 @@
+package scala.scalanative.nio.fs.unix
+
+import scala.scalanative.unsafe.{CChar, fromCString, stackalloc}
+import scala.scalanative.unsigned._
+import scala.scalanative.posix.unistd
+import scala.scalanative.libc.errno
+import scala.collection.immutable.{Map => SMap}
+import scala.scalanative.nio.fs.GenericFileSystemProvider
+import java.nio.file.attribute._
+import java.nio.file.FileSystem
+
+class UnixFileSystemProvider extends GenericFileSystemProvider {
+
+  protected lazy val fs: FileSystem =
+    new UnixFileSystem(this, "/", getUserDir())
+
+  protected val knownFileAttributeViews: AttributeViewMapping = {
+    def PosixFileAttrView = (p, l) => new PosixFileAttributeViewImpl(p, l)
+    SMap(
+      classOf[BasicFileAttributeView] -> PosixFileAttrView,
+      classOf[PosixFileAttributeView] -> PosixFileAttrView,
+      classOf[FileOwnerAttributeView] -> PosixFileAttrView
+    )
+  }
+
+  private def getUserDir(): String = {
+    val buff = stackalloc[CChar](4096.toUInt)
+    val res = unistd.getcwd(buff, 4095.toUInt)
+    if (res == null)
+      throw UnixException(
+        "Could not determine current working directory",
+        errno.errno
+      )
+    fromCString(res)
+  }
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixPath.scala
@@ -1,19 +1,9 @@
-package scala.scalanative.nio.fs
+package scala.scalanative.nio.fs.unix
 
 import java.io.File
 import java.net.URI
-import java.nio.file.{
-  FileSystem,
-  Files,
-  LinkOption,
-  NoSuchFileException,
-  Path,
-  WatchEvent,
-  WatchKey
-}
+import java.nio.file._
 import java.util.Iterator
-
-import scala.collection.mutable.UnrolledBuffer
 
 class UnixPath(private val fs: UnixFileSystem, rawPath: String) extends Path {
   import UnixPath._

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsAclFileAttributeView.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsAclFileAttributeView.scala
@@ -1,0 +1,79 @@
+package scala.scalanative.nio.fs.windows
+
+import java.util.{HashMap, HashSet, Set}
+import java.util.concurrent.TimeUnit
+import java.nio.file.{LinkOption, Path}
+import java.nio.file.attribute._
+
+import scalanative.unsigned._
+import scalanative.unsafe._
+import scalanative.libc._
+import scalanative.annotation.stub
+import scala.scalanative.windows._
+import java.nio.file.WindowsException
+import java.util.WindowsHelperMethods._
+import java.{util => ju}
+
+class WindowsAclFileAttributeView(path: Path, options: Array[LinkOption])
+    extends AclFileAttributeView {
+  import SecurityBaseApi._
+  import MinWinBaseApi._
+  import WinBaseApi._
+  import WinBaseApiExt._
+  import AclApi._
+
+  def name(): String = "acl"
+
+  def getOwner(): UserPrincipal =
+    Zone { implicit z =>
+      val filename = toCWideStringUTF16LE(path.toString)
+      val ownerSid = stackalloc[SIDPtr]
+
+      if (AclApi.GetNamedSecurityInfoW(
+            filename,
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION,
+            sidOwner = ownerSid,
+            sidGroup = null,
+            dacl = null,
+            sacl = null,
+            securityDescriptor = null
+          ) != 0.toUInt) {
+        throw WindowsException("Failed to get ownership info")
+      }
+      WindowsUserPrincipal(!ownerSid)
+    }
+
+  def setOwner(owner: UserPrincipal): Unit = Zone { implicit z =>
+    val filename = toCWideStringUTF16LE(path.toString)
+
+    val sidCString = owner match {
+      case WindowsUserPrincipal.User(sidString, _, _) =>
+        toCWideStringUTF16LE(sidString)
+      case _ =>
+        throw WindowsException(
+          "Unsupported user principal type " + owner.getClass.getName
+        )
+    }
+    val newOwnerSid = stackalloc[SIDPtr]
+
+    if (!SddlApi.ConvertStringSidToSidW(sidCString, newOwnerSid)) {
+      throw WindowsException("Cannot convert user principal to sid")
+    }
+
+    if (AclApi.SetNamedSecurityInfoW(
+          filename,
+          SE_FILE_OBJECT,
+          OWNER_SECURITY_INFORMATION,
+          sidOwner = !newOwnerSid,
+          sidGroup = null,
+          dacl = null,
+          sacl = null
+        ) != 0.toUInt) {
+      throw WindowsException("Failed to set new owner")
+    }
+  }
+
+  @stub def getAcl(): ju.List[AclEntry] = ???
+  @stub def setAcl(x: ju.List[AclEntry]): Unit = ???
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsDosFileAttributeView.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsDosFileAttributeView.scala
@@ -174,7 +174,6 @@ final class WindowsDosFileAttributeView(path: Path, options: Array[LinkOption])
       }
   }
 
-  @alwaysinline
   private lazy val pathAbs = path.toAbsolutePath().toString
 
   private def toFileTime(winFileTime: WinFileTime): FileTime = {

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsDosFileAttributeView.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsDosFileAttributeView.scala
@@ -1,0 +1,196 @@
+package scala.scalanative.nio.fs.windows
+
+import java.util.{HashMap => JHashMap}
+import java.util.concurrent.TimeUnit
+import java.nio.file.{LinkOption, Path}
+import java.nio.file.attribute._
+import java.lang.{Boolean => JBoolean}
+import niocharset.StandardCharsets
+import scalanative.unsigned._
+import scalanative.unsafe._
+import scalanative.libc._
+import scala.scalanative.windows._
+import scala.scalanative.windows.MinWinBaseApi.{FileTime => WinFileTime, _}
+import scala.scalanative.windows.MinWinBaseApiOps.FileTimeOps._
+import scala.scalanative.windows.FileApi._
+import scala.scalanative.windows.FileApiExt._
+import scala.scalanative.windows.FileApiOps._
+import scala.scalanative.windows.winnt.AccessRights._
+import java.nio.file.WindowsException
+import scala.scalanative.annotation.alwaysinline
+import java.util.WindowsHelperMethods._
+
+final class WindowsDosFileAttributeView(path: Path, options: Array[LinkOption])
+    extends DosFileAttributeView {
+  def name(): String = "dos"
+
+  private val followLinks = !options.contains(LinkOption.NOFOLLOW_LINKS)
+  private val fileOpeningFlags = {
+    FILE_FLAG_BACKUP_SEMANTICS | {
+      if (followLinks) 0.toUInt
+      else FILE_FLAG_OPEN_REPARSE_POINT
+    }
+  }
+
+  override def setAttribute(name: String, value: Object): Unit =
+    (name, value) match {
+      case ("lastModifiedTime", time: FileTime) => setTimes(time, null, null)
+      case ("lastAccessTime", time: FileTime)   => setTimes(null, time, null)
+      case ("creationTime", time: FileTime)     => setTimes(null, null, time)
+      case ("readonly", v: JBoolean)            => setReadOnly(v)
+      case ("hidden", v: JBoolean)              => setHidden(v)
+      case ("system", v: JBoolean)              => setSystem(v)
+      case ("archive", v: JBoolean)             => setArchive(v)
+      case _ => super.setAttribute(name, value)
+    }
+
+  override def asMap: JHashMap[String, Object] = {
+    val map = new JHashMap[String, Object]()
+    map.put("lastModifiedTime", attributes.lastModifiedTime())
+    map.put("lastAccessTime", attributes.lastAccessTime())
+    map.put("creationTime", attributes.creationTime())
+    map.put("fileKey", attributes.fileKey())
+    map.put("size", Long.box(attributes.size()))
+    map.put("isRegularFile", Boolean.box(attributes.isRegularFile()))
+    map.put("isDirectory", Boolean.box(attributes.isDirectory()))
+    map.put("isSymbolicLink", Boolean.box(attributes.isSymbolicLink()))
+    map.put("isOther", Boolean.box(attributes.isOther()))
+    map.put("readonly", Boolean.box(attributes.isReadOnly()))
+    map.put("hidden", Boolean.box(attributes.isHidden()))
+    map.put("system", Boolean.box(attributes.isSystem()))
+    map.put("archive", Boolean.box(attributes.isArchive()))
+    map
+  }
+
+  def setArchive(value: Boolean): Unit =
+    setWinAttribute(FILE_ATTRIBUTE_ARCHIVE, value)
+
+  def setHidden(value: Boolean): Unit =
+    setWinAttribute(FILE_ATTRIBUTE_HIDDEN, value)
+
+  def setReadOnly(value: Boolean): Unit =
+    setWinAttribute(FILE_ATTRIBUTE_READONLY, value)
+
+  def setSystem(value: Boolean): Unit =
+    setWinAttribute(FILE_ATTRIBUTE_SYSTEM, value)
+
+  def setTimes(
+      lastModifiedTime: FileTime,
+      lastAccessTime: FileTime,
+      createTime: FileTime
+  ): Unit = Zone { implicit z =>
+    def setOrNull(ref: Ptr[WinFileTime], value: FileTime): Ptr[WinFileTime] = {
+      if (value == null) null
+      else {
+        !ref = toWindowsFileTime(value)
+        ref
+      }
+    }
+
+    withFileOpen(
+      pathAbs,
+      access = FILE_GENERIC_WRITE,
+      attributes = fileOpeningFlags
+    ) { handle =>
+      val create, access, write = stackalloc[WinFileTime]
+      if (!SetFileTime(
+            handle,
+            creationTime = setOrNull(create, createTime),
+            lastAccessTime = setOrNull(access, lastAccessTime),
+            lastWriteTime = setOrNull(write, lastModifiedTime)
+          )) {
+        throw WindowsException("Failed to set file times")
+      }
+    }
+  }
+
+  def readAttributes(): DosFileAttributes = attributes
+
+  private lazy val attributes: DosFileAttributes = Zone { implicit z: Zone =>
+    val fileInfo = alloc[ByHandleFileInformation]
+
+    withFileOpen(
+      pathAbs,
+      access = FILE_READ_ATTRIBUTES,
+      attributes = fileOpeningFlags
+    ) {
+      FileApi.GetFileInformationByHandle(_, fileInfo)
+    }
+
+    new DosFileAttributes {
+      class DosFileKey(volumeId: DWord, fileIndex: ULargeInteger)
+
+      private val attrs = fileInfo.fileAttributes
+      private val createdAt = toFileTime(fileInfo.creationTime)
+      private val accessedAt = toFileTime(fileInfo.lastAccessTime)
+      private val modifiedAt = toFileTime(fileInfo.lastWriteTime)
+      private val fileSize = fileInfo.fileSize
+      private val dosFileKey =
+        new DosFileKey(
+          volumeId = fileInfo.volumeSerialNumber,
+          fileIndex = fileInfo.fileIndex
+        )
+
+      def creationTime(): FileTime = createdAt
+      def lastAccessTime(): FileTime = accessedAt
+      def lastModifiedTime(): FileTime = modifiedAt
+      def fileKey(): Object = dosFileKey
+      def size(): Long = fileSize.toLong
+
+      //to replace with checking reparse tag
+      def isSymbolicLink(): Boolean = hasAttrSet(FILE_ATTRIBUTE_REPARSE_POINT)
+      def isDirectory(): Boolean = hasAttrSet(FILE_ATTRIBUTE_DIRECTORY)
+      def isOther(): Boolean =
+        hasAttrSet(FILE_ATTRIBUTE_REPARSE_POINT | FILE_ATTRIBUTE_DEVICE)
+      def isRegularFile(): Boolean = {
+        !isSymbolicLink() &&
+        !isDirectory() &&
+        !isOther()
+      }
+
+      def isArchive(): Boolean = hasAttrSet(FILE_ATTRIBUTE_ARCHIVE)
+      def isHidden(): Boolean = hasAttrSet(FILE_ATTRIBUTE_HIDDEN)
+      def isReadOnly(): Boolean = hasAttrSet(FILE_ATTRIBUTE_READONLY)
+      def isSystem(): Boolean = hasAttrSet(FILE_ATTRIBUTE_SYSTEM)
+
+      private def hasAttrSet(attr: DWord): Boolean =
+        (attrs & attr) != 0.toUInt
+    }
+  }
+
+  private def setWinAttribute(attribute: DWord, enabled: Boolean): Unit = Zone {
+    implicit z =>
+      val filename = toCWideStringUTF16LE(pathAbs)
+      val previousAttrs = FileApi.GetFileAttributesW(filename)
+      def setNewAttrs(): Boolean = {
+        val newAttributes =
+          if (enabled) previousAttrs | attribute
+          else previousAttrs & ~attribute
+        FileApi.SetFileAttributesW(filename, newAttributes)
+      }
+
+      if (previousAttrs == INVALID_FILE_ATTRIBUTES || !setNewAttrs()) {
+        throw WindowsException("Failed to set file attributes")
+      }
+  }
+
+  @alwaysinline
+  private lazy val pathAbs = path.toAbsolutePath().toString
+
+  private def toFileTime(winFileTime: WinFileTime): FileTime = {
+    try {
+      val withEpochAdjustment = winFileTime.toLong - UnixEpochDifference
+      val windowsNanos = Math.multiplyExact(withEpochAdjustment, EpochInterval)
+      FileTime.from(windowsNanos, TimeUnit.NANOSECONDS)
+    } catch {
+      case _: ArithmeticException =>
+        val seconds = toUnixEpochMillis(winFileTime)
+        FileTime.from(seconds, TimeUnit.MILLISECONDS)
+    }
+  }
+
+  private def toWindowsFileTime(fileTime: FileTime): WinFileTime = {
+    val asWindowsEpoch = fileTime.to(TimeUnit.NANOSECONDS) / EpochInterval
+    (asWindowsEpoch + UnixEpochDifference).toULong
+  }
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
@@ -1,0 +1,81 @@
+package scala.scalanative.nio.fs.windows
+
+import java.lang.Iterable
+import java.nio.charset.StandardCharsets
+import java.nio.file.{
+  FileStore,
+  FileSystem,
+  Path,
+  Paths,
+  PathMatcher,
+  PathMatcherImpl,
+  WatchService
+}
+import java.nio.file.spi.FileSystemProvider
+import java.nio.file.attribute.UserPrincipalLookupService
+import java.util.{LinkedList, Set}
+
+import scalanative.unsafe._
+import scalanative.unsigned._
+import scalanative.annotation.stub
+import scalanative.windows.FileApi._
+import scala.annotation.tailrec
+
+class WindowsFileSystem(override val provider: WindowsFileSystemProvider)
+    extends FileSystem {
+
+  override def close(): Unit = throw new UnsupportedOperationException()
+
+  @stub
+  override def getFileStores(): Iterable[FileStore] = ???
+
+  override def getPath(first: String, more: Array[String]): Path =
+    WindowsPathParser((first +: more).mkString(getSeparator()))(this)
+
+  override def getPathMatcher(syntaxAndPattern: String): PathMatcher =
+    PathMatcherImpl(syntaxAndPattern)
+
+  override def getRootDirectories(): Iterable[Path] = {
+    val list = new LinkedList[Path]()
+    val bufferSize = GetLogicalDriveStringsW(0.toUInt, null)
+    val buffer = stackalloc[CChar16](bufferSize)
+
+    @tailrec
+    def readStringsBlock(ptr: Ptr[CChar16]): Unit = {
+      val path = fromCWideString(ptr, StandardCharsets.UTF_16LE)
+      // GetLogicalDriveStrings returns block of null-terminated strings with
+      // additional null-termination character after last string.
+      // Empty string means we reached the end.
+      if (path.nonEmpty) {
+        list.add(Paths.get(path, Array.empty))
+        readStringsBlock(ptr + path.length + 1)
+      }
+    }
+
+    if (GetLogicalDriveStringsW(bufferSize, buffer) > 0.toUInt) {
+      readStringsBlock(buffer)
+    }
+    list
+  }
+  def getUserPrincipalLookupService(): UserPrincipalLookupService =
+    WindowsUserPrincipalLookupService
+
+  override def getSeparator(): String = "\\"
+
+  override def isOpen(): Boolean = true
+
+  override def isReadOnly(): Boolean = false
+
+  override def newWatchService(): WatchService =
+    throw new UnsupportedOperationException()
+
+  override def supportedFileAttributeViews(): Set[String] = {
+    val set = new java.util.HashSet[String]()
+    set.add("basic")
+    set.add("owner")
+    set.add("dos")
+    set.add("acl")
+    set
+  }
+
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystemProvider.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystemProvider.scala
@@ -1,0 +1,27 @@
+package scala.scalanative.nio.fs.windows
+
+import scala.scalanative.unsafe.{CChar, fromCString, stackalloc}
+import scala.scalanative.unsigned._
+import scala.collection.immutable.{Map => SMap}
+import scala.scalanative.nio.fs.GenericFileSystemProvider
+import java.nio.file.attribute._
+import java.nio.file.FileSystem
+
+class WindowsFileSystemProvider extends GenericFileSystemProvider {
+
+  protected lazy val fs: FileSystem =
+    new WindowsFileSystem(this)
+
+  protected val knownFileAttributeViews: AttributeViewMapping = {
+    def Dos = (p, l) => new WindowsDosFileAttributeView(p, l)
+    def Acl = (p, l) => new WindowsAclFileAttributeView(p, l)
+
+    SMap(
+      classOf[BasicFileAttributeView] -> Dos,
+      classOf[DosFileAttributeView] -> Dos,
+      classOf[AclFileAttributeView] -> Acl,
+      classOf[FileOwnerAttributeView] -> Acl
+    )
+  }
+
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
@@ -1,0 +1,276 @@
+package scala.scalanative.nio.fs.windows
+
+import java.io.File
+import java.net.URI
+import java.nio.file.{
+  FileSystem,
+  Files,
+  LinkOption,
+  NoSuchFileException,
+  Path,
+  WatchEvent,
+  WatchKey
+}
+import java.util.Iterator
+import scala.scalanative.nio.fs.unix._
+import scala.collection.mutable.UnrolledBuffer
+import scalanative.annotation.alwaysinline
+import java.awt.Window
+
+class WindowsPath private[windows] (
+    val pathType: WindowsPath.PathType,
+    val root: Option[String],
+    val segments: List[String]
+)(implicit private val fs: WindowsFileSystem)
+    extends Path {
+  import WindowsPath._
+
+  private def this(segments: List[String])(implicit fs: WindowsFileSystem) = {
+    this(WindowsPath.PathType.Relative, None, segments)
+  }
+
+  private def this(path: String)(implicit fs: WindowsFileSystem) = {
+    this(path :: Nil)
+  }
+
+  private lazy val path: String = {
+    val drivePrefix = (pathType, root) match {
+      case (PathType.UNC, Some(root)) =>
+        root.drop(2).split('\\') match {
+          case Array(host, share) => share + "\\"
+          case _                  => ""
+        }
+      case (PathType.Absolute, Some(root))          => root
+      case (PathType.DirectoryRelative, Some(root)) => root + "\\"
+      case _                                        => ""
+    }
+    drivePrefix + segments.mkString(seperator)
+  }
+
+  @alwaysinline
+  final private def seperator: String = fs.getSeparator()
+
+  override def getFileSystem(): FileSystem = fs
+
+  override def isAbsolute(): Boolean = pathType == PathType.Absolute
+
+  override def getRoot(): Path =
+    if (root.isEmpty) null
+    else new WindowsPath(pathType, root, Nil)
+
+  override def getFileName(): Path = {
+    if (root.contains(path)) null
+    else if (segments.isEmpty) this
+    else new WindowsPath(segments.last)
+  }
+
+  override def getParent(): Path = {
+    val nameCount = getNameCount()
+    if (nameCount == 0 || (nameCount == 1 && !isAbsolute()))
+      null
+    else if (root.isDefined)
+      new WindowsPath(pathType, root, segments.init)
+    else
+      subpath(0, getNameCount() - 1)
+  }
+
+  override def getNameCount(): Int = segments.length
+
+  @inline private def getNameString(index: Int): String = {
+    val nameCount = getNameCount()
+    if (index < 0 || nameCount == 0 || index >= nameCount)
+      throw new IllegalArgumentException
+    else {
+      if (path.isEmpty()) null
+      else segments(index)
+    }
+  }
+
+  override def getName(index: Int): Path = getNameString(index) match {
+    case null => this
+    case n    => new WindowsPath(n)
+  }
+
+  override def subpath(beginIndex: Int, endIndex: Int): Path =
+    new WindowsPath(segments.slice(beginIndex, endIndex))
+
+  override def startsWith(other: Path): Boolean =
+    if (fs.provider == other.getFileSystem().provider()) {
+      val otherLength = other.getNameCount()
+      val thisLength = getNameCount()
+
+      if (otherLength > thisLength) false
+      else if (isAbsolute() ^ other.isAbsolute()) false
+      else {
+        (0 until otherLength).forall(i => getName(i) == other.getName(i))
+      }
+    } else {
+      false
+    }
+
+  override def startsWith(other: String): Boolean =
+    startsWith(WindowsPathParser(other))
+
+  override def endsWith(other: Path): Boolean =
+    if (fs.provider == other.getFileSystem().provider()) {
+      val otherLength = other.getNameCount()
+      val thisLength = getNameCount()
+      if (otherLength > thisLength) false
+      else if (!other.isAbsolute()) {
+        (0 until otherLength).forall(i =>
+          getName(thisLength - 1 - i) == other.getName(otherLength - 1 - i)
+        )
+      } else if (isAbsolute()) {
+        this == other
+      } else {
+        false
+      }
+    } else {
+      false
+    }
+
+  override def endsWith(other: String): Boolean =
+    endsWith(WindowsPathParser(other))
+
+  private lazy val normalizedPath = WindowsPathParser(normalized(this))
+
+  override def normalize(): Path = normalizedPath
+
+  override def resolve(other: Path): Path = {
+    if (other.isAbsolute() || path.isEmpty()) other
+    else if (other.toString.isEmpty()) this
+    else
+      other match {
+        case winPath: WindowsPath =>
+          new WindowsPath(pathType, root, segments ++ winPath.segments)
+        case _ =>
+          WindowsPathParser(path.toString + seperator + other.toString)
+      }
+  }
+
+  override def resolve(other: String): Path =
+    resolve(WindowsPathParser(other))
+
+  override def resolveSibling(other: Path): Path = {
+    val parent = getParent()
+    if (parent == null) other
+    else parent.resolve(other)
+  }
+
+  override def resolveSibling(other: String): Path =
+    resolveSibling(WindowsPathParser(other))
+
+  override def relativize(other: Path): Path = {
+    if (isAbsolute() ^ other.isAbsolute()) {
+      throw new IllegalArgumentException("'other' is different type of Path")
+    } else if (path.isEmpty()) {
+      other
+    } else if (other.startsWith(this)) {
+      other.subpath(getNameCount(), other.getNameCount())
+    } else if (getParent() == null) {
+      new WindowsPath("../" + other.toString())
+    } else {
+      val next = getParent().relativize(other).toString()
+      if (next.isEmpty()) new WindowsPath("..")
+      else new WindowsPath("../" + next)
+    }
+  }
+
+  private lazy val absPath =
+    if (isAbsolute()) this
+    else WindowsPathParser(toFile().getAbsolutePath())
+
+  override def toAbsolutePath(): Path = absPath
+
+  override def toRealPath(options: Array[LinkOption]): Path = {
+    if (options.contains(LinkOption.NOFOLLOW_LINKS)) toAbsolutePath()
+    else {
+      WindowsPathParser(toFile().getCanonicalPath()) match {
+        case p if Files.exists(p, Array.empty) => p
+        case p => throw new NoSuchFileException(p.path)
+      }
+    }
+  }
+
+  override def toFile(): File = new File(path)
+
+  private lazy val uri =
+    new URI(
+      scheme = "file",
+      userInfo = null,
+      host = null,
+      port = -1,
+      path = absPath.path,
+      query = null,
+      fragment = null
+    )
+
+  override def toUri(): URI = uri
+
+  override def iterator(): Iterator[Path] =
+    new Iterator[Path] {
+      private var i: Int = 0
+      override def remove(): Unit = throw new UnsupportedOperationException()
+      override def hasNext(): Boolean = i < getNameCount()
+      override def next(): Path =
+        if (hasNext()) {
+          val name = getName(i)
+          i += 1
+          name
+        } else {
+          throw new NoSuchElementException()
+        }
+    }
+
+  override def compareTo(other: Path): Int =
+    if (fs.provider == other.getFileSystem().provider()) {
+      this.toString().compareTo(other.toString)
+    } else {
+      throw new ClassCastException()
+    }
+
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case other: WindowsPath =>
+        this.fs == other.fs && this.path == other.path
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    path.##
+
+  override def toString(): String =
+    path
+
+}
+
+private[windows] object WindowsPath {
+  sealed trait PathType
+  object PathType {
+    case object Absolute extends PathType
+    case object Relative extends PathType
+    case object DirectoryRelative extends PathType
+    case object DriveRelative extends PathType
+    case object UNC extends PathType
+  }
+
+  def normalized(path: WindowsPath): String = {
+    if (path.path.length < 2) return path.path
+    val components = path.segments
+      .foldLeft(List.empty[String]) {
+        case (acc, "..") =>
+          if (acc.isEmpty && path.isAbsolute()) Nil
+          else if (acc.isEmpty) List("..")
+          else acc.tail
+        case (acc, ".") => acc
+        case (acc, "")  => acc
+        case (acc, seg) => seg :: acc
+      }
+      .reverse
+
+    path.root.fold(components.mkString(path.seperator)) {
+      components.mkString(_, path.seperator, "")
+    }
+  }
+
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
@@ -100,7 +100,7 @@ class WindowsPath private[windows] (
       val thisLength = getNameCount()
 
       if (otherLength > thisLength) false
-      else if (isAbsolute() ^ other.isAbsolute()) false
+      else if (isAbsolute() != other.isAbsolute()) false
       else {
         (0 until otherLength).forall(i => getName(i) == other.getName(i))
       }

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPathParser.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPathParser.scala
@@ -1,0 +1,151 @@
+package scala.scalanative.nio.fs.windows
+
+import java.io.File
+import java.net.URI
+import java.nio.file.{
+  FileSystem,
+  Files,
+  LinkOption,
+  NoSuchFileException,
+  Path,
+  WatchEvent,
+  WatchKey
+}
+import java.util.Iterator
+import scala.collection.mutable.UnrolledBuffer
+import scalanative.annotation.alwaysinline
+import java.awt.Window
+import java.nio.file.InvalidPathException
+import scala.annotation.tailrec
+
+object WindowsPathParser {
+  import WindowsPath.PathType._
+
+  def apply(rawPath: String)(implicit fs: WindowsFileSystem): WindowsPath = {
+    def charAtIdx(n: Int, pred: Char => Boolean): Boolean = {
+      rawPath.size > n && pred(rawPath.charAt(n))
+    }
+
+    val (tpe, root) = if (charAtIdx(0, isSlash)) {
+      if (charAtIdx(1, isSlash))
+        UNC -> getUNCRoot(rawPath)
+      else if (charAtIdx(1, isAnsiLetter) && charAtIdx(2, _ == ':'))
+        // URI specific, absolute path starts with / followed by absolute path
+        Absolute -> Some(rawPath.substring(1, 4))
+      else
+        DriveRelative -> None
+    } else if (charAtIdx(0, isAnsiLetter) && charAtIdx(1, _ == ':')) {
+      if (charAtIdx(2, isSlash))
+        Absolute -> Some(rawPath.substring(0, 3))
+      else
+        DirectoryRelative -> Some(rawPath.substring(0, 2))
+    } else Relative -> None
+
+    val relativePath = root
+      .map(r => rawPath.substring(r.length))
+      .getOrElse(rawPath)
+
+    val segments = pathSegments(relativePath)
+
+    new WindowsPath(tpe, root.map(fixSlashes), segments)
+  }
+
+  private def fixSlashes(str: String): String = str.map {
+    case '/' => '\\'
+    case c   => c
+  }
+
+  private def isSlash(c: Char): Boolean = {
+    c == '\\' || c == '/'
+  }
+
+  private def isAnsiLetter(c: Char): Boolean = {
+    (c >= 'a' && c <= 'z') ||
+    (c >= 'A' && c <= 'Z')
+  }
+
+  private def getUNCRoot(rawPath: String): Option[String] = {
+    val hostStartIdx = 2
+    val hostEndIdx = rawPath.indexWhere(isSlash, hostStartIdx)
+    if (hostEndIdx < 0) {
+      throw new InvalidPathException(rawPath, "UNC path is missing host")
+    }
+    val shareStartIdx = hostEndIdx + 1
+    val shareEndIdx = rawPath.indexWhere(isSlash, shareStartIdx)
+    if (shareEndIdx < 0) {
+      throw new InvalidPathException(rawPath, "UNC path is missing share name")
+    }
+
+    // Host can contain `?` or `.` used to indicate DOS device path
+    val host = substringAndCheck(rawPath, hostStartIdx, hostEndIdx, "?")
+    // We also accept `:` after drive letter
+    val share = substringAndCheck(rawPath, shareStartIdx, shareEndIdx, ":")
+
+    Some(raw"""\\$host\$share\""")
+  }
+
+  private def pathSegments(path: String): List[String] = {
+    @tailrec
+    def loop(acc: List[String], idx: Int): List[String] = {
+      if (idx >= path.length()) acc.reverse
+      else {
+        val endIdx = path.indexWhere(isSlash, idx) match {
+          case -1     => path.length()
+          case endIdx => endIdx
+        }
+        val segment = substringAndCheck(path, idx, endIdx)
+        val fromNext = endIdx + 1
+
+        if (segment.isEmpty)
+          loop(acc, fromNext)
+        else {
+          val lastChar = segment.last
+          if (lastChar.isWhitespace) {
+            throw new InvalidPathException(
+              path,
+              s"Trailing char `$lastChar`",
+              endIdx - 1
+            )
+          }
+          loop(segment :: acc, fromNext)
+        }
+      }
+    }
+    loop(Nil, 0)
+  }
+
+  private final val pathReservedChars = "<>:\"/|?*"
+
+  private def substringAndCheck(
+      path: String,
+      from: Int,
+      to: Int,
+      allowedChars: String = ""
+  ): String = {
+    def isControlOrReservedChar(c: Char) = {
+      c <= '\u0020' || pathReservedChars.contains(c)
+    }
+    def checkValidSegment(
+        segment: String,
+        path: String,
+        segmentIdx: Int
+    ): Unit = {
+
+      val invalidCharIdx = segment.indexWhere { c =>
+        isControlOrReservedChar(c) && !allowedChars.contains(c)
+      }
+      if (invalidCharIdx >= 0) {
+        throw new InvalidPathException(
+          path,
+          s"Illegal character `${segment.charAt(invalidCharIdx)}` in path",
+          segmentIdx + invalidCharIdx
+        )
+      }
+    }
+
+    val substring = path.substring(from, to)
+    checkValidSegment(substring, path, from)
+    substring
+  }
+
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipal.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipal.scala
@@ -1,0 +1,76 @@
+package scala.scalanative.nio.fs.windows
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.attribute._
+import scalanative.unsafe._
+import scalanative.unsigned._
+import scalanative.windows._
+import java.util.WindowsHelperMethods._
+import java.nio.file.WindowsException
+
+sealed trait WindowsUserPrincipal extends UserPrincipal
+
+object WindowsUserPrincipal {
+  import SecurityBaseApi._
+  import MinWinBaseApi._
+  import WinBaseApi._
+  import AclApi._
+  import winnt.SidNameUse
+
+  case class User(sidString: String, accountName: String, sidType: SidNameUse)
+      extends WindowsUserPrincipal {
+    def getName(): String = accountName
+  }
+  class Group(sidString: String, accountName: String, sidType: SidNameUse)
+      extends User(sidString, accountName, sidType)
+      with GroupPrincipal
+
+  def apply(sidRef: SIDPtr): WindowsUserPrincipal = {
+    import SidNameUse._
+    val sidString = {
+      val sidCString = stackalloc[CWString]
+      if (!SddlApi.ConvertSidToStringSidW(sidRef, sidCString)) {
+        throw WindowsException("Unable to convert SID to string")
+      }
+      fromCWideString(!sidCString, StandardCharsets.UTF_16LE)
+    }
+
+    val (accountName, accountType) =
+      try {
+        val nameSize, domainSize = stackalloc[DWord]
+        !nameSize = 255.toUInt
+        !domainSize = 255.toUInt
+        val nameRef = stackalloc[WChar](!nameSize)
+        val domainRef = stackalloc[WChar](!domainSize)
+        val useRef = stackalloc[SidNameUse]
+        if (!LookupAccountSidW(
+              systemName = null,
+              sid = sidRef,
+              name = nameRef,
+              nameSize = nameSize,
+              referencedDomainName = domainRef,
+              referencedDomainNameSize = domainSize,
+              use = useRef
+            )) {
+          throw WindowsException("Failed to lookup account info")
+        }
+
+        val accountName = {
+          val charset = StandardCharsets.UTF_16LE
+          fromCWideString(domainRef, charset) +
+            "\\" +
+            fromCWideString(nameRef, charset)
+        }
+        (accountName, !useRef)
+      } catch {
+        case ex: WindowsException => (sidString, SidTypeUnknown)
+      }
+
+    val groupTypes = SidTypeGroup | SidTypeWellKnownGroup | SidTypeAlias
+    val isGroup = (accountType & groupTypes) != 0
+    if (isGroup)
+      new Group(sidString, accountName, accountType)
+    else
+      new User(sidString, accountName, accountType)
+  }
+}

--- a/unit-tests/jvm/src/test/resources/BlacklistedTests.txt
+++ b/unit-tests/jvm/src/test/resources/BlacklistedTests.txt
@@ -28,7 +28,6 @@ scala/javalib/util/zip/ZipInputStreamTest.scala
 scala/javalib/util/zip/InflaterTest.scala
 scala/javalib/util/zip/ZipEntryTest.scala
 
-scala/javalib/nio/file/FileSystemExceptionTest.scala
 scala/javalib/nio/file/FilesTest.scala
 scala/javalib/nio/file/DirectoryStreamTest.scala
 

--- a/unit-tests/jvm/src/test/resources/BlacklistedTests.txt
+++ b/unit-tests/jvm/src/test/resources/BlacklistedTests.txt
@@ -43,7 +43,7 @@ scala/scala/PrimitiveTest.scala
 scala/scala/bugcompat/LongFloatPrimitiveTest.scala
 
 # Tests that work on java 8, but fail on java 16
-scala/javalib/nio/file/PathTest.scala
+#scala/javalib/nio/file/UnixPathTest.scala
 scala/javalib/net/URLEncoderTest.scala
 scala/javalib/util/jar/JarFileTest.scala
 scala/javalib/util/zip/ZipFileTest.scala

--- a/unit-tests/jvm/src/test/resources/BlacklistedTests.txt
+++ b/unit-tests/jvm/src/test/resources/BlacklistedTests.txt
@@ -43,7 +43,6 @@ scala/scala/PrimitiveTest.scala
 scala/scala/bugcompat/LongFloatPrimitiveTest.scala
 
 # Tests that work on java 8, but fail on java 16
-#scala/javalib/nio/file/UnixPathTest.scala
 scala/javalib/net/URLEncoderTest.scala
 scala/javalib/util/jar/JarFileTest.scala
 scala/javalib/util/zip/ZipFileTest.scala

--- a/unit-tests/shared/src/test/scala/javalib/io/FileOutputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/FileOutputStreamTest.scala
@@ -5,7 +5,7 @@ import java.io._
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import org.scalanative.testsuite.utils.Platform._
+import org.scalanative.testsuite.utils.Platform.isWindows
 
 import scalanative.junit.utils.AssertThrows.assertThrows
 
@@ -93,10 +93,6 @@ class FileOutputStreamTest {
   }
 
   @Test def attemptToOpenDirectory(): Unit = {
-    assumeTrue(
-      "Uses not yet implemented java.nio methods",
-      !isWindows || executingInJVM
-    )
     withTempDirectory { dir =>
       assertThrows(classOf[FileNotFoundException], new FileOutputStream(dir))
     }

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/FileSystemExceptionTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/FileSystemExceptionTest.scala
@@ -24,15 +24,19 @@ class FileSystemExceptionTest {
       new FileSystemException(null, "other", "reason")
         .getMessage() == " -> other: reason"
     )
-    assertEquals("reason"    ,
-      new FileSystemException(null, null, "reason").getMessage() )
-    assertEquals(" -> other",
+    assertEquals(
+      "reason",
+      new FileSystemException(null, null, "reason").getMessage()
+    )
+    assertEquals(
+      " -> other",
       new FileSystemException(null, "other", null).getMessage()
     )
-    assertEquals("file",
+    assertEquals(
+      "file",
       new FileSystemException("file", null, null).getMessage()
     )
-    assertEquals(null,new FileSystemException(null, null, null).getMessage())
+    assertEquals(null, new FileSystemException(null, null, null).getMessage())
 
     assertEquals("file", new FileSystemException("file").getMessage())
     assertEquals(null, new FileSystemException(null).getMessage())

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/FileSystemExceptionTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/FileSystemExceptionTest.scala
@@ -24,18 +24,17 @@ class FileSystemExceptionTest {
       new FileSystemException(null, "other", "reason")
         .getMessage() == " -> other: reason"
     )
-    assertTrue(
-      new FileSystemException(null, null, "reason").getMessage() == ": reason"
+    assertEquals("reason"    ,
+      new FileSystemException(null, null, "reason").getMessage() )
+    assertEquals(" -> other",
+      new FileSystemException(null, "other", null).getMessage()
     )
-    assertTrue(
-      new FileSystemException(null, "other", null).getMessage() == " -> other"
+    assertEquals("file",
+      new FileSystemException("file", null, null).getMessage()
     )
-    assertTrue(
-      new FileSystemException("file", null, null).getMessage() == "file"
-    )
-    assertTrue(new FileSystemException(null, null, null).getMessage() == "")
+    assertEquals(null,new FileSystemException(null, null, null).getMessage())
 
-    assertTrue(new FileSystemException("file").getMessage() == "file")
-    assertTrue(new FileSystemException(null).getMessage() == "")
+    assertEquals("file", new FileSystemException("file").getMessage())
+    assertEquals(null, new FileSystemException(null).getMessage())
   }
 }

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/FilesTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/FilesTest.scala
@@ -20,7 +20,7 @@ import org.scalanative.testsuite.utils.Platform.isWindows
 class FilesTest {
   import FilesTest._
 
-  def checkShouldTestSymlinks(): Unit = {
+  def assumeShouldTestSymlinks(): Unit = {
     assumeFalse(
       "Do not test symlinks on windows, admin privilege needed",
       isWindows
@@ -191,7 +191,7 @@ class FilesTest {
   }
 
   @Test def filesCopyDoesNotCopySymlinks(): Unit = {
-    checkShouldTestSymlinks()
+    assumeShouldTestSymlinks()
 
     withTemporaryDirectory { dirFile =>
       val dir = dirFile.toPath
@@ -304,7 +304,7 @@ class FilesTest {
   }
 
   @Test def filesExistsHandlesSymlinks(): Unit = {
-    checkShouldTestSymlinks()
+    assumeShouldTestSymlinks()
 
     withTemporaryDirectory { dirFile =>
       val dir = dirFile.toPath()
@@ -541,7 +541,7 @@ class FilesTest {
   }
 
   @Test def filesIsRegularFileHandlesSymlinks(): Unit = {
-    checkShouldTestSymlinks()
+    assumeShouldTestSymlinks()
 
     withTemporaryDirectory { dirFile =>
       val dir = dirFile.toPath
@@ -672,7 +672,7 @@ class FilesTest {
   }
 
   @Test def filesReadSymbolicLinkCanReadValidSymbolicLink(): Unit = {
-    checkShouldTestSymlinks()
+    assumeShouldTestSymlinks()
 
     withTemporaryDirectory { dirFile =>
       val dir = dirFile.toPath()
@@ -689,7 +689,7 @@ class FilesTest {
 
   @Test def filesReadSymbolicLinkCanReadBrokenSymbolicLink(): Unit = {
     // Does fail on Windows. Cannot open broken link
-    checkShouldTestSymlinks()
+    assumeShouldTestSymlinks()
 
     withTemporaryDirectory { dirFile =>
       val dir = dirFile.toPath()
@@ -752,7 +752,7 @@ class FilesTest {
   }
 
   @Test def filesWalkFollowsSymlinks(): Unit = {
-    checkShouldTestSymlinks()
+    assumeShouldTestSymlinks()
 
     withTemporaryDirectory { dirFile =>
       val dir = dirFile.toPath()
@@ -792,7 +792,7 @@ class FilesTest {
   }
 
   @Test def filesWalkDetectsCycles(): Unit = {
-    checkShouldTestSymlinks()
+    assumeShouldTestSymlinks()
 
     withTemporaryDirectory { dirFile =>
       val dir = dirFile.toPath()
@@ -973,7 +973,7 @@ class FilesTest {
   // "NIO File Walker fails on broken links."
 
   @Test def filesWalkFileTreeRespectsFileVisitOptionFollowLinksNo(): Unit = {
-    checkShouldTestSymlinks()
+    assumeShouldTestSymlinks()
 
     withTemporaryDirectoryPath { dirPath =>
       val context = new FollowLinksTestsContext(dirPath)
@@ -995,7 +995,7 @@ class FilesTest {
   }
 
   @Test def filesWalkFileTreeRespectsFileVisitOptionFollowLinksYes(): Unit = {
-    checkShouldTestSymlinks()
+    assumeShouldTestSymlinks()
 
     withTemporaryDirectoryPath { dirPath =>
       val context = new FollowLinksTestsContext(dirPath)
@@ -1081,7 +1081,7 @@ class FilesTest {
   }
 
   @Test def filesFindRespectsFileVisitOptionFollowLinksValidSymlinks(): Unit = {
-    checkShouldTestSymlinks()
+    assumeShouldTestSymlinks()
 
     withTemporaryDirectory { dirFile =>
       val soughtName = "quaesitum" // That which is sought.
@@ -1122,7 +1122,7 @@ class FilesTest {
   // Issue #1530
   @Test def filesFindRespectsFileVisitOptionFollowLinksBrokenSymlinks()
       : Unit = {
-    checkShouldTestSymlinks()
+    assumeShouldTestSymlinks()
 
     withTemporaryDirectory { dirFile =>
       val soughtName = "quaesitum" // That which is sought.

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/PathsTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/PathsTest.scala
@@ -8,27 +8,31 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform.isWindows
 
 class PathsTest {
   @Test def pathsGetRelativePathReturnsPathRelativeToCwd(): Unit = {
-    val path = Paths.get("foo/bar")
-    val file = new File("foo/bar")
-    assertTrue(path.toString == "foo/bar")
+    val pathString = if (isWindows) raw"foo\bar" else "foo/bar"
+    val path = Paths.get(pathString)
+    val file = new File(pathString)
+    assertEquals(pathString, path.toString)
     assertTrue(path.toAbsolutePath.toString != path.toString)
     assertTrue(path.toAbsolutePath.toString.endsWith(path.toString))
 
     assertTrue(file.getAbsolutePath != path.toString)
-    assertTrue(file.getAbsolutePath == path.toAbsolutePath.toString)
+    assertEquals(path.toAbsolutePath.toString, file.getAbsolutePath)
   }
 
   @Test def pathsGetAbsolutePathReturnsAnAbsolutePath(): Unit = {
-    val path = Paths.get("/foo/bar")
-    val file = new File("/foo/bar")
-    assertTrue(path.toString == "/foo/bar")
-    assertTrue(path.toAbsolutePath.toString == path.toString)
+    val pathString = if (isWindows) raw"C:\foo\bar" else "/foo/bar"
 
-    assertTrue(file.getAbsolutePath == path.toString)
-    assertTrue(file.getAbsolutePath == path.toAbsolutePath.toString)
+    val path = Paths.get(pathString)
+    val file = new File(pathString)
+    assertEquals(pathString, path.toString)
+    assertEquals(path.toString, path.toAbsolutePath.toString)
+
+    assertEquals(path.toString, file.getAbsolutePath)
+    assertEquals(path.toAbsolutePath.toString, file.getAbsolutePath)
   }
 
   @Test def pathsGetUriThrowsExceptionWhenSchemeIsMissing(): Unit = {
@@ -46,12 +50,17 @@ class PathsTest {
   }
 
   @Test def pathsGetUriReturnsPathIfSchemeIsFile(): Unit = {
+    val pathString1 = if (isWindows) "/C:/foo/bar" else "/foo/bar"
+    val expected1 = if (isWindows) raw"C:\foo\bar" else pathString1
+    val pathString2 = if (isWindows) "/C:/hello/world" else "/hello/world"
+    val expected2 = if (isWindows) raw"C:\hello\world" else pathString2
+
     val path =
-      Paths.get(new URI("file", null, null, 0, "/foo/bar", null, null))
-    assertTrue(path.toString == "/foo/bar")
+      Paths.get(new URI("file", null, null, 0, pathString1, null, null))
+    assertEquals(expected1, path.toString)
 
     val path2 =
-      Paths.get(new URI("fIlE", null, null, 0, "/hello/world", null, null))
-    assertTrue(path2.toString == "/hello/world")
+      Paths.get(new URI("fIlE", null, null, 0, pathString2, null, null))
+    assertEquals(expected2, path2.toString)
   }
 }

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/UnixPathTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/UnixPathTest.scala
@@ -2,12 +2,22 @@ package javalib.nio.file
 
 import java.nio.file._
 
-import org.junit.Test
+import org.junit.{Test, Before}
 import org.junit.Assert._
+import org.junit.Assume._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform.isWindows
 
-class PathTest {
+class UnixPathTest {
+
+  @Before
+  def checkIsUnix() {
+    assumeFalse(
+      "Not checking Unix paths on Windows",
+      isWindows
+    )
+  }
 
   @Test def pathGetNameCount(): Unit = {
     assertTrue(Paths.get("/").getNameCount == 0)

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/UnixPathTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/UnixPathTest.scala
@@ -2,23 +2,24 @@ package javalib.nio.file
 
 import java.nio.file._
 
-import org.junit.{Test, Before}
+import org.junit.{Test, BeforeClass}
 import org.junit.Assert._
 import org.junit.Assume._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform.isWindows
 
-class UnixPathTest {
-
-  @Before
-  def checkIsUnix() {
+object UnixPathTest {
+  @BeforeClass
+  def assumeIsUnix() {
     assumeFalse(
       "Not checking Unix paths on Windows",
       isWindows
     )
   }
+}
 
+class UnixPathTest {
   @Test def pathGetNameCount(): Unit = {
     assertTrue(Paths.get("/").getNameCount == 0)
     assertTrue(Paths.get("///").getNameCount == 0)

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/attribute/UserPrincipalLookupServiceTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/attribute/UserPrincipalLookupServiceTest.scala
@@ -5,8 +5,10 @@ import java.nio.file.FileSystems
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform.isWindows
 import org.scalanative.testsuite
 
 class UserPrincipalLookupServiceTest {
@@ -14,6 +16,7 @@ class UserPrincipalLookupServiceTest {
   val lookupService = FileSystems.getDefault.getUserPrincipalLookupService
 
   @Test def lookupPrincipalByNameSucceedsForNumeric(): Unit = {
+    assumeFalse("Numeric user names not supported on Windows", isWindows)
     val expected = (Int.MaxValue / 2).toString // an arbitrary value
 
     assertEquals(
@@ -23,11 +26,21 @@ class UserPrincipalLookupServiceTest {
   }
 
   @Test def lookupPrincipalByGroupNameSucceedsForNumeric(): Unit = {
+    assumeFalse("Numeric group names not supported on Windows", isWindows)
     val expected = (Int.MaxValue / 3).toString // an arbitrary value
 
     assertEquals(
       expected,
       lookupService.lookupPrincipalByGroupName(expected).getName
+    )
+  }
+
+  @Test def lookupPrincipalByNameSucceedsForCurrentDirOwner(): Unit = {
+    import java.nio.file._
+    val currentDirOwner = Files.getOwner(Paths.get("."))
+    assertEquals(
+      currentDirOwner,
+      lookupService.lookupPrincipalByName(currentDirOwner.getName())
     )
   }
 }

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/accessMode.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/accessMode.c
@@ -1,0 +1,13 @@
+#if defined(_WIN32) || defined(WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <AccCtrl.h>
+
+int scalanative_win32_accctrl_not_used_access() { return NOT_USED_ACCESS; }
+int scalanative_win32_accctrl_grant_access() { return GRANT_ACCESS; }
+int scalanative_win32_accctrl_set_access() { return SET_ACCESS; }
+int scalanative_win32_accctrl_deny_access() { return DENY_ACCESS; }
+int scalanative_win32_accctrl_revoke_access() { return REVOKE_ACCESS; }
+int scalanative_win32_accctrl_set_audit_success() { return SET_AUDIT_SUCCESS; }
+int scalanative_win32_accctrl_set_audit_failure() { return SET_AUDIT_FAILURE; }
+
+#endif // defined(_WIN32)

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeForm.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeForm.c
@@ -1,0 +1,15 @@
+#if defined(_WIN32) || defined(WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <AccCtrl.h>
+
+int scalanative_win32_accctrl_trustee_is_sid() { return TRUSTEE_IS_SID; }
+int scalanative_win32_accctrl_trustee_is_name() { return TRUSTEE_IS_NAME; }
+int scalanative_win32_accctrl_trustee_bad_form() { return TRUSTEE_BAD_FORM; }
+int scalanative_win32_accctrl_trustee_is_objects_and_sid() {
+    return TRUSTEE_IS_OBJECTS_AND_SID;
+}
+int scalanative_win32_accctrl_trustee_is_objects_and_name() {
+    return TRUSTEE_IS_OBJECTS_AND_NAME;
+}
+
+#endif // defined(_WIN32)

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeType.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeType.c
@@ -1,0 +1,25 @@
+#if defined(_WIN32) || defined(WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <AccCtrl.h>
+
+int scalanative_win32_accctrl_trustee_is_unknown() {
+    return TRUSTEE_IS_UNKNOWN;
+}
+int scalanative_win32_accctrl_trustee_is_user() { return TRUSTEE_IS_USER; }
+int scalanative_win32_accctrl_trustee_is_group() { return TRUSTEE_IS_GROUP; }
+int scalanative_win32_accctrl_trustee_is_domain() { return TRUSTEE_IS_DOMAIN; }
+int scalanative_win32_accctrl_trustee_is_alias() { return TRUSTEE_IS_ALIAS; }
+int scalanative_win32_accctrl_trustee_is_well_known_group() {
+    return TRUSTEE_IS_WELL_KNOWN_GROUP;
+}
+int scalanative_win32_accctrl_trustee_is_deleted() {
+    return TRUSTEE_IS_DELETED;
+}
+int scalanative_win32_accctrl_trustee_is_invalid() {
+    return TRUSTEE_IS_INVALID;
+}
+int scalanative_win32_accctrl_trustee_is_computer() {
+    return TRUSTEE_IS_COMPUTER;
+}
+
+#endif // defined(_WIN32)

--- a/windowslib/src/main/resources/scala-native/windows/winnt/helpers.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/helpers.c
@@ -1,0 +1,12 @@
+#if defined(_WIN32) || defined(WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#pragma comment(lib, "Advapi32.lib")
+
+BOOL scalanative_win32_winnt_setupUsersGroupSid(PSID *ref) {
+    SID_IDENTIFIER_AUTHORITY authNt = SECURITY_NT_AUTHORITY;
+    return AllocateAndInitializeSid(&authNt, 2, SECURITY_BUILTIN_DOMAIN_RID,
+                                    DOMAIN_ALIAS_RID_USERS, 0, 0, 0, 0, 0, 0,
+                                    ref);
+}
+#endif // defined(_WIN32)

--- a/windowslib/src/main/resources/scala-native/windows/winnt/sidNameUse.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/sidNameUse.c
@@ -1,0 +1,31 @@
+#if defined(_WIN32) || defined(WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <WinNT.h>
+
+int scalanative_win32_winnt_sid_name_use_sidtypeuser() { return SidTypeUser; }
+int scalanative_win32_winnt_sid_name_use_sidtypegroup() { return SidTypeGroup; }
+int scalanative_win32_winnt_sid_name_use_sidtypedomain() {
+    return SidTypeDomain;
+}
+int scalanative_win32_winnt_sid_name_use_sidtypealias() { return SidTypeAlias; }
+int scalanative_win32_winnt_sid_name_use_sidtypewellknowngroup() {
+    return SidTypeWellKnownGroup;
+}
+int scalanative_win32_winnt_sid_name_use_sidtypedeletedaccount() {
+    return SidTypeDeletedAccount;
+}
+int scalanative_win32_winnt_sid_name_use_sidtypeinvalid() {
+    return SidTypeInvalid;
+}
+int scalanative_win32_winnt_sid_name_use_sidtypeunknown() {
+    return SidTypeUnknown;
+}
+int scalanative_win32_winnt_sid_name_use_sidtypecomputer() {
+    return SidTypeComputer;
+}
+int scalanative_win32_winnt_sid_name_use_sidtypelabel() { return SidTypeLabel; }
+int scalanative_win32_winnt_sid_name_use_sidtypelogonsession() {
+    return SidTypeLogonSession;
+}
+#endif // defined(Win32)

--- a/windowslib/src/main/resources/scala-native/windows/winnt/tokenInformationClass.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/tokenInformationClass.c
@@ -1,0 +1,142 @@
+#if defined(_WIN32) || defined(WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <WinNT.h>
+
+int scalanative_win32_winnt_token_info_class_user() { return TokenUser; }
+int scalanative_win32_winnt_token_info_class_groups() { return TokenGroups; }
+int scalanative_win32_winnt_token_info_class_privileges() {
+    return TokenPrivileges;
+}
+int scalanative_win32_winnt_token_info_class_owner() { return TokenOwner; }
+int scalanative_win32_winnt_token_info_class_primarygroup() {
+    return TokenPrimaryGroup;
+}
+int scalanative_win32_winnt_token_info_class_defaultdacl() {
+    return TokenDefaultDacl;
+}
+int scalanative_win32_winnt_token_info_class_source() { return TokenSource; }
+int scalanative_win32_winnt_token_info_class_type() { return TokenType; }
+int scalanative_win32_winnt_token_info_class_impersonationlevel() {
+    return TokenImpersonationLevel;
+}
+int scalanative_win32_winnt_token_info_class_statistics() {
+    return TokenStatistics;
+}
+int scalanative_win32_winnt_token_info_class_restrictedsids() {
+    return TokenRestrictedSids;
+}
+int scalanative_win32_winnt_token_info_class_sessionid() {
+    return TokenSessionId;
+}
+int scalanative_win32_winnt_token_info_class_groupsandprivileges() {
+    return TokenGroupsAndPrivileges;
+}
+int scalanative_win32_winnt_token_info_class_sessionreference() {
+    return TokenSessionReference;
+}
+int scalanative_win32_winnt_token_info_class_sandboxinert() {
+    return TokenSandBoxInert;
+}
+int scalanative_win32_winnt_token_info_class_auditpolicy() {
+    return TokenAuditPolicy;
+}
+int scalanative_win32_winnt_token_info_class_origin() { return TokenOrigin; }
+int scalanative_win32_winnt_token_info_class_elevationtype() {
+    return TokenElevationType;
+}
+int scalanative_win32_winnt_token_info_class_linkedtoken() {
+    return TokenLinkedToken;
+}
+int scalanative_win32_winnt_token_info_class_elevation() {
+    return TokenElevation;
+}
+int scalanative_win32_winnt_token_info_class_hasrestrictions() {
+    return TokenHasRestrictions;
+}
+int scalanative_win32_winnt_token_info_class_accessinformation() {
+    return TokenAccessInformation;
+}
+int scalanative_win32_winnt_token_info_class_virtualizationallowed() {
+    return TokenVirtualizationAllowed;
+}
+int scalanative_win32_winnt_token_info_class_virtualizationenabled() {
+    return TokenVirtualizationEnabled;
+}
+int scalanative_win32_winnt_token_info_class_integritylevel() {
+    return TokenIntegrityLevel;
+}
+int scalanative_win32_winnt_token_info_class_uiaccess() {
+    return TokenUIAccess;
+}
+int scalanative_win32_winnt_token_info_class_mandatorypolicy() {
+    return TokenMandatoryPolicy;
+}
+int scalanative_win32_winnt_token_info_class_logonsid() {
+    return TokenLogonSid;
+}
+int scalanative_win32_winnt_token_info_class_isappcontainer() {
+    return TokenIsAppContainer;
+}
+int scalanative_win32_winnt_token_info_class_capabilities() {
+    return TokenCapabilities;
+}
+int scalanative_win32_winnt_token_info_class_appcontainersid() {
+    return TokenAppContainerSid;
+}
+int scalanative_win32_winnt_token_info_class_appcontainernumber() {
+    return TokenAppContainerNumber;
+}
+int scalanative_win32_winnt_token_info_class_userclaimattributes() {
+    return TokenUserClaimAttributes;
+}
+int scalanative_win32_winnt_token_info_class_deviceclaimattributes() {
+    return TokenDeviceClaimAttributes;
+}
+int scalanative_win32_winnt_token_info_class_restricteduserclaimattributes() {
+    return TokenRestrictedUserClaimAttributes;
+}
+int scalanative_win32_winnt_token_info_class_restricteddeviceclaimattributes() {
+    return TokenRestrictedDeviceClaimAttributes;
+}
+int scalanative_win32_winnt_token_info_class_devicegroups() {
+    return TokenDeviceGroups;
+}
+int scalanative_win32_winnt_token_info_class_restricteddevicegroups() {
+    return TokenRestrictedDeviceGroups;
+}
+int scalanative_win32_winnt_token_info_class_securityattributes() {
+    return TokenSecurityAttributes;
+}
+int scalanative_win32_winnt_token_info_class_isrestricted() {
+    return TokenIsRestricted;
+}
+int scalanative_win32_winnt_token_info_class_processtrustlevel() {
+    return TokenProcessTrustLevel;
+}
+int scalanative_win32_winnt_token_info_class_privatenamespace() {
+    return TokenPrivateNameSpace;
+}
+int scalanative_win32_winnt_token_info_class_singletonattributes() {
+    return TokenSingletonAttributes;
+}
+int scalanative_win32_winnt_token_info_class_bnoisolation() {
+    return TokenBnoIsolation;
+}
+int scalanative_win32_winnt_token_info_class_childprocessflags() {
+    return TokenChildProcessFlags;
+}
+int scalanative_win32_winnt_token_info_class_islessprivilegedappcontainer() {
+    return TokenIsLessPrivilegedAppContainer;
+}
+int scalanative_win32_winnt_token_info_class_issandboxed() {
+    return TokenIsSandboxed;
+}
+int scalanative_win32_winnt_token_info_class_originatingprocesstrustlevel() {
+    return TokenOriginatingProcessTrustLevel;
+}
+int scalanative_win32_winnt_token_info_class_infoclass_max() {
+    return MaxTokenInfoClass;
+}
+
+#endif // defined(_WIN32)

--- a/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
@@ -10,6 +10,38 @@ import WinBaseApi.SecurityAttributes
 @extern
 object FileApi {
   private[windows] type PathMax = Nat.Digit3[Nat._2, Nat._6, Nat._0]
+  private[windows] type FileName[C] = CArray[C, PathMax]
+  private[windows] type AlternateFileName[C] =
+    CArray[C, Nat.Digit2[Nat._1, Nat._4]]
+  private[windows] type Win32FindData[C] = CStruct13[
+    DWord,
+    FileTimeStruct,
+    FileTimeStruct,
+    FileTimeStruct,
+    DWord,
+    DWord,
+    DWord,
+    DWord,
+    FileName[C],
+    AlternateFileName[C],
+    DWord,
+    DWord,
+    Word
+  ]
+  type Win32FindDataW = Win32FindData[WChar]
+  type Win32FindDataA = Win32FindData[CChar]
+  type ByHandleFileInformation = CStruct10[
+    DWord,
+    FileTimeStruct,
+    FileTimeStruct,
+    FileTimeStruct,
+    DWord,
+    DWord,
+    DWord,
+    DWord,
+    DWord,
+    DWord
+  ]
 
   def CreateFileA(
       filename: CString,
@@ -43,9 +75,33 @@ object FileApi {
     extern
   def DeleteFileA(filename: CString): Boolean = extern
   def DeleteFileW(filename: CWString): Boolean = extern
+  def FindFirstFileA(
+      filename: CString,
+      findFileData: Ptr[Win32FindDataA]
+  ): Handle = extern
+  def FindNextFileA(
+      searchHandle: Handle,
+      findFileData: Ptr[Win32FindDataA]
+  ): Boolean = extern
+
+  def FindFirstFileW(
+      filename: CWString,
+      findFileData: Ptr[Win32FindDataW]
+  ): Handle = extern
+  def FindNextFileW(
+      searchHandle: Handle,
+      findFileData: Ptr[Win32FindDataW]
+  ): Boolean = extern
+  def FindClose(searchHandle: Handle): Boolean = extern
   def FlushFileBuffers(handle: Handle): Boolean = extern
   def GetFileAttributesA(filename: CString): DWord = extern
   def GetFileAttributesW(filename: CWString): DWord = extern
+
+  def GetFileInformationByHandle(
+      file: Handle,
+      fileInformation: Ptr[ByHandleFileInformation]
+  ): Boolean =
+    extern
 
   def GetFinalPathNameByHandleA(
       handle: Handle,
@@ -81,8 +137,26 @@ object FileApi {
       lastAccessTime: Ptr[FileTime],
       lastWriteTime: Ptr[FileTime]
   ): Boolean = extern
+
+  def GetLogicalDriveStringsW(bufferLength: DWord, buffer: CWString): DWord =
+    extern
+
+  def GetTempFileNameW(
+      pathName: CWString,
+      prefixString: CWString,
+      unique: UInt,
+      tempFileName: CWString
+  ): UInt = extern
+
   def GetTempPathA(bufferLength: DWord, buffer: CString): DWord = extern
   def GetTempPathW(bufferLength: DWord, buffer: CWString): DWord = extern
+
+  def GetVolumePathNameW(
+      filename: CWString,
+      volumePathName: CWString,
+      bufferLength: DWord
+  ): Boolean = extern
+
   def ReadFile(
       fileHandle: Handle,
       buffer: Ptr[Byte],
@@ -189,4 +263,95 @@ object FileApiExt {
   final val VOLUME_NAME_GUID = 0x01.toUInt
   final val VOLUME_NAME_NT = 0x02.toUInt
   final val VOLUME_NAME_NONE = 0x04.toUInt
+}
+
+object FileApiOps {
+  import FileApi._
+  import MinWinBaseApiOps._
+  import util.Conversion._
+  import scalanative.libc.string.strcpy
+  import scala.scalanative.libc.wchar.wcscpy
+
+  abstract class Win32FileDataOps[C: Tag](ref: Ptr[Win32FindData[C]]) {
+    def fileAttributes: DWord = ref._1
+    def creationTime: FileTime = ref.at2.fileTime
+    def lastAccessTime: FileTime = ref.at3.fileTime
+    def lastWriteTime: FileTime = ref.at4.fileTime
+    private def fileSizeHigh: DWord = ref._5
+    private def fileSizeLow: DWord = ref._6
+    def fileSize: ULargeInteger =
+      dwordPairToULargeInteger(fileSizeHigh, fileSizeLow)
+    def reserved0: DWord = ref._7
+    def reserved1: DWord = ref._8
+    def fileName: Ptr[C] = ref._9.at(0)
+    def alternateFileName: Ptr[C] = ref._10.at(0)
+    // following fields are not used on some devices, though should not be written
+    def fileType: DWord = ref._11
+    def creatorType: DWord = ref._12
+    def finderFlags: Word = ref._13
+
+    def fileAttributes_=(v: DWord): Unit = ref._1 = v
+    def creationTime_=(v: FileTime): Unit = ref.at2.fileTime = v
+    def lastAccessTime_=(v: FileTime): Unit = ref.at3.fileTime = v
+    def lastWriteTime_=(v: FileTime): Unit = ref.at4.fileTime = v
+    def fileSize_=(v: ULargeInteger): Unit =
+      uLargeIntegerToDWordPair(v, ref.at5, ref.at6)
+    def reserved0_=(v: DWord): Unit = ref._7 = v
+    def reserved1_=(v: DWord): Unit = ref._8 = v
+
+    def fileName_=(v: Ptr[C]): Unit
+    def alternateFileName_=(v: Ptr[C]): Unit
+  }
+
+  implicit final class Win32FileDataAOps(ref: Ptr[Win32FindDataA])
+      extends Win32FileDataOps[CChar](ref) {
+    override def fileName_=(v: CString): Unit = strcpy(ref.at9.at(0), v)
+    override def alternateFileName_=(v: CString): Unit =
+      strcpy(ref.at10.at(0), v)
+  }
+
+  implicit final class Win32FileDataWOps(ref: Ptr[Win32FindDataW])
+      extends Win32FileDataOps[CChar16](ref) {
+    override def fileName_=(v: CWString): Unit =
+      wcscpy(
+        ref.at9.at(0).asInstanceOf[CWideString],
+        v.asInstanceOf[CWideString]
+      )
+
+    override def alternateFileName_=(v: CWString): Unit =
+      wcscpy(
+        ref.at10.at(0).asInstanceOf[CWideString],
+        v.asInstanceOf[CWideString]
+      )
+  }
+
+  implicit class ByHandleFileInformationOps(
+      val ref: Ptr[ByHandleFileInformation]
+  ) extends AnyVal {
+    def fileAttributes: DWord = ref._1
+    def creationTime: FileTime = ref.at2.fileTime
+    def lastAccessTime: FileTime = ref.at3.fileTime
+    def lastWriteTime: FileTime = ref.at4.fileTime
+    def volumeSerialNumber: DWord = ref._5
+    private def fileSizeHigh: DWord = ref._6
+    private def fileSizeLow: DWord = ref._7
+    def fileSize: ULargeInteger =
+      dwordPairToULargeInteger(fileSizeHigh, fileSizeLow)
+    def numberOfLinks: DWord = ref._8
+    private def fileIndexHigh: DWord = ref._9
+    private def fileIndexLow: DWord = ref._10
+    def fileIndex: ULargeInteger =
+      dwordPairToULargeInteger(fileIndexHigh, fileIndexLow)
+
+    def fileAttributes_=(v: DWord): Unit = ref._1 = v
+    def creationTime_=(v: FileTime): Unit = ref.at2.fileTime = v
+    def lastAccessTime_=(v: FileTime): Unit = ref.at3.fileTime = v
+    def lastWriteTime_=(v: FileTime): Unit = ref.at4.fileTime = v
+    def volumeSerialNumber_=(v: DWord): Unit = ref._5
+    def fileSize_=(v: ULargeInteger): Unit =
+      uLargeIntegerToDWordPair(v, ref.at6, ref.at7)
+    def numberOfLinks_=(v: DWord): Unit = ref._8
+    def fileIndex_=(v: ULargeInteger): Unit =
+      uLargeIntegerToDWordPair(v, ref.at9, ref.at10)
+  }
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/SddlApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SddlApi.scala
@@ -1,0 +1,20 @@
+package scala.scalanative.windows
+
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+import scala.scalanative.windows.HandleApi.Handle
+
+@link("Advapi32")
+@extern()
+object SddlApi {
+  import MinWinBaseApi._
+  import SecurityBaseApi._
+  def ConvertSidToStringSidW(sid: SIDPtr, stringSid: Ptr[CWString]): Boolean =
+    extern
+
+  def ConvertStringSidToSidW(
+      sidString: CWString,
+      sidRef: Ptr[SIDPtr]
+  ): Boolean =
+    extern
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
@@ -49,7 +49,74 @@ object WinBaseApi {
   def GetCurrentDirectoryA(bufferLength: DWord, buffer: CString): DWord = extern
   def GetCurrentDirectoryW(bufferLength: DWord, buffer: CWString): DWord =
     extern
+  def GetFileSecurityW(
+      filename: CWString,
+      requestedInformation: SecurityInformation,
+      securityDescriptor: Ptr[SecurityDescriptor],
+      length: DWord,
+      lengthNeeded: Ptr[DWord]
+  ): Boolean =
+    extern
+
   def LocalFree(ref: LocalHandle): LocalHandle = extern
+  def LookupAccountNameA(
+      systemName: CString,
+      accountName: CString,
+      sid: SIDPtr,
+      cbSid: Ptr[DWord],
+      referencedDomainName: CString,
+      referencedDomainNameSize: Ptr[DWord],
+      use: Ptr[SidNameUse]
+  ): Boolean = extern
+  def LookupAccountNameW(
+      systemName: CWString,
+      accountName: CWString,
+      sid: SIDPtr,
+      cbSid: Ptr[DWord],
+      referencedDomainName: CWString,
+      referencedDomainNameSize: Ptr[DWord],
+      use: Ptr[SidNameUse]
+  ): Boolean = extern
+  def LookupAccountSidA(
+      systemName: Ptr[CString],
+      sid: SIDPtr,
+      name: CString,
+      nameSize: Ptr[DWord],
+      referencedDomainName: CString,
+      referencedDomainNameSize: Ptr[DWord],
+      use: Ptr[SidNameUse]
+  ): Boolean = extern
+  def LookupAccountSidW(
+      systemName: CWString,
+      sid: SIDPtr,
+      name: CWString,
+      nameSize: Ptr[DWord],
+      referencedDomainName: CWString,
+      referencedDomainNameSize: Ptr[DWord],
+      use: Ptr[SidNameUse]
+  ): Boolean = extern
+  def MoveFileExA(
+      existingFileName: CString,
+      newFileName: CString,
+      flags: DWord
+  ): Boolean = extern
+
+  def MoveFileExW(
+      existingFileName: CWString,
+      newFileName: CWString,
+      flags: DWord
+  ): Boolean = extern
+
+  def RegisterWaitForSingleObject(
+      retHandle: Ptr[Handle],
+      ref: Handle,
+      callbackFn: WaitOrTimerCallback,
+      context: Ptr[Byte],
+      miliseconds: DWord,
+      flags: DWord
+  ): Boolean = extern
+
+  def UnregisterWait(handle: Handle): Boolean = extern
 
   @name("scalanative_win32_default_language")
   final def DefaultLanguageId: DWord = extern

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/SidNameUse.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/SidNameUse.scala
@@ -1,0 +1,38 @@
+package scala.scalanative.windows.winnt
+
+import scalanative.unsafe._
+@extern
+object SidNameUse {
+  @name("scalanative_win32_winnt_sid_name_use_sidtypeuser")
+  def SidTypeUser: SidNameUse = extern
+
+  @name("scalanative_win32_winnt_sid_name_use_sidtypegroup")
+  def SidTypeGroup: SidNameUse = extern
+
+  @name("scalanative_win32_winnt_sid_name_use_sidtypedomain")
+  def SidTypeDomain: SidNameUse = extern
+
+  @name("scalanative_win32_winnt_sid_name_use_sidtypealias")
+  def SidTypeAlias: SidNameUse = extern
+
+  @name("scalanative_win32_winnt_sid_name_use_sidtypewellknowngroup")
+  def SidTypeWellKnownGroup: SidNameUse = extern
+
+  @name("scalanative_win32_winnt_sid_name_use_sidtypedeletedaccount")
+  def SidTypeDeletedAccount: SidNameUse = extern
+
+  @name("scalanative_win32_winnt_sid_name_use_sidtypeinvalid")
+  def SidTypeInvalid: SidNameUse = extern
+
+  @name("scalanative_win32_winnt_sid_name_use_sidtypeunknown")
+  def SidTypeUnknown: SidNameUse = extern
+
+  @name("scalanative_win32_winnt_sid_name_use_sidtypecomputer")
+  def SidTypeComputer: SidNameUse = extern
+
+  @name("scalanative_win32_winnt_sid_name_use_sidtypelabel")
+  def SidTypeLabel: SidNameUse = extern
+
+  @name("scalanative_win32_winnt_sid_name_use_sidtypelogonsession")
+  def SidTypeLogonSession: SidNameUse = extern
+}


### PR DESCRIPTION
This PR adds Windows implementation for all `java.nio` methods supported on Unix. 

Scope of changes: 
* Implement WindowsFileSysytem, its provider and Views
* Implement WindowsPath and it's parser
* Moved Unix FileSystem implementation to its own package
* Conditionally select FS providers using linktime condition
* Adjust some of the java.nio test to be JVM compliment. 
* Added windowslib bindings used by java.nio