### PR TITLE
Allow to execute scripted tests on Windows

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -152,3 +152,53 @@ jobs:
           testsExt/test
           testsExtJVM/test
         shell: cmd
+
+  run-scripted-tests:
+    name: Run scripted tests
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2019]
+        scala: [2.12.15]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure Pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+        with:
+          minimum-size: 4GB
+          maximum-size: 16GB
+
+      #Prepare environment, clang needs to be installed
+      #Compilation on MSVC needs c++14 or higher and expects llvm 11.0.0 or newer
+      #Cache commonly used files: Coursier, ivy cache
+      - name: Resolve env variables
+        id: resolve-env
+        run: |
+          echo "::set-output name=ProgramFiles::${env:ProgramFiles}"
+          echo "::set-output name=LocalAppData::${env:LocalAppData}"
+          echo "::set-output name=UserProfile::${env:UserProfile}"
+
+      - name: Cache dependencies
+        id: cache-deps
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{steps.resolve-env.outputs.ProgramFiles}}\LLVM\
+            ${{steps.resolve-env.outputs.LocalAppData}}\Coursier\Cache\v1\
+            ${{steps.resolve-env.outputs.UserProfile}}\.ivy2\cache
+          key: ${{ runner.os }}-${{ matrix.scala }}-deps
+
+      # Install LLVM in case if cache is missing
+      - name: Install LLVM
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: choco install llvm --version=11.0.0
+
+      - name: Add LLVM on Path
+        run: echo "${env:ProgramFiles}\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Assert clang installed and on path
+        run: clang --version
+
+      - name: Test scripted
+        run: sbt ++${{matrix.scala}};test-scripted
+        shell: cmd

--- a/build.sbt
+++ b/build.sbt
@@ -416,7 +416,8 @@ lazy val sbtPluginSettings: Seq[Setting[_]] =
             "-Xmx1024M",
             "-XX:MaxMetaspaceSize=256M",
             "-Dplugin.version=" + version.value,
-            "-Dscala.version=" + (nativelib / scalaVersion).value
+            "-Dscala.version=" + (nativelib / scalaVersion).value,
+            "-Dfile.encoding=UTF-8" // Windows uses Cp1250 as default
           ) ++
           ivyPaths.value.ivyHome.map(home => s"-Dsbt.ivy.home=$home").toSeq
       }

--- a/scripted-tests/run/java-io-file-1/Files.scala
+++ b/scripted-tests/run/java-io-file-1/Files.scala
@@ -1,4 +1,5 @@
 import java.io.File
