### PR TITLE
Fix sn.regex parsing of OR expressions with a common prefix and \Q\E quoted expressions

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
+++ b/nativelib/src/main/scala/scala/scalanative/regex/Parser.scala
@@ -826,9 +826,14 @@ class Parser(wholeRegexp: String, _flags: Int) {
                   if (i >= 0) {
                     lit = lit.substring(0, i)
                   }
+
+                  // Ported directly to Scala Native from Go Repository
+                  // commit 0680e9c0c16a7d900e3564e1836b8cb93d962a2b
+                  // to fix Go issue #11187.
+                  lit.foreach(ch => literal(ch))
+
                   t.skipString(lit)
                   t.skipString("\\E")
-                  push(literalRegexp(lit, flags))
                   breakBigswitch = true
                 case 'z' =>
                   op(ROP.END_TEXT)

--- a/unit-tests/native/src/test/scala/scala/scalanative/regex/ParserTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/regex/ParserTest.scala
@@ -234,6 +234,7 @@ class ParserTest {
     // Test Perl quoted literals
     Array("\\Q+|*?{[\\E", "str{+|*?{[}"),
     Array("\\Q+\\E+", "plus{lit{+}}"),
+    Array("\\Qab\\E+", "cat{lit{a}plus{lit{b}}}"),
     Array("\\Q\\\\E", "lit{\\}"),
     Array("\\Q\\\\\\E", "str{\\\\}"),
     // Test Perl \A and \z


### PR DESCRIPTION
This PR is a rebase of #1701 and #1702 by @LeeTibbert fixing two issues in sn.regex by porting PR’s from the go and re2j repositories. Like before, I think it would be best if the commit messages were left intact in the merge to master, preserving their original intent.