### PR TITLE
Add missing FileChannel functionality in javalib

### DIFF
--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -24,7 +24,13 @@ class FileInputStream(fd: FileDescriptor, file: Option[File])
   def this(str: String) = this(new File(str))
 
   private val channel: FileChannelImpl =
-    new FileChannelImpl(fd, file, deleteFileOnClose = false, openForReading = true, openForWriting  = false)
+    new FileChannelImpl(
+      fd,
+      file,
+      deleteFileOnClose = false,
+      openForReading = true,
+      openForWriting = false
+    )
 
   override def available(): Int = channel.available()
 

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -1,6 +1,4 @@
 package java.io
-
-import java.nio.file.WindowsException
 import scala.scalanative.annotation.stub
 import scala.scalanative.libc._
 import scala.scalanative.libc.stdio._

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -1,17 +1,10 @@
 package java.io
-import scala.scalanative.annotation.stub
-import scala.scalanative.libc._
 import scala.scalanative.libc.stdio._
 import scala.scalanative.meta.LinktimeInfo.isWindows
-import scala.scalanative.posix.unistd
 import scala.scalanative.posix.unistd.lseek
-import scala.scalanative.nio.fs.unix.UnixException
-import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
-import scala.scalanative.{runtime, windows}
 import scala.scalanative.windows.FileApi._
 import scala.scalanative.windows.FileApiExt._
-import scala.scalanative.windows.{ErrorCodes, ErrorHandlingApi}
 import java.nio.channels.{FileChannel, FileChannelImpl}
 
 class FileInputStream(fd: FileDescriptor, file: Option[File])

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -29,10 +29,7 @@ class FileInputStream(fd: FileDescriptor, file: Option[File])
   override def available(): Int = channel.available()
 
   override def close(): Unit = {
-    if (channel.isOpen()) {
-      channel.close()
-    }
-    fd.close()
+    channel.close()
   }
 
   override protected def finalize(): Unit =

--- a/javalib/src/main/scala/java/io/FileInputStream.scala
+++ b/javalib/src/main/scala/java/io/FileInputStream.scala
@@ -24,7 +24,7 @@ class FileInputStream(fd: FileDescriptor, file: Option[File])
   def this(str: String) = this(new File(str))
 
   private val channel: FileChannelImpl =
-    new FileChannelImpl(fd, file, deleteOnClose = false)
+    new FileChannelImpl(fd, file, deleteFileOnClose = false, openForReading = true, openForWriting  = false)
 
   override def available(): Int = channel.available()
 

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -27,7 +27,7 @@ class FileOutputStream(fd: FileDescriptor, file: Option[File])
   private val channel: FileChannelImpl =
     new FileChannelImpl(fd, file, deleteOnClose = false)
 
-  override def close(): Unit = fd.close()
+  override def close(): Unit = channel.close()
 
   override protected def finalize(): Unit = close()
 

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -25,7 +25,7 @@ class FileOutputStream(fd: FileDescriptor, file: Option[File])
   def this(name: String) = this(new File(name))
 
   private val channel: FileChannelImpl =
-    new FileChannelImpl(fd, file, deleteOnClose = false)
+    new FileChannelImpl(fd, file, deleteFileOnClose = false, openForReading = false, openForWriting = true)
 
   override def close(): Unit = channel.close()
 

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -25,7 +25,13 @@ class FileOutputStream(fd: FileDescriptor, file: Option[File])
   def this(name: String) = this(new File(name))
 
   private val channel: FileChannelImpl =
-    new FileChannelImpl(fd, file, deleteFileOnClose = false, openForReading = false, openForWriting = true)
+    new FileChannelImpl(
+      fd,
+      file,
+      deleteFileOnClose = false,
+      openForReading = false,
+      openForWriting = true
+    )
 
   override def close(): Unit = channel.close()
 

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -1,12 +1,8 @@
 package java.io
-import scala.scalanative.nio.fs.unix.UnixException
 import scala.scalanative.libc._
 import scala.scalanative.meta.LinktimeInfo.isWindows
-import scala.scalanative.posix.unistd
-import scala.scalanative.runtime
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
-import scala.scalanative.windows.ErrorHandlingApi._
 import scala.scalanative.windows.FileApi._
 import scala.scalanative.windows.FileApiExt._
 import scala.scalanative.windows.HandleApiExt._

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -1,6 +1,4 @@
 package java.io
-
-import java.nio.file.WindowsException
 import scala.scalanative.nio.fs.unix.UnixException
 import scala.scalanative.libc._
 import scala.scalanative.meta.LinktimeInfo.isWindows

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -27,7 +27,8 @@ class FileOutputStream(fd: FileDescriptor, file: Option[File])
       openForWriting = true
     )
 
-  override def close(): Unit = channel.close()
+  override def close(): Unit =
+    channel.close()
 
   override protected def finalize(): Unit = close()
 

--- a/javalib/src/main/scala/java/io/FileOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FileOutputStream.scala
@@ -13,6 +13,7 @@ import scala.scalanative.windows.FileApi._
 import scala.scalanative.windows.FileApiExt._
 import scala.scalanative.windows.HandleApiExt._
 import scala.scalanative.windows.winnt.AccessRights._
+import java.nio.channels.{FileChannelImpl, FileChannel}
 
 class FileOutputStream(fd: FileDescriptor, file: Option[File])
     extends OutputStream {
@@ -22,6 +23,9 @@ class FileOutputStream(fd: FileDescriptor, file: Option[File])
   def this(file: File) = this(file, false)
   def this(name: String, append: Boolean) = this(new File(name), append)
   def this(name: String) = this(new File(name))
+
+  private val channel: FileChannelImpl =
+    new FileChannelImpl(fd, file, deleteOnClose = false)
 
   override def close(): Unit = fd.close()
 
@@ -37,43 +41,13 @@ class FileOutputStream(fd: FileDescriptor, file: Option[File])
     write(buffer, 0, buffer.length)
   }
 
-  override def write(buffer: Array[Byte], offset: Int, count: Int): Unit = {
-    if (buffer == null) {
-      throw new NullPointerException
-    }
-    if (offset < 0 || count < 0 || count > buffer.length - offset) {
-      throw new IndexOutOfBoundsException
-    }
-    if (count == 0) {
-      return
-    }
-
-    // we use the runtime knowledge of the array layout to avoid
-    // intermediate buffer, and read straight from the array memory
-    val buf = buffer.asInstanceOf[runtime.ByteArray].at(offset)
-    if (isWindows) {
-      val hasSucceded =
-        WriteFile(fd.handle, buf, count.toUInt, null, null)
-      if (!hasSucceded) {
-        throw WindowsException.onPath(
-          file.fold("<file descriptor>")(_.toString)
-        )
-      }
-    } else {
-      val writeCount = unistd.write(fd.fd, buf, count.toUInt)
-
-      if (writeCount < 0) {
-        // negative value (typically -1) indicates that write failed
-        throw UnixException(file.fold("")(_.toString), errno.errno)
-      }
-    }
-  }
+  override def write(buffer: Array[Byte], offset: Int, count: Int): Unit =
+    channel.write(buffer, offset, count)
 
   override def write(b: Int): Unit =
     write(Array(b.toByte))
 
