### PR TITLE
Fix invalid nullability resolution for boxed primitives

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -32,7 +32,7 @@ sealed abstract class Op {
     case Op.Copy(v)   => v.ty
     case Op.Sizeof(_) => Type.Long
     case Op.Box(refty: Type.RefKind, _) =>
-      val nullable = !Type.isPtrBox(refty)
+      val nullable = Type.isPtrBox(refty)
       Type.Ref(refty.className, exact = true, nullable = nullable)
     case Op.Unbox(ty, _)      => Type.unbox(ty)
     case Op.Var(ty)           => Type.Var(ty)

--- a/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Combine.scala
@@ -420,19 +420,13 @@ trait Combine { self: Interflow =>
 
       // Comparing non-nullable value with null will always
       // yield the same result.
-      // This is not true however for ptr boxes, since they
-      // underlying value might be null
-      case (Ieq, v @ Of(ty: Type.RefKind), Val.Null)
-          if !ty.isNullable && !Type.isPtrBox(ty) =>
+      case (Ieq, v @ Of(ty: Type.RefKind), Val.Null) if !ty.isNullable =>
         Val.False
-      case (Ieq, Val.Null, v @ Of(ty: Type.RefKind))
-          if !ty.isNullable && !Type.isPtrBox(ty) =>
+      case (Ieq, Val.Null, v @ Of(ty: Type.RefKind)) if !ty.isNullable =>
         Val.False
-      case (Ine, v @ Of(ty: Type.RefKind), Val.Null)
-          if !ty.isNullable && !Type.isPtrBox(ty) =>
+      case (Ine, v @ Of(ty: Type.RefKind), Val.Null) if !ty.isNullable =>
         Val.True
-      case (Ine, Val.Null, v @ Of(ty: Type.RefKind))
-          if !ty.isNullable && !Type.isPtrBox(ty) =>
+      case (Ine, Val.Null, v @ Of(ty: Type.RefKind)) if !ty.isNullable =>
         Val.True
 
       // Ptr boxes are null if underlying pointer is null.


### PR DESCRIPTION
This PR fixes recently observed failures in the CI. The previous resolution of nullability of boxed primitives was wrong and probably was the aftermath of the bug fixed in #2133 
Since Boxed pointers were treated as NOT nullable, the optimizer removed the `redundant` check to make `Ptr[_] == null` comparison. We can only treat numeral primitives as not nullable, where pointers should always to treated as potentially containing null