### PR TITLE
Partest junit tests runs with Scala 2.12.15 and on Windows

### DIFF
--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -84,7 +84,7 @@ jobs:
         shell: cmd
       
       - name: Test runtime
-        if: matrix.gc != 'gc'
+        if: matrix.gc != 'none'
         run: >
           set SCALANATIVE_GC=${{matrix.gc}}&
           set SCALANATIVE_INCLUDE_DIRS=${{steps.resolve-env.outputs.VcpkgLibs}}\include&

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -65,7 +65,26 @@ jobs:
       - name: Install libs
         run: vcpkg install bdwgc zlib --triplet=x64-windows-static
 
+      # None GC takes too much memory on Windows to execute partest JUnit tests
+      # leading to spurious failures in the CI. Perform subset of tests instead
+      - name: Test runtime None GC
+        if: matrix.gc == 'none'
+        run: >
+          set SCALANATIVE_GC=${{matrix.gc}}&
+          set SCALANATIVE_INCLUDE_DIRS=${{steps.resolve-env.outputs.VcpkgLibs}}\include&
+          set SCALANATIVE_LIB_DIRS=${{steps.resolve-env.outputs.VcpkgLibs}}\lib&
+          set SCALANATIVE &
+          sbt ++${{matrix.scala}}
+          sandbox/run
+          testsJVM/test
+          tests/test
+          testsExt/test
+          testsExtJVM/test
+          "scalaPartestTests/testOnly -- --showDiff neg/abstract.scala pos/abstract.scala run/Course-2002-01.scala"
+        shell: cmd
+      
       - name: Test runtime
+        if: matrix.gc != 'gc'
         run: >
           set SCALANATIVE_GC=${{matrix.gc}}&
           set SCALANATIVE_INCLUDE_DIRS=${{steps.resolve-env.outputs.VcpkgLibs}}\include&

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -72,11 +72,8 @@ jobs:
           set SCALANATIVE_LIB_DIRS=${{steps.resolve-env.outputs.VcpkgLibs}}\lib&
           set SCALANATIVE &
           sbt ++${{matrix.scala}}
-          sandbox/run
-          testsJVM/test
-          tests/test
-          testsExt/test
-          testsExtJVM/test
+          test-runtime
+          "scalaPartestTests/testOnly -- --showDiff neg/abstract.scala pos/abstract.scala run/Course-2002-01.scala"
         shell: cmd
 
   run-scripted-tests:

--- a/build.sbt
+++ b/build.sbt
@@ -1163,7 +1163,7 @@ lazy val scalaPartestTests: Project = project
         (auxlib / Compile / packageBin).value,
         (scalalib / Compile / packageBin).value,
         (scalaPartestRuntime / Compile / packageBin).value
-      ).map(_.absolutePath).mkString(":")
+      ).map(_.absolutePath).mkString(pathSeparator)
 
       Tests.Argument(s"--nativeClasspath=$nativeCp")
     },

--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/Defaults.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/Defaults.scala
@@ -3,10 +3,14 @@ package scala.tools.partest.scalanative
 import java.nio.file.{Files, Path, Paths}
 import scala.scalanative.build._
 import scala.scalanative.nir.Attr.Link
+import scala.scalanative.build.Platform
 
 object Defaults {
   // List of all libraries that need to be linked when precompiling libraries
-  val links: Seq[Link] = Seq("z", "pthread").map(Link)
+  val links: Seq[Link] = {
+    if (Platform.isWindows) Seq("zlib")
+    else Seq("z, pthread")
+  }.map(Link)
 
   def workdir(): Path = Files.createTempDirectory("partest-")
 

--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/Defaults.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/Defaults.scala
@@ -9,7 +9,7 @@ object Defaults {
   // List of all libraries that need to be linked when precompiling libraries
   val links: Seq[Link] = {
     if (Platform.isWindows) Seq("zlib")
-    else Seq("z, pthread")
+    else Seq("z", "pthread")
   }.map(Link)
 
   def workdir(): Path = Files.createTempDirectory("partest-")

--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/ScalaNativePartestOptions.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/ScalaNativePartestOptions.scala
@@ -2,6 +2,7 @@
 
 package scala.tools.partest.scalanative
 import java.nio.file.{Path, Paths}
+import java.io.File.pathSeparator
 import scalanative.build
 
 case class ScalaNativePartestOptions private (
@@ -21,8 +22,8 @@ case class ScalaNativePartestOptions private (
     s"-Dscalanative.partest.mode=${buildMode.name}",
     s"-Dscalanative.partest.gc=${gc.name}",
     s"-Dscalanative.partest.lto=${lto.name}",
-    s"-Dscalanative.partest.nativeCp=${nativeClasspath.mkString(":")}",
-    s"-Dscalanative.build.paths.libobj=${precompiledLibrariesPaths.mkString(":")}"
+    s"-Dscalanative.partest.nativeCp=${nativeClasspath.mkString(pathSeparator)}",
+    s"-Dscalanative.build.paths.libobj=${precompiledLibrariesPaths.mkString(pathSeparator)}"
   )
 
   def show: String =


### PR DESCRIPTION
This PR fixes problems when trying to run Scala partests on Windows. Additionally, now CI runs 1 example of each kind of partests (run, neg, pos) to test that infrastructure is working correctly as we do for Unix tests.

* Explicit list of unit tests projects to run was replaced with `test-runtime` alias containing missing partest JUnit tests
* Added missing list of ignored partest junit tests and build changes for Scala 2.12.15
