### PR TITLE
Fix incorrect definition of Class.getConstructor stub method

### DIFF
--- a/nativelib/src/main/scala/java/lang/Class.scala
+++ b/nativelib/src/main/scala/java/lang/Class.scala
@@ -131,7 +131,7 @@ final class _Class[A] {
   @stub
   def getClassLoader(): java.lang.ClassLoader = ???
   @stub
-  def getConstructor(args: Array[Object]): java.lang.reflect.Constructor[_] =
+  def getConstructor(args: Array[_Class[_]]): java.lang.reflect.Constructor[_] =
     ???
   @stub
   def getConstructors(): Array[Object] = ???

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -47,7 +47,9 @@ object BinaryIncompatibilities {
     // package-private
     exclude[MissingClassProblem]("scala.scalanative.runtime.*Shutdown*"),
     exclude[Problem]("scala.scalanative.runtime.ClassInstancesRegistry*"),
-    exclude[Problem]("scala.scalanative.runtime.package*TypeOps*")
+    exclude[Problem]("scala.scalanative.runtime.package*TypeOps*"),
+    // Stub with incorrect signature
+    exclude[Problem]("java.lang._Class.getConstructor")
   )
   final val CLib: Filters = Nil
   final val PosixLib: Filters = Seq(

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -838,12 +838,18 @@ class Reach(
   }
 
   protected def addMissing(global: Global, pos: Position): Unit = {
-    val prev = missing.getOrElse(global, Set.empty)
-    val position = NonReachablePosition(
-      path = Paths.get(pos.source),
-      line = pos.line + 1
-    )
-    missing(global) = prev + position
+    if (config.linkStubs) {
+      config.logger.warn(s"Found usage of undefined symbol not marked as stub: ${global.mangle}")
+    } else {
+      val prev = missing.getOrElse(global, Set.empty)
+
+      val position = NonReachablePosition(
+        path = Paths.get(pos.source),
+        line = pos.line + 1
+      )
+      missing(global) = prev + position
+      reachUnavailable(global)
+    }
   }
 
   private def reportMissing(): Unit = {

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -838,18 +838,12 @@ class Reach(
   }
 
   protected def addMissing(global: Global, pos: Position): Unit = {
-    if (config.linkStubs) {
-      config.logger.warn(s"Found usage of undefined symbol not marked as stub: ${global.mangle}")
-    } else {
-      val prev = missing.getOrElse(global, Set.empty)
-
-      val position = NonReachablePosition(
-        path = Paths.get(pos.source),
-        line = pos.line + 1
-      )
-      missing(global) = prev + position
-      reachUnavailable(global)
-    }
+    val prev = missing.getOrElse(global, Set.empty)
+    val position = NonReachablePosition(
+      path = Paths.get(pos.source),
+      line = pos.line + 1
+    )
+    missing(global) = prev + position
   }
 
   private def reportMissing(): Unit = {


### PR DESCRIPTION
This PR resolves #2421, by chaning the definition of `Class::getConstructor` method defined as a stub. Because it was defined with incorrect parameter types (`Array[Object]`  instead of `Array[Class[_]]`) it would lead to build failure in case of usage when `linkStubs` settings is enabled. 