### PR TITLE
Fix #2396: URI normalize doesn't seem to work

### DIFF
--- a/javalib/src/main/scala/java/net/URI.scala
+++ b/javalib/src/main/scala/java/net/URI.scala
@@ -940,8 +940,8 @@ final class URI private () extends Comparable[URI] with Serializable {
     val include: Array[Boolean] = Array.ofDim[Boolean](size)
     // break the path into segments and store in the list
     var current: Int = 0
-    var index2: Int = path.indexOf('/', index + 1)
     index = if (pathlen > 0 && path.charAt(0) == '/') 1 else 0
+    var index2: Int = path.indexOf('/', index + 1)
     while (index2 != -1) {
       seglist({ current += 1; current - 1 }) = path.substring(index, index2)
       index = index2 + 1

--- a/unit-tests/shared/src/test/scala/javalib/net/URITest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/URITest.scala
@@ -237,4 +237,33 @@ class URITest {
     }
   }
 
+  @Test def normalize(): Unit = {
+    def testNormalize(relative: Boolean): Unit = {
+      val first = if (relative) "" else "/"
+      assertEquals(new URI(s"${first}a/b"), new URI(s"${first}a/b").normalize())
+      assertEquals(
+        new URI(s"${first}a/b"),
+        new URI(s"${first}a/./b").normalize()
+      )
+      assertEquals(
+        new URI(s"${first}b"),
+        new URI(s"${first}a/../b").normalize()
+      )
+      assertEquals(
+        new URI(s"${first}../a/b"),
+        new URI(s"${first}../a/b").normalize()
+      )
+      assertEquals(
+        new URI(s"${first}a/"),
+        new URI(s"${first}a/b/..").normalize()
+      )
+      assertEquals(
+        new URI(s"${first}a/"),
+        new URI(s"${first}a/b/./..").normalize()
+      )
+    }
+    testNormalize(relative = true)
+    testNormalize(relative = false)
+  }
+
 }


### PR DESCRIPTION
Before, it used to always throw StringIndexOutOfBoundsException. Now, related instructions have been swapped, so this should no longer be the case. Additional tests were also added.