### PR TITLE
Fix issue with checkFatalWarnings not ending build on a warning in checker

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -148,6 +148,12 @@ private[scalanative] object ScalaNative {
           }
           warn("")
           warn(s"${errors.size} errors found")
+
+          if (config.compilerConfig.checkFatalWarnings) {
+            throw new BuildException(
+              "Fatal warning(s) found; see the error output for details."
+            )
+          }
         }
       }
     }


### PR DESCRIPTION
Previously, the build would continue even after detecting and displaying an error. Now this is fixed as BuildException is being thrown on that occasion.