### PR TITLE
Fix bug with File.getCanonicalFile leading to infinite recursion loop on Windows

### DIFF
--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -838,12 +838,9 @@ object File {
 
         // found an absolute path. continue from there.
         case link if link(0) == separatorChar =>
-          if (Platform.isWindows() &&
-              strncmp(link, c"\\\\?\\", 4.toUInt) == 0 &&
-              strlen(link) <= 7.toUInt) {
-            // It's root directory
+          if (Platform.isWindows() && strncmp(link, c"\\\\?\\", 4.toUInt) == 0)
             path
-          } else
+          else
             resolveLink(link, resolveAbsolute, restart = resolveAbsolute)
 
         // found a relative path. append to the current path, and continue.

--- a/unit-tests/shared/src/test/scala/javalib/io/FileTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/FileTest.scala
@@ -45,4 +45,29 @@ class FileTest {
     assertEquals(expectedPath, u2.getPath())
     assertEquals(s"file:$expectedPath", u2.toString)
   }
+
+  @Test def getCanonicalPathForRelativePath(): Unit = {
+    val cwd = {
+      val dir = System.getProperty("user.dir")
+      assertNotNull(dir)
+      dir.stripSuffix(java.io.File.separator)
+    }
+
+    def assertCanonicalPathEquals(expected: String, tested: String) =
+      assertEquals(
+        tested,
+        expected.replace(File.separator, "/"),
+        new File(tested)
+          .getCanonicalPath()
+          .replace(File.separator, "/")
+          .stripSuffix("/")
+      )
+
+    assertCanonicalPathEquals(cwd, ".")
+    assertCanonicalPathEquals(cwd, "")
+    assertCanonicalPathEquals(s"$cwd/foo/bar/baz", "./foo/bar/baz")
+    assertCanonicalPathEquals(s"$cwd/foo/bar/baz", "foo/bar/baz")
+    assertCanonicalPathEquals(s"$cwd/foo/baz", "./foo/bar/../baz")
+    assertCanonicalPathEquals(cwd, "foo/../baz/..")
+  }
 }


### PR DESCRIPTION
The current implementation of `java.io.File::getCanonicalPath` contained a bug leading to an infinite recursion loop when trying to resolve the relative path. This PR fixes this issue and adds additional tests. 