### PR TITLE
System.properties define `os.arch`

### DIFF
--- a/nativelib/src/main/resources/scala-native/platform.c
+++ b/nativelib/src/main/resources/scala-native/platform.c
@@ -58,16 +58,7 @@ int scalanative_little_endian() {
 void scalanative_set_os_props(void (*add_prop)(const char *, const char *)) {
 #ifdef _WIN32
     add_prop("os.name", "Windows (Unknown version)");
-    wchar_t wcharPath[MAX_PATH];
-    size_t size = sizeof(wchar_t) * wcslen(wcharPath);
-    char path[MAX_PATH];
-    if (GetTempPathW(MAX_PATH, wcharPath) &&
-        wcstombs_s(&size, path, MAX_PATH, wcharPath, MAX_PATH - 1) == 0 &&
-        size > 0) {
-        add_prop("java.io.tmpdir", (const char *)path);
-    }
-#else
-#ifdef __APPLE__
+#elif defined(__APPLE__)
     add_prop("os.name", "Mac OS X");
 #else
     struct utsname name;


### PR DESCRIPTION
Currently system property `os.arch` is not defined, this PR changes it by usage of macro definitions on Windows and uname of Unix platforms with additional support for legacy names compliant with behaviour on the JVM: 
* For all OS except MacOSX we replace `x86_64` with `amd64`
* For all Linux os's we replace `x86` with `i386` 

Additionally no longer used `java.io.tmpdir` prop setup in native code was removed (it is now set in Scala codebase)