### PR TITLE
Enforce usage of LLVM 11 in Windows CI

### DIFF
--- a/.github/actions/windows-setup-env/action.yml
+++ b/.github/actions/windows-setup-env/action.yml
@@ -50,7 +50,7 @@ runs:
     # Install LLVM in case if cache is missing
     - name: Install LLVM
       shell: pwsh
-      run: choco install llvm --version=11.0.0
+      run: choco install llvm --version=11.0.0 --allow-downgrade
 
     - name: Add LLVM on Path
       shell: pwsh


### PR DESCRIPTION
Since 29th September some Windows CI runners can be found to have preinstalled LLVM 12.0.0. To make our tests consistent and to follow testing with a minimum supported version we need to enforce usage of the older versions. Otherwise, `choco` used to install our dependencies would exit with an error. 