### PR TITLE
Port and update collections and tests to support IdentityHashMap

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -882,11 +882,7 @@ lazy val tests =
     .settings(noPublishSettings)
     .settings(
       nativeConfig ~= {
-        _.withLinkStubs(true) // default false
-          .withOptimize(true)
-          .withLTO(LTO.default)
-          .withMode(Mode.default)
-          .withGC(GC.default)
+        _.withLinkStubs(true)
       },
       testsCommonSettings,
       sharedTestSource(withBlacklist = false),

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ import scala.collection.mutable
 import scala.util.Try
 import build.ScalaVersions._
 import build.BinaryIncompatibilities
+import scala.scalanative.build._
 import com.typesafe.tools.mima.core.ProblemFilter
 
 // Convert "SomeName" to "some-name".
@@ -880,7 +881,13 @@ lazy val tests =
     .settings(buildInfoSettings)
     .settings(noPublishSettings)
     .settings(
-      nativeLinkStubs := true,
+      nativeConfig ~= {
+        _.withLinkStubs(true) // default false
+          .withOptimize(true)
+          .withLTO(LTO.default)
+          .withMode(Mode.default)
+          .withGC(GC.default)
+      },
       testsCommonSettings,
       sharedTestSource(withBlacklist = false),
       Test / unmanagedSourceDirectories ++= {

--- a/javalib/src/main/scala/java/util/AbstractMap.scala
+++ b/javalib/src/main/scala/java/util/AbstractMap.scala
@@ -2,6 +2,8 @@
 
 package java.util
 
+import java.{lang => jl}
+
 import scala.annotation.tailrec
 
 import ScalaOps._
@@ -44,7 +46,10 @@ object AbstractMap {
       entryHashCode(this)
 
     override def toString(): String =
-      "" + getKey() + "=" + getValue()
+      new jl.StringBuilder(getKey().toString)
+        .append("=")
+        .append(getValue().toString)
+        .toString
   }
 
   class SimpleImmutableEntry[K, V](key: K, value: V)
@@ -68,7 +73,10 @@ object AbstractMap {
       entryHashCode(this)
 
     override def toString(): String =
-      "" + getKey() + "=" + getValue()
+      new jl.StringBuilder(getKey().toString)
+        .append("=")
+        .append(getValue().toString)
+        .toString
   }
 }
 
@@ -176,7 +184,9 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
     entrySet().scalaOps.foldLeft(0)((prev, item) => item.hashCode + prev)
 
   override def toString(): String = {
-    var result = "{"
+    // Scala.js Strings are treated as primitive types
+    // so we use jl.StringBuilder for Scala Native
+    val sb = new jl.StringBuilder("{")
     var first = true
     val iter = entrySet().iterator()
     while (iter.hasNext()) {
@@ -184,9 +194,11 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
       if (first)
         first = false
       else
-        result += ", "
-      result = result + entry.getKey() + "=" + entry.getValue()
+        sb.append(", ")
+      sb.append(entry.getKey().toString)
+        .append("=")
+        .append(entry.getValue().toString)
     }
-    result + "}"
+    sb.append("}").toString
   }
 }

--- a/javalib/src/main/scala/java/util/AbstractMap.scala
+++ b/javalib/src/main/scala/java/util/AbstractMap.scala
@@ -1,29 +1,24 @@
+// Ported from Scala.js commit: a6c1451 dated: 2021-10-16
+
 package java.util
 
 import scala.annotation.tailrec
-import java.util.ScalaOps._
+
+import ScalaOps._
 
 object AbstractMap {
 
   private def entryEquals[K, V](entry: Map.Entry[K, V], other: Any): Boolean = {
     other match {
       case other: Map.Entry[_, _] =>
-        entry.getKey() === other.getKey() &&
-          entry.getValue() === other.getValue()
+        Objects.equals(entry.getKey(), other.getKey()) &&
+          Objects.equals(entry.getValue(), other.getValue())
       case _ => false
     }
   }
 
-  private def entryHashCode[K, V](entry: Map.Entry[K, V]): Int = {
-    val keyHash =
-      if (entry.getKey() == null) 0
-      else entry.getKey().hashCode
-    val valueHash =
-      if (entry.getValue() == null) 0
-      else entry.getValue().hashCode
-
-    keyHash ^ valueHash
-  }
+  private def entryHashCode[K, V](entry: Map.Entry[K, V]): Int =
+    Objects.hashCode(entry.getKey()) ^ Objects.hashCode(entry.getValue())
 
   class SimpleEntry[K, V](private var key: K, private var value: V)
       extends Map.Entry[K, V]
@@ -85,30 +80,30 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
   def isEmpty(): Boolean = size() == 0
 
   def containsValue(value: Any): Boolean =
-    entrySet().iterator().scalaOps.exists(value === _.getValue())
+    entrySet().scalaOps.exists(entry => Objects.equals(value, entry.getValue()))
 
   def containsKey(key: Any): Boolean =
-    entrySet().iterator().scalaOps.exists(entry => entry === key)
+    entrySet().scalaOps.exists(entry => Objects.equals(key, entry.getKey()))
 
   def get(key: Any): V = {
-    entrySet()
-      .iterator()
-      .scalaOps
-      .find(_.getKey() === key)
+    entrySet().scalaOps
+      .find(entry => Objects.equals(key, entry.getKey()))
       .fold[V] {
         null.asInstanceOf[V]
-      } { entry => entry.getValue() }
+      } { entry =>
+        entry.getValue()
+      }
   }
 
   def put(key: K, value: V): V =
     throw new UnsupportedOperationException()
 
-  override def remove(key: Any): V = {
+  def remove(key: Any): V = {
     @tailrec
     def findAndRemove(iter: Iterator[Map.Entry[K, V]]): V = {
       if (iter.hasNext()) {
         val item = iter.next()
-        if (key === item.getKey()) {
+        if (Objects.equals(key, item.getKey())) {
           iter.remove()
           item.getValue()
         } else
@@ -120,10 +115,7 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
   }
 
   def putAll(m: Map[_ <: K, _ <: V]): Unit =
-    m.entrySet()
-      .iterator()
-      .scalaOps
-      .foreach(e => put(e.getKey(), e.getValue()))
+    m.entrySet().scalaOps.foreach(e => put(e.getKey(), e.getValue()))
 
   def clear(): Unit =
     entrySet().clear()
@@ -171,10 +163,10 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
     else {
       o match {
         case m: Map[_, _] =>
-          (self.size() == m.size() &&
+          self.size() == m.size() &&
             entrySet().scalaOps.forall(item =>
-              m.get(item.getKey()) === item.getValue()
-            ))
+              Objects.equals(m.get(item.getKey()), item.getValue())
+            )
         case _ => false
       }
     }
@@ -184,11 +176,17 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
     entrySet().scalaOps.foldLeft(0)((prev, item) => item.hashCode + prev)
 
   override def toString(): String = {
-    entrySet()
-      .iterator()
-      .scalaOps
-      .map(e => s"${e.getKey()}=${e.getValue()}")
-      .scalaOps
-      .mkString("{", ", ", "}")
+    var result = "{"
+    var first = true
+    val iter = entrySet().iterator()
+    while (iter.hasNext()) {
+      val entry = iter.next()
+      if (first)
+        first = false
+      else
+        result += ", "
+      result = result + entry.getKey() + "=" + entry.getValue()
+    }
+    result + "}"
   }
 }

--- a/javalib/src/main/scala/java/util/Collections.scala
+++ b/javalib/src/main/scala/java/util/Collections.scala
@@ -611,7 +611,7 @@ object Collections {
     added
   }
 
-  def newSetFromMap[E](map: Map[E, java.lang.Boolean]): Set[E] = {
+  def newSetFromMap[E](map: Map[E, jl.Boolean]): Set[E] = {
     if (!map.isEmpty())
       throw new IllegalArgumentException
 
@@ -619,11 +619,11 @@ object Collections {
       override protected val inner: Set[E] = map.keySet()
 
       override def add(e: E): Boolean =
-        map.put(e, true) == null
+        map.put(e, jl.Boolean.TRUE) == null
 
       override def addAll(c: Collection[_ <: E]): Boolean =
         c.scalaOps.foldLeft(false)((prev, elem) =>
-          map.put(elem, true) == null || prev
+          map.put(elem, jl.Boolean.TRUE) == null || prev
         )
     }
   }

--- a/javalib/src/main/scala/java/util/HashMap.scala
+++ b/javalib/src/main/scala/java/util/HashMap.scala
@@ -1,164 +1,744 @@
+// Ported from Scala.js commit: a6c1451 dated: 2021-10-16
+
 package java.util
 
-import scala.collection.mutable
+import scala.annotation.tailrec
 
-class HashMap[K, V] protected (inner: mutable.Map[AnyRef, V])
+import java.{util => ju}
+import java.util.function.{BiConsumer, BiFunction, Function}
+
+import ScalaOps._
+
+class HashMap[K, V](initialCapacity: Int, loadFactor: Float)
     extends AbstractMap[K, V]
     with Serializable
-    with Cloneable { self =>
+    with Cloneable {
+  self =>
 
-  protected def boxKey(key: K): AnyRef =
-    key.asInstanceOf[AnyRef]
-  protected def unboxKey(box: AnyRef): K =
-    box.asInstanceOf[K]
+  import HashMap._
+
+  if (initialCapacity < 0)
+    throw new IllegalArgumentException("initialCapacity < 0")
+  if (loadFactor <= 0.0f)
+    throw new IllegalArgumentException("loadFactor <= 0.0")
 
   def this() =
-    this(mutable.AnyRefMap.empty[AnyRef, V])
-
-  def this(initialCapacity: Int, loadFactor: Float) = {
-    this()
-    if (initialCapacity < 0)
-      throw new IllegalArgumentException("initialCapacity < 0")
-    else if (loadFactor < 0.0)
-      throw new IllegalArgumentException("loadFactor <= 0.0")
-  }
+    this(HashMap.DEFAULT_INITIAL_CAPACITY, HashMap.DEFAULT_LOAD_FACTOR)
 
   def this(initialCapacity: Int) =
     this(initialCapacity, HashMap.DEFAULT_LOAD_FACTOR)
 
   def this(m: Map[_ <: K, _ <: V]) = {
-    this()
+    this(m.size())
     putAll(m)
   }
 
-  override def clear(): Unit =
-    inner.clear()
+  /** The actual hash table.
+   *
+   *  In each bucket, nodes are sorted by increasing value of `hash`.
+   *
+   *  Deviation from the JavaDoc: we do not use `initialCapacity` as is for the
+   *  number of buckets. Instead we round it up to the next power of 2. This
+   *  allows some algorithms to be more efficient, notably `index()` and
+   *  `growTable()`. Since the number of buckets is not observable from the
+   *  outside, this deviation does not change any semantics.
+   */
+  private[this] var table = new Array[Node[K, V]](tableSizeFor(initialCapacity))
 
-  override def clone(): AnyRef = {
-    new HashMap(inner.clone())
+  /** The next size value at which to resize (capacity * load factor). */
+  private[this] var threshold: Int = newThreshold(table.length)
+
+  private[this] var contentSize: Int = 0
+
+  /* Internal API for LinkedHashMap: these methods are overridden in
+   * LinkedHashMap to implement its insertion- or access-order.
+   */
+
+  private[util] def newNode(
+      key: K,
+      hash: Int,
+      value: V,
+      previous: Node[K, V],
+      next: Node[K, V]
+  ): Node[K, V] = {
+    new Node(key, hash, value, previous, next)
   }
 
-  override def containsKey(key: Any): Boolean =
-    inner.contains(boxKey(key.asInstanceOf[K]))
+  private[util] def nodeWasAccessed(node: Node[K, V]): Unit = ()
 
-  override def containsValue(value: Any): Boolean =
-    inner.valuesIterator.contains(value.asInstanceOf[V])
+  private[util] def nodeWasAdded(node: Node[K, V]): Unit = ()
 
-  override def entrySet(): Set[Map.Entry[K, V]] =
-    new EntrySet
+  private[util] def nodeWasRemoved(node: Node[K, V]): Unit = ()
 
-  override def get(key: Any): V = inner match {
-    case _: mutable.AnyRefMap[_, _] =>
-      val inner = this.inner.asInstanceOf[mutable.AnyRefMap[AnyRef, V]]
-      inner.getOrNull(boxKey(key.asInstanceOf[K]))
-    case _ =>
-      inner.get(boxKey(key.asInstanceOf[K])).getOrElse(null.asInstanceOf[V])
-  }
-
-  override def isEmpty(): Boolean =
-    inner.isEmpty
-
-  override def keySet(): Set[K] =
-    new KeySet
-
-  override def put(key: K, value: V): V =
-    inner.put(boxKey(key), value).getOrElse(null.asInstanceOf[V])
-
-  override def remove(key: Any): V = {
-    val boxedKey = boxKey(key.asInstanceOf[K])
-    inner.get(boxedKey).fold(null.asInstanceOf[V]) { value =>
-      inner -= boxedKey
-      value
-    }
-  }
+  // Public API
 
   override def size(): Int =
-    inner.size
+    contentSize
 
-  override def values(): Collection[V] =
-    new ValuesView
+  override def isEmpty(): Boolean =
+    contentSize == 0
 
-  private class EntrySet
-      extends AbstractSet[Map.Entry[K, V]]
-      with AbstractMapView[Map.Entry[K, V]] {
-    override def iterator(): Iterator[Map.Entry[K, V]] = {
-      new AbstractMapViewIterator[Map.Entry[K, V]] {
-        override protected def getNextForm(key: AnyRef): Map.Entry[K, V] = {
-          new AbstractMap.SimpleEntry(unboxKey(key), inner(key)) {
-            override def setValue(value: V): V = {
-              inner.update(key, value)
-              super.setValue(value)
-            }
+  override def get(key: Any): V =
+    getOrDefaultImpl(key, null.asInstanceOf[V])
+
+  override def containsKey(key: Any): Boolean =
+    findNode(key) ne null
+
+  override def put(key: K, value: V): V =
+    put0(key, value, ifAbsent = false)
+
+  override def putAll(m: Map[_ <: K, _ <: V]): Unit = {
+    m match {
+      case m: ju.HashMap[_, _] =>
+        val iter = m.nodeIterator()
+        while (iter.hasNext()) {
+          val next = iter.next()
+          put0(next.key, next.value, next.hash, ifAbsent = false)
+        }
+      case _ =>
+        super.putAll(m)
+    }
+  }
+
+  override def remove(key: Any): V = {
+    val node = remove0(key)
+    if (node eq null) null.asInstanceOf[V]
+    else node.value
+  }
+
+  override def clear(): Unit = {
+    ju.Arrays.fill(table.asInstanceOf[Array[AnyRef]], null)
+    contentSize = 0
+  }
+
+  override def containsValue(value: Any): Boolean =
+    valueIterator().scalaOps.exists(Objects.equals(value, _))
+
+  override def keySet(): ju.Set[K] =
+    new KeySet
+
+  override def values(): ju.Collection[V] =
+    new Values
+
+  def entrySet(): ju.Set[ju.Map.Entry[K, V]] =
+    new EntrySet
+
+  override def getOrDefault(key: Any, defaultValue: V): V =
+    getOrDefaultImpl(key, defaultValue)
+
+  /** Common implementation for get() and getOrDefault().
+   *
+   *  It is not directly inside the body of getOrDefault(), because subclasses
+   *  could override getOrDefault() to re-rely on get().
+   */
+  private def getOrDefaultImpl(key: Any, defaultValue: V): V = {
+    val node = findNode(key)
+    if (node eq null) {
+      defaultValue
+    } else {
+      nodeWasAccessed(node)
+      node.value
+    }
+  }
+
+  override def putIfAbsent(key: K, value: V): V =
+    put0(key, value, ifAbsent = true)
+
+  override def remove(key: Any, value: Any): Boolean = {
+    val (node, idx) = findNodeAndIndexForRemoval(key)
+    if ((node ne null) && Objects.equals(node.value, value)) {
+      remove0(node, idx)
+      true
+    } else {
+      false
+    }
+  }
+
+  override def replace(key: K, oldValue: V, newValue: V): Boolean = {
+    val node = findNode(key)
+    if ((node ne null) && Objects.equals(node.value, oldValue)) {
+      node.value = newValue
+      nodeWasAccessed(node)
+      true
+    } else {
+      false
+    }
+  }
+
+  override def replace(key: K, value: V): V = {
+    val node = findNode(key)
+    if (node ne null) {
+      val old = node.value
+      node.value = value
+      nodeWasAccessed(node)
+      old
+    } else {
+      null.asInstanceOf[V]
+    }
+  }
+
+  override def computeIfAbsent(
+      key: K,
+      mappingFunction: Function[_ >: K, _ <: V]
+  ): V = {
+    val (node, hash, idx, oldValue) = getNode0(key)
+    if (oldValue != null) {
+      oldValue
+    } else {
+      val newValue = mappingFunction.apply(key)
+      if (newValue != null)
+        put0(key, newValue, hash, node)
+      newValue
+    }
+  }
+
+  override def computeIfPresent(
+      key: K,
+      remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]
+  ): V = {
+    val (node, hash, idx, oldValue) = getNode0(key)
+    if (oldValue == null) {
+      oldValue
+    } else {
+      val newValue = remappingFunction.apply(key, oldValue)
+      putOrRemove0(key, hash, idx, node, newValue)
+    }
+  }
+
+  override def compute(
+      key: K,
+      remappingFunction: BiFunction[_ >: K, _ >: V, _ <: V]
+  ): V = {
+    val (node, hash, idx, oldValue) = getNode0(key)
+    val newValue = remappingFunction.apply(key, oldValue)
+    putOrRemove0(key, hash, idx, node, newValue)
+  }
+
+  override def merge(
+      key: K,
+      value: V,
+      remappingFunction: BiFunction[_ >: V, _ >: V, _ <: V]
+  ): V = {
+    Objects.requireNonNull(value)
+
+    val (node, hash, idx, oldValue) = getNode0(key)
+    val newValue =
+      if (oldValue == null) value
+      else remappingFunction.apply(oldValue, value)
+    putOrRemove0(key, hash, idx, node, newValue)
+  }
+
+  override def forEach(action: BiConsumer[_ >: K, _ >: V]): Unit = {
+    val len = table.length
+    var i = 0
+    while (i != len) {
+      var node = table(i)
+      while (node ne null) {
+        action.accept(node.key, node.value)
+        node = node.next
+      }
+      i += 1
+    }
+  }
+
+  override def clone(): AnyRef =
+    new HashMap[K, V](this)
+
+  // Elementary operations
+
+  @inline private def index(hash: Int): Int =
+    hash & (table.length - 1)
+
+  @inline
+  private def findNode(key: Any): Node[K, V] = {
+    val hash = computeHash(key)
+    findNode0(key, hash, index(hash))
+  }
+
+  @inline
+  private def findNodeAndIndexForRemoval(key: Any): (Node[K, V], Int) = {
+    val hash = computeHash(key)
+    val idx = index(hash)
+    val node = findNode0(key, hash, idx)
+    (node, idx)
+  }
+
+  private def findNode0(key: Any, hash: Int, idx: Int): Node[K, V] = {
+    @inline
+    @tailrec
+    def loop(node: Node[K, V]): Node[K, V] = {
+      if (node eq null) null
+      else if (hash == node.hash && Objects.equals(key, node.key)) node
+      else if (hash < node.hash) null
+      else loop(node.next)
+    }
+    loop(table(idx))
+  }
+
+  // Helpers for compute-like methods
+
+  @inline
+  private def getNode0(key: Any): (Node[K, V], Int, Int, V) = {
+    val hash = computeHash(key)
+    val idx = index(hash)
+    val node = findNode0(key, hash, idx)
+    val value = if (node eq null) {
+      null.asInstanceOf[V]
+    } else {
+      nodeWasAccessed(node)
+      node.value
+    }
+    (node, hash, idx, value)
+  }
+
+  private def putOrRemove0(
+      key: K,
+      hash: Int,
+      idx: Int,
+      node: Node[K, V],
+      newValue: V
+  ): V = {
+    if (newValue != null)
+      put0(key, newValue, hash, node)
+    else if (node ne null)
+      remove0(node, idx)
+    newValue
+  }
+
+  // Heavy lifting: modifications
+
+  /** Puts a key-value pair into this map.
+   *
+   *  If an entry already exists for the given key, `nodeWasAccessed` is called,
+   *  and, unless `ifAbsent` is true, its value is updated.
+   *
+   *  If no entry existed for the given key, a new entry is created with the
+   *  given value, and `nodeWasAdded` is called.
+   *
+   *  @param key
+   *    the key to put
+   *  @param value
+   *    the value to put
+   *  @param ifAbsent
+   *    if true, do not override an existing mapping
+   *  @return
+   *    the old value associated with `key`, or `null` if there was none
+   */
+  @inline
+  private[this] def put0(key: K, value: V, ifAbsent: Boolean): V =
+    put0(key, value, computeHash(key), ifAbsent)
+
+  /** Puts a key-value pair into this map.
+   *
+   *  If an entry already exists for the given key, `nodeWasAccessed` is called,
+   *  and, unless `ifAbsent` is true, its value is updated.
+   *
+   *  If no entry existed for the given key, a new entry is created with the
+   *  given value, and `nodeWasAdded` is called.
+   *
+   *  @param key
+   *    the key to put
+   *  @param value
+   *    the value to put
+   *  @param hash
+   *    the **improved** hashcode of `key` (see computeHash)
+   *  @param ifAbsent
+   *    if true, do not override an existing mapping
+   *  @return
+   *    the old value associated with `key`, or `null` if there was none
+   */
+  private[this] def put0(key: K, value: V, hash: Int, ifAbsent: Boolean): V = {
+    // scalastyle:off return
+    val newContentSize = contentSize + 1
+    if (newContentSize >= threshold)
+      growTable()
+    val idx = index(hash)
+    val newNode = table(idx) match {
+      case null =>
+        val newNode = this.newNode(key, hash, value, null, null)
+        table(idx) = newNode
+        newNode
+      case first =>
+        var prev: Node[K, V] = null
+        var n = first
+        while ((n ne null) && n.hash <= hash) {
+          if (n.hash == hash && Objects.equals(key, n.key)) {
+            nodeWasAccessed(n)
+            val old = n.value
+            if (!ifAbsent || (old == null))
+              n.value = value
+            return old
+          }
+          prev = n
+          n = n.next
+        }
+        val newNode = this.newNode(key, hash, value, prev, n)
+        if (prev eq null)
+          table(idx) = newNode
+        else
+          prev.next = newNode
+        if (n ne null)
+          n.previous = newNode
+        newNode
+    }
+    contentSize = newContentSize
+    nodeWasAdded(newNode)
+    null.asInstanceOf[V]
+    // scalastyle:on return
+  }
+
+  /** Puts a key-value pair into this map, given the result of an existing
+   *  lookup.
+   *
+   *  The parameter `node` must be the result of a lookup for the given key. If
+   *  null, this method assumes that there is no entry for the given key in the
+   *  map.
+   *
+   *  `nodeWasAccessed` is NOT called by this method, since it must already have
+   *  been called by the prerequisite lookup.
+   *
+   *  If no entry existed for the given key, a new entry is created with the
+   *  given value, and `nodeWasAdded` is called.
+   *
+   *  @param key
+   *    the key to add
+   *  @param value
+   *    the value to add
+   *  @param hash
+   *    the **improved** hashcode of `key` (see computeHash)
+   *  @param node
+   *    the entry for the given `key`, or `null` if there is no such entry
+   */
+  private[this] def put0(
+      key: K,
+      value: V,
+      hash: Int,
+      node: Node[K, V]
+  ): Unit = {
+    if (node ne null) {
+      node.value = value
+    } else {
+      val newContentSize = contentSize + 1
+      if (newContentSize >= threshold)
+        growTable()
+      val idx = index(hash)
+      val newNode = table(idx) match {
+        case null =>
+          val newNode = this.newNode(key, hash, value, null, null)
+          table(idx) = newNode
+          newNode
+        case first =>
+          var prev: Node[K, V] = null
+          var n = first
+          while ((n ne null) && n.hash < hash) {
+            prev = n
+            n = n.next
+          }
+          val newNode = this.newNode(key, hash, value, prev, n)
+          if (prev eq null)
+            table(idx) = newNode
+          else
+            prev.next = newNode
+          if (n ne null)
+            n.previous = newNode
+          newNode
+      }
+      contentSize = newContentSize
+      nodeWasAdded(newNode)
+    }
+  }
+
+  /** Removes a key from this map if it exists.
+   *
+   *  @param key
+   *    the key to remove
+   *  @return
+   *    the node that contained `key` if it was present, otherwise null
+   */
+  private def remove0(key: Any): Node[K, V] = {
+    val (node, idx) = findNodeAndIndexForRemoval(key)
+    if (node ne null)
+      remove0(node, idx)
+    node
+  }
+
+  private[util] final def removeNode(node: Node[K, V]): Unit =
+    remove0(node, index(node.hash))
+
+  private def remove0(node: Node[K, V], idx: Int): Unit = {
+    val previous = node.previous
+    val next = node.next
+    if (previous eq null)
+      table(idx) = next
+    else
+      previous.next = next
+    if (next ne null)
+      next.previous = previous
+    contentSize -= 1
+    nodeWasRemoved(node)
+  }
+
+  /** Grow the size of the table (always times 2). */
+  private[this] def growTable(): Unit = {
+    val oldTable = table
+    val oldlen = oldTable.length
+    val newlen = oldlen * 2
+    val newTable = new Array[Node[K, V]](newlen)
+    table = newTable
+    threshold = newThreshold(newlen)
+
+    /* Split the nodes of each bucket from the old table into the "low" and
+     * "high" indices of the new table. Since the new table contains exactly
+     * twice as many buckets as the old table, every index `i` from the old
+     * table is split into indices `i` and `oldlen + i` in the new table.
+     */
+    var i = 0
+    while (i < oldlen) {
+      var lastLow: Node[K, V] = null
+      var lastHigh: Node[K, V] = null
+      var node = oldTable(i)
+      while (node ne null) {
+        if ((node.hash & oldlen) == 0) {
+          // go to low
+          node.previous = lastLow
+          if (lastLow eq null)
+            newTable(i) = node
+          else
+            lastLow.next = node
+          lastLow = node
+        } else {
+          // go to high
+          node.previous = lastHigh
+          if (lastHigh eq null)
+            newTable(oldlen + i) = node
+          else
+            lastHigh.next = node
+          lastHigh = node
+        }
+        node = node.next
+      }
+      if (lastLow ne null)
+        lastLow.next = null
+      if (lastHigh ne null)
+        lastHigh.next = null
+      i += 1
+    }
+  }
+
+  /** Rounds up `capacity` to a power of 2, with a maximum of 2^30. */
+  @inline private[this] def tableSizeFor(capacity: Int): Int =
+    Math.min(Integer.highestOneBit(Math.max(capacity - 1, 4)) * 2, 1 << 30)
+
+  @inline private[this] def newThreshold(size: Int): Int =
+    (size.toDouble * loadFactor.toDouble).toInt
+
+  // Iterators
+
+  private[util] def nodeIterator(): ju.Iterator[Node[K, V]] =
+    new NodeIterator
+
+  private[util] def keyIterator(): ju.Iterator[K] =
+    new KeyIterator
+
+  private[util] def valueIterator(): ju.Iterator[V] =
+    new ValueIterator
+
+  // The cast works around the lack of definition-site variance
+  private[util] final def entrySetIterator(): ju.Iterator[Map.Entry[K, V]] =
+    nodeIterator().asInstanceOf[ju.Iterator[Map.Entry[K, V]]]
+
+  private final class NodeIterator extends AbstractHashMapIterator[Node[K, V]] {
+    protected[this] def extract(node: Node[K, V]): Node[K, V] = node
+  }
+
+  private final class KeyIterator extends AbstractHashMapIterator[K] {
+    protected[this] def extract(node: Node[K, V]): K = node.key
+  }
+
+  private final class ValueIterator extends AbstractHashMapIterator[V] {
+    protected[this] def extract(node: Node[K, V]): V = node.value
+  }
+
+  private abstract class AbstractHashMapIterator[A] extends ju.Iterator[A] {
+    private[this] val len = table.length
+    private[this] var nextIdx: Int = _ // 0
+    private[this] var nextNode: Node[K, V] = _ // null
+    private[this] var lastNode: Node[K, V] = _ // null
+
+    protected[this] def extract(node: Node[K, V]): A
+
+    /* Movements of `nextNode` and `nextIdx` are spread over `hasNext()` to
+     * simplify initial conditions, and preserving as much performance as
+     * possible while guaranteeing that constructing the iterator remains O(1)
+     * (the first linear behavior can happen when calling `hasNext()`, not
+     * before).
+     */
+
+    def hasNext(): Boolean = {
+      // scalastyle:off return
+      if (nextNode ne null) {
+        true
+      } else {
+        while (nextIdx < len) {
+          val node = table(nextIdx)
+          nextIdx += 1
+          if (node ne null) {
+            nextNode = node
+            return true
           }
         }
+        false
       }
+      // scalastyle:on return
+    }
+
+    def next(): A = {
+      if (!hasNext())
+        throw new NoSuchElementException("next on empty iterator")
+      val node = nextNode
+      lastNode = node
+      nextNode = node.next
+      extract(node)
+    }
+
+    override def remove(): Unit = {
+      val last = lastNode
+      if (last eq null)
+        throw new IllegalStateException(
+          "next must be called at least once before remove"
+        )
+      removeNode(last)
+      lastNode = null
     }
   }
 
-  private class KeySet extends AbstractSet[K] with AbstractMapView[K] {
-    override def remove(o: Any): Boolean = {
-      val boxedKey = boxKey(o.asInstanceOf[K])
-      val contains = inner.contains(boxedKey)
-      if (contains)
-        inner -= boxedKey
-      contains
-    }
+  // Views
 
-    override def iterator(): Iterator[K] = {
-      new AbstractMapViewIterator[K] {
-        protected def getNextForm(key: AnyRef): K =
-          unboxKey(key)
-      }
-    }
-  }
+  private final class KeySet extends AbstractSet[K] {
+    def iterator(): Iterator[K] =
+      keyIterator()
 
-  private class ValuesView extends AbstractMapView[V] {
-    override def size(): Int =
-      inner.size
+    def size(): Int =
+      self.size()
 
-    override def iterator(): Iterator[V] = {
-      new AbstractMapViewIterator[V] {
-        protected def getNextForm(key: AnyRef): V = inner(key)
-      }
-    }
-  }
+    override def contains(o: Any): Boolean =
+      containsKey(o)
 
-  private trait AbstractMapView[E] extends AbstractCollection[E] {
-    override def size(): Int =
-      inner.size
+    override def remove(o: Any): Boolean =
+      self.remove0(o) ne null
 
     override def clear(): Unit =
-      inner.clear()
+      self.clear()
   }
 
-  private abstract class AbstractMapViewIterator[E] extends Iterator[E] {
-    protected val innerIterator = inner.keySet.iterator
+  private final class Values extends AbstractCollection[V] {
+    def iterator(): ju.Iterator[V] =
+      valueIterator()
 
-    protected var lastKey: Option[AnyRef] = None
+    def size(): Int =
+      self.size()
 
-    protected def getNextForm(key: AnyRef): E
+    override def contains(o: Any): Boolean =
+      containsValue(o)
 
-    final override def next(): E = {
-      lastKey = Some(innerIterator.next())
-      getNextForm(lastKey.get)
+    override def clear(): Unit =
+      self.clear()
+  }
+
+  private final class EntrySet extends AbstractSet[Map.Entry[K, V]] {
+    def iterator(): Iterator[Map.Entry[K, V]] =
+      entrySetIterator()
+
+    def size(): Int =
+      self.size()
+
+    override def contains(o: Any): Boolean = o match {
+      case o: Map.Entry[_, _] =>
+        val node = findNode(o.getKey())
+        (node ne null) && Objects.equals(node.getValue(), o.getValue())
+      case _ =>
+        false
     }
 
-    final override def hasNext(): Boolean =
-      innerIterator.hasNext
-
-    final override def remove(): Unit = {
-      lastKey match {
-        case Some(key) =>
-          inner.remove(key)
-          lastKey = None
-        case None =>
-          throw new IllegalStateException
-      }
+    override def remove(o: Any): Boolean = o match {
+      case o: Map.Entry[_, _] =>
+        val key = o.getKey()
+        val (node, idx) = findNodeAndIndexForRemoval(key)
+        if ((node ne null) && Objects.equals(node.getValue(), o.getValue())) {
+          remove0(node, idx)
+          true
+        } else {
+          false
+        }
+      case _ =>
+        false
     }
+
+    override def clear(): Unit =
+      self.clear()
   }
 }
 
 object HashMap {
-  private[HashMap] final val DEFAULT_INITIAL_CAPACITY = 16
-  private[HashMap] final val DEFAULT_LOAD_FACTOR = 0.75f
+  private[util] final val DEFAULT_INITIAL_CAPACITY = 16
+  private[util] final val DEFAULT_LOAD_FACTOR = 0.75f
+
+  /** Computes the improved hash of an original (`any.hashCode()`) hash. */
+  @inline private def improveHash(originalHash: Int): Int = {
+    /* Improve the hash by xoring the high 16 bits into the low 16 bits just in
+     * case entropy is skewed towards the high-value bits. We only use the
+     * lowest bits to determine the hash bucket.
+     *
+     * This function is also its own inverse. That is, for all ints i,
+     * improveHash(improveHash(i)) = i
+     * this allows us to retrieve the original hash when we need it, and that
+     * is why unimproveHash simply forwards to this method.
+     */
+    originalHash ^ (originalHash >>> 16)
+  }
+
+  /** Performs the inverse operation of improveHash.
+   *
+   *  In this case, it happens to be identical to improveHash.
+   */
+  @inline private def unimproveHash(improvedHash: Int): Int =
+    improveHash(improvedHash)
+
+  /** Computes the improved hash of this key */
+  @inline private def computeHash(k: Any): Int =
+    if (k == null) 0
+    else improveHash(k.hashCode())
+
+  private[util] class Node[K, V](
+      val key: K,
+      val hash: Int,
+      var value: V,
+      var previous: Node[K, V],
+      var next: Node[K, V]
+  ) extends Map.Entry[K, V] {
+
+    def getKey(): K = key
+
+    def getValue(): V = value
+
+    def setValue(v: V): V = {
+      val oldValue = value
+      value = v
+      oldValue
+    }
+
+    override def equals(that: Any): Boolean = that match {
+      case that: Map.Entry[_, _] =>
+        Objects.equals(getKey(), that.getKey()) &&
+          Objects.equals(getValue(), that.getValue())
+      case _ =>
+        false
+    }
+
+    override def hashCode(): Int =
+      unimproveHash(hash) ^ Objects.hashCode(value)
+
+    override def toString(): String =
+      "" + getKey() + "=" + getValue()
+  }
 }

--- a/javalib/src/main/scala/java/util/IdentityHashMap.scala
+++ b/javalib/src/main/scala/java/util/IdentityHashMap.scala
@@ -1,13 +1,298 @@
+// Ported from Scala.js commit: a6c1451 dated: 2021-10-16
+
 package java.util
 
-class IdentityHashMap[K, V] extends HashMap[K, V] {
+import java.{util => ju}
 
-  override def boxKey(key: K): AnyRef =
-    IdentityBox(key)
+import scala.annotation.tailrec
 
-  override def unboxKey(box: AnyRef): K =
-    box match {
-      case IdentityBox(value) => value.asInstanceOf[K]
-      case _                  => null.asInstanceOf[K]
+import ScalaOps._
+
+/* The additional `internal` parameter works around
+ * https://github.com/scala/bug/issues/11755
+ */
+class IdentityHashMap[K, V] private (
+    inner: HashMap[IdentityHashMap.IdentityBox[K], V],
+    internal: Boolean
+) extends AbstractMap[K, V]
+    with Map[K, V]
+    with Serializable
+    with Cloneable {
+  self =>
+
+  import IdentityHashMap._
+
+  def this(expectedMaxSize: Int) = {
+    this(
+      new HashMap[IdentityHashMap.IdentityBox[K], V](
+        expectedMaxSize,
+        HashMap.DEFAULT_LOAD_FACTOR
+      ),
+      internal = true
+    )
+  }
+
+  def this() =
+    this(HashMap.DEFAULT_INITIAL_CAPACITY)
+
+  def this(initialMap: java.util.Map[_ <: K, _ <: V]) = {
+    this(initialMap.size())
+    putAll(initialMap)
+  }
+
+  override def clear(): Unit = inner.clear()
+
+  override def clone(): AnyRef = {
+    new IdentityHashMap(
+      inner.clone().asInstanceOf[HashMap[IdentityBox[K], V]],
+      internal = true
+    )
+  }
+
+  override def containsKey(key: Any): Boolean =
+    inner.containsKey(IdentityBox(key))
+
+  override def containsValue(value: Any): Boolean =
+    inner.valueIterator().scalaOps.exists(same(_, value))
+
+  override def get(key: Any): V =
+    inner.get(IdentityBox(key))
+
+  override def isEmpty(): Boolean = inner.isEmpty()
+
+  override def put(key: K, value: V): V =
+    inner.put(IdentityBox(key), value)
+
+  override def remove(key: Any): V =
+    inner.remove(IdentityBox(key))
+
+  override def size(): Int = inner.size()
+
+  override def values(): Collection[V] = new Values
+
+  override def keySet(): ju.Set[K] = new KeySet
+
+  override def entrySet(): Set[Map.Entry[K, V]] = new EntrySet
+
+  // Views
+
+  private final class Values extends AbstractCollection[V] {
+    def iterator(): ju.Iterator[V] =
+      inner.valueIterator()
+
+    def size(): Int =
+      self.size()
+
+    override def contains(o: Any): Boolean =
+      containsValue(o)
+
+    override def remove(o: Any): Boolean = {
+      @tailrec
+      def findAndRemove(iter: Iterator[V]): Boolean = {
+        if (iter.hasNext()) {
+          if (same(iter.next(), o)) {
+            iter.remove()
+            true
+          } else {
+            findAndRemove(iter)
+          }
+        } else {
+          false
+        }
+      }
+      findAndRemove(iterator())
     }
+
+    override def removeAll(c: Collection[_]): Boolean =
+      c.scalaOps.foldLeft(false)((prev, elem) => this.remove(elem) || prev)
+
+    override def retainAll(c: Collection[_]): Boolean = {
+      val iter = iterator()
+      var changed = false
+      while (iter.hasNext()) {
+        val elem = iter.next()
+        if (!findSame(elem, c)) {
+          iter.remove()
+          changed = true
+        }
+      }
+      changed
+    }
+
+    override def clear(): Unit =
+      self.clear()
+  }
+
+  private final class KeySet extends AbstractSet[K] {
+    def iterator(): Iterator[K] = {
+      new ju.Iterator[K] {
+        private val iter = inner.keyIterator()
+
+        def hasNext(): Boolean =
+          iter.hasNext()
+
+        def next(): K =
+          iter.next().inner
+
+        override def remove(): Unit =
+          iter.remove()
+      }
+    }
+
+    def size(): Int =
+      self.size()
+
+    override def contains(o: Any): Boolean =
+      containsKey(o)
+
+    override def remove(o: Any): Boolean = {
+      val hasKey = contains(o)
+      if (hasKey)
+        self.remove(o)
+      hasKey
+    }
+
+    override def removeAll(c: Collection[_]): Boolean = {
+      if (size() > c.size()) {
+        c.scalaOps.foldLeft(false)((prev, elem) => this.remove(elem) || prev)
+      } else {
+        @tailrec
+        def removeAll(iter: Iterator[K], modified: Boolean): Boolean = {
+          if (iter.hasNext()) {
+            if (findSame(iter.next(), c)) {
+              iter.remove()
+              removeAll(iter, true)
+            } else {
+              removeAll(iter, modified)
+            }
+          } else {
+            modified
+          }
+        }
+        removeAll(this.iterator(), false)
+      }
+    }
+
+    override def retainAll(c: Collection[_]): Boolean = {
+      val iter = iterator()
+      var changed = false
+      while (iter.hasNext()) {
+        val elem = iter.next()
+        if (!findSame(elem, c)) {
+          iter.remove()
+          changed = true
+        }
+      }
+      changed
+    }
+
+    override def clear(): Unit =
+      self.clear()
+  }
+
+  private final class EntrySet extends AbstractSet[Map.Entry[K, V]] {
+    def iterator(): Iterator[Map.Entry[K, V]] = {
+      new ju.Iterator[Map.Entry[K, V]] {
+        private val iter = inner.entrySetIterator()
+
+        def hasNext(): Boolean =
+          iter.hasNext()
+
+        def next(): Map.Entry[K, V] =
+          new MapEntry(iter.next())
+
+        override def remove(): Unit =
+          iter.remove()
+      }
+    }
+
+    def size(): Int =
+      inner.size()
+
+    override def contains(value: Any): Boolean = {
+      value match {
+        case value: Map.Entry[_, _] =>
+          val thatKey = value.getKey()
+          self.containsKey(thatKey) && same(self.get(thatKey), value.getValue())
+        case _ =>
+          false
+      }
+    }
+
+    override def remove(value: Any): Boolean = {
+      value match {
+        case value: Map.Entry[_, _] =>
+          val thatKey = value.getKey()
+          val thatValue = value.getValue()
+          if (self.containsKey(thatKey) && same(self.get(thatKey), thatValue)) {
+            self.remove(thatKey)
+            true
+          } else {
+            false
+          }
+        case _ =>
+          false
+      }
+    }
+
+    override def clear(): Unit =
+      inner.clear()
+  }
+}
+
+object IdentityHashMap {
+  private final case class IdentityBox[+K](inner: K) {
+    override def equals(o: Any): Boolean = {
+      o match {
+        case o: IdentityBox[_] =>
+          same(inner, o.inner)
+        case _ =>
+          false
+      }
+    }
+
+    override def hashCode(): Int =
+      System.identityHashCode(inner.asInstanceOf[AnyRef]) // cast
+  }
+
+  @inline private def same(v1: Any, v2: Any): Boolean =
+    v1.asInstanceOf[AnyRef] eq v2.asInstanceOf[AnyRef]
+
+  private def findSame[K](elem: K, c: Collection[_]): Boolean = {
+    val iter = c.iterator()
+    while (iter.hasNext()) {
+      if (same(elem, iter.next()))
+        return true
+    }
+    false
+  }
+
+  private final class MapEntry[K, V](entry: Map.Entry[IdentityBox[K], V])
+      extends Map.Entry[K, V] {
+
+    override def equals(other: Any): Boolean =
+      other match {
+        case other: Map.Entry[_, _] =>
+          same(this.getKey(), other.getKey()) &&
+            same(this.getValue(), other.getValue())
+        case _ =>
+          false
+      }
+
+    def getKey(): K =
+      entry.getKey().inner
+
+    def getValue(): V =
+      entry.getValue()
+
+    override def hashCode(): Int =
+      entry.getKey().hashCode() ^
+        System.identityHashCode(entry.getValue().asInstanceOf[AnyRef]) // cast
+
+    def setValue(value: V): V =
+      entry.setValue(value)
+
+    override def toString(): String =
+      "" + this.getKey() + "=" + this.getValue()
+  }
 }

--- a/javalib/src/main/scala/java/util/LinkedHashMap.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashMap.scala
@@ -1,76 +1,185 @@
+// Ported from Scala.js commit: a6c1451 dated: 2021-10-16
+
 package java.util
 
-import scala.collection.mutable
+import java.{util => ju}
+import java.util.function.BiConsumer
 
-class LinkedHashMap[K, V] private (
-    inner: mutable.LinkedHashMap[AnyRef, V],
+class LinkedHashMap[K, V](
+    initialCapacity: Int,
+    loadFactor: Float,
     accessOrder: Boolean
-) extends HashMap[K, V](inner) { self =>
+) extends HashMap[K, V](initialCapacity, loadFactor) {
+  self =>
 
-  override protected def boxKey(key: K): AnyRef =
-    Box(key)
-  override protected def unboxKey(box: AnyRef): K =
-    box.asInstanceOf[Box[K]].inner
+  import LinkedHashMap._
 
-  def this() =
-    this(mutable.LinkedHashMap.empty[AnyRef, V], false)
+  /** Node that was least recently created (or accessed under access-order). */
+  private var eldest: Node[K, V] = _
 
-  def this(initialCapacity: Int, loadFactor: Float, accessOrder: Boolean) = {
-    this(mutable.LinkedHashMap.empty[AnyRef, V], accessOrder)
-    if (initialCapacity < 0)
-      throw new IllegalArgumentException("initialCapacity < 0")
-    else if (loadFactor < 0.0)
-      throw new IllegalArgumentException("loadFactor <= 0.0")
-  }
+  /** Node that was most recently created (or accessed under access-order). */
+  private var youngest: Node[K, V] = _
 
   def this(initialCapacity: Int, loadFactor: Float) =
     this(initialCapacity, loadFactor, false)
 
   def this(initialCapacity: Int) =
-    this(initialCapacity, LinkedHashMap.DEFAULT_LOAD_FACTOR)
+    this(initialCapacity, HashMap.DEFAULT_LOAD_FACTOR)
+
+  def this() =
+    this(HashMap.DEFAULT_INITIAL_CAPACITY)
 
   def this(m: Map[_ <: K, _ <: V]) = {
-    this()
+    this(m.size())
     putAll(m)
   }
 
-  override def get(key: scala.Any): V = {
-    val value = super.get(key)
-    if (accessOrder) {
-      val boxedKey = Box(key.asInstanceOf[K])
-      if (value != null || containsKey(boxedKey)) {
-        inner.remove(boxedKey)
-        inner(boxedKey) = value
-      }
-    }
-    value
+  private def asMyNode(node: HashMap.Node[K, V]): Node[K, V] =
+    node.asInstanceOf[Node[K, V]]
+
+  private[util] override def newNode(
+      key: K,
+      hash: Int,
+      value: V,
+      previous: HashMap.Node[K, V],
+      next: HashMap.Node[K, V]
+  ): HashMap.Node[K, V] = {
+    new Node(key, hash, value, previous, next, null, null)
   }
 
-  override def put(key: K, value: V): V = {
-    val oldValue = {
-      if (accessOrder) {
-        val old = remove(key)
-        super.put(key, value)
-        old
-      } else {
-        super.put(key, value)
+  private[util] override def nodeWasAccessed(node: HashMap.Node[K, V]): Unit = {
+    if (accessOrder) {
+      val myNode = asMyNode(node)
+      if (myNode.younger ne null) {
+        removeFromOrderedList(myNode)
+        appendToOrderedList(myNode)
       }
     }
-    val iter = entrySet().iterator()
-    if (iter.hasNext() && removeEldestEntry(iter.next()))
-      iter.remove()
-    oldValue
+  }
+
+  private[util] override def nodeWasAdded(node: HashMap.Node[K, V]): Unit = {
+    appendToOrderedList(asMyNode(node))
+    if (removeEldestEntry(eldest))
+      removeNode(eldest)
+  }
+
+  private[util] override def nodeWasRemoved(node: HashMap.Node[K, V]): Unit =
+    removeFromOrderedList(asMyNode(node))
+
+  private def appendToOrderedList(node: Node[K, V]): Unit = {
+    val older = youngest
+    if (older ne null)
+      older.younger = node
+    else
+      eldest = node
+    node.older = older
+    node.younger = null
+    youngest = node
+  }
+
+  private def removeFromOrderedList(node: Node[K, V]): Unit = {
+    val older = node.older
+    val younger = node.younger
+    if (older eq null)
+      eldest = younger
+    else
+      older.younger = younger
+    if (younger eq null)
+      youngest = older
+    else
+      younger.older = older
+  }
+
+  override def clear(): Unit = {
+    super.clear()
+
+    /* #4195 HashMap.clear() won't call `nodeWasRemoved` for every node, which
+     * would be inefficient, so `eldest` and `yougest` are not automatically
+     * updated. We must explicitly set them to `null` here.
+     */
+    eldest = null
+    youngest = null
   }
 
   protected def removeEldestEntry(eldest: Map.Entry[K, V]): Boolean = false
 
+  override def forEach(action: BiConsumer[_ >: K, _ >: V]): Unit = {
+    var node = eldest
+    while (node ne null) {
+      action.accept(node.key, node.value)
+      node = node.younger
+    }
+  }
+
+  private[util] override def nodeIterator(): ju.Iterator[HashMap.Node[K, V]] =
+    new NodeIterator
+
+  private[util] override def keyIterator(): ju.Iterator[K] =
+    new KeyIterator
+
+  private[util] override def valueIterator(): ju.Iterator[V] =
+    new ValueIterator
+
+  private final class NodeIterator
+      extends AbstractLinkedHashMapIterator[HashMap.Node[K, V]] {
+    protected[this] def extract(node: Node[K, V]): Node[K, V] = node
+  }
+
+  private final class KeyIterator extends AbstractLinkedHashMapIterator[K] {
+    protected[this] def extract(node: Node[K, V]): K = node.key
+  }
+
+  private final class ValueIterator extends AbstractLinkedHashMapIterator[V] {
+    protected[this] def extract(node: Node[K, V]): V = node.value
+  }
+
+  private abstract class AbstractLinkedHashMapIterator[A]
+      extends ju.Iterator[A] {
+    private[this] var nextNode: Node[K, V] = eldest
+    private[this] var lastNode: Node[K, V] = _
+
+    protected[this] def extract(node: Node[K, V]): A
+
+    def hasNext(): Boolean =
+      nextNode ne null
+
+    def next(): A = {
+      if (!hasNext())
+        throw new NoSuchElementException("next on empty iterator")
+      val node = nextNode
+      lastNode = node
+      nextNode = node.younger
+      extract(node)
+    }
+
+    override def remove(): Unit = {
+      val last = lastNode
+      if (last eq null)
+        throw new IllegalStateException(
+          "next must be called at least once before remove"
+        )
+      removeNode(last)
+      lastNode = null
+    }
+  }
+
   override def clone(): AnyRef = {
-    new LinkedHashMap(inner.clone(), accessOrder)
+    val result = new LinkedHashMap[K, V](size(), loadFactor, accessOrder)
+    result.putAll(this)
+    result
   }
 }
 
 object LinkedHashMap {
 
-  private[LinkedHashMap] final val DEFAULT_INITIAL_CAPACITY = 16
-  private[LinkedHashMap] final val DEFAULT_LOAD_FACTOR = 0.75f
+  private final class Node[K, V](
+      key: K,
+      hash: Int,
+      value: V,
+      previous: HashMap.Node[K, V],
+      next: HashMap.Node[K, V],
+      var older: Node[K, V],
+      var younger: Node[K, V]
+  ) extends HashMap.Node[K, V](key, hash, value, previous, next)
+
 }

--- a/javalib/src/main/scala/java/util/Map.scala
+++ b/javalib/src/main/scala/java/util/Map.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js  commit f7be410 dated: 2020-10-07
+// Ported from Scala.js commit f7be410 dated: 2020-10-07
 
 package java.util
 

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -82,8 +82,9 @@ private[scalanative] object ScalaNative {
             linker.Link(config, linked.entries, optimized)
           }
         } else {
-          config.logger.info("Optimizing (false)")
-          linked
+          config.logger.time("Optimizing (false)") {
+            linked
+          }
         }
       }
     }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -82,6 +82,7 @@ private[scalanative] object ScalaNative {
             linker.Link(config, linked.entries, optimized)
           }
         } else {
+          config.logger.info("Optimizing (false)")
           linked
         }
       }

--- a/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/ScalaNative.scala
@@ -82,7 +82,7 @@ private[scalanative] object ScalaNative {
             linker.Link(config, linked.entries, optimized)
           }
         } else {
-          config.logger.time("Optimizing (false)") {
+          config.logger.time("Optimizing (skipped)") {
             linked
           }
         }

--- a/unit-tests/jvm/src/test/resources/BlacklistedTests.txt
+++ b/unit-tests/jvm/src/test/resources/BlacklistedTests.txt
@@ -14,7 +14,6 @@ scala/javalib/net/ServerSocketTest.scala
 
 scala/javalib/util/DefaultFormatterTest.scala
 scala/javalib/util/FormatterTest.scala
-scala/javalib/util/IdentityHashMapTest.scala
 scala/javalib/util/Base64Test.scala
 
 scala/javalib/nio/file/FileSystemExceptionTest.scala

--- a/unit-tests/shared/src/test/scala/javalib/util/AbstractMapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/AbstractMapTest.scala
@@ -1,4 +1,4 @@
-package javalib.util
+package org.scalanative.testsuite.javalib.util
 
 import java.util._
 

--- a/unit-tests/shared/src/test/scala/javalib/util/AbstractSetTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/AbstractSetTest.scala
@@ -1,0 +1,15 @@
+// Ported from Scala.js commit: a6c1451 dated: 2021-10-16
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+import scala.reflect.ClassTag
+
+abstract class AbstractSetTest extends SetTest {
+  def factory: AbstractSetFactory
+}
+
+trait AbstractSetFactory extends SetFactory {
+  def empty[E: ClassTag]: ju.AbstractSet[E]
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/CollectionTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/CollectionTest.scala
@@ -13,7 +13,7 @@ import org.scalanative.testsuite.javalib.lang.IterableTest
 import scala.reflect.ClassTag
 
 import scala.scalanative.junit.utils.AssertThrows.assertThrows
-import scala.scalanative.junit.utils.Utils._
+import Utils._
 
 trait CollectionTest extends IterableTest {
 

--- a/unit-tests/shared/src/test/scala/javalib/util/HashMapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/HashMapTest.scala
@@ -1,4 +1,4 @@
-package javalib.util
+package org.scalanative.testsuite.javalib.util
 
 import java.util._
 

--- a/unit-tests/shared/src/test/scala/javalib/util/HashSetTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/HashSetTest.scala
@@ -1,0 +1,19 @@
+// Ported from Scala.js commit: a6c1451 dated: 2021-10-16
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+import scala.reflect.ClassTag
+
+class HashSetTest extends AbstractSetTest {
+  def factory: HashSetFactory = new HashSetFactory
+}
+
+class HashSetFactory extends AbstractSetFactory {
+  def implementationName: String =
+    "java.util.HashSet"
+
+  def empty[E: ClassTag]: ju.HashSet[E] =
+    new ju.HashSet[E]()
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/IdentityHashMapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/IdentityHashMapTest.scala
@@ -1,4 +1,4 @@
-package javalib.util
+package org.scalanative.testsuite.javalib.util
 
 import java.util._
 

--- a/unit-tests/shared/src/test/scala/javalib/util/IdentityHashMapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/IdentityHashMapTest.scala
@@ -1,15 +1,18 @@
+// Ported from Scala.js commit: a6c1451 dated: 2021-10-16
+
 package org.scalanative.testsuite.javalib.util
 
 import java.util._
-
-// Ported from Scala.js
-
 import java.{util => ju}
 
 import scala.reflect.ClassTag
 
 import org.junit.Assert._
 import org.junit.Test
+
+import org.scalanative.testsuite.utils.Platform._
+
+import Utils._
 
 class IdentityHashMapTest extends MapTest {
   import MapTest._
@@ -29,96 +32,370 @@ class IdentityHashMapTest extends MapTest {
     }
   }
 
-  // tests from Harmony
-  // tests with null keys and values
-  val map = factory.empty[AnyRef, AnyRef]
-  var result: AnyRef = _
-  var value: AnyRef = _
-  var anothervalue: AnyRef = _
+  // Tests that check by value rather than identity (false negative tests)
+  // Similar to tests already in MapTest (copied and modified)
 
-  @Test def nullKeyAndValue(): Unit = {
-    result = map.put(null, null)
-    assertTrue(map.containsKey(null))
-    assertTrue(map.containsValue(null))
-    assertNull(map.get(null))
-    assertNull(result)
+  @Test def testIdentityMapWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    val key100 = TestObj(100)
+    val val12345 = TestObj(12345)
+    mp.put(key100, val12345)
+    mp.put(testObj(100), testObj(12345))
+
+    assertEquals(2, mp.size())
+    assertTrue(testObj(12345) eq mp.get(testObj(100)))
+    assertTrue(val12345 eq mp.get(key100))
+    assertFalse(testObj(12345) eq mp.get(key100))
+    assertFalse(val12345 eq mp.get(testObj(100)))
+    assertTrue(mp.containsKey(testObj(100)))
+    assertTrue(mp.containsKey(key100))
+    assertTrue(mp.containsValue(testObj(12345)))
+    assertTrue(mp.containsValue(val12345))
+
+    val rem1 = mp.remove(testObj(100))
+    assertTrue(rem1 eq testObj(12345))
+    assertFalse(rem1 eq val12345)
+    assertTrue(mp.containsKey(key100))
+    assertFalse(mp.containsKey(testObj(100)))
+    assertTrue(mp.containsValue(val12345))
+    assertFalse(mp.containsValue(testObj(12345)))
+
+    val rem2 = mp.remove(key100)
+    assertFalse(rem2 eq testObj(12345))
+    assertTrue(rem2 eq val12345)
+    assertFalse(mp.containsKey(key100))
+    assertFalse(mp.containsKey(testObj(100)))
+    assertFalse(mp.containsValue(val12345))
+    assertFalse(mp.containsValue(testObj(12345)))
+    assertTrue(mp.isEmpty())
   }
 
-  @Test def nullKeyReplaces(): Unit = {
-    value = "a value"
-    result = map.put(null, value)
-    assertTrue(map.containsKey(null))
-    assertTrue(map.containsValue(value))
-    assertTrue(map.get(null) eq value)
-    assertNull(result)
+  @Test def testIdentityEntrySetIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    mp.put(testObj(5), null)
+    mp.put(null, testObj(55))
+    val entrySet = mp.entrySet()
+
+    assertTrue(entrySet.contains(SIE(testObj(1), testObj(11))))
+    assertFalse(entrySet.contains(SIE(testObj(1), TestObj(11))))
+    assertFalse(entrySet.contains(SIE(TestObj(1), testObj(11))))
+
+    assertTrue(entrySet.contains(SIE(testObj(5), null)))
+    assertFalse(entrySet.contains(SIE(TestObj(5), null)))
+    assertFalse(entrySet.contains(SIE(testObj(6), null)))
+
+    assertTrue(entrySet.contains(SIE(null, testObj(55))))
+    assertFalse(entrySet.contains(SIE(null, TestObj(55))))
+
+    mp.put(testObj(3), testObj(33))
+
+    // containsAll calls contains tested above
+
+    val coll1 = TrivialImmutableCollection(
+      SIE(testObj(1), testObj(11)),
+      SIE(testObj(2), testObj(22)),
+      SIE(testObj(3), testObj(33))
+    )
+    val coll1a = TrivialImmutableCollection(
+      SIE(testObj(1), TestObj(11)),
+      SIE(testObj(2), testObj(22)),
+      SIE(testObj(3), testObj(33))
+    )
+    assertTrue(entrySet.containsAll(coll1))
+    assertFalse(entrySet.containsAll(coll1a))
   }
 
-  @Test def nullValue(): Unit = {
-    val key = "a key"
-    result = map.put(key, null)
-    assertTrue(map.containsKey(key))
-    assertTrue(map.containsValue(null))
-    assertNull(map.get(key))
-    assertNull(result)
+  @Test def testIdentityEntrySetIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    val entrySet = mp.entrySet()
+
+    assertFalse(entrySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    entrySet.clear()
+    assertTrue(entrySet.isEmpty)
+    assertTrue(mp.isEmpty)
+
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    mp.put(null, testObj(55))
+    mp.put(testObj(5), null)
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(TestObj(1)))
+    assertTrue(entrySet.remove(SIE(testObj(1), testObj(11))))
+    assertFalse(entrySet.remove(SIE(testObj(2), TestObj(22))))
+    assertFalse(entrySet.remove(SIE(testObj(2), testObj(44))))
+    assertFalse(entrySet.remove(SIE(TestObj(5), null)))
+    assertTrue(entrySet.remove(SIE(testObj(5), null)))
+
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(3), testObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    //removeAll and retainAll include non Entry values
+
+    entrySet.removeAll(
+      TrivialImmutableCollection(
+        SIE(testObj(1), TestObj(11)),
+        SIE(testObj(2), testObj(22)),
+        SIE(testObj(3), testObj(44)),
+        TestObj(3),
+        33
+      )
+    )
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    mp.put(testObj(2), testObj(22))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    entrySet.retainAll(
+      TrivialImmutableCollection(
+        SIE(testObj(1), testObj(11)),
+        SIE(testObj(2), testObj(22)),
+        SIE(testObj(3), TestObj(33)),
+        testObj(3),
+        42
+      )
+    )
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertFalse(mp.containsKey(testObj(3)))
+
+    val key1 = TestObj(1)
+    val val11 = TestObj(11)
+    mp.put(key1, val11)
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(key1))
+    entrySet.remove(SIE(testObj(1), testObj(11)))
+    assertFalse(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(key1))
+    entrySet.remove(SIE(key1, TestObj(11)))
+    assertFalse(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(key1))
+    entrySet.remove(SIE(key1, val11))
+    assertFalse(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(key1))
   }
 
-  @Test def anotherNullKeyReplacesOldVal(): Unit = {
-    anothervalue = "another value"
-    result = map.put(null, anothervalue)
-    assertTrue(map.containsKey(null))
-    assertTrue(map.containsValue(anothervalue))
-    assertTrue(map.get(null) eq anothervalue)
-    assertTrue(result eq value)
+  @Test def testIdentityKeySetIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+    val keySet = mp.keySet()
+
+    assertTrue(keySet.contains(testObj(1)))
+    assertFalse(keySet.contains(TestObj(1)))
+    assertTrue(keySet.contains(testObj(2)))
+    assertFalse(keySet.contains(TestObj(2)))
+    assertFalse(keySet.contains(testObj(3)))
+
+    mp.put(testObj(3), TestObj(33))
+
+    assertTrue(keySet.contains(testObj(3)))
+    assertFalse(keySet.contains(TestObj(3)))
+
+    val coll1 = TrivialImmutableCollection(testObj(1), testObj(2), testObj(3))
+    val coll1a = TrivialImmutableCollection(testObj(1), testObj(2), TestObj(3))
+    assertTrue(keySet.containsAll(coll1))
+    assertFalse(keySet.containsAll(coll1a))
   }
 
-  @Test def removeANullKey(): Unit = {
-    result = map.remove(null)
-    assertTrue(result eq anothervalue)
-    assertTrue(!map.containsKey(null))
-    assertTrue(!map.containsValue(anothervalue))
-    assertNull(map.get(null))
+  @Test def testIdentityKeySetIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+    val keySet = mp.keySet()
+
+    assertFalse(keySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    keySet.clear()
+
+    assertTrue(keySet.isEmpty)
+
+    assertTrue(mp.isEmpty)
+
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    keySet.remove(testObj(1))
+    assertFalse(mp.containsKey(testObj(1)))
+
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(3), TestObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+    assertFalse(mp.containsKey(TestObj(3)))
+
+    val coll1 =
+      TrivialImmutableCollection(testObj(1), TestObj(2), testObj(3), testObj(5))
+    keySet.removeAll(coll1)
+
+    assertFalse(mp.containsKey(testObj(1)))
+    if (!executingInJVM)
+      assertTrue(mp.containsKey(testObj(2)))
+    assertFalse(mp.containsKey(testObj(3)))
+
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+    mp.put(testObj(3), TestObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    val coll2 = TrivialImmutableCollection(testObj(1), testObj(2), TestObj(3))
+    keySet.retainAll(coll2)
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    if (!executingInJVM)
+      assertFalse(mp.containsKey(testObj(3)))
+    assertFalse(mp.containsKey(TestObj(3)))
+
+    mp.put(null, TestObj(111))
+    assertTrue(mp.containsKey(null))
+    assertTrue(keySet.contains(null))
+    assertTrue(keySet.remove(null))
+    assertFalse(mp.containsKey(null))
+
+    mp.put(testObj(4), null)
+    assertTrue(mp.containsKey(testObj(4)))
+    assertFalse(mp.containsKey(TestObj(4)))
+    assertTrue(keySet.contains(testObj(4)))
+    assertFalse(keySet.contains(TestObj(4)))
+    assertFalse(keySet.remove(TestObj(4)))
+    assertFalse(mp.containsKey(TestObj(4)))
+    assertTrue(mp.containsKey(testObj(4)))
+    assertTrue(keySet.contains(testObj(4)))
+    assertTrue(keySet.remove(testObj(4)))
+    assertFalse(mp.containsKey(testObj(4)))
+    assertFalse(keySet.contains(testObj(4)))
+
+    val key1 = TestObj(1)
+    val val11 = TestObj(11)
+    mp.put(key1, val11)
+    mp.put(testObj(1), TestObj(11))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(key1))
+    keySet.remove(testObj(1))
+    assertFalse(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(key1))
+    keySet.remove(key1)
+    assertFalse(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(key1))
   }
 
-  @Test def checkPutNullKeyNullValue(): Unit = {
-    val map = factory.empty[AnyRef, AnyRef]
-    val value = "Some value"
-    map.put(null, value)
-    assertEquals(value, map.get(null))
-    val key = "Some key"
-    map.put(key, null)
-    assertNull(map.get(key))
+  @Test def testIdentityValuesIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    val values = mp.values()
+
+    assertTrue(values.contains(testObj(11)))
+    assertFalse(values.contains(TestObj(11)))
+    assertTrue(values.contains(testObj(22)))
+    assertFalse(values.contains(testObj(33)))
+
+    mp.put(testObj(3), testObj(33))
+
+    assertTrue(values.contains(testObj(33)))
+
+    val coll1 =
+      TrivialImmutableCollection(testObj(11), TestObj(22), testObj(33))
+    assertFalse(values.containsAll(coll1))
+
+    val coll2 = TrivialImmutableCollection(
+      testObj(11),
+      testObj(22),
+      testObj(33),
+      testObj(44)
+    )
+    assertFalse(values.containsAll(coll2))
   }
 
-  @Test def checkRemove(): Unit = {
-    val map = factory.empty[AnyRef, AnyRef]
-    map.put(null, null)
-    map.put("key1", "value1")
-    map.put("key2", "value2")
-    map.remove("key1")
-    assertTrue(!map.containsKey("key1")) // Did not remove key1
-    assertTrue(!map.containsValue("value1")) // Did not remove the value for key
-    assertTrue(
-      map.get("key2") != null && (map.get("key2") eq "value2")
-    ) // Modified key2
-    assertNull(map.get(null)) // Modified null entry
-  }
+  @Test def testIdentityValuesIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    mp.put(testObj(3), testObj(33))
+    val values = mp.values()
 
-  @Test def regressionForHarmony37(): Unit = {
-    // cannot link: @java.util.IdentityHashMap::field.size
-    // requires size()
-    val map = factory.empty[String, String]
-    map.remove("absent")
-    assertEquals(0, map.size()) // Size is incorrect
-    map.put("key", "value")
-    map.remove("key")
-    // After removing non-null element size is incorrect
-    assertEquals(0, map.size())
-    map.put(null, null)
-    assertEquals(1, map.size()) // adding literal null failed
-    map.remove(null)
-    assertEquals(0, map.size()) // After removing null element size is incorrect
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    assertTrue(values.remove(testObj(11)))
+    assertTrue(values.remove(testObj(22)))
+    assertFalse(values.remove(TestObj(33)))
+
+    assertFalse(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    mp.put(testObj(3), testObj(33))
+
+    val coll1 =
+      TrivialImmutableCollection(testObj(11), testObj(22), TestObj(33))
+    values.removeAll(coll1)
+
+    assertFalse(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(testObj(2)))
+    if (!executingInJVM)
+      assertTrue(mp.containsKey(testObj(3)))
+
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    mp.put(testObj(3), testObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    values.retainAll(
+      TrivialImmutableCollection(testObj(11), testObj(22), TestObj(33))
+    )
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    if (!executingInJVM)
+      assertFalse(mp.containsKey(testObj(3)))
+
+    val key1 = TestObj(1)
+    val val11 = TestObj(11)
+    mp.put(key1, val11)
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(key1))
+    values.remove(testObj(11))
+    assertFalse(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(key1))
+    values.remove(val11)
+    assertFalse(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(key1))
   }
-  // other Harmony tests available
 }
 
 class IdentityHashMapFactory extends MapFactory {

--- a/unit-tests/shared/src/test/scala/javalib/util/LinkedHashMapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/LinkedHashMapTest.scala
@@ -1,4 +1,4 @@
-package javalib.util
+package org.scalanative.testsuite.javalib.util
 
 import java.util._
 

--- a/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
@@ -1,4 +1,4 @@
-package javalib.util
+package org.scalanative.testsuite.javalib.util
 
 import java.util._
 

--- a/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
@@ -1661,13 +1661,19 @@ trait MapTest {
     mp.put("ONE", "one")
     assertEquals("{ONE=one}", mp.toString())
     mp.put("TWO", "two")
-    assertEquals("{ONE=one, TWO=two}", mp.toString())
+    // handle ordering issues
+    val o1 = "{ONE=one, TWO=two}"
+    val o2 = "{TWO=two, ONE=one}"
+    val res = mp.toString()
+    if (o1 == res) assertEquals(o1, res)
+    else assertEquals(o2, res)
   }
 
   @Test def testIntMapEntryToString(): Unit = {
     val mp = factory.empty[Int, Int]
     mp.put(1, 10)
     assertEquals("1=10", mp.entrySet.iterator().next().toString())
+    mp.clear()
     mp.put(2, 20)
     assertEquals("2=20", mp.entrySet.iterator().next().toString())
   }

--- a/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
@@ -29,6 +29,12 @@ trait MapTest {
       executingInJVM && factory.isIdentityBased
     )
 
+  private def assumeNotIdentityHashMapOnJVMAndNative(): Unit =
+    assumeFalse(
+      "JVM and Native vs JS cache differences",
+      (executingInJVM || executingInScalaNative) && factory.isIdentityBased
+    )
+
   @Test def testSizeGetPutWithStrings(): Unit = {
     assumeNotIdentityHashMapOnJVM()
 
@@ -55,19 +61,16 @@ trait MapTest {
   }
 
   @Test def testSizeGetPutWithStringsLargeMap(): Unit = {
-    assumeNotIdentityHashMapOnJVM()
+    assumeNotIdentityHashMapOnJVMAndNative()
 
     val largeMap = factory.empty[String, Int]
     for (i <- 0 until 1000)
       largeMap.put(i.toString(), i)
     val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
     assertEquals(expectedSize, largeMap.size())
-    if (!factory.isIdentityBased) {
-      for (i <- (1000 - expectedSize) until 1000)
-        assertEquals(i, largeMap.get(i.toString()))
-    }
+    for (i <- (1000 - expectedSize) until 1000)
+      assertEquals(i, largeMap.get(i.toString()))
     assertNull(largeMap.get("1000"))
-
     assertEquals(null, largeMap.get("THREE"))
     assertEquals(null, largeMap.get(42))
     assertEquals(null, largeMap.get(testObj(42)))
@@ -98,17 +101,15 @@ trait MapTest {
   }
 
   @Test def testSizeGetPutWithIntsLargeMap(): Unit = {
-    assumeNotIdentityHashMapOnJVM()
+    assumeNotIdentityHashMapOnJVMAndNative()
 
     val largeMap = factory.empty[Int, Int]
     for (i <- 0 until 1000)
       largeMap.put(i, i * 2)
     val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
     assertEquals(expectedSize, largeMap.size())
-    if (!factory.isIdentityBased) {
-      for (i <- (1000 - expectedSize) until 1000)
-        assertEquals(i * 2, largeMap.get(i))
-    }
+    for (i <- (1000 - expectedSize) until 1000)
+      assertEquals(i * 2, largeMap.get(i))
     assertNull(largeMap.get(1000))
 
     assertEquals(null, largeMap.get(-42))

--- a/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
@@ -62,8 +62,10 @@ trait MapTest {
       largeMap.put(i.toString(), i)
     val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
     assertEquals(expectedSize, largeMap.size())
-    for (i <- (1000 - expectedSize) until 1000)
-      assertEquals(i, largeMap.get(i.toString()))
+    if (!factory.isIdentityBased) {
+      for (i <- (1000 - expectedSize) until 1000)
+        assertEquals(i, largeMap.get(i.toString()))
+    }
     assertNull(largeMap.get("1000"))
 
     assertEquals(null, largeMap.get("THREE"))
@@ -103,8 +105,10 @@ trait MapTest {
       largeMap.put(i, i * 2)
     val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
     assertEquals(expectedSize, largeMap.size())
-    for (i <- (1000 - expectedSize) until 1000)
-      assertEquals(i * 2, largeMap.get(i))
+    if (!factory.isIdentityBased) {
+      for (i <- (1000 - expectedSize) until 1000)
+        assertEquals(i * 2, largeMap.get(i))
+    }
     assertNull(largeMap.get(1000))
 
     assertEquals(null, largeMap.get(-42))

--- a/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
@@ -1,20 +1,20 @@
+// Ported from Scala.js commit: 9683b0c dated: 2021-10-22
+
 package org.scalanative.testsuite.javalib.util
 
-import java.util._
-
-// Ported from Scala.js
-
 import java.{util => ju}
+import java.util.function.{BiConsumer, BiFunction, Function}
+
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
+
 import scala.scalanative.junit.utils.AssertThrows.assertThrows
-import scala.collection.{immutable => im}
-import scala.collection.{mutable => mu}
+import org.scalanative.testsuite.utils.Platform._
 
 import scala.reflect.ClassTag
-import scala.scalanative.junit.utils.CollectionConverters._
-import org.scalanative.testsuite.utils.Platform._
+
+import Utils._
 
 trait MapTest {
   import MapTest._
@@ -24,16 +24,11 @@ trait MapTest {
   def testObj(i: Int): TestObj = TestObj(i)
 
   private def assumeNotIdentityHashMapOnJVM(): Unit =
-    assumeFalse(
-      "JVM vs Native cache differences",
-      executingInJVM && factory.isIdentityBased
-    )
+    assumeFalse("JVM vs JS cache differences", executingInJVM && factory.isIdentityBased)
 
-  // temp implementation
-  // private def assumeNotIdentityHashMapOnJVM(): Unit =
-  //   assumeFalse("JVM vs Native cache differences", factory.isIdentityBased)
+  @Test def testSizeGetPutWithStrings(): Unit = {
+    assumeNotIdentityHashMapOnJVM()
 
-  @Test def shouldStoreStrings(): Unit = {
     val mp = factory.empty[String, String]
 
     assertEquals(0, mp.size())
@@ -43,19 +38,117 @@ trait MapTest {
     mp.put("TWO", "two")
     assertEquals(2, mp.size())
     assertEquals("two", mp.get("TWO"))
+    mp.put("ONE", "three")
+    assertEquals(2, mp.size())
+    assertEquals("three", mp.get("ONE"))
+
+    assertEquals(null, mp.get("THREE"))
+    assertEquals(null, mp.get(42))
+    assertEquals(null, mp.get(testObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, mp.get(null))
+    else
+      assertThrows(classOf[NullPointerException], mp.get(null))
   }
 
-  @Test def shouldStoreIntegers(): Unit = {
+  @Test def testSizeGetPutWithStringsLargeMap(): Unit = {
     assumeNotIdentityHashMapOnJVM()
+
+    val largeMap = factory.empty[String, Int]
+    for (i <- 0 until 1000)
+      largeMap.put(i.toString(), i)
+    val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
+    assertEquals(expectedSize, largeMap.size())
+    for (i <- (1000 - expectedSize) until 1000)
+      assertEquals(i, largeMap.get(i.toString()))
+    assertNull(largeMap.get("1000"))
+
+    assertEquals(null, largeMap.get("THREE"))
+    assertEquals(null, largeMap.get(42))
+    assertEquals(null, largeMap.get(testObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, largeMap.get(null))
+  }
+
+  @Test def testSizeGetPutWithInts(): Unit = {
+    assumeNotIdentityHashMapOnJVM()
+
     val mp = factory.empty[Int, Int]
 
     mp.put(100, 12345)
     assertEquals(1, mp.size())
-    val one = mp.get(100)
-    assertEquals(12345, one)
+    assertEquals(12345, mp.get(100))
+    mp.put(150, 54321)
+    assertEquals(2, mp.size())
+    assertEquals(54321, mp.get(150))
+    mp.put(100, 3)
+    assertEquals(2, mp.size())
+    assertEquals(3, mp.get(100))
+
+    assertEquals(null, mp.get(42))
+    assertEquals(null, mp.get("THREE"))
+    assertEquals(null, mp.get(testObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, mp.get(null))
   }
 
-  @Test def shouldStoreDoublesAlsoInCornerCases() {
+  @Test def testSizeGetPutWithIntsLargeMap(): Unit = {
+    assumeNotIdentityHashMapOnJVM()
+
+    val largeMap = factory.empty[Int, Int]
+    for (i <- 0 until 1000)
+      largeMap.put(i, i * 2)
+    val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
+    assertEquals(expectedSize, largeMap.size())
+    for (i <- (1000 - expectedSize) until 1000)
+      assertEquals(i * 2, largeMap.get(i))
+    assertNull(largeMap.get(1000))
+
+    assertEquals(null, largeMap.get(-42))
+    assertEquals(null, largeMap.get("THREE"))
+    assertEquals(null, largeMap.get(testObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, largeMap.get(null))
+  }
+
+  @Test def testSizeGetPutWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+
+    mp.put(testObj(100), TestObj(12345))
+    assertEquals(1, mp.size())
+    assertEquals(12345, mp.get(testObj(100)).num)
+    mp.put(testObj(150), TestObj(54321))
+    assertEquals(2, mp.size())
+    assertEquals(54321, mp.get(testObj(150)).num)
+    mp.put(testObj(100), TestObj(3))
+    assertEquals(2, mp.size())
+    assertEquals(3, mp.get(testObj(100)).num)
+
+    assertEquals(null, mp.get("THREE"))
+    assertEquals(null, mp.get(42))
+    assertEquals(null, mp.get(testObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, mp.get(null))
+  }
+
+  @Test def testSizeGetPutWithCustomObjectsLargeMap(): Unit = {
+    val largeMap = factory.empty[TestObj, Int]
+    for (i <- 0 until 1000)
+      largeMap.put(testObj(i), i * 2)
+    val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
+    assertEquals(expectedSize, largeMap.size())
+    for (i <- (1000 - expectedSize) until 1000)
+      assertEquals(i * 2, largeMap.get(testObj(i)))
+    assertNull(largeMap.get(1000))
+
+    assertEquals(null, largeMap.get(testObj(-42)))
+    assertEquals(null, largeMap.get("THREE"))
+    assertEquals(null, largeMap.get(42))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, largeMap.get(null))
+  }
+
+  @Test def testSizeGetPutWithDoublesCornerCasesOfEquals(): Unit = {
     assumeNotIdentityHashMapOnJVM()
 
     val mp = factory.empty[Double, Double]
@@ -81,33 +174,65 @@ trait MapTest {
     assertEquals(44444.0, four, 0.0)
   }
 
-  @Test def shouldStoreCustomObjects(): Unit = {
-    case class TestObj(num: Int)
-    val mp = factory.empty[TestObj, TestObj]
-
-    val testKey = TestObj(100)
-    mp.put(testKey, TestObj(12345))
-    assertEquals(1, mp.size())
-    if (factory.isIdentityBased) {
-      val one = mp.get(testKey)
-      assertEquals(12345, one.num)
-    } else {
-      val one = mp.get(TestObj(100))
-      assertEquals(12345, one.num)
-    }
-  }
-
-  @Test def shouldRemoveStoredElements(): Unit = {
+  @Test def testRemoveWithStrings(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
-    assertEquals(1, mp.size())
+    for (i <- 0 until 30)
+      mp.put(s"key $i", s"value $i")
+    assertEquals(31, mp.size())
     assertEquals("one", mp.remove("ONE"))
-    val newOne = mp.get("ONE")
     assertNull(mp.get("ONE"))
+    assertNull(mp.remove("ONE"))
+
+    assertNull(mp.remove("foobar"))
+    assertNull(mp.remove(42))
+    assertNull(mp.remove(testObj(42)))
+    if (factory.allowsNullKeys)
+      assertNull(mp.remove(null))
+    else
+      assertThrows(classOf[NullPointerException], mp.remove(null))
   }
 
-  @Test def shouldRemoveStoredElementsInDoubleCornerCases() {
+  @Test def testRemoveWithInts(): Unit = {
+    assumeNotIdentityHashMapOnJVM()
+
+    val mp = factory.empty[Int, String]
+
+    mp.put(543, "one")
+    for (i <- 0 until 30)
+      mp.put(i, s"value $i")
+    assertEquals(31, mp.size())
+    assertEquals("one", mp.remove(543))
+    assertNull(mp.get(543))
+    assertNull(mp.remove(543))
+
+    assertNull(mp.remove("foobar"))
+    assertNull(mp.remove(42))
+    assertNull(mp.remove(testObj(42)))
+    if (factory.allowsNullKeys)
+      assertNull(mp.remove(null))
+  }
+
+  @Test def testRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, String]
+
+    mp.put(testObj(543), "one")
+    for (i <- 0 until 30)
+      mp.put(testObj(i), s"value $i")
+    assertEquals(31, mp.size())
+    assertEquals("one", mp.remove(testObj(543)))
+    assertNull(mp.get(testObj(543)))
+    assertNull(mp.remove(testObj(543)))
+
+    assertNull(mp.remove(testObj(42)))
+    assertNull(mp.remove("foobar"))
+    assertNull(mp.remove(42))
+    if (factory.allowsNullKeys)
+      assertNull(mp.remove(null))
+  }
+
+  @Test def testRemoveWithDoublesCornerCasesOfEquals(): Unit = {
     assumeNotIdentityHashMapOnJVM()
 
     val mp = factory.empty[Double, String]
@@ -142,39 +267,68 @@ trait MapTest {
     assertTrue(mp.isEmpty)
   }
 
-  @Test def shouldPutOrFailOnNullKeys(): Unit = {
+  @Test def testGetPutRemoveNullKeys(): Unit = {
+    val mp = factory.empty[String, String]
+    for (i <- 0 until 30)
+      mp.put(s"key $i", s"value $i")
+
     if (factory.allowsNullKeys) {
-      val mp = factory.empty[String, String]
       mp.put(null, "one")
+      assertEquals(31, mp.size())
       assertEquals("one", mp.get(null))
+      assertEquals("one", mp.remove(null))
+      assertNull(mp.get(null))
+      assertNull(mp.remove(null))
     } else {
-      val mp = factory.empty[String, String]
       assertThrows(classOf[NullPointerException], mp.put(null, "one"))
     }
   }
 
-  @Test def shouldPutOrFailOnNullValues(): Unit = {
+  @Test def testGetPutRemoveNullValues(): Unit = {
+    val mp = factory.empty[String, String]
+    for (i <- 0 until 30)
+      mp.put(s"key $i", s"value $i")
+
     if (factory.allowsNullValues) {
-      val mp = factory.empty[String, String]
       mp.put("one", null)
+      assertEquals(31, mp.size())
+      assertNull(mp.get("one"))
+      assertNull(mp.remove("one"))
+      assertEquals(30, mp.size())
       assertNull(mp.get("one"))
     } else {
-      val mp = factory.empty[String, String]
       assertThrows(classOf[NullPointerException], mp.put("one", null))
     }
   }
 
-  @Test def shouldBeClearedWithOneOperation(): Unit = {
+  @Test def testClear(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
     mp.put("TWO", "two")
     assertEquals(2, mp.size())
     mp.clear()
+
+    // Test the content size
     assertEquals(0, mp.size())
+
+    // Test the hash table
+    assertNull(mp.get("ONE"))
+    assertNull(mp.get("TWO"))
+
+    // Test the iterators (different from the hash table for LinkedHashMap)
+    assertFalse(mp.entrySet().iterator().hasNext())
+    assertFalse(mp.keySet().iterator().hasNext())
+    assertFalse(mp.values().iterator().hasNext())
+
+    // can be reused after clear()
+    mp.put("TWO", "value 2")
+    mp.put("THREE", "value 3")
+    assertEquals("value 2", mp.get("TWO"))
+    assertEquals("value 3", mp.get("THREE"))
   }
 
-  @Test def shouldCheckContainedKeyPresence(): Unit = {
+  @Test def testContainsKey(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
@@ -183,10 +337,10 @@ trait MapTest {
     if (factory.allowsNullKeysQueries)
       assertFalse(mp.containsKey(null))
     else
-      assertThrows(classOf[Throwable], mp.containsKey(null))
+      assertThrows(classOf[NullPointerException], mp.containsKey(null))
   }
 
-  @Test def shouldCheckContainedValuePresence(): Unit = {
+  @Test def testContainsValue(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
@@ -195,29 +349,50 @@ trait MapTest {
     if (factory.allowsNullValuesQueries)
       assertFalse(mp.containsValue(null))
     else
-      assertThrows(classOf[Throwable], mp.containsValue(null))
+      assertThrows(classOf[NullPointerException], mp.containsValue(null))
   }
 
-  @Test def shouldGiveProperCollectionOverValues(): Unit = {
+  @Test def testPutAll(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
+
+    mp.putAll(TrivialImmutableMap("X" -> "y", "A" -> "b"))
+    assertEquals(3, mp.size())
+    assertEquals("one", mp.get("ONE"))
+    assertEquals("y", mp.get("X"))
+    assertEquals("b", mp.get("A"))
+
+    val nullMap = TrivialImmutableMap((null: String) -> "y", "X" -> "z")
+    if (factory.allowsNullKeys) {
+      mp.putAll(nullMap)
+      assertEquals("y", mp.get(null))
+      assertEquals("z", mp.get("X"))
+      assertEquals("one", mp.get("ONE"))
+      assertEquals("b", mp.get("A"))
+    } else {
+      assertThrows(classOf[NullPointerException], mp.putAll(nullMap))
+    }
+  }
+
+  @Test def testValuesSizeIteratorBasic(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+
     val values = mp.values()
-    assertEquals(1, values.size())
+    assertEquals(1, values.size)
     val iter = values.iterator
     assertTrue(iter.hasNext)
     assertEquals("one", iter.next)
     assertFalse(iter.hasNext)
   }
 
-  @Test def shouldGiveProperEntrySetOverKeyValuePairs(): Unit = {
+  @Test def testEntrySetSizeIteratorBasic(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
-    val entrySet = mp.entrySet
 
-    assertEquals(1, entrySet.size())
-
+    val entrySet = mp.entrySet()
+    assertEquals(1, entrySet.size)
     val iter = entrySet.iterator
     assertTrue(iter.hasNext)
     val next = iter.next
@@ -226,123 +401,104 @@ trait MapTest {
     assertEquals("one", next.getValue)
   }
 
-  @Test def shouldGiveProperKeySetOverKeys(): Unit = {
+  @Test def testKeySetSizeIteratorBasic(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
+
     val keySet = mp.keySet()
-
-    assertEquals(1, keySet.size())
-
+    assertEquals(1, keySet.size)
     val iter = keySet.iterator
     assertTrue(iter.hasNext)
     assertEquals("ONE", iter.next)
     assertFalse(iter.hasNext)
   }
 
-  @Test def shouldPutAWholeMapInto(): Unit = {
+  @Test def testValuesIsViewForSize(): Unit = {
     val mp = factory.empty[String, String]
-
-    val m = mu.Map[String, String]("X" -> "y")
-    mp.putAll(m.toJavaMap[String, String])
-    assertEquals(1, mp.size())
-    assertEquals("y", mp.get("X"))
-
-    val nullMap = mu.Map[String, String]((null: String) -> "y", "X" -> "y")
-
-    if (factory.allowsNullKeys) {
-      mp.putAll(nullMap.toJavaMap[String, String])
-      assertEquals("y", mp.get(null))
-      assertEquals("y", mp.get("X"))
-    } else {
-      assertThrows(
-        classOf[NullPointerException],
-        mp.putAll(nullMap.toJavaMap[String, String])
-      )
-    }
-  }
-
-  class SimpleQueryableMap[K, V](inner: mu.HashMap[K, V])
-      extends ju.AbstractMap[K, V] {
-    def entrySet(): java.util.Set[java.util.Map.Entry[K, V]] = {
-      inner
-        .map {
-          case (k, v) =>
-            val entry = new ju.AbstractMap.SimpleImmutableEntry(k, v)
-            entry: java.util.Map.Entry[K, V]
-        }
-        .toSet
-        .toJavaSet
-    }
-  }
-
-  @Test def valuesShouldMirrorTheRelatedMapSize(): Unit = {
-    val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
-
     val values = mp.values()
-    assertEquals(2, values.size())
 
+    assertEquals(2, values.size)
     mp.put("THREE", "three")
-
-    assertEquals(3, values.size())
-
+    assertEquals(3, values.size)
     mp.remove("ONE")
-
-    assertEquals(2, values.size())
-
+    assertEquals(2, values.size)
     assertFalse(values.isEmpty)
-
     mp.clear()
-
-    assertEquals(0, values.size())
-
+    assertEquals(0, values.size)
     assertTrue(values.isEmpty)
-
-    val hm1 = mu.HashMap("ONE" -> "one", "TWO" -> "two")
-    val hm2 = mu.HashMap("ONE" -> null, "TWO" -> "two")
-    val hm3 = mu.HashMap((null: String) -> "one", "TWO" -> "two")
-    val hm4 = mu.HashMap((null: String) -> null, "TWO" -> "two")
-
-    assertEquals(2, new SimpleQueryableMap(hm1).values().size())
-    assertEquals(2, new SimpleQueryableMap(hm2).values().size())
-    assertEquals(2, new SimpleQueryableMap(hm3).values().size())
-    assertEquals(2, new SimpleQueryableMap(hm4).values().size())
   }
 
-  @Test def valuesShouldCheckSingleAndMultipleObjectsPresence(): Unit = {
+  @Test def testValuesIsViewForQueriesWithStrings(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
-
     val values = mp.values()
+
     assertTrue(values.contains("one"))
     assertTrue(values.contains("two"))
     assertFalse(values.contains("three"))
     if (factory.allowsNullValuesQueries)
       assertFalse(values.contains(null))
     else
-      assertThrows(classOf[Throwable], mp.values().contains(null))
+      assertThrows(classOf[NullPointerException], values.contains(null))
 
     mp.put("THREE", "three")
 
     assertTrue(values.contains("three"))
 
-    val coll1 = im.Set("one", "two", "three").toJavaSet
+    val coll1 = TrivialImmutableCollection("one", "two", "three")
     assertTrue(values.containsAll(coll1))
 
-    val coll2 = im.Set("one", "two", "three", "four").toJavaSet
+    val coll2 = TrivialImmutableCollection("one", "two", "three", "four")
     assertFalse(values.containsAll(coll2))
 
-    val coll3 = im.Set("one", "two", "three", null).toJavaSet
+    if (factory.allowsNullValuesQueries) {
+      val coll3 = TrivialImmutableCollection("one", "two", "three", null)
+      assertFalse(values.containsAll(coll3))
+    }
+  }
+
+  @Test def testValuesIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    val values = mp.values()
+
+    assertTrue(values.contains(testObj(11)))
+    assertTrue(values.contains(testObj(22)))
+    assertFalse(values.contains(testObj(33)))
+    if (factory.allowsNullValuesQueries)
+      assertFalse(values.contains(null))
+    else
+      assertThrows(classOf[NullPointerException], values.contains(null))
+
+    mp.put(testObj(3), testObj(33))
+
+    assertTrue(values.contains(testObj(33)))
+
+    val coll1 = TrivialImmutableCollection(testObj(11), testObj(22),
+        testObj(33))
+    assertTrue(values.containsAll(coll1))
+
+    val coll2 = TrivialImmutableCollection(testObj(11), testObj(22),
+        testObj(33), testObj(44))
     assertFalse(values.containsAll(coll2))
+
+    if (factory.allowsNullValuesQueries) {
+      val coll3 = TrivialImmutableCollection(testObj(11), testObj(22),
+          testObj(33), null)
+      assertFalse(values.containsAll(coll3))
+    }
+  }
+
+  @Test def testValuesIsViewForQueriesWithDoublesCornerCaseOfEquals(): Unit = {
+    assumeNotIdentityHashMapOnJVM()
 
     val nummp = factory.empty[Double, Double]
-
     val numValues = nummp.values()
+
     nummp.put(1, +0.0)
     assertTrue(numValues.contains(+0.0))
     assertFalse(numValues.contains(-0.0))
@@ -357,27 +513,14 @@ trait MapTest {
     assertTrue(numValues.contains(+0.0))
     assertTrue(numValues.contains(-0.0))
     assertTrue(numValues.contains(Double.NaN))
-
-    val hm1 = mu.HashMap(1.0 -> null, 2.0 -> 2.0)
-    val hm2 = mu.HashMap((null: Any) -> 1.0, 2.0 -> 2.0)
-    val hm3 = mu.HashMap((null: Any) -> null, 2.0 -> 2.0)
-
-    assertFalse(new SimpleQueryableMap(hm1).values().contains(1.0))
-    assertTrue(new SimpleQueryableMap(hm2).values().contains(1.0))
-    assertFalse(new SimpleQueryableMap(hm3).values().contains(1.0))
-
-    assertTrue(new SimpleQueryableMap(hm1).values().contains(null))
-    assertFalse(new SimpleQueryableMap(hm2).values().contains(null))
-    assertTrue(new SimpleQueryableMap(hm3).values().contains(null))
   }
 
-  @Test def valuesShouldSideEffectClearRemoveRetainOnTheRelatedMap(): Unit = {
+  @Test def testValuesIsViewForRemoveWithStrings(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
-
     val values = mp.values()
+
     assertFalse(values.isEmpty)
     assertFalse(mp.isEmpty)
 
@@ -390,9 +533,7 @@ trait MapTest {
     mp.put("TWO", "two")
 
     assertTrue(mp.containsKey("ONE"))
-
     values.remove("one")
-
     assertFalse(mp.containsKey("ONE"))
 
     mp.put("ONE", "one")
@@ -402,7 +543,7 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    values.removeAll(im.List("one", "two").toJavaList)
+    values.removeAll(TrivialImmutableCollection("one", "two"))
 
     assertFalse(mp.containsKey("ONE"))
     assertFalse(mp.containsKey("TWO"))
@@ -416,80 +557,145 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    values.retainAll(im.List("one", "two").toJavaList)
+    values.retainAll(TrivialImmutableCollection("one", "two"))
 
     assertTrue(mp.containsKey("ONE"))
     assertTrue(mp.containsKey("TWO"))
     assertFalse(mp.containsKey("THREE"))
   }
 
-  @Test def keySetShouldMirrorTheRelatedMapSize(): Unit = {
-    val mp = factory.empty[String, String]
+  @Test def testValuesIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    val values = mp.values()
 
-    mp.put("ONE", "one")
-    mp.put("TWO", "two")
+    assertFalse(values.isEmpty)
+    assertFalse(mp.isEmpty)
 
-    val keySet = mp.keySet()
-    assertEquals(2, keySet.size())
+    values.clear()
 
-    mp.put("THREE", "three")
+    assertTrue(values.isEmpty)
+    assertTrue(mp.isEmpty)
 
-    assertEquals(3, keySet.size())
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
 
-    mp.remove("ONE")
+    assertTrue(mp.containsKey(testObj(1)))
+    values.remove(testObj(11))
+    assertFalse(mp.containsKey(testObj(1)))
 
-    assertEquals(2, keySet.size())
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(3), testObj(33))
 
-    assertFalse(keySet.isEmpty)
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
 
-    mp.clear()
+    values.removeAll(TrivialImmutableCollection(testObj(11), testObj(22)))
 
-    assertEquals(0, keySet.size())
+    assertFalse(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
 
-    assertTrue(keySet.isEmpty)
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    mp.put(testObj(3), testObj(33))
 
-    val hm1 = mu.HashMap("ONE" -> "one", "TWO" -> "two")
-    val hm2 = mu.HashMap("ONE" -> null, "TWO" -> "two")
-    val hm3 = mu.HashMap((null: String) -> "one", "TWO" -> "two")
-    val hm4 = mu.HashMap((null: String) -> null, "TWO" -> "two")
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
 
-    assertEquals(2, new SimpleQueryableMap(hm1).keySet().size())
-    assertEquals(2, new SimpleQueryableMap(hm2).keySet().size())
-    assertEquals(2, new SimpleQueryableMap(hm3).keySet().size())
-    assertEquals(2, new SimpleQueryableMap(hm4).keySet().size())
+    values.retainAll(TrivialImmutableCollection(testObj(11), testObj(22)))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertFalse(mp.containsKey(testObj(3)))
   }
 
-  @Test def keySetShouldCheckSingleAndMultipleObjectsPresence(): Unit = {
+  @Test def testKeySetIsViewForSize(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
-
     val keySet = mp.keySet()
+
+    assertEquals(2, keySet.size)
+    mp.put("THREE", "three")
+    assertEquals(3, keySet.size)
+    mp.remove("ONE")
+    assertEquals(2, keySet.size)
+    assertFalse(keySet.isEmpty)
+    mp.clear()
+    assertEquals(0, keySet.size)
+    assertTrue(keySet.isEmpty)
+  }
+
+  @Test def testKeySetIsViewForQueriesWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val keySet = mp.keySet()
+
     assertTrue(keySet.contains("ONE"))
     assertTrue(keySet.contains("TWO"))
     assertFalse(keySet.contains("THREE"))
     if (factory.allowsNullKeysQueries)
       assertFalse(keySet.contains(null))
     else
-      assertThrows(classOf[Throwable], mp.keySet().contains(null))
+      assertThrows(classOf[NullPointerException], keySet.contains(null))
 
     mp.put("THREE", "three")
 
     assertTrue(keySet.contains("THREE"))
 
-    val coll1 = im.Set("ONE", "TWO", "THREE").toJavaSet
+    val coll1 = TrivialImmutableCollection("ONE", "TWO", "THREE")
     assertTrue(keySet.containsAll(coll1))
 
-    val coll2 = im.Set("ONE", "TWO", "THREE", "FOUR").toJavaSet
+    val coll2 = TrivialImmutableCollection("ONE", "TWO", "THREE", "FOUR")
     assertFalse(keySet.containsAll(coll2))
 
-    val coll3 = im.Set("ONE", "TWO", "THREE", null).toJavaSet
+    if (factory.allowsNullKeysQueries) {
+      val coll3 = TrivialImmutableCollection("ONE", "TWO", "THREE", null)
+      assertFalse(keySet.containsAll(coll3))
+    }
+  }
+
+  @Test def testKeySetIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+    val keySet = mp.keySet()
+
+    assertTrue(keySet.contains(testObj(1)))
+    assertTrue(keySet.contains(testObj(2)))
+    assertFalse(keySet.contains(testObj(3)))
+    if (factory.allowsNullKeysQueries)
+      assertFalse(keySet.contains(null))
+    else
+      assertThrows(classOf[NullPointerException], keySet.contains(null))
+
+    mp.put(testObj(3), TestObj(33))
+
+    assertTrue(keySet.contains(testObj(3)))
+
+    val coll1 = TrivialImmutableCollection(testObj(1), testObj(2), testObj(3))
+    assertTrue(keySet.containsAll(coll1))
+
+    val coll2 = TrivialImmutableCollection(testObj(1), testObj(2), testObj(4))
     assertFalse(keySet.containsAll(coll2))
+
+    if (factory.allowsNullKeysQueries) {
+      val coll3 = TrivialImmutableCollection(testObj(1), testObj(2), null)
+      assertFalse(keySet.containsAll(coll3))
+    }
+  }
+
+  @Test def testKeySetIsViewForQueriesWithDoublesCornerCaseOfEquals(): Unit = {
+    assumeNotIdentityHashMapOnJVM()
 
     val nummp = factory.empty[Double, Double]
-
     val numkeySet = nummp.keySet()
+
     nummp.put(+0.0, 1)
     assertTrue(numkeySet.contains(+0.0))
     assertFalse(numkeySet.contains(-0.0))
@@ -504,27 +710,14 @@ trait MapTest {
     assertTrue(numkeySet.contains(+0.0))
     assertTrue(numkeySet.contains(-0.0))
     assertTrue(numkeySet.contains(Double.NaN))
-
-    val hm1 = mu.HashMap(1.0 -> null, 2.0 -> 2.0)
-    val hm2 = mu.HashMap((null: Any) -> 1.0, 2.0 -> 2.0)
-    val hm3 = mu.HashMap((null: Any) -> null, 2.0 -> 2.0)
-
-    assertTrue(new SimpleQueryableMap(hm1).keySet().contains(1.0))
-    assertFalse(new SimpleQueryableMap(hm2).keySet().contains(1.0))
-    assertFalse(new SimpleQueryableMap(hm3).keySet().contains(1.0))
-
-    assertFalse(new SimpleQueryableMap(hm1).keySet().contains(null))
-    assertTrue(new SimpleQueryableMap(hm2).keySet().contains(null))
-    assertTrue(new SimpleQueryableMap(hm3).keySet().contains(null))
   }
 
-  @Test def keySetShouldSideEffectClearRemoveRetainOnTheRelatedMap(): Unit = {
+  @Test def testKeySetIsViewForRemoveWithStrings(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
-
     val keySet = mp.keySet()
+
     assertFalse(keySet.isEmpty)
     assertFalse(mp.isEmpty)
 
@@ -538,9 +731,7 @@ trait MapTest {
     mp.put("TWO", "two")
 
     assertTrue(mp.containsKey("ONE"))
-
     keySet.remove("ONE")
-
     assertFalse(mp.containsKey("ONE"))
 
     mp.put("ONE", "one")
@@ -550,7 +741,7 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    keySet.removeAll(im.List("ONE", "TWO").toJavaList)
+    keySet.removeAll(TrivialImmutableCollection("ONE", "TWO", "FIVE"))
 
     assertFalse(mp.containsKey("ONE"))
     assertFalse(mp.containsKey("TWO"))
@@ -564,11 +755,721 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    keySet.retainAll(im.List("ONE", "TWO").toJavaList)
+    keySet.retainAll(TrivialImmutableCollection("ONE", "TWO", "FIVE"))
 
     assertTrue(mp.containsKey("ONE"))
     assertTrue(mp.containsKey("TWO"))
     assertFalse(mp.containsKey("THREE"))
+
+    if (factory.allowsNullKeys) {
+      mp.put(null, "NULL")
+      assertTrue(mp.containsKey(null))
+      assertTrue(keySet.contains(null))
+      assertTrue(keySet.remove(null))
+      assertFalse(mp.containsKey(null))
+    }
+
+    if (factory.allowsNullValues) {
+      mp.put("NULL", null)
+      assertTrue(mp.containsKey("NULL"))
+      assertTrue(keySet.contains("NULL"))
+      assertTrue(keySet.remove("NULL"))
+      assertFalse(mp.containsKey("NULL"))
+    }
+  }
+
+  @Test def testKeySetIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+    val keySet = mp.keySet()
+
+    assertFalse(keySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    keySet.clear()
+
+    assertTrue(keySet.isEmpty)
+
+    assertTrue(mp.isEmpty)
+
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    keySet.remove(testObj(1))
+    assertFalse(mp.containsKey(testObj(1)))
+
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(3), TestObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    keySet.removeAll(TrivialImmutableCollection(testObj(1), testObj(2),
+        testObj(5)))
+
+    assertFalse(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+    mp.put(testObj(3), TestObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    keySet.retainAll(TrivialImmutableCollection(testObj(1), testObj(2),
+        testObj(5)))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertFalse(mp.containsKey(testObj(3)))
+
+    if (factory.allowsNullKeys) {
+      mp.put(null, TestObj(111))
+      assertTrue(mp.containsKey(null))
+      assertTrue(keySet.contains(null))
+      assertTrue(keySet.remove(null))
+      assertFalse(mp.containsKey(null))
+    }
+
+    if (factory.allowsNullValues) {
+      mp.put(testObj(4), null)
+      assertTrue(mp.containsKey(testObj(4)))
+      assertTrue(keySet.contains(testObj(4)))
+      assertTrue(keySet.remove(testObj(4)))
+      assertFalse(mp.containsKey(testObj(4)))
+    }
+  }
+
+  @Test def testEntrySetIsViewForSize(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val entrySet = mp.entrySet()
+
+    assertEquals(2, entrySet.size)
+    mp.put("THREE", "three")
+    assertEquals(3, entrySet.size)
+    mp.remove("ONE")
+    assertEquals(2, entrySet.size)
+    assertFalse(entrySet.isEmpty)
+    mp.clear()
+    assertEquals(0, entrySet.size)
+    assertTrue(entrySet.isEmpty)
+  }
+
+  @Test def testEntrySetIsViewForQueriesWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    if (factory.allowsNullKeys)
+      mp.put(null, "NULL")
+    if (factory.allowsNullValues)
+      mp.put("NULL", null)
+    val entrySet = mp.entrySet()
+
+    assertTrue(entrySet.contains(SIE("ONE", "one")))
+    assertTrue(entrySet.contains(SIE("TWO", "two")))
+    assertFalse(entrySet.contains(SIE("THREE", "three")))
+    assertFalse(entrySet.contains(SIE("ONE", "two")))
+    assertFalse(entrySet.contains(SIE("THREE", "one")))
+    if (factory.allowsNullValuesQueries) {
+      assertTrue(entrySet.contains(SIE("NULL", null)))
+      assertTrue(entrySet.contains(SIE(null, "NULL")))
+      assertFalse(entrySet.contains(SIE("NOTFOUND", null)))
+    }
+
+    mp.put("THREE", "three")
+
+    assertTrue(entrySet.contains(SIE("THREE", "three")))
+
+    val coll1 = TrivialImmutableCollection(SIE("ONE", "one"),
+        SIE("TWO", "two"), SIE("THREE", "three"))
+    assertTrue(entrySet.containsAll(coll1))
+
+    val coll2 = TrivialImmutableCollection(SIE("ONE", "one"),
+        SIE("TWO", "two"), SIE("THREE", "three"), SIE("FOUR", "four"))
+    assertFalse(entrySet.containsAll(coll2))
+
+    val coll3 = TrivialImmutableCollection(SIE("ONE", "one"),
+        SIE("TWO", "four"), SIE("THREE", "three"))
+    assertFalse(entrySet.containsAll(coll3))
+
+    val coll4 = TrivialImmutableCollection(SIE("ONE", "one"),
+        SIE("four", "two"), SIE("THREE", "three"))
+    assertFalse(entrySet.containsAll(coll4))
+  }
+
+  @Test def testEntrySetIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    if (factory.allowsNullValues)
+      mp.put(testObj(5), null)
+    if (factory.allowsNullKeys)
+      mp.put(null, testObj(55))
+    val entrySet = mp.entrySet()
+
+    assertTrue(entrySet.contains(SIE(testObj(1), testObj(11))))
+    assertTrue(entrySet.contains(SIE(testObj(2), testObj(22))))
+    assertFalse(entrySet.contains(SIE(testObj(3), testObj(33))))
+    assertFalse(entrySet.contains(SIE(testObj(1), testObj(22))))
+    assertFalse(entrySet.contains(SIE(testObj(3), testObj(11))))
+    if (factory.allowsNullValuesQueries) {
+      assertTrue(entrySet.contains(SIE(testObj(5), null)))
+      assertFalse(entrySet.contains(SIE(testObj(6), null)))
+    }
+    if (factory.allowsNullKeysQueries)
+      assertTrue(entrySet.contains(SIE(null, testObj(55))))
+
+    if (factory.allowsNullValuesQueries)
+      assertFalse(entrySet.contains(SIE(testObj(7), null)))
+
+    mp.put(testObj(3), testObj(33))
+
+    assertTrue(entrySet.contains(SIE(testObj(3), testObj(33))))
+
+    val coll1 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+        SIE(testObj(2), testObj(22)), SIE(testObj(3), testObj(33)))
+    assertTrue(entrySet.containsAll(coll1))
+
+    val coll2 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+        SIE(testObj(2), testObj(22)), SIE(testObj(3), testObj(33)),
+        SIE(testObj(4), testObj(44)))
+    assertFalse(entrySet.containsAll(coll2))
+
+    val coll3 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+        SIE(testObj(2), testObj(44)), SIE(testObj(3), testObj(33)))
+    assertFalse(entrySet.containsAll(coll3))
+
+    val coll4 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+        SIE(testObj(4), testObj(22)), SIE(testObj(3), testObj(33)))
+    assertFalse(entrySet.containsAll(coll4))
+  }
+
+  @Test def testEntrySetIsViewForRemoveWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val entrySet = mp.entrySet()
+
+    assertFalse(entrySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    entrySet.clear()
+    assertTrue(entrySet.isEmpty)
+    assertTrue(mp.isEmpty)
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    if (factory.allowsNullKeys)
+      mp.put(null, "NULL")
+    if (factory.allowsNullValues)
+      mp.put("NULL", null)
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(entrySet.remove(SIE("ONE", "one")))
+    assertFalse(entrySet.remove(SIE("TWO", "four")))
+    assertFalse(entrySet.remove("TWO"))
+    assertFalse(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    if (factory.allowsNullKeysQueries)
+      assertTrue(mp.containsKey(null))
+    if (factory.allowsNullValuesQueries) {
+      assertTrue(mp.containsValue(null))
+      assertFalse(entrySet.remove(SIE("NOTFOUND", null)))
+    }
+
+    mp.put("ONE", "one")
+    mp.put("THREE", "three")
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    entrySet.removeAll(TrivialImmutableCollection(SIE("ONE", "one"),
+        SIE("TWO", "two"), SIE("THREE", "four"), "THREE", 42))
+
+    assertFalse(mp.containsKey("ONE"))
+    assertFalse(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    mp.put("THREE", "three")
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    entrySet.retainAll(TrivialImmutableCollection(SIE("ONE", "one"),
+        SIE("TWO", "two"), SIE("THREE", "four"), "THREE", 42))
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertFalse(mp.containsKey("THREE"))
+  }
+
+  @Test def testEntrySetIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    val entrySet = mp.entrySet()
+
+    assertFalse(entrySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    entrySet.clear()
+    assertTrue(entrySet.isEmpty)
+    assertTrue(mp.isEmpty)
+
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    if (factory.allowsNullKeys)
+      mp.put(null, testObj(55))
+    if (factory.allowsNullValues)
+      mp.put(testObj(5), null)
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(entrySet.remove(SIE(testObj(1), testObj(11))))
+    assertFalse(entrySet.remove(SIE(testObj(2), testObj(44))))
+    assertFalse(entrySet.remove(testObj(2))) // remove should take Map.Entry
+    assertFalse(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    if (factory.allowsNullKeysQueries)
+      assertTrue(mp.containsKey(null))
+    if (factory.allowsNullValuesQueries) {
+      assertTrue(mp.containsValue(null))
+      assertFalse(entrySet.remove(SIE(testObj(6), null)))
+    }
+
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(3), testObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    entrySet.removeAll(TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+        SIE(testObj(2), testObj(22)), SIE(testObj(3), testObj(44)),
+        testObj(3), 42))
+
+    assertFalse(mp.containsKey(testObj(1)))
+    assertFalse(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    mp.put(testObj(1), testObj(11))
+    mp.put(testObj(2), testObj(22))
+    mp.put(testObj(3), testObj(33))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertTrue(mp.containsKey(testObj(3)))
+
+    entrySet.retainAll(TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
+        SIE(testObj(2), testObj(22)), SIE(testObj(3), testObj(44)),
+        testObj(3), 42))
+
+    assertTrue(mp.containsKey(testObj(1)))
+    assertTrue(mp.containsKey(testObj(2)))
+    assertFalse(mp.containsKey(testObj(3)))
+  }
+
+  @Test def testEntrySetIsViewForSetValueWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val entrySet = mp.entrySet()
+
+    val entry = entrySet.iterator().next()
+    val key = entry.getKey()
+    assertTrue(key == "ONE" || key == "TWO")
+    val expectedValue = if (key == "ONE") "one" else "two"
+
+    assertEquals(expectedValue, entry.getValue())
+    assertEquals(expectedValue, entry.setValue("new value"))
+    assertEquals("new value", entry.getValue())
+    assertEquals("new value", mp.get(key))
+  }
+
+  @Test def testEntrySetIsViewForSetValueWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(testObj(1), TestObj(11))
+    mp.put(testObj(2), TestObj(22))
+    val entrySet = mp.entrySet()
+
+    val entry = entrySet.iterator().next()
+    val key = entry.getKey()
+    assertTrue(key.num == 1 || key.num == 2)
+    val expectedValue = TestObj(if (key.num == 1) 11 else 22)
+
+    assertEquals(expectedValue, entry.getValue())
+    assertEquals(expectedValue, entry.setValue(TestObj(56)))
+    assertEquals(TestObj(56), entry.getValue())
+    assertEquals(TestObj(56), mp.get(key))
+  }
+
+  @Test def testGetOrDefault(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    assertEquals("one", mp.getOrDefault("ONE", "def"))
+    assertEquals("def", mp.getOrDefault("FOUR", "def"))
+    assertNull(mp.getOrDefault("FIVE", null))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertNull(mp.getOrDefault("nullable", "def"))
+    }
+  }
+
+  @Test def testForEach(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    val b = List.newBuilder[(String, String)]
+    mp.forEach(new BiConsumer[String, String] {
+      def accept(key: String, value: String): Unit =
+        b += ((key, value))
+    })
+    val result = b.result()
+
+    val expected = List("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    if (factory.guaranteesInsertionOrder)
+      assertEquals(expected, result)
+    else
+      assertEquals(expected.toSet, result.toSet)
+  }
+
+  @Test def testReplaceAll(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    mp.replaceAll(new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String =
+        s"$key -> $value"
+    })
+
+    assertEquals(3, mp.size())
+    assertEquals("ONE -> one", mp.get("ONE"))
+    assertEquals("TWO -> two", mp.get("TWO"))
+    assertEquals("THREE -> three", mp.get("THREE"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+
+      mp.replaceAll(new BiFunction[String, String, String] {
+        def apply(key: String, value: String): String =
+          if (key.startsWith("ONE")) null
+          else if (value == null) "it was null"
+          else value
+      })
+
+      assertTrue(mp.containsKey("ONE"))
+      assertNull(mp.get("ONE"))
+      assertEquals("it was null", mp.get("nullable"))
+    } else {
+      assertThrows(classOf[NullPointerException], mp.replaceAll(new BiFunction[String, String, String] {
+        def apply(key: String, value: String): String = null
+      }))
+    }
+  }
+
+  @Test def testPutIfAbsent(): Unit = {
+    val mp = factory.empty[String, String]
+    assertNull(mp.putIfAbsent("abc", "def"))
+    assertEquals("def", mp.get("abc"))
+    assertNull(mp.putIfAbsent("123", "456"))
+    assertEquals("456", mp.get("123"))
+    assertEquals("def", mp.putIfAbsent("abc", "def"))
+    assertEquals("def", mp.putIfAbsent("abc", "ghi"))
+    assertEquals("456", mp.putIfAbsent("123", "789"))
+    assertEquals("def", mp.putIfAbsent("abc", "jkl"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertNull(mp.putIfAbsent("nullable", "non null"))
+      assertEquals("non null", mp.get("nullable"))
+    } else {
+      assertThrows(classOf[NullPointerException], mp.putIfAbsent("abc", null))
+      assertThrows(classOf[NullPointerException], mp.putIfAbsent("new key", null))
+    }
+
+    if (!factory.allowsNullKeys) {
+      assertThrows(classOf[NullPointerException], mp.putIfAbsent(null, "def"))
+    }
+  }
+
+  @Test def testConditionalRemove(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    assertFalse(mp.remove("non existing", "value"))
+    assertFalse(mp.containsKey("non existing"))
+
+    assertFalse(mp.remove("TWO", "one"))
+    assertEquals("two", mp.get("TWO"))
+    assertFalse(mp.remove("TWO", null))
+    assertEquals("two", mp.get("TWO"))
+
+    assertTrue(mp.remove("ONE", "one"))
+    assertFalse(mp.containsKey("ONE"))
+
+    if (factory.allowsNullKeys) {
+      mp.put(null, "one")
+      assertFalse(mp.remove(null, "not exist"))
+      assertTrue(mp.containsKey(null))
+      assertTrue(mp.remove(null, "one"))
+      assertFalse(mp.containsKey(null))
+    } else {
+      assertThrows(classOf[NullPointerException], mp.remove(null, "old value"))
+    }
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertFalse(mp.remove("nullable", "value"))
+      assertTrue(mp.containsKey("nullable"))
+      assertTrue(mp.remove("nullable", null))
+      assertFalse(mp.containsKey("nullable"))
+    } else {
+      // mp#(key, null) should not remove. https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6272521
+      assertFalse(mp.remove("THREE", null))
+    }
+  }
+
+  @Test def testUnconditionalRemove(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    assertEquals(null, mp.remove("non existing"))
+    assertFalse(mp.containsKey("non existing"))
+
+    assertEquals("two", mp.remove("TWO"))
+    assertEquals(null, mp.get("TWO"))
+
+    if (factory.allowsNullKeys) {
+      mp.put(null, "one")
+      assertTrue(mp.containsKey(null))
+      assertEquals("one", mp.remove(null))
+      assertFalse(mp.containsKey(null))
+    } else {
+      assertThrows(classOf[NullPointerException], mp.remove(null))
+    }
+  }
+
+  @Test def testConditionalReplace(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    assertTrue(mp.replace("ONE", "one", "four"))
+    assertEquals("four", mp.get("ONE"))
+    assertFalse(mp.replace("TWO", "not two", "five"))
+    assertEquals("two", mp.get("TWO"))
+    assertFalse(mp.replace("non existing", "foo", "bar"))
+    assertFalse(mp.containsKey("non existing"))
+
+    if (factory.allowsNullValues) {
+      assertFalse(mp.replace("ONE", null, "new value"))
+      assertEquals("four", mp.get("ONE"))
+
+      mp.put("nullable", null)
+      assertFalse(mp.replace("nullable", "not null", "new value"))
+      assertTrue(mp.replace("nullable", null, "nullable value"))
+      assertEquals("nullable value", mp.get("nullable"))
+
+      assertTrue(mp.replace("nullable", "nullable value", null))
+      assertTrue(mp.containsKey("nullable"))
+      assertNull(mp.get("nullable"))
+    } else {
+      assertThrows(classOf[NullPointerException], mp.replace("ONE", null, "one"))
+      assertThrows(classOf[NullPointerException], mp.replace("ONE", "four", null))
+    }
+
+    if (factory.allowsNullKeys) {
+      assertFalse(null, mp.replace(null, "value", "new value"))
+      assertFalse(mp.containsKey(null))
+
+      mp.put(null, "null value")
+      assertTrue(mp.replace(null, "null value", "new value"))
+      assertEquals("new value", mp.get(null))
+    } else {
+      assertThrows(classOf[NullPointerException], mp.replace(null, "one", "two"))
+    }
+  }
+
+  @Test def testUnconditionalReplace(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    assertEquals("one", mp.replace("ONE", "four"))
+    assertEquals("four", mp.get("ONE"))
+    assertEquals("two", mp.get("TWO"))
+
+    assertNull(mp.replace("non existing", "value"))
+    assertFalse(mp.containsKey("non existing"))
+
+    if (factory.allowsNullValues) {
+      assertEquals("four", mp.replace("ONE", null))
+      assertTrue(mp.containsKey("ONE"))
+      assertNull(mp.get("ONE"))
+
+      assertNull(mp.replace("ONE", "new one"))
+      assertEquals("new one", mp.get("ONE"))
+    } else {
+      assertThrows(classOf[NullPointerException], mp.replace("ONE", null))
+      assertEquals("four", mp.get("ONE"))
+    }
+
+    if (factory.allowsNullKeys) {
+      assertEquals(null, mp.replace(null, "value"))
+      assertFalse(mp.containsKey(null))
+
+      mp.put(null, "null value")
+      assertEquals("null value", mp.replace(null, "new value"))
+      assertEquals("new value", mp.get(null))
+    } else {
+      assertThrows(classOf[NullPointerException], mp.replace(null, "one"))
+    }
+  }
+
+  @Test def testComputeIfAbsent(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    val notCalled = new Function[String, String] {
+      def apply(key: String): String =
+        throw new AssertionError(s"function should not have been called for $key")
+    }
+
+    val lengthAsString = new Function[String, String] {
+      def apply(key: String): String = key.length().toString()
+    }
+
+    val returnsNull = new Function[String, String] {
+      def apply(key: String): String = null
+    }
+
+    assertEquals("two", mp.computeIfAbsent("TWO", notCalled))
+    assertEquals("5", mp.computeIfAbsent("SEVEN", lengthAsString))
+    assertEquals("5", mp.get("SEVEN"))
+
+    assertNull(mp.computeIfAbsent("non existing", returnsNull))
+    assertFalse(mp.containsKey("non existing"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertEquals("8", mp.computeIfAbsent("nullable", lengthAsString))
+      assertEquals("8", mp.get("nullable"))
+    }
+  }
+
+  @Test def testComputeIfPresent(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    val notCalled = new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String =
+        throw new AssertionError(s"function should not have been called for $key")
+    }
+
+    val remappingFun = new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String = s"$key - $value"
+    }
+
+    val returnsNull = new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String = null
+    }
+
+    assertEquals("TWO - two", mp.computeIfPresent("TWO", remappingFun))
+    assertEquals("TWO - two", mp.get("TWO"))
+
+    assertNull(mp.computeIfPresent("ONE", returnsNull))
+    assertFalse(mp.containsKey("ONE"))
+
+    assertNull(mp.computeIfPresent("non existing", notCalled))
+    assertFalse(mp.containsKey("non existing"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertNull(mp.computeIfPresent("nullable", notCalled))
+      assertTrue(mp.containsKey("nullable"))
+      assertNull(mp.get("nullable"))
+    }
+  }
+
+  @Test def testCompute(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    val remappingFun = new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String = s"$key - $value"
+    }
+
+    val returnsNull = new BiFunction[String, String, String] {
+      def apply(key: String, value: String): String = null
+    }
+
+    assertEquals("TWO - two", mp.compute("TWO", remappingFun))
+    assertEquals("TWO - two", mp.get("TWO"))
+
+    assertEquals("SEVEN - null", mp.compute("SEVEN", remappingFun))
+    assertEquals("SEVEN - null", mp.get("SEVEN"))
+
+    assertNull(mp.compute("non existing", returnsNull))
+    assertFalse(mp.containsKey("non existing"))
+
+    assertNull(mp.compute("ONE", returnsNull))
+    assertFalse(mp.containsKey("ONE"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertNull(mp.compute("nullable", returnsNull))
+      assertFalse(mp.containsKey("nullable"))
+
+      mp.put("nullable", null)
+      assertEquals("nullable - null", mp.compute("nullable", remappingFun))
+      assertEquals("nullable - null", mp.get("nullable"))
+    }
+  }
+
+  @Test def testMerge(): Unit = {
+    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+
+    val notCalled = new BiFunction[String, String, String] {
+      def apply(prevValue: String, newValue: String): String =
+        throw new AssertionError(s"function should not have been called for $prevValue")
+    }
+
+    val remappingFun = new BiFunction[String, String, String] {
+      def apply(prevValue: String, newValue: String): String = s"$prevValue - $newValue"
+    }
+
+    val returnsNull = new BiFunction[String, String, String] {
+      def apply(prevValue: String, newValue: String): String = null
+    }
+
+    assertEquals("two - def", mp.merge("TWO", "def", remappingFun))
+    assertEquals("two - def", mp.get("TWO"))
+
+    assertEquals("def", mp.merge("SEVEN", "def", notCalled))
+    assertEquals("def", mp.get("SEVEN"))
+
+    assertThrows(classOf[NullPointerException], mp.merge("non existing", null, notCalled))
+    assertThrows(classOf[NullPointerException], mp.merge("ONE", null, notCalled))
+
+    assertNull(mp.merge("ONE", "def", returnsNull))
+    assertFalse(mp.containsKey("ONE"))
+
+    if (factory.allowsNullValues) {
+      mp.put("nullable", null)
+      assertEquals("def", mp.merge("nullable", "def", notCalled))
+      assertEquals("def", mp.get("nullable"))
+    }
+  }
+
+  @Test def additionToKeySet(): Unit = {
+    val set = factory.empty[String, String].keySet()
+
+    assertThrows(classOf[UnsupportedOperationException], set.add("ONE"))
+    assertThrows(classOf[UnsupportedOperationException], set.addAll(ju.Arrays.asList("ONE")))
+    assertThrows(classOf[UnsupportedOperationException], set.addAll(ju.Arrays.asList(null)))
+    assertThrows(classOf[UnsupportedOperationException], set.add(null))
   }
 }
 
@@ -581,6 +1482,13 @@ trait MapFactory {
 
   def empty[K: ClassTag, V: ClassTag]: ju.Map[K, V]
 
+  def fromKeyValuePairs[K: ClassTag, V: ClassTag](pairs: (K, V)*): ju.Map[K, V] = {
+    val result = empty[K, V]
+    for ((key, value) <- pairs)
+      result.put(key, value)
+    result
+  }
+
   def allowsNullKeys: Boolean
 
   def allowsNullValues: Boolean
@@ -592,4 +1500,6 @@ trait MapFactory {
   def withSizeLimit: Option[Int] = None
 
   def isIdentityBased: Boolean = false
+
+  def guaranteesInsertionOrder: Boolean = false
 }

--- a/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
@@ -14,6 +14,7 @@ import scala.collection.{mutable => mu}
 
 import scala.reflect.ClassTag
 import scala.scalanative.junit.utils.CollectionConverters._
+import org.scalanative.testsuite.utils.Platform._
 
 trait MapTest {
   import MapTest._
@@ -22,17 +23,15 @@ trait MapTest {
 
   def testObj(i: Int): TestObj = TestObj(i)
 
-  // temporary until Platform is introduced
-  val executingInJVM = false
-
-  // replace when new IdentityHashMap from Scala.js
-  // private def assumeNotIdentityHashMapOnJVM(): Unit =
-  //   assumeFalse("JVM vs Native cache differences",
-  //               executingInJVM && factory.isIdentityBased)
+  private def assumeNotIdentityHashMapOnJVM(): Unit =
+    assumeFalse(
+      "JVM vs Native cache differences",
+      executingInJVM && factory.isIdentityBased
+    )
 
   // temp implementation
-  private def assumeNotIdentityHashMapOnJVM(): Unit =
-    assumeFalse("JVM vs Native cache differences", factory.isIdentityBased)
+  // private def assumeNotIdentityHashMapOnJVM(): Unit =
+  //   assumeFalse("JVM vs Native cache differences", factory.isIdentityBased)
 
   @Test def shouldStoreStrings(): Unit = {
     val mp = factory.empty[String, String]

--- a/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
@@ -24,7 +24,10 @@ trait MapTest {
   def testObj(i: Int): TestObj = TestObj(i)
 
   private def assumeNotIdentityHashMapOnJVM(): Unit =
-    assumeFalse("JVM vs JS cache differences", executingInJVM && factory.isIdentityBased)
+    assumeFalse(
+      "JVM vs JS cache differences",
+      executingInJVM && factory.isIdentityBased
+    )
 
   @Test def testSizeGetPutWithStrings(): Unit = {
     assumeNotIdentityHashMapOnJVM()
@@ -478,17 +481,21 @@ trait MapTest {
 
     assertTrue(values.contains(testObj(33)))
 
-    val coll1 = TrivialImmutableCollection(testObj(11), testObj(22),
-        testObj(33))
+    val coll1 =
+      TrivialImmutableCollection(testObj(11), testObj(22), testObj(33))
     assertTrue(values.containsAll(coll1))
 
-    val coll2 = TrivialImmutableCollection(testObj(11), testObj(22),
-        testObj(33), testObj(44))
+    val coll2 = TrivialImmutableCollection(
+      testObj(11),
+      testObj(22),
+      testObj(33),
+      testObj(44)
+    )
     assertFalse(values.containsAll(coll2))
 
     if (factory.allowsNullValuesQueries) {
-      val coll3 = TrivialImmutableCollection(testObj(11), testObj(22),
-          testObj(33), null)
+      val coll3 =
+        TrivialImmutableCollection(testObj(11), testObj(22), testObj(33), null)
       assertFalse(values.containsAll(coll3))
     }
   }
@@ -807,8 +814,9 @@ trait MapTest {
     assertTrue(mp.containsKey(testObj(2)))
     assertTrue(mp.containsKey(testObj(3)))
 
-    keySet.removeAll(TrivialImmutableCollection(testObj(1), testObj(2),
-        testObj(5)))
+    keySet.removeAll(
+      TrivialImmutableCollection(testObj(1), testObj(2), testObj(5))
+    )
 
     assertFalse(mp.containsKey(testObj(1)))
     assertFalse(mp.containsKey(testObj(2)))
@@ -822,8 +830,9 @@ trait MapTest {
     assertTrue(mp.containsKey(testObj(2)))
     assertTrue(mp.containsKey(testObj(3)))
 
-    keySet.retainAll(TrivialImmutableCollection(testObj(1), testObj(2),
-        testObj(5)))
+    keySet.retainAll(
+      TrivialImmutableCollection(testObj(1), testObj(2), testObj(5))
+    )
 
     assertTrue(mp.containsKey(testObj(1)))
     assertTrue(mp.containsKey(testObj(2)))
@@ -888,20 +897,33 @@ trait MapTest {
 
     assertTrue(entrySet.contains(SIE("THREE", "three")))
 
-    val coll1 = TrivialImmutableCollection(SIE("ONE", "one"),
-        SIE("TWO", "two"), SIE("THREE", "three"))
+    val coll1 = TrivialImmutableCollection(
+      SIE("ONE", "one"),
+      SIE("TWO", "two"),
+      SIE("THREE", "three")
+    )
     assertTrue(entrySet.containsAll(coll1))
 
-    val coll2 = TrivialImmutableCollection(SIE("ONE", "one"),
-        SIE("TWO", "two"), SIE("THREE", "three"), SIE("FOUR", "four"))
+    val coll2 = TrivialImmutableCollection(
+      SIE("ONE", "one"),
+      SIE("TWO", "two"),
+      SIE("THREE", "three"),
+      SIE("FOUR", "four")
+    )
     assertFalse(entrySet.containsAll(coll2))
 
-    val coll3 = TrivialImmutableCollection(SIE("ONE", "one"),
-        SIE("TWO", "four"), SIE("THREE", "three"))
+    val coll3 = TrivialImmutableCollection(
+      SIE("ONE", "one"),
+      SIE("TWO", "four"),
+      SIE("THREE", "three")
+    )
     assertFalse(entrySet.containsAll(coll3))
 
-    val coll4 = TrivialImmutableCollection(SIE("ONE", "one"),
-        SIE("four", "two"), SIE("THREE", "three"))
+    val coll4 = TrivialImmutableCollection(
+      SIE("ONE", "one"),
+      SIE("four", "two"),
+      SIE("THREE", "three")
+    )
     assertFalse(entrySet.containsAll(coll4))
   }
 
@@ -934,21 +956,33 @@ trait MapTest {
 
     assertTrue(entrySet.contains(SIE(testObj(3), testObj(33))))
 
-    val coll1 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
-        SIE(testObj(2), testObj(22)), SIE(testObj(3), testObj(33)))
+    val coll1 = TrivialImmutableCollection(
+      SIE(testObj(1), testObj(11)),
+      SIE(testObj(2), testObj(22)),
+      SIE(testObj(3), testObj(33))
+    )
     assertTrue(entrySet.containsAll(coll1))
 
-    val coll2 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
-        SIE(testObj(2), testObj(22)), SIE(testObj(3), testObj(33)),
-        SIE(testObj(4), testObj(44)))
+    val coll2 = TrivialImmutableCollection(
+      SIE(testObj(1), testObj(11)),
+      SIE(testObj(2), testObj(22)),
+      SIE(testObj(3), testObj(33)),
+      SIE(testObj(4), testObj(44))
+    )
     assertFalse(entrySet.containsAll(coll2))
 
-    val coll3 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
-        SIE(testObj(2), testObj(44)), SIE(testObj(3), testObj(33)))
+    val coll3 = TrivialImmutableCollection(
+      SIE(testObj(1), testObj(11)),
+      SIE(testObj(2), testObj(44)),
+      SIE(testObj(3), testObj(33))
+    )
     assertFalse(entrySet.containsAll(coll3))
 
-    val coll4 = TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
-        SIE(testObj(4), testObj(22)), SIE(testObj(3), testObj(33)))
+    val coll4 = TrivialImmutableCollection(
+      SIE(testObj(1), testObj(11)),
+      SIE(testObj(4), testObj(22)),
+      SIE(testObj(3), testObj(33))
+    )
     assertFalse(entrySet.containsAll(coll4))
   }
 
@@ -992,8 +1026,15 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    entrySet.removeAll(TrivialImmutableCollection(SIE("ONE", "one"),
-        SIE("TWO", "two"), SIE("THREE", "four"), "THREE", 42))
+    entrySet.removeAll(
+      TrivialImmutableCollection(
+        SIE("ONE", "one"),
+        SIE("TWO", "two"),
+        SIE("THREE", "four"),
+        "THREE",
+        42
+      )
+    )
 
     assertFalse(mp.containsKey("ONE"))
     assertFalse(mp.containsKey("TWO"))
@@ -1007,8 +1048,15 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    entrySet.retainAll(TrivialImmutableCollection(SIE("ONE", "one"),
-        SIE("TWO", "two"), SIE("THREE", "four"), "THREE", 42))
+    entrySet.retainAll(
+      TrivialImmutableCollection(
+        SIE("ONE", "one"),
+        SIE("TWO", "two"),
+        SIE("THREE", "four"),
+        "THREE",
+        42
+      )
+    )
 
     assertTrue(mp.containsKey("ONE"))
     assertTrue(mp.containsKey("TWO"))
@@ -1055,9 +1103,15 @@ trait MapTest {
     assertTrue(mp.containsKey(testObj(2)))
     assertTrue(mp.containsKey(testObj(3)))
 
-    entrySet.removeAll(TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
-        SIE(testObj(2), testObj(22)), SIE(testObj(3), testObj(44)),
-        testObj(3), 42))
+    entrySet.removeAll(
+      TrivialImmutableCollection(
+        SIE(testObj(1), testObj(11)),
+        SIE(testObj(2), testObj(22)),
+        SIE(testObj(3), testObj(44)),
+        testObj(3),
+        42
+      )
+    )
 
     assertFalse(mp.containsKey(testObj(1)))
     assertFalse(mp.containsKey(testObj(2)))
@@ -1071,9 +1125,15 @@ trait MapTest {
     assertTrue(mp.containsKey(testObj(2)))
     assertTrue(mp.containsKey(testObj(3)))
 
-    entrySet.retainAll(TrivialImmutableCollection(SIE(testObj(1), testObj(11)),
-        SIE(testObj(2), testObj(22)), SIE(testObj(3), testObj(44)),
-        testObj(3), 42))
+    entrySet.retainAll(
+      TrivialImmutableCollection(
+        SIE(testObj(1), testObj(11)),
+        SIE(testObj(2), testObj(22)),
+        SIE(testObj(3), testObj(44)),
+        testObj(3),
+        42
+      )
+    )
 
     assertTrue(mp.containsKey(testObj(1)))
     assertTrue(mp.containsKey(testObj(2)))
@@ -1115,7 +1175,11 @@ trait MapTest {
   }
 
   @Test def testGetOrDefault(): Unit = {
-    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+    val mp = factory.fromKeyValuePairs(
+      "ONE" -> "one",
+      "TWO" -> "two",
+      "THREE" -> "three"
+    )
 
     assertEquals("one", mp.getOrDefault("ONE", "def"))
     assertEquals("def", mp.getOrDefault("FOUR", "def"))
@@ -1128,7 +1192,11 @@ trait MapTest {
   }
 
   @Test def testForEach(): Unit = {
-    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+    val mp = factory.fromKeyValuePairs(
+      "ONE" -> "one",
+      "TWO" -> "two",
+      "THREE" -> "three"
+    )
 
     val b = List.newBuilder[(String, String)]
     mp.forEach(new BiConsumer[String, String] {
@@ -1146,7 +1214,11 @@ trait MapTest {
   }
 
   @Test def testReplaceAll(): Unit = {
-    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+    val mp = factory.fromKeyValuePairs(
+      "ONE" -> "one",
+      "TWO" -> "two",
+      "THREE" -> "three"
+    )
 
     mp.replaceAll(new BiFunction[String, String, String] {
       def apply(key: String, value: String): String =
@@ -1172,9 +1244,12 @@ trait MapTest {
       assertNull(mp.get("ONE"))
       assertEquals("it was null", mp.get("nullable"))
     } else {
-      assertThrows(classOf[NullPointerException], mp.replaceAll(new BiFunction[String, String, String] {
-        def apply(key: String, value: String): String = null
-      }))
+      assertThrows(
+        classOf[NullPointerException],
+        mp.replaceAll(new BiFunction[String, String, String] {
+          def apply(key: String, value: String): String = null
+        })
+      )
     }
   }
 
@@ -1195,7 +1270,10 @@ trait MapTest {
       assertEquals("non null", mp.get("nullable"))
     } else {
       assertThrows(classOf[NullPointerException], mp.putIfAbsent("abc", null))
-      assertThrows(classOf[NullPointerException], mp.putIfAbsent("new key", null))
+      assertThrows(
+        classOf[NullPointerException],
+        mp.putIfAbsent("new key", null)
+      )
     }
 
     if (!factory.allowsNullKeys) {
@@ -1204,7 +1282,11 @@ trait MapTest {
   }
 
   @Test def testConditionalRemove(): Unit = {
-    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+    val mp = factory.fromKeyValuePairs(
+      "ONE" -> "one",
+      "TWO" -> "two",
+      "THREE" -> "three"
+    )
 
     assertFalse(mp.remove("non existing", "value"))
     assertFalse(mp.containsKey("non existing"))
@@ -1240,7 +1322,11 @@ trait MapTest {
   }
 
   @Test def testUnconditionalRemove(): Unit = {
-    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+    val mp = factory.fromKeyValuePairs(
+      "ONE" -> "one",
+      "TWO" -> "two",
+      "THREE" -> "three"
+    )
 
     assertEquals(null, mp.remove("non existing"))
     assertFalse(mp.containsKey("non existing"))
@@ -1259,7 +1345,11 @@ trait MapTest {
   }
 
   @Test def testConditionalReplace(): Unit = {
-    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+    val mp = factory.fromKeyValuePairs(
+      "ONE" -> "one",
+      "TWO" -> "two",
+      "THREE" -> "three"
+    )
 
     assertTrue(mp.replace("ONE", "one", "four"))
     assertEquals("four", mp.get("ONE"))
@@ -1281,8 +1371,14 @@ trait MapTest {
       assertTrue(mp.containsKey("nullable"))
       assertNull(mp.get("nullable"))
     } else {
-      assertThrows(classOf[NullPointerException], mp.replace("ONE", null, "one"))
-      assertThrows(classOf[NullPointerException], mp.replace("ONE", "four", null))
+      assertThrows(
+        classOf[NullPointerException],
+        mp.replace("ONE", null, "one")
+      )
+      assertThrows(
+        classOf[NullPointerException],
+        mp.replace("ONE", "four", null)
+      )
     }
 
     if (factory.allowsNullKeys) {
@@ -1293,12 +1389,19 @@ trait MapTest {
       assertTrue(mp.replace(null, "null value", "new value"))
       assertEquals("new value", mp.get(null))
     } else {
-      assertThrows(classOf[NullPointerException], mp.replace(null, "one", "two"))
+      assertThrows(
+        classOf[NullPointerException],
+        mp.replace(null, "one", "two")
+      )
     }
   }
 
   @Test def testUnconditionalReplace(): Unit = {
-    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+    val mp = factory.fromKeyValuePairs(
+      "ONE" -> "one",
+      "TWO" -> "two",
+      "THREE" -> "three"
+    )
 
     assertEquals("one", mp.replace("ONE", "four"))
     assertEquals("four", mp.get("ONE"))
@@ -1332,11 +1435,17 @@ trait MapTest {
   }
 
   @Test def testComputeIfAbsent(): Unit = {
-    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+    val mp = factory.fromKeyValuePairs(
+      "ONE" -> "one",
+      "TWO" -> "two",
+      "THREE" -> "three"
+    )
 
     val notCalled = new Function[String, String] {
       def apply(key: String): String =
-        throw new AssertionError(s"function should not have been called for $key")
+        throw new AssertionError(
+          s"function should not have been called for $key"
+        )
     }
 
     val lengthAsString = new Function[String, String] {
@@ -1362,11 +1471,17 @@ trait MapTest {
   }
 
   @Test def testComputeIfPresent(): Unit = {
-    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+    val mp = factory.fromKeyValuePairs(
+      "ONE" -> "one",
+      "TWO" -> "two",
+      "THREE" -> "three"
+    )
 
     val notCalled = new BiFunction[String, String, String] {
       def apply(key: String, value: String): String =
-        throw new AssertionError(s"function should not have been called for $key")
+        throw new AssertionError(
+          s"function should not have been called for $key"
+        )
     }
 
     val remappingFun = new BiFunction[String, String, String] {
@@ -1395,7 +1510,11 @@ trait MapTest {
   }
 
   @Test def testCompute(): Unit = {
-    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+    val mp = factory.fromKeyValuePairs(
+      "ONE" -> "one",
+      "TWO" -> "two",
+      "THREE" -> "three"
+    )
 
     val remappingFun = new BiFunction[String, String, String] {
       def apply(key: String, value: String): String = s"$key - $value"
@@ -1429,15 +1548,22 @@ trait MapTest {
   }
 
   @Test def testMerge(): Unit = {
-    val mp = factory.fromKeyValuePairs("ONE" -> "one", "TWO" -> "two", "THREE" -> "three")
+    val mp = factory.fromKeyValuePairs(
+      "ONE" -> "one",
+      "TWO" -> "two",
+      "THREE" -> "three"
+    )
 
     val notCalled = new BiFunction[String, String, String] {
       def apply(prevValue: String, newValue: String): String =
-        throw new AssertionError(s"function should not have been called for $prevValue")
+        throw new AssertionError(
+          s"function should not have been called for $prevValue"
+        )
     }
 
     val remappingFun = new BiFunction[String, String, String] {
-      def apply(prevValue: String, newValue: String): String = s"$prevValue - $newValue"
+      def apply(prevValue: String, newValue: String): String =
+        s"$prevValue - $newValue"
     }
 
     val returnsNull = new BiFunction[String, String, String] {
@@ -1450,8 +1576,14 @@ trait MapTest {
     assertEquals("def", mp.merge("SEVEN", "def", notCalled))
     assertEquals("def", mp.get("SEVEN"))
 
-    assertThrows(classOf[NullPointerException], mp.merge("non existing", null, notCalled))
-    assertThrows(classOf[NullPointerException], mp.merge("ONE", null, notCalled))
+    assertThrows(
+      classOf[NullPointerException],
+      mp.merge("non existing", null, notCalled)
+    )
+    assertThrows(
+      classOf[NullPointerException],
+      mp.merge("ONE", null, notCalled)
+    )
 
     assertNull(mp.merge("ONE", "def", returnsNull))
     assertFalse(mp.containsKey("ONE"))
@@ -1467,8 +1599,14 @@ trait MapTest {
     val set = factory.empty[String, String].keySet()
 
     assertThrows(classOf[UnsupportedOperationException], set.add("ONE"))
-    assertThrows(classOf[UnsupportedOperationException], set.addAll(ju.Arrays.asList("ONE")))
-    assertThrows(classOf[UnsupportedOperationException], set.addAll(ju.Arrays.asList(null)))
+    assertThrows(
+      classOf[UnsupportedOperationException],
+      set.addAll(ju.Arrays.asList("ONE"))
+    )
+    assertThrows(
+      classOf[UnsupportedOperationException],
+      set.addAll(ju.Arrays.asList(null))
+    )
     assertThrows(classOf[UnsupportedOperationException], set.add(null))
   }
 }
@@ -1482,7 +1620,9 @@ trait MapFactory {
 
   def empty[K: ClassTag, V: ClassTag]: ju.Map[K, V]
 
-  def fromKeyValuePairs[K: ClassTag, V: ClassTag](pairs: (K, V)*): ju.Map[K, V] = {
+  def fromKeyValuePairs[K: ClassTag, V: ClassTag](
+      pairs: (K, V)*
+  ): ju.Map[K, V] = {
     val result = empty[K, V]
     for ((key, value) <- pairs)
       result.put(key, value)

--- a/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/MapTest.scala
@@ -1655,6 +1655,22 @@ trait MapTest {
     )
     assertThrows(classOf[UnsupportedOperationException], set.add(null))
   }
+
+  @Test def testStringMapToString(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    assertEquals("{ONE=one}", mp.toString())
+    mp.put("TWO", "two")
+    assertEquals("{ONE=one, TWO=two}", mp.toString())
+  }
+
+  @Test def testIntMapEntryToString(): Unit = {
+    val mp = factory.empty[Int, Int]
+    mp.put(1, 10)
+    assertEquals("1=10", mp.entrySet.iterator().next().toString())
+    mp.put(2, 20)
+    assertEquals("2=20", mp.entrySet.iterator().next().toString())
+  }
 }
 
 object MapTest {

--- a/unit-tests/shared/src/test/scala/javalib/util/PropertiesTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/PropertiesTest.scala
@@ -1,6 +1,6 @@
-/** Ported from Scala.js and Harmony
- */
-package javalib.util
+// Ported from Scala.js
+
+package org.scalanative.testsuite.javalib.util
 
 import java.util._
 
@@ -13,7 +13,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import scala.scalanative.junit.utils.AssertThrows.assertThrows
-import scala.scalanative.junit.utils.Utils._
+import Utils._
 
 import org.scalanative.testsuite.utils.Platform._
 

--- a/unit-tests/shared/src/test/scala/javalib/util/SetTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/SetTest.scala
@@ -1,0 +1,195 @@
+// Ported from Scala.js commit: a6c1451 dated: 2021-10-16
+
+package org.scalanative.testsuite.javalib.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
+
+import java.{util => ju, lang => jl}
+
+import scala.reflect.ClassTag
+
+import Utils._
+
+trait SetTest extends CollectionTest {
+
+  def factory: SetFactory
+
+  @Test def size(): Unit = {
+    val hs = factory.empty[String]
+
+    assertEquals(0, hs.size())
+    assertTrue(hs.add("ONE"))
+    assertEquals(1, hs.size())
+    assertTrue(hs.add("TWO"))
+    assertEquals(2, hs.size())
+  }
+
+  @Test def addInt(): Unit = {
+    val hs = factory.empty[Int]
+
+    assertTrue(hs.add(100))
+    assertEquals(1, hs.size())
+    assertTrue(hs.contains(100))
+    assertEquals(100, hs.iterator.next())
+  }
+
+  @Test def addAnyRefCustomObjectsWithSameHashCode(): Unit = {
+    val hs = factory.empty[AnyRef]
+    trait A extends Comparable[A] {
+      def compareTo(o: A): Int = toString.compareTo(o.toString)
+    }
+    object B extends A {
+      override def hashCode(): Int = 42
+    }
+    object C extends A {
+      override def hashCode(): Int = 42
+    }
+
+    assertTrue(hs.add(B))
+    assertTrue(hs.add(C))
+    assertEquals(2, hs.size())
+  }
+
+  @Test def addDoubleCornerCases(): Unit = {
+    val hs = factory.empty[Double]
+
+    assertTrue(hs.add(11111.0))
+    assertEquals(1, hs.size())
+    assertTrue(hs.contains(11111.0))
+    assertEquals(11111.0, hs.iterator.next(), 0.0)
+
+    assertTrue(hs.add(Double.NaN))
+    assertEquals(2, hs.size())
+    assertTrue(hs.contains(Double.NaN))
+    assertFalse(hs.contains(+0.0))
+    assertFalse(hs.contains(-0.0))
+
+    assertTrue(hs.remove(Double.NaN))
+    assertTrue(hs.add(+0.0))
+    assertEquals(2, hs.size())
+    assertFalse(hs.contains(Double.NaN))
+    assertTrue(hs.contains(+0.0))
+    assertFalse(hs.contains(-0.0))
+
+    assertTrue(hs.remove(+0.0))
+    assertTrue(hs.add(-0.0))
+    assertEquals(2, hs.size())
+    assertFalse(hs.contains(Double.NaN))
+    assertFalse(hs.contains(+0.0))
+    assertTrue(hs.contains(-0.0))
+
+    assertTrue(hs.add(+0.0))
+    assertTrue(hs.add(Double.NaN))
+    assertTrue(hs.contains(Double.NaN))
+    assertTrue(hs.contains(+0.0))
+    assertTrue(hs.contains(-0.0))
+  }
+
+  @Test def addCustomClass(): Unit = {
+    case class TestObj(num: Int) extends jl.Comparable[TestObj] {
+      override def compareTo(o: TestObj): Int = o.num - num
+    }
+
+    val hs = factory.empty[TestObj]
+
+    assertTrue(hs.add(TestObj(100)))
+    assertEquals(1, hs.size())
+    assertTrue(hs.contains(TestObj(100)))
+    assertEquals(100, hs.iterator.next().num)
+  }
+
+  @Test def removeRemoveAllRetainAll(): Unit = {
+    val hs = factory.empty[String]
+
+    assertEquals(0, hs.size())
+    assertTrue(hs.add("ONE"))
+    assertFalse(hs.add("ONE"))
+    assertEquals(1, hs.size())
+    assertTrue(hs.add("TWO"))
+    assertEquals(2, hs.size())
+    assertTrue(hs.remove("ONE"))
+    assertFalse(hs.remove("ONE"))
+    assertEquals(1, hs.size())
+    assertTrue(hs.remove("TWO"))
+    assertEquals(0, hs.size())
+
+    assertTrue(hs.add("ONE"))
+    assertTrue(hs.add("TWO"))
+    assertEquals(2, hs.size())
+    assertTrue(hs.removeAll(TrivialImmutableCollection("ONE", "TWO")))
+    assertEquals(0, hs.size())
+
+    assertTrue(hs.add("ONE"))
+    assertTrue(hs.add("TWO"))
+    assertEquals(2, hs.size())
+    assertTrue(hs.retainAll(TrivialImmutableCollection("ONE", "THREE")))
+    assertEquals(1, hs.size())
+    assertTrue(hs.contains("ONE"))
+    assertFalse(hs.contains("TWO"))
+  }
+
+  @Test def clearSet(): Unit = {
+    val hs = factory.empty[String]
+
+    assertTrue(hs.add("ONE"))
+    assertTrue(hs.add("TWO"))
+    assertEquals(2, hs.size())
+
+    hs.clear()
+    assertEquals(0, hs.size())
+    assertTrue(hs.isEmpty)
+  }
+
+  @Test def contains(): Unit = {
+    val hs = factory.empty[String]
+
+    assertTrue(hs.add("ONE"))
+    assertTrue(hs.contains("ONE"))
+    assertFalse(hs.contains("TWO"))
+    if (factory.allowsNullElement) {
+      assertFalse(hs.contains(null))
+      assertTrue(hs.add(null))
+      assertTrue(hs.contains(null))
+    } else {
+      assertThrows(classOf[Exception], hs.add(null))
+    }
+  }
+
+  @Test def addAllCollectionStringSet(): Unit = {
+    val hs = factory.empty[String]
+
+    val l = TrivialImmutableCollection("ONE", "TWO", null)
+
+    if (factory.allowsNullElement) {
+      assertTrue(hs.addAll(l))
+      assertEquals(3, hs.size)
+      assertTrue(hs.contains("ONE"))
+      assertTrue(hs.contains("TWO"))
+      assertTrue(hs.contains(null))
+    } else {
+      assertThrows(classOf[Exception], hs.addAll(l))
+    }
+  }
+
+  @Test def iterator(): Unit = {
+    val hs = factory.empty[String]
+
+    val l = {
+      if (factory.allowsNullElement)
+        List("ONE", "TWO", null)
+      else
+        List("ONE", "TWO", "THREE")
+    }
+    assertTrue(hs.addAll(TrivialImmutableCollection(l: _*)))
+    assertEquals(3, hs.size)
+
+    assertIteratorSameElementsAsSet(l: _*)(hs.iterator())
+  }
+}
+
+trait SetFactory extends CollectionFactory {
+  def empty[E: ClassTag]: ju.Set[E]
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/TrivialImmutableMap.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/TrivialImmutableMap.scala
@@ -8,17 +8,17 @@ import java.util.Map.Entry
 final class TrivialImmutableMap[K, V] private (contents: List[Entry[K, V]])
     extends ju.AbstractMap[K, V] {
 
-  def entrySet(): ju.Set[Entry[K,V]] = {
+  def entrySet(): ju.Set[Entry[K, V]] = {
     new ju.AbstractSet[Entry[K, V]] {
       def size(): Int = contents.size
 
-      def iterator(): ju.Iterator[Entry[K,V]] = {
+      def iterator(): ju.Iterator[Entry[K, V]] = {
         new ju.Iterator[Entry[K, V]] {
           private var remaining: List[Entry[K, V]] = contents
 
           def hasNext(): Boolean = remaining.nonEmpty
 
-          def next(): Entry[K,V] = {
+          def next(): Entry[K, V] = {
             val head = remaining.head
             remaining = remaining.tail
             head
@@ -34,5 +34,9 @@ object TrivialImmutableMap {
     new TrivialImmutableMap(contents)
 
   def apply[K, V](contents: (K, V)*): TrivialImmutableMap[K, V] =
-    apply(contents.toList.map(kv => new ju.AbstractMap.SimpleImmutableEntry(kv._1, kv._2)))
+    apply(
+      contents.toList.map(kv =>
+        new ju.AbstractMap.SimpleImmutableEntry(kv._1, kv._2)
+      )
+    )
 }

--- a/unit-tests/shared/src/test/scala/javalib/util/TrivialImmutableMap.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/TrivialImmutableMap.scala
@@ -1,0 +1,38 @@
+// Ported from Scala.js commit: 9683b0c dated: 2021-10-22
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+import java.util.Map.Entry
+
+final class TrivialImmutableMap[K, V] private (contents: List[Entry[K, V]])
+    extends ju.AbstractMap[K, V] {
+
+  def entrySet(): ju.Set[Entry[K,V]] = {
+    new ju.AbstractSet[Entry[K, V]] {
+      def size(): Int = contents.size
+
+      def iterator(): ju.Iterator[Entry[K,V]] = {
+        new ju.Iterator[Entry[K, V]] {
+          private var remaining: List[Entry[K, V]] = contents
+
+          def hasNext(): Boolean = remaining.nonEmpty
+
+          def next(): Entry[K,V] = {
+            val head = remaining.head
+            remaining = remaining.tail
+            head
+          }
+        }
+      }
+    }
+  }
+}
+
+object TrivialImmutableMap {
+  def apply[K, V](contents: List[Entry[K, V]]): TrivialImmutableMap[K, V] =
+    new TrivialImmutableMap(contents)
+
+  def apply[K, V](contents: (K, V)*): TrivialImmutableMap[K, V] =
+    apply(contents.toList.map(kv => new ju.AbstractMap.SimpleImmutableEntry(kv._1, kv._2)))
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/Utils.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/Utils.scala
@@ -1,16 +1,6 @@
-/*
- * Ported from Scala.js (https://www.scala-js.org/)
- *
- * Copyright EPFL.
- *
- * Licensed under Apache License 2.0
- * (https://www.apache.org/licenses/LICENSE-2.0).
- *
- * See the NOTICE file distributed with this work for
- * additional information regarding copyright ownership.
- */
+// Ported from Scala.js commit: unk dated: unk
 
-package scala.scalanative.junit.utils
+package org.scalanative.testsuite.javalib.util
 
 import java.{util => ju}
 

--- a/unit-tests/shared/src/test/scala/javalib/util/Utils.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/Utils.scala
@@ -1,4 +1,4 @@
-// Ported from Scala.js commit: unk dated: unk
+// Ported from Scala.js commit: a6c1451 dated: 2021-10-16
 
 package org.scalanative.testsuite.javalib.util
 
@@ -27,19 +27,16 @@ object Utils {
       def hasNext(): Boolean = iter.hasNext()
 
       def next(): B = f(iter.next())
-
-      override def remove(): Unit =
-        throw new UnsupportedOperationException("Iterator.remove()")
     }
   }
 
-  def enumerationIsEmpty(enum: ju.Enumeration[_]): Boolean =
-    !enum.hasMoreElements()
+  def enumerationIsEmpty(enumeration: ju.Enumeration[_]): Boolean =
+    !enumeration.hasMoreElements()
 
-  def enumerationSize(enum: ju.Enumeration[_]): Int = {
+  def enumerationSize(enumeration: ju.Enumeration[_]): Int = {
     var result = 0
-    while (enum.hasMoreElements()) {
-      enum.nextElement()
+    while (enumeration.hasMoreElements()) {
+      enumeration.nextElement()
       result += 1
     }
     result
@@ -47,12 +44,10 @@ object Utils {
 
   def assertEnumSameElementsAsSet[A](
       expected: A*
-  )(enum: ju.Enumeration[_ <: A]): Unit = {
+  )(enumeration: ju.Enumeration[_ <: A]): Unit = {
     assertIteratorSameElementsAsSet(expected: _*)(new ju.Iterator[A] {
-      def hasNext(): Boolean = enum.hasMoreElements()
-      def next(): A = enum.nextElement()
-      override def remove(): Unit =
-        throw new UnsupportedOperationException("Iterator.remove()")
+      def hasNext(): Boolean = enumeration.hasMoreElements()
+      def next(): A = enumeration.nextElement()
     })
   }
 


### PR DESCRIPTION
Trying to find defect via increased test coverage. The following only fails for Scala Native not JVM or Scala.js. https://github.com/ekrich/sconfig/pull/205