### PR TITLE
Remove non standard value for Windows TokenInformationClass bindings

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -1,7 +1,7 @@
 // sscanf and getEnv is deprecated in WinCRT, disable warnings
 // These functions are not used directly, but are included in "Parsing.h".
-// The definition used to disable warnings needs to be placed before the first 
-// include of Windows.h, depending on the version of Windows runtime 
+// The definition used to disable warnings needs to be placed before the first
+// include of Windows.h, depending on the version of Windows runtime
 // it might happen while preprocessing some of stdlib headers.
 #define _CRT_SECURE_NO_WARNINGS
 

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -1,3 +1,6 @@
+// sscanf and getEnv is deprecated in WinCRT, disable warnings
+#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdlib.h>
 #include <stdio.h>
 #include "MemoryMap.h"

--- a/nativelib/src/main/resources/scala-native/gc/none/gc.c
+++ b/nativelib/src/main/resources/scala-native/gc/none/gc.c
@@ -1,4 +1,8 @@
 // sscanf and getEnv is deprecated in WinCRT, disable warnings
+// These functions are not used directly, but are included in "Parsing.h".
+// The definition used to disable warnings needs to be placed before the first 
+// include of Windows.h, depending on the version of Windows runtime 
+// it might happen while preprocessing some of stdlib headers.
 #define _CRT_SECURE_NO_WARNINGS
 
 #include <stdlib.h>

--- a/windowslib/src/main/resources/scala-native/windows/winnt/tokenInformationClass.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/tokenInformationClass.c
@@ -132,9 +132,6 @@ int scalanative_win32_winnt_token_info_class_islessprivilegedappcontainer() {
 int scalanative_win32_winnt_token_info_class_issandboxed() {
     return TokenIsSandboxed;
 }
-int scalanative_win32_winnt_token_info_class_originatingprocesstrustlevel() {
-    return TokenOriginatingProcessTrustLevel;
-}
 int scalanative_win32_winnt_token_info_class_infoclass_max() {
     return MaxTokenInfoClass;
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/TokenInformationClass.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/TokenInformationClass.scala
@@ -151,9 +151,6 @@ object TokenInformationClass {
   @name("scalanative_win32_winnt_token_info_class_issandboxed")
   def TokenIsSandboxed: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_originatingprocesstrustlevel")
-  def TokenOriginatingProcessTrustLevel: TokenInformationClass = extern
-
   @name("scalanative_win32_winnt_token_info_class_infoclass_max")
   def MaxTokenInfoClass: TokenInformationClass = extern
 


### PR DESCRIPTION
One of defined TokenInformationClass bindings was non standard, leading to failures in the CI. 
It looks like for Windows Runtime library in version 10.0.22000.0 used in CI `TokenOriginatingProcessTrustLevel` enum is no longer defined. However, it looks like this value was defined in older version 10.0.19041.0, used locally on my machine. 
The decision about the removal of this value can be also justified by the fact that mentioned enum value is not defined in [official Microsoft documentation](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-token_information_class) 

Additionally based on the logs from the CI deprecation warnings in the None GC were removed by usage of special Windows macro definition. This warning was probably not present before (they're already defined in `Parsing.h` file using `sscanf` and `getenv` functions treated as deprecated) and it might suggest that main `Windows.h` file header is now being included earlier and though ignoring previous definition of `_CRT_SECURE_NO_WARNINGS` 