### PR TITLE
Adjust naming of Windows native functions with existing naming rules

### DIFF
--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/accessMode.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/accessMode.c
@@ -2,12 +2,12 @@
 #define WIN32_LEAN_AND_MEAN
 #include <AccCtrl.h>
 
-int scalanative_win32_accctrl_not_used_access() { return NOT_USED_ACCESS; }
-int scalanative_win32_accctrl_grant_access() { return GRANT_ACCESS; }
-int scalanative_win32_accctrl_set_access() { return SET_ACCESS; }
-int scalanative_win32_accctrl_deny_access() { return DENY_ACCESS; }
-int scalanative_win32_accctrl_revoke_access() { return REVOKE_ACCESS; }
-int scalanative_win32_accctrl_set_audit_success() { return SET_AUDIT_SUCCESS; }
-int scalanative_win32_accctrl_set_audit_failure() { return SET_AUDIT_FAILURE; }
+int scalanative_not_used_access() { return NOT_USED_ACCESS; }
+int scalanative_grant_access() { return GRANT_ACCESS; }
+int scalanative_set_access() { return SET_ACCESS; }
+int scalanative_deny_access() { return DENY_ACCESS; }
+int scalanative_revoke_access() { return REVOKE_ACCESS; }
+int scalanative_set_audit_success() { return SET_AUDIT_SUCCESS; }
+int scalanative_set_audit_failure() { return SET_AUDIT_FAILURE; }
 
 #endif // defined(_WIN32)

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/securityObjectType.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/securityObjectType.c
@@ -2,35 +2,21 @@
 #define WIN32_LEAN_AND_MEAN
 #include <AccCtrl.h>
 
