### PR TITLE
Update RE2 regex implementation

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
@@ -1116,6 +1116,15 @@ class Parser(wholeRegexp: String, _flags: Int) {
       if (c == 'P') {
         sign = -1
       }
+      if (!t.more()) {
+        val pos = t.pos()
+        t.rewindTo(startPos);
+        throw new PatternSyntaxException(
+          ERR_UNKNOWN_CHARACTER_PROPERTY_NAME,
+          t.rest(),
+          pos
+        )
+      }
       c = t.pop()
       var name: String = ""
       if (c != '{') {
@@ -1126,11 +1135,12 @@ class Parser(wholeRegexp: String, _flags: Int) {
         val rest = t.rest()
         val end = rest.indexOf('}')
         if (end < 0) {
+          val pos = t.pos()
           t.rewindTo(startPos)
           throw new PatternSyntaxException(
-            ERR_INVALID_CHAR_RANGE,
+            ERR_UNKNOWN_CHARACTER_PROPERTY_NAME,
             t.str,
-            t.pos() - 1
+            pos
           )
         }
         name = rest.substring(0, end) // e.g. "Han"
@@ -1325,7 +1335,7 @@ object Parser {
     "Unknown inline modifier"
 
   private final val ERR_INVALID_REPEAT_OP =
-    "invalid nested repetition operator"
+    "Invalid nested repetition operator"
 
   private final val ERR_INVALID_REPEAT_SIZE =
     "Dangling meta character '*'"
@@ -1341,6 +1351,9 @@ object Parser {
 
   private final val ERR_UNMATCHED_CLOSING_PAREN =
     "Unmatched closing ')'"
+
+  private final val ERR_UNKNOWN_CHARACTER_PROPERTY_NAME =
+    "Unknown character property name"
 
   // Hack to expose ArrayList.removeRange().
   private class Stack extends ArrayList[Regexp] {

--- a/unit-tests/native/src/test/scala/scala/scalanative/regex/ParserTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/regex/ParserTest.scala
@@ -332,12 +332,23 @@ class ParserTest {
   private val NOMATCHNL_TESTS = Array(
     Array(".", "dnl{}"),
     Array("\n", "lit{\n}"),
+    // These two tests exercise a pattern containing NL, using the NOMATCHNL
+    // flag (well, flags == 0). Dot will not match NL, so the alternation
+    // ".|\n" idiom is uses as a way to match any character, including NL.
+    //
+    // Yes, these tests belong here and not in MATCHNL_TESTS above.
+    // When MATCHNL, a.k.a DOTALL is the flag, there is no need for the idiom.
+    //
+    // Test both forms of alternation idiom for ROP.ANY_CHAR a.k.a. dot{}.
+    // The code paths differ slightly depending on the left term.
+    Array(".|\\n", "dot{}"),
+    Array("\\n|.", "dot{}"),
     Array("[^a]", "cc{0x0-0x9 0xb-0x60 0x62-0x10ffff}"),
     Array("[a\\n]", "cc{0xa 0x61}")
   )
 
   @Test def parseNoMatchNL(): Unit = {
-    testParseDump(NOMATCHNL_TESTS, 0)
+    testParseDump(NOMATCHNL_TESTS, 0) // All flags are clear.
   }
 
   // Test Parse -> Dump.

--- a/unit-tests/native/src/test/scala/scala/scalanative/regex/RE2CompileTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/regex/RE2CompileTest.scala
@@ -42,9 +42,11 @@ class RE2CompileTest {
 //          "Illegal/unsupported character class near index 3\n[a-z\n   ^"),
     Array("[z-a]", "Illegal character range near index 3\n[z-a]\n   ^"),
     Array("abc\\", "Trailing Backslash near index 4\nabc\\\n    ^"),
-    Array("a**", "invalid nested repetition operator near index 0\n**\n^"),
-    Array("a*+", "invalid nested repetition operator near index 0\n*+\n^"),
-    Array("\\x", "Illegal/unsupported escape sequence near index 1\n\\x\n ^")
+    Array("a**", "Invalid nested repetition operator near index 0\n**\n^"),
+    Array("a*+", "Invalid nested repetition operator near index 0\n*+\n^"),
+    Array("\\x", "Illegal/unsupported escape sequence near index 1\n\\x\n ^"),
+    Array("\\p", "Unknown character property name near index 2\n\\p\n  ^"),
+    Array("\\p{", "Unknown character property name near index 3\n\\p{\n   ^")
   )
 
   @Test def compile(): Unit = {


### PR DESCRIPTION
This PR is a rebased set of 3 of @LeeTibbert's PR's: #1690 #1691 and #1692. This includes:

* Fixing detection of an invalid unique specification "\p"
* Fixing the ANY_CHARACTER idiom
* Mutual exclusion improvements
* General updates to keep our implementation compatible with the original re2j one, for simplified maintenance

Original commit/PR messages were left untouched (mostly, as issue #1091 was fixed after the original commits, leading to some roundabout changes no longer being necessary) to preserve their intent and I think it would be best to merge with those messages intact.