### PR TITLE
Fix WeakReference test spuriously failing on an environment with a large heap

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/commix/ComixGC.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/ComixGC.c
@@ -14,6 +14,7 @@
 #include "Settings.h"
 #include "GCThread.h"
 #include "WeakRefGreyList.h"
+#include "Sweeper.h"
 
 void scalanative_collect();
 
@@ -71,7 +72,13 @@ INLINE void *scalanative_alloc_atomic(void *info, size_t size) {
     return scalanative_alloc(info, size);
 }
 
-INLINE void scalanative_collect() { Heap_Collect(&heap); }
+INLINE void scalanative_collect() {
+    // Wait until sweeping will end, otherwise we risk segmentation
+    // fault or failing an assertion.
+    while (!Sweeper_IsSweepDone(&heap))
+        thread_yield();
+    Heap_Collect(&heap);
+}
 
 INLINE void scalanative_register_weak_reference_handler(void *handler) {
     WeakRefGreyList_SetHandler(handler);


### PR DESCRIPTION
It was observed that a certain WeakReference test sometimes fails in the CI. The inconsistency in when this would happen lead me to believe this was due to the GC sometimes not being called when required. Now, we have more control over when and if GC will be called - so we can call it explicitly in the required place. To achieve this, issue #2367 was also fixed as part of this PR. 