-  // TODO:
-  // def getChannel(): FileChannel
+  def getChannel(): FileChannel = channel
 }
 
 object FileOutputStream {

--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -1,9 +1,8 @@
 package java.io
 
 import java.{lang => jl}
-import scalanative.unsafe.{Zone, stackalloc, toCString, toCWideStringUTF16LE}
-import scalanative.libc.stdio
-import scalanative.posix.{fcntl, unistd}
+import scalanative.unsafe.{Zone, toCString, toCWideStringUTF16LE}
+import scalanative.posix.fcntl
 import scalanative.posix.sys.stat
 import scalanative.meta.LinktimeInfo.isWindows
 import scala.scalanative.windows

--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -27,7 +27,6 @@ class RandomAccessFile private (
     )
   def this(name: String, mode: String) = this(new File(name), mode)
 
-  private var closed: Boolean = false
   private lazy val in = new DataInputStream(new FileInputStream(fd))
   private lazy val out = new DataOutputStream(new FileOutputStream(fd))
   private lazy val channel =
@@ -39,12 +38,11 @@ class RandomAccessFile private (
       openForWriting = mode.contains('w')
     )
 
-  override def close(): Unit = {
-    closed = true
+  override def close(): Unit =
     channel.close()
-  }
 
-  final def getChannel(): FileChannel = channel
+  final def getChannel(): FileChannel =
+    channel
 
   def getFD(): FileDescriptor =
     fd
@@ -56,15 +54,15 @@ class RandomAccessFile private (
     file.length()
 
   def read(): Int =
-    if (closed) throw new IOException("Stream Closed")
+    if (!channel.isOpen()) throw new IOException("Stream Closed")
     else in.read()
 
   def read(b: Array[Byte]): Int =
-    if (closed) throw new IOException("Stream Closed")
+    if (!channel.isOpen()) throw new IOException("Stream Closed")
     else in.read(b)
 
   def read(b: Array[Byte], off: Int, len: Int): Int =
-    if (closed) throw new IOException("Stream Closed")
+    if (!channel.isOpen()) throw new IOException("Stream Closed")
     else in.read(b, off, len)
 
   override final def readBoolean(): Boolean =

--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -33,11 +33,12 @@ class RandomAccessFile private (
   private lazy val out = new DataOutputStream(new FileOutputStream(fd))
   private lazy val channel =
     new FileChannelImpl(
-      fd, 
-      Some(file), 
-      deleteFileOnClose = false, 
+      fd,
+      Some(file),
+      deleteFileOnClose = false,
       openForReading = true,
-      openForWriting = mode.contains('w'))
+      openForWriting = mode.contains('w')
+    )
 
   override def close(): Unit = {
     closed = true

--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -32,7 +32,12 @@ class RandomAccessFile private (
   private lazy val in = new DataInputStream(new FileInputStream(fd))
   private lazy val out = new DataOutputStream(new FileOutputStream(fd))
   private lazy val channel =
-    new FileChannelImpl(fd, Some(file), deleteOnClose = false)
+    new FileChannelImpl(
+      fd, 
+      Some(file), 
+      deleteFileOnClose = false, 
+      openForReading = true,
+      openForWriting = mode.contains('w'))
 
   override def close(): Unit = {
     closed = true

--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -9,6 +9,7 @@ import scalanative.meta.LinktimeInfo.isWindows
 import scala.scalanative.windows
 import windows._
 import windows.FileApiExt._
+import java.nio.channels.{FileChannelImpl, FileChannel}
 
 class RandomAccessFile private (
     file: File,
@@ -30,13 +31,16 @@ class RandomAccessFile private (
   private var closed: Boolean = false
   private lazy val in = new DataInputStream(new FileInputStream(fd))
   private lazy val out = new DataOutputStream(new FileOutputStream(fd))
+  private lazy val channel =
+    new FileChannelImpl(fd, Some(file), deleteOnClose = false)
 
   override def close(): Unit = {
     closed = true
     if (isWindows) HandleApi.CloseHandle(fd.handle)
     else unistd.close(fd.fd)
   }
-  // final def getChannel(): FileChannel
+
+  final def getChannel(): FileChannel = channel
 
   def getFD(): FileDescriptor =
     fd

--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -36,8 +36,7 @@ class RandomAccessFile private (
 
   override def close(): Unit = {
     closed = true
-    if (isWindows) HandleApi.CloseHandle(fd.handle)
-    else unistd.close(fd.fd)
+    channel.close()
   }
 
   final def getChannel(): FileChannel = channel

--- a/javalib/src/main/scala/java/nio/Buffer.scala
+++ b/javalib/src/main/scala/java/nio/Buffer.scala
@@ -100,7 +100,7 @@ abstract class Buffer private[nio] (val _capacity: Int) {
    * We only declare the methods we need somewhere.
    */
 
-  private[nio] def _array: Array[ElementType]
+  private[nio] def _array: GenArray[ElementType]
   private[nio] def _arrayOffset: Int
 
   /** Loads an element at the given absolute, unchecked index. */
@@ -112,7 +112,7 @@ abstract class Buffer private[nio] (val _capacity: Int) {
   /** Loads a range of elements with absolute, unchecked indices. */
   private[nio] def load(
       startIndex: Int,
-      dst: Array[ElementType],
+      dst: GenArray[ElementType],
       offset: Int,
       length: Int
   ): Unit
@@ -120,7 +120,7 @@ abstract class Buffer private[nio] (val _capacity: Int) {
   /** Stores a range of elements with absolute, unchecked indices. */
   private[nio] def store(
       startIndex: Int,
-      src: Array[ElementType],
+      src: GenArray[ElementType],
       offset: Int,
       length: Int
   ): Unit
@@ -128,7 +128,7 @@ abstract class Buffer private[nio] (val _capacity: Int) {
   /* Only for HeapByteBufferViews -- but that's the only place we can put it.
    * For all other types, it will be dce'ed.
    */
-  private[nio] def _byteArray: Array[Byte] =
+  private[nio] def _byteArray: GenArray[Byte] =
     throw new UnsupportedOperationException
   private[nio] def _byteArrayOffset: Int =
     throw new UnsupportedOperationException
@@ -143,7 +143,7 @@ abstract class Buffer private[nio] (val _capacity: Int) {
   }
 
   @inline private[nio] def validateArrayIndexRange(
-      array: Array[_],
+      array: GenArray[_],
       offset: Int,
       length: Int
   ): Unit = {

--- a/javalib/src/main/scala/java/nio/ByteArrayBits.scala
+++ b/javalib/src/main/scala/java/nio/ByteArrayBits.scala
@@ -1,9 +1,11 @@
 package java.nio
 
+import scala.scalanative.unsafe.Ptr
+
 // Ported from Scala.js
 private[nio] object ByteArrayBits {
   def apply(
-      array: Array[Byte],
+      array: Ptr[Byte],
       arrayOffset: Int,
       isBigEndian: Boolean,
       indexMultiplier: Int = 1
@@ -13,7 +15,7 @@ private[nio] object ByteArrayBits {
 
 @inline
 private[nio] final class ByteArrayBits(
-    array: Array[Byte],
+    array: Ptr[Byte],
     arrayOffset: Int,
     isBigEndian: Boolean,
     indexMultiplier: Int

--- a/javalib/src/main/scala/java/nio/ByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ByteBuffer.scala
@@ -11,7 +11,14 @@ object ByteBuffer {
   def allocateDirect(capacity: Int): ByteBuffer = allocate(capacity)
 
   def wrap(array: Array[Byte], offset: Int, length: Int): ByteBuffer =
-    HeapByteBuffer.wrap(array, 0, array.length, offset, length, false)
+    HeapByteBuffer.wrap(
+      ScalaArray(array),
+      0,
+      array.length,
+      offset,
+      length,
+      false
+    )
 
   def wrap(array: Array[Byte]): ByteBuffer =
     wrap(array, 0, array.length)
@@ -19,7 +26,7 @@ object ByteBuffer {
 
 abstract class ByteBuffer private[nio] (
     _capacity: Int,
-    private[nio] val _array: Array[Byte],
+    private[nio] val _array: GenArray[Byte],
     private[nio] val _arrayOffset: Int
 ) extends Buffer(_capacity)
     with Comparable[ByteBuffer] {
@@ -47,7 +54,7 @@ abstract class ByteBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Byte], offset: Int, length: Int): ByteBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   def get(dst: Array[Byte]): ByteBuffer =
     get(dst, 0, dst.length)
@@ -58,7 +65,7 @@ abstract class ByteBuffer private[nio] (
 
   @noinline
   def put(src: Array[Byte], offset: Int, length: Int): ByteBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   final def put(src: Array[Byte]): ByteBuffer =
     put(src, 0, src.length)
@@ -191,7 +198,7 @@ abstract class ByteBuffer private[nio] (
   @inline
   private[nio] def load(
       startIndex: Int,
-      dst: Array[Byte],
+      dst: GenArray[Byte],
       offset: Int,
       length: Int
   ): Unit =
@@ -200,7 +207,7 @@ abstract class ByteBuffer private[nio] (
   @inline
   private[nio] def store(
       startIndex: Int,
-      src: Array[Byte],
+      src: GenArray[Byte],
       offset: Int,
       length: Int
   ): Unit =

--- a/javalib/src/main/scala/java/nio/CharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/CharBuffer.scala
@@ -152,7 +152,7 @@ abstract class CharBuffer private[nio] (
   override def toString(): String = {
     if (_array != null) {
       // even if read-only
-      new String(_array.toArray, position() + _arrayOffset, remaining())
+      new String(_array.toArray(), position() + _arrayOffset, remaining())
     } else {
       val chars = new Array[Char](remaining())
       val savedPos = position()

--- a/javalib/src/main/scala/java/nio/CharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/CharBuffer.scala
@@ -21,7 +21,7 @@ object CharBuffer {
 
 abstract class CharBuffer private[nio] (
     _capacity: Int,
-    private[nio] val _array: Array[Char],
+    private[nio] val _array: GenArray[Char],
     private[nio] val _arrayOffset: Int
 ) extends Buffer(_capacity)
     with Comparable[CharBuffer]
@@ -40,7 +40,7 @@ abstract class CharBuffer private[nio] (
     if (n == 0) -1
     else if (_array != null) {
       // even if read-only
-      target.put(_array, _arrayOffset, n)
+      GenBuffer(target).generic_put(_array, _arrayOffset, n)
       n
     } else {
       val savedPos = position()
@@ -66,7 +66,7 @@ abstract class CharBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   def get(dst: Array[Char]): CharBuffer =
     get(dst, 0, dst.length)
@@ -77,7 +77,7 @@ abstract class CharBuffer private[nio] (
 
   @noinline
   def put(src: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   final def put(src: Array[Char]): CharBuffer =
     put(src, 0, src.length)
@@ -152,7 +152,7 @@ abstract class CharBuffer private[nio] (
   override def toString(): String = {
     if (_array != null) {
       // even if read-only
-      new String(_array, position() + _arrayOffset, remaining())
+      new String(_array.toArray, position() + _arrayOffset, remaining())
     } else {
       val chars = new Array[Char](remaining())
       val savedPos = position()
@@ -188,7 +188,7 @@ abstract class CharBuffer private[nio] (
   @inline
   private[nio] def load(
       startIndex: Int,
-      dst: Array[Char],
+      dst: GenArray[Char],
       offset: Int,
       length: Int
   ): Unit =
@@ -197,7 +197,7 @@ abstract class CharBuffer private[nio] (
   @inline
   private[nio] def store(
       startIndex: Int,
-      src: Array[Char],
+      src: GenArray[Char],
       offset: Int,
       length: Int
   ): Unit =

--- a/javalib/src/main/scala/java/nio/DoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DoubleBuffer.scala
@@ -16,7 +16,7 @@ object DoubleBuffer {
 
 abstract class DoubleBuffer private[nio] (
     _capacity: Int,
-    private[nio] val _array: Array[Double],
+    private[nio] val _array: GenArray[Double],
     private[nio] val _arrayOffset: Int
 ) extends Buffer(_capacity)
     with Comparable[DoubleBuffer] {
@@ -42,7 +42,7 @@ abstract class DoubleBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   def get(dst: Array[Double]): DoubleBuffer =
     get(dst, 0, dst.length)
@@ -53,7 +53,7 @@ abstract class DoubleBuffer private[nio] (
 
   @noinline
   def put(src: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   final def put(src: Array[Double]): DoubleBuffer =
     put(src, 0, src.length)
@@ -132,7 +132,7 @@ abstract class DoubleBuffer private[nio] (
   @inline
   private[nio] def load(
       startIndex: Int,
-      dst: Array[Double],
+      dst: GenArray[Double],
       offset: Int,
       length: Int
   ): Unit =
@@ -141,7 +141,7 @@ abstract class DoubleBuffer private[nio] (
   @inline
   private[nio] def store(
       startIndex: Int,
-      src: Array[Double],
+      src: GenArray[Double],
       offset: Int,
       length: Int
   ): Unit =

--- a/javalib/src/main/scala/java/nio/FloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/FloatBuffer.scala
@@ -16,7 +16,7 @@ object FloatBuffer {
 
 abstract class FloatBuffer private[nio] (
     _capacity: Int,
-    private[nio] val _array: Array[Float],
+    private[nio] val _array: GenArray[Float],
     private[nio] val _arrayOffset: Int
 ) extends Buffer(_capacity)
     with Comparable[FloatBuffer] {
@@ -42,7 +42,7 @@ abstract class FloatBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   def get(dst: Array[Float]): FloatBuffer =
     get(dst, 0, dst.length)
@@ -53,7 +53,7 @@ abstract class FloatBuffer private[nio] (
 
   @noinline
   def put(src: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   final def put(src: Array[Float]): FloatBuffer =
     put(src, 0, src.length)
@@ -132,7 +132,7 @@ abstract class FloatBuffer private[nio] (
   @inline
   private[nio] def load(
       startIndex: Int,
-      dst: Array[Float],
+      dst: GenArray[Float],
       offset: Int,
       length: Int
   ): Unit =
@@ -141,7 +141,7 @@ abstract class FloatBuffer private[nio] (
   @inline
   private[nio] def store(
       startIndex: Int,
-      src: Array[Float],
+      src: GenArray[Float],
       offset: Int,
       length: Int
   ): Unit =

--- a/javalib/src/main/scala/java/nio/GenArray.scala
+++ b/javalib/src/main/scala/java/nio/GenArray.scala
@@ -1,0 +1,48 @@
+package java.nio
+import scala.scalanative.unsafe._
+import scala.scalanative.runtime.ByteArray
+
+private[nio] sealed trait GenArray[T] {
+  def update(index: Int, value: T): Unit
+  def apply(index: Int): T
+  def toArray(): Array[T]
+  def toPtr(): Ptr[Byte]
+  val length: Int
+}
+private[nio] case class ScalaArray[T](array: Array[T]) extends GenArray[T] {
+  
+  @inline override def update(index: Int, value: T): Unit =
+    array(index) = value
+
+  @inline override def apply(index: Int): T =
+    array(index)
+
+  @inline override def toArray(): Array[T] =
+    array
+
+  @inline override def toPtr(): Ptr[Byte] =
+    array.asInstanceOf[ByteArray].at(0)
+
+  val length = array.length
+}
+
+private[nio] case class PtrArray(array: Ptr[Byte], val length: Int)
+    extends GenArray[Byte] {
+  
+  @inline override def update(index: Int, value: Byte): Unit =
+    array(index) = value
+
+  @inline override def apply(index: Int): Byte =
+    array(index)
+
+  @inline override def toArray(): Array[Byte] = {
+    val a = Array.ofDim[Byte](length)
+    for (i <- 0 until length) {
+      a(i) = array(i)
+    }
+    a
+  }
+
+  @inline override def toPtr(): Ptr[Byte] =
+    array
+}

--- a/javalib/src/main/scala/java/nio/GenArray.scala
+++ b/javalib/src/main/scala/java/nio/GenArray.scala
@@ -10,7 +10,7 @@ private[nio] sealed trait GenArray[T] {
   val length: Int
 }
 private[nio] case class ScalaArray[T](array: Array[T]) extends GenArray[T] {
-  
+
   @inline override def update(index: Int, value: T): Unit =
     array(index) = value
 
@@ -28,7 +28,7 @@ private[nio] case class ScalaArray[T](array: Array[T]) extends GenArray[T] {
 
 private[nio] case class PtrArray(array: Ptr[Byte], val length: Int)
     extends GenArray[Byte] {
-  
+
   @inline override def update(index: Int, value: Byte): Unit =
     array(index) = value
 

--- a/javalib/src/main/scala/java/nio/GenBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenBuffer.scala
@@ -34,7 +34,7 @@ private[nio] final class GenBuffer[B <: Buffer](val self: B) extends AnyVal {
 
   @inline
   def generic_get(
-      dst: Array[ElementType],
+      dst: GenArray[ElementType],
       offset: Int,
       length: Int
   ): BufferType = {
@@ -70,7 +70,7 @@ private[nio] final class GenBuffer[B <: Buffer](val self: B) extends AnyVal {
 
   @inline
   def generic_put(
-      src: Array[ElementType],
+      src: GenArray[ElementType],
       offset: Int,
       length: Int
   ): BufferType = {
@@ -86,7 +86,7 @@ private[nio] final class GenBuffer[B <: Buffer](val self: B) extends AnyVal {
 
   @inline
   def generic_array(): Array[ElementType] = {
-    val a = _array
+    val a = _array.toArray()
     if (a == null)
       throw new UnsupportedOperationException
     if (isReadOnly())
@@ -148,7 +148,7 @@ private[nio] final class GenBuffer[B <: Buffer](val self: B) extends AnyVal {
   @inline
   def generic_load(
       startIndex: Int,
-      dst: Array[ElementType],
+      dst: GenArray[ElementType],
       offset: Int,
       length: Int
   ): Unit = {
@@ -165,7 +165,7 @@ private[nio] final class GenBuffer[B <: Buffer](val self: B) extends AnyVal {
   @inline
   def generic_store(
       startIndex: Int,
-      src: Array[ElementType],
+      src: GenArray[ElementType],
       offset: Int,
       length: Int
   ): Unit = {

--- a/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
@@ -9,7 +9,7 @@ private[nio] object GenHeapBuffer {
   trait NewHeapBuffer[BufferType <: Buffer, ElementType] {
     def apply(
         capacity: Int,
-        array: Array[ElementType],
+        array: GenArray[ElementType],
         arrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,
@@ -19,7 +19,7 @@ private[nio] object GenHeapBuffer {
 
   @inline
   def generic_wrap[BufferType <: Buffer, ElementType](
-      array: Array[ElementType],
+      array: GenArray[ElementType],
       arrayOffset: Int,
       capacity: Int,
       initialPosition: Int,
@@ -100,7 +100,13 @@ private[nio] final class GenHeapBuffer[B <: Buffer](val self: B)
 
     val len = remaining()
     System
-      .arraycopy(_array, _arrayOffset + position(), _array, _arrayOffset, len)
+      .arraycopy(
+        _array.toArray(),
+        _arrayOffset + position(),
+        _array.toArray(),
+        _arrayOffset,
+        len
+      )
     _mark = -1
     limit(capacity())
     position(len)
@@ -118,18 +124,30 @@ private[nio] final class GenHeapBuffer[B <: Buffer](val self: B)
   @inline
   def generic_load(
       startIndex: Int,
-      dst: Array[ElementType],
+      dst: GenArray[ElementType],
       offset: Int,
       length: Int
   ): Unit =
-    System.arraycopy(_array, _arrayOffset + startIndex, dst, offset, length)
+    System.arraycopy(
+      _array.toArray(),
+      _arrayOffset + startIndex,
+      dst.toArray(),
+      offset,
+      length
+    )
 
   @inline
   def generic_store(
       startIndex: Int,
-      src: Array[ElementType],
+      src: GenArray[ElementType],
       offset: Int,
       length: Int
   ): Unit =
-    System.arraycopy(src, offset, _array, _arrayOffset + startIndex, length)
+    System.arraycopy(
+      src.toArray(),
+      offset,
+      _array.toArray(),
+      _arrayOffset + startIndex,
+      length
+    )
 }

--- a/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
@@ -1,7 +1,5 @@
 package java.nio
 
-import scala.scalanative.runtime.ByteArray
-
 // Ported from Scala.js
 private[nio] object GenHeapBufferView {
   def apply[B <: Buffer](self: B): GenHeapBufferView[B] =

--- a/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
@@ -1,5 +1,7 @@
 package java.nio
 
+import scala.scalanative.runtime.ByteArray
+
 // Ported from Scala.js
 private[nio] object GenHeapBufferView {
   def apply[B <: Buffer](self: B): GenHeapBufferView[B] =
@@ -10,7 +12,7 @@ private[nio] object GenHeapBufferView {
 
     def apply(
         capacity: Int,
-        byteArray: Array[Byte],
+        byteArray: GenArray[Byte],
         byteArrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,
@@ -105,9 +107,9 @@ private[nio] final class GenHeapBufferView[B <: Buffer](val self: B)
     val len = remaining()
     val bytesPerElem = newHeapBufferView.bytesPerElem
     System.arraycopy(
-      _byteArray,
+      _byteArray.toArray(),
       _byteArrayOffset + bytesPerElem * position(),
-      _byteArray,
+      _byteArray.toArray(),
       _byteArrayOffset,
       bytesPerElem * len
     )
@@ -127,7 +129,7 @@ private[nio] final class GenHeapBufferView[B <: Buffer](val self: B)
       newHeapBufferView: NewThisHeapBufferView
   ): ByteArrayBits = {
     ByteArrayBits(
-      _byteArray,
+      _byteArray.toPtr(),
       _byteArrayOffset,
       isBigEndian,
       newHeapBufferView.bytesPerElem

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -2,7 +2,7 @@ package java.nio
 
 // Ported from Scala.js
 
-private[nio] final class HeapByteBuffer private (
+private[nio] class HeapByteBuffer(
     _capacity: Int,
     _array0: GenArray[Byte],
     _arrayOffset0: Int,

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -4,7 +4,7 @@ package java.nio
 
 private[nio] final class HeapByteBuffer private (
     _capacity: Int,
-    _array0: Array[Byte],
+    _array0: GenArray[Byte],
     _arrayOffset0: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -51,11 +51,11 @@ private[nio] final class HeapByteBuffer private (
 
   @noinline
   override def get(dst: Array[Byte], offset: Int, length: Int): ByteBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Byte], offset: Int, length: Int): ByteBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): ByteBuffer =
@@ -64,7 +64,7 @@ private[nio] final class HeapByteBuffer private (
   // Here begins the stuff specific to ByteArrays
 
   @inline private def arrayBits: ByteArrayBits =
-    ByteArrayBits(_array, _arrayOffset, isBigEndian)
+    ByteArrayBits(_array.toPtr(), _arrayOffset, isBigEndian)
 
   @noinline def getChar(): Char =
     arrayBits.loadChar(getPosAndAdvanceRead(2))
@@ -175,7 +175,7 @@ private[nio] final class HeapByteBuffer private (
   @inline
   override private[nio] def load(
       startIndex: Int,
-      dst: Array[Byte],
+      dst: GenArray[Byte],
       offset: Int,
       length: Int
   ): Unit =
@@ -184,7 +184,7 @@ private[nio] final class HeapByteBuffer private (
   @inline
   override private[nio] def store(
       startIndex: Int,
-      src: Array[Byte],
+      src: GenArray[Byte],
       offset: Int,
       length: Int
   ): Unit =
@@ -196,7 +196,7 @@ private[nio] object HeapByteBuffer {
       extends GenHeapBuffer.NewHeapBuffer[ByteBuffer, Byte] {
     def apply(
         capacity: Int,
-        array: Array[Byte],
+        array: GenArray[Byte],
         arrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,
@@ -215,7 +215,7 @@ private[nio] object HeapByteBuffer {
 
   @noinline
   private[nio] def wrap(
-      array: Array[Byte],
+      array: GenArray[Byte],
       arrayOffset: Int,
       capacity: Int,
       initialPosition: Int,

--- a/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
@@ -3,7 +3,7 @@ package java.nio
 // Ported from Scala.js
 private[nio] final class HeapByteBufferCharView private (
     _capacity: Int,
-    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArray: GenArray[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -65,11 +65,11 @@ private[nio] final class HeapByteBufferCharView private (
 
   @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): CharBuffer =
@@ -97,7 +97,7 @@ private[nio] object HeapByteBufferCharView {
 
     def apply(
         capacity: Int,
-        byteArray: Array[Byte],
+        byteArray: GenArray[Byte],
         byteArrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,

--- a/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
@@ -3,7 +3,7 @@ package java.nio
 // Ported from Scala.js
 private[nio] final class HeapByteBufferDoubleView private (
     _capacity: Int,
-    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArray: GenArray[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -51,11 +51,11 @@ private[nio] final class HeapByteBufferDoubleView private (
 
   @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): DoubleBuffer =
@@ -83,7 +83,7 @@ private[nio] object HeapByteBufferDoubleView {
 
     def apply(
         capacity: Int,
-        byteArray: Array[Byte],
+        byteArray: GenArray[Byte],
         byteArrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,

--- a/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
@@ -3,7 +3,7 @@ package java.nio
 // Ported from Scala.js
 private[nio] final class HeapByteBufferFloatView private (
     _capacity: Int,
-    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArray: GenArray[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -51,11 +51,11 @@ private[nio] final class HeapByteBufferFloatView private (
 
   @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): FloatBuffer =
@@ -83,7 +83,7 @@ private[nio] object HeapByteBufferFloatView {
 
     def apply(
         capacity: Int,
-        byteArray: Array[Byte],
+        byteArray: GenArray[Byte],
         byteArrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,

--- a/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
@@ -3,7 +3,7 @@ package java.nio
 // Ported from Scala.js
 private[nio] final class HeapByteBufferIntView private (
     _capacity: Int,
-    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArray: GenArray[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -51,11 +51,11 @@ private[nio] final class HeapByteBufferIntView private (
 
   @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): IntBuffer =
@@ -83,7 +83,7 @@ private[nio] object HeapByteBufferIntView {
 
     def apply(
         capacity: Int,
-        byteArray: Array[Byte],
+        byteArray: GenArray[Byte],
         byteArrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,

--- a/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
@@ -3,7 +3,7 @@ package java.nio
 // Ported from Scala.js
 private[nio] final class HeapByteBufferLongView private (
     _capacity: Int,
-    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArray: GenArray[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -51,11 +51,11 @@ private[nio] final class HeapByteBufferLongView private (
 
   @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): LongBuffer =
@@ -83,7 +83,7 @@ private[nio] object HeapByteBufferLongView {
 
     def apply(
         capacity: Int,
-        byteArray: Array[Byte],
+        byteArray: GenArray[Byte],
         byteArrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,

--- a/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
@@ -3,7 +3,7 @@ package java.nio
 // Ported from Scala.js
 private[nio] final class HeapByteBufferShortView private (
     _capacity: Int,
-    override private[nio] val _byteArray: Array[Byte],
+    override private[nio] val _byteArray: GenArray[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -51,11 +51,11 @@ private[nio] final class HeapByteBufferShortView private (
 
   @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): ShortBuffer =
@@ -83,7 +83,7 @@ private[nio] object HeapByteBufferShortView {
 
     def apply(
         capacity: Int,
-        byteArray: Array[Byte],
+        byteArray: GenArray[Byte],
         byteArrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,

--- a/javalib/src/main/scala/java/nio/HeapCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapCharBuffer.scala
@@ -4,7 +4,7 @@ package java.nio
 
 private[nio] final class HeapCharBuffer private (
     _capacity: Int,
-    _array0: Array[Char],
+    _array0: GenArray[Char],
     _arrayOffset0: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -64,11 +64,11 @@ private[nio] final class HeapCharBuffer private (
 
   @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): CharBuffer =
@@ -89,7 +89,7 @@ private[nio] final class HeapCharBuffer private (
   @inline
   override private[nio] def load(
       startIndex: Int,
-      dst: Array[Char],
+      dst: GenArray[Char],
       offset: Int,
       length: Int
   ): Unit =
@@ -98,7 +98,7 @@ private[nio] final class HeapCharBuffer private (
   @inline
   override private[nio] def store(
       startIndex: Int,
-      src: Array[Char],
+      src: GenArray[Char],
       offset: Int,
       length: Int
   ): Unit =
@@ -110,7 +110,7 @@ private[nio] object HeapCharBuffer {
       extends GenHeapBuffer.NewHeapBuffer[CharBuffer, Char] {
     def apply(
         capacity: Int,
-        array: Array[Char],
+        array: GenArray[Char],
         arrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,
@@ -136,7 +136,7 @@ private[nio] object HeapCharBuffer {
       isReadOnly: Boolean
   ): CharBuffer = {
     GenHeapBuffer.generic_wrap(
-      array,
+      ScalaArray(array),
       arrayOffset,
       capacity,
       initialPosition,

--- a/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
@@ -3,7 +3,7 @@ package java.nio
 // Ported from Scala.js
 private[nio] final class HeapDoubleBuffer private (
     _capacity: Int,
-    _array0: Array[Double],
+    _array0: GenArray[Double],
     _arrayOffset0: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -50,11 +50,11 @@ private[nio] final class HeapDoubleBuffer private (
 
   @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): DoubleBuffer =
@@ -75,7 +75,7 @@ private[nio] final class HeapDoubleBuffer private (
   @inline
   override private[nio] def load(
       startIndex: Int,
-      dst: Array[Double],
+      dst: GenArray[Double],
       offset: Int,
       length: Int
   ): Unit =
@@ -84,7 +84,7 @@ private[nio] final class HeapDoubleBuffer private (
   @inline
   override private[nio] def store(
       startIndex: Int,
-      src: Array[Double],
+      src: GenArray[Double],
       offset: Int,
       length: Int
   ): Unit =
@@ -96,7 +96,7 @@ private[nio] object HeapDoubleBuffer {
       extends GenHeapBuffer.NewHeapBuffer[DoubleBuffer, Double] {
     def apply(
         capacity: Int,
-        array: Array[Double],
+        array: GenArray[Double],
         arrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,
@@ -123,7 +123,7 @@ private[nio] object HeapDoubleBuffer {
       isReadOnly: Boolean
   ): DoubleBuffer = {
     GenHeapBuffer.generic_wrap(
-      array,
+      ScalaArray(array),
       arrayOffset,
       capacity,
       initialPosition,

--- a/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
@@ -3,7 +3,7 @@ package java.nio
 // Ported from Scala.js
 private[nio] final class HeapFloatBuffer private (
     _capacity: Int,
-    _array0: Array[Float],
+    _array0: GenArray[Float],
     _arrayOffset0: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -50,11 +50,11 @@ private[nio] final class HeapFloatBuffer private (
 
   @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): FloatBuffer =
@@ -75,7 +75,7 @@ private[nio] final class HeapFloatBuffer private (
   @inline
   override private[nio] def load(
       startIndex: Int,
-      dst: Array[Float],
+      dst: GenArray[Float],
       offset: Int,
       length: Int
   ): Unit =
@@ -84,7 +84,7 @@ private[nio] final class HeapFloatBuffer private (
   @inline
   override private[nio] def store(
       startIndex: Int,
-      src: Array[Float],
+      src: GenArray[Float],
       offset: Int,
       length: Int
   ): Unit =
@@ -96,7 +96,7 @@ private[nio] object HeapFloatBuffer {
       extends GenHeapBuffer.NewHeapBuffer[FloatBuffer, Float] {
     def apply(
         capacity: Int,
-        array: Array[Float],
+        array: GenArray[Float],
         arrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,
@@ -123,7 +123,7 @@ private[nio] object HeapFloatBuffer {
       isReadOnly: Boolean
   ): FloatBuffer = {
     GenHeapBuffer.generic_wrap(
-      array,
+      ScalaArray(array),
       arrayOffset,
       capacity,
       initialPosition,

--- a/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
@@ -3,7 +3,7 @@ package java.nio
 // Ported from Scala.js
 private[nio] final class HeapIntBuffer private (
     _capacity: Int,
-    _array0: Array[Int],
+    _array0: GenArray[Int],
     _arrayOffset0: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -49,11 +49,11 @@ private[nio] final class HeapIntBuffer private (
 
   @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): IntBuffer =
@@ -74,7 +74,7 @@ private[nio] final class HeapIntBuffer private (
   @inline
   override private[nio] def load(
       startIndex: Int,
-      dst: Array[Int],
+      dst: GenArray[Int],
       offset: Int,
       length: Int
   ): Unit =
@@ -83,7 +83,7 @@ private[nio] final class HeapIntBuffer private (
   @inline
   override private[nio] def store(
       startIndex: Int,
-      src: Array[Int],
+      src: GenArray[Int],
       offset: Int,
       length: Int
   ): Unit =
@@ -95,7 +95,7 @@ private[nio] object HeapIntBuffer {
       extends GenHeapBuffer.NewHeapBuffer[IntBuffer, Int] {
     def apply(
         capacity: Int,
-        array: Array[Int],
+        array: GenArray[Int],
         arrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,
@@ -122,7 +122,7 @@ private[nio] object HeapIntBuffer {
       isReadOnly: Boolean
   ): IntBuffer = {
     GenHeapBuffer.generic_wrap(
-      array,
+      ScalaArray(array),
       arrayOffset,
       capacity,
       initialPosition,

--- a/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
@@ -3,7 +3,7 @@ package java.nio
 // Ported from Scala.js
 private[nio] final class HeapLongBuffer private (
     _capacity: Int,
-    _array0: Array[Long],
+    _array0: GenArray[Long],
     _arrayOffset0: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -50,11 +50,11 @@ private[nio] final class HeapLongBuffer private (
 
   @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): LongBuffer =
@@ -75,7 +75,7 @@ private[nio] final class HeapLongBuffer private (
   @inline
   override private[nio] def load(
       startIndex: Int,
-      dst: Array[Long],
+      dst: GenArray[Long],
       offset: Int,
       length: Int
   ): Unit =
@@ -84,7 +84,7 @@ private[nio] final class HeapLongBuffer private (
   @inline
   override private[nio] def store(
       startIndex: Int,
-      src: Array[Long],
+      src: GenArray[Long],
       offset: Int,
       length: Int
   ): Unit =
@@ -96,7 +96,7 @@ private[nio] object HeapLongBuffer {
       extends GenHeapBuffer.NewHeapBuffer[LongBuffer, Long] {
     def apply(
         capacity: Int,
-        array: Array[Long],
+        array: GenArray[Long],
         arrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,
@@ -123,7 +123,7 @@ private[nio] object HeapLongBuffer {
       isReadOnly: Boolean
   ): LongBuffer = {
     GenHeapBuffer.generic_wrap(
-      array,
+      ScalaArray(array),
       arrayOffset,
       capacity,
       initialPosition,

--- a/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
@@ -3,7 +3,7 @@ package java.nio
 // Ported from Scala.js
 private[nio] final class HeapShortBuffer private (
     _capacity: Int,
-    _array0: Array[Short],
+    _array0: GenArray[Short],
     _arrayOffset0: Int,
     _initialPosition: Int,
     _initialLimit: Int,
@@ -50,11 +50,11 @@ private[nio] final class HeapShortBuffer private (
 
   @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   @noinline
   override def put(src: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   @noinline
   def compact(): ShortBuffer =
@@ -75,7 +75,7 @@ private[nio] final class HeapShortBuffer private (
   @inline
   override private[nio] def load(
       startIndex: Int,
-      dst: Array[Short],
+      dst: GenArray[Short],
       offset: Int,
       length: Int
   ): Unit =
@@ -84,7 +84,7 @@ private[nio] final class HeapShortBuffer private (
   @inline
   override private[nio] def store(
       startIndex: Int,
-      src: Array[Short],
+      src: GenArray[Short],
       offset: Int,
       length: Int
   ): Unit =
@@ -96,7 +96,7 @@ private[nio] object HeapShortBuffer {
       extends GenHeapBuffer.NewHeapBuffer[ShortBuffer, Short] {
     def apply(
         capacity: Int,
-        array: Array[Short],
+        array: GenArray[Short],
         arrayOffset: Int,
         initialPosition: Int,
         initialLimit: Int,
@@ -123,7 +123,7 @@ private[nio] object HeapShortBuffer {
       isReadOnly: Boolean
   ): ShortBuffer = {
     GenHeapBuffer.generic_wrap(
-      array,
+      ScalaArray(array),
       arrayOffset,
       capacity,
       initialPosition,

--- a/javalib/src/main/scala/java/nio/IntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/IntBuffer.scala
@@ -16,7 +16,7 @@ object IntBuffer {
 
 abstract class IntBuffer private[nio] (
     _capacity: Int,
-    private[nio] val _array: Array[Int],
+    private[nio] val _array: GenArray[Int],
     private[nio] val _arrayOffset: Int
 ) extends Buffer(_capacity)
     with Comparable[IntBuffer] {
@@ -42,7 +42,7 @@ abstract class IntBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   def get(dst: Array[Int]): IntBuffer =
     get(dst, 0, dst.length)
@@ -53,7 +53,7 @@ abstract class IntBuffer private[nio] (
 
   @noinline
   def put(src: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   final def put(src: Array[Int]): IntBuffer =
     put(src, 0, src.length)
@@ -135,7 +135,7 @@ abstract class IntBuffer private[nio] (
   @inline
   private[nio] def load(
       startIndex: Int,
-      dst: Array[Int],
+      dst: GenArray[Int],
       offset: Int,
       length: Int
   ): Unit =
@@ -144,7 +144,7 @@ abstract class IntBuffer private[nio] (
   @inline
   private[nio] def store(
       startIndex: Int,
-      src: Array[Int],
+      src: GenArray[Int],
       offset: Int,
       length: Int
   ): Unit =

--- a/javalib/src/main/scala/java/nio/LongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/LongBuffer.scala
@@ -16,7 +16,7 @@ object LongBuffer {
 
 abstract class LongBuffer private[nio] (
     _capacity: Int,
-    private[nio] val _array: Array[Long],
+    private[nio] val _array: GenArray[Long],
     private[nio] val _arrayOffset: Int
 ) extends Buffer(_capacity)
     with Comparable[LongBuffer] {
@@ -42,7 +42,7 @@ abstract class LongBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   def get(dst: Array[Long]): LongBuffer =
     get(dst, 0, dst.length)
@@ -53,7 +53,7 @@ abstract class LongBuffer private[nio] (
 
   @noinline
   def put(src: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   final def put(src: Array[Long]): LongBuffer =
     put(src, 0, src.length)
@@ -132,7 +132,7 @@ abstract class LongBuffer private[nio] (
   @inline
   private[nio] def load(
       startIndex: Int,
-      dst: Array[Long],
+      dst: GenArray[Long],
       offset: Int,
       length: Int
   ): Unit =
@@ -141,7 +141,7 @@ abstract class LongBuffer private[nio] (
   @inline
   private[nio] def store(
       startIndex: Int,
-      src: Array[Long],
+      src: GenArray[Long],
       offset: Int,
       length: Int
   ): Unit =

--- a/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
@@ -16,12 +16,13 @@ abstract class MappedByteBuffer private[nio] (
       mode == FileChannel.MapMode.READ_ONLY
     ) {
 
+  def this(mode: FileChannel.MapMode, _capacity: Int, _array: Array[Byte], _arrayOffset: Int) = 
+      this(mode, _capacity, ScalaArray(_array), _arrayOffset)
+
   def force(): MappedByteBuffer
 
   def isLoaded(): Boolean
 
   def load(): MappedByteBuffer
-
-  def unmap(): Unit
 
 }

--- a/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
@@ -2,170 +2,26 @@ package java.nio
 
 import java.nio.channels.{FileChannel, NonWritableChannelException}
 
-abstract class MappedByteBuffer(
+abstract class MappedByteBuffer private[nio] (
     mode: FileChannel.MapMode,
     _capacity: Int,
-    _array: Array[Byte],
+    _array: GenArray[Byte],
     _arrayOffset: Int
-) extends ByteBuffer(_capacity, _array, _arrayOffset) {
+) extends HeapByteBuffer(
+      _capacity,
+      _array,
+      _arrayOffset,
+      _arrayOffset,
+      _capacity,
+      mode == FileChannel.MapMode.READ_ONLY
+    ) {
 
-  private val underlying = ByteBuffer.wrap(_array, _arrayOffset, _capacity)
+  def force(): MappedByteBuffer
 
-  override def isReadOnly(): Boolean =
-    mode == FileChannel.MapMode.READ_ONLY
+  def isLoaded(): Boolean
 
-  override def asCharBuffer(): CharBuffer =
-    underlying.asCharBuffer()
+  def load(): MappedByteBuffer
 
-  override def asDoubleBuffer(): DoubleBuffer =
-    underlying.asDoubleBuffer()
+  def unmap(): Unit
 
-  override def asFloatBuffer(): FloatBuffer =
-    underlying.asFloatBuffer()
-
-  override def asIntBuffer(): IntBuffer =
-    underlying.asIntBuffer()
-
-  override def asLongBuffer(): LongBuffer =
-    underlying.asLongBuffer()
-
-  override def asShortBuffer(): ShortBuffer =
-    underlying.asShortBuffer()
-
-  override def asReadOnlyBuffer(): ByteBuffer =
-    if (isReadOnly()) this
-    else underlying.asReadOnlyBuffer()
-
-  override def compact(): ByteBuffer =
-    underlying.compact()
-
-  override def duplicate(): ByteBuffer =
-    underlying.duplicate()
-
-  override def get(index: Int): Byte =
-    underlying.get(index)
-
-  override def get(): Byte =
-    underlying.get()
-
-  override def getChar(index: Int): Char =
-    underlying.getChar(index)
-
-  override def getChar(): Char =
-    underlying.getChar()
-
-  override def getDouble(index: Int): Double =
-    underlying.getDouble(index)
-
-  override def getDouble(): Double =
-    underlying.getDouble()
-
-  override def getFloat(index: Int): Float =
-    underlying.getFloat(index)
-
-  override def getFloat(): Float =
-    underlying.getFloat()
-
-  override def getInt(index: Int): Int =
-    underlying.getInt(index)
-
-  override def getInt(): Int =
-    underlying.getInt()
-
-  override def getLong(index: Int): Long =
-    underlying.getLong(index)
-
-  override def getLong(): Long =
-    underlying.getLong()
-
-  override def getShort(index: Int): Short =
-    underlying.getShort(index)
-
-  override def getShort(): Short =
-    underlying.getShort()
-
-  override def isDirect(): Boolean =
-    underlying.isDirect()
-
-  private[nio] override def load(index: Int): Byte =
-    underlying.load(index)
-
-  override def put(index: Int, b: Byte): ByteBuffer = {
-    ensureWritable()
-    underlying.put(index, b)
-  }
-
-  override def put(b: Byte): ByteBuffer = {
-    ensureWritable()
-    underlying.put(b)
-  }
-
-  override def putChar(index: Int, value: Char): ByteBuffer = {
-    ensureWritable()
-    underlying.putChar(index, value)
-  }
-
-  override def putChar(value: Char): ByteBuffer = {
-    ensureWritable()
-    underlying.putChar(value)
-  }
-
-  override def putDouble(index: Int, value: Double): ByteBuffer = {
-    ensureWritable()
-    underlying.putDouble(index, value)
-  }
-
-  override def putDouble(value: Double): ByteBuffer = {
-    ensureWritable()
-    underlying.putDouble(value)
-  }
-
-  override def putFloat(index: Int, value: Float): ByteBuffer = {
-    ensureWritable()
-    underlying.putFloat(index, value)
-  }
-
-  override def putFloat(value: Float): ByteBuffer = {
-    ensureWritable()
-    underlying.putFloat(value)
-  }
-
-  override def putInt(index: Int, value: Int): ByteBuffer = {
-    ensureWritable()
-    underlying.putInt(index, value)
-  }
-
-  override def putInt(value: Int): ByteBuffer = {
-    ensureWritable()
-    underlying.putInt(value)
-  }
-
-  override def putLong(index: Int, value: Long): ByteBuffer = {
-    ensureWritable()
-    underlying.putLong(index, value)
-  }
-
-  override def putLong(value: Long): ByteBuffer = {
-    ensureWritable()
-    underlying.putLong(value)
-  }
-
-  override def putShort(index: Int, value: Short): ByteBuffer = {
-    ensureWritable()
-    underlying.putShort(index, value)
-  }
-
-  override def putShort(value: Short): ByteBuffer = {
-    ensureWritable()
-    underlying.putShort(value)
-  }
-
-  override def slice(): ByteBuffer =
-    underlying.slice()
-
-  private[nio] override def store(index: Int, elem: Byte): Unit =
-    underlying.store(index, elem)
-
-  private def ensureWritable(): Unit =
-    if (isReadOnly()) throw new NonWritableChannelException()
 }

--- a/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
@@ -1,6 +1,6 @@
 package java.nio
 
-import java.nio.channels.{FileChannel, NonWritableChannelException}
+import java.nio.channels.FileChannel
 
 abstract class MappedByteBuffer private[nio] (
     mode: FileChannel.MapMode,

--- a/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
@@ -16,8 +16,13 @@ abstract class MappedByteBuffer private[nio] (
       mode == FileChannel.MapMode.READ_ONLY
     ) {
 
-  def this(mode: FileChannel.MapMode, _capacity: Int, _array: Array[Byte], _arrayOffset: Int) = 
-      this(mode, _capacity, ScalaArray(_array), _arrayOffset)
+  def this(
+      mode: FileChannel.MapMode,
+      _capacity: Int,
+      _array: Array[Byte],
+      _arrayOffset: Int
+  ) =
+    this(mode, _capacity, ScalaArray(_array), _arrayOffset)
 
   def force(): MappedByteBuffer
 

--- a/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
@@ -16,14 +16,6 @@ abstract class MappedByteBuffer private[nio] (
       mode == FileChannel.MapMode.READ_ONLY
     ) {
 
-  def this(
-      mode: FileChannel.MapMode,
-      _capacity: Int,
-      _array: Array[Byte],
-      _arrayOffset: Int
-  ) =
-    this(mode, _capacity, ScalaArray(_array), _arrayOffset)
-
   def force(): MappedByteBuffer
 
   def isLoaded(): Boolean

--- a/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
@@ -1,24 +1,16 @@
 package java.nio
 
 import scala.scalanative.posix.sys.mman._
-import scala.scalanative.posix.unistd
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 
-import scala.scalanative.runtime.ByteArray
-import scala.scalanative.runtime.IntArray
 import scala.scalanative.meta.LinktimeInfo.isWindows
 
 import scala.scalanative.windows.WinBaseApi.CreateFileMappingA
 import scala.scalanative.windows.WinBaseApiExt._
 import scala.scalanative.windows.MemoryApi._
 import scala.scalanative.windows.HandleApi._
-import scala.scalanative.windows.FileApi
-import scala.scalanative.windows.FileApiExt._
 import scala.scalanative.windows._
-
-import scala.scalanative.libc.errno._
-import scala.scalanative.libc.stdlib._
 
 import java.io.IOException
 import java.io.FileDescriptor
@@ -26,9 +18,6 @@ import java.nio.channels.FileChannel.MapMode
 import java.nio.channels.FileChannel
 import scala.scalanative.annotation.alwaysinline
 import java.lang.ref.{WeakReference, WeakReferenceRegistry}
-
-import scala.scalanative.windows.ErrorHandlingApi._
-import java.lang.ref.ReferenceQueue
 
 // Finalization object used to unmap file after GC.
 class MappedByteBufferFinalizer(
@@ -96,7 +85,7 @@ private[nio] object MappedByteBufferImpl {
 
     val prevPosition = channel.position()
 
-    def throwException(): Unit =
+    @alwaysinline def throwException(): Unit =
       throw new IOException("Could not map file to memory")
 
     // JVM resizes file to accomodate mapping

--- a/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
@@ -81,7 +81,7 @@ private[nio] object MappedByteBufferImpl {
   ): MappedByteBufferImpl = {
 
     val prevPosition = channel.position()
-    
+
     def throwException(): Unit =
       throw new IOException("Could not map file to memory")
 
@@ -91,9 +91,9 @@ private[nio] object MappedByteBufferImpl {
       val minSize = position + size
       if (minSize > prevSize) {
         channel.truncate(minSize)
-        if(isWindows){
+        if (isWindows) {
           channel.position(prevSize)
-          for(i <- prevSize until minSize)
+          for (i <- prevSize until minSize)
             channel.write(ByteBuffer.wrap(Array[Byte](0.toByte)))
           channel.position(prevPosition)
         }

--- a/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
@@ -1,0 +1,101 @@
+package java.nio
+
+import scala.scalanative.posix.sys.mman._
+import scala.scalanative.posix.unistd.ftruncate
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+import scala.scalanative.runtime.ByteArray
+import scala.scalanative.runtime.IntArray
+import scala.scalanative.meta.LinktimeInfo.isWindows
+
+import scala.scalanative.libc.errno._
+import scala.scalanative.libc.stdlib._
+
+import java.io.IOException
+import java.io.FileDescriptor
+import java.nio.channels.FileChannel.MapMode
+import java.nio.channels.FileChannel
+
+// Unmap is not actually found in Java API. Unmapping should be done on
+// garbage collection, however, Scala Native does not provide that
+// functionality. Users have to rely on automatic unmapping at the end
+// of a process. Essentially, a memory leak on lost reference.
+class MappedByteBufferImpl private (
+    mode: MapMode,
+    size: Int,
+    array: GenArray[Byte],
+    fd: FileDescriptor,
+    ptr: Ptr[Byte]
+) extends MappedByteBuffer(mode, size, array, 0) {
+
+  override def force(): MappedByteBuffer = {
+    if (mode eq MapMode.READ_WRITE) {
+      if (isWindows) {
+        ???
+      } else {
+        if (msync(ptr, size.toUInt, MS_SYNC) == -1)
+          throw new IOException
+      }
+    }
+    this
+  }
+
+  // Not found in java API
+  override def unmap(): Unit = {
+    if (isWindows) {
+      ???
+    } else {
+      if (munmap(ptr, size.toUInt) == -1)
+        throw new IOException
+    }
+  }
+
+  override def isLoaded(): Boolean = true
+
+  override def load(): MappedByteBuffer = this
+}
+
+private[nio] object MappedByteBufferImpl {
+  def map(
+      mode: MapMode,
+      position: Long,
+      size: Int,
+      fd: FileDescriptor,
+      channel: FileChannel
+  ): MappedByteBufferImpl = {
+
+    // JVM resizes file to accomodate mapping
+    if (mode ne MapMode.READ_ONLY) {
+      if (position + size > channel.size())
+        if (isWindows) ???
+        else {
+          if (ftruncate(fd.fd, position + size) == -1)
+            throw new IOException
+        }
+    }
+
+    val ptr: Ptr[Byte] =
+      if (isWindows) {
+        ???
+      } else {
+        val (prot: Int, isPrivate: Int) =
+          if (mode eq MapMode.PRIVATE) (PROT_WRITE, MAP_PRIVATE)
+          else if (mode eq MapMode.READ_ONLY) (PROT_READ, MAP_SHARED)
+          else if (mode eq MapMode.READ_WRITE) (PROT_WRITE, MAP_SHARED)
+
+        val ptr = mmap(
+          null,
+          size.toUInt,
+          prot,
+          isPrivate,
+          fd.fd,
+          position
+        )
+        if (ptr.toInt == -1) throw new IOException
+        ptr
+      }
+
+    new MappedByteBufferImpl(mode, size, PtrArray(ptr, size), fd, ptr)
+  }
+}

--- a/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
@@ -9,6 +9,12 @@ import scala.scalanative.runtime.ByteArray
 import scala.scalanative.runtime.IntArray
 import scala.scalanative.meta.LinktimeInfo.isWindows
 
+import scala.scalanative.windows.WinBaseApi.CreateFileMappingA
+import scala.scalanative.windows.WinBaseApiExt._
+import scala.scalanative.windows.MemoryApi._
+import scala.scalanative.windows.HandleApi._
+import scala.scalanative.windows._
+
 import scala.scalanative.libc.errno._
 import scala.scalanative.libc.stdlib._
 
@@ -25,14 +31,26 @@ class MappedByteBufferImpl private (
     mode: MapMode,
     size: Int,
     array: GenArray[Byte],
-    fd: FileDescriptor,
-    ptr: Ptr[Byte]
+    ptr: Ptr[Byte],
+    windowsMappingHandler: Option[Handle]
 ) extends MappedByteBuffer(mode, size, array, 0) {
+
+  // Not found in java API
+  override def unmap(): Unit = {
+    if (isWindows) {
+      if (!UnmapViewOfFile(ptr)) throw new IOException
+      if (!CloseHandle(windowsMappingHandler.get)) throw new IOException
+    } else {
+      if (munmap(ptr, size.toUInt) == -1)
+        throw new IOException
+    }
+  }
 
   override def force(): MappedByteBuffer = {
     if (mode eq MapMode.READ_WRITE) {
       if (isWindows) {
-        ???
+        if (!FlushViewOfFile(ptr, size.toUInt))
+          throw new IOException
       } else {
         if (msync(ptr, size.toUInt, MS_SYNC) == -1)
           throw new IOException
@@ -41,22 +59,13 @@ class MappedByteBufferImpl private (
     this
   }
 
-  // Not found in java API
-  override def unmap(): Unit = {
-    if (isWindows) {
-      ???
-    } else {
-      if (munmap(ptr, size.toUInt) == -1)
-        throw new IOException
-    }
-  }
-
   override def isLoaded(): Boolean = true
 
   override def load(): MappedByteBuffer = this
 }
 
 private[nio] object MappedByteBufferImpl {
+
   def map(
       mode: MapMode,
       position: Long,
@@ -68,16 +77,46 @@ private[nio] object MappedByteBufferImpl {
     // JVM resizes file to accomodate mapping
     if (mode ne MapMode.READ_ONLY) {
       if (position + size > channel.size())
-        if (isWindows) ???
-        else {
+        if (isWindows) {
+          // _chsize( _fileno(f), size);
+          ???
+        } else {
           if (ftruncate(fd.fd, position + size) == -1)
             throw new IOException
         }
     }
 
-    val ptr: Ptr[Byte] =
+    val (ptr: Ptr[Byte], windowsMappingHandler: Option[Handle]) =
       if (isWindows) {
-        ???
+        val (flProtect: DWord, dwDesiredAccess: DWord) =
+          if (mode eq MapMode.PRIVATE)
+            (PAGE_WRITECOPY, FILE_MAP_WRITE | FILE_MAP_COPY)
+          else if (mode eq MapMode.READ_ONLY) (PAGE_READONLY, FILE_MAP_READ)
+          else if (mode eq MapMode.READ_WRITE) (PAGE_READWRITE, FILE_MAP_WRITE)
+
+        val mappingHandle =
+          CreateFileMappingA(
+            fd.handle,
+            null,
+            flProtect,
+            0.toUInt,
+            0.toUInt,
+            null
+          )
+        if (mappingHandle == null) throw new IOException
+
+        val dwFileOffsetHigh = (position >> 32).toInt.toUInt
+        val dwFileOffsetLow = position.toInt.toUInt
+
+        val ptr = MapViewOfFile(
+          mappingHandle,
+          dwDesiredAccess,
+          dwFileOffsetHigh,
+          dwFileOffsetLow,
+          size.toUInt
+        )
+        if (ptr.toInt == -1) throw new IOException
+        (ptr, Some(mappingHandle))
       } else {
         val (prot: Int, isPrivate: Int) =
           if (mode eq MapMode.PRIVATE) (PROT_WRITE, MAP_PRIVATE)
@@ -93,9 +132,15 @@ private[nio] object MappedByteBufferImpl {
           position
         )
         if (ptr.toInt == -1) throw new IOException
-        ptr
+        (ptr, None)
       }
 
-    new MappedByteBufferImpl(mode, size, PtrArray(ptr, size), fd, ptr)
+    new MappedByteBufferImpl(
+      mode,
+      size,
+      PtrArray(ptr, size),
+      ptr,
+      windowsMappingHandler
+    )
   }
 }

--- a/javalib/src/main/scala/java/nio/ShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ShortBuffer.scala
@@ -16,7 +16,7 @@ object ShortBuffer {
 
 abstract class ShortBuffer private[nio] (
     _capacity: Int,
-    private[nio] val _array: Array[Short],
+    private[nio] val _array: GenArray[Short],
     private[nio] val _arrayOffset: Int
 ) extends Buffer(_capacity)
     with Comparable[ShortBuffer] {
@@ -42,7 +42,7 @@ abstract class ShortBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   def get(dst: Array[Short]): ShortBuffer =
     get(dst, 0, dst.length)
@@ -53,7 +53,7 @@ abstract class ShortBuffer private[nio] (
 
   @noinline
   def put(src: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    GenBuffer(this).generic_put(ScalaArray(src), offset, length)
 
   final def put(src: Array[Short]): ShortBuffer =
     put(src, 0, src.length)
@@ -132,7 +132,7 @@ abstract class ShortBuffer private[nio] (
   @inline
   private[nio] def load(
       startIndex: Int,
-      dst: Array[Short],
+      dst: GenArray[Short],
       offset: Int,
       length: Int
   ): Unit =
@@ -141,7 +141,7 @@ abstract class ShortBuffer private[nio] (
   @inline
   private[nio] def store(
       startIndex: Int,
-      src: Array[Short],
+      src: GenArray[Short],
       offset: Int,
       length: Int
   ): Unit =

--- a/javalib/src/main/scala/java/nio/StringCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/StringCharBuffer.scala
@@ -59,7 +59,7 @@ private[nio] final class StringCharBuffer private (
 
   @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    GenBuffer(this).generic_get(ScalaArray(dst), offset, length)
 
   override def put(src: Array[Char], offset: Int, length: Int): CharBuffer =
     throw new ReadOnlyBufferException
@@ -87,7 +87,7 @@ private[nio] final class StringCharBuffer private (
   @inline
   override private[nio] def load(
       startIndex: Int,
-      dst: Array[Char],
+      dst: GenArray[Char],
       offset: Int,
       length: Int
   ): Unit =
@@ -96,7 +96,7 @@ private[nio] final class StringCharBuffer private (
   @inline
   override private[nio] def store(
       startIndex: Int,
-      src: Array[Char],
+      src: GenArray[Char],
       offset: Int,
       length: Int
   ): Unit =

--- a/javalib/src/main/scala/java/nio/channels/FileChannel.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannel.scala
@@ -5,16 +5,9 @@ import java.nio.file.{OpenOption, Path}
 import java.nio.file.attribute.FileAttribute
 import spi.AbstractInterruptibleChannel
 
-import java.io.FileDescriptor
-
 import java.util.{HashSet, Set}
 import java.io.RandomAccessFile
 
-import scala.scalanative.windows.ErrorHandlingApi._
-import scala.scalanative.windows.FileApi._
-import scala.scalanative.windows.FileApiExt._
-import scala.scalanative.windows.HandleApiExt._
-import scala.scalanative.windows.winnt.AccessRights._
 import java.nio.file._
 
 abstract class FileChannel protected ()

--- a/javalib/src/main/scala/java/nio/channels/FileChannel.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannel.scala
@@ -134,7 +134,9 @@ object FileChannel {
     new FileChannelImpl(
       raf.getFD(),
       Some(file),
-      deleteOnClose = options.contains(StandardOpenOption.DELETE_ON_CLOSE)
+      deleteFileOnClose = options.contains(StandardOpenOption.DELETE_ON_CLOSE),
+      openForReading = true,
+      openForWriting = writing
     )
   }
 

--- a/javalib/src/main/scala/java/nio/channels/FileChannel.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannel.scala
@@ -5,7 +5,17 @@ import java.nio.file.{OpenOption, Path}
 import java.nio.file.attribute.FileAttribute
 import spi.AbstractInterruptibleChannel
 
+import java.io.FileDescriptor
+
 import java.util.{HashSet, Set}
+import java.io.RandomAccessFile
+
+import scala.scalanative.windows.ErrorHandlingApi._
+import scala.scalanative.windows.FileApi._
+import scala.scalanative.windows.FileApiExt._
+import scala.scalanative.windows.HandleApiExt._
+import scala.scalanative.windows.winnt.AccessRights._
+import java.nio.file._
 
 abstract class FileChannel protected ()
     extends AbstractInterruptibleChannel
@@ -14,11 +24,13 @@ abstract class FileChannel protected ()
     with ScatteringByteChannel {
 
   // def force(metadata: Boolean): Unit
-  // final def lock(): FileLock =
-  //   lock(0L, Long.MaxValue, false)
+
+  // final def lock(): FileLock = lock(0L, Long.MaxValue, false)
+
   // def lock(position: Long, size: Long, shared: Boolean): FileLock
-  // final def tryLock(): FileLock =
-  //   tryLock(0L, Long.MaxValue, false)
+
+  // final def tryLock(): FileLock = tryLock(0L, Long.MaxValue, false)
+
   // def tryLock(position: Long, size: Long, shared: Boolean): FileLock
 
   def map(
@@ -71,8 +83,60 @@ object FileChannel {
       path: Path,
       options: Set[_ <: OpenOption],
       attrs: Array[FileAttribute[_]]
-  ): FileChannel =
-    new FileChannelImpl(path, options, attrs)
+  ): FileChannel = {
+    import StandardOpenOption._
+
+    if (options.contains(APPEND) && options.contains(TRUNCATE_EXISTING)) {
+      throw new IllegalArgumentException(
+        "APPEND + TRUNCATE_EXISTING not allowed"
+      )
+    }
+
+    if (options.contains(APPEND) && options.contains(READ)) {
+      throw new IllegalArgumentException("APPEND + READ not allowed")
+    }
+
+    val writing = options.contains(WRITE) || options.contains(APPEND)
+
+    val mode = new StringBuilder("r")
+    if (writing) mode.append("w")
+
+    if (!Files.exists(path, Array.empty)) {
+      if (!options.contains(CREATE) && !options.contains(CREATE_NEW)) {
+        throw new NoSuchFileException(path.toString)
+      } else if (writing) {
+        Files.createFile(path, attrs)
+      }
+    } else if (options.contains(CREATE_NEW)) {
+      throw new FileAlreadyExistsException(path.toString)
+    }
+
+    if (writing && options.contains(DSYNC) && !options
+          .contains(SYNC)) {
+      mode.append("d")
+    }
+
+    if (writing && options.contains(SYNC)) {
+      mode.append("s")
+    }
+
+    val file = path.toFile()
+    val raf = new RandomAccessFile(file, mode.toString)
+
+    if (writing && options.contains(TRUNCATE_EXISTING)) {
+      raf.setLength(0L)
+    }
+
+    if (writing && options.contains(APPEND)) {
+      raf.seek(raf.length())
+    }
+
+    new FileChannelImpl(
+      raf.getFD(),
+      Some(file),
+      deleteOnClose = options.contains(StandardOpenOption.DELETE_ON_CLOSE)
+    )
+  }
 
   def open(path: Path, options: Array[OpenOption]): FileChannel = {
     var i = 0

--- a/javalib/src/main/scala/java/nio/channels/FileChannel.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannel.scala
@@ -23,15 +23,15 @@ abstract class FileChannel protected ()
     with GatheringByteChannel
     with ScatteringByteChannel {
 
-  // def force(metadata: Boolean): Unit
+  def force(metadata: Boolean): Unit
 
-  // final def lock(): FileLock = lock(0L, Long.MaxValue, false)
+  final def lock(): FileLock = lock(0L, Long.MaxValue, false)
 
-  // def lock(position: Long, size: Long, shared: Boolean): FileLock
+  def lock(position: Long, size: Long, shared: Boolean): FileLock
 
-  // final def tryLock(): FileLock = tryLock(0L, Long.MaxValue, false)
+  final def tryLock(): FileLock = tryLock(0L, Long.MaxValue, false)
 
-  // def tryLock(position: Long, size: Long, shared: Boolean): FileLock
+  def tryLock(position: Long, size: Long, shared: Boolean): FileLock
 
   def map(
       mode: FileChannel.MapMode,

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -11,7 +11,7 @@ import java.nio.file.{
 import java.nio.file.attribute.FileAttribute
 import java.nio.{ByteBuffer, MappedByteBuffer, MappedByteBufferImpl}
 import java.nio.file.WindowsException
-import scala.scalanative.nio.fs.UnixException
+import scala.scalanative.nio.fs.unix.UnixException
 
 import java.io.FileDescriptor
 import java.io.File

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -68,7 +68,7 @@ private[java] final class FileChannelImpl(
     lock
   }
 
-  @inline def lockUnix(
+  @inline private def lockUnix(
       position: Long,
       size: Long,
       shared: Boolean,
@@ -86,7 +86,7 @@ private[java] final class FileChannelImpl(
     new FileLockImpl(this, position, size, shared, fd)
   }
 
-  @inline def lockWindows(position: Long, size: Long): FileLock = {
+  @inline private def lockWindows(position: Long, size: Long): FileLock = {
     if (!LockFile(
           fd.handle,
           position.toInt.toUInt,

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -1,22 +1,13 @@
 package java.nio.channels
 
-import java.nio.file.{
-  FileAlreadyExistsException,
-  Files,
-  NoSuchFileException,
-  OpenOption,
-  Path,
-  StandardOpenOption
-}
-import java.nio.file.attribute.FileAttribute
+import java.nio.file.Files
+
 import java.nio.{ByteBuffer, MappedByteBuffer, MappedByteBufferImpl}
 import java.nio.file.WindowsException
 import scala.scalanative.nio.fs.unix.UnixException
 
 import java.io.FileDescriptor
 import java.io.File
-
-import java.util.Set
 
 import scala.scalanative.meta.LinktimeInfo.isWindows
 import java.io.IOException
@@ -35,8 +26,6 @@ import scala.scalanative.libc.errno
 import scala.scalanative.windows.ErrorHandlingApi
 import scala.scalanative.windows.FileApi._
 import scala.scalanative.windows.FileApiExt._
-import scala.scalanative.windows.HandleApiExt._
-import scala.scalanative.windows.winnt.AccessRights._
 import scala.scalanative.windows.ErrorCodes
 import scala.scalanative.windows._
 

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -244,7 +244,7 @@ private[java] final class FileChannelImpl(
   }
 
   override def size(): Long = {
-    if(isWindows){
+    if (isWindows) {
       val size = stackalloc[windows.LargeInteger]
       if (GetFileSizeEx(fd.handle, size)) (!size).toLong
       else 0L
@@ -280,7 +280,7 @@ private[java] final class FileChannelImpl(
   }
 
   override def truncate(size: Long): FileChannel =
-    if(!openForWriting) {
+    if (!openForWriting) {
       throw new IOException("Invalid argument")
     } else {
       ensureOpen()

--- a/javalib/src/main/scala/java/nio/channels/FileLock.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileLock.scala
@@ -21,6 +21,8 @@ abstract class FileLock private (
   ) =
     this(channel: Channel, position, size, shared)
 
+  require(position >= 0 && size >= 0, "position and size must be non negative")
+
   final def channel(): FileChannel =
     channel match {
       case fc: FileChannel => fc
@@ -34,7 +36,7 @@ abstract class FileLock private (
     shared
 
   final def overlaps(pos: Long, siz: Long): Boolean =
-    (pos + siz) >= position || (position + size) >= pos
+    (pos + siz) > position && (position + size) > pos
 
   def isValid(): Boolean
 

--- a/javalib/src/main/scala/java/nio/channels/FileLockImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileLockImpl.scala
@@ -1,0 +1,49 @@
+package java.nio.channels
+
+import scala.scalanative.meta.LinktimeInfo.isWindows
+import scala.scalanative.posix.fcntl._
+import scala.scalanative.posix.fcntlOps._
+import scala.scalanative.libc.stdio
+import scalanative.unsafe._
+import java.io.IOException
+import java.io.FileDescriptor
+import scala.scalanative.windows.FileApi
+import scala.scalanative.unsigned._
+
+// Works only between system processes. No thread support
+private[java] final class FileLockImpl(
+    channel: FileChannel,
+    position: Long,
+    size: Long,
+    shared: Boolean,
+    fd: FileDescriptor
+) extends FileLock(channel, position, size, shared) {
+  var released: Boolean = false
+
+  override def isValid(): Boolean =
+    !released && channel.isOpen()
+
+  override def release(): Unit = {
+    if (!channel.isOpen()) throw new ClosedChannelException()
+    if (isWindows) {
+      if (!FileApi.UnlockFile(
+            fd.handle,
+            position.toInt.toUInt,
+            (position >> 32).toInt.toUInt,
+            size.toInt.toUInt,
+            (size >> 32).toInt.toUInt
+          ))
+        throw new IOException()
+    } else {
+      val fl = stackalloc[flock]
+      fl.l_start = position
+      fl.l_len = size
+      fl.l_pid = 0
+      fl.l_type = F_UNLCK
+      fl.l_whence = stdio.SEEK_SET
+      if (fcntl(fd.fd, F_SETLK, fl) != 0)
+        throw new IOException()
+    }
+    released = true
+  }
+}

--- a/posixlib/src/main/resources/scala-native/fcntl.c
+++ b/posixlib/src/main/resources/scala-native/fcntl.c
@@ -52,4 +52,23 @@ int scalanative_o_rdwr() { return O_RDWR; }
 
 int scalanative_o_wronly() { return O_WRONLY; }
 
+struct scalanative_flock {
+    off_t l_start;  /* starting offset */
+    off_t l_len;    /* len = 0 means until end of file */
+    pid_t l_pid;    /* lock owner */
+    short l_type;   /* lock type: read/write, etc. */
+    short l_whence; /* type of l_start */
+};
+
+int scalanative_fcntl(int fd, int cmd, struct scalanative_flock *flock_struct) {
+    struct flock *flock_buf;
+    flock_buf->l_start = flock_struct->l_start;
+    flock_buf->l_len = flock_struct->l_len;
+    flock_buf->l_pid = flock_struct->l_pid;
+    flock_buf->l_type = flock_struct->l_type;
+    flock_buf->l_whence = flock_struct->l_whence;
+
+    return fcntl(fd, cmd, flock_buf);
+}
+
 #endif // Unix or Mac OS

--- a/posixlib/src/main/resources/scala-native/fcntl.c
+++ b/posixlib/src/main/resources/scala-native/fcntl.c
@@ -61,14 +61,14 @@ struct scalanative_flock {
 };
 
 int scalanative_fcntl(int fd, int cmd, struct scalanative_flock *flock_struct) {
-    struct flock *flock_buf;
-    flock_buf->l_start = flock_struct->l_start;
-    flock_buf->l_len = flock_struct->l_len;
-    flock_buf->l_pid = flock_struct->l_pid;
-    flock_buf->l_type = flock_struct->l_type;
-    flock_buf->l_whence = flock_struct->l_whence;
+    struct flock flock_buf;
+    flock_buf.l_start = flock_struct->l_start;
+    flock_buf.l_len = flock_struct->l_len;
+    flock_buf.l_pid = flock_struct->l_pid;
+    flock_buf.l_type = flock_struct->l_type;
+    flock_buf.l_whence = flock_struct->l_whence;
 
-    return fcntl(fd, cmd, flock_buf);
+    return fcntl(fd, cmd, &flock_buf);
 }
 
 #endif // Unix or Mac OS

--- a/posixlib/src/main/resources/scala-native/sys/mman.c
+++ b/posixlib/src/main/resources/scala-native/sys/mman.c
@@ -1,14 +1,14 @@
 #include <sys/mman.h>
 
-int scalanative_prot_exec(){ return PROT_EXEC; }
-int scalanative_prot_read(){ return PROT_READ; }
-int scalanative_prot_write(){ return PROT_WRITE; }
-int scalanative_prot_none(){ return PROT_NONE; }
+int scalanative_prot_exec() { return PROT_EXEC; }
+int scalanative_prot_read() { return PROT_READ; }
+int scalanative_prot_write() { return PROT_WRITE; }
+int scalanative_prot_none() { return PROT_NONE; }
 
-int scalanative_map_shared(){ return MAP_SHARED; }
-int scalanative_map_private(){ return MAP_PRIVATE; }
-int scalanative_map_fixed(){ return MAP_FIXED; }
+int scalanative_map_shared() { return MAP_SHARED; }
+int scalanative_map_private() { return MAP_PRIVATE; }
+int scalanative_map_fixed() { return MAP_FIXED; }
 
-int scalanative_ms_sync(){ return MS_SYNC; }
-int scalanative_ms_async(){ return MS_ASYNC; }
-int scalanative_ms_invalidate(){ return MS_INVALIDATE; }
+int scalanative_ms_sync() { return MS_SYNC; }
+int scalanative_ms_async() { return MS_ASYNC; }
+int scalanative_ms_invalidate() { return MS_INVALIDATE; }

--- a/posixlib/src/main/resources/scala-native/sys/mman.c
+++ b/posixlib/src/main/resources/scala-native/sys/mman.c
@@ -1,3 +1,6 @@
+#if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
+    (defined(__APPLE__) && defined(__MACH__))
+
 #include <sys/mman.h>
 
 int scalanative_prot_exec() { return PROT_EXEC; }
@@ -12,3 +15,5 @@ int scalanative_map_fixed() { return MAP_FIXED; }
 int scalanative_ms_sync() { return MS_SYNC; }
 int scalanative_ms_async() { return MS_ASYNC; }
 int scalanative_ms_invalidate() { return MS_INVALIDATE; }
+
+#endif // Unix or Mac OS

--- a/posixlib/src/main/resources/scala-native/sys/mman.c
+++ b/posixlib/src/main/resources/scala-native/sys/mman.c
@@ -1,0 +1,14 @@
+#include <sys/mman.h>
+
+int scalanative_prot_exec(){ return PROT_EXEC; }
+int scalanative_prot_read(){ return PROT_READ; }
+int scalanative_prot_write(){ return PROT_WRITE; }
+int scalanative_prot_none(){ return PROT_NONE; }
+
+int scalanative_map_shared(){ return MAP_SHARED; }
+int scalanative_map_private(){ return MAP_PRIVATE; }
+int scalanative_map_fixed(){ return MAP_FIXED; }
+
+int scalanative_ms_sync(){ return MS_SYNC; }
+int scalanative_ms_async(){ return MS_ASYNC; }
+int scalanative_ms_invalidate(){ return MS_INVALIDATE; }

--- a/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
@@ -3,6 +3,8 @@ package posix
 
 import scalanative.unsafe._
 import scalanative.posix.sys.stat.mode_t
+import scala.scalanative.posix.unistd.off_t
+import scala.scalanative.posix.sys.types.pid_t
 
 @extern
 object fcntl {
@@ -12,6 +14,17 @@ object fcntl {
   def open(pathname: CString, flags: CInt, mode: mode_t): CInt = extern
 
   def fcntl(fd: CInt, cmd: CInt, flags: CInt): CInt = extern
+
+  @name("scalanative_fcntl")
+  def fcntl(fd: CInt, cmd: CInt, flock_struct: Ptr[flock]): CInt = extern
+
+  type flock = CStruct5[
+    off_t, // l_start starting offset
+    off_t, // l_len len = 0 means until end of file
+    pid_t, // l_pid lock owner
+    CInt, // l_type lock type: read/write, etc.
+    CInt // l_whence type of l_start
+  ]
 
   @name("scalanative_f_dupfd")
   def F_DUPFD: CInt = extern
@@ -87,4 +100,22 @@ object fcntl {
 
   @name("scalanative_o_wronly")
   def O_WRONLY: CInt = extern
+}
+
+object fcntlOps {
+  import fcntl._
+
+  implicit class flockOps(val ptr: Ptr[flock]) extends AnyVal {
+    def l_start: off_t = ptr._1
+    def l_start_=(value: off_t): Unit = ptr._1 = value
+    def l_len: off_t = ptr._2
+    def l_len_=(value: off_t): Unit = ptr._2 = value
+    def l_pid: pid_t = ptr._3
+    def l_pid_=(value: pid_t): Unit = ptr._3 = value
+    def l_type: CInt = ptr._4
+    def l_type_=(value: CInt): Unit = ptr._4 = value
+    def l_whence: CInt = ptr._5
+    def l_whence_=(value: CInt): Unit = ptr._5 = value
+  }
+
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
@@ -3,7 +3,6 @@ package posix
 package sys
 
 import scala.scalanative.unsafe._
-import scala.scalanative.unsigned._
 import scala.scalanative.unsafe.extern
 import scala.scalanative.posix.sys.types._
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
@@ -1,0 +1,49 @@
+package scala.scalanative
+package posix
+package sys
+ 
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+import scala.scalanative.unsafe.extern
+import scala.scalanative.posix.sys.types._
+
+@extern
+object mman{
+  def mmap(addr: Ptr[_], length: size_t, prot: CInt, flags: CInt,
+                  fd: CInt, offset: off_t): Ptr[Byte] = extern
+  
+  def munmap(addr: Ptr[_], length: size_t): CInt = extern
+
+  def msync(addr: Ptr[_], length: size_t, flags: CInt): CInt = extern
+
+  @name("scalanative_prot_exec")
+  def PROT_EXEC: CInt = extern
+
+  @name("scalanative_prot_read")
+  def PROT_READ: CInt = extern
+
+  @name("scalanative_prot_write")
+  def PROT_WRITE: CInt = extern
+
+  @name("scalanative_prot_none")
+  def PROT_NONE: CInt = extern
+
+  @name("scalanative_map_shared")
+  def MAP_SHARED: CInt = extern
+
+  @name("scalanative_map_private")
+  def MAP_PRIVATE: CInt = extern
+
+  @name("scalanative_map_fixed")
+  def MAP_FIXED: CInt = extern
+
+  @name("scalanative_ms_async")
+  def MS_ASYNC: CInt = extern
+
+  @name("scalanative_ms_invalidate")
+  def MS_SYNC: CInt = extern
+
+  @name("scalanative_ms_invalidate")
+  def MS_INVALIDATE: CInt = extern
+
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
@@ -1,17 +1,23 @@
 package scala.scalanative
 package posix
 package sys
- 
+
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 import scala.scalanative.unsafe.extern
 import scala.scalanative.posix.sys.types._
 
 @extern
-object mman{
-  def mmap(addr: Ptr[_], length: size_t, prot: CInt, flags: CInt,
-                  fd: CInt, offset: off_t): Ptr[Byte] = extern
-  
+object mman {
+  def mmap(
+      addr: Ptr[_],
+      length: size_t,
+      prot: CInt,
+      flags: CInt,
+      fd: CInt,
+      offset: off_t
+  ): Ptr[Byte] = extern
+
   def munmap(addr: Ptr[_], length: size_t): CInt = extern
 
   def msync(addr: Ptr[_], length: size_t, flags: CInt): CInt = extern

--- a/unit-tests/shared/src/test/scala/javalib/nio/MappedByteBufferTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/MappedByteBufferTest.scala
@@ -66,8 +66,9 @@ class MappedByteBufferTest {
       writeBytes(mapped, count)
       mapped.force()
 
-      assertEquals("File size after mapping", file.length(), count)
+      assertEquals("File length after mapping", file.length(), count)
 
+      ch.position(0)
       for (i <- 0 until count) {
         val expected = ('A'.toByte + i / 10).toByte
         assertEquals(f"Byte #${i}", file.read(), expected)
@@ -84,10 +85,11 @@ class MappedByteBufferTest {
       writeBytes(mapped, count)
       mapped.force()
 
-      assertEquals(file.length(), 100)
+      assertEquals("FIle length after mapping", file.length(), 100)
 
+      file.seek(0)
       for (i <- 0 until count) {
-        assertEquals(file.read(), 0)
+        assertEquals(s"Byte ${i}", file.read(), 0)
       }
     }
   }

--- a/unit-tests/shared/src/test/scala/javalib/nio/MappedByteBufferTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/MappedByteBufferTest.scala
@@ -13,8 +13,8 @@ import java.io._
 class MappedByteBufferTest {
 
   def writeBytes(buffer: ByteBuffer, count: Int): Unit = {
-    for(i <- 0 until count) {
-      val byte = ('A'.toByte + i/10).toByte
+    for (i <- 0 until count) {
+      val byte = ('A'.toByte + i / 10).toByte
       buffer.put(byte)
     }
   }
@@ -23,11 +23,14 @@ class MappedByteBufferTest {
     val file = File.createTempFile("test", ".tmp")
     val memoryMappedFile = new RandomAccessFile(file, mode)
     fn(memoryMappedFile)
-  }  
+  }
 
   @Test def readWriteOnReadOnlyFileThrowsException(): Unit = {
     withTemporaryFile("r") { file: RandomAccessFile =>
-      assertThrows(classOf[NonWritableChannelException], file.getChannel.map(MapMode.READ_WRITE, 0, 100))
+      assertThrows(
+        classOf[NonWritableChannelException],
+        file.getChannel.map(MapMode.READ_WRITE, 0, 100)
+      )
       file.getChannel().close()
     }
   }
@@ -35,8 +38,8 @@ class MappedByteBufferTest {
   @Test def readOnlyMappedBuffer(): Unit = {
     withTemporaryFile("rw") { file: RandomAccessFile =>
       val count = 100
-      for(i <- 0 until count) {
-        val byte = ('A'.toByte + i/10).toByte
+      for (i <- 0 until count) {
+        val byte = ('A'.toByte + i / 10).toByte
         file.writeByte(byte)
       }
       file.seek(0)
@@ -44,8 +47,8 @@ class MappedByteBufferTest {
       val mapped = ch.map(MapMode.READ_ONLY, 0, count)
       ch.close()
 
-      for(i <- 0 until count) {
-        val expected = ('A'.toByte + i/10).toByte
+      for (i <- 0 until count) {
+        val expected = ('A'.toByte + i / 10).toByte
         assertEquals(f"Byte #${i}", mapped.get(), expected)
       }
 
@@ -59,14 +62,14 @@ class MappedByteBufferTest {
       val count = 100
       val ch = file.getChannel()
       val mapped = ch.map(MapMode.READ_WRITE, 0, count)
-      
+
       writeBytes(mapped, count)
       mapped.force()
 
       assertEquals("File size after mapping", file.length(), count)
-      
-      for(i <- 0 until count) {
-        val expected = ('A'.toByte + i/10).toByte
+
+      for (i <- 0 until count) {
+        val expected = ('A'.toByte + i / 10).toByte
         assertEquals(f"Byte #${i}", file.read(), expected)
       }
       ch.close()
@@ -83,12 +86,11 @@ class MappedByteBufferTest {
 
       assertEquals(file.length(), 100)
 
-      for(i <- 0 until count) {
+      for (i <- 0 until count) {
         assertEquals(file.read(), 0)
       }
     }
   }
-
 
   // Apache Harmony tests
   var tmpFile: File = null
@@ -103,16 +105,16 @@ class MappedByteBufferTest {
     val fileChannel = fileOutputStream.getChannel();
     val byteBuffer = ByteBuffer.allocateDirect(26 + 20);
     for (i <- 0 until 26) {
-        byteBuffer.put(('A' + i).toByte);
+      byteBuffer.put(('A' + i).toByte);
     }
     for (i <- 0 until 5) {
-        byteBuffer.putInt(i + 1);
+      byteBuffer.putInt(i + 1);
     }
     byteBuffer.rewind();
     fileChannel.write(byteBuffer);
     fileChannel.close();
     fileOutputStream.close();
-    
+
     emptyFile = File.createTempFile("harmony", "test");
     emptyFile.deleteOnExit();
   }
@@ -122,62 +124,69 @@ class MappedByteBufferTest {
     // buffer was not mapped in read/write mode
     val fileInputStream = new FileInputStream(tmpFile);
     val fileChannelRead = fileInputStream.getChannel();
-    val mmbRead = fileChannelRead.map(MapMode.READ_ONLY, 0,
-            fileChannelRead.size());
+    val mmbRead =
+      fileChannelRead.map(MapMode.READ_ONLY, 0, fileChannelRead.size());
 
     mmbRead.force();
 
     val inputStream = new FileInputStream(tmpFile);
     val fileChannelR = inputStream.getChannel();
-    val resultRead = fileChannelR.map(MapMode.READ_ONLY, 0,
-            fileChannelR.size());
+    val resultRead =
+      fileChannelR.map(MapMode.READ_ONLY, 0, fileChannelR.size());
 
-    // If this buffer was not mapped in read/write mode, 
+    // If this buffer was not mapped in read/write mode,
     // then invoking this method has no effect.
     assertEquals(
-            "Invoking force() should have no effect when this buffer was not mapped in read/write mode",
-            mmbRead, resultRead);
+      "Invoking force() should have no effect when this buffer was not mapped in read/write mode",
+      mmbRead,
+      resultRead
+    );
 
     // Buffer was mapped in read/write mode
     val randomFile = new RandomAccessFile(tmpFile, "rw");
     val fileChannelReadWrite = randomFile.getChannel();
     val mmbReadWrite = fileChannelReadWrite.map(
-            MapMode.READ_WRITE, 0, fileChannelReadWrite.size());
+      MapMode.READ_WRITE,
+      0,
+      fileChannelReadWrite.size()
+    );
 
     mmbReadWrite.put('o'.toByte);
     mmbReadWrite.force();
 
     val random = new RandomAccessFile(tmpFile, "rw");
     val fileChannelRW = random.getChannel();
-    val resultReadWrite = fileChannelRW.map(
-            MapMode.READ_WRITE, 0, fileChannelRW.size());
+    val resultReadWrite =
+      fileChannelRW.map(MapMode.READ_WRITE, 0, fileChannelRW.size());
 
     // Invoking force() will change the buffer
     assertFalse(mmbReadWrite.equals(resultReadWrite));
-    
+
     fileChannelRead.close();
     fileChannelR.close();
     fileChannelReadWrite.close();
     fileChannelRW.close();
   }
 
-
   // Ported from Apache Harmony
   @Test def testLoad(): Unit = {
     val fileInputStream = new FileInputStream(tmpFile);
     val fileChannelRead = fileInputStream.getChannel();
-    val mmbRead = fileChannelRead.map(MapMode.READ_ONLY, 0,
-            fileChannelRead.size());
-    
+    val mmbRead =
+      fileChannelRead.map(MapMode.READ_ONLY, 0, fileChannelRead.size());
+
     assertEquals(mmbRead, mmbRead.load());
 
     val randomFile = new RandomAccessFile(tmpFile, "rw");
     val fileChannelReadWrite = randomFile.getChannel();
     val mmbReadWrite = fileChannelReadWrite.map(
-            MapMode.READ_WRITE, 0, fileChannelReadWrite.size());
+      MapMode.READ_WRITE,
+      0,
+      fileChannelReadWrite.size()
+    );
 
     assertEquals(mmbReadWrite, mmbReadWrite.load());
-    
+
     fileChannelRead.close();
     fileChannelReadWrite.close();
   }

--- a/unit-tests/shared/src/test/scala/javalib/nio/MappedByteBufferTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/MappedByteBufferTest.scala
@@ -1,0 +1,206 @@
+package javalib.nio
+
+import java.nio._
+import java.nio.channels.FileChannel.MapMode
+import java.nio.channels.NonWritableChannelException
+
+import org.junit.{Test, Before}
+import org.junit.Assert._
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
+
+import java.io._
+
+class MappedByteBufferTest {
+
+  def writeBytes(buffer: ByteBuffer, count: Int): Unit = {
+    for(i <- 0 until count) {
+      val byte = ('A'.toByte + i/10).toByte
+      buffer.put(byte)
+    }
+  }
+
+  def withTemporaryFile(mode: String)(fn: RandomAccessFile => Unit): Unit = {
+    val file = File.createTempFile("test", ".tmp")
+    val memoryMappedFile = new RandomAccessFile(file, mode)
+    fn(memoryMappedFile)
+  }  
+
+  @Test def readWriteOnReadOnlyFileThrowsException(): Unit = {
+    withTemporaryFile("r") { file: RandomAccessFile =>
+      assertThrows(classOf[NonWritableChannelException], file.getChannel.map(MapMode.READ_WRITE, 0, 100))
+      file.getChannel().close()
+    }
+  }
+
+  @Test def readOnlyMappedBuffer(): Unit = {
+    withTemporaryFile("rw") { file: RandomAccessFile =>
+      val count = 100
+      for(i <- 0 until count) {
+        val byte = ('A'.toByte + i/10).toByte
+        file.writeByte(byte)
+      }
+      file.seek(0)
+      val ch = file.getChannel()
+      val mapped = ch.map(MapMode.READ_ONLY, 0, count)
+      ch.close()
+
+      for(i <- 0 until count) {
+        val expected = ('A'.toByte + i/10).toByte
+        assertEquals(f"Byte #${i}", mapped.get(), expected)
+      }
+
+      mapped.position(0)
+      assertThrows(classOf[ReadOnlyBufferException], mapped.put(0.toByte))
+    }
+  }
+
+  @Test def readWriteMappedBuffer(): Unit = {
+    withTemporaryFile("rw") { file: RandomAccessFile =>
+      val count = 100
+      val ch = file.getChannel()
+      val mapped = ch.map(MapMode.READ_WRITE, 0, count)
+      
+      writeBytes(mapped, count)
+      mapped.force()
+
+      assertEquals("File size after mapping", file.length(), count)
+      
+      for(i <- 0 until count) {
+        val expected = ('A'.toByte + i/10).toByte
+        assertEquals(f"Byte #${i}", file.read(), expected)
+      }
+      ch.close()
+    }
+  }
+
+  @Test def privateMappedBuffer(): Unit = {
+    withTemporaryFile("rw") { file: RandomAccessFile =>
+      val count = 100
+      val mapped = file.getChannel.map(MapMode.PRIVATE, 0, count)
+
+      writeBytes(mapped, count)
+      mapped.force()
+
+      assertEquals(file.length(), 100)
+
+      for(i <- 0 until count) {
+        assertEquals(file.read(), 0)
+      }
+    }
+  }
+
+
+  // Apache Harmony tests
+  var tmpFile: File = null
+  var emptyFile: File = null
+
+  // Ported from Apache Harmony
+  @Before def setUp(): Unit = {
+    // Create temp file with 26 bytes and 5 ints
+    tmpFile = File.createTempFile("harmony", "test");
+    tmpFile.deleteOnExit();
+    val fileOutputStream = new FileOutputStream(tmpFile);
+    val fileChannel = fileOutputStream.getChannel();
+    val byteBuffer = ByteBuffer.allocateDirect(26 + 20);
+    for (i <- 0 until 26) {
+        byteBuffer.put(('A' + i).toByte);
+    }
+    for (i <- 0 until 5) {
+        byteBuffer.putInt(i + 1);
+    }
+    byteBuffer.rewind();
+    fileChannel.write(byteBuffer);
+    fileChannel.close();
+    fileOutputStream.close();
+    
+    emptyFile = File.createTempFile("harmony", "test");
+    emptyFile.deleteOnExit();
+  }
+
+  // Ported from Apache Harmony
+  @Test def testForce(): Unit = {
+    // buffer was not mapped in read/write mode
+    val fileInputStream = new FileInputStream(tmpFile);
+    val fileChannelRead = fileInputStream.getChannel();
+    val mmbRead = fileChannelRead.map(MapMode.READ_ONLY, 0,
+            fileChannelRead.size());
+
+    mmbRead.force();
+
+    val inputStream = new FileInputStream(tmpFile);
+    val fileChannelR = inputStream.getChannel();
+    val resultRead = fileChannelR.map(MapMode.READ_ONLY, 0,
+            fileChannelR.size());
+
+    // If this buffer was not mapped in read/write mode, 
+    // then invoking this method has no effect.
+    assertEquals(
+            "Invoking force() should have no effect when this buffer was not mapped in read/write mode",
+            mmbRead, resultRead);
+
+    // Buffer was mapped in read/write mode
+    val randomFile = new RandomAccessFile(tmpFile, "rw");
+    val fileChannelReadWrite = randomFile.getChannel();
+    val mmbReadWrite = fileChannelReadWrite.map(
+            MapMode.READ_WRITE, 0, fileChannelReadWrite.size());
+
+    mmbReadWrite.put('o'.toByte);
+    mmbReadWrite.force();
+
+    val random = new RandomAccessFile(tmpFile, "rw");
+    val fileChannelRW = random.getChannel();
+    val resultReadWrite = fileChannelRW.map(
+            MapMode.READ_WRITE, 0, fileChannelRW.size());
+
+    // Invoking force() will change the buffer
+    assertFalse(mmbReadWrite.equals(resultReadWrite));
+    
+    fileChannelRead.close();
+    fileChannelR.close();
+    fileChannelReadWrite.close();
+    fileChannelRW.close();
+  }
+
+
+  // Ported from Apache Harmony
+  @Test def testLoad(): Unit = {
+    val fileInputStream = new FileInputStream(tmpFile);
+    val fileChannelRead = fileInputStream.getChannel();
+    val mmbRead = fileChannelRead.map(MapMode.READ_ONLY, 0,
+            fileChannelRead.size());
+    
+    assertEquals(mmbRead, mmbRead.load());
+
+    val randomFile = new RandomAccessFile(tmpFile, "rw");
+    val fileChannelReadWrite = randomFile.getChannel();
+    val mmbReadWrite = fileChannelReadWrite.map(
+            MapMode.READ_WRITE, 0, fileChannelReadWrite.size());
+
+    assertEquals(mmbReadWrite, mmbReadWrite.load());
+    
+    fileChannelRead.close();
+    fileChannelReadWrite.close();
+  }
+
+  // Ported from Apache Harmony
+  @Test def testPosition(): Unit = {
+    val tmp = File.createTempFile("hmy", "tmp");
+    tmp.deleteOnExit();
+    val f = new RandomAccessFile(tmp, "rw");
+    val ch = f.getChannel();
+    val mbb = ch.map(MapMode.READ_WRITE, 0L, 100L);
+    ch.close();
+
+    mbb.putInt(1, 1);
+    mbb.position(50);
+    mbb.putInt(50);
+
+    mbb.flip();
+    mbb.get();
+    assertEquals(1, mbb.getInt());
+
+    mbb.position(50);
+    assertEquals(50, mbb.getInt());
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/javalib/nio/channels/FileChannelTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/channels/FileChannelTest.scala
@@ -10,6 +10,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
+import java.io.{FileInputStream, FileOutputStream}
 
 class FileChannelTest {
   @Test def fileChannelCanReadBufferFromFile(): Unit = {
@@ -163,6 +164,50 @@ class FileChannelTest {
       assertTrue(newLines.get(0) == "hello, world")
     }
   }
+
+  // @Test def getChannelFromFileInputStreamCoherency(): Unit = {
+  //   withTemporaryDirectory { dir =>
+  //     val f = dir.resolve("f")
+  //     val bytes = Array.apply[Byte](1, 2, 3, 4, 5)
+  //     Files.write(f, bytes)
+  //     val in = new FileInputStream(f.toString())
+  //     val channel = in.getChannel()
+  //     val read345 = ByteBuffer.allocate(3)
+
+  //     in.read()
+  //     in.read()
+  //     channel.read(read345)
+
+  //     var i = 2
+  //     while (i < bytes.length) {
+  //       assertEquals(f"Byte#$i", read345.get(i - 2), bytes(i))
+  //       i += 1
+  //     }
+  //   }
+  // }
+
+  // @Test def getChannelFromFileOutputStreamCoherency(): Unit = {
+  //   withTemporaryDirectory { dir =>
+  //     val f = dir.resolve("f")
+  //     val out = new FileOutputStream(f.toString())
+  //     val channel = out.getChannel()
+
+  //     val bytes = Array.apply[Byte](1, 2, 3, 4, 5)
+
+  //     var i = 0
+  //     while (i < 3) {
+  //       out.write(bytes(i))
+  //       i += 1
+  //     }
+  //     while (i < bytes.length) {
+  //       channel.write(ByteBuffer.wrap(Array[Byte](bytes(i))))
+  //       i += 1
+  //     }
+  //     val readb = Files.readAllBytes(f)
+  //     println(new String(readb))
+  //     assertTrue(bytes sameElements readb)
+  //   }
+  // }
 
   def withTemporaryDirectory(fn: Path => Unit) {
     val file = File.createTempFile("test", ".tmp")

--- a/unit-tests/shared/src/test/scala/javalib/nio/channels/FileChannelTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/channels/FileChannelTest.scala
@@ -170,7 +170,7 @@ class FileChannelTest {
     withTemporaryDirectory { dir =>
       val f = dir.resolve("f")
       Files.write(f, "hello".getBytes("UTF-8"))
-      val channel = new RandomAccessFile(f.toFile(),"rw").getChannel()
+      val channel = new RandomAccessFile(f.toFile(), "rw").getChannel()
       assertEquals(channel.position(), 0)
       channel.position(3)
       assertEquals(channel.position(), 3)

--- a/unit-tests/shared/src/test/scala/javalib/nio/channels/FileChannelTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/channels/FileChannelTest.scala
@@ -165,49 +165,49 @@ class FileChannelTest {
     }
   }
 
-  // @Test def getChannelFromFileInputStreamCoherency(): Unit = {
-  //   withTemporaryDirectory { dir =>
-  //     val f = dir.resolve("f")
-  //     val bytes = Array.apply[Byte](1, 2, 3, 4, 5)
-  //     Files.write(f, bytes)
-  //     val in = new FileInputStream(f.toString())
-  //     val channel = in.getChannel()
-  //     val read345 = ByteBuffer.allocate(3)
+  @Test def getChannelFromFileInputStreamCoherency(): Unit = {
+    withTemporaryDirectory { dir =>
+      val f = dir.resolve("f")
+      val bytes = Array.apply[Byte](1, 2, 3, 4, 5)
+      Files.write(f, bytes)
+      val in = new FileInputStream(f.toString())
+      val channel = in.getChannel()
+      val read345 = ByteBuffer.allocate(3)
 
-  //     in.read()
-  //     in.read()
-  //     channel.read(read345)
+      in.read()
+      in.read()
+      channel.read(read345)
 
-  //     var i = 2
-  //     while (i < bytes.length) {
-  //       assertEquals(f"Byte#$i", read345.get(i - 2), bytes(i))
-  //       i += 1
-  //     }
-  //   }
-  // }
+      var i = 2
+      while (i < bytes.length) {
+        assertEquals(f"Byte#$i", read345.get(i - 2), bytes(i))
+        i += 1
+      }
+    }
+  }
 
-  // @Test def getChannelFromFileOutputStreamCoherency(): Unit = {
-  //   withTemporaryDirectory { dir =>
-  //     val f = dir.resolve("f")
-  //     val out = new FileOutputStream(f.toString())
-  //     val channel = out.getChannel()
+  @Test def getChannelFromFileOutputStreamCoherency(): Unit = {
+    withTemporaryDirectory { dir =>
+      val f = dir.resolve("f")
+      val out = new FileOutputStream(f.toString())
+      val channel = out.getChannel()
 
-  //     val bytes = Array.apply[Byte](1, 2, 3, 4, 5)
+      val bytes = Array.apply[Byte](1, 2, 3, 4, 5)
 
-  //     var i = 0
-  //     while (i < 3) {
-  //       out.write(bytes(i))
-  //       i += 1
-  //     }
-  //     while (i < bytes.length) {
-  //       channel.write(ByteBuffer.wrap(Array[Byte](bytes(i))))
-  //       i += 1
-  //     }
-  //     val readb = Files.readAllBytes(f)
-  //     println(new String(readb))
-  //     assertTrue(bytes sameElements readb)
-  //   }
-  // }
+      var i = 0
+      while (i < 3) {
+        out.write(bytes(i))
+        i += 1
+      }
+      while (i < bytes.length) {
+        channel.write(ByteBuffer.wrap(Array[Byte](bytes(i))))
+        i += 1
+      }
+      val readb = Files.readAllBytes(f)
+      println(new String(readb))
+      assertTrue(bytes sameElements readb)
+    }
+  }
 
   def withTemporaryDirectory(fn: Path => Unit) {
     val file = File.createTempFile("test", ".tmp")

--- a/unit-tests/shared/src/test/scala/javalib/nio/channels/FileLockTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/channels/FileLockTest.scala
@@ -2,8 +2,8 @@ package javalib.nio.channels
 
 // Ported from Apache Harmony
 
-import java.io.{File, FileOutputStream, IOException, RandomAccessFile}
-import java.nio.channels.{ClosedChannelException, FileChannel, FileLock}
+import java.io.{File, RandomAccessFile}
+import java.nio.channels.{FileChannel, FileLock}
 
 import org.junit.{Test, Before, After}
 import org.junit.Assert._

--- a/unit-tests/shared/src/test/scala/javalib/nio/channels/FileLockTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/channels/FileLockTest.scala
@@ -1,20 +1,6 @@
-/* Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-// Ported from apache harmony
 package javalib.nio.channels
+
+// Ported from Apache Harmony
 
 import java.io.{File, FileOutputStream, IOException, RandomAccessFile}
 import java.nio.channels.{ClosedChannelException, FileChannel, FileLock}
@@ -36,15 +22,13 @@ class FileLockTest {
       shared: Boolean
   ) extends FileLock(channel, position, size, shared) {
 
-    var valid = true
+    private var valid = true
 
-    def isValid(): Boolean = {
-      return valid
-    }
+    def isValid(): Boolean =
+      valid
 
-    def release() = {
+    def release() =
       valid = false
-    }
   }
 
   @Before def setUp(): Unit = {

--- a/unit-tests/shared/src/test/scala/javalib/nio/channels/FileLockTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/channels/FileLockTest.scala
@@ -1,0 +1,164 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Ported from apache harmony
+package javalib.nio.channels
+
+import java.io.{File, FileOutputStream, IOException, RandomAccessFile}
+import java.nio.channels.{ClosedChannelException, FileChannel, FileLock}
+
+import org.junit.{Test, Before, After}
+import org.junit.Assert._
+
+import scalanative.junit.utils.AssertThrows.assertThrows
+
+class FileLockTest {
+
+  private var readWriteChannel: FileChannel = null
+  private var mockLock: MockFileLock = null
+
+  class MockFileLock(
+      channel: FileChannel,
+      position: Long,
+      size: Long,
+      shared: Boolean
+  ) extends FileLock(channel, position, size, shared) {
+
+    var valid = true
+
+    def isValid(): Boolean = {
+      return valid
+    }
+
+    def release() = {
+      valid = false
+    }
+  }
+
+  @Before def setUp(): Unit = {
+    val tempFile = File.createTempFile("testing", "tmp")
+    tempFile.deleteOnExit()
+    val randomAccessFile = new RandomAccessFile(tempFile, "rw")
+    readWriteChannel = randomAccessFile.getChannel()
+    mockLock = new MockFileLock(readWriteChannel, 10, 100, false)
+  }
+
+  @After def tearDown(): Unit = {
+    if (readWriteChannel != null) {
+      readWriteChannel.close()
+    }
+  }
+
+  /** @tests
+   *    java.nio.channels.FileLock#FileLock(FileChannel, long, long, boolean)
+   */
+  @Test def test_Constructor_Ljava_nio_channels_FileChannelJJZ(): Unit = {
+    val fileLock1 = new MockFileLock(null, 0, 0, false)
+    assertNull(fileLock1.channel())
+    assertThrows(
+      classOf[IllegalArgumentException],
+      new MockFileLock(readWriteChannel, -1, 0, false)
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      new MockFileLock(readWriteChannel, 0, -1, false)
+    )
+  }
+
+  /** @tests
+   *    java.nio.channels.FileLock#channel()
+   */
+  @Test def test_channel(): Unit = {
+    assertSame(readWriteChannel, mockLock.channel())
+    val lock = new MockFileLock(null, 0, 10, true)
+    assertNull(lock.channel())
+  }
+
+  /** @tests
+   *    java.nio.channels.FileLock#position()
+   */
+  @Test def test_position(): Unit = {
+    val fileLock1 = new MockFileLock(readWriteChannel, 20, 100, true)
+    assertEquals(20, fileLock1.position())
+
+    val position = Integer.MAX_VALUE.toLong + 1
+    val fileLock2 = new MockFileLock(readWriteChannel, position, 100, true)
+    assertEquals(position, fileLock2.position())
+  }
+
+  /** @tests
+   *    java.nio.channels.FileLock#size()
+   */
+  @Test def test_size(): Unit = {
+    val fileLock1 = new MockFileLock(readWriteChannel, 20, 100, true)
+    assertEquals(100, fileLock1.size())
+
+    val position = 0x0fffffffffffffffL
+    val size = Integer.MAX_VALUE.toLong + 1
+    val fileLock2 = new MockFileLock(readWriteChannel, position, size, true)
+    assertEquals(size, fileLock2.size())
+  }
+
+  /** @tests
+   *    java.nio.channels.FileLock#isShared()
+   */
+  @Test def test_isShared(): Unit = {
+    assertFalse(mockLock.isShared())
+    val lock = new MockFileLock(null, 0, 10, true)
+    assertTrue(lock.isShared())
+  }
+
+  /** @tests
+   *    java.nio.channels.FileLock#overlaps(long, long)
+   */
+  @Test def test_overlaps_JJ(): Unit = {
+    assertTrue("mockLock.overlaps(0, 11)", mockLock.overlaps(0, 11))
+    assertFalse("mockLock.overlaps(0, 10)", mockLock.overlaps(0, 10))
+    assertTrue("mockLock.overlaps(100, 110)", mockLock.overlaps(100, 110))
+    assertTrue("mockLock.overlaps(99, 110)", mockLock.overlaps(99, 110))
+    assertFalse("mockLock.overlaps(-1, 10)", mockLock.overlaps(-1, 10))
+  }
+
+  /** @tests
+   *    java.nio.channels.FileLock#isValid()
+   */
+  @Test def test_isValid(): Unit = {
+    val fileLock = readWriteChannel.lock()
+    assertTrue(fileLock.isValid())
+    fileLock.release()
+    assertFalse(fileLock.isValid())
+  }
+
+  /** @tests
+   *    java.nio.channels.FileLock#release()
+   */
+//   @Test def test_release(): Unit = {
+//     val file = File.createTempFile("test", "tmp");
+//     file.deleteOnExit();
+//     val fout = new FileOutputStream(file);
+//     val fileChannel = fout.getChannel();
+//     val fileLock = fileChannel.lock();
+//     fileChannel.close();
+//     assertThrows(classOf[ClosedChannelException], fileLock.release())
+
+//     // release after release
+//     val fout2 = new FileOutputStream(file);
+//     val fileChannel2 = fout.getChannel();
+//     val fileLock2 = fileChannel.lock();
+//     fileLock2.release();
+//     fileChannel2.close();
+//     assertThrows(classOf[ClosedChannelException], fileLock2.release())
+//   }
+}

--- a/unit-tests/shared/src/test/scala/javalib/nio/channels/FileLockTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/channels/FileLockTest.scala
@@ -45,10 +45,7 @@ class FileLockTest {
     }
   }
 
-  /** @tests
-   *    java.nio.channels.FileLock#FileLock(FileChannel, long, long, boolean)
-   */
-  @Test def test_Constructor_Ljava_nio_channels_FileChannelJJZ(): Unit = {
+  @Test def testConstructorLjava_nio_channels_FileChannelJJZ(): Unit = {
     val fileLock1 = new MockFileLock(null, 0, 0, false)
     assertNull(fileLock1.channel())
     assertThrows(
@@ -61,19 +58,13 @@ class FileLockTest {
     )
   }
 
-  /** @tests
-   *    java.nio.channels.FileLock#channel()
-   */
-  @Test def test_channel(): Unit = {
+  @Test def testChannel(): Unit = {
     assertSame(readWriteChannel, mockLock.channel())
     val lock = new MockFileLock(null, 0, 10, true)
     assertNull(lock.channel())
   }
 
-  /** @tests
-   *    java.nio.channels.FileLock#position()
-   */
-  @Test def test_position(): Unit = {
+  @Test def testPosition(): Unit = {
     val fileLock1 = new MockFileLock(readWriteChannel, 20, 100, true)
     assertEquals(20, fileLock1.position())
 
@@ -82,10 +73,7 @@ class FileLockTest {
     assertEquals(position, fileLock2.position())
   }
 
-  /** @tests
-   *    java.nio.channels.FileLock#size()
-   */
-  @Test def test_size(): Unit = {
+  @Test def testSize(): Unit = {
     val fileLock1 = new MockFileLock(readWriteChannel, 20, 100, true)
     assertEquals(100, fileLock1.size())
 
@@ -95,19 +83,13 @@ class FileLockTest {
     assertEquals(size, fileLock2.size())
   }
 
-  /** @tests
-   *    java.nio.channels.FileLock#isShared()
-   */
-  @Test def test_isShared(): Unit = {
+  @Test def testIsShared(): Unit = {
     assertFalse(mockLock.isShared())
     val lock = new MockFileLock(null, 0, 10, true)
     assertTrue(lock.isShared())
   }
 
-  /** @tests
-   *    java.nio.channels.FileLock#overlaps(long, long)
-   */
-  @Test def test_overlaps_JJ(): Unit = {
+  @Test def testOverlapsJJ(): Unit = {
     assertTrue("mockLock.overlaps(0, 11)", mockLock.overlaps(0, 11))
     assertFalse("mockLock.overlaps(0, 10)", mockLock.overlaps(0, 10))
     assertTrue("mockLock.overlaps(100, 110)", mockLock.overlaps(100, 110))
@@ -115,34 +97,11 @@ class FileLockTest {
     assertFalse("mockLock.overlaps(-1, 10)", mockLock.overlaps(-1, 10))
   }
 
-  /** @tests
-   *    java.nio.channels.FileLock#isValid()
-   */
-  @Test def test_isValid(): Unit = {
+  @Test def testIsValid(): Unit = {
     val fileLock = readWriteChannel.lock()
     assertTrue(fileLock.isValid())
     fileLock.release()
     assertFalse(fileLock.isValid())
   }
 
-  /** @tests
-   *    java.nio.channels.FileLock#release()
-   */
-//   @Test def test_release(): Unit = {
-//     val file = File.createTempFile("test", "tmp");
-//     file.deleteOnExit();
-//     val fout = new FileOutputStream(file);
-//     val fileChannel = fout.getChannel();
-//     val fileLock = fileChannel.lock();
-//     fileChannel.close();
-//     assertThrows(classOf[ClosedChannelException], fileLock.release())
-
-//     // release after release
-//     val fout2 = new FileOutputStream(file);
-//     val fileChannel2 = fout.getChannel();
-//     val fileLock2 = fileChannel.lock();
-//     fileLock2.release();
-//     fileChannel2.close();
-//     assertThrows(classOf[ClosedChannelException], fileLock2.release())
-//   }
 }

--- a/windowslib/src/main/resources/scala-native/windows/memory.c
+++ b/windowslib/src/main/resources/scala-native/windows/memory.c
@@ -2,12 +2,14 @@
 #define WIN32_LEAN_AND_MEAN
 #import <windows.h>
 
-DWORD scalanative_file_map_all_access() { FILE_MAP_ALL_ACCESS }
-DWORD scalanative_file_map_read() { FILE_MAP_READ }
-DWORD scalanative_file_map_write() { FILE_MAP_WRITE }
-DWORD scalanative_file_map_copy() { FILE_MAP_COPY }
-DWORD scalanative_file_map_execute() { FILE_MAP_EXECUTE }
-DWORD scalanative_file_map_large_pages() { FILE_MAP_LARGE_PAGES }
-DWORD scalanative_file_map_targets_invalid() { FILE_MAP_TARGETS_INVALID }
+DWORD scalanative_file_map_all_access() { return FILE_MAP_ALL_ACCESS; }
+DWORD scalanative_file_map_read() { return FILE_MAP_READ; }
+DWORD scalanative_file_map_write() { return FILE_MAP_WRITE; }
+DWORD scalanative_file_map_copy() { return FILE_MAP_COPY; }
+DWORD scalanative_file_map_execute() { return FILE_MAP_EXECUTE; }
+DWORD scalanative_file_map_large_pages() { return FILE_MAP_LARGE_PAGES; }
+DWORD scalanative_file_map_targets_invalid() {
+    return FILE_MAP_TARGETS_INVALID;
+}
 
 #endif // defined(Win32)

--- a/windowslib/src/main/resources/scala-native/windows/memory.c
+++ b/windowslib/src/main/resources/scala-native/windows/memory.c
@@ -1,0 +1,13 @@
+#if defined(_WIN32) || defined(WIN32)
+#define WIN32_LEAN_AND_MEAN
+#import <windows.h>
+
+DWORD scalanative_file_map_all_access() { FILE_MAP_ALL_ACCESS }
+DWORD scalanative_file_map_read() { FILE_MAP_READ }
+DWORD scalanative_file_map_write() { FILE_MAP_WRITE }
+DWORD scalanative_file_map_copy() { FILE_MAP_COPY }
+DWORD scalanative_file_map_execute() { FILE_MAP_EXECUTE }
+DWORD scalanative_file_map_large_pages() { FILE_MAP_LARGE_PAGES }
+DWORD scalanative_file_map_targets_invalid() { FILE_MAP_TARGETS_INVALID }
+
+#endif // defined(Win32)

--- a/windowslib/src/main/resources/scala-native/windows/memory.c
+++ b/windowslib/src/main/resources/scala-native/windows/memory.c
@@ -1,6 +1,7 @@
 #if defined(_WIN32) || defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
-#import <windows.h>
+#include <windows.h>
+#include <Winbase.h>
 
 DWORD scalanative_file_map_all_access() { return FILE_MAP_ALL_ACCESS; }
 DWORD scalanative_file_map_read() { return FILE_MAP_READ; }
@@ -12,4 +13,4 @@ DWORD scalanative_file_map_targets_invalid() {
     return FILE_MAP_TARGETS_INVALID;
 }
 
-#endif // defined(Win32)
+#endif // defined(_WIN32)

--- a/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
@@ -192,6 +192,22 @@ object FileApi {
       bytesWritten: Ptr[DWord],
       overlapped: Ptr[Byte]
   ): Boolean = extern
+
+  def LockFile(
+      hfile: Handle,
+      dwFileOffsetLow: DWord,
+      dwFileOffsetHigh: DWord,
+      nNumberOfBytesToLockLow: DWord,
+      nNumberOfBytesToLockHigh: DWord
+  ): Boolean = extern
+
+  def UnlockFile(
+      hfile: Handle,
+      dwFileOffsetLow: DWord,
+      dwFileOffsetHigh: DWord,
+      nNumberOfBytesToUnlockLow: DWord,
+      nNumberOfBytesToUnlockHigh: DWord
+  ): Boolean = extern
 }
 
 object FileApiExt {

--- a/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/FileApi.scala
@@ -201,6 +201,15 @@ object FileApi {
       nNumberOfBytesToLockHigh: DWord
   ): Boolean = extern
 
+  def LockFileEx(
+      hfile: Handle,
+      dwFlags: DWord,
+      dwReserved: DWord,
+      nNumberOfBytesToLockLow: DWord,
+      nNumberOfBytesToLockHigh: DWord,
+      lpOverlapped: Ptr[_OVERLAPPED]
+  ): Boolean = extern
+
   def UnlockFile(
       hfile: Handle,
       dwFileOffsetLow: DWord,
@@ -279,6 +288,10 @@ object FileApiExt {
   final val VOLUME_NAME_GUID = 0x01.toUInt
   final val VOLUME_NAME_NT = 0x02.toUInt
   final val VOLUME_NAME_NONE = 0x04.toUInt
+
+  // File lock flags
+  final val LOCKFILE_EXCLUSIVE_LOCK = 0x00000002.toUInt
+  final val LOCKFILE_FAIL_IMMEDIATELY = 0x00000001.toUInt
 }
 
 object FileApiOps {

--- a/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
@@ -1,7 +1,6 @@
 package scala.scalanative.windows
 
 import scala.scalanative.windows.HandleApi.Handle
-import scala.scalanative.unsigned._
 import scala.scalanative.unsafe._
 
 @extern

--- a/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
@@ -1,0 +1,46 @@
+package scala.scalanative.windows
+
+import scala.scalanative.windows.HandleApi.Handle
+import scala.scalanative.unsigned._
+import scala.scalanative.unsafe._
+
+@extern
+object MemoryApi {
+
+  def MapViewOfFile(
+      hFileMappingObject: Handle,
+      dwDesiredAccess: DWord,
+      dwFileOffsetHigh: DWord,
+      dwFileOffsetLow: DWord,
+      dwNumberOfBytesToMap: DWord
+  ): Ptr[Byte] = extern
+
+  def UnmapViewOfFile(lpBaseAddress: Ptr[Byte]): Boolean = extern
+
+  def FlushViewOfFile(
+      lpBaseAddress: Ptr[Byte],
+      dwNumberOfBytesToFlush: DWord
+  ): Boolean = extern
+
+  @name("scalanative_file_map_all_access")
+  def FILE_MAP_ALL_ACCESS: DWord = extern
+
+  @name("scalanative_file_map_read")
+  def FILE_MAP_READ: DWord = extern
+
+  @name("scalanative_file_map_write")
+  def FILE_MAP_WRITE: DWord = extern
+
+  @name("scalanative_file_map_copy")
+  def FILE_MAP_COPY: DWord = extern
+
+  @name("scalanative_file_map_execute")
+  def FILE_MAP_EXECUTE: DWord = extern
+
+  @name("scalanative_file_map_large_pages")
+  def FILE_MAP_LARGE_PAGES: DWord = extern
+
+  @name("scalanative_file_map_targets_invalid")
+  def FILE_MAP_TARGETS_INVALID: DWord = extern
+
+}

--- a/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/MemoryApi.scala
@@ -12,7 +12,7 @@ object MemoryApi {
       dwDesiredAccess: DWord,
       dwFileOffsetHigh: DWord,
       dwFileOffsetLow: DWord,
-      dwNumberOfBytesToMap: DWord
+      dwNumberOfBytesToMap: CSize
   ): Ptr[Byte] = extern
 
   def UnmapViewOfFile(lpBaseAddress: Ptr[Byte]): Boolean = extern

--- a/windowslib/src/main/scala/scala/scalanative/windows/MinWinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/MinWinBaseApi.scala
@@ -4,11 +4,14 @@ import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 import scala.language.implicitConversions
 import scala.scalanative.windows.util.Conversion
+import HandleApi._
 
 object MinWinBaseApi {
   type FileTime = ULargeInteger
   type FileTimeStruct = CStruct2[DWord, DWord]
   type SystemTime = CStruct8[Word, Word, Word, Word, Word, Word, Word, Word]
+  type DUMMYSTRUCTNAME = CStruct2[DWord, DWord]
+  type _OVERLAPPED = CStruct4[ULong, ULong, DUMMYSTRUCTNAME, Handle]
 }
 
 object MinWinBaseApiOps {
@@ -76,5 +79,26 @@ object MinWinBaseApiOps {
     def minute_=(v: Word): Unit = ref._6
     def second_=(v: Word): Unit = ref._7
     def milliseconds_=(v: Word): Unit = ref._8
+  }
+
+  implicit class OverlappedOps(val ref: Ptr[_OVERLAPPED]) extends AnyVal {
+    def Internal: ULong = ref._1
+    def InternalHigh: ULong = ref._2
+    def DUMMYSTRUCTNAME: DUMMYSTRUCTNAME = ref._3
+    def hEvent: Handle = ref._4
+
+    def Internal_=(v: ULong): Unit = ref._1 = v
+    def InternalHigh_=(v: ULong): Unit = ref._2 = v
+    def DUMMYSTRUCTNAME_=(v: DUMMYSTRUCTNAME): Unit = ref._3 = v
+    def hEvent_=(v: Handle): Unit = ref._4 = v
+  }
+
+  implicit class DUMMYSTRUCTNAMEOps(val ref: Ptr[DUMMYSTRUCTNAME])
+      extends AnyVal {
+    def Offset: DWord = ref._1
+    def OffsetHigh: DWord = ref._2
+
+    def Offset_=(v: DWord) = ref._1 = v
+    def OffsetHigh_=(v: DWord) = ref._2 = v
   }
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
@@ -118,6 +118,15 @@ object WinBaseApi {
 
   def UnregisterWait(handle: Handle): Boolean = extern
 
+  def CreateFileMappingA(
+      hFile: Handle,
+      lpFileMappingAttributes: SecurityAttributes,
+      flProtect: DWord,
+      dwMaximumSizeHigh: DWord,
+      dwMaximumSizeLow: DWord,
+      lpName: Ptr[Byte]
+  ): Handle = extern
+
   @name("scalanative_win32_default_language")
   final def DefaultLanguageId: DWord = extern
 }
@@ -177,4 +186,9 @@ object WinBaseApiOps {
     def securityDescriptor_=(v: Ptr[Byte]): Unit = ref._2 = v
     def inheritHandle_=(v: Boolean): Unit = ref._3 = v
   }
+
+  final val PAGE_READONLY: DWord = 0x02.toUInt
+  final val PAGE_READWRITE: DWord = 0x04.toUInt
+  final val PAGE_WRITECOPY: DWord = 0x08.toUInt
+
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
@@ -172,6 +172,10 @@ object WinBaseApiExt {
   final val PROTECTED_SACL_SECURITY_INFORMATION = 0x40000000L.toUInt
   final val UNPROTECTED_DACL_SECURITY_INFORMATION = 0x20000000L.toUInt
   final val UNPROTECTED_SACL_SECURITY_INFORMATION = 0x10000000L.toUInt
+
+  final val PAGE_READONLY: DWord = 0x02.toUInt
+  final val PAGE_READWRITE: DWord = 0x04.toUInt
+  final val PAGE_WRITECOPY: DWord = 0x08.toUInt
 }
 
 object WinBaseApiOps {
@@ -186,9 +190,4 @@ object WinBaseApiOps {
     def securityDescriptor_=(v: Ptr[Byte]): Unit = ref._2 = v
     def inheritHandle_=(v: Boolean): Unit = ref._3 = v
   }
-
-  final val PAGE_READONLY: DWord = 0x02.toUInt
-  final val PAGE_READWRITE: DWord = 0x04.toUInt
-  final val PAGE_WRITECOPY: DWord = 0x08.toUInt
-
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
@@ -124,7 +124,16 @@ object WinBaseApi {
       flProtect: DWord,
       dwMaximumSizeHigh: DWord,
       dwMaximumSizeLow: DWord,
-      lpName: Ptr[Byte]
+      lpName: CString
+  ): Handle = extern
+
+  def CreateFileMappingW(
+      hFile: Handle,
+      lpFileMappingAttributes: SecurityAttributes,
+      flProtect: DWord,
+      dwMaximumSizeHigh: DWord,
+      dwMaximumSizeLow: DWord,
+      lpName: CWString
   ): Handle = extern
 
   @name("scalanative_win32_default_language")
@@ -173,9 +182,9 @@ object WinBaseApiExt {
   final val UNPROTECTED_DACL_SECURITY_INFORMATION = 0x20000000L.toUInt
   final val UNPROTECTED_SACL_SECURITY_INFORMATION = 0x10000000L.toUInt
 
-  final val PAGE_READONLY: DWord = 0x02.toUInt
-  final val PAGE_READWRITE: DWord = 0x04.toUInt
-  final val PAGE_WRITECOPY: DWord = 0x08.toUInt
+  final val PAGE_READONLY = 0x02.toUInt
+  final val PAGE_READWRITE = 0x04.toUInt
+  final val PAGE_WRITECOPY = 0x08.toUInt
 }
 
 object WinBaseApiOps {


### PR DESCRIPTION
Add missing FileChannel functionality
This includes:
* Now FileInputStream, FileOutputStream and RandomAccessFile can return a FileChannel, with file pointers being consistent between the two (like it happens in JVM)
* With that came a minor refactorization of the four classes. Before, a FileChannel was composed of a Random Access File, which could be composed of a FileInputStream and FileOutputStream. Now, RAF can contain all three of the other, with FileInputStream and FileOutputStream depending on FIleChannel as well. To achieve this, some methods were moved from the three classes to FileChannel.
* File locking via lock() and tryLock() methods, with majority of the tests ported from Apache Harmony.
* MappedByteBuffer support via the map() method, with finalization done through WeakReferenceRegistry implemented in a previous PR. This is important, as Java Api does not provide any other way to unmap a file. Some of the tests were ported from apache harmony.

The finalization ended up being somewhat messy. My hope was to use partially applied functions, however tracing references in GC revealed that `this` is always being passed to them, so the data and method was moved to another class, which also registers the function to WeakReferenceRegistry. Perhaps we should redesign WeakReferenceRegistry to simply contain Finalization objects instead of functions, to remove ambiguity about the feature (I’m thinking about the potential future contributors here). 