-int scalanative_win32_se_object_type_unknown_object_type() {
-    return SE_UNKNOWN_OBJECT_TYPE;
-}
-int scalanative_win32_se_object_type_file_object() { return SE_FILE_OBJECT; }
-int scalanative_win32_se_object_type_service() { return SE_SERVICE; }
-int scalanative_win32_se_object_type_printer() { return SE_PRINTER; }
-int scalanative_win32_se_object_type_registry_key() { return SE_REGISTRY_KEY; }
-int scalanative_win32_se_object_type_lmshare() { return SE_LMSHARE; }
-int scalanative_win32_se_object_type_kernel_object() {
-    return SE_KERNEL_OBJECT;
-}
-int scalanative_win32_se_object_type_window_object() {
-    return SE_WINDOW_OBJECT;
-}
-int scalanative_win32_se_object_type_ds_object() { return SE_DS_OBJECT; }
-int scalanative_win32_se_object_type_ds_object_all() {
-    return SE_DS_OBJECT_ALL;
-}
-int scalanative_win32_se_object_type_provider_defined_object() {
+int scalanative_se_unknown_object_type() { return SE_UNKNOWN_OBJECT_TYPE; }
+int scalanative_se_file_object() { return SE_FILE_OBJECT; }
+int scalanative_se_service() { return SE_SERVICE; }
+int scalanative_se_printer() { return SE_PRINTER; }
+int scalanative_se_registry_key() { return SE_REGISTRY_KEY; }
+int scalanative_se_lmshare() { return SE_LMSHARE; }
+int scalanative_se_kernel_object() { return SE_KERNEL_OBJECT; }
+int scalanative_se_window_object() { return SE_WINDOW_OBJECT; }
+int scalanative_se_ds_object() { return SE_DS_OBJECT; }
+int scalanative_se_ds_object_all() { return SE_DS_OBJECT_ALL; }
+int scalanative_se_provider_defined_object() {
     return SE_PROVIDER_DEFINED_OBJECT;
 }
-int scalanative_win32_se_object_type_wmiguid_object() {
-    return SE_WMIGUID_OBJECT;
-}
-int scalanative_win32_se_object_type_registry_wow64_32key() {
-    return SE_REGISTRY_WOW64_32KEY;
-}
-int scalanative_win32_se_object_type_registry_wow64_64key() {
-    return SE_REGISTRY_WOW64_64KEY;
-}
+int scalanative_se_wmiguid_object() { return SE_WMIGUID_OBJECT; }
+int scalanative_se_registry_wow64_32key() { return SE_REGISTRY_WOW64_32KEY; }
+int scalanative_se_registry_wow64_64key() { return SE_REGISTRY_WOW64_64KEY; }
 
 #endif // defined(_WIN32)

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeForm.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeForm.c
@@ -2,13 +2,13 @@
 #define WIN32_LEAN_AND_MEAN
 #include <AccCtrl.h>
 
-int scalanative_win32_accctrl_trustee_is_sid() { return TRUSTEE_IS_SID; }
-int scalanative_win32_accctrl_trustee_is_name() { return TRUSTEE_IS_NAME; }
-int scalanative_win32_accctrl_trustee_bad_form() { return TRUSTEE_BAD_FORM; }
-int scalanative_win32_accctrl_trustee_is_objects_and_sid() {
+int scalanative_trustee_is_sid() { return TRUSTEE_IS_SID; }
+int scalanative_trustee_is_name() { return TRUSTEE_IS_NAME; }
+int scalanative_trustee_bad_form() { return TRUSTEE_BAD_FORM; }
+int scalanative_trustee_is_objects_and_sid() {
     return TRUSTEE_IS_OBJECTS_AND_SID;
 }
-int scalanative_win32_accctrl_trustee_is_objects_and_name() {
+int scalanative_trustee_is_objects_and_name() {
     return TRUSTEE_IS_OBJECTS_AND_NAME;
 }
 

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeType.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeType.c
@@ -2,9 +2,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <AccCtrl.h>
 
-int scalanative_trustee_is_unknown() {
-    return TRUSTEE_IS_UNKNOWN;
-}
+int scalanative_trustee_is_unknown() { return TRUSTEE_IS_UNKNOWN; }
 int scalanative_trustee_is_user() { return TRUSTEE_IS_USER; }
 int scalanative_trustee_is_group() { return TRUSTEE_IS_GROUP; }
 int scalanative_trustee_is_domain() { return TRUSTEE_IS_DOMAIN; }
@@ -12,14 +10,8 @@ int scalanative_trustee_is_alias() { return TRUSTEE_IS_ALIAS; }
 int scalanative_trustee_is_well_known_group() {
     return TRUSTEE_IS_WELL_KNOWN_GROUP;
 }
-int scalanative_trustee_is_deleted() {
-    return TRUSTEE_IS_DELETED;
-}
-int scalanative_trustee_is_invalid() {
-    return TRUSTEE_IS_INVALID;
-}
-int scalanative_trustee_is_computer() {
-    return TRUSTEE_IS_COMPUTER;
-}
+int scalanative_trustee_is_deleted() { return TRUSTEE_IS_DELETED; }
+int scalanative_trustee_is_invalid() { return TRUSTEE_IS_INVALID; }
+int scalanative_trustee_is_computer() { return TRUSTEE_IS_COMPUTER; }
 
 #endif // defined(_WIN32)

--- a/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeType.c
+++ b/windowslib/src/main/resources/scala-native/windows/accCtrl/trusteeType.c
@@ -2,23 +2,23 @@
 #define WIN32_LEAN_AND_MEAN
 #include <AccCtrl.h>
 
-int scalanative_win32_accctrl_trustee_is_unknown() {
+int scalanative_trustee_is_unknown() {
     return TRUSTEE_IS_UNKNOWN;
 }
-int scalanative_win32_accctrl_trustee_is_user() { return TRUSTEE_IS_USER; }
-int scalanative_win32_accctrl_trustee_is_group() { return TRUSTEE_IS_GROUP; }
-int scalanative_win32_accctrl_trustee_is_domain() { return TRUSTEE_IS_DOMAIN; }
-int scalanative_win32_accctrl_trustee_is_alias() { return TRUSTEE_IS_ALIAS; }
-int scalanative_win32_accctrl_trustee_is_well_known_group() {
+int scalanative_trustee_is_user() { return TRUSTEE_IS_USER; }
+int scalanative_trustee_is_group() { return TRUSTEE_IS_GROUP; }
+int scalanative_trustee_is_domain() { return TRUSTEE_IS_DOMAIN; }
+int scalanative_trustee_is_alias() { return TRUSTEE_IS_ALIAS; }
+int scalanative_trustee_is_well_known_group() {
     return TRUSTEE_IS_WELL_KNOWN_GROUP;
 }
-int scalanative_win32_accctrl_trustee_is_deleted() {
+int scalanative_trustee_is_deleted() {
     return TRUSTEE_IS_DELETED;
 }
-int scalanative_win32_accctrl_trustee_is_invalid() {
+int scalanative_trustee_is_invalid() {
     return TRUSTEE_IS_INVALID;
 }
-int scalanative_win32_accctrl_trustee_is_computer() {
+int scalanative_trustee_is_computer() {
     return TRUSTEE_IS_COMPUTER;
 }
 

--- a/windowslib/src/main/resources/scala-native/windows/console.c
+++ b/windowslib/src/main/resources/scala-native/windows/console.c
@@ -2,7 +2,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-DWORD scalanative_win32_console_std_in_handle() { return STD_INPUT_HANDLE; }
-DWORD scalanative_win32_console_std_out_handle() { return STD_OUTPUT_HANDLE; }
-DWORD scalanative_win32_console_std_err_handle() { return STD_ERROR_HANDLE; }
+DWORD scalanative_std_input_handle() { return STD_INPUT_HANDLE; }
+DWORD scalanative_std_output_handle() { return STD_OUTPUT_HANDLE; }
+DWORD scalanative_std_error_handle() { return STD_ERROR_HANDLE; }
 #endif // defined(Win32)

--- a/windowslib/src/main/resources/scala-native/windows/constants.c
+++ b/windowslib/src/main/resources/scala-native/windows/constants.c
@@ -5,13 +5,7 @@
 // Needed to find symbols from UCRT - Windows Universal C Runtime
 #pragma comment(lib, "legacy_stdio_definitions.lib")
 
-size_t scalanative_win32_winnt_empty_priviliges_size() {
-    PRIVILEGE_SET privileges = {0};
-    return sizeof(privileges);
-}
-
-DWORD scalanative_win32_infinite() { return INFINITE; }
-
-LANGID scalanative_win32_default_language() { return LANG_USER_DEFAULT; }
+DWORD scalanative_infinite() { return INFINITE; }
+LANGID scalanative_lang_user_default() { return LANG_USER_DEFAULT; }
 
 #endif // defined(Win32)

--- a/windowslib/src/main/resources/scala-native/windows/securityImpersonation.c
+++ b/windowslib/src/main/resources/scala-native/windows/securityImpersonation.c
@@ -2,17 +2,9 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-DWORD scalanative_win32_security_impersonation_anonymous() {
-    return SecurityAnonymous;
-}
-DWORD scalanative_win32_security_impersonation_identification() {
-    return SecurityIdentification;
-}
-DWORD scalanative_win32_security_impersonation_impersonation() {
-    return SecurityImpersonation;
-}
-DWORD scalanative_win32_security_impersonation_delegation() {
-    return SecurityDelegation;
-}
+DWORD scalanative_securityanonymous() { return SecurityAnonymous; }
+DWORD scalanative_securityidentification() { return SecurityIdentification; }
+DWORD scalanative_securityimpersonation() { return SecurityImpersonation; }
+DWORD scalanative_securitydelegation() { return SecurityDelegation; }
 
 #endif // defined(_WIN32)

--- a/windowslib/src/main/resources/scala-native/windows/winSocket.c
+++ b/windowslib/src/main/resources/scala-native/windows/winSocket.c
@@ -5,13 +5,8 @@
 
 #pragma comment(lib, "Ws2_32.lib")
 
-DWORD scalanative_winsock_wsadata_size() { return sizeof(WSADATA); }
-
-DWORD scalanative_winsocket_fionbio() { return FIONBIO; }
-
 SOCKET scalanative_winsock_invalid_socket() { return INVALID_SOCKET; }
-
-SHORT scalanative_winsock_poll_pollin() { return POLLIN; }
-SHORT scalanative_winsock_poll_pollout() { return POLLOUT; }
+DWORD scalanative_winsock_wsadata_size() { return sizeof(WSADATA); }
+DWORD scalanative_winsock_fionbio() { return FIONBIO; }
 
 #endif // defined(_WIN32)

--- a/windowslib/src/main/resources/scala-native/windows/winnls.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnls.c
@@ -2,29 +2,29 @@
 #define WIN32_LEAN_AND_MEAN
 #include "Windows.h"
 
-PCWSTR scalanative_win32_LocaleName_Invariant() {
+PCWSTR scalanative_locale_name_invariant() {
     return LOCALE_NAME_INVARIANT;
 }
-PCWSTR scalanative_win32_locale_name_system_default() {
+PCWSTR scalanative_locale_name_system_default() {
     return LOCALE_NAME_SYSTEM_DEFAULT;
 }
-PCWSTR scalanative_win32_locale_name_user_default() {
+PCWSTR scalanative_locale_name_user_default() {
     return LOCALE_NAME_USER_DEFAULT;
 }
 
-LCTYPE scalanative_win32_locale_siso639langname() {
+LCTYPE scalanative_locale_siso639langname() {
     return LOCALE_SISO639LANGNAME;
 }
 
-LCTYPE scalanative_win32_locale_siso639langname2() {
+LCTYPE scalanative_locale_siso639langname2() {
     return LOCALE_SISO639LANGNAME2;
 }
 
-LCTYPE scalanative_win32_locale_siso3166ctryname() {
+LCTYPE scalanative_locale_siso3166ctryname() {
     return LOCALE_SISO3166CTRYNAME;
 }
 
-LCTYPE scalanative_win32_locale_siso3166ctryname2() {
+LCTYPE scalanative_locale_siso3166ctryname2() {
     return LOCALE_SISO3166CTRYNAME2;
 }
 

--- a/windowslib/src/main/resources/scala-native/windows/winnls.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnls.c
@@ -2,9 +2,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include "Windows.h"
 
-PCWSTR scalanative_locale_name_invariant() {
-    return LOCALE_NAME_INVARIANT;
-}
+PCWSTR scalanative_locale_name_invariant() { return LOCALE_NAME_INVARIANT; }
 PCWSTR scalanative_locale_name_system_default() {
     return LOCALE_NAME_SYSTEM_DEFAULT;
 }
@@ -12,17 +10,11 @@ PCWSTR scalanative_locale_name_user_default() {
     return LOCALE_NAME_USER_DEFAULT;
 }
 
-LCTYPE scalanative_locale_siso639langname() {
-    return LOCALE_SISO639LANGNAME;
-}
+LCTYPE scalanative_locale_siso639langname() { return LOCALE_SISO639LANGNAME; }
 
-LCTYPE scalanative_locale_siso639langname2() {
-    return LOCALE_SISO639LANGNAME2;
-}
+LCTYPE scalanative_locale_siso639langname2() { return LOCALE_SISO639LANGNAME2; }
 
-LCTYPE scalanative_locale_siso3166ctryname() {
-    return LOCALE_SISO3166CTRYNAME;
-}
+LCTYPE scalanative_locale_siso3166ctryname() { return LOCALE_SISO3166CTRYNAME; }
 
 LCTYPE scalanative_locale_siso3166ctryname2() {
     return LOCALE_SISO3166CTRYNAME2;

--- a/windowslib/src/main/resources/scala-native/windows/winnt/accessRights.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/accessRights.c
@@ -2,46 +2,24 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-DWORD scalanative_winnt_access_rights_file_generic_all() { return GENERIC_ALL; }
+DWORD scalanative_generic_all() { return GENERIC_ALL; }
 
-DWORD scalanative_winnt_access_rights_file_generic_execute() {
-    return FILE_GENERIC_EXECUTE;
-}
-DWORD scalanative_winnt_access_rights_file_execute() { return FILE_EXECUTE; }
-DWORD scalanative_winnt_access_rights_standard_rights_execute() {
-    return STANDARD_RIGHTS_EXECUTE;
-}
+DWORD scalanative_generic_execute() { return FILE_GENERIC_EXECUTE; }
+DWORD scalanative_execute() { return FILE_EXECUTE; }
+DWORD scalanative_standard_rights_execute() { return STANDARD_RIGHTS_EXECUTE; }
 
-DWORD scalanative_winnt_access_rights_file_generic_read() {
-    return FILE_GENERIC_READ;
-}
-DWORD scalanative_winnt_access_rights_file_read_attributes() {
-    return FILE_READ_ATTRIBUTES;
-}
-DWORD scalanative_winnt_access_rights_file_read_data() {
-    return FILE_READ_DATA;
-}
-DWORD scalanative_winnt_access_rights_file_read_ea() { return FILE_READ_EA; }
-DWORD scalanative_winnt_access_rights_standard_rights_read() {
-    return STANDARD_RIGHTS_READ;
-}
+DWORD scalanative_generic_read() { return FILE_GENERIC_READ; }
+DWORD scalanative_read_attributes() { return FILE_READ_ATTRIBUTES; }
+DWORD scalanative_read_data() { return FILE_READ_DATA; }
+DWORD scalanative_read_ea() { return FILE_READ_EA; }
+DWORD scalanative_standard_rights_read() { return STANDARD_RIGHTS_READ; }
 
-DWORD scalanative_winnt_access_rights_file_generic_write() {
-    return FILE_GENERIC_WRITE;
-}
-DWORD scalanative_winnt_access_rights_file_append_data() {
-    return FILE_APPEND_DATA;
-}
-DWORD scalanative_winnt_access_rights_file_write_attributes() {
-    return FILE_WRITE_ATTRIBUTES;
-}
-DWORD scalanative_winnt_access_rights_file_write_data() {
-    return FILE_WRITE_DATA;
-}
-DWORD scalanative_winnt_access_rights_file_write_ea() { return FILE_WRITE_EA; }
-DWORD scalanative_winnt_access_rights_standard_rights_write() {
-    return STANDARD_RIGHTS_WRITE;
-}
-DWORD scalanative_winnt_access_rights_synchronize() { return SYNCHRONIZE; }
+DWORD scalanative_generic_write() { return FILE_GENERIC_WRITE; }
+DWORD scalanative_append_data() { return FILE_APPEND_DATA; }
+DWORD scalanative_write_attributes() { return FILE_WRITE_ATTRIBUTES; }
+DWORD scalanative_write_data() { return FILE_WRITE_DATA; }
+DWORD scalanative_write_ea() { return FILE_WRITE_EA; }
+DWORD scalanative_standard_rights_write() { return STANDARD_RIGHTS_WRITE; }
+DWORD scalanative_synchronize() { return SYNCHRONIZE; }
 
 #endif // defined(Win32)

--- a/windowslib/src/main/resources/scala-native/windows/winnt/accessToken.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/accessToken.c
@@ -2,30 +2,18 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-DWORD scalanative_winnt_access_token_adjust_default() {
-    return TOKEN_ADJUST_DEFAULT;
-}
-DWORD scalanative_winnt_access_token_adjust_groups() {
-    return TOKEN_ADJUST_GROUPS;
-}
-DWORD scalanative_winnt_access_token_adjust_privileges() {
-    return TOKEN_ADJUST_PRIVILEGES;
-}
-DWORD scalanative_winnt_access_token_adjust_sessionid() {
-    return TOKEN_ADJUST_SESSIONID;
-}
-DWORD scalanative_winnt_access_token_assign_primary() {
-    return TOKEN_ASSIGN_PRIMARY;
-}
-DWORD scalanative_winnt_access_token_duplicate() { return TOKEN_DUPLICATE; }
-DWORD scalanative_winnt_access_token_execute() { return TOKEN_EXECUTE; }
-DWORD scalanative_winnt_access_token_impersonate() { return TOKEN_IMPERSONATE; }
-DWORD scalanative_winnt_access_token_query() { return TOKEN_QUERY; }
-DWORD scalanative_winnt_access_token_query_source() {
-    return TOKEN_QUERY_SOURCE;
-}
-DWORD scalanative_winnt_access_token_read() { return TOKEN_READ; }
-DWORD scalanative_winnt_access_token_write() { return TOKEN_WRITE; }
-DWORD scalanative_winnt_access_token_all_access() { return TOKEN_ALL_ACCESS; }
+DWORD scalanative_token_adjust_default() { return TOKEN_ADJUST_DEFAULT; }
+DWORD scalanative_token_adjust_groups() { return TOKEN_ADJUST_GROUPS; }
+DWORD scalanative_token_adjust_privileges() { return TOKEN_ADJUST_PRIVILEGES; }
+DWORD scalanative_token_adjust_sessionid() { return TOKEN_ADJUST_SESSIONID; }
+DWORD scalanative_token_assign_primary() { return TOKEN_ASSIGN_PRIMARY; }
+DWORD scalanative_token_duplicate() { return TOKEN_DUPLICATE; }
+DWORD scalanative_token_execute() { return TOKEN_EXECUTE; }
+DWORD scalanative_token_impersonate() { return TOKEN_IMPERSONATE; }
+DWORD scalanative_token_query() { return TOKEN_QUERY; }
+DWORD scalanative_token_query_source() { return TOKEN_QUERY_SOURCE; }
+DWORD scalanative_token_read() { return TOKEN_READ; }
+DWORD scalanative_token_write() { return TOKEN_WRITE; }
+DWORD scalanative_token_all_access() { return TOKEN_ALL_ACCESS; }
 
 #endif // defined(Win32)

--- a/windowslib/src/main/resources/scala-native/windows/winnt/helpers.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/helpers.c
@@ -3,7 +3,12 @@
 #include <Windows.h>
 #pragma comment(lib, "Advapi32.lib")
 
-BOOL scalanative_win32_winnt_setupUsersGroupSid(PSID *ref) {
+size_t scalanative_winnt_empty_priviliges_size() {
+    PRIVILEGE_SET privileges = {0};
+    return sizeof(privileges);
+}
+
+BOOL scalanative_winnt_setupUsersGroupSid(PSID *ref) {
     SID_IDENTIFIER_AUTHORITY authNt = SECURITY_NT_AUTHORITY;
     return AllocateAndInitializeSid(&authNt, 2, SECURITY_BUILTIN_DOMAIN_RID,
                                     DOMAIN_ALIAS_RID_USERS, 0, 0, 0, 0, 0, 0,

--- a/windowslib/src/main/resources/scala-native/windows/winnt/sidNameUse.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/sidNameUse.c
@@ -3,29 +3,15 @@
 #include <Windows.h>
 #include <WinNT.h>
 
-int scalanative_win32_winnt_sid_name_use_sidtypeuser() { return SidTypeUser; }
-int scalanative_win32_winnt_sid_name_use_sidtypegroup() { return SidTypeGroup; }
-int scalanative_win32_winnt_sid_name_use_sidtypedomain() {
-    return SidTypeDomain;
-}
-int scalanative_win32_winnt_sid_name_use_sidtypealias() { return SidTypeAlias; }
-int scalanative_win32_winnt_sid_name_use_sidtypewellknowngroup() {
-    return SidTypeWellKnownGroup;
-}
-int scalanative_win32_winnt_sid_name_use_sidtypedeletedaccount() {
-    return SidTypeDeletedAccount;
-}
-int scalanative_win32_winnt_sid_name_use_sidtypeinvalid() {
-    return SidTypeInvalid;
-}
-int scalanative_win32_winnt_sid_name_use_sidtypeunknown() {
-    return SidTypeUnknown;
-}
-int scalanative_win32_winnt_sid_name_use_sidtypecomputer() {
-    return SidTypeComputer;
-}
-int scalanative_win32_winnt_sid_name_use_sidtypelabel() { return SidTypeLabel; }
-int scalanative_win32_winnt_sid_name_use_sidtypelogonsession() {
-    return SidTypeLogonSession;
-}
+int scalanative_sidtypeuser() { return SidTypeUser; }
+int scalanative_sidtypegroup() { return SidTypeGroup; }
+int scalanative_sidtypedomain() { return SidTypeDomain; }
+int scalanative_sidtypealias() { return SidTypeAlias; }
+int scalanative_sidtypewellknowngroup() { return SidTypeWellKnownGroup; }
+int scalanative_sidtypedeletedaccount() { return SidTypeDeletedAccount; }
+int scalanative_sidtypeinvalid() { return SidTypeInvalid; }
+int scalanative_sidtypeunknown() { return SidTypeUnknown; }
+int scalanative_sidtypecomputer() { return SidTypeComputer; }
+int scalanative_sidtypelabel() { return SidTypeLabel; }
+int scalanative_sidtypelogonsession() { return SidTypeLogonSession; }
 #endif // defined(Win32)

--- a/windowslib/src/main/resources/scala-native/windows/winnt/tokenInformationClass.c
+++ b/windowslib/src/main/resources/scala-native/windows/winnt/tokenInformationClass.c
@@ -3,137 +3,67 @@
 #include <Windows.h>
 #include <WinNT.h>
 
-int scalanative_win32_winnt_token_info_class_user() { return TokenUser; }
-int scalanative_win32_winnt_token_info_class_groups() { return TokenGroups; }
-int scalanative_win32_winnt_token_info_class_privileges() {
-    return TokenPrivileges;
-}
-int scalanative_win32_winnt_token_info_class_owner() { return TokenOwner; }
-int scalanative_win32_winnt_token_info_class_primarygroup() {
-    return TokenPrimaryGroup;
-}
-int scalanative_win32_winnt_token_info_class_defaultdacl() {
-    return TokenDefaultDacl;
-}
-int scalanative_win32_winnt_token_info_class_source() { return TokenSource; }
-int scalanative_win32_winnt_token_info_class_type() { return TokenType; }
-int scalanative_win32_winnt_token_info_class_impersonationlevel() {
-    return TokenImpersonationLevel;
-}
-int scalanative_win32_winnt_token_info_class_statistics() {
-    return TokenStatistics;
-}
-int scalanative_win32_winnt_token_info_class_restrictedsids() {
-    return TokenRestrictedSids;
-}
-int scalanative_win32_winnt_token_info_class_sessionid() {
-    return TokenSessionId;
-}
-int scalanative_win32_winnt_token_info_class_groupsandprivileges() {
-    return TokenGroupsAndPrivileges;
-}
-int scalanative_win32_winnt_token_info_class_sessionreference() {
-    return TokenSessionReference;
-}
-int scalanative_win32_winnt_token_info_class_sandboxinert() {
-    return TokenSandBoxInert;
-}
-int scalanative_win32_winnt_token_info_class_auditpolicy() {
-    return TokenAuditPolicy;
-}
-int scalanative_win32_winnt_token_info_class_origin() { return TokenOrigin; }
-int scalanative_win32_winnt_token_info_class_elevationtype() {
-    return TokenElevationType;
-}
-int scalanative_win32_winnt_token_info_class_linkedtoken() {
-    return TokenLinkedToken;
-}
-int scalanative_win32_winnt_token_info_class_elevation() {
-    return TokenElevation;
-}
-int scalanative_win32_winnt_token_info_class_hasrestrictions() {
-    return TokenHasRestrictions;
-}
-int scalanative_win32_winnt_token_info_class_accessinformation() {
-    return TokenAccessInformation;
-}
-int scalanative_win32_winnt_token_info_class_virtualizationallowed() {
+int scalanative_tokenuser() { return TokenUser; }
+int scalanative_tokengroups() { return TokenGroups; }
+int scalanative_tokenprivileges() { return TokenPrivileges; }
+int scalanative_tokenowner() { return TokenOwner; }
+int scalanative_tokenprimarygroup() { return TokenPrimaryGroup; }
+int scalanative_tokendefaultdacl() { return TokenDefaultDacl; }
+int scalanative_tokensource() { return TokenSource; }
+int scalanative_tokentype() { return TokenType; }
+int scalanative_tokenimpersonationlevel() { return TokenImpersonationLevel; }
+int scalanative_tokenstatistics() { return TokenStatistics; }
+int scalanative_tokenrestrictedsids() { return TokenRestrictedSids; }
+int scalanative_tokensessionid() { return TokenSessionId; }
+int scalanative_tokengroupsandprivileges() { return TokenGroupsAndPrivileges; }
+int scalanative_tokensessionreference() { return TokenSessionReference; }
+int scalanative_tokensandboxinert() { return TokenSandBoxInert; }
+int scalanative_tokenauditpolicy() { return TokenAuditPolicy; }
+int scalanative_tokenorigin() { return TokenOrigin; }
+int scalanative_tokenelevationtype() { return TokenElevationType; }
+int scalanative_tokenlinkedtoken() { return TokenLinkedToken; }
+int scalanative_tokenelevation() { return TokenElevation; }
+int scalanative_tokenhasrestrictions() { return TokenHasRestrictions; }
+int scalanative_tokenaccessinformation() { return TokenAccessInformation; }
+int scalanative_tokenvirtualizationallowed() {
     return TokenVirtualizationAllowed;
 }
-int scalanative_win32_winnt_token_info_class_virtualizationenabled() {
+int scalanative_tokenvirtualizationenabled() {
     return TokenVirtualizationEnabled;
 }
-int scalanative_win32_winnt_token_info_class_integritylevel() {
-    return TokenIntegrityLevel;
-}
-int scalanative_win32_winnt_token_info_class_uiaccess() {
-    return TokenUIAccess;
-}
-int scalanative_win32_winnt_token_info_class_mandatorypolicy() {
-    return TokenMandatoryPolicy;
-}
-int scalanative_win32_winnt_token_info_class_logonsid() {
-    return TokenLogonSid;
-}
-int scalanative_win32_winnt_token_info_class_isappcontainer() {
-    return TokenIsAppContainer;
-}
-int scalanative_win32_winnt_token_info_class_capabilities() {
-    return TokenCapabilities;
-}
-int scalanative_win32_winnt_token_info_class_appcontainersid() {
-    return TokenAppContainerSid;
-}
-int scalanative_win32_winnt_token_info_class_appcontainernumber() {
-    return TokenAppContainerNumber;
-}
-int scalanative_win32_winnt_token_info_class_userclaimattributes() {
-    return TokenUserClaimAttributes;
-}
-int scalanative_win32_winnt_token_info_class_deviceclaimattributes() {
+int scalanative_tokenintegritylevel() { return TokenIntegrityLevel; }
+int scalanative_tokenuiaccess() { return TokenUIAccess; }
+int scalanative_tokenmandatorypolicy() { return TokenMandatoryPolicy; }
+int scalanative_tokenlogonsid() { return TokenLogonSid; }
+int scalanative_tokenisappcontainer() { return TokenIsAppContainer; }
+int scalanative_tokencapabilities() { return TokenCapabilities; }
+int scalanative_tokenappcontainersid() { return TokenAppContainerSid; }
+int scalanative_tokenappcontainernumber() { return TokenAppContainerNumber; }
+int scalanative_tokenuserclaimattributes() { return TokenUserClaimAttributes; }
+int scalanative_tokendeviceclaimattributes() {
     return TokenDeviceClaimAttributes;
 }
-int scalanative_win32_winnt_token_info_class_restricteduserclaimattributes() {
+int scalanative_tokenrestricteduserclaimattributes() {
     return TokenRestrictedUserClaimAttributes;
 }
-int scalanative_win32_winnt_token_info_class_restricteddeviceclaimattributes() {
+int scalanative_tokenrestricteddeviceclaimattributes() {
     return TokenRestrictedDeviceClaimAttributes;
 }
-int scalanative_win32_winnt_token_info_class_devicegroups() {
-    return TokenDeviceGroups;
-}
-int scalanative_win32_winnt_token_info_class_restricteddevicegroups() {
+int scalanative_tokendevicegroups() { return TokenDeviceGroups; }
+int scalanative_tokenrestricteddevicegroups() {
     return TokenRestrictedDeviceGroups;
 }
-int scalanative_win32_winnt_token_info_class_securityattributes() {
-    return TokenSecurityAttributes;
-}
-int scalanative_win32_winnt_token_info_class_isrestricted() {
-    return TokenIsRestricted;
-}
-int scalanative_win32_winnt_token_info_class_processtrustlevel() {
-    return TokenProcessTrustLevel;
-}
-int scalanative_win32_winnt_token_info_class_privatenamespace() {
-    return TokenPrivateNameSpace;
-}
-int scalanative_win32_winnt_token_info_class_singletonattributes() {
-    return TokenSingletonAttributes;
-}
-int scalanative_win32_winnt_token_info_class_bnoisolation() {
-    return TokenBnoIsolation;
-}
-int scalanative_win32_winnt_token_info_class_childprocessflags() {
-    return TokenChildProcessFlags;
-}
-int scalanative_win32_winnt_token_info_class_islessprivilegedappcontainer() {
+int scalanative_tokensecurityattributes() { return TokenSecurityAttributes; }
+int scalanative_tokenisrestricted() { return TokenIsRestricted; }
+int scalanative_tokenprocesstrustlevel() { return TokenProcessTrustLevel; }
+int scalanative_tokenprivatenamespace() { return TokenPrivateNameSpace; }
+int scalanative_tokensingletonattributes() { return TokenSingletonAttributes; }
+int scalanative_tokenbnoisolation() { return TokenBnoIsolation; }
+int scalanative_tokenchildprocessflags() { return TokenChildProcessFlags; }
+int scalanative_tokenislessprivilegedappcontainer() {
     return TokenIsLessPrivilegedAppContainer;
 }
-int scalanative_win32_winnt_token_info_class_issandboxed() {
-    return TokenIsSandboxed;
-}
-int scalanative_win32_winnt_token_info_class_infoclass_max() {
-    return MaxTokenInfoClass;
-}
+int scalanative_tokenissandboxed() { return TokenIsSandboxed; }
+int scalanative_maxtokeninfoclass() { return MaxTokenInfoClass; }
 
 #endif // defined(_WIN32)

--- a/windowslib/src/main/scala/scala/scalanative/windows/AclApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/AclApi.scala
@@ -60,32 +60,32 @@ object AclApi {
   ): DWord = extern
 
   // SecurityObjectType enum
-  @name("scalanative_win32_se_object_type_unknown_object_type")
+  @name("scalanative_se_unknown_object_type")
   def SE_UNKNOWN_OBJECT_TYPE: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_file_object")
+  @name("scalanative_se_file_object")
   def SE_FILE_OBJECT: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_service")
+  @name("scalanative_se_service")
   def SE_SERVICE: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_printer")
+  @name("scalanative_se_printer")
   def SE_PRINTER: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_registry_key")
+  @name("scalanative_se_registry_key")
   def SE_REGISTRY_KEY: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_lmshare")
+  @name("scalanative_se_lmshare")
   def SE_LMSHARE: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_kernel_object")
+  @name("scalanative_se_kernel_object")
   def SE_KERNEL_OBJECT: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_window_object")
+  @name("scalanative_se_window_object")
   def SE_WINDOW_OBJECT: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_ds_object")
+  @name("scalanative_se_ds_object")
   def SE_DS_OBJECT: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_ds_object_all")
+  @name("scalanative_se_ds_object_all")
   def SE_DS_OBJECT_ALL: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_provider_defined_object")
+  @name("scalanative_se_provider_defined_object")
   def SE_PROVIDER_DEFINED_OBJECT: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_wmiguid_object")
+  @name("scalanative_se_wmiguid_object")
   def SE_WMIGUID_OBJECT: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_registry_wow64_32key")
+  @name("scalanative_se_registry_wow64_32key")
   def SE_REGISTRY_WOW64_32KEY: SecurityObjectType = extern
-  @name("scalanative_win32_se_object_type_registry_wow64_64key")
+  @name("scalanative_se_registry_wow64_64key")
   def SE_REGISTRY_WOW64_64KEY: SecurityObjectType = extern
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/ConsoleApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/ConsoleApi.scala
@@ -8,13 +8,13 @@ object ConsoleApi {
   def GetStdHandle(handleNum: DWord): Handle = extern
   def SetStdHandle(stdHandle: DWord, handle: Handle): Boolean = extern
 
-  @name("scalanative_win32_console_std_in_handle")
+  @name("scalanative_std_input_handle")
   final def STD_INPUT_HANDLE: DWord = extern
 
-  @name("scalanative_win32_console_std_out_handle")
+  @name("scalanative_std_output_handle")
   final def STD_OUTPUT_HANDLE: DWord = extern
 
-  @name("scalanative_win32_console_std_err_handle")
+  @name("scalanative_std_error_handle")
   final def STD_ERROR_HANDLE: DWord = extern
 }
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/SecurityBaseApi.scala
@@ -62,20 +62,20 @@ object SecurityBaseApi {
   ): Unit = extern
 
   // SecurityImpersonationLevel enum
-  @name("scalanative_win32_security_impersonation_anonymous")
+  @name("scalanative_securityanonymous")
   def SecurityAnonymous: SecurityImpersonationLevel = extern
 
-  @name("scalanative_win32_security_impersonation_identification")
+  @name("scalanative_securityidentification")
   def SecurityIdentification: SecurityImpersonationLevel = extern
 
-  @name("scalanative_win32_security_impersonation_impersonation")
+  @name("scalanative_securityimpersonation")
   def SecurityImpersonation: SecurityImpersonationLevel = extern
 
-  @name("scalanative_win32_security_impersonation_delegation")
+  @name("scalanative_securitydelegation")
   def SecurityDelegation: SecurityImpersonationLevel = extern
 
   // utils
-  @name("scalanative_win32_winnt_empty_priviliges_size")
+  @name("scalanative_winnt_empty_priviliges_size")
   def emptyPriviligesSize: CSize = extern
 
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinBaseApi.scala
@@ -118,7 +118,7 @@ object WinBaseApi {
 
   def UnregisterWait(handle: Handle): Boolean = extern
 
-  @name("scalanative_win32_default_language")
+  @name("scalanative_lang_user_default")
   final def DefaultLanguageId: DWord = extern
 }
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinNlsApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinNlsApi.scala
@@ -15,22 +15,22 @@ object WinNlsApi {
       bufferSize: UInt
   ): Int = extern
 
-  @name("scalanative_win32_locale_name_invariant")
+  @name("scalanative_locale_name_invariant")
   def LOCALE_NAME_INVARIANT: CWString = extern
-  @name("scalanative_win32_locale_name_system_default")
+  @name("scalanative_locale_name_system_default")
   def LOCALE_NAME_SYSTEM_DEFAULT: CWString = extern
-  @name("scalanative_win32_locale_name_user_default")
+  @name("scalanative_locale_name_user_default")
   def LOCALE_NAME_USER_DEFAULT: CWString = extern
 
-  @name("scalanative_win32_locale_siso639langname")
+  @name("scalanative_locale_siso639langname")
   def LOCALE_SISO639LANGNAME: LCType = extern
 
-  @name("scalanative_win32_locale_siso639langname2")
+  @name("scalanative_locale_siso639langname2")
   def LOCALE_SISO639LANGNAME2: LCType = extern
 
-  @name("scalanative_win32_locale_siso3166ctryname")
+  @name("scalanative_locale_siso3166ctryname")
   def LOCALE_SISO3166CTRYNAME: LCType = extern
 
-  @name("scalanative_win32_locale_siso3166ctryname2")
+  @name("scalanative_locale_siso3166ctryname2")
   def LOCALE_SISO3166CTRYNAME2: LCType = extern
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinSocketApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinSocketApi.scala
@@ -44,7 +44,7 @@ object WinSocketApi {
   @name("closesocket")
   def closeSocket(socket: Socket): CInt = extern
 
-  @name("scalanative_winsocket_fionbio")
+  @name("scalanative_winsock_fionbio")
   final def FIONBIO: CInt = extern
 
   @name("scalanative_winsock_wsadata_size")

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/AccessMode.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/AccessMode.scala
@@ -4,18 +4,18 @@ import scala.scalanative.unsafe._
 
 @extern
 object AccessMode {
-  @name("scalanative_win32_accctrl_not_used_access")
+  @name("scalanative_not_used_access")
   def NOT_USED_ACCESS: AccessMode = extern
-  @name("scalanative_win32_accctrl_grant_access")
+  @name("scalanative_grant_access")
   def GRANT_ACCESS: AccessMode = extern
-  @name("scalanative_win32_accctrl_set_access")
+  @name("scalanative_set_access")
   def SET_ACCESS: AccessMode = extern
-  @name("scalanative_win32_accctrl_deny_access")
+  @name("scalanative_deny_access")
   def DENY_ACCESS: AccessMode = extern
-  @name("scalanative_win32_accctrl_revoke_access")
+  @name("scalanative_revoke_access")
   def REVOKE_ACCESS: AccessMode = extern
-  @name("scalanative_win32_accctrl_set_audit_success")
+  @name("scalanative_set_audit_success")
   def SET_AUDIT_SUCCESS: AccessMode = extern
-  @name("scalanative_win32_accctrl_set_audit_failure")
+  @name("scalanative_set_audit_failure")
   def SET_AUDIT_FAILURE: AccessMode = extern
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/MultipleTrusteeOperation.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/MultipleTrusteeOperation.scala
@@ -4,8 +4,8 @@ import scala.scalanative.unsafe._
 
 @extern
 object MultipleTrusteeOperation {
-  @name("scalanative_win32_accctrl_no_multiple_trustee")
+  @name("scalanative_no_multiple_trustee")
   def NO_MULTIPLE_TRUSTEE: MultipleTruteeOperation = extern
-  @name("scalanative_win32_accctrl_trustee_is_impersonate")
+  @name("scalanative_trustee_is_impersonate")
   def TRUSTEE_IS_IMPERSONATE: MultipleTruteeOperation = extern
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/TrusteeForm.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/TrusteeForm.scala
@@ -4,14 +4,14 @@ import scala.scalanative.unsafe._
 
 @extern
 object TrusteeForm {
-  @name("scalanative_win32_accctrl_trustee_is_sid")
+  @name("scalanative_trustee_is_sid")
   def TRUSTEE_IS_SID: TrusteeForm = extern
-  @name("scalanative_win32_accctrl_trustee_is_name")
+  @name("scalanative_trustee_is_name")
   def TRUSTEE_IS_NAME: TrusteeForm = extern
-  @name("scalanative_win32_accctrl_trustee_bad_form")
+  @name("scalanative_trustee_bad_form")
   def TRUSTEE_BAD_FORM: TrusteeForm = extern
-  @name("scalanative_win32_accctrl_trustee_is_objects_and_sid")
+  @name("scalanative_trustee_is_objects_and_sid")
   def TRUSTEE_IS_OBJECTS_AND_SID: TrusteeForm = extern
-  @name("scalanative_win32_accctrl_trustee_is_objects_and_name")
+  @name("scalanative_trustee_is_objects_and_name")
   def TRUSTEE_IS_OBJECTS_AND_NAME: TrusteeForm = extern
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/accctrl/TrusteeType.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/accctrl/TrusteeType.scala
@@ -4,22 +4,22 @@ import scala.scalanative.unsafe._
 
 @extern
 object TrusteeType {
-  @name("scalanative_win32_accctrl_trustee_is_unknown")
+  @name("scalanative_trustee_is_unknown")
   def TRUSTEE_IS_UNKNOWN: TrusteeType = extern
-  @name("scalanative_win32_accctrl_trustee_is_user")
+  @name("scalanative_trustee_is_user")
   def TRUSTEE_IS_USER: TrusteeType = extern
-  @name("scalanative_win32_accctrl_trustee_is_group")
+  @name("scalanative_trustee_is_group")
   def TRUSTEE_IS_GROUP: TrusteeType = extern
-  @name("scalanative_win32_accctrl_trustee_is_domain")
+  @name("scalanative_trustee_is_domain")
   def TRUSTEE_IS_DOMAIN: TrusteeType = extern
-  @name("scalanative_win32_accctrl_trustee_is_alias")
+  @name("scalanative_trustee_is_alias")
   def TRUSTEE_IS_ALIAS: TrusteeType = extern
-  @name("scalanative_win32_accctrl_trustee_is_well_known_group")
+  @name("scalanative_trustee_is_well_known_group")
   def TRUSTEE_IS_WELL_KNOWN_GROUP: TrusteeType = extern
-  @name("scalanative_win32_accctrl_trustee_is_deleted")
+  @name("scalanative_trustee_is_deleted")
   def TRUSTEE_IS_DELETED: TrusteeType = extern
-  @name("scalanative_win32_accctrl_trustee_is_invalid")
+  @name("scalanative_trustee_is_invalid")
   def TRUSTEE_IS_INVALID: TrusteeType = extern
-  @name("scalanative_win32_accctrl_trustee_is_computer")
+  @name("scalanative_trustee_is_computer")
   def TRUSTEE_IS_COMPUTER: TrusteeType = extern
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/package.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/package.scala
@@ -22,7 +22,7 @@ package object windows {
 
   @extern
   object Constants {
-    @name("scalanative_win32_infinite")
+    @name("scalanative_infinite")
     def Infinite: DWord = extern
   }
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/AccessRights.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/AccessRights.scala
@@ -5,54 +5,54 @@ import scala.scalanative.unsafe._
 @link("Advapi32")
 @extern
 object AccessRights {
-  @name("scalanative_winnt_access_rights_file_generic_all")
+  @name("scalanative_generic_all")
   def FILE_GENERIC_ALL: AccessRights = extern
 
   //execute
-  @name("scalanative_winnt_access_rights_file_generic_execute")
+  @name("scalanative_generic_execute")
   def FILE_GENERIC_EXECUTE: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_file_execute")
+  @name("scalanative_execute")
   def FILE_EXECUTE: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_file_read_attributes")
+  @name("scalanative_read_attributes")
   def STANDARD_RIGHTS_EXECUTE: AccessRights = extern
 
   //read
-  @name("scalanative_winnt_access_rights_file_generic_read")
+  @name("scalanative_generic_read")
   def FILE_GENERIC_READ: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_file_read_attributes")
+  @name("scalanative_read_attributes")
   def FILE_READ_ATTRIBUTES: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_file_read_data")
+  @name("scalanative_read_data")
   def FILE_READ_DATA: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_file_read_ea")
+  @name("scalanative_read_ea")
   def FILE_READ_EA: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_standard_rights_read")
+  @name("scalanative_standard_rights_read")
   def STANDARD_RIGHTS_READ: AccessRights = extern
 
   //write
-  @name("scalanative_winnt_access_rights_file_generic_write")
+  @name("scalanative_generic_write")
   def FILE_GENERIC_WRITE: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_file_append_data")
+  @name("scalanative_append_data")
   def FILE_APPEND_DATA: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_file_write_attributes")
+  @name("scalanative_write_attributes")
   def FILE_WRITE_ATTRIBUTES: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_file_write_data")
+  @name("scalanative_write_data")
   def FILE_WRITE_DATA: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_file_write_ea")
+  @name("scalanative_write_ea")
   def FILE_WRITE_EA: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_standard_rights_write")
+  @name("scalanative_standard_rights_write")
   def STANDARD_RIGHTS_WRITE: AccessRights = extern
 
-  @name("scalanative_winnt_access_rights_synchronize")
+  @name("scalanative_synchronize")
   def SYNCHRONIZE: AccessRights = extern
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/AccessToken.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/AccessToken.scala
@@ -8,61 +8,61 @@ object AccessToken {
   /** Required to change the default owner, primary group, or DACL of an access
    *  token.
    */
-  @name("scalanative_winnt_access_token_adjust_default")
+  @name("scalanative_token_adjust_default")
   def TOKEN_ADJUST_DEFAULT: AccessToken = extern
 
   /** Required to adjust the attributes of the groups in an access token. */
-  @name("scalanative_winnt_access_token_adjust_groups")
+  @name("scalanative_token_adjust_groups")
   def TOKEN_ADJUST_GROUP: AccessToken = extern
 
   /** Required to enable or disable the privileges in an access token. */
-  @name("scalanative_winnt_access_token_adjust_privileges")
+  @name("scalanative_token_adjust_privileges")
   def TOKEN_ADJUST_PRIVILEGES: AccessToken = extern
 
   /** Required to adjust the session ID of an access token. The SE_TCB_NAME
    *  privilege is required.
    */
-  @name("scalanative_winnt_access_token_adjust_sessionid")
+  @name("scalanative_token_adjust_sessionid")
   def TOKEN_ADJUST_SESSIONID: AccessToken = extern
 
   /** Required to attach a primary token to a process. The
    *  SE_ASSIGNPRIMARYTOKEN_NAME privilege is also required to accomplish this
    *  task.
    */
-  @name("scalanative_winnt_access_token_assign_primary")
+  @name("scalanative_token_assign_primary")
   def TOKEN_ASSIGN_PRIMARY: AccessToken = extern
 
   /** Required to duplicate an access token. */
-  @name("scalanative_winnt_access_token_duplicate")
+  @name("scalanative_token_duplicate")
   def TOKEN_DUPLICATE: AccessToken = extern
 
   /** Combines STANDARD_RIGHTS_EXECUTE and TOKEN_IMPERSONATE. */
-  @name("scalanative_winnt_access_token_execute")
+  @name("scalanative_token_execute")
   def TOKEN_EXECUTE: AccessToken = extern
 
   /** Required to attach an impersonation access token to a process. */
-  @name("scalanative_winnt_access_token_impersonate")
+  @name("scalanative_token_impersonate")
   def TOKEN_IMPERSONATE: AccessToken = extern
 
   /** Required to query an access token. */
-  @name("scalanative_winnt_access_token_query")
+  @name("scalanative_token_query")
   def TOKEN_QUERY: AccessToken = extern
 
   /** Required to query the source of an access token. */
-  @name("scalanative_winnt_access_token_query_source")
+  @name("scalanative_token_query_source")
   def TOKEN_QUERY_SOURCE: AccessToken = extern
 
   /** Combines STANDARD_RIGHTS_READ and TOKEN_QUERY. */
-  @name("scalanative_winnt_access_token_read")
+  @name("scalanative_token_read")
   def TOKEN_READ: AccessToken = extern
 
   /** Combines STANDARD_RIGHTS_WRITE, TOKEN_ADJUST_PRIVILEGES,
    *  TOKEN_ADJUST_GROUPS, and TOKEN_ADJUST_DEFAULT.
    */
-  @name("scalanative_winnt_access_token_write")
+  @name("scalanative_token_write")
   def TOKEN_WRITE: AccessToken = extern
 
   /** Combines all possible access rights for a token. */
-  @name("scalanative_winnt_access_token_all_access")
+  @name("scalanative_token_all_access")
   def TOKEN_ALL_ACCESS: AccessToken = extern
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/HelperMethods.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/HelperMethods.scala
@@ -8,6 +8,6 @@ import scala.scalanative.windows.SecurityBaseApi._
 @link("Advapi32")
 @extern
 object HelperMethods {
-  @name("scalanative_win32_winnt_setupUsersGroupSid")
+  @name("scalanative_winnt_setupUsersGroupSid")
   def setupUserGroupSid(ref: Ptr[SIDPtr]): Boolean = extern
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/SidNameUse.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/SidNameUse.scala
@@ -3,36 +3,36 @@ package scala.scalanative.windows.winnt
 import scalanative.unsafe._
 @extern
 object SidNameUse {
-  @name("scalanative_win32_winnt_sid_name_use_sidtypeuser")
+  @name("scalanative_sidtypeuser")
   def SidTypeUser: SidNameUse = extern
 
-  @name("scalanative_win32_winnt_sid_name_use_sidtypegroup")
+  @name("scalanative_sidtypegroup")
   def SidTypeGroup: SidNameUse = extern
 
-  @name("scalanative_win32_winnt_sid_name_use_sidtypedomain")
+  @name("scalanative_sidtypedomain")
   def SidTypeDomain: SidNameUse = extern
 
-  @name("scalanative_win32_winnt_sid_name_use_sidtypealias")
+  @name("scalanative_sidtypealias")
   def SidTypeAlias: SidNameUse = extern
 
-  @name("scalanative_win32_winnt_sid_name_use_sidtypewellknowngroup")
+  @name("scalanative_sidtypewellknowngroup")
   def SidTypeWellKnownGroup: SidNameUse = extern
 
-  @name("scalanative_win32_winnt_sid_name_use_sidtypedeletedaccount")
+  @name("scalanative_sidtypedeletedaccount")
   def SidTypeDeletedAccount: SidNameUse = extern
 
-  @name("scalanative_win32_winnt_sid_name_use_sidtypeinvalid")
+  @name("scalanative_sidtypeinvalid")
   def SidTypeInvalid: SidNameUse = extern
 
-  @name("scalanative_win32_winnt_sid_name_use_sidtypeunknown")
+  @name("scalanative_sidtypeunknown")
   def SidTypeUnknown: SidNameUse = extern
 
-  @name("scalanative_win32_winnt_sid_name_use_sidtypecomputer")
+  @name("scalanative_sidtypecomputer")
   def SidTypeComputer: SidNameUse = extern
 
-  @name("scalanative_win32_winnt_sid_name_use_sidtypelabel")
+  @name("scalanative_sidtypelabel")
   def SidTypeLabel: SidNameUse = extern
 
-  @name("scalanative_win32_winnt_sid_name_use_sidtypelogonsession")
+  @name("scalanative_sidtypelogonsession")
   def SidTypeLogonSession: SidNameUse = extern
 }

--- a/windowslib/src/main/scala/scala/scalanative/windows/winnt/TokenInformationClass.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/winnt/TokenInformationClass.scala
@@ -6,152 +6,152 @@ import scalanative.windows.DWord
 @link("Advapi32")
 @extern
 object TokenInformationClass {
-  @name("scalanative_win32_winnt_token_info_class_user")
+  @name("scalanative_tokenuser")
   def TokenUser: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_groups")
+  @name("scalanative_tokengroups")
   def TokenGroups: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_privileges")
+  @name("scalanative_tokenprivileges")
   def TokenPrivileges: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_owner")
+  @name("scalanative_tokenowner")
   def TokenOwner: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_primarygroup")
+  @name("scalanative_tokenprimarygroup")
   def TokenPrimaryGroup: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_defaultdacl")
+  @name("scalanative_tokendefaultdacl")
   def TokenDefaultDacl: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_source")
+  @name("scalanative_tokensource")
   def TokenSource: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_type")
+  @name("scalanative_tokentype")
   def TokenTokenInformationClass: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_impersonationlevel")
+  @name("scalanative_tokenimpersonationlevel")
   def TokenImpersonationLevel: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_statistics")
+  @name("scalanative_tokenstatistics")
   def TokenStatistics: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_restrictedsids")
+  @name("scalanative_tokenrestrictedsids")
   def TokenRestrictedSids: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_sessionid")
+  @name("scalanative_tokensessionid")
   def TokenSessionId: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_groupsandprivileges")
+  @name("scalanative_tokengroupsandprivileges")
   def TokenGroupsAndPrivileges: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_sessionreference")
+  @name("scalanative_tokensessionreference")
   def TokenSessionReference: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_sandboxinert")
+  @name("scalanative_tokensandboxinert")
   def TokenSandBoxInert: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_auditpolicy")
+  @name("scalanative_tokenauditpolicy")
   def TokenAuditPolicy: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_origin")
+  @name("scalanative_tokenorigin")
   def TokenOrigin: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_elevationtype")
+  @name("scalanative_tokenelevationtype")
   def TokenElevationTokenInformationClass: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_linkedtoken")
+  @name("scalanative_tokenlinkedtoken")
   def TokenLinkedToken: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_elevation")
+  @name("scalanative_tokenelevation")
   def TokenElevation: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_hasrestrictions")
+  @name("scalanative_tokenhasrestrictions")
   def TokenHasRestrictions: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_accessinformation")
+  @name("scalanative_tokenaccessinformation")
   def TokenAccessInformation: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_virtualizationallowed")
+  @name("scalanative_tokenvirtualizationallowed")
   def TokenVirtualizationAllowed: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_virtualizationenabled")
+  @name("scalanative_tokenvirtualizationenabled")
   def TokenVirtualizationEnabled: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_integritylevel")
+  @name("scalanative_tokenintegritylevel")
   def TokenIntegrityLevel: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_uiaccess")
+  @name("scalanative_tokenuiaccess")
   def TokenUIAccess: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_mandatorypolicy")
+  @name("scalanative_tokenmandatorypolicy")
   def TokenMandatoryPolicy: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_logonsid")
+  @name("scalanative_tokenlogonsid")
   def TokenLogonSid: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_isappcontainer")
+  @name("scalanative_tokenisappcontainer")
   def TokenIsAppContainer: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_capabilities")
+  @name("scalanative_tokencapabilities")
   def TokenCapabilities: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_appcontainersid")
+  @name("scalanative_tokenappcontainersid")
   def TokenAppContainerSid: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_appcontainernumber")
+  @name("scalanative_tokenappcontainernumber")
   def TokenAppContainerNumber: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_userclaimattributes")
+  @name("scalanative_tokenuserclaimattributes")
   def TokenUserClaimAttributes: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_deviceclaimattributes")
+  @name("scalanative_tokendeviceclaimattributes")
   def TokenDeviceClaimAttributes: TokenInformationClass = extern
 
   @name(
-    "scalanative_win32_winnt_token_info_class_restricteduserclaimattributes"
+    "scalanative_tokenrestricteduserclaimattributes"
   )
   def TokenRestrictedUserClaimAttributes: TokenInformationClass = extern
 
   @name(
-    "scalanative_win32_winnt_token_info_class_restricteddeviceclaimattributes"
+    "scalanative_tokenrestricteddeviceclaimattributes"
   )
   def TokenRestrictedDeviceClaimAttributes: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_devicegroups")
+  @name("scalanative_tokendevicegroups")
   def TokenDeviceGroups: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_restricteddevicegroups")
+  @name("scalanative_tokenrestricteddevicegroups")
   def TokenRestrictedDeviceGroups: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_securityattributes")
+  @name("scalanative_tokensecurityattributes")
   def TokenSecurityAttributes: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_isrestricted")
+  @name("scalanative_tokenisrestricted")
   def TokenIsRestricted: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_processtrustlevel")
+  @name("scalanative_tokenprocesstrustlevel")
   def TokenProcessTrustLevel: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_privatenamespace")
+  @name("scalanative_tokenprivatenamespace")
   def TokenPrivateNameSpace: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_singletonattributes")
+  @name("scalanative_tokensingletonattributes")
   def TokenSingletonAttributes: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_bnoisolation")
+  @name("scalanative_tokenbnoisolation")
   def TokenBnoIsolation: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_childprocessflags")
+  @name("scalanative_tokenchildprocessflags")
   def TokenChildProcessFlags: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_islessprivilegedappcontainer")
+  @name("scalanative_tokenislessprivilegedappcontainer")
   def TokenIsLessPrivilegedAppContainer: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_issandboxed")
+  @name("scalanative_tokenissandboxed")
   def TokenIsSandboxed: TokenInformationClass = extern
 
-  @name("scalanative_win32_winnt_token_info_class_infoclass_max")
+  @name("scalanative_maxtokeninfoclass")
   def MaxTokenInfoClass: TokenInformationClass = extern
 
 }


### PR DESCRIPTION
This PR does not add any new features. It only does adjust the naming of C functions defined in windowslib project to be aligned with the accepted naming conventions used in other projects.  Additionally, some unused functions were removed, others were placed in more appropriate files. 
In some cases (eg. WinSockets) naming for functions was adjusted in order to make a clear distinguishment from functions existing in POSIX with the same names. 