### PR TITLE
Make `java.nio.MappedByteBuffer` JDK9+ compliant

### DIFF
--- a/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBuffer.scala
@@ -18,4 +18,39 @@ abstract class MappedByteBuffer private[nio] (
 
   def load(): MappedByteBuffer
 
+  @inline override def position(newPosition: Int): MappedByteBuffer = {
+    super.position(newPosition)
+    this
+  }
+
+  @inline override def limit(newLimit: Int): MappedByteBuffer = {
+    super.limit(newLimit)
+    this
+  }
+
+  @inline override def mark(): MappedByteBuffer = {
+    super.mark()
+    this
+  }
+
+  @inline override def reset(): MappedByteBuffer = {
+    super.reset()
+    this
+  }
+
+  @inline override def clear(): MappedByteBuffer = {
+    super.clear()
+    this
+  }
+
+  @inline override def flip(): MappedByteBuffer = {
+    super.flip()
+    this
+  }
+
+  @inline override def rewind(): MappedByteBuffer = {
+    super.rewind()
+    this
+  }
+
 }


### PR DESCRIPTION
This PR does override methods for which return type was changed in JDK9 for `java.nio.MapedByteBuffer`. Now for methods like `flip`, `position`, etc, the return type is correct `MappedByteBuffer` instead of `ByteBuffer`. This change is backwards compatible with JDK8 as `MappedByteBuffer` is a subtype of `ByteBuffer`. 
Tested locally as we are not yet ready to run JDK9+ tests in the CI