### PR TITLE
Port `CVarArgList` implementation for Windows

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/libc.scala
@@ -9,6 +9,7 @@ import scalanative.unsafe._
 @extern
 object libc {
   def malloc(size: CSize): RawPtr = extern
+  def realloc(ptr: RawPtr, size: CSize): RawPtr = extern
   def free(ptr: RawPtr): Unit = extern
   def strlen(str: CString): CSize = extern
   def wcslen(str: CWideString): CSize = extern

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgListTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgListTest.scala
@@ -11,13 +11,6 @@ import scalanative.libc.{stdio, stdlib, string}
 import scalanative.windows
 import scalanative.meta.LinktimeInfo.isWindows
 
-object CVarArgListTest {
-  @BeforeClass
-  def assumeIsImplemented(): Unit = {
-    assumeFalse("CVarArgList not implemented on Windows", isWindows)
-  }
-}
-
 class CVarArgListTest {
   def vatest(cstr: CString, varargs: Seq[CVarArg], output: String): Unit =
     Zone { implicit z =>


### PR DESCRIPTION
The current implementation for passing a variadic list of arguments to extern functions was partially ported from apple/swift repo, however, it contained only Unix specific parts of this mechanism. This PR adds the remaining logic for creating `CVarArgList` when using Windows. 

Original Swift source file can be found [under this link](https://github.com/apple/swift/blob/main/stdlib/public/core/VarArgs.swift)