### PR TITLE
Fix #2413: Add note to docs for creating sn project in mounted directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ _build/
 *.dot
 *.ppm
 .idea
-_build/
 scripts/.coursier
 scripts/.scalafmt*
 sbt-crossproject/
@@ -35,3 +34,6 @@ bin/
 
 # vim
 *.swp
+
+# Virtual env generated dependecies, for generating docs
+.venv

--- a/docs/contrib/build.rst
+++ b/docs/contrib/build.rst
@@ -258,6 +258,25 @@ if it's not the present script will try to use directory with corresponding Scal
 or it would try to use Scala epoch version or `overrides` directory. If none of these directories exists it will fail. 
 It is also possible to define explicitly overrides directory to use by passing it as the third argument to the script.
 
+
+Locally publish docs
+---------------------------------------
+Follow the steps after cloning the `scalanative <https://github.com/scala-native/scala-native>`_ repo and changing to `scala-native` directory.
+
+1. First time building the docs. This command will setup & build the docs.
+
+.. code-block:: text
+
+    $ bash scripts/makedocs setup
+
+2. If setup is already done. This command will only build the docs assuming setup is already done.
+
+.. code-block:: text
+
+    $ bash scripts/makedocs 
+
+3. Navigate to ``docs/_build/html`` directory and open ``index.html`` file in your browser.
+
 The next section has more build and development information for those wanting
 to work on :ref:`compiler`.
 

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -13,6 +13,11 @@ template.  In an empty working directory, execute::
 
     sbt new scala-native/scala-native.g8
 
+.. note:: New project should not be created in `mounted` directories, like external storage devices.
+
+  Incase of WSL2(Windows Subsystem Linux), windows file system like `C` or `D` drive are percieved as `mounted`. So creating new projects in these location will not work.
+
+  In wsl2 environment, creating new project wsl2 file path work. e.g /home/<USER>/sn-projects.
 This will:
 
 * start sbt.

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -15,7 +15,7 @@ template.  In an empty working directory, execute::
 
 .. note:: New project should not be created in `mounted` directories, like external storage devices.
 
-  Incase of WSL2(Windows Subsystem Linux), windows file system like `C` or `D` drive are percieved as `mounted`. So creating new projects in these location will not work.
+  In the case of WSL2 (Windows Subsystem Linux), Windows file system drives like `C` or `D` are perceived as `mounted`. So creating new projects in these locations will not work.
 
   In wsl2 environment, creating new project wsl2 file path work. e.g /home/<USER>/sn-projects.
 This will:

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -17,7 +17,7 @@ template.  In an empty working directory, execute::
 
   In the case of WSL2 (Windows Subsystem Linux), Windows file system drives like `C` or `D` are perceived as `mounted`. So creating new projects in these locations will not work.
 
-  In wsl2 environment, creating new project wsl2 file path work. e.g /home/<USER>/sn-projects.
+  In the WSL2 environment, it is recommended to create projects in the user files path, e.g /home/<USER>/sn-projects.
 This will:
 
 * start sbt.

--- a/scripts/makedocs
+++ b/scripts/makedocs
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+cd docs
+function create_venv {
+  virtualenv .venv
+}
+
+function activate_venv {
+  source .venv/bin/activate
+}
+
+function install_req {
+  pip install Sphinx==4.2.0
+  pip install recommonmark==0.7.1
+}
+
+function generate_docs {
+  make html
+}
+
+function usage {
+  echo "  Usage:"
+  echo "    1. bash makedocs setup # if setup is not done."
+  echo "    2. bash makedocs       # if setup is done and building docs is needed"
+
+}
+
+case $@ in
+  "")       activate_venv; generate_docs; exit 0 ;;
+  setup)    create_venv; activate_venv; install_req; generate_docs; exit 0 ;;
+  *)        echo "Unknown parameters $@"; usage; exit 1 ;;
+esac

--- a/scripts/makedocs
+++ b/scripts/makedocs
@@ -21,7 +21,6 @@ function usage {
   echo "  Usage:"
   echo "    1. bash makedocs setup # if setup is not done."
   echo "    2. bash makedocs       # if setup is done and building docs is needed"
-
 }
 
 case $@ in


### PR DESCRIPTION
This commit includes
1. Note, when creating sn project in mounted directory
2. Add bash scripts to generate docs and add documention on running the bash script in `contrib/build.rst`