### PR TITLE
Sbt nativeLink command should fail in case of clang failure

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -65,7 +65,7 @@ private[scalanative] object LLVM {
         val result = Process(compilec, config.workdir.toFile) ! Logger
           .toProcessLogger(config.logger)
         if (result != 0) {
-          sys.error(s"Failed to compile ${inpath}")
+          throw new BuildException(s"Failed to compile ${inpath}")
         }
       }
       objPath

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -62,8 +62,8 @@ private[scalanative] object LLVM {
             Seq("-c", inpath, "-o", outpath)
 
         config.logger.running(compilec)
-        val result = Process(compilec, config.workdir.toFile) ! Logger
-          .toProcessLogger(config.logger)
+        val result = Process(compilec, config.workdir.toFile) !
+          Logger.toProcessLogger(config.logger)
         if (result != 0) {
           throw new BuildException(s"Failed to compile ${inpath}")
         }
@@ -131,8 +131,8 @@ private[scalanative] object LLVM {
       s"Linking native code (${config.gc.name} gc, ${config.LTO.name} lto)"
     ) {
       config.logger.running(compile)
-      val result = Process(compile, config.workdir.toFile) ! Logger
-        .toProcessLogger(config.logger)
+      val result = Process(compile, config.workdir.toFile) !
+        Logger.toProcessLogger(config.logger)
       if (result != 0) {
         throw new BuildException(s"Failed to link ${outpath}")
       }

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -131,11 +131,9 @@ private[scalanative] object LLVM {
       s"Linking native code (${config.gc.name} gc, ${config.LTO.name} lto)"
     ) {
       config.logger.running(compile)
-      val result =
-        Process(compile, config.workdir.toFile) ! Logger.toProcessLogger(
-          config.logger
-        )
-      if(result != 0){
+      val result = Process(compile, config.workdir.toFile) ! Logger
+        .toProcessLogger(config.logger)
+      if (result != 0) {
         throw new BuildException(s"Failed to link ${outpath}")
       }
     }

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -131,9 +131,13 @@ private[scalanative] object LLVM {
       s"Linking native code (${config.gc.name} gc, ${config.LTO.name} lto)"
     ) {
       config.logger.running(compile)
-      Process(compile, config.workdir.toFile) ! Logger.toProcessLogger(
-        config.logger
-      )
+      val result =
+        Process(compile, config.workdir.toFile) ! Logger.toProcessLogger(
+          config.logger
+        )
+      if(result != 0){
+        throw new BuildException(s"Failed to link ${outpath}")
+      }
     }
     outpath
   }


### PR DESCRIPTION
This PR fixes #2363, now in case of clang failure when compiling or linking it would throw appropriate BuildException. 