+import Utils._
 
 object Files {
 
@@ -55,18 +56,36 @@ object Files {
   val linkToDirectory = new File("linkToDirectory")
 
   // Those files are there to test the canonical name
-  val canon0F = new File("/.")
-  val canon0N = "/"
-  val canon1F = new File("/../")
-  val canon1N = "/"
-  val canon2F = new File("/foo/./bar")
-  val canon2N = "/foo/bar"
-  val canon3F = new File("/foo/../bar")
-  val canon3N = "/bar"
-  val canon4F = new File("/foo/../../bar")
-  val canon4N = "/../bar"
-  val canon5F = new File("/foo/../../../bar")
-  val canon5N = "/bar"
+  def osFilePathTuple(
+      unix: (String, String),
+      windows: (String, String)
+  ): (File, String) = {
+    val (path, expected) =
+      if (isWindows) windows
+      else unix
+    new File(path) -> expected
+  }
+
+  val (canon0F, canon0N) =
+    osFilePathTuple(unix = "/." -> "/", windows = "C:\\." -> "C:\\")
+  val (canon1F, canon1N) =
+    osFilePathTuple(unix = "/../" -> "/", windows = "C:\\.." -> "C:\\")
+  val (canon2F, canon2N) = osFilePathTuple(
+    unix = "/foo/./bar" -> "/foo/bar",
+    windows = "C:\\foo\\.\\bar" -> "C:\\foo\\bar"
+  )
+  val (canon3F, canon3N) = osFilePathTuple(
+    unix = "/foo/../bar" -> "/bar",
+    windows = "C:\\foo\\..\\bar" -> "C:\\bar"
+  )
+  val (canon4F, canon4N) = osFilePathTuple(
+    unix = "/foo/../../bar" -> "/../bar",
+    windows = "C:/foo/../../bar" -> "C:\\bar"
+  )
+  val (canon5F, canon5N) = osFilePathTuple(
+    unix = "/foo/../../../bar" -> "/bar",
+    windows = "C:/foo/../../../bar" -> "C:\\bar"
+  )
 
   // To test absolute names
   val absoluteUnixStyle = new File("/foo/bar")
@@ -77,16 +96,22 @@ object Files {
   val relative1 = new File("\\")
   val relative2 = new File("../")
 
-  val children0 = new File("/foo/bar")
-  val expectedParent0 = "/foo"
-  val children1 = new File("foo/bar")
-  val expectedParent1 = "foo"
-  val children2 = new File("/foobar")
-  val expectedParent2 = "/"
-  val children3 = new File("foobar")
-  val expectedParent3 = null
-  val children4 = new File("")
-  val expectedParent4 = null
+  val (children0, expectedParent0) =
+    osFilePathTuple(
+      unix = "/foo/bar" -> "/foo",
+      windows = "C:/foo/bar" -> "C:\\foo"
+    )
+  val (children1, expectedParent1) =
+    osFilePathTuple(
+      unix = "foo/bar" -> "foo",
+      windows = "C:/foo/bar" -> "C:\\foo"
+    )
+  val (children2, expectedParent2) =
+    osFilePathTuple(unix = "/foobar" -> "/", windows = "C:/foobar" -> "C:\\")
+  val (children3, expectedParent3) =
+    osFilePathTuple(unix = "foobar" -> null, windows = "C:/" -> null)
+  val (children4, expectedParent4) =
+    osFilePathTuple(unix = "" -> null, windows = "" -> null)
   val expectedParent5 = new File("foo")
   val children5 = new File(expectedParent5, "bar")
 

--- a/scripted-tests/run/java-io-file-1/Files.scala
+++ b/scripted-tests/run/java-io-file-1/Files.scala
@@ -61,7 +61,7 @@ object Files {
       windows: (String, String)
   ): (File, String) = {
     val (path, expected) =
-      if (isWindows) windows
+      if (Platform.isWindows) windows
       else unix
     new File(path) -> expected
   }

--- a/scripted-tests/run/java-io-file-1/Platform.scala
+++ b/scripted-tests/run/java-io-file-1/Platform.scala
@@ -1,0 +1,5 @@
+// This file is used only when compiling sources using Scala Native
+
+object Platform {
+  val isWindows = scalanative.runtime.Platform.isWindows
+}

--- a/scripted-tests/run/java-io-file-1/Utils.scala
+++ b/scripted-tests/run/java-io-file-1/Utils.scala
@@ -1,0 +1,18 @@
+import java.util.Locale
+
+object Utils {
+  val isWindows = System
+    .getProperty("os.name", "unknown")
+    .toLowerCase()
+    .startsWith("windows")
+
+  def assertOsSpecific(
+      pred: Boolean,
+      msg: => String
+  )(onUnix: Boolean, onWindows: Boolean) = {
+    val expected =
+      if (isWindows) onWindows
+      else onUnix
+    assert(pred == expected, msg)
+  }
+}

--- a/scripted-tests/run/java-io-file-1/Utils.scala
+++ b/scripted-tests/run/java-io-file-1/Utils.scala
@@ -1,17 +1,12 @@
 import java.util.Locale
 
 object Utils {
-  val isWindows = System
-    .getProperty("os.name", "unknown")
-    .toLowerCase(Locale.ROOT)
-    .startsWith("windows")
-
   def assertOsSpecific(
       pred: Boolean,
       msg: => String
   )(onUnix: Boolean, onWindows: Boolean) = {
     val expected =
-      if (isWindows) onWindows
+      if (Platform.isWindows) onWindows
       else onUnix
     assert(pred == expected, msg)
   }

--- a/scripted-tests/run/java-io-file-1/Utils.scala
+++ b/scripted-tests/run/java-io-file-1/Utils.scala
@@ -3,7 +3,7 @@ import java.util.Locale
 object Utils {
   val isWindows = System
     .getProperty("os.name", "unknown")
-    .toLowerCase()
+    .toLowerCase(Locale.ROOT)
     .startsWith("windows")
 
   def assertOsSpecific(

--- a/scripted-tests/run/java-io-file-1/build.sbt
+++ b/scripted-tests/run/java-io-file-1/build.sbt
@@ -153,7 +153,7 @@ setupTests := {
   assert(existingHiddenFile.exists())
   assert(existingHiddenDirectory.exists())
   assert(!nonexistentHiddenFile.exists())
-  if (isWindows) {
+  if (Platform.isWindows) {
     Seq(currentDirectory, existingHiddenDirectory, existingHiddenFile)
       .map(_.toPath)
       .foreach(NioFiles.setAttribute(_, "dos:hidden", true.booleanValue()))
@@ -185,7 +185,7 @@ setupTests := {
 
   IO.createDirectory(directoryLinkedTo)
   assert(directoryLinkedTo.exists)
-  if (!isWindows) {
+  if (!Platform.isWindows) {
     // Symbolic links on Windows are broken, needs admin priviliges
     NioFiles.createSymbolicLink(
       linkToDirectory.toPath,

--- a/scripted-tests/run/java-io-file-1/project/Platform.scala
+++ b/scripted-tests/run/java-io-file-1/project/Platform.scala
@@ -2,7 +2,7 @@
 import java.util.Locale
 
 object Platform {
-    val isWindows = System
+  val isWindows = System
     .getProperty("os.name", "unknown")
     .toLowerCase(Locale.ROOT)
     .startsWith("windows")

--- a/scripted-tests/run/java-io-file-1/project/Platform.scala
+++ b/scripted-tests/run/java-io-file-1/project/Platform.scala
@@ -1,0 +1,9 @@
+// This file is used only inside sbt (JVM)
+import java.util.Locale
+
+object Platform {
+    val isWindows = System
+    .getProperty("os.name", "unknown")
+    .toLowerCase(Locale.ROOT)
+    .startsWith("windows")
+}

--- a/scripted-tests/run/java-io-file-1/test
+++ b/scripted-tests/run/java-io-file-1/test
@@ -1,5 +1,6 @@
-# Make `Files.scala` usable in build.sbt
+# Make `Files.scala` and `Utils.scala` usable in build.sbt
 $ copy-file Files.scala project/Files.scala
+$ copy-file Utils.scala project/Utils.scala
 > setupTests
 
 $ copy-file tests/CanExecuteTest.scala Main.scala

--- a/scripted-tests/run/java-io-file-1/tests/CanExecuteTest.scala
+++ b/scripted-tests/run/java-io-file-1/tests/CanExecuteTest.scala
@@ -1,15 +1,22 @@
 object CanExecuteTest {
   import Files._
+  import Utils._
 
   def main(args: Array[String]): Unit = {
     assert(!emptyNameFile.canExecute())
 
     assert(executableFile.canExecute())
-    assert(!unexecutableFile.canExecute())
+    assertOsSpecific(
+      unexecutableFile.canExecute(),
+      "unexecutableFile.canExecute"
+    )(onUnix = false, onWindows = true)
     assert(!nonexistentFile.canExecute())
 
     assert(executableDirectory.canExecute())
-    assert(!unexecutableDirectory.canExecute())
+    assertOsSpecific(
+      unexecutableDirectory.canExecute(),
+      "!unexecutableDirectory.canExecute"
+    )(onUnix = false, onWindows = true)
     assert(!nonexistentDirectory.canExecute())
   }
 

--- a/scripted-tests/run/java-io-file-1/tests/CanReadTest.scala
+++ b/scripted-tests/run/java-io-file-1/tests/CanReadTest.scala
@@ -1,15 +1,22 @@
 object CanReadTest {
   import Files._
+  import Utils._
 
   def main(args: Array[String]): Unit = {
     assert(!emptyNameFile.canRead())
 
     assert(readableFile.canRead())
-    assert(!unreadableFile.canRead())
+    assertOsSpecific(
+      unreadableFile.canRead(),
+      "unreadableFile.canRead()"
+    )(onUnix = false, onWindows = true)
     assert(!nonexistentFile.canRead())
 
     assert(readableDirectory.canRead())
-    assert(!unreadableDirectory.canRead())
+    assertOsSpecific(
+      unreadableDirectory.canRead(),
+      "unreadableDirectory.canRead()"
+    )(onUnix = false, onWindows = true)
     assert(!nonexistentDirectory.canRead())
   }
 

--- a/scripted-tests/run/java-io-file-1/tests/CanWriteTest.scala
+++ b/scripted-tests/run/java-io-file-1/tests/CanWriteTest.scala
@@ -1,5 +1,6 @@
 object CanWriteTest {
   import Files._
+  import Utils._
 
   def main(args: Array[String]): Unit = {
     assert(!emptyNameFile.canWrite())
@@ -8,8 +9,11 @@ object CanWriteTest {
     assert(!unwritableFile.canWrite())
     assert(!nonexistentFile.canWrite())
 
-    assert(writableFile.canWrite())
-    assert(!unwritableFile.canWrite())
+    assert(writableDirectory.canWrite())
+    assertOsSpecific(
+      unwritableDirectory.canWrite(),
+      "unwritableDirectory.canWrite()"
+    )(onUnix = false, onWindows = true)
     assert(!nonexistentDirectory.canWrite())
   }
 

--- a/scripted-tests/run/java-io-file-1/tests/IsAbsoluteTest.scala
+++ b/scripted-tests/run/java-io-file-1/tests/IsAbsoluteTest.scala
@@ -1,18 +1,27 @@
 object IsAbsoluteTest {
   import Files._
+  import Utils._
 
   def main(args: Array[String]): Unit = {
-    if (java.io.File.separator == "/") {
-      assert(absoluteUnixStyle.isAbsolute)
-      assert(!absoluteWinStyle0.isAbsolute)
-      assert(!absoluteWinStyle1.isAbsolute)
-      assert(!absoluteWinStyle2.isAbsolute)
-    } else {
-      assert(!absoluteUnixStyle.isAbsolute)
-      assert(absoluteWinStyle0.isAbsolute)
-      assert(absoluteWinStyle1.isAbsolute)
-      assert(absoluteWinStyle2.isAbsolute)
-    }
+    assertOsSpecific(
+      absoluteUnixStyle.isAbsolute,
+      "absoluteUnixStyle.isAbsolute"
+    )(onUnix = true, onWindows = false)
+
+    assertOsSpecific(
+      absoluteWinStyle0.isAbsolute,
+      "absoluteWinStyle0.isAbsolute"
+    )(onUnix = false, onWindows = true)
+
+    assertOsSpecific(
+      absoluteWinStyle1.isAbsolute,
+      "absoluteWinStyle1.isAbsolute"
+    )(onUnix = false, onWindows = true)
+
+    assertOsSpecific(
+      absoluteWinStyle2.isAbsolute,
+      "absoluteWinStyle2.isAbsolute"
+    )(onUnix = false, onWindows = true)
 
     assert(!relative0.isAbsolute)
     assert(!relative1.isAbsolute)

--- a/scripted-tests/run/java-io-file-2/Files.scala
+++ b/scripted-tests/run/java-io-file-2/Files.scala
@@ -1,4 +1,5 @@
 import java.io.File
+import Utils._
 
 object Files {
 
@@ -55,18 +56,36 @@ object Files {
   val linkToDirectory = new File("linkToDirectory")
 
   // Those files are there to test the canonical name
-  val canon0F = new File("/.")
-  val canon0N = "/"
-  val canon1F = new File("/../")
-  val canon1N = "/"
-  val canon2F = new File("/foo/./bar")
-  val canon2N = "/foo/bar"
-  val canon3F = new File("/foo/../bar")
-  val canon3N = "/bar"
-  val canon4F = new File("/foo/../../bar")
-  val canon4N = "/../bar"
-  val canon5F = new File("/foo/../../../bar")
-  val canon5N = "/bar"
+  def osFilePathTuple(
+      unix: (String, String),
+      windows: (String, String)
+  ): (File, String) = {
+    val (path, expected) =
+      if (isWindows) windows
+      else unix
+    new File(path) -> expected
+  }
+
+  val (canon0F, canon0N) =
+    osFilePathTuple(unix = "/." -> "/", windows = "C:\\." -> "C:\\")
+  val (canon1F, canon1N) =
+    osFilePathTuple(unix = "/../" -> "/", windows = "C:\\.." -> "C:\\")
+  val (canon2F, canon2N) = osFilePathTuple(
+    unix = "/foo/./bar" -> "/foo/bar",
+    windows = "C:\\foo\\.\\bar" -> "C:\\foo\\bar"
+  )
+  val (canon3F, canon3N) = osFilePathTuple(
+    unix = "/foo/../bar" -> "/bar",
+    windows = "C:\\foo\\..\\bar" -> "C:\\bar"
+  )
+  val (canon4F, canon4N) = osFilePathTuple(
+    unix = "/foo/../../bar" -> "/../bar",
+    windows = "C:/foo/../../bar" -> "C:\\bar"
+  )
+  val (canon5F, canon5N) = osFilePathTuple(
+    unix = "/foo/../../../bar" -> "/bar",
+    windows = "C:/foo/../../../bar" -> "C:\\bar"
+  )
 
   // To test absolute names
   val absoluteUnixStyle = new File("/foo/bar")
@@ -77,16 +96,22 @@ object Files {
   val relative1 = new File("\\")
   val relative2 = new File("../")
 
-  val children0 = new File("/foo/bar")
-  val expectedParent0 = "/foo"
-  val children1 = new File("foo/bar")
-  val expectedParent1 = "foo"
-  val children2 = new File("/foobar")
-  val expectedParent2 = "/"
-  val children3 = new File("foobar")
-  val expectedParent3 = null
-  val children4 = new File("")
-  val expectedParent4 = null
+  val (children0, expectedParent0) =
+    osFilePathTuple(
+      unix = "/foo/bar" -> "/foo",
+      windows = "C:/foo/bar" -> "C:\\foo"
+    )
+  val (children1, expectedParent1) =
+    osFilePathTuple(
+      unix = "foo/bar" -> "foo",
+      windows = "C:/foo/bar" -> "C:\\foo"
+    )
+  val (children2, expectedParent2) =
+    osFilePathTuple(unix = "/foobar" -> "/", windows = "C:/foobar" -> "C:\\")
+  val (children3, expectedParent3) =
+    osFilePathTuple(unix = "foobar" -> null, windows = "C:/" -> null)
+  val (children4, expectedParent4) =
+    osFilePathTuple(unix = "" -> null, windows = "" -> null)
   val expectedParent5 = new File("foo")
   val children5 = new File(expectedParent5, "bar")
 

--- a/scripted-tests/run/java-io-file-2/Files.scala
+++ b/scripted-tests/run/java-io-file-2/Files.scala
@@ -61,7 +61,7 @@ object Files {
       windows: (String, String)
   ): (File, String) = {
     val (path, expected) =
-      if (isWindows) windows
+      if (Platform.isWindows) windows
       else unix
     new File(path) -> expected
   }

--- a/scripted-tests/run/java-io-file-2/Platform.scala
+++ b/scripted-tests/run/java-io-file-2/Platform.scala
@@ -1,0 +1,5 @@
+// This file is used only when compiling sources using Scala Native
+
+object Platform {
+  val isWindows = scalanative.runtime.Platform.isWindows
+}

--- a/scripted-tests/run/java-io-file-2/Utils.scala
+++ b/scripted-tests/run/java-io-file-2/Utils.scala
@@ -1,0 +1,18 @@
+import java.util.Locale
+
+object Utils {
+  val isWindows = System
+    .getProperty("os.name", "unknown")
+    .toLowerCase()
+    .startsWith("windows")
+
+  def assertOsSpecific(
+      pred: Boolean,
+      msg: => String
+  )(onUnix: Boolean, onWindows: Boolean) = {
+    val expected =
+      if (isWindows) onWindows
+      else onUnix
+    assert(pred == expected, msg)
+  }
+}

--- a/scripted-tests/run/java-io-file-2/Utils.scala
+++ b/scripted-tests/run/java-io-file-2/Utils.scala
@@ -3,7 +3,7 @@ import java.util.Locale
 object Utils {
   val isWindows = System
     .getProperty("os.name", "unknown")
-    .toLowerCase()
+    .toLowerCase(Locale.ROOT)
     .startsWith("windows")
 
   def assertOsSpecific(

--- a/scripted-tests/run/java-io-file-2/Utils.scala
+++ b/scripted-tests/run/java-io-file-2/Utils.scala
@@ -1,17 +1,10 @@
-import java.util.Locale
-
 object Utils {
-  val isWindows = System
-    .getProperty("os.name", "unknown")
-    .toLowerCase(Locale.ROOT)
-    .startsWith("windows")
-
   def assertOsSpecific(
       pred: Boolean,
       msg: => String
   )(onUnix: Boolean, onWindows: Boolean) = {
     val expected =
-      if (isWindows) onWindows
+      if (Platform.isWindows) onWindows
       else onUnix
     assert(pred == expected, msg)
   }

--- a/scripted-tests/run/java-io-file-2/build.sbt
+++ b/scripted-tests/run/java-io-file-2/build.sbt
@@ -1,4 +1,5 @@
 import Files._
+import Utils._
 import java.nio.file.{Files => NioFiles}
 
 enablePlugins(ScalaNativePlugin)
@@ -20,64 +21,102 @@ lazy val setupTests = taskKey[Unit]("")
 setupTests := {
 
   IO.touch(readableFile)
-  readableFile.setReadable(true)
+  assert(readableFile.setReadable(true))
   assert(readableFile.exists())
   assert(readableFile.canRead())
 
   IO.touch(unreadableFile)
-  unreadableFile.setReadable(false)
   assert(unreadableFile.exists())
-  assert(!unreadableFile.canRead())
+  // setReadable(false) not possible on Windows
+  assertOsSpecific(
+    unreadableFile.setReadable(false),
+    "unreadableFile.setReadable(false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    unreadableFile.canRead(),
+    "!unreadableFile.canRead()"
+  )(onUnix = false, onWindows = true)
 
   IO.createDirectory(readableDirectory)
-  readableDirectory.setReadable(true)
+  assert(readableDirectory.setReadable(true))
   assert(readableDirectory.exists())
   assert(readableDirectory.canRead())
 
   IO.createDirectory(unreadableDirectory)
-  unreadableDirectory.setReadable(false)
   assert(unreadableDirectory.exists())
-  assert(!unreadableDirectory.canRead())
+  // setReadable(false) not possible on Windows
+  assertOsSpecific(
+    unreadableDirectory.setReadable(false),
+    "unreadableDirectory.setReadable(false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    unreadableDirectory.canRead(),
+    "!unreadableDirectory.canRead()"
+  )(onUnix = false, onWindows = true)
 
   IO.touch(executableFile)
-  executableFile.setExecutable(true)
+  assert(executableFile.setExecutable(true))
   assert(executableFile.exists())
   assert(executableFile.canExecute())
 
   IO.touch(unexecutableFile)
-  unexecutableFile.setExecutable(false)
   assert(unexecutableFile.exists())
-  assert(!unexecutableFile.canExecute())
-
+  // setExecutable(false) not possible on Windows
+  assertOsSpecific(
+    unexecutableFile.setExecutable(false),
+    "unexecutableFile.setExecutable(false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    unexecutableFile.canExecute(),
+    "!unexecutableFile.canExecute()"
+  )(onUnix = false, onWindows = true)
   IO.createDirectory(executableDirectory)
-  executableDirectory.setExecutable(true)
+  assert(executableDirectory.setExecutable(true))
   assert(executableDirectory.exists())
   assert(executableDirectory.canExecute())
 
   IO.createDirectory(unexecutableDirectory)
-  unexecutableDirectory.setExecutable(false)
   assert(unexecutableDirectory.exists())
-  assert(!unexecutableDirectory.canExecute())
+  // setExecutable(false) not possible on Windows
+  assertOsSpecific(
+    unexecutableDirectory.setExecutable(false),
+    "unexecutableDirectory.setExecutable(false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    unexecutableDirectory.canExecute(),
+    "!unexecutableDirectory.canExecute()"
+  )(onUnix = false, onWindows = true)
 
   IO.touch(writableFile)
-  writableFile.setWritable(true)
+  assert(writableFile.setWritable(true))
   assert(writableFile.exists())
   assert(writableFile.canWrite())
 
   IO.touch(unwritableFile)
-  unwritableFile.setWritable(false)
+  assert(unwritableFile.setWritable(false))
   assert(unwritableFile.exists())
   assert(!unwritableFile.canWrite())
 
   IO.createDirectory(writableDirectory)
-  writableDirectory.setWritable(true)
   assert(writableDirectory.exists())
+  // setWritable directory not possible on Windows
+  assertOsSpecific(
+    writableDirectory.setWritable(true),
+    "writableDirectory.setWritable(true)"
+  )(onUnix = true, onWindows = false)
   assert(writableDirectory.canWrite())
 
   IO.createDirectory(unwritableDirectory)
-  unwritableDirectory.setWritable(false)
   assert(unwritableDirectory.exists())
-  assert(!unwritableDirectory.canWrite())
+  // setWritable directory not possible on Windows
+  assertOsSpecific(
+    unwritableDirectory.setWritable(false),
+    "unwritableDirectory.setWritable(false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    unwritableDirectory.canWrite(),
+    "!unwritableDirectory.canWrite()"
+  )(onUnix = false, onWindows = true)
 
   assert(fileA.compareTo(fileB) < 0)
   assert(fileA.compareTo(fileA) == 0)
@@ -113,14 +152,21 @@ setupTests := {
 
   IO.touch(existingHiddenFile)
   IO.createDirectory(existingHiddenDirectory)
-  assert(currentDirectory.isHidden())
   assert(existingHiddenFile.exists())
-  assert(existingHiddenFile.isHidden())
   assert(existingHiddenDirectory.exists())
-  assert(existingHiddenDirectory.isHidden())
   assert(!nonexistentHiddenFile.exists())
-  assert(nonexistentHiddenFile.isHidden())
-
+  if (isWindows) {
+    Seq(currentDirectory, existingHiddenDirectory, existingHiddenFile)
+      .map(_.toPath)
+      .foreach(NioFiles.setAttribute(_, "dos:hidden", true.booleanValue()))
+  }
+  assert(currentDirectory.isHidden())
+  assert(existingHiddenFile.isHidden())
+  assert(existingHiddenDirectory.isHidden())
+  assertOsSpecific(
+    nonexistentHiddenFile.isHidden(),
+    "nonexistentHiddenFile.isHidden()"
+  )(onUnix = true, onWindows = false)
   IO.write(fileWith3Bytes, Array[Byte](1, 2, 3))
   assert(fileWith3Bytes.exists())
   assert(fileWith3Bytes.length() == 3L)
@@ -140,11 +186,19 @@ setupTests := {
   assert(!willBeRenamedTo.exists)
 
   IO.createDirectory(directoryLinkedTo)
-  NioFiles.createSymbolicLink(linkToDirectory.toPath, directoryLinkedTo.toPath)
   assert(directoryLinkedTo.exists)
-  assert(linkToDirectory.exists)
-  assert(linkToDirectory.getCanonicalPath == directoryLinkedTo.getCanonicalPath)
-  assert(linkToDirectory.getName != directoryLinkedTo.getName)
+  if (!isWindows) {
+    // Symbolic links on Windows are broken, needs admin priviliges
+    NioFiles.createSymbolicLink(
+      linkToDirectory.toPath,
+      directoryLinkedTo.toPath
+    )
+    assert(linkToDirectory.exists)
+    assert(
+      linkToDirectory.getCanonicalPath == directoryLinkedTo.getCanonicalPath
+    )
+    assert(linkToDirectory.getName != directoryLinkedTo.getName)
+  }
 
   assert(canon0F.getCanonicalPath == canon0N)
   assert(canon1F.getCanonicalPath == canon1N)
@@ -153,17 +207,22 @@ setupTests := {
   assert(canon4F.getCanonicalPath == canon4N)
   assert(canon5F.getCanonicalPath == canon5N)
 
-  if (java.io.File.separator == "/") {
-    assert(absoluteUnixStyle.isAbsolute)
-    assert(!absoluteWinStyle0.isAbsolute)
-    assert(!absoluteWinStyle1.isAbsolute)
-    assert(!absoluteWinStyle2.isAbsolute)
-  } else {
-    assert(!absoluteUnixStyle.isAbsolute)
-    assert(absoluteWinStyle0.isAbsolute)
-    assert(absoluteWinStyle1.isAbsolute)
-    assert(absoluteWinStyle2.isAbsolute)
-  }
+  assertOsSpecific(
+    absoluteUnixStyle.isAbsolute,
+    "absoluteUnixStyle.isAbsolute"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    absoluteWinStyle0.isAbsolute,
+    "!absoluteWinStyle0.isAbsolute"
+  )(onUnix = false, onWindows = true)
+  assertOsSpecific(
+    absoluteWinStyle1.isAbsolute,
+    "!absoluteWinStyle1.isAbsolute"
+  )(onUnix = false, onWindows = true)
+  assertOsSpecific(
+    absoluteWinStyle2.isAbsolute,
+    "!absoluteWinStyle2.isAbsolute"
+  )(onUnix = false, onWindows = true)
 
   assert(!relative0.isAbsolute)
   assert(!relative1.isAbsolute)
@@ -183,7 +242,7 @@ setupTests := {
 
   IO.touch(fileWithLastModifiedSet)
   assert(fileWithLastModifiedSet.exists())
-  fileWithLastModifiedSet.setLastModified(expectedLastModified)
+  assert(fileWithLastModifiedSet.setLastModified(expectedLastModified))
   assert(fileWithLastModifiedSet.lastModified == expectedLastModified)
   IO.touch(willBeSetLastModified)
   assert(willBeSetLastModified.exists)
@@ -197,44 +256,99 @@ setupTests := {
   IO.createDirectory(willBeSetReadOnlyDirectory)
   assert(willBeSetReadOnlyDirectory.exists)
   assert(willBeSetReadOnlyDirectory.setReadable(true, false))
-  assert(willBeSetReadOnlyDirectory.setWritable(true, false))
+  // Not supported on Windows
+  assertOsSpecific(
+    willBeSetReadOnlyDirectory.setWritable(true, false),
+    "willBeSetReadOnlyDirectory.setWritable(true, false)"
+  )(onUnix = true, onWindows = false)
   assert(willBeSetReadOnlyDirectory.setExecutable(true, false))
 
   IO.touch(willBeSetExecutableFile)
   assert(willBeSetExecutableFile.exists)
-  assert(willBeSetExecutableFile.setReadable(false, false))
   assert(willBeSetExecutableFile.setWritable(false, false))
-  assert(willBeSetExecutableFile.setExecutable(false, false))
+  // Not supported on Windows
+  assertOsSpecific(
+    willBeSetExecutableFile.setReadable(false, false),
+    "willBeSetExecutableFile.setReadable(false, false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    willBeSetExecutableFile.setExecutable(false, false),
+    "willBeSetExecutableFile.setExecutable(false, false)"
+  )(onUnix = true, onWindows = false)
 
   IO.createDirectory(willBeSetExecutableDirectory)
   assert(willBeSetExecutableDirectory.exists)
-  assert(willBeSetExecutableDirectory.setReadable(false, false))
-  assert(willBeSetExecutableDirectory.setWritable(false, false))
-  assert(willBeSetExecutableDirectory.setExecutable(false, false))
+  // Not supported on Windows
+  assertOsSpecific(
+    willBeSetExecutableDirectory.setReadable(false, false),
+    "willBeSetExecutableDirectory.setReadable(false, false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    willBeSetExecutableDirectory.setWritable(false, false),
+    "willBeSetExecutableDirectory.setWritable(false, false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    willBeSetExecutableDirectory.setExecutable(false, false),
+    "willBeSetExecutableDirectory.setExecutable(false, false)"
+  )(onUnix = true, onWindows = false)
 
   IO.touch(willBeSetReadableFile)
   assert(willBeSetReadableFile.exists)
-  assert(willBeSetReadableFile.setReadable(false, false))
   assert(willBeSetReadableFile.setWritable(false, false))
-  assert(willBeSetReadableFile.setExecutable(false, false))
+  // Not supported on Windows
+  assertOsSpecific(
+    willBeSetReadableFile.setReadable(false, false),
+    "willBeSetReadableFile.setReadable(false, false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    willBeSetReadableFile.setExecutable(false, false),
+    "willBeSetReadableFile.setExecutable(false, false)"
+  )(onUnix = true, onWindows = false)
 
   IO.createDirectory(willBeSetReadableDirectory)
   assert(willBeSetReadableDirectory.exists)
-  assert(willBeSetReadableDirectory.setReadable(false, false))
-  assert(willBeSetReadableDirectory.setWritable(false, false))
-  assert(willBeSetReadableDirectory.setExecutable(false, false))
+  // Not supported on Windows
+  assertOsSpecific(
+    willBeSetReadableDirectory.setReadable(false, false),
+    "willBeSetReadableDirectory.setReadable(false, false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    willBeSetReadableDirectory.setWritable(false, false),
+    "willBeSetReadableDirectory.setWritable(false, false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    willBeSetReadableDirectory.setExecutable(false, false),
+    "willBeSetReadableDirectory.setExecutable(false, false)"
+  )(onUnix = true, onWindows = false)
 
   IO.touch(willBeSetWritableFile)
   assert(willBeSetWritableFile.exists)
-  assert(willBeSetWritableFile.setReadable(false, false))
   assert(willBeSetWritableFile.setWritable(false, false))
-  assert(willBeSetWritableFile.setExecutable(false, false))
+  // Not supported on Windows
+  assertOsSpecific(
+    willBeSetWritableFile.setReadable(false, false),
+    "willBeSetWritableFile.setReadable(false, false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    willBeSetWritableFile.setExecutable(false, false),
+    "willBeSetWritableFile.setExecutable(false, false)"
+  )(onUnix = true, onWindows = false)
 
   IO.createDirectory(willBeSetWritableDirectory)
   assert(willBeSetWritableDirectory.exists)
-  assert(willBeSetWritableDirectory.setReadable(false, false))
-  assert(willBeSetWritableDirectory.setWritable(false, false))
-  assert(willBeSetWritableDirectory.setExecutable(false, false))
+  // Not supported on Windows
+  assertOsSpecific(
+    willBeSetWritableDirectory.setReadable(false, false),
+    "willBeSetWritableDirectory.setReadable(false, false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    willBeSetWritableDirectory.setWritable(false, false),
+    "willBeSetWritableDirectory.setWritable(false, false)"
+  )(onUnix = true, onWindows = false)
+  assertOsSpecific(
+    willBeSetWritableDirectory.setExecutable(false, false),
+    "willBeSetWritableDirectory.setExecutable(false, false)"
+  )(onUnix = true, onWindows = false)
 
   assert(!nonexistentFile.exists())
   assert(!nonexistentDirectory.exists())

--- a/scripted-tests/run/java-io-file-2/build.sbt
+++ b/scripted-tests/run/java-io-file-2/build.sbt
@@ -155,7 +155,7 @@ setupTests := {
   assert(existingHiddenFile.exists())
   assert(existingHiddenDirectory.exists())
   assert(!nonexistentHiddenFile.exists())
-  if (isWindows) {
+  if (Platform.isWindows) {
     Seq(currentDirectory, existingHiddenDirectory, existingHiddenFile)
       .map(_.toPath)
       .foreach(NioFiles.setAttribute(_, "dos:hidden", true.booleanValue()))
@@ -187,7 +187,7 @@ setupTests := {
 
   IO.createDirectory(directoryLinkedTo)
   assert(directoryLinkedTo.exists)
-  if (!isWindows) {
+  if (!Platform.isWindows) {
     // Symbolic links on Windows are broken, needs admin priviliges
     NioFiles.createSymbolicLink(
       linkToDirectory.toPath,

--- a/scripted-tests/run/java-io-file-2/project/Platform.scala
+++ b/scripted-tests/run/java-io-file-2/project/Platform.scala
@@ -2,7 +2,7 @@
 import java.util.Locale
 
 object Platform {
-    val isWindows = System
+  val isWindows = System
     .getProperty("os.name", "unknown")
     .toLowerCase(Locale.ROOT)
     .startsWith("windows")

--- a/scripted-tests/run/java-io-file-2/project/Platform.scala
+++ b/scripted-tests/run/java-io-file-2/project/Platform.scala
@@ -1,0 +1,9 @@
+// This file is used only inside sbt (JVM)
+import java.util.Locale
+
+object Platform {
+    val isWindows = System
+    .getProperty("os.name", "unknown")
+    .toLowerCase(Locale.ROOT)
+    .startsWith("windows")
+}

--- a/scripted-tests/run/java-io-file-2/test
+++ b/scripted-tests/run/java-io-file-2/test
@@ -1,5 +1,6 @@
-# Make `Files.scala` usable in build.sbt
+# Make `Files.scala` and `Utils.scala` usable in build.sbt
 $ copy-file Files.scala project/Files.scala
+$ copy-file Utils.scala project/Utils.scala
 > setupTests
 
 $ copy-file tests/IsDirectoryTest.scala Main.scala

--- a/scripted-tests/run/java-io-file-2/tests/IsHiddenTest.scala
+++ b/scripted-tests/run/java-io-file-2/tests/IsHiddenTest.scala
@@ -1,5 +1,6 @@
 object IsHiddenTest {
   import Files._
+  import Utils._
 
   def main(args: Array[String]): Unit = {
     assert(currentDirectory.isHidden())
@@ -8,6 +9,10 @@ object IsHiddenTest {
     assert(existingHiddenDirectory.exists())
     assert(existingHiddenDirectory.isHidden())
     assert(!nonexistentHiddenFile.exists())
-    assert(nonexistentHiddenFile.isHidden())
+    // On Windows (JVM) isHidden for non existing file returns false
+    assertOsSpecific(
+      nonexistentHiddenFile.isHidden(),
+      "nonexistentHiddenFile.isHidden()"
+    )(onUnix = true, onWindows = false)
   }
 }

--- a/scripted-tests/run/java-io-file-2/tests/LinksTest.scala
+++ b/scripted-tests/run/java-io-file-2/tests/LinksTest.scala
@@ -1,12 +1,16 @@
 object LinksTest {
   import Files._
+  import Utils._
 
   def main(args: Array[String]): Unit = {
-    assert(directoryLinkedTo.exists)
-    assert(linkToDirectory.exists)
-    assert(
-      linkToDirectory.getCanonicalPath == directoryLinkedTo.getCanonicalPath
-    )
-    assert(linkToDirectory.getName != directoryLinkedTo.getName)
+    if (!isWindows) {
+      // Not testing symbolic links on Windows, needs admin privileges
+      assert(directoryLinkedTo.exists)
+      assert(linkToDirectory.exists)
+      assert(
+        linkToDirectory.getCanonicalPath == directoryLinkedTo.getCanonicalPath
+      )
+      assert(linkToDirectory.getName != directoryLinkedTo.getName)
+    }
   }
 }

--- a/scripted-tests/run/java-io-file-2/tests/LinksTest.scala
+++ b/scripted-tests/run/java-io-file-2/tests/LinksTest.scala
@@ -3,7 +3,7 @@ object LinksTest {
   import Utils._
 
   def main(args: Array[String]): Unit = {
-    if (!isWindows) {
+    if (!Platform.isWindows) {
       // Not testing symbolic links on Windows, needs admin privileges
       assert(directoryLinkedTo.exists)
       assert(linkToDirectory.exists)

--- a/scripted-tests/run/java-io-file-2/tests/SetExecutableTest.scala
+++ b/scripted-tests/run/java-io-file-2/tests/SetExecutableTest.scala
@@ -1,35 +1,89 @@
 object SetExecutableTest {
   import Files._
+  import Utils._
+
   def main(args: Array[String]): Unit = {
     assert(willBeSetExecutableFile.exists())
-    assert(!willBeSetExecutableFile.canExecute())
-    assert(!willBeSetExecutableFile.canRead())
+    // Windows (JVM) does not allow for setExecutable(false),
+    // at this point it would always return true
+    assertOsSpecific(
+      willBeSetExecutableFile.canExecute(),
+      "!willBeSetExecutableFile.canExecute() 1"
+    )(onUnix = false, onWindows = true)
+    // Windows (JVM) setRedable(false, false) always returns false
+    // at this point it would be still possible to read file
+    assertOsSpecific(
+      willBeSetExecutableFile.canRead(),
+      "!willBeSetExecutableFile.canRead() 1"
+    )(onUnix = false, onWindows = true)
     assert(!willBeSetExecutableFile.canWrite())
 
     assert(willBeSetExecutableFile.setExecutable(true))
     assert(willBeSetExecutableFile.canExecute())
-    assert(!willBeSetExecutableFile.canRead())
+    assertOsSpecific(
+      willBeSetExecutableFile.canRead(),
+      "!willBeSetExecutableFile.canRead() 2"
+    )(onUnix = false, onWindows = true)
     assert(!willBeSetExecutableFile.canWrite())
 
-    assert(willBeSetExecutableFile.setExecutable(false))
-    assert(!willBeSetExecutableFile.canExecute())
-    assert(!willBeSetExecutableFile.canRead())
+    // Windows (JVM) does not allow for setExecutable(false)
+    assertOsSpecific(
+      willBeSetExecutableFile.setExecutable(false),
+      "willBeSetExecutableFile.setExecutable(false)"
+    )(onUnix = true, onWindows = false)
+    assertOsSpecific(
+      willBeSetExecutableFile.canExecute(),
+      "!willBeSetExecutableFile.canExecute() 3"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetExecutableFile.canRead(),
+      "!willBeSetExecutableFile.canRead() 3"
+    )(onUnix = false, onWindows = true)
     assert(!willBeSetExecutableFile.canWrite())
 
     assert(willBeSetExecutableDirectory.exists())
-    assert(!willBeSetExecutableDirectory.canExecute())
-    assert(!willBeSetExecutableDirectory.canRead())
-    assert(!willBeSetExecutableDirectory.canWrite())
-
+    // Winodws (JVM) complience
+    assertOsSpecific(
+      willBeSetExecutableDirectory.canExecute(),
+      "!willBeSetExecutableDirectory.canExecute()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetExecutableDirectory.canRead(),
+      "!willBeSetExecutableDirectory.canRead()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetExecutableDirectory.canWrite(),
+      "!willBeSetExecutableDirectory.canWrite()"
+    )(onUnix = false, onWindows = true)
     assert(willBeSetExecutableDirectory.setExecutable(true))
     assert(willBeSetExecutableDirectory.canExecute())
-    assert(!willBeSetExecutableDirectory.canRead())
-    assert(!willBeSetExecutableDirectory.canWrite())
+    // Windows (JVM) complience
+    assertOsSpecific(
+      willBeSetExecutableDirectory.canRead(),
+      "!willBeSetExecutableDirectory.canRead()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetExecutableDirectory.canWrite(),
+      "!willBeSetExecutableDirectory.canWrite()"
+    )(onUnix = false, onWindows = true)
 
-    assert(willBeSetExecutableDirectory.setExecutable(false))
-    assert(!willBeSetExecutableDirectory.canExecute())
-    assert(!willBeSetExecutableDirectory.canRead())
-    assert(!willBeSetExecutableDirectory.canWrite())
+    // Windows (JVM) complience, no support for setExecutable(false)
+    assertOsSpecific(
+      willBeSetExecutableDirectory.setExecutable(false),
+      "willBeSetExecutableDirectory.setExecutable(false)"
+    )(onUnix = true, onWindows = false)
+    assertOsSpecific(
+      willBeSetExecutableDirectory.canExecute(),
+      "!willBeSetExecutableDirectory.canExecute()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetExecutableDirectory.canRead(),
+      "!willBeSetExecutableDirectory.canRead()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetExecutableDirectory.canWrite(),
+      "!willBeSetExecutableDirectory.canWrite()"
+    )(onUnix = false, onWindows = true)
 
     assert(!nonexistentFile.exists)
     assert(!nonexistentFile.setExecutable(true))

--- a/scripted-tests/run/java-io-file-2/tests/SetReadableTest.scala
+++ b/scripted-tests/run/java-io-file-2/tests/SetReadableTest.scala
@@ -1,33 +1,68 @@
 object SetReadableTest {
   import Files._
+  import Utils._
+
   def main(args: Array[String]): Unit = {
     assert(willBeSetReadableFile.exists())
-    assert(!willBeSetReadableFile.canExecute())
-    assert(!willBeSetReadableFile.canRead())
+    // Winodws (JVM) complience
+    assertOsSpecific(
+      willBeSetReadableFile.canExecute(),
+      "!willBeSetReadableFile.canExecute()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetReadableFile.canRead(),
+      "!willBeSetReadableFile.canRead()"
+    )(onUnix = false, onWindows = true)
     assert(!willBeSetReadableFile.canWrite())
 
     assert(willBeSetReadableFile.setReadable(true))
-    assert(!willBeSetReadableFile.canExecute())
+    // Winodws (JVM) complience
+    assertOsSpecific(
+      willBeSetReadableFile.canExecute(),
+      "!willBeSetReadableFile.canExecute()"
+    )(onUnix = false, onWindows = true)
     assert(willBeSetReadableFile.canRead())
     assert(!willBeSetReadableFile.canWrite())
 
     assert(willBeSetReadableFile.setReadable(false))
-    assert(!willBeSetReadableFile.canExecute())
+    assertOsSpecific(
+      willBeSetReadableFile.canExecute(),
+      "!willBeSetReadableFile.canExecute()"
+    )(onUnix = false, onWindows = true)
     assert(!willBeSetReadableFile.canRead())
     assert(!willBeSetReadableFile.canWrite())
 
     assert(willBeSetReadableDirectory.exists())
-    assert(!willBeSetReadableDirectory.canExecute())
-    assert(!willBeSetReadableDirectory.canRead())
-    assert(!willBeSetReadableDirectory.canWrite())
+    // Winodws (JVM) complience
+    assertOsSpecific(
+      willBeSetReadableDirectory.canExecute(),
+      "!willBeSetReadableDirectory.canExecute()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetReadableDirectory.canRead(),
+      "!willBeSetReadableDirectory.canRead()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetReadableDirectory.canWrite(),
+      "!willBeSetReadableDirectory.canWrite()"
+    )(onUnix = false, onWindows = true)
 
     assert(willBeSetReadableDirectory.setReadable(true))
-    assert(!willBeSetReadableDirectory.canExecute())
+    assertOsSpecific(
+      willBeSetReadableDirectory.canExecute(),
+      "!willBeSetReadableDirectory.canExecute()"
+    )(onUnix = false, onWindows = true)
     assert(willBeSetReadableDirectory.canRead())
-    assert(!willBeSetReadableDirectory.canWrite())
+    assertOsSpecific(
+      willBeSetReadableDirectory.canWrite(),
+      "!willBeSetReadableDirectory.canWrite()"
+    )(onUnix = false, onWindows = true)
 
     assert(willBeSetReadableDirectory.setReadable(false))
-    assert(!willBeSetReadableDirectory.canExecute())
+    assertOsSpecific(
+      willBeSetReadableDirectory.canExecute(),
+      "!willBeSetReadableDirectory.canExecute()"
+    )(onUnix = false, onWindows = true)
     assert(!willBeSetReadableDirectory.canRead())
     assert(!willBeSetReadableDirectory.canWrite())
 

--- a/scripted-tests/run/java-io-file-2/tests/SetWritableTest.scala
+++ b/scripted-tests/run/java-io-file-2/tests/SetWritableTest.scala
@@ -1,33 +1,70 @@
 object SetWritableTest {
   import Files._
+  import Utils._
   def main(args: Array[String]): Unit = {
     assert(willBeSetWritableFile.exists())
-    assert(!willBeSetWritableFile.canExecute())
-    assert(!willBeSetWritableFile.canRead())
+    assertOsSpecific(
+      willBeSetWritableFile.canExecute(),
+      "!willBeSetWritableFile.canExecute()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetWritableFile.canRead(),
+      "!willBeSetWritableFile.canRead()"
+    )(onUnix = false, onWindows = true)
     assert(!willBeSetWritableFile.canWrite())
 
     assert(willBeSetWritableFile.setWritable(true))
-    assert(!willBeSetWritableFile.canExecute())
-    assert(!willBeSetWritableFile.canRead())
-    assert(willBeSetWritableFile.canWrite())
+    assertOsSpecific(
+      willBeSetWritableFile.canExecute(),
+      "!willBeSetWritableFile.canExecute()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetWritableFile.canRead(),
+      "!willBeSetWritableFile.canRead()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetWritableFile.canWrite(),
+      "willBeSetWritableFile.canWrite()"
+    )(onUnix = true, onWindows = false)
 
     assert(willBeSetWritableFile.setWritable(false))
-    assert(!willBeSetWritableFile.canExecute())
+    assertOsSpecific(
+      willBeSetWritableFile.canExecute(),
+      "!willBeSetWritableFile.canExecute()"
+    )(onUnix = false, onWindows = true)
     assert(!willBeSetWritableFile.canRead())
     assert(!willBeSetWritableFile.canWrite())
 
     assert(willBeSetWritableDirectory.exists())
-    assert(!willBeSetWritableDirectory.canExecute())
-    assert(!willBeSetWritableDirectory.canRead())
-    assert(!willBeSetWritableDirectory.canWrite())
+    assertOsSpecific(
+      willBeSetWritableDirectory.canExecute(),
+      "!willBeSetWritableDirectory.canExecute()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetWritableDirectory.canRead(),
+      "!willBeSetWritableDirectory.canRead()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetWritableDirectory.canWrite(),
+      "!willBeSetWritableDirectory.canWrite()"
+    )(onUnix = false, onWindows = true)
 
     assert(willBeSetWritableDirectory.setWritable(true))
-    assert(!willBeSetWritableDirectory.canExecute())
-    assert(!willBeSetWritableDirectory.canRead())
+    assertOsSpecific(
+      willBeSetWritableDirectory.canExecute(),
+      "!willBeSetWritableDirectory.canExecute()"
+    )(onUnix = false, onWindows = true)
+    assertOsSpecific(
+      willBeSetWritableDirectory.canRead(),
+      "!willBeSetWritableDirectory.canRead()"
+    )(onUnix = false, onWindows = true)
     assert(willBeSetWritableDirectory.canWrite())
 
     assert(willBeSetWritableDirectory.setWritable(false))
-    assert(!willBeSetWritableDirectory.canExecute())
+    assertOsSpecific(
+      willBeSetWritableDirectory.canExecute(),
+      "!willBeSetWritableDirectory.canExecute()"
+    )(onUnix = false, onWindows = true)
     assert(!willBeSetWritableDirectory.canRead())
     assert(!willBeSetWritableDirectory.canWrite())
 

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -47,8 +47,18 @@ Compile / compile := {
     opath
   }
 
-  val archivePath = cwd / "liblink-order-test.a"
-  val archive = Seq("ar", "cr", abs(archivePath)) ++ opaths
+  val libName = {
+    import java.util.Locale
+    val isWindows = System
+      .getProperty("os.name", "unknown")
+      .toLowerCase(Locale.ROOT)
+      .startsWith("windows")
+
+    if (isWindows) "link-order-test.lib"
+    else "liblink-order-test.a"
+  }
+  val archivePath = cwd / libName
+  val archive = Seq("llvm-ar", "cr", abs(archivePath)) ++ opaths
   if (run(archive) != 0) {
     sys.error(s"Failed to create archive $archivePath")
   }


### PR DESCRIPTION
This PR fixes scripted tests to allow execution of them on Windows. 
Due to the limitations of Windows, some tests needed to be made OS-specific, mostly in `java-io-{1,2}` scripted tests. 
Also to allow proper communication via sockets in `java-net-socket` scripted tests file encoding used on the JVM endpoint was changed to UTF-8 (default on Windows is Cp1025, however, we don't support it)
`link-order` test was also adjusted to use Windows compliant naming convention for compiled sources. 

Execution of scripted tests was added to CI - running as separate task only for Scala 2.12 latest version (similarly as it is done linux tests)