### PR TITLE
Add build-docs.yml action for github workflow. Modify sbt.rst warning issue

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,16 @@
+name: Build docs
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+jobs:
+  build-docs:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          pre-build-command: "pip install Sphinx==4.2.0 recommonmark==0.7.1"
+          docs-folder: "docs/"
+

--- a/docs/user/sbt.rst
+++ b/docs/user/sbt.rst
@@ -13,11 +13,13 @@ template.  In an empty working directory, execute::
 
     sbt new scala-native/scala-native.g8
 
-.. note:: New project should not be created in `mounted` directories, like external storage devices.
+.. note:: 
+  New project should not be created in `mounted` directories, like external storage devices.
 
   In the case of WSL2 (Windows Subsystem Linux), Windows file system drives like `C` or `D` are perceived as `mounted`. So creating new projects in these locations will not work.
 
   In the WSL2 environment, it is recommended to create projects in the user files path, e.g /home/<USER>/sn-projects.
+
 This will:
 
 * start sbt.


### PR DESCRIPTION
This pull request contains:
- build-docs.yml action for Github workflow
- Fix the warning for `sbt.rst`.

Explanation about `build-docs.yml`
- Build on top of [sphinx-action](https://github.com/marketplace/actions/sphinx-build)
- Updated to Sphinx version `4.2.0`
- Warning in docs comes as `warning`.
- Action `build-docs` is tested locally with [nektos/act](https://github.com/nektos/act)