### PR TITLE
Adapt `unsafe` package for upcoming Scala 3 support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ runtime designed specifically for Scala. It features:
 
       type Vec = CStruct3[Double, Double, Double]
 
-      val vec = stackalloc[Vec] // allocate c struct on stack
+      val vec = stackalloc[Vec]() // allocate c struct on stack
       vec._1 = 10.0             // initialize fields
       vec._2 = 20.0
       vec._3 = 30.0

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -289,7 +289,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
    */
   private def simplifyExistingPath(path: String)(implicit z: Zone): String = {
     if (isWindows) {
-      val resolvedName = alloc[WChar](FileApiExt.MAX_PATH)
+      val resolvedName: Ptr[WChar] = alloc[WChar](FileApiExt.MAX_PATH)
       GetFullPathNameW(
         toCWideStringUTF16LE(properPath),
         FileApiExt.MAX_PATH,
@@ -298,7 +298,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
       )
       fromCWideString(resolvedName, StandardCharsets.UTF_16LE)
     } else {
-      val resolvedName = alloc[Byte](limits.PATH_MAX)
+      val resolvedName: Ptr[Byte] = alloc[Byte](limits.PATH_MAX)
       if (realpath(toCString(path), resolvedName) == null) {
         throw new IOException(
           s"realpath can't resolve: ${fromCString(resolvedName)}"
@@ -677,7 +677,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
           val privilegeSetLength = stackalloc[windows.DWord]
           !privilegeSetLength = emptyPriviligesSize.toUInt
 
-          val privilegeSet = stackalloc[Byte](!privilegeSetLength)
+          val privilegeSet: Ptr[Byte] = stackalloc[Byte](!privilegeSetLength)
           memset(privilegeSet, 0, !privilegeSetLength)
 
           val grantedAcccess = stackalloc[windows.DWord]
@@ -854,7 +854,7 @@ object File {
 
           // previous path up to last /, plus result of resolving the link.
           val newPathLength = last + linkLength + `1UL`
-          val newPath = alloc[Byte](newPathLength)
+          val newPath: Ptr[Byte] = alloc[Byte](newPathLength)
           strncpy(newPath, path, last)
           strncat(newPath, link, linkLength)
 

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -403,7 +403,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
         ) {
           case INVALID_HANDLE_VALUE => 0L
           case handle =>
-            val lastModified = stackalloc[WinFileTime]
+            val lastModified = stackalloc[WinFileTime]()
             GetFileTime(
               handle,
               creationTime = null,
@@ -459,7 +459,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
           ) {
             case INVALID_HANDLE_VALUE => false
             case handle =>
-              val lastModified = stackalloc[WinFileTime]
+              val lastModified = stackalloc[WinFileTime]()
               !lastModified =
                 MinWinBaseApiOps.FileTimeOps.fromUnixEpochMillis(time)
               SetFileTime(
@@ -628,7 +628,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
       access: windows.DWord
   )(implicit zone: Zone): Boolean = {
     // based on this article https://blog.aaronballman.com/2011/08/how-to-check-access-rights/
-    val accessStatus = stackalloc[Boolean]
+    val accessStatus = stackalloc[Boolean]()
 
     def withFileSecurityDescriptor(
         fn: Ptr[SecurityDescriptor] => Unit
@@ -665,7 +665,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
     else {
       withFileSecurityDescriptor { securityDescriptor =>
         withImpersonatedToken { impersonatedToken =>
-          val genericMapping = stackalloc[GenericMapping]
+          val genericMapping = stackalloc[GenericMapping]()
           genericMapping.genericRead = FILE_GENERIC_READ
           genericMapping.genericWrite = FILE_GENERIC_WRITE
           genericMapping.genericExecute = FILE_GENERIC_EXECUTE

--- a/javalib/src/main/scala/java/io/FileDescriptor.scala
+++ b/javalib/src/main/scala/java/io/FileDescriptor.scala
@@ -77,7 +77,7 @@ final class FileDescriptor private[java] (
 
   def valid(): Boolean =
     if (isWindows) {
-      val flags = stackalloc[DWord]
+      val flags = stackalloc[DWord]()
       handle != INVALID_HANDLE_VALUE &&
       GetHandleInformation(handle, flags)
     } else {

--- a/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
+++ b/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
@@ -51,7 +51,7 @@ private[java] object IEEE754Helpers {
 
       val cStr = bytesToCString(bytes, bytesLen)
 
-      val end = stackalloc[CString] // Address one past last parsed cStr byte.
+      val end = stackalloc[CString]() // Address one past last parsed cStr byte.
 
       errno.errno = 0
       var res = f(cStr, end)

--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -49,8 +49,8 @@ private[lang] object StackTraceElement {
   object Fail extends scala.util.control.NoStackTrace
 
   def fromSymbol(sym: CString): StackTraceElement = {
-    val className = stackalloc[CChar](1024.toUInt)
-    val methodName = stackalloc[CChar](1024.toUInt)
+    val className: Ptr[CChar] = stackalloc[CChar](1024.toUInt)
+    val methodName: Ptr[CChar] = stackalloc[CChar](1024.toUInt)
     SymbolFormatter.asyncSafeFromSymbol(sym, className, methodName)
 
     new StackTraceElement(

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -128,7 +128,7 @@ object System {
   private def getCurrentDirectory(): Option[String] = {
     val bufSize = 1024.toUInt
     if (isWindows) {
-      val buf = stackalloc[CChar16](bufSize)
+      val buf: Ptr[CChar16] = stackalloc[CChar16](bufSize)
       if (GetCurrentDirectoryW(bufSize, buf) != 0.toUInt)
         Some(fromCWideString(buf, StandardCharsets.UTF_16LE))
       else None
@@ -144,7 +144,7 @@ object System {
       WindowsHelperMethods.withUserToken(AccessToken.TOKEN_QUERY) { token =>
         val bufSize = stackalloc[UInt]()
         !bufSize = 256.toUInt
-        val buf = stackalloc[CChar16](!bufSize)
+        val buf: Ptr[CChar16] = stackalloc[CChar16](!bufSize)
         if (GetUserProfileDirectoryW(token, buf, bufSize))
           Some(fromCWideString(buf, StandardCharsets.UTF_16LE))
         else None
@@ -163,7 +163,7 @@ object System {
       infoCode: LCType,
       bufSize: UInt
   ): Option[String] = {
-    val buf = stackalloc[CChar16](bufSize)
+    val buf: Ptr[CChar16] = stackalloc[CChar16](bufSize)
     GetLocaleInfoEx(
       LOCALE_NAME_USER_DEFAULT,
       infoCode,

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -142,7 +142,7 @@ object System {
   private def getUserHomeDirectory(): Option[String] = {
     if (isWindows) {
       WindowsHelperMethods.withUserToken(AccessToken.TOKEN_QUERY) { token =>
-        val bufSize = stackalloc[UInt]
+        val bufSize = stackalloc[UInt]()
         !bufSize = 256.toUInt
         val buf = stackalloc[CChar16](!bufSize)
         if (GetUserProfileDirectoryW(token, buf, bufSize))

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -13,7 +13,7 @@ private[lang] object StackTrace {
       cursor: Ptr[scala.Byte]
   ): StackTraceElement = {
     val nameMax = 1024
-    val name = stackalloc[CChar](nameMax.toUInt)
+    val name: Ptr[CChar] = stackalloc[CChar](nameMax.toUInt)
     val offset = stackalloc[scala.Byte](8.toUInt)
 
     unwind.get_proc_name(cursor, name, nameMax.toUInt, offset)

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -40,7 +40,7 @@ private[lang] object StackTrace {
     val cursor = stackalloc[scala.Byte](2048.toUInt)
     val context = stackalloc[scala.Byte](2048.toUInt)
     val offset = stackalloc[scala.Byte](8.toUInt)
-    val ip = stackalloc[CUnsignedLongLong]
+    val ip = stackalloc[CUnsignedLongLong]()
     var buffer = mutable.ArrayBuffer.empty[StackTraceElement]
 
     unwind.get_context(context)

--- a/javalib/src/main/scala/java/lang/impl/PosixThread.scala
+++ b/javalib/src/main/scala/java/lang/impl/PosixThread.scala
@@ -11,7 +11,7 @@ private[lang] object PosixThread {
   def sleep(millis: scala.Long, nanos: scala.Int): Unit = {
     @tailrec
     def doSleep(requestedTime: Ptr[timespec]): Unit = {
-      val remaining = stackalloc[timespec]
+      val remaining = stackalloc[timespec]()
       nanosleep(requestedTime, remaining) match {
         case _ if Thread.interrupted() =>
           throw new InterruptedException("Sleep was interrupted")
@@ -23,7 +23,7 @@ private[lang] object PosixThread {
       }
     }
 
-    val requestedTime = stackalloc[timespec]
+    val requestedTime = stackalloc[timespec]()
     requestedTime.tv_sec = millis / 1000
     requestedTime.tv_nsec = (millis % 1000) * 1e6.toInt + nanos
     doSleep(requestedTime)

--- a/javalib/src/main/scala/java/lang/process/PipeIO.scala
+++ b/javalib/src/main/scala/java/lang/process/PipeIO.scala
@@ -86,7 +86,7 @@ private[lang] object PipeIO {
     private[this] var drained = false
     private def availableFD() = {
       if (isWindows) {
-        val availableTotal = stackalloc[DWord]
+        val availableTotal = stackalloc[DWord]()
         val hasPeaked = PeekNamedPipe(
           pipe = is.getFD().handle,
           buffer = null,
@@ -98,7 +98,7 @@ private[lang] object PipeIO {
         if (hasPeaked) (!availableTotal).toInt
         else 0
       } else {
-        val res = stackalloc[CInt]
+        val res = stackalloc[CInt]()
         ioctl(
           is.getFD().fd,
           FIONREAD,

--- a/javalib/src/main/scala/java/lang/process/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcess.scala
@@ -149,8 +149,8 @@ object UnixProcess {
   private def waitForPid(pid: Int, ts: Ptr[timespec], res: Ptr[CInt]): CInt =
     ProcessMonitor.waitForPid(pid, ts, res)
   def apply(builder: ProcessBuilder): Process = Zone { implicit z =>
-    val infds = stackalloc[CInt](2.toUInt)
-    val outfds = stackalloc[CInt](2.toUInt)
+    val infds: Ptr[CInt] = stackalloc[CInt](2.toUInt)
+    val outfds: Ptr[CInt] = stackalloc[CInt](2.toUInt)
     val errfds =
       if (builder.redirectErrorStream()) outfds else stackalloc[CInt](2.toUInt)
 
@@ -242,7 +242,7 @@ object UnixProcess {
   @inline private def nullTerminate(
       seq: collection.Seq[String]
   )(implicit z: Zone) = {
-    val res = alloc[CString]((seq.size + 1).toUInt)
+    val res: Ptr[CString] = alloc[CString]((seq.size + 1).toUInt)
     seq.zipWithIndex foreach { case (s, i) => !(res + i) = toCString(s) }
     res
   }

--- a/javalib/src/main/scala/java/lang/process/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcess.scala
@@ -74,8 +74,8 @@ private[lang] class UnixProcess private (
   override def waitFor(timeout: scala.Long, unit: TimeUnit): scala.Boolean =
     checkResult() match {
       case -1 =>
-        val ts = stackalloc[timespec]
-        val tv = stackalloc[timeval]
+        val ts = stackalloc[timespec]()
+        val tv = stackalloc[timeval]()
         throwOnError(gettimeofday(tv, null), "Failed to set time of day.")
         val nsec = unit.toNanos(timeout) + TimeUnit.MICROSECONDS.toNanos(tv._2)
         val sec = TimeUnit.NANOSECONDS.toSeconds(nsec)
@@ -124,7 +124,7 @@ private[lang] class UnixProcess private (
     }
   }
   private[this] def waitFor(ts: Ptr[timespec]): Int = {
-    val res = stackalloc[CInt]
+    val res = stackalloc[CInt]()
     !res = -1
     val result = UnixProcess.waitForPid(pid, ts, res)
     setExitValue(!res)

--- a/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/WindowsProcess.scala
@@ -102,7 +102,7 @@ private[lang] class WindowsProcess private (
   private[lang] def checkResult(): CInt = {
     cachedExitValue
       .getOrElse {
-        val exitCode: Ptr[DWord] = stackalloc[DWord]
+        val exitCode: Ptr[DWord] = stackalloc[DWord]()
         if (!GetExitCodeProcess(handle, exitCode)) -1
         else {
           (!exitCode) match {
@@ -164,8 +164,8 @@ object WindowsProcess {
     }.asInstanceOf[Ptr[Byte]]
 
     // stackalloc is documented as returning zeroed memory
-    val processInfo = stackalloc[ProcessInformation]
-    val startupInfo = stackalloc[StartupInfoW]
+    val processInfo = stackalloc[ProcessInformation]()
+    val startupInfo = stackalloc[StartupInfoW]()
     startupInfo.cb = sizeof[StartupInfoW].toUInt
     startupInfo.stdInput = inRead
     startupInfo.stdOutput = outWrite
@@ -216,12 +216,12 @@ object WindowsProcess {
       msg: => String
   )(implicit z: Zone): (Handle, Handle) = {
 
-    val securityAttributes = stackalloc[SecurityAttributes]
+    val securityAttributes = stackalloc[SecurityAttributes]()
     securityAttributes.length = sizeof[SecurityAttributes].toUInt
     securityAttributes.inheritHandle = true
     securityAttributes.securityDescriptor = null
 
-    val pipe: PipeHandles = !stackalloc[PipeHandles]
+    val pipe: PipeHandles = !stackalloc[PipeHandles]()
     val pipeEnds @ (pipeRead, pipeWrite) = (pipe.at(readEnd), pipe.at(writeEnd))
     val pipeCreated =
       CreatePipe(pipeRead, pipeWrite, null, 0.toUInt)

--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -133,7 +133,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
       tryPollOnAccept()
     }
 
-    val storage = stackalloc[Byte](sizeof[in.sockaddr_in6])
+    val storage: Ptr[Byte] = stackalloc[Byte](sizeof[in.sockaddr_in6])
     val len = stackalloc[socket.socklen_t]
     !len = sizeof[in.sockaddr_in6].toUInt
 
@@ -144,7 +144,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     }
     val family =
       storage.asInstanceOf[Ptr[socket.sockaddr_storage]].ss_family.toInt
-    val ipstr = stackalloc[CChar](in.INET6_ADDRSTRLEN.toULong)
+    val ipstr: Ptr[CChar] = stackalloc[CChar](in.INET6_ADDRSTRLEN.toULong)
 
     if (family == socket.AF_INET) {
       val sa = storage.asInstanceOf[Ptr[in.sockaddr_in]]

--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -90,7 +90,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
   }
 
   override def bind(addr: InetAddress, port: Int): Unit = {
-    val hints = stackalloc[addrinfo]
+    val hints = stackalloc[addrinfo]()
     val ret = stackalloc[Ptr[addrinfo]]
     hints.ai_family = socket.AF_UNSPEC
     hints.ai_flags = AI_NUMERICHOST
@@ -186,7 +186,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     throwIfClosed("connect") // Do not send negative fd.fd to poll()
 
     val inetAddr = address.asInstanceOf[InetSocketAddress]
-    val hints = stackalloc[addrinfo]
+    val hints = stackalloc[addrinfo]()
     val ret = stackalloc[Ptr[addrinfo]]
     hints.ai_family = socket.AF_UNSPEC
     hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV
@@ -340,7 +340,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     if (shutInput) {
       0
     } else {
-      val bytesAvailable = stackalloc[CInt]
+      val bytesAvailable = stackalloc[CInt]()
       ioctl(fd.fd, FIONREAD, bytesAvailable.asInstanceOf[Ptr[Byte]])
       !bytesAvailable match {
         case -1 =>
@@ -453,7 +453,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     val opt = optID match {
       case SocketOptions.TCP_NODELAY | SocketOptions.SO_KEEPALIVE |
           SocketOptions.SO_REUSEADDR | SocketOptions.SO_OOBINLINE =>
-        val ptr = stackalloc[CInt]
+        val ptr = stackalloc[CInt]()
         !ptr = if (value.asInstanceOf[Boolean]) 1 else 0
         ptr.asInstanceOf[Ptr[Byte]]
       case SocketOptions.SO_LINGER =>
@@ -473,11 +473,11 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
         this.timeout = mseconds
 
         if (isWindows) {
-          val ptr = stackalloc[DWord]
+          val ptr = stackalloc[DWord]()
           !ptr = mseconds.toUInt
           ptr.asInstanceOf[Ptr[Byte]]
         } else {
-          val ptr = stackalloc[timeval]
+          val ptr = stackalloc[timeval]()
 
           ptr.tv_sec = mseconds / 1000
           ptr.tv_usec = (mseconds % 1000) * 1000
@@ -485,7 +485,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
           ptr.asInstanceOf[Ptr[Byte]]
         }
       case _ =>
-        val ptr = stackalloc[CInt]
+        val ptr = stackalloc[CInt]()
         !ptr = value.asInstanceOf[Int]
         ptr.asInstanceOf[Ptr[Byte]]
     }

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -43,7 +43,7 @@ object SocketHelpers {
   def isReachableByEcho(ip: String, timeout: Int, port: Int): Boolean =
     Zone { implicit z =>
       val cIP = toCString(ip)
-      val hints = stackalloc[addrinfo]
+      val hints = stackalloc[addrinfo]()
       val ret = stackalloc[Ptr[addrinfo]]
 
       hints.ai_family = AF_UNSPEC
@@ -67,14 +67,14 @@ object SocketHelpers {
         }
         setSocketNonBlocking(sock)
         // stackalloc is documented as returning zeroed memory
-        val fdsetPtr = stackalloc[fd_set] //  No need to FD_ZERO
+        val fdsetPtr = stackalloc[fd_set]() //  No need to FD_ZERO
         FD_SET(sock, fdsetPtr)
 
         // calculate once and use a second time below.
         val tv_sec = timeout / 1000
         val tv_usec = (timeout % 1000) * 1000
 
-        val time = stackalloc[timeval]
+        val time = stackalloc[timeval]()
         time.tv_sec = tv_sec
         time.tv_usec = tv_usec
 
@@ -84,7 +84,7 @@ object SocketHelpers {
 
         if (select(sock + 1, null, fdsetPtr, null, time) == 1) {
           val so_error = stackalloc[CInt].asInstanceOf[Ptr[Byte]]
-          val len = stackalloc[socklen_t]
+          val len = stackalloc[socklen_t]()
           !len = sizeof[CInt].toUInt
           getsockopt(sock, SOL_SOCKET, SO_ERROR, so_error, len)
           if (!(so_error.asInstanceOf[Ptr[CInt]]) != 0) {
@@ -126,7 +126,7 @@ object SocketHelpers {
 
   def hostToIp(host: String): Option[String] =
     Zone { implicit z =>
-      val hints = stackalloc[addrinfo]
+      val hints = stackalloc[addrinfo]()
       val ret = stackalloc[Ptr[addrinfo]]
 
       val ipstr = stackalloc[CChar]((INET6_ADDRSTRLEN + 1).toUInt)
@@ -160,7 +160,7 @@ object SocketHelpers {
 
   def hostToIpArray(host: String): scala.Array[String] =
     Zone { implicit z =>
-      val hints = stackalloc[addrinfo]
+      val hints = stackalloc[addrinfo]()
       val ret = stackalloc[Ptr[addrinfo]]
 
       hints.ai_family = AF_UNSPEC
@@ -231,7 +231,7 @@ object SocketHelpers {
       // of C function failures here and in tailorSockaddr() is not feasible.
 
       val host = stackalloc[CChar](MAXHOSTNAMELEN)
-      val addr = stackalloc[sockaddr]
+      val addr = stackalloc[sockaddr]()
 
       if (!tailorSockaddr(ip, isV6, addr)) {
         None

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -108,7 +108,7 @@ object SocketHelpers {
         if (select(sock + 1, fdsetPtr, null, null, time) != 1) {
           return false
         } else {
-          val buf = stackalloc[CChar](5.toUInt)
+          val buf: Ptr[CChar] = stackalloc[CChar](5.toUInt)
           val recBytes = recv(sock, buf, 5.toUInt, 0)
           if (recBytes < 4) {
             return false
@@ -129,7 +129,7 @@ object SocketHelpers {
       val hints = stackalloc[addrinfo]()
       val ret = stackalloc[Ptr[addrinfo]]
 
-      val ipstr = stackalloc[CChar]((INET6_ADDRSTRLEN + 1).toUInt)
+      val ipstr: Ptr[CChar] = stackalloc[CChar]((INET6_ADDRSTRLEN + 1).toUInt)
       hints.ai_family = AF_UNSPEC
       hints.ai_socktype = 0
       hints.ai_next = null
@@ -175,7 +175,7 @@ object SocketHelpers {
 
       var ai = !ret
       while (ai != null) {
-        val ipstr = stackalloc[CChar]((INET6_ADDRSTRLEN + 1).toUInt)
+        val ipstr: Ptr[CChar] = stackalloc[CChar]((INET6_ADDRSTRLEN + 1).toUInt)
         val addr =
           if (ai.ai_family == AF_INET) {
             ai.ai_addr
@@ -230,7 +230,7 @@ object SocketHelpers {
       // does not allow/specify Exceptions, so better error reporting
       // of C function failures here and in tailorSockaddr() is not feasible.
 
-      val host = stackalloc[CChar](MAXHOSTNAMELEN)
+      val host: Ptr[CChar] = stackalloc[CChar](MAXHOSTNAMELEN)
       val addr = stackalloc[sockaddr]()
 
       if (!tailorSockaddr(ip, isV6, addr)) {

--- a/javalib/src/main/scala/java/net/UnixPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/UnixPlainSocketImpl.scala
@@ -21,7 +21,7 @@ private[net] class UnixPlainSocketImpl extends AbstractPlainSocketImpl {
 
   protected def tryPollOnConnect(timeout: Int): Unit = {
     val nAlloc = 1.toUInt
-    val pollFd = stackalloc[struct_pollfd](nAlloc)
+    val pollFd: Ptr[struct_pollfd] = stackalloc[struct_pollfd](nAlloc)
 
     pollFd.fd = fd.fd
     pollFd.revents = 0
@@ -56,7 +56,7 @@ private[net] class UnixPlainSocketImpl extends AbstractPlainSocketImpl {
 
   protected def tryPollOnAccept(): Unit = {
     val nAlloc = 1.toUInt
-    val pollFd = stackalloc[struct_pollfd](nAlloc)
+    val pollFd: Ptr[struct_pollfd] = stackalloc[struct_pollfd](nAlloc)
 
     pollFd.fd = fd.fd
     pollFd.revents = 0

--- a/javalib/src/main/scala/java/net/WindowsPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/WindowsPlainSocketImpl.scala
@@ -33,7 +33,7 @@ private[net] class WindowsPlainSocketImpl extends AbstractPlainSocketImpl {
 
   protected def tryPollOnConnect(timeout: Int): Unit = {
     val nAlloc = 1.toUInt
-    val pollFd = stackalloc[WSAPollFd](nAlloc)
+    val pollFd: Ptr[WSAPollFd] = stackalloc[WSAPollFd](nAlloc)
 
     pollFd.socket = fd.handle
     pollFd.revents = 0.toShort
@@ -68,7 +68,7 @@ private[net] class WindowsPlainSocketImpl extends AbstractPlainSocketImpl {
 
   protected def tryPollOnAccept(): Unit = {
     val nAlloc = 1.toUInt
-    val pollFd = stackalloc[WSAPollFd](nAlloc)
+    val pollFd: Ptr[WSAPollFd] = stackalloc[WSAPollFd](nAlloc)
 
     pollFd.socket = fd.handle
     pollFd.revents = 0.toShort

--- a/javalib/src/main/scala/java/net/WindowsPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/WindowsPlainSocketImpl.scala
@@ -107,7 +107,7 @@ private[net] class WindowsPlainSocketImpl extends AbstractPlainSocketImpl {
       fd: FileDescriptor,
       blocking: Boolean
   ): Unit = {
-    val mode = stackalloc[Int]
+    val mode = stackalloc[Int]()
     if (blocking)
       !mode = 0
     else

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -72,7 +72,7 @@ private[java] final class FileChannelImpl(
       shared: Boolean,
       command: CInt
   ): FileLock = {
-    val fl = stackalloc[flock]
+    val fl = stackalloc[flock]()
     fl.l_start = position
     fl.l_len = size
     fl.l_pid = 0
@@ -90,10 +90,10 @@ private[java] final class FileChannelImpl(
       flags: DWord
   ): FileLock = {
 
-    val dummy = stackalloc[DUMMYSTRUCTNAME]
+    val dummy = stackalloc[DUMMYSTRUCTNAME]()
     dummy.Offset = position.toInt.toUInt
     dummy.OffsetHigh = (position >> 32).toInt.toUInt
-    val overlapped = stackalloc[OVERLAPPED]
+    val overlapped = stackalloc[OVERLAPPED]()
     overlapped.Internal = 0.toULong
     overlapped.InternalHigh = 0.toULong
     overlapped.DUMMYSTRUCTNAME = !dummy
@@ -143,7 +143,7 @@ private[java] final class FileChannelImpl(
 
   override def position(): Long =
     if (isWindows) {
-      val filePointer = stackalloc[LargeInteger]
+      val filePointer = stackalloc[LargeInteger]()
       FileApi.SetFilePointerEx(
         fd.handle,
         0,

--- a/javalib/src/main/scala/java/nio/channels/FileLockImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileLockImpl.scala
@@ -42,7 +42,7 @@ private[java] final class FileLockImpl(
           ))
         throw new IOException()
     } else {
-      val fl = stackalloc[flock]
+      val fl = stackalloc[flock]()
       fl.l_start = position
       fl.l_len = size
       fl.l_pid = 0

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -726,7 +726,7 @@ object Files {
             access = FILE_GENERIC_READ
           ) { handle =>
             val bufferSize = FileApiExt.MAX_PATH
-            val buffer = alloc[WChar](bufferSize)
+            val buffer: Ptr[WChar] = alloc[WChar](bufferSize)
             val pathSize =
               FileApi.GetFinalPathNameByHandleW(
                 handle,

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -622,7 +622,7 @@ object Files {
     val bytes = scala.scalanative.runtime.ByteArray.alloc(len)
 
     if (isWindows) {
-      val bytesRead = stackalloc[DWord]
+      val bytesRead = stackalloc[DWord]()
 
       withFileOpen(
         path.toString,

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -75,7 +75,7 @@ object Date {
         // Most result strings should be about 28 + 1 for terminal NULL
         // + 2 because some IANA timezone abbreviation can have 5 characters.
         val bufSize = 40.toULong // no toSize_t() yet
-        val buf = alloc[Byte](bufSize)
+        val buf: Ptr[Byte] = alloc[Byte](bufSize)
 
         val n = {
           // %Z on Windows might produce long, localized names of variable length

--- a/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
+++ b/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
@@ -84,7 +84,7 @@ object WindowsHelperMethods {
       }
     }
 
-    val data = alloc[Byte](!dataSize)
+    val data: Ptr[Byte] = alloc[Byte](!dataSize)
     if (!GetTokenInformation(
           token,
           informationClass,

--- a/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
+++ b/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
@@ -20,7 +20,7 @@ import java.nio.file.WindowsException
  */
 object WindowsHelperMethods {
   def withUserToken[T](desiredAccess: DWord)(fn: Handle => T): T = {
-    val tokenHandle = stackalloc[Handle]
+    val tokenHandle = stackalloc[Handle]()
     def getProcessToken =
       OpenProcessToken(GetCurrentProcess(), desiredAccess, tokenHandle)
     def getThreadToken =
@@ -45,7 +45,7 @@ object WindowsHelperMethods {
     withUserToken(
       TOKEN_IMPERSONATE | TOKEN_READ | TOKEN_DUPLICATE
     ) { tokenHandle =>
-      val impersonatedToken = stackalloc[Handle]
+      val impersonatedToken = stackalloc[Handle]()
       if (!DuplicateToken(
             tokenHandle,
             SecurityImpersonation,

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -92,7 +92,7 @@ object FileHelpers {
       if (searchPath.length.toUInt > FileApiExt.MAX_PATH)
         throw new IOException("File name to long")
 
-      val fileData = stackalloc[Win32FindDataW]
+      val fileData = stackalloc[Win32FindDataW]()
       val searchHandle =
         FindFirstFileW(toCWideStringUTF16LE(searchPath), fileData)
       if (searchHandle == INVALID_HANDLE_VALUE) {

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -203,7 +203,7 @@ object FileHelpers {
 
   lazy val tempDir: String = {
     if (isWindows) {
-      val buffer = stackalloc[WChar](MAX_PATH)
+      val buffer: Ptr[WChar] = stackalloc[WChar](MAX_PATH)
       GetTempPathW(MAX_PATH, buffer)
       fromCWideString(buffer, StandardCharsets.UTF_16LE)
     } else {

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystemProvider.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystemProvider.scala
@@ -1,6 +1,6 @@
 package scala.scalanative.nio.fs.unix
 
-import scala.scalanative.unsafe.{CChar, fromCString, stackalloc}
+import scala.scalanative.unsafe.{CChar, Ptr, fromCString, stackalloc}
 import scala.scalanative.unsigned._
 import scala.scalanative.posix.unistd
 import scala.scalanative.libc.errno
@@ -24,7 +24,7 @@ class UnixFileSystemProvider extends GenericFileSystemProvider {
   }
 
   private def getUserDir(): String = {
-    val buff = stackalloc[CChar](4096.toUInt)
+    val buff: Ptr[CChar] = stackalloc[CChar](4096.toUInt)
     val res = unistd.getcwd(buff, 4095.toUInt)
     if (res == null)
       throw UnixException(

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsAclFileAttributeView.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsAclFileAttributeView.scala
@@ -27,7 +27,7 @@ class WindowsAclFileAttributeView(path: Path, options: Array[LinkOption])
   def getOwner(): UserPrincipal =
     Zone { implicit z =>
       val filename = toCWideStringUTF16LE(path.toString)
-      val ownerSid = stackalloc[SIDPtr]
+      val ownerSid = stackalloc[SIDPtr]()
 
       if (AclApi.GetNamedSecurityInfoW(
             filename,
@@ -55,7 +55,7 @@ class WindowsAclFileAttributeView(path: Path, options: Array[LinkOption])
           "Unsupported user principal type " + owner.getClass.getName
         )
     }
-    val newOwnerSid = stackalloc[SIDPtr]
+    val newOwnerSid = stackalloc[SIDPtr]()
 
     if (!SddlApi.ConvertStringSidToSidW(sidCString, newOwnerSid)) {
       throw WindowsException("Cannot convert user principal to sid")

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsDosFileAttributeView.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsDosFileAttributeView.scala
@@ -92,7 +92,7 @@ final class WindowsDosFileAttributeView(path: Path, options: Array[LinkOption])
       access = FILE_GENERIC_WRITE,
       attributes = fileOpeningFlags
     ) { handle =>
-      val create, access, write = stackalloc[WinFileTime]
+      val create, access, write = stackalloc[WinFileTime]()
       if (!SetFileTime(
             handle,
             creationTime = setOrNull(create, createTime),

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
@@ -38,7 +38,7 @@ class WindowsFileSystem(override val provider: WindowsFileSystemProvider)
   override def getRootDirectories(): Iterable[Path] = {
     val list = new LinkedList[Path]()
     val bufferSize = GetLogicalDriveStringsW(0.toUInt, null)
-    val buffer = stackalloc[CChar16](bufferSize)
+    val buffer: Ptr[CChar16] = stackalloc[CChar16](bufferSize)
 
     @tailrec
     def readStringsBlock(ptr: Ptr[CChar16]): Unit = {

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipal.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipal.scala
@@ -40,8 +40,8 @@ object WindowsUserPrincipal {
         val nameSize, domainSize = stackalloc[DWord]()
         !nameSize = 255.toUInt
         !domainSize = 255.toUInt
-        val nameRef = stackalloc[WChar](!nameSize)
-        val domainRef = stackalloc[WChar](!domainSize)
+        val nameRef: Ptr[WChar] = stackalloc[WChar](!nameSize)
+        val domainRef: Ptr[WChar] = stackalloc[WChar](!domainSize)
         val useRef = stackalloc[SidNameUse]()
         if (!LookupAccountSidW(
               systemName = null,

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipal.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipal.scala
@@ -28,7 +28,7 @@ object WindowsUserPrincipal {
   def apply(sidRef: SIDPtr): WindowsUserPrincipal = {
     import SidNameUse._
     val sidString = {
-      val sidCString = stackalloc[CWString]
+      val sidCString = stackalloc[CWString]()
       if (!SddlApi.ConvertSidToStringSidW(sidRef, sidCString)) {
         throw WindowsException("Unable to convert SID to string")
       }
@@ -37,12 +37,12 @@ object WindowsUserPrincipal {
 
     val (accountName, accountType) =
       try {
-        val nameSize, domainSize = stackalloc[DWord]
+        val nameSize, domainSize = stackalloc[DWord]()
         !nameSize = 255.toUInt
         !domainSize = 255.toUInt
         val nameRef = stackalloc[WChar](!nameSize)
         val domainRef = stackalloc[WChar](!domainSize)
-        val useRef = stackalloc[SidNameUse]
+        val useRef = stackalloc[SidNameUse]()
         if (!LookupAccountSidW(
               systemName = null,
               sid = sidRef,

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipalLookupService.scala
@@ -35,7 +35,7 @@ object WindowsUserPrincipalLookupService extends UserPrincipalLookupService {
 
   private def lookupByName(name: String): Try[WindowsUserPrincipal] = Zone {
     implicit z =>
-      val cbSid, domainSize = stackalloc[DWord]
+      val cbSid, domainSize = stackalloc[DWord]()
       !cbSid = 0.toUInt
       !domainSize = 0.toUInt
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipalLookupService.scala
@@ -56,7 +56,8 @@ object WindowsUserPrincipalLookupService extends UserPrincipalLookupService {
         )
       } else {
         val sidRef: SIDPtr = alloc[Byte](!cbSid)
-        val domainName = alloc[CChar16](!domainSize).asInstanceOf[CWString]
+        val domainName: CWString =
+          alloc[CChar16](!domainSize).asInstanceOf[CWString]
 
         if (!LookupAccountNameW(
               systemName = null,

--- a/nativelib/src/main/scala/scala/scalanative/annotation/extern.scala
+++ b/nativelib/src/main/scala/scala/scalanative/annotation/extern.scala
@@ -1,5 +1,4 @@
-package scala.scalanative
-package unsafe
+package scala.scalanative.annotation
 
 /** An annotation that is used to mark objects that contain externally-defined
  *  members.

--- a/nativelib/src/main/scala/scala/scalanative/annotation/extern.scala
+++ b/nativelib/src/main/scala/scala/scalanative/annotation/extern.scala
@@ -1,6 +1,0 @@
-package scala.scalanative.annotation
-
-/** An annotation that is used to mark objects that contain externally-defined
- *  members.
- */
-final class extern extends scala.annotation.StaticAnnotation

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -99,6 +99,10 @@ package object unsafe {
   /** C-style alignment operator. */
   @alwaysinline def alignmentof[T](implicit tag: Tag[T]): CSize = tag.alignment
 
+  // Scala 3 does not allow to use extern method and extern annotation class
+  // defined in separate files in the same package
+  type extern = scala.scalanative.annotation.extern
+
   /** Heap allocate and zero-initialize a value using current implicit
    *  allocator.
    */

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -106,8 +106,18 @@ package object unsafe {
   /** Heap allocate and zero-initialize a value using current implicit
    *  allocator.
    */
+  @deprecated(
+    "In Scala 3 alloc[T](n) can be confused with alloc[T].apply(n) leading to runtime erros, use alloc[T]() instead",
+    since = "0.5.0"
+  )
   def alloc[T](implicit tag: Tag[T], z: Zone): Ptr[T] =
     macro MacroImpl.alloc1[T]
+
+  /** Heap allocate and zero-initialize a value using current implicit
+   *  allocator.
+   */
+  def alloc[T]()(implicit tag: Tag[T], z: Zone): Ptr[T] =
+    macro MacroImpl.allocSingle[T]
 
   /** Heap allocate and zero-initialize n values using current implicit
    *  allocator.
@@ -130,8 +140,19 @@ package object unsafe {
    *
    *  Note: unlike alloc, the memory is not zero-initialized.
    */
+  @deprecated(
+    "In Scala 3 alloc[T](n) can be confused with alloc[T].apply(n) leading to runtime erros, use alloc[T]() instead",
+    since = "0.5.0"
+  )
   def stackalloc[T](implicit tag: Tag[T]): Ptr[T] =
     macro MacroImpl.stackalloc1[T]
+
+  /** Stack allocate a value of given type.
+   *
+   *  Note: unlike alloc, the memory is not zero-initialized.
+   */
+  def stackalloc[T]()(implicit tag: Tag[T]): Ptr[T] =
+    macro MacroImpl.stackallocSingle[T]
 
   /** Stack allocate n values of given type.
    *
@@ -350,6 +371,10 @@ package object unsafe {
       }"""
     }
 
+    def allocSingle[T: c.WeakTypeTag](
+        c: Context
+    )()(tag: c.Tree, z: c.Tree): c.Tree = alloc1(c)(tag, z)
+
     def allocN[T: c.WeakTypeTag](
         c: Context
     )(n: c.Tree)(tag: c.Tree, z: c.Tree): c.Tree = {
@@ -370,6 +395,9 @@ package object unsafe {
         $ptr.asInstanceOf[Ptr[$T]]
       }"""
     }
+
+    def stackallocSingle[T: c.WeakTypeTag](c: Context)()(tag: c.Tree): c.Tree =
+      stackalloc1(c)(tag)
 
     def stackalloc1[T: c.WeakTypeTag](c: Context)(tag: c.Tree): c.Tree = {
       import c.universe._

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/package.scala
@@ -99,10 +99,6 @@ package object unsafe {
   /** C-style alignment operator. */
   @alwaysinline def alignmentof[T](implicit tag: Tag[T]): CSize = tag.alignment
 
-  // Scala 3 does not allow to use extern method and extern annotation class
-  // defined in separate files in the same package
-  type extern = scala.scalanative.annotation.extern
-
   /** Heap allocate and zero-initialize a value using current implicit
    *  allocator.
    */
@@ -173,6 +169,11 @@ package object unsafe {
   )
   def stackalloc[T](n: CSSize)(implicit tag: Tag[T]): Ptr[T] =
     macro MacroImpl.stackallocN[T]
+
+  /** An annotation that is used to mark objects that contain externally-defined
+   *  members
+   */
+  final class extern extends scala.annotation.StaticAnnotation
 
   /** Used as right hand side of external method and field declarations. */
   def extern: Nothing = intrinsic

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -22,7 +22,9 @@ trait NirDefinitions {
 
     lazy val NameClass = getRequiredClass("scala.scalanative.unsafe.name")
     lazy val LinkClass = getRequiredClass("scala.scalanative.unsafe.link")
-    lazy val ExternClass = getRequiredClass("scala.scalanative.annotation.extern")
+    lazy val ExternClass = getRequiredClass(
+      "scala.scalanative.annotation.extern"
+    )
     lazy val StubClass = getRequiredClass("scala.scalanative.annotation.stub")
 
     lazy val AlwaysInlineClass = getRequiredClass(

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -22,7 +22,9 @@ trait NirDefinitions {
 
     lazy val NameClass = getRequiredClass("scala.scalanative.unsafe.name")
     lazy val LinkClass = getRequiredClass("scala.scalanative.unsafe.link")
-    lazy val ExternClass = getRequiredClass("scala.scalanative.unsafe.package$extern")
+    lazy val ExternClass = getRequiredClass(
+      "scala.scalanative.unsafe.package$extern"
+    )
     lazy val StubClass = getRequiredClass("scala.scalanative.annotation.stub")
 
     lazy val AlwaysInlineClass = getRequiredClass(

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -22,9 +22,7 @@ trait NirDefinitions {
 
     lazy val NameClass = getRequiredClass("scala.scalanative.unsafe.name")
     lazy val LinkClass = getRequiredClass("scala.scalanative.unsafe.link")
-    lazy val ExternClass = getRequiredClass(
-      "scala.scalanative.annotation.extern"
-    )
+    lazy val ExternClass = getRequiredClass("scala.scalanative.unsafe.package$extern")
     lazy val StubClass = getRequiredClass("scala.scalanative.annotation.stub")
 
     lazy val AlwaysInlineClass = getRequiredClass(

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -22,8 +22,7 @@ trait NirDefinitions {
 
     lazy val NameClass = getRequiredClass("scala.scalanative.unsafe.name")
     lazy val LinkClass = getRequiredClass("scala.scalanative.unsafe.link")
-    lazy val ExternClass = getRequiredClass("scala.scalanative.unsafe.extern")
-    lazy val PinClass = getRequiredClass("scala.scalanative.unsafe.pin")
+    lazy val ExternClass = getRequiredClass("scala.scalanative.annotation.extern")
     lazy val StubClass = getRequiredClass("scala.scalanative.annotation.stub")
 
     lazy val AlwaysInlineClass = getRequiredClass(

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
@@ -26,7 +26,7 @@ private[testinterface] object SignalConfig {
 
     def printError(str: CString): Unit =
       if (isWindows) {
-        val written = stackalloc[DWord]
+        val written = stackalloc[DWord]()
         FileApi.WriteFile(
           ConsoleApiExt.stdErr,
           str,
@@ -77,7 +77,7 @@ private[testinterface] object SignalConfig {
 
     while (unwind.step(cursor) > 0) {
       val offset = stackalloc[scala.Byte](8.toUInt)
-      val pc = stackalloc[CUnsignedLongLong]
+      val pc = stackalloc[CUnsignedLongLong]()
       unwind.get_reg(cursor, unwind.UNW_REG_IP, pc)
       if (pc == 0)
         return

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
@@ -43,7 +43,7 @@ private[testinterface] object SignalConfig {
       }
 
     def signalToCString(str: CString, signal: Int): Unit = {
-      val reversedStr = stackalloc[CChar](8.toUInt)
+      val reversedStr: Ptr[CChar] = stackalloc[CChar](8.toUInt)
       var index = 0
       var signalPart = signal
       while (signalPart > 0) {
@@ -59,10 +59,10 @@ private[testinterface] object SignalConfig {
       str(index) = 0.toByte
     }
 
-    val signalNumberStr = stackalloc[CChar](8.toUInt)
+    val signalNumberStr: Ptr[CChar] = stackalloc[CChar](8.toUInt)
     signalToCString(signalNumberStr, sig)
 
-    val stackTraceHeader = stackalloc[CChar](2048.toUInt)
+    val stackTraceHeader: Ptr[CChar] = stackalloc[CChar](2048.toUInt)
     stackTraceHeader(0.toUInt) = 0.toByte
     strcat(stackTraceHeader, errorTag)
     strcat(stackTraceHeader, c" Fatal signal ")
@@ -82,7 +82,7 @@ private[testinterface] object SignalConfig {
       if (pc == 0)
         return
       val symMax = 1024
-      val sym = stackalloc[CChar](symMax.toUInt)
+      val sym: Ptr[CChar] = stackalloc[CChar](symMax.toUInt)
       if (unwind.get_proc_name(
             cursor,
             sym,
@@ -90,11 +90,11 @@ private[testinterface] object SignalConfig {
             offset
           ) == 0) {
         sym(symMax - 1) = 0.toByte
-        val className = stackalloc[CChar](1024.toUInt)
-        val methodName = stackalloc[CChar](1024.toUInt)
+        val className: Ptr[CChar] = stackalloc[CChar](1024.toUInt)
+        val methodName: Ptr[CChar] = stackalloc[CChar](1024.toUInt)
         SymbolFormatter.asyncSafeFromSymbol(sym, className, methodName)
 
-        val formattedSymbol = stackalloc[CChar](2048.toUInt)
+        val formattedSymbol: Ptr[CChar] = stackalloc[CChar](2048.toUInt)
         formattedSymbol(0) = 0.toByte
         strcat(formattedSymbol, errorTag)
         strcat(formattedSymbol, c"   at ")

--- a/unit-tests/native/src/test/scala/java/lang/ProcessInheritTest.scala
+++ b/unit-tests/native/src/test/scala/java/lang/ProcessInheritTest.scala
@@ -49,7 +49,7 @@ class ProcessInheritTest {
       import FileApiExt._
       import winnt.AccessRights._
       val f = Files.createTempFile("tmp", "out")
-      val readEnd, writeEnd, stdOutDup = stackalloc[Handle]
+      val readEnd, writeEnd, stdOutDup = stackalloc[Handle]()
 
       assertEquals(
         "createPipe",

--- a/unit-tests/native/src/test/scala/java/net/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/java/net/UdpSocketTest.scala
@@ -144,7 +144,7 @@ class UdpSocketTest {
 
         // Provide extra room to allow detecting extra junk being sent.
         val maxInData = 2 * outData.length
-        val inData = alloc[Byte](maxInData)
+        val inData: Ptr[Byte] = alloc[Byte](maxInData)
 
         // Try to prevent spourious race conditions
         Thread.sleep(100)

--- a/unit-tests/native/src/test/scala/java/net/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/java/net/UdpSocketTest.scala
@@ -30,7 +30,7 @@ class UdpSocketTest {
   // on Unix, probably due to bug in linktime conditions.
   private def setSocketBlocking(socket: CInt): Unit = {
     if (isWindows) {
-      val mode = stackalloc[CInt]
+      val mode = stackalloc[CInt]()
       !mode = 1
       assertNotEquals(
         "iotctl setBLocking",

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -39,7 +39,7 @@ class TimeTest {
     if (isWindows) false
     else {
       Zone { implicit z =>
-        val time_ptr = stackalloc[time_t]
+        val time_ptr = stackalloc[time_t]()
         !time_ptr = now_time_t
         val localtime: Ptr[tm] = localtime_r(time_ptr, alloc[tm])
 
@@ -77,7 +77,7 @@ class TimeTest {
         "Skipping localtime test since FreeBSD hasn't the 'timezone' variable",
         Platform.isFreeBSD
       )
-      val time_ptr = stackalloc[time_t]
+      val time_ptr = stackalloc[time_t]()
       !time_ptr = epoch + timezone
       val time: Ptr[tm] = localtime(time_ptr)
       val cstr: CString = asctime(time)
@@ -97,7 +97,7 @@ class TimeTest {
           "Skipping localtime_r test since FreeBSD hasn't the 'timezone' variable",
           Platform.isFreeBSD
         )
-        val time_ptr = stackalloc[time_t]
+        val time_ptr = stackalloc[time_t]()
         !time_ptr = epoch + timezone
         val time: Ptr[tm] = localtime_r(time_ptr, alloc[tm])
         val cstr: CString = asctime_r(time, alloc[Byte](26))

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -169,7 +169,7 @@ class TimeTest {
 
         // grossly over-provision rather than chase fencepost bugs.
         val bufSize = 70.toULong
-        val buf = alloc[Byte](bufSize)
+        val buf: Ptr[Byte] = alloc[Byte](bufSize)
 
         val n = strftime(buf, bufSize, c"%a %b %d %T %Z %Y", tmPtr)
 
@@ -300,7 +300,7 @@ class TimeTest {
         )
 
         val tmBufSize = 56.toULong
-        val tmBuf = alloc[Byte](tmBufSize)
+        val tmBuf: Ptr[Byte] = alloc[Byte](tmBufSize)
 
         val tmPtr = tmBuf.asInstanceOf[Ptr[tm]]
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/reflect/ReflectiveInstantiationTest.scala
@@ -226,7 +226,7 @@ class ReflectiveInstantiationTest {
     // test with array of bytes
     Zone { implicit z =>
       val size = 64
-      val buffer = alloc[Byte](size.toUInt)
+      val buffer: Ptr[Byte] = alloc[Byte](size.toUInt)
 
       def fn(idx: Int) = size - idx
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgListTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CVarArgListTest.scala
@@ -14,7 +14,7 @@ import scalanative.meta.LinktimeInfo.isWindows
 class CVarArgListTest {
   def vatest(cstr: CString, varargs: Seq[CVarArg], output: String): Unit =
     Zone { implicit z =>
-      val buff = alloc[CChar](1024)
+      val buff: Ptr[CChar] = alloc[CChar](1024)
       stdio.vsprintf(buff, cstr, toCVarArgList(varargs))
       val got = fromCString(buff)
       assertTrue(s"$got != $output", got == output)

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
@@ -30,8 +30,8 @@ object ExternTest {
   def runTest(): Unit = {
     import scalanative.libc.string
     val bufsize = 10.toUInt
-    val buf1 = stackalloc[Byte](bufsize)
-    val buf2 = stackalloc[Byte](bufsize)
+    val buf1: Ptr[Byte] = stackalloc[Byte](bufsize)
+    val buf2: Ptr[Byte] = stackalloc[Byte](bufsize)
     Ext1.snprintf(buf1, bufsize, c"%s", c"hello")
     assertTrue(string.strcmp(buf1, c"hello") == 0)
     Ext2.p(buf2, bufsize, c"%d", 1)
@@ -53,7 +53,7 @@ class ExternTest {
     val args = Seq("skipped", "skipped", "skipped", "-b", "-f", "farg")
 
     Zone { implicit z =>
-      val argv = stackalloc[CString](args.length.toUInt)
+      val argv: Ptr[CString] = stackalloc[CString](args.length.toUInt)
 
       for ((arg, i) <- args.zipWithIndex) {
         argv(i) = toCString(arg)

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrBoxingTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrBoxingTest.scala
@@ -191,7 +191,7 @@ class PtrBoxingTest {
 
   @Test def loadAndStoreCFuncPtr(): Unit = {
     Zone { implicit z =>
-      val x: Ptr[Functions] = stackalloc[Functions]
+      val x: Ptr[Functions] = stackalloc[Functions]()
       x._1 = CFuncPtr0.fromScalaFunction(getInt)
       x._2 = CFuncPtr1.fromScalaFunction(stringLength)
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
@@ -8,7 +8,7 @@ import scalanative.unsigned._
 class StackallocTest {
 
   @Test def stackallocInt(): Unit = {
-    val ptr = stackalloc[Int]
+    val ptr = stackalloc[Int]()
 
     !ptr = 42
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
@@ -16,7 +16,7 @@ class StackallocTest {
   }
 
   @Test def stackallocInt4(): Unit = {
-    val ptr = stackalloc[Int](4.toUInt)
+    val ptr: Ptr[Int] = stackalloc[Int](4.toUInt)
 
     ptr(0) = 1
     ptr(1) = 2

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ZoneTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ZoneTest.scala
@@ -32,7 +32,7 @@ class ZoneTest {
 
       assertAccessible(ptr, 64)
 
-      val ptr2 = alloc[Int](128.toUInt)
+      val ptr2: Ptr[Int] = alloc[Int](128.toUInt)
 
       assertAccessible(ptr2, 128)
     }
@@ -47,7 +47,7 @@ class ZoneTest {
 
     assertAccessible(ptr, 64)
 
-    val ptr2 = alloc[Int](128.toUInt)
+    val ptr2: Ptr[Int] = alloc[Int](128.toUInt)
 
     assertAccessible(ptr2, 128)
 

--- a/windowslib/src/main/scala/scala/scalanative/windows/ErrorHandlingApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/ErrorHandlingApi.scala
@@ -14,7 +14,7 @@ object ErrorHandlingApiOps {
     import WinBaseApi._
     import WinBaseApiExt._
 
-    val msgBuffer = stackalloc[CWString]
+    val msgBuffer = stackalloc[CWString]()
     FormatMessageW(
       flags = FORMAT_MESSAGE_ALLOCATE_BUFFER |
         FORMAT_MESSAGE_FROM_SYSTEM |

--- a/windowslib/src/main/scala/scala/scalanative/windows/WinSocketApi.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/WinSocketApi.scala
@@ -188,8 +188,9 @@ object WinSocketApiOps {
   final def init(): Unit = {
     if (!winSocketsInitialized) {
       val requiredVersion = (wordFromBytes _).tupled(WinSocketVersion)
-      val winSocketData = stackalloc[Byte](WinSocketApi.WSADataSize)
-        .asInstanceOf[Ptr[WSAData]]
+      val winSocketData: Ptr[WSAData] =
+        stackalloc[Byte](WinSocketApi.WSADataSize)
+          .asInstanceOf[Ptr[WSAData]]
 
       val initError = WinSocketApi.WSAStartup(requiredVersion, winSocketData)
       if (initError != 0) {


### PR DESCRIPTION
This PR introduces changes that are needed to proper implementation of `unsafe` package methods. 

* `scalanative.unsafe.extern` annotation was moved to `scalanative.unsafe` package  object - Scala 3 does not allow to use classes and methods with the same names defined in the separate files, usage of `@extern` would be treated as trying to use `extern` method 
* No parens methods `alloc[T]` and `stackalloc[T]` were deprecated and empty parens variants of this methods were added - In Scala 3 `alloc[T](10)` can be interpreted as `alloc[T].apply(10)` which means instead of allocation memory of 10x size of T we would allocate 1x size of T and would try to access it's 10th element, it would lead to multiple silent yet deadly bugs 
* All usages of no parens `alloc` and `stackalloc` methods were replaced with empty parens variant
* All usages of `alloc(n)` and `stackalloc(n)` methods without explicit type, were given explicit type to make sure that we would not try access nth element of allocated memory as described above

Even though changing `alloc[T]` to `alloc[T]()` is less user friendly this syntax is matches standard denotation for non-pure methods, which both alloc and stackalloc definitely are. 

