### PR TITLE
Fix #2418: Building docs should be a part of the CI.

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,13 +3,13 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 jobs:
   build-docs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: ammaraskar/sphinx-action@0.4
         with:
-          pre-build-command: "pip install Sphinx==4.2.0 recommonmark==0.7.1"
           docs-folder: "docs/"
+          build-command: 'sphinx-build -b html . _build/html -W --keep-going -n'

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -11,5 +11,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ammaraskar/sphinx-action@0.4
         with:
+          pre-build-command: "pip install Sphinx==7.0.1 recommonmark==0.7.1"
           docs-folder: "docs/"
-          build-command: 'sphinx-build -b html . _build/html -W --keep-going -n -Dexclude_patterns=["**/requirements.txt"]'
+          build-command: 'sphinx-build -b html . _build/html -W --keep-going -n'

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: ammaraskar/sphinx-action@0.4
         with:
           docs-folder: "docs/"
-          build-command: 'sphinx-build -b html . _build/html -W --keep-going -n'
+          build-command: 'sphinx-build -b html . _build/html -W --keep-going -n -Dexclude_patterns=["**/requirements.txt"]'

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,4 +13,3 @@ jobs:
         with:
           pre-build-command: "pip install Sphinx==4.2.0 recommonmark==0.7.1"
           docs-folder: "docs/"
-

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: ammaraskar/sphinx-action@master
+      - uses: ammaraskar/sphinx-action@0.4
         with:
           pre-build-command: "pip install Sphinx==4.2.0 recommonmark==0.7.1"
           docs-folder: "docs/"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,16 @@
+name: Build docs
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+jobs:
+  build-docs:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          pre-build-command: "pip install Sphinx==4.2.0 recommonmark==0.7.1"
+          docs-folder: "docs/"
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx==7.0.1
+recommonmark==0.7.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-Sphinx==7.0.1
-recommonmark==0.7.1


### PR DESCRIPTION
In this commit:
- Add action `build-docs`
- Modify `docs/user/sbt.rst` to remove the warning

Explanation about `build-docs` action
- Build on top of [sphinx-action](https://github.com/marketplace/actions/sphinx-build)
- Update Sphinx to `4.2.0` 
- Warning in building docs bubble as GitHub warning
- Action `build-docs` is tested locally by [nektos/act](https://github.com/nektos/act)