### PR TITLE
Delay discovery for clang and clang++

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -42,6 +42,7 @@ object ScalaNativePluginInternal {
   lazy val scalaNativeBaseSettings: Seq[Setting[_]] = Seq(
     crossVersion := ScalaNativeCrossVersion.binary,
     platformDepsCrossVersion := ScalaNativeCrossVersion.binary,
+    // deprecated loose settings in NativeConfig since 0.4.0
     nativeClang := nativeConfig.value.clang.toFile,
     nativeClangPP := nativeConfig.value.clangPP.toFile,
     nativeCompileOptions := nativeConfig.value.compileOptions,
@@ -55,15 +56,15 @@ object ScalaNativePluginInternal {
   )
 
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
-    nativeConfig := build.NativeConfig.empty
-      .withClang(interceptBuildException(Discover.clang()))
-      .withClangPP(interceptBuildException(Discover.clangpp()))
-      .withCompileOptions(Discover.compileOptions())
-      .withLinkingOptions(Discover.linkingOptions())
-      .withLTO(Discover.LTO())
-      .withGC(Discover.GC())
-      .withMode(Discover.mode())
-      .withOptimize(Discover.optimize()),
+    nativeConfig := {
+      build.NativeConfig.empty
+        .withCompileOptions(Discover.compileOptions())
+        .withLinkingOptions(Discover.linkingOptions())
+        .withLTO(Discover.LTO())
+        .withGC(Discover.GC())
+        .withMode(Discover.mode())
+        .withOptimize(Discover.optimize())
+    },
     nativeWarnOldJVM := {
       val logger = streams.value.log
       Try(Class.forName("java.util.function.Function")).toOption match {
@@ -97,6 +98,8 @@ object ScalaNativePluginInternal {
       workdir
     },
     nativeConfig := {
+      // convert deprecated loose settings to NativeConfig
+      // change to empty when loose settings are removed
       nativeConfig.value
         .withClang(nativeClang.value.toPath)
         .withClangPP(nativeClangPP.value.toPath)

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -58,12 +58,6 @@ object ScalaNativePluginInternal {
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
     nativeConfig := {
       build.NativeConfig.empty
-        .withCompileOptions(Discover.compileOptions())
-        .withLinkingOptions(Discover.linkingOptions())
-        .withLTO(Discover.LTO())
-        .withGC(Discover.GC())
-        .withMode(Discover.mode())
-        .withOptimize(Discover.optimize())
     },
     nativeWarnOldJVM := {
       val logger = streams.value.log

--- a/scripted-tests/run/link-order/build.sbt
+++ b/scripted-tests/run/link-order/build.sbt
@@ -1,6 +1,7 @@
 enablePlugins(ScalaNativePlugin)
 
 import scala.sys.process._
+import scala.scalanative.build._
 
 scalaVersion := {
   val scalaVersion = System.getProperty("scala.version")
@@ -19,7 +20,7 @@ Compile / compile := {
   val cwd = target.value
   val compileOptions = nativeCompileOptions.value
   val cpaths = (baseDirectory.value.getAbsoluteFile * "*.c").get
-  val clangPath = nativeClang.value.toPath.toAbsolutePath.toString
+  val clangPath = Discover.clang().toString
 
   cwd.mkdirs()
 

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -92,7 +92,7 @@ object Build {
         libObjectPaths ++ llObjectPaths
       }
 
-      LLVM.link(config, linked, objectPaths, outpath)
+      LLVM.link(fconfig, linked, objectPaths, outpath)
     }
 
   def findAndCompileNativeSources(

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -94,7 +94,7 @@ object Discover {
   }
 
   /** Use current config and discover any needed settings */
-  def complete(config: Config): Config = {
+  private[scalanative] def complete(config: Config): Config = {
     val fconfig = {
       val fclasspath = NativeLib.filterClasspath(config.classPath)
       config.withClassPath(fclasspath)

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -99,7 +99,7 @@ object Discover {
       val fclasspath = NativeLib.filterClasspath(config.classPath)
       config.withClassPath(fclasspath)
     }
-    println(fconfig.compilerConfig)
+    //println(fconfig.compilerConfig)
     val empty = NativeConfig.empty
     val nconfig = fconfig
       .withCompilerConfig(c =>
@@ -109,7 +109,7 @@ object Discover {
         if (c.clangPP.equals(empty.clangPP)) c.withClangPP(Discover.clangpp())
         else c
       )
-    println(nconfig.compilerConfig)
+    //println(nconfig.compilerConfig)
     nconfig
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -93,23 +93,62 @@ object Discover {
     )
   }
 
-  /** Use current config and discover any needed settings */
+  /** Run discovery on any items in the config that have default settings.
+   *
+   *  @param config
+   *    the config passed to the build
+   *  @return
+   *    the config with updated settings in compilerConfig found via discovery
+   */
   private[scalanative] def complete(config: Config): Config = {
     val fconfig = {
       val fclasspath = NativeLib.filterClasspath(config.classPath)
       config.withClassPath(fclasspath)
     }
-    //println(fconfig.compilerConfig)
+
     val empty = NativeConfig.empty
     val nconfig = fconfig
       .withCompilerConfig(c =>
-        if (c.clang.equals(empty.clang)) c.withClang(Discover.clang()) else c
+        if (c.clang.equals(empty.clang)) c.withClang(Discover.clang())
+        else c
       )
       .withCompilerConfig(c =>
         if (c.clangPP.equals(empty.clangPP)) c.withClangPP(Discover.clangpp())
         else c
       )
-    //println(nconfig.compilerConfig)
+      .withCompilerConfig(c =>
+        if (c.compileOptions.equals(empty.compileOptions))
+          c.withCompileOptions(Discover.compileOptions())
+        else c
+      )
+      .withCompilerConfig(c =>
+        if (c.linkingOptions.equals(empty.linkingOptions))
+          c.withLinkingOptions(Discover.linkingOptions())
+        else c
+      )
+      .withCompilerConfig(c =>
+        if (c.lto.equals(empty.lto)) c.withLTO(Discover.LTO())
+        else c
+      )
+      .withCompilerConfig(c =>
+        if (c.gc.equals(empty.gc)) c.withGC(Discover.GC())
+        else c
+      )
+      .withCompilerConfig(c =>
+        if (c.mode.equals(empty.mode)) c.withMode(Discover.mode())
+        else c
+      )
+      .withCompilerConfig(c =>
+        if (c.optimize.equals(empty.optimize))
+          c.withOptimize(Discover.optimize())
+        else c
+      )
+      .withCompilerConfig(c =>
+        if (c.linktimeProperties.equals(empty.linktimeProperties))
+          c.withLinktimeProperties(Discover.linktimeProperties())
+        else c
+      )
+
     nconfig
   }
 

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -109,42 +109,42 @@ object Discover {
     val empty = NativeConfig.empty
     val nconfig = fconfig
       .withCompilerConfig(c =>
-        if (c.clang.equals(empty.clang)) c.withClang(Discover.clang())
+        if (c.clang == empty.clang) c.withClang(Discover.clang())
         else c
       )
       .withCompilerConfig(c =>
-        if (c.clangPP.equals(empty.clangPP)) c.withClangPP(Discover.clangpp())
+        if (c.clangPP == empty.clangPP) c.withClangPP(Discover.clangpp())
         else c
       )
       .withCompilerConfig(c =>
-        if (c.compileOptions.equals(empty.compileOptions))
+        if (c.compileOptions == empty.compileOptions)
           c.withCompileOptions(Discover.compileOptions())
         else c
       )
       .withCompilerConfig(c =>
-        if (c.linkingOptions.equals(empty.linkingOptions))
+        if (c.linkingOptions == empty.linkingOptions)
           c.withLinkingOptions(Discover.linkingOptions())
         else c
       )
       .withCompilerConfig(c =>
-        if (c.lto.equals(empty.lto)) c.withLTO(Discover.LTO())
+        if (c.lto == empty.lto) c.withLTO(Discover.LTO())
         else c
       )
       .withCompilerConfig(c =>
-        if (c.gc.equals(empty.gc)) c.withGC(Discover.GC())
+        if (c.gc == empty.gc) c.withGC(Discover.GC())
         else c
       )
       .withCompilerConfig(c =>
-        if (c.mode.equals(empty.mode)) c.withMode(Discover.mode())
+        if (c.mode == empty.mode) c.withMode(Discover.mode())
         else c
       )
       .withCompilerConfig(c =>
-        if (c.optimize.equals(empty.optimize))
+        if (c.optimize == empty.optimize)
           c.withOptimize(Discover.optimize())
         else c
       )
       .withCompilerConfig(c =>
-        if (c.linktimeProperties.equals(empty.linktimeProperties))
+        if (c.linktimeProperties == empty.linktimeProperties)
           c.withLinktimeProperties(Discover.linktimeProperties())
         else c
       )

--- a/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
+++ b/tools/src/main/scala/scala/scalanative/build/NativeConfig.scala
@@ -212,7 +212,7 @@ object NativeConfig {
         | - check:              $check
         | - checkFatalWarnings: $checkFatalWarnings
         | - dump:               $dump
-        | - optimize            $optimize
+        | - optimize:           $optimize
         | - linktimeProperties: $listLinktimeProperties
         |)""".stripMargin
     }


### PR DESCRIPTION
This change starts moving towards late discovery. Previously, discovery occurred early and threw a build exception which was reported to not allow setting `clang` and `clang++` via env vars passed to `NativeConfig` methods. This more closely matches what happens when calling the build tools API directly. If we do this with all the `Discover` calls then much less would need to be called by other build tools or programs.

The other early discovery methods do not throw errors so they may not be a problem. You should be able to do the following (code not tested):

```scala
import scala.scalanative.build._
nativeConfig ~= {
  _.withLTO(LTO.thin)
  .withClang(System.getenv("CC"))
  .withClangPP(System.getenv("CXX"))
}
```