### PR TITLE
Reimplement `Thread.sleep` to be OS-specific and multithreading safe

### DIFF
--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -1,8 +1,8 @@
 package java.lang
 
-import scalanative.unsigned._
 import scalanative.annotation.stub
-import scalanative.libc.errno
+import scalanative.meta.LinktimeInfo.isWindows
+import impl._
 
 class Thread private (runnable: Runnable) extends Runnable {
   if (runnable ne Thread.MainRunnable) ???
@@ -73,15 +73,6 @@ object Thread {
   }
 
   def sleep(millis: scala.Long, nanos: scala.Int): Unit = {
-    import scala.scalanative.posix.errno.EINTR
-    import scala.scalanative.unsafe._
-    import scala.scalanative.posix.unistd
-
-    def checkErrno() =
-      if (errno.errno == EINTR) {
-        throw new InterruptedException("Sleep was interrupted")
-      }
-
     if (millis < 0) {
       throw new IllegalArgumentException("millis must be >= 0")
     }
@@ -89,10 +80,8 @@ object Thread {
       throw new IllegalArgumentException("nanos value out of range")
     }
 
-    val secs = millis / 1000
-    val usecs = (millis % 1000) * 1000 + nanos / 1000
-    if (secs > 0 && unistd.sleep(secs.toUInt) != 0.toUInt) checkErrno()
-    if (usecs > 0 && unistd.usleep(usecs.toUInt) != 0) checkErrno()
+    if (isWindows) WindowsThread.sleep(millis, nanos)
+    else PosixThread.sleep(millis, nanos)
   }
 
   def sleep(millis: scala.Long): Unit = sleep(millis, 0)

--- a/javalib/src/main/scala/java/lang/Thread.scala
+++ b/javalib/src/main/scala/java/lang/Thread.scala
@@ -2,7 +2,7 @@ package java.lang
 
 import scalanative.annotation.stub
 import scalanative.meta.LinktimeInfo.isWindows
-import impl._
+import java.lang.impl._
 
 class Thread private (runnable: Runnable) extends Runnable {
   if (runnable ne Thread.MainRunnable) ???

--- a/javalib/src/main/scala/java/lang/impl/PosixThread.scala
+++ b/javalib/src/main/scala/java/lang/impl/PosixThread.scala
@@ -1,0 +1,33 @@
+package java.lang.impl
+
+import scala.annotation.tailrec
+import scala.scalanative.posix.errno.EINTR
+import scala.scalanative.posix.time._
+import scala.scalanative.posix.timeOps._
+import scala.scalanative.unsafe._
+import scala.scalanative.posix.unistd
+import scala.scalanative.libc.errno
+
+private[lang] object PosixThread {
+  def sleep(millis: scala.Long, nanos: scala.Int): Unit = {
+    @tailrec
+    def doSleep(requestedTime: Ptr[timespec]): Unit = {
+      val remaining = stackalloc[timespec]
+      unistd.nanosleep(requestedTime, remaining) match {
+        case _ if Thread.interrupted() =>
+          throw new InterruptedException("Sleep was interrupted")
+
+        case -1 if errno.errno == EINTR =>
+          doSleep(remaining)
+
+        case _ => ()
+      }
+    }
+
+    val requestedTime = stackalloc[timespec]
+    requestedTime.tv_sec = millis / 1000
+    requestedTime.tv_nsec = (millis % 1000) * 1e6.toInt + nanos
+    doSleep(requestedTime)
+  }
+
+}

--- a/javalib/src/main/scala/java/lang/impl/PosixThread.scala
+++ b/javalib/src/main/scala/java/lang/impl/PosixThread.scala
@@ -5,7 +5,6 @@ import scala.scalanative.posix.errno.EINTR
 import scala.scalanative.posix.time._
 import scala.scalanative.posix.timeOps._
 import scala.scalanative.unsafe._
-import scala.scalanative.posix.unistd
 import scala.scalanative.libc.errno
 
 private[lang] object PosixThread {
@@ -13,7 +12,7 @@ private[lang] object PosixThread {
     @tailrec
     def doSleep(requestedTime: Ptr[timespec]): Unit = {
       val remaining = stackalloc[timespec]
-      unistd.nanosleep(requestedTime, remaining) match {
+      nanosleep(requestedTime, remaining) match {
         case _ if Thread.interrupted() =>
           throw new InterruptedException("Sleep was interrupted")
 

--- a/javalib/src/main/scala/java/lang/impl/WindowsThread.scala
+++ b/javalib/src/main/scala/java/lang/impl/WindowsThread.scala
@@ -5,8 +5,15 @@ import scala.scalanative.windows.SynchApi._
 
 object WindowsThread {
   def sleep(millis: scala.Long, nanos: scala.Int): Unit = {
-    // No support for nanos sleep on Windows
-    Sleep(millis.toUInt)
+    // No support for nanos sleep on Windows,
+    // assume minimal granularity equal to 1ms
+    val sleepForMillis = nanos match {
+      case 0 => millis
+      case _ => millis + 1
+    }
+    // Make sure that we don't pass 0 as argument, otherwise it would
+    // sleep infinitely.
+    Sleep(sleepForMillis.max(1L).toUInt)
     if (Thread.interrupted()) {
       throw new InterruptedException("Sleep was interrupted")
     }

--- a/javalib/src/main/scala/java/lang/impl/WindowsThread.scala
+++ b/javalib/src/main/scala/java/lang/impl/WindowsThread.scala
@@ -1,0 +1,14 @@
+package java.lang.impl
+
+import scala.scalanative.unsigned._
+import scala.scalanative.windows.SynchApi._
+
+object WindowsThread {
+  def sleep(millis: scala.Long, nanos: scala.Int): Unit = {
+    // No support for nanos sleep on Windows
+    Sleep(millis.toUInt)
+    if (Thread.interrupted()) {
+      throw new InterruptedException("Sleep was interrupted")
+    }
+  }
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -54,6 +54,9 @@ object time {
   @name("scalanative_mktime")
   def mktime(time: Ptr[tm]): time_t = extern
 
+  def nanosleep(requested: Ptr[timespec], remaining: Ptr[timespec]): CInt =
+    extern
+
   @name("scalanative_strftime")
   def strftime(
       str: Ptr[CChar],

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -33,6 +33,10 @@ object unistd {
   def truncate(path: CString, length: off_t): CInt = extern
   def unlink(path: CString): CInt = extern
   def usleep(usecs: CUnsignedInt): CInt = extern
+  def nanosleep(
+      requested: Ptr[time.timespec],
+      remaining: Ptr[time.timespec]
+  ): CInt = extern
   def vfork(): CInt = extern
   def write(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -33,10 +33,6 @@ object unistd {
   def truncate(path: CString, length: off_t): CInt = extern
   def unlink(path: CString): CInt = extern
   def usleep(usecs: CUnsignedInt): CInt = extern
-  def nanosleep(
-      requested: Ptr[time.timespec],
-      remaining: Ptr[time.timespec]
-  ): CInt = extern
   def vfork(): CInt = extern
   def write(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
 

--- a/unit-tests/shared/src/test/scala/javalib/lang/ThreadTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/ThreadTest.scala
@@ -56,4 +56,12 @@ class ThreadTest {
     assertFalse(t.isInterrupted())
     assertFalse(Thread.interrupted())
   }
+
+  @Test def sleepShouldSuspendForAtLeastSpecifiedMillis(): Unit = {
+    val sleepForMillis = 10
+    val start = System.currentTimeMillis()
+    Thread.sleep(sleepForMillis, 0)
+    val elapsedMillis = System.currentTimeMillis() - start
+    assertTrue("Slept for less then expected", elapsedMillis >= sleepForMillis)
+  }
 }

--- a/unit-tests/shared/src/test/scala/javalib/lang/ThreadTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/ThreadTest.scala
@@ -13,10 +13,8 @@ import java.lang._
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalanative.testsuite.utils.Platform.{
-  executingInJVM,
-  executingInScalaNative
-}
+import org.scalanative.testsuite.utils.Platform._
+import scala.scalanative.junit.utils.AssumesHelper._
 
 class ThreadTest {
 
@@ -66,6 +64,13 @@ class ThreadTest {
   }
 
   @Test def sleepShouldSuspendForAtLeastSpecifiedNanos(): Unit = {
+    if (isWindows) {
+      // Behaviour for Thread.sleep(0, nanos) is not well documented on the JVM
+      // when executing on Windows. Local tests have proven that sleep might
+      // take undefined amount of time, in multiple cases less then expected.
+      // In SN for Windows we assume minimal granuality of sleep to be 1ms
+      assumeNotJVMCompliant()
+    }
     val sleepForNanos = 500000 // 0.5ms
     val start = System.nanoTime()
     Thread.sleep(0, sleepForNanos)

--- a/unit-tests/shared/src/test/scala/javalib/lang/ThreadTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/ThreadTest.scala
@@ -60,8 +60,16 @@ class ThreadTest {
   @Test def sleepShouldSuspendForAtLeastSpecifiedMillis(): Unit = {
     val sleepForMillis = 10
     val start = System.currentTimeMillis()
-    Thread.sleep(sleepForMillis, 0)
+    Thread.sleep(sleepForMillis)
     val elapsedMillis = System.currentTimeMillis() - start
     assertTrue("Slept for less then expected", elapsedMillis >= sleepForMillis)
+  }
+
+  @Test def sleepShouldSuspendForAtLeastSpecifiedNanos(): Unit = {
+    val sleepForNanos = 500000 // 0.5ms
+    val start = System.nanoTime()
+    Thread.sleep(0, sleepForNanos)
+    val elapsedNanos = System.nanoTime() - start
+    assertTrue("Slept for less then expected", elapsedNanos >= sleepForNanos)
   }
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/SynchApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SynchApi.scala
@@ -4,11 +4,12 @@ import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 import HandleApi.Handle
 
-@extern()
+@extern
 object SynchApi {
   type CallbackContext = Ptr[Byte]
   type WaitOrTimerCallback = CFuncPtr2[CallbackContext, Boolean, Unit]
 
+  def Sleep(milliseconds: DWord): Unit = extern
   def WaitForSingleObject(
       ref: Handle,
       miliseconds: DWord


### PR DESCRIPTION
This PR changes the implementation of `Thread.sleep` function, to allow usage of it from Windows  - currently used functions `sleep` and `usleep` are POSIX-specific. Instead, it provides separate implementation depended on Windows-native `Sleep` function. 

Additionally, Unix implementation was improved to prepare for multithreaded execution - current implementation would be invoked from sleep in case of interruption by signal - this scenario is common eg. when using Boehm GC in multithreaded mode, leading to premature leaving the `Thread.sleep` function. To make it easier and more accurate, the new implementation uses the` unistd.nanosleep` function returning remaining time of requested sleep.  

Newly created objects in package `java.lang.impl` would be extended in the future, as they will contain OS-specific implementation for interacting with Threads (starting os threads, parking mechanism etc) in the future. This change was cherry picked from my [multithreading develop branch](https://github.com/WojciechMazur/scala-native/tree/multithreading/develop/javalib/src/main/scala/java/lang/impl). 