### PR TITLE
Fix #2433: spaces not being allowed in Paths on Windows

### DIFF
--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPathParser.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPathParser.scala
@@ -121,7 +121,8 @@ object WindowsPathParser {
       allowedChars: String = ""
   ): String = {
     def isControlOrReservedChar(c: Char) = {
-      c < '\u0020' || pathReservedChars.contains(c)
+      // '\u0001F' - last control character (no. 31)
+      c <= '\u001F' || pathReservedChars.contains(c)
     }
     def checkValidSegment(
         segment: String,

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPathParser.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPathParser.scala
@@ -120,8 +120,8 @@ object WindowsPathParser {
       to: Int,
       allowedChars: String = ""
   ): String = {
-    def isSpaceOrReservedChar(c: Char) = {
-      c.isSpaceChar || pathReservedChars.contains(c)
+    def isControlOrReservedChar(c: Char) = {
+      c < '\u0020' || pathReservedChars.contains(c)
     }
     def checkValidSegment(
         segment: String,
@@ -130,7 +130,7 @@ object WindowsPathParser {
     ): Unit = {
 
       val invalidCharIdx = segment.indexWhere { c =>
-        isSpaceOrReservedChar(c) && !allowedChars.contains(c)
+        isControlOrReservedChar(c) && !allowedChars.contains(c)
       }
       if (invalidCharIdx >= 0) {
         throw new InvalidPathException(

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/PathsTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/PathsTest.scala
@@ -63,4 +63,13 @@ class PathsTest {
       Paths.get(new URI("fIlE", null, null, 0, pathString2, null, null))
     assertEquals(expected2, path2.toString)
   }
+
+  // issue #2433
+  @Test def spaceAllowedInPath() = {
+    val withSpaces = "space dir/space file"
+    val expected = if (isWindows) raw"space dir\space file" else withSpaces
+
+    val path = Paths.get("space dir/space file")
+    assertEquals(expected, path.toString)
+  }
 }


### PR DESCRIPTION
According to the Windows documentation, merely characters with codes 0-31 are considered to be the control characters forbidden for paths. Since spaces (of code 32) are allowed, they were removed from the check.

A test for the issue was also added.