### PR TITLE
Fix 2378; Allow to read from stdin when using `run` command

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -143,10 +143,9 @@ object ScalaNativePluginInternal {
       logger.running(binary +: args)
 
      val exitCode = {
-        // It seams that scala.sys.process have some bug leading to possible 
-        // ignoring of inherited IO and termination of wrapper thread with 
-        // an exception. We use java.lang ProcessBuilder for a workaround 
-        //
+        // It seems that previously used Scala Process has some bug leading
+        // to possible ignoring of inherited IO and termination of wrapper
+        // thread with an exception. We use java.lang ProcessBuilder instead
         val proc = new ProcessBuilder()
           .command((Seq(binary) ++ args): _*)
           .inheritIO()

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -142,7 +142,7 @@ object ScalaNativePluginInternal {
 
       logger.running(binary +: args)
 
-     val exitCode = {
+      val exitCode = {
         // It seems that previously used Scala Process has some bug leading
         // to possible ignoring of inherited IO and termination of wrapper
         // thread with an exception. We use java.lang ProcessBuilder instead


### PR DESCRIPTION
This PR fixes long-standing issues with problems when trying to read from stdin in created executable when running it directly from sbt using `run` task. 
I've observed that after changing Scala Proces Builder argument `connectInput` to `true` application managed to run correctly and read from stdin, however Thread wrapping this process was failing with exception each time. Because of that I've changed the implementation to use Java ProcessBuilder which seems to be more stable as it's more simple (it does not wrap process in a dedicated thread). 

<details>
<summary>
Here's an example stack trace of exceptions from Scala Process (click to expand)
</summary>

```
Exception in thread "Thread-969" java.lang.InterruptedException
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2014)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2048)
        at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
        at sbt.internal.util.Terminal$WriteableInputStream.read(Terminal.scala:514)
        at sbt.internal.util.Terminal$WriteableInputStream.read(Terminal.scala:521)
        at sbt.internal.util.Terminal$proxyInputStream$.read(Terminal.scala:663)
        at sbt.internal.util.Terminal$SimpleInputStream.read(Terminal.scala:610)
        at sbt.internal.util.Terminal$SimpleInputStream.read$(Terminal.scala:609)
        at sbt.internal.util.Terminal$proxyInputStream$.read(Terminal.scala:618)
        at java.io.FilterInputStream.read(FilterInputStream.java:133)
        at java.io.FilterInputStream.read(FilterInputStream.java:107)
        at scala.sys.process.BasicIO$.loop$1(BasicIO.scala:238)
        at scala.sys.process.BasicIO$.transferFullyImpl(BasicIO.scala:246)
        at scala.sys.process.BasicIO$.transferFully(BasicIO.scala:227)
        at scala.sys.process.BasicIO$.connectToIn(BasicIO.scala:196)
        at scala.sys.process.BasicIO$.$anonfun$input$1(BasicIO.scala:203)
        at scala.sys.process.BasicIO$.$anonfun$input$1$adapted(BasicIO.scala:202)
        at scala.sys.process.ProcessBuilderImpl$Simple.$anonfun$run$2(ProcessBuilderImpl.scala:79)
        at scala.sys.process.ProcessImpl$Spawn$$anon$1.run(ProcessImpl.scala:27)
```
</details>
