### PR TITLE
Initialize _String with `_` `Array[Char]`

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -16,7 +16,7 @@ final class _String()
     extends Serializable
     with Comparable[_String]
     with CharSequence {
-  protected[_String] var value: Array[Char] = new Array[Char](0)
+  protected[_String] var value: Array[Char] = _
   protected[_String] var offset: Int = 0
   protected[_String] var count: Int = 0
   protected[_String] var cachedHashCode: Int = _


### PR DESCRIPTION
Reading through the code, I noticed that the class java.lang.String creates a `new Array[Char](0)` before running the constructors. I don't know if this allocation is optimized away or not, but it seemed a good idea to remove it in case it actually happens. Especially since strings are everywhere and a little improvement can make a difference.