### PR TITLE
Add missing unistd function getppid()

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -23,6 +23,7 @@ object unistd {
   def getcwd(buf: CString, size: CSize): CString = extern
   def gethostname(name: CString, len: CSize): CInt = extern
   def getpid(): CInt = extern
+  def getppid(): CInt = extern
   def getuid(): uid_t = extern
   def lseek(fildes: CInt, offset: off_t, whence: CInt): off_t = extern
   def pipe(fildes: Ptr[CInt]): CInt = extern


### PR DESCRIPTION
Add missing `unistd` function `getppid()`. I don't know if this pull request is useful but I wanted to add this function that I often use. I can also add the other missing functions of `unistd` if necessary.

```
getppid() returns the process ID of the parent of the calling process.  This will be either  the
ID of the process that created this process using fork(), or, if that process has already termi‐
nated, the ID of the process to which this process has been  reparented  (either  init(1)  or  a
"subreaper" process defined via the prctl(2) PR_SET_CHILD_SUBREAPER operation).
```