### PR TITLE
Ensure `javalib` source compatibility for Scala 3 build

### DIFF
--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -297,3 +297,5 @@ jobs:
           posixlib3/compile
           windowslib3/compile
           auxlib3/compile
+          javalib3/compile
+          scalalib3/compile

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,6 +9,8 @@ project.git = true
 project.excludePaths = [
   "glob:**/scalalib/**"
 ]
+# Default runner.dialect is deprecated now, needs to be explicitly set
+runner.dialect = scala213
 # This creates less of a diff but is not default
 # but is more aligned with Scala.js syntax.
 newlines.beforeCurlyLambdaParams = multilineWithCaseOnly
@@ -24,4 +26,9 @@ rewriteTokens = {
   "⇒": "=>"
   "→": "->"
   "←": "<-"
+}
+fileOverride {
+  "glob:**/src/**/scala-3/**" {
+     runner.dialect = scala3
+  }
 }

--- a/javalib/src/main/scala-2/java/io/Serializable.scala
+++ b/javalib/src/main/scala-2/java/io/Serializable.scala
@@ -1,0 +1,5 @@
+// Classes in this file needs special handling in Scala 3, we need to make sure
+// that they would not be compiled with Scala 3 compiler
+package java.io
+
+trait Serializable {}

--- a/javalib/src/main/scala-2/java/io/Serializable.scala
+++ b/javalib/src/main/scala-2/java/io/Serializable.scala
@@ -1,4 +1,4 @@
-// Classes in this file needs special handling in Scala 3, we need to make sure
+// Classes in this file need special handling in Scala 3, we need to make sure
 // that they would not be compiled with Scala 3 compiler
 package java.io
 

--- a/javalib/src/main/scala-2/java/lang/Cloneable.scala
+++ b/javalib/src/main/scala-2/java/lang/Cloneable.scala
@@ -1,0 +1,6 @@
+// Classes in this file needs special handling in Scala 3, we need to make sure
+// that they would not be compiled with Scala 3 compiler
+
+package java.lang
+
+trait Cloneable

--- a/javalib/src/main/scala-2/java/lang/Cloneable.scala
+++ b/javalib/src/main/scala-2/java/lang/Cloneable.scala
@@ -1,4 +1,4 @@
-// Classes in this file needs special handling in Scala 3, we need to make sure
+// Classes in this file need special handling in Scala 3, we need to make sure
 // that they would not be compiled with Scala 3 compiler
 
 package java.lang

--- a/javalib/src/main/scala-2/java/lang/Comparable.scala
+++ b/javalib/src/main/scala-2/java/lang/Comparable.scala
@@ -1,0 +1,8 @@
+// Classes in this file needs special handling in Scala 3, we need to make sure
+// that they would not be compiled with Scala 3 compiler
+
+package java.lang
+
+trait Comparable[A] {
+  def compareTo(o: A): scala.Int
+}

--- a/javalib/src/main/scala-2/java/lang/Comparable.scala
+++ b/javalib/src/main/scala-2/java/lang/Comparable.scala
@@ -1,4 +1,4 @@
-// Classes in this file needs special handling in Scala 3, we need to make sure
+// Classes in this file need special handling in Scala 3, we need to make sure
 // that they would not be compiled with Scala 3 compiler
 
 package java.lang

--- a/javalib/src/main/scala-2/java/lang/Enum.scala
+++ b/javalib/src/main/scala-2/java/lang/Enum.scala
@@ -1,3 +1,6 @@
+// Classes in this file needs special handling in Scala 3, we need to make sure
+// that they would not be compiled with Scala 3 compiler
+
 package java.lang
 
 abstract class Enum[E <: Enum[E]] protected (_name: String, _ordinal: Int)

--- a/javalib/src/main/scala-2/java/lang/Enum.scala
+++ b/javalib/src/main/scala-2/java/lang/Enum.scala
@@ -1,4 +1,4 @@
-// Classes in this file needs special handling in Scala 3, we need to make sure
+// Classes in this file need special handling in Scala 3, we need to make sure
 // that they would not be compiled with Scala 3 compiler
 
 package java.lang

--- a/javalib/src/main/scala-2/java/lang/ProcessBuilder.scala
+++ b/javalib/src/main/scala-2/java/lang/ProcessBuilder.scala
@@ -1,0 +1,212 @@
+// Any changes to this files needs to be synced with it's Scala3 counter part.
+// Due to enum restrictions it is impossible to create common implementation
+// for both Scala versions
+
+package java.lang
+
+import java.util.{ArrayList, List}
+import java.util.Map
+import java.io.{File, IOException}
+import java.util
+import java.util.Arrays
+import scala.scalanative.unsafe._
+import scala.scalanative.posix.unistd
+import scala.scalanative.runtime.Platform
+import scala.scalanative.meta.LinktimeInfo.isWindows
+import ProcessBuilder.Redirect
+
+final class ProcessBuilder(private var _command: List[String]) {
+  def this(command: Array[String]) = {
+    this(Arrays.asList(command))
+  }
+
+  def command(): List[String] = _command
+
+  def command(command: Array[String]): ProcessBuilder =
+    set { _command = Arrays.asList(command) }
+
+  def command(command: List[String]): ProcessBuilder = set {
+    _command = command
+  }
+
+  def environment(): Map[String, String] = _environment
+
+  def directory(): File = _directory
+
+  def directory(dir: File): ProcessBuilder =
+    set {
+      _directory = dir match {
+        case null => defaultDirectory
+        case _    => dir
+      }
+    }
+
+  def inheritIO(): ProcessBuilder = {
+    redirectInput(Redirect.INHERIT)
+    redirectOutput(Redirect.INHERIT)
+    redirectError(Redirect.INHERIT)
+  }
+
+  def redirectError(destination: Redirect): ProcessBuilder = destination match {
+    case null => set { _redirectOutput = Redirect.PIPE }
+    case d =>
+      d.`type`() match {
+        case Redirect.Type.READ =>
+          throw new IllegalArgumentException(
+            s"Redirect.READ cannot be used for error."
+          )
+        case _ =>
+          set { _redirectError = destination }
+      }
+  }
+
+  def redirectInput(source: Redirect): ProcessBuilder = source match {
+    case null => set { _redirectInput = Redirect.PIPE }
+    case s =>
+      s.`type`() match {
+        case Redirect.Type.WRITE | Redirect.Type.APPEND =>
+          throw new IllegalArgumentException(s"$s cannot be used for input.")
+        case _ =>
+          set { _redirectInput = source }
+      }
+  }
+
+  def redirectOutput(destination: Redirect): ProcessBuilder =
+    destination match {
+      case null => set { _redirectOutput = Redirect.PIPE }
+      case s =>
+        s.`type`() match {
+          case Redirect.Type.READ =>
+            throw new IllegalArgumentException(
+              s"Redirect.READ cannot be used for output."
+            )
+          case _ =>
+            set { _redirectOutput = destination }
+        }
+    }
+
+  def redirectInput(file: File): ProcessBuilder = {
+    redirectInput(Redirect.from(file))
+  }
+
+  def redirectOutput(file: File): ProcessBuilder = {
+    redirectOutput(Redirect.to(file))
+  }
+
+  def redirectError(file: File): ProcessBuilder = {
+    redirectError(Redirect.to(file))
+  }
+
+  def redirectInput(): Redirect = _redirectInput
+
+  def redirectOutput(): Redirect = _redirectOutput
+
+  def redirectError(): Redirect = _redirectError
+
+  def redirectErrorStream(): scala.Boolean = _redirectErrorStream
+
+  def redirectErrorStream(redirectErrorStream: scala.Boolean): ProcessBuilder =
+    set { _redirectErrorStream = redirectErrorStream }
+
+  def start(): Process = {
+    if (_command.isEmpty()) throw new IndexOutOfBoundsException()
+    if (_command.contains(null)) throw new NullPointerException()
+    if (isWindows) process.WindowsProcess(this)
+    else process.UnixProcess(this)
+  }
+
+  @inline private[this] def set(f: => Unit): ProcessBuilder = {
+    f
+    this
+  }
+  private def defaultDirectory = System.getenv("user.dir") match {
+    case null => new File(".")
+    case f    => new File(f)
+  }
+  private var _directory = defaultDirectory
+  private val _environment = {
+    val env = System.getenv()
+    new java.util.HashMap[String, String](env)
+  }
+  private var _redirectInput = Redirect.PIPE
+  private var _redirectOutput = Redirect.PIPE
+  private var _redirectError = Redirect.PIPE
+  private var _redirectErrorStream = false
+}
+
+object ProcessBuilder {
+  abstract class Redirect {
+    def file(): File = null
+
+    def `type`(): Redirect.Type
+
+    override def equals(other: Any): scala.Boolean = other match {
+      case that: Redirect => file() == that.file() && `type`() == that.`type`()
+      case _              => false
+    }
+
+    override def hashCode(): Int = {
+      var hash = 1
+      hash = hash * 31 + file().hashCode()
+      hash = hash * 31 + `type`().hashCode()
+      hash
+    }
+  }
+
+  object Redirect {
+    private class RedirectImpl(tpe: Redirect.Type, redirectFile: File)
+        extends Redirect {
+      override def `type`(): Type = tpe
+
+      override def file(): File = redirectFile
+
+      override def toString =
+        s"Redirect.$tpe${if (redirectFile != null) s": ${redirectFile}" else ""}"
+    }
+
+    val INHERIT: Redirect = new RedirectImpl(Type.INHERIT, null)
+
+    val PIPE: Redirect = new RedirectImpl(Type.PIPE, null)
+
+    def appendTo(file: File): Redirect = {
+      if (file == null) throw new NullPointerException()
+      new RedirectImpl(Type.APPEND, file)
+    }
+
+    def from(file: File): Redirect = {
+      if (file == null) throw new NullPointerException()
+      new RedirectImpl(Type.READ, file)
+    }
+
+    def to(file: File): Redirect = {
+      if (file == null) throw new NullPointerException()
+      new RedirectImpl(Type.WRITE, file)
+    }
+
+    class Type private (name: String, ordinal: Int)
+        extends Enum[Type](name, ordinal)
+
+    object Type {
+      final val PIPE = new Type("PIPE", 0)
+      final val INHERIT = new Type("INHERIT", 1)
+      final val READ = new Type("READ", 2)
+      final val WRITE = new Type("WRITE", 3)
+      final val APPEND = new Type("APPEND", 4)
+
+      def valueOf(name: String): Type = {
+        if (name == null) throw new NullPointerException()
+        _values.toSeq.find(_.name() == name) match {
+          case Some(t) => t
+          case None =>
+            throw new IllegalArgumentException(
+              s"$name is not a valid Type name"
+            )
+        }
+      }
+
+      def values(): Array[Type] = _values
+
+      private val _values = Array(PIPE, INHERIT, READ, WRITE, APPEND)
+    }
+  }
+}

--- a/javalib/src/main/scala-2/java/lang/ProcessBuilder.scala
+++ b/javalib/src/main/scala-2/java/lang/ProcessBuilder.scala
@@ -1,137 +1,23 @@
-// Any changes to this files needs to be synced with it's Scala3 counter part.
-// Due to enum restrictions it is impossible to create common implementation
-// for both Scala versions
+// Due to enums source-compatibility reasons `ProcessBuilder` was split into two
+// seperate files. `ProcessBuilder` contains constructors and Scala version specific
+// definition of enums. `ProcessBuilderImpl` defines actual logic of ProcessBuilder
+// that should be shared between both implementations
+// Make sure to sync content of this file with its Scala 3 counterpart
 
 package java.lang
 
 import java.util.{ArrayList, List}
 import java.util.Map
 import java.io.{File, IOException}
-import java.util
 import java.util.Arrays
-import scala.scalanative.unsafe._
-import scala.scalanative.posix.unistd
-import scala.scalanative.runtime.Platform
-import scala.scalanative.meta.LinktimeInfo.isWindows
 import ProcessBuilder.Redirect
+import java.lang.process.ProcessBuilderImpl
 
-final class ProcessBuilder(private var _command: List[String]) {
+final class ProcessBuilder(_command: List[String])
+    extends ProcessBuilderImpl(_command) {
   def this(command: Array[String]) = {
     this(Arrays.asList(command))
   }
-
-  def command(): List[String] = _command
-
-  def command(command: Array[String]): ProcessBuilder =
-    set { _command = Arrays.asList(command) }
-
-  def command(command: List[String]): ProcessBuilder = set {
-    _command = command
-  }
-
-  def environment(): Map[String, String] = _environment
-
-  def directory(): File = _directory
-
-  def directory(dir: File): ProcessBuilder =
-    set {
-      _directory = dir match {
-        case null => defaultDirectory
-        case _    => dir
-      }
-    }
-
-  def inheritIO(): ProcessBuilder = {
-    redirectInput(Redirect.INHERIT)
-    redirectOutput(Redirect.INHERIT)
-    redirectError(Redirect.INHERIT)
-  }
-
-  def redirectError(destination: Redirect): ProcessBuilder = destination match {
-    case null => set { _redirectOutput = Redirect.PIPE }
-    case d =>
-      d.`type`() match {
-        case Redirect.Type.READ =>
-          throw new IllegalArgumentException(
-            s"Redirect.READ cannot be used for error."
-          )
-        case _ =>
-          set { _redirectError = destination }
-      }
-  }
-
-  def redirectInput(source: Redirect): ProcessBuilder = source match {
-    case null => set { _redirectInput = Redirect.PIPE }
-    case s =>
-      s.`type`() match {
-        case Redirect.Type.WRITE | Redirect.Type.APPEND =>
-          throw new IllegalArgumentException(s"$s cannot be used for input.")
-        case _ =>
-          set { _redirectInput = source }
-      }
-  }
-
-  def redirectOutput(destination: Redirect): ProcessBuilder =
-    destination match {
-      case null => set { _redirectOutput = Redirect.PIPE }
-      case s =>
-        s.`type`() match {
-          case Redirect.Type.READ =>
-            throw new IllegalArgumentException(
-              s"Redirect.READ cannot be used for output."
-            )
-          case _ =>
-            set { _redirectOutput = destination }
-        }
-    }
-
-  def redirectInput(file: File): ProcessBuilder = {
-    redirectInput(Redirect.from(file))
-  }
-
-  def redirectOutput(file: File): ProcessBuilder = {
-    redirectOutput(Redirect.to(file))
-  }
-
-  def redirectError(file: File): ProcessBuilder = {
-    redirectError(Redirect.to(file))
-  }
-
-  def redirectInput(): Redirect = _redirectInput
-
-  def redirectOutput(): Redirect = _redirectOutput
-
-  def redirectError(): Redirect = _redirectError
-
-  def redirectErrorStream(): scala.Boolean = _redirectErrorStream
-
-  def redirectErrorStream(redirectErrorStream: scala.Boolean): ProcessBuilder =
-    set { _redirectErrorStream = redirectErrorStream }
-
-  def start(): Process = {
-    if (_command.isEmpty()) throw new IndexOutOfBoundsException()
-    if (_command.contains(null)) throw new NullPointerException()
-    if (isWindows) process.WindowsProcess(this)
-    else process.UnixProcess(this)
-  }
-
-  @inline private[this] def set(f: => Unit): ProcessBuilder = {
-    f
-    this
-  }
-  private def defaultDirectory = System.getenv("user.dir") match {
-    case null => new File(".")
-    case f    => new File(f)
-  }
-  private var _directory = defaultDirectory
-  private val _environment = {
-    val env = System.getenv()
-    new java.util.HashMap[String, String](env)
-  }
-  private var _redirectInput = Redirect.PIPE
-  private var _redirectOutput = Redirect.PIPE
-  private var _redirectError = Redirect.PIPE
-  private var _redirectErrorStream = false
 }
 
 object ProcessBuilder {

--- a/javalib/src/main/scala-2/java/lang/ThrowablesCompat.scala
+++ b/javalib/src/main/scala-2/java/lang/ThrowablesCompat.scala
@@ -1,0 +1,8 @@
+// Classes in this file needs special handling in Scala 3, we need to make sure
+// that they would not be compiled with Scala 3 compiler
+
+package java.lang
+
+class NullPointerException(s: String) extends RuntimeException(s) {
+  def this() = this(null)
+}

--- a/javalib/src/main/scala-2/java/lang/ThrowablesCompat.scala
+++ b/javalib/src/main/scala-2/java/lang/ThrowablesCompat.scala
@@ -1,4 +1,4 @@
-// Classes in this file needs special handling in Scala 3, we need to make sure
+// Classes in this file need special handling in Scala 3, we need to make sure
 // that they would not be compiled with Scala 3 compiler
 
 package java.lang

--- a/javalib/src/main/scala-2/java/lang/annotation/Retention.scala
+++ b/javalib/src/main/scala-2/java/lang/annotation/Retention.scala
@@ -1,4 +1,4 @@
-// Classes in this file needs special handling in Scala 3, we need to make sure
+// Classes in this file need special handling in Scala 3, we need to make sure
 // that they would not be compiled with Scala 3 compiler
 
 package java.lang.annotation

--- a/javalib/src/main/scala-2/java/lang/annotation/Retention.scala
+++ b/javalib/src/main/scala-2/java/lang/annotation/Retention.scala
@@ -1,0 +1,6 @@
+// Classes in this file needs special handling in Scala 3, we need to make sure
+// that they would not be compiled with Scala 3 compiler
+
+package java.lang.annotation
+
+trait Retention

--- a/javalib/src/main/scala-2/java/lang/annotation/RetentionPolicy.scala
+++ b/javalib/src/main/scala-2/java/lang/annotation/RetentionPolicy.scala
@@ -1,3 +1,5 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+
 package java.lang.annotation
 
 final class RetentionPolicy private (name: String, ordinal: Int)

--- a/javalib/src/main/scala-2/java/lang/annotation/RetentionPolicy.scala
+++ b/javalib/src/main/scala-2/java/lang/annotation/RetentionPolicy.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
 
 package java.lang.annotation
 

--- a/javalib/src/main/scala-2/java/lang/annotation/RetentionPolicy.scala
+++ b/javalib/src/main/scala-2/java/lang/annotation/RetentionPolicy.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file with Scala 3 implementation
 
 package java.lang.annotation
 

--- a/javalib/src/main/scala-2/java/math/RoundingMode.scala
+++ b/javalib/src/main/scala-2/java/math/RoundingMode.scala
@@ -1,3 +1,5 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+
 /*
  * Ported by Alistair Johnson from
  * https://android.googlesource.com/platform/libcore/+/master/luni/src/main/java/java/math/RoundingMode.java

--- a/javalib/src/main/scala-2/java/math/RoundingMode.scala
+++ b/javalib/src/main/scala-2/java/math/RoundingMode.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
 
 /*
  * Ported by Alistair Johnson from

--- a/javalib/src/main/scala-2/java/math/RoundingMode.scala
+++ b/javalib/src/main/scala-2/java/math/RoundingMode.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file with Scala 3 implementation
 
 /*
  * Ported by Alistair Johnson from

--- a/javalib/src/main/scala-2/java/nio/file/FileVisitOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/FileVisitOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file with Scala 3 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-2/java/nio/file/FileVisitOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/FileVisitOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-2/java/nio/file/FileVisitOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/FileVisitOption.scala
@@ -1,3 +1,5 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+
 package java.nio.file
 
 class FileVisitOption private (name: String, ordinal: Int)

--- a/javalib/src/main/scala-2/java/nio/file/FileVisitResult.scala
+++ b/javalib/src/main/scala-2/java/nio/file/FileVisitResult.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file with Scala 3 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-2/java/nio/file/FileVisitResult.scala
+++ b/javalib/src/main/scala-2/java/nio/file/FileVisitResult.scala
@@ -1,3 +1,5 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+
 package java.nio.file
 
 final class FileVisitResult private (name: String, ordinal: Int)

--- a/javalib/src/main/scala-2/java/nio/file/FileVisitResult.scala
+++ b/javalib/src/main/scala-2/java/nio/file/FileVisitResult.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-2/java/nio/file/LinkOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/LinkOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file with Scala 3 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-2/java/nio/file/LinkOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/LinkOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-2/java/nio/file/LinkOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/LinkOption.scala
@@ -1,3 +1,5 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+
 package java.nio.file
 
 final class LinkOption private (name: String, ordinal: Int)

--- a/javalib/src/main/scala-2/java/nio/file/StandardCopyOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/StandardCopyOption.scala
@@ -1,3 +1,5 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+
 package java.nio.file
 
 class StandardCopyOption private (name: String, ordinal: Int)

--- a/javalib/src/main/scala-2/java/nio/file/StandardCopyOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/StandardCopyOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file with Scala 3 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-2/java/nio/file/StandardCopyOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/StandardCopyOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-2/java/nio/file/StandardOpenOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/StandardOpenOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file with Scala 3 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-2/java/nio/file/StandardOpenOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/StandardOpenOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-2/java/nio/file/StandardOpenOption.scala
+++ b/javalib/src/main/scala-2/java/nio/file/StandardOpenOption.scala
@@ -1,3 +1,5 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+
 package java.nio.file
 
 class StandardOpenOption private (name: String, ordinal: Int)

--- a/javalib/src/main/scala-2/java/nio/file/attribute/PosixFilePermission.scala
+++ b/javalib/src/main/scala-2/java/nio/file/attribute/PosixFilePermission.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
 
 package java.nio.file.attribute
 

--- a/javalib/src/main/scala-2/java/nio/file/attribute/PosixFilePermission.scala
+++ b/javalib/src/main/scala-2/java/nio/file/attribute/PosixFilePermission.scala
@@ -1,3 +1,5 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+
 package java.nio.file.attribute
 
 class PosixFilePermission private (name: String, ordinal: Int)
@@ -13,7 +15,7 @@ object PosixFilePermission {
   final val OTHERS_WRITE = new PosixFilePermission("OTHERS_WRITE", 7)
   final val OTHERS_EXECUTE = new PosixFilePermission("OTHERS_EXECUTE", 8)
 
-  def values(): Array[PosixFilePermission] = _values.clone()
+  def values: Array[PosixFilePermission] = _values.clone()
 
   private[this] val _values = Array(
     OWNER_READ,

--- a/javalib/src/main/scala-2/java/nio/file/attribute/PosixFilePermission.scala
+++ b/javalib/src/main/scala-2/java/nio/file/attribute/PosixFilePermission.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file with Scala 3 implementation
 
 package java.nio.file.attribute
 

--- a/javalib/src/main/scala-2/java/util/Formatter.scala
+++ b/javalib/src/main/scala-2/java/util/Formatter.scala
@@ -1,0 +1,116 @@
+package java.util
+// Ported from Scala.js, commit: 0383e9f, dated: 2021-03-07
+
+import java.io._
+import java.lang.{
+  Double => JDouble,
+  Boolean => JBoolean,
+  StringBuilder => JStringBuilder
+}
+import java.math.{BigDecimal, BigInteger}
+import java.nio.CharBuffer
+import java.nio.charset.Charset
+import scala.annotation.{switch, tailrec}
+
+final class Formatter private (
+    dest: Appendable,
+    formatterLocaleInfo: Formatter.LocaleInfo
+) extends FormatterImpl(dest, formatterLocaleInfo) {
+  import Formatter._
+
+  def this() =
+    this(new JStringBuilder(), Formatter.RootLocaleInfo)
+  def this(a: Appendable) =
+    this(a, Formatter.RootLocaleInfo)
+  def this(l: Locale) =
+    this(new JStringBuilder(), new Formatter.LocaleLocaleInfo(l))
+
+  def this(a: Appendable, l: Locale) =
+    this(a, new Formatter.LocaleLocaleInfo(l))
+
+  private def this(
+      os: OutputStream,
+      csn: String,
+      localeInfo: Formatter.LocaleInfo
+  ) =
+    this(
+      new BufferedWriter(new OutputStreamWriter(os, csn)),
+      localeInfo
+    )
+  def this(os: OutputStream, csn: String, l: Locale) =
+    this(os, csn, new Formatter.LocaleLocaleInfo(l))
+  def this(os: OutputStream, csn: String) =
+    this(os, csn, Formatter.RootLocaleInfo)
+  def this(os: OutputStream) =
+    this(os, Charset.defaultCharset().name(), Formatter.RootLocaleInfo)
+
+  private def this(file: File, csn: String, l: Formatter.LocaleInfo) =
+    this(
+      {
+        var fout: FileOutputStream = null
+        try {
+          fout = new FileOutputStream(file)
+          val writer = new OutputStreamWriter(fout, csn)
+          new BufferedWriter(writer)
+        } catch {
+          case e @ (_: RuntimeException | _: UnsupportedEncodingException) =>
+            if (fout != null) {
+              try { fout.close() }
+              catch {
+                case _: IOException => () // silently
+              }
+            }
+            throw e
+        }
+      },
+      l
+    )
+
+  def this(file: File, csn: String, l: Locale) =
+    this(file, csn, new Formatter.LocaleLocaleInfo(l))
+  def this(file: File, csn: String) =
+    this(file, csn, Formatter.RootLocaleInfo)
+
+  def this(file: File) =
+    this(new FileOutputStream(file))
+  def this(ps: PrintStream) =
+    this(
+      {
+        if (null == ps)
+          throw new NullPointerException()
+        ps
+      },
+      Formatter.RootLocaleInfo
+    )
+
+  def this(fileName: String, csn: String, l: Locale) =
+    this(new File(fileName), csn, l)
+  def this(fileName: String, csn: String) =
+    this(new File(fileName), csn)
+  def this(fileName: String) =
+    this(new File(fileName))
+
+}
+
+object Formatter extends FormatterCompanionImpl {
+  final class BigDecimalLayoutForm private (name: String, ordinal: Int)
+      extends Enum[BigDecimalLayoutForm](name, ordinal)
+
+  object BigDecimalLayoutForm {
+
+    final val SCIENTIFIC = new BigDecimalLayoutForm("SCIENTIFIC", 0)
+    final val DECIMAL_FLOAT = new BigDecimalLayoutForm("DECIMAL_FLOAT", 1)
+
+    def valueOf(name: String): BigDecimalLayoutForm =
+      _values.find(_.name() == name).getOrElse {
+        throw new IllegalArgumentException(
+          "No enum constant java.util.Formatter.BigDecimalLayoutForm." + name
+        )
+      }
+
+    private val _values: Array[BigDecimalLayoutForm] =
+      Array(SCIENTIFIC, DECIMAL_FLOAT)
+
+    def values(): Array[BigDecimalLayoutForm] = _values.clone()
+  }
+}

--- a/javalib/src/main/scala-2/java/util/Formatter.scala
+++ b/javalib/src/main/scala-2/java/util/Formatter.scala
@@ -1,3 +1,9 @@
+// Make sure to sync this file with its Scala 3 counterpart.
+// Duo to problems with source-comaptibility of enums between Scala 2 and 3
+// main logic of Formatter was factored out to a shared `FormatterImpl` trait.
+// `Formatter` class should define only members that cannot be defined
+// in `FormatterImpl` like constructors and enums
+
 package java.util
 // Ported from Scala.js, commit: 0383e9f, dated: 2021-03-07
 

--- a/javalib/src/main/scala-2/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala-2/java/util/concurrent/TimeUnit.scala
@@ -1,3 +1,5 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+
 package java.util.concurrent
 
 // Ported from Scala.js

--- a/javalib/src/main/scala-2/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala-2/java/util/concurrent/TimeUnit.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file with Scala 3 implementation
 
 package java.util.concurrent
 

--- a/javalib/src/main/scala-2/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala-2/java/util/concurrent/TimeUnit.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 3 implementation
+// Enums are not source-compatible, make sure to sync this file's Scala 3 implementation
 
 package java.util.concurrent
 

--- a/javalib/src/main/scala-3/java/io/Serializable.scala
+++ b/javalib/src/main/scala-3/java/io/Serializable.scala
@@ -1,0 +1,7 @@
+// Classes defined in this file are registered inside Scala 3 compiler,
+// compiling them in javalib would lead to fatal error of compiler. They need
+// to be defined with a different name and renamed when generating NIR name
+
+package java.io
+
+trait _Serializable {}

--- a/javalib/src/main/scala-3/java/lang/Cloneable.scala
+++ b/javalib/src/main/scala-3/java/lang/Cloneable.scala
@@ -1,0 +1,7 @@
+// Classes defined in this file are registered inside Scala 3 compiler,
+// compiling them in javalib would lead to fatal error of compiler. They need
+// to be defined with a different name and renamed when generating NIR name
+
+package java.lang
+
+trait _Cloneable

--- a/javalib/src/main/scala-3/java/lang/Comparable.scala
+++ b/javalib/src/main/scala-3/java/lang/Comparable.scala
@@ -1,0 +1,9 @@
+// Classes defined in this file are registered inside Scala 3 compiler,
+// compiling them in javalib would lead to fatal error of compiler. They need
+// to be defined with a different name and renamed when generating NIR name
+
+package java.lang
+
+trait _Comparable[A] {
+  def compareTo(o: A): scala.Int
+}

--- a/javalib/src/main/scala-3/java/lang/Enum.scala
+++ b/javalib/src/main/scala-3/java/lang/Enum.scala
@@ -1,0 +1,14 @@
+// Classes defined in this file are registered inside Scala 3 compiler,
+// compiling them in javalib would lead to fatal error of compiler. They need
+// to be defined with a different name and renamed when generating NIR name
+
+package java.lang
+
+abstract class _Enum[E <: _Enum[E]] protected (_name: String, _ordinal: Int)
+    extends Comparable[E]
+    with java.io.Serializable {
+  def name(): String = _name
+  def ordinal(): Int = _ordinal
+  override def toString(): String = _name
+  final def compareTo(o: E): Int = _ordinal.compareTo(o.ordinal())
+}

--- a/javalib/src/main/scala-3/java/lang/ProcessBuilder.scala
+++ b/javalib/src/main/scala-3/java/lang/ProcessBuilder.scala
@@ -1,3 +1,7 @@
+// Any changes to this files needs to be synced with it's Scala2 counter part.
+// Due to enum restrictions it is impossible to create common implementation
+// for both Scala versions
+
 package java.lang
 
 import java.util.{ArrayList, List}
@@ -150,14 +154,14 @@ object ProcessBuilder {
   }
 
   object Redirect {
-    private class RedirectImpl(tpe: Redirect.Type, file: File)
+    private class RedirectImpl(tpe: Redirect.Type, redirectFile: File)
         extends Redirect {
       override def `type`(): Type = tpe
 
-      override def file(): File = file
+      override def file(): File = redirectFile
 
       override def toString =
-        s"Redirect.$tpe${if (file != null) s": ${file}" else ""}"
+        s"Redirect.$tpe${if (redirectFile != null) s": ${redirectFile}" else ""}"
     }
 
     val INHERIT: Redirect = new RedirectImpl(Type.INHERIT, null)
@@ -179,30 +183,12 @@ object ProcessBuilder {
       new RedirectImpl(Type.WRITE, file)
     }
 
-    class Type private (name: String, ordinal: Int)
-        extends Enum[Type](name, ordinal)
-
-    object Type {
-      final val PIPE = new Type("PIPE", 0)
-      final val INHERIT = new Type("INHERIT", 1)
-      final val READ = new Type("READ", 2)
-      final val WRITE = new Type("WRITE", 3)
-      final val APPEND = new Type("APPEND", 4)
-
-      def valueOf(name: String): Type = {
-        if (name == null) throw new NullPointerException()
-        _values.toSeq.find(_.name() == name) match {
-          case Some(t) => t
-          case None =>
-            throw new IllegalArgumentException(
-              s"$name is not a valid Type name"
-            )
-        }
-      }
-
-      def values(): Array[Type] = _values
-
-      private val _values = Array(PIPE, INHERIT, READ, WRITE, APPEND)
+    enum Type extends Enum[Type]() {
+      case PIPE extends Type
+      case INHERIT extends Type
+      case READ extends Type
+      case WRITE extends Type
+      case APPEND extends Type
     }
   }
 }

--- a/javalib/src/main/scala-3/java/lang/ProcessBuilder.scala
+++ b/javalib/src/main/scala-3/java/lang/ProcessBuilder.scala
@@ -1,4 +1,4 @@
-// Any changes to this files needs to be synced with it's Scala2 counter part.
+// Any changes to this file need to be synced with it's Scala2 counterpart.
 // Due to enum restrictions it is impossible to create common implementation
 // for both Scala versions
 

--- a/javalib/src/main/scala-3/java/lang/ProcessBuilder.scala
+++ b/javalib/src/main/scala-3/java/lang/ProcessBuilder.scala
@@ -1,137 +1,24 @@
-// Any changes to this file need to be synced with it's Scala2 counterpart.
-// Due to enum restrictions it is impossible to create common implementation
-// for both Scala versions
+// Due to enums source-compatibility reasons `ProcessBuilder` was split into two
+// seperate files. `ProcessBuilder` contains constructors and Scala version specific
+// definition of enums. `ProcessBuilderImpl` defines actual logic of ProcessBuilder
+// that should be shared between both implementations
+// Make sure to sync content of this file with its Scala 3 counterpart
 
 package java.lang
 
 import java.util.{ArrayList, List}
 import java.util.Map
 import java.io.{File, IOException}
-import java.util
 import java.util.Arrays
-import scala.scalanative.unsafe._
-import scala.scalanative.posix.unistd
-import scala.scalanative.runtime.Platform
-import scala.scalanative.meta.LinktimeInfo.isWindows
 import ProcessBuilder.Redirect
+import java.lang.process.ProcessBuilderImpl
 
-final class ProcessBuilder(private var _command: List[String]) {
+final class ProcessBuilder(_command: List[String])
+    extends ProcessBuilderImpl(_command) {
   def this(command: Array[String]) = {
     this(Arrays.asList(command))
   }
 
-  def command(): List[String] = _command
-
-  def command(command: Array[String]): ProcessBuilder =
-    set { _command = Arrays.asList(command) }
-
-  def command(command: List[String]): ProcessBuilder = set {
-    _command = command
-  }
-
-  def environment(): Map[String, String] = _environment
-
-  def directory(): File = _directory
-
-  def directory(dir: File): ProcessBuilder =
-    set {
-      _directory = dir match {
-        case null => defaultDirectory
-        case _    => dir
-      }
-    }
-
-  def inheritIO(): ProcessBuilder = {
-    redirectInput(Redirect.INHERIT)
-    redirectOutput(Redirect.INHERIT)
-    redirectError(Redirect.INHERIT)
-  }
-
-  def redirectError(destination: Redirect): ProcessBuilder = destination match {
-    case null => set { _redirectOutput = Redirect.PIPE }
-    case d =>
-      d.`type`() match {
-        case Redirect.Type.READ =>
-          throw new IllegalArgumentException(
-            s"Redirect.READ cannot be used for error."
-          )
-        case _ =>
-          set { _redirectError = destination }
-      }
-  }
-
-  def redirectInput(source: Redirect): ProcessBuilder = source match {
-    case null => set { _redirectInput = Redirect.PIPE }
-    case s =>
-      s.`type`() match {
-        case Redirect.Type.WRITE | Redirect.Type.APPEND =>
-          throw new IllegalArgumentException(s"$s cannot be used for input.")
-        case _ =>
-          set { _redirectInput = source }
-      }
-  }
-
-  def redirectOutput(destination: Redirect): ProcessBuilder =
-    destination match {
-      case null => set { _redirectOutput = Redirect.PIPE }
-      case s =>
-        s.`type`() match {
-          case Redirect.Type.READ =>
-            throw new IllegalArgumentException(
-              s"Redirect.READ cannot be used for output."
-            )
-          case _ =>
-            set { _redirectOutput = destination }
-        }
-    }
-
-  def redirectInput(file: File): ProcessBuilder = {
-    redirectInput(Redirect.from(file))
-  }
-
-  def redirectOutput(file: File): ProcessBuilder = {
-    redirectOutput(Redirect.to(file))
-  }
-
-  def redirectError(file: File): ProcessBuilder = {
-    redirectError(Redirect.to(file))
-  }
-
-  def redirectInput(): Redirect = _redirectInput
-
-  def redirectOutput(): Redirect = _redirectOutput
-
-  def redirectError(): Redirect = _redirectError
-
-  def redirectErrorStream(): scala.Boolean = _redirectErrorStream
-
-  def redirectErrorStream(redirectErrorStream: scala.Boolean): ProcessBuilder =
-    set { _redirectErrorStream = redirectErrorStream }
-
-  def start(): Process = {
-    if (_command.isEmpty()) throw new IndexOutOfBoundsException()
-    if (_command.contains(null)) throw new NullPointerException()
-    if (isWindows) process.WindowsProcess(this)
-    else process.UnixProcess(this)
-  }
-
-  @inline private[this] def set(f: => Unit): ProcessBuilder = {
-    f
-    this
-  }
-  private def defaultDirectory = System.getenv("user.dir") match {
-    case null => new File(".")
-    case f    => new File(f)
-  }
-  private var _directory = defaultDirectory
-  private val _environment = {
-    val env = System.getenv()
-    new java.util.HashMap[String, String](env)
-  }
-  private var _redirectInput = Redirect.PIPE
-  private var _redirectOutput = Redirect.PIPE
-  private var _redirectError = Redirect.PIPE
-  private var _redirectErrorStream = false
 }
 
 object ProcessBuilder {

--- a/javalib/src/main/scala-3/java/lang/ThrowablesCompat.scala
+++ b/javalib/src/main/scala-3/java/lang/ThrowablesCompat.scala
@@ -1,0 +1,9 @@
+// Classes defined in this file are registered inside Scala 3 compiler,
+// compiling them in javalib would lead to fatal error of compiler. They need
+// to be defined with a different name and renamed when generating NIR name
+
+package java.lang
+
+class _NullPointerException(s: String) extends RuntimeException(s) {
+  def this() = this(null)
+}

--- a/javalib/src/main/scala-3/java/lang/annotation/Retention.scala
+++ b/javalib/src/main/scala-3/java/lang/annotation/Retention.scala
@@ -1,3 +1,7 @@
+// Classes defined in this file are registered inside Scala 3 compiler,
+// compiling them in javalib would lead to fatal error of compiler. They need
+// to be defined with a different name and renamed when generating NIR name
+
 package java.lang.annotation
 
 trait _Retention

--- a/javalib/src/main/scala-3/java/lang/annotation/Retention.scala
+++ b/javalib/src/main/scala-3/java/lang/annotation/Retention.scala
@@ -1,3 +1,3 @@
 package java.lang.annotation
 
-trait Retention
+trait _Retention

--- a/javalib/src/main/scala-3/java/lang/annotation/RetentionPolicy.scala
+++ b/javalib/src/main/scala-3/java/lang/annotation/RetentionPolicy.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+// Enums are not source-compatbile, make sure to sync this file with Scala 2 implementation
 
 package java.lang.annotation
 

--- a/javalib/src/main/scala-3/java/lang/annotation/RetentionPolicy.scala
+++ b/javalib/src/main/scala-3/java/lang/annotation/RetentionPolicy.scala
@@ -1,0 +1,8 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+
+package java.lang.annotation
+
+enum RetentionPolicy(name: String, ordinal: Int):
+  case SOURCE extends RetentionPolicy("SOURCE", 0)
+  case CLASS extends RetentionPolicy("CLASS", 1)
+  case RUNTIME extends RetentionPolicy("RUNTIME", 2)

--- a/javalib/src/main/scala-3/java/math/RoundingMode.scala
+++ b/javalib/src/main/scala-3/java/math/RoundingMode.scala
@@ -1,0 +1,42 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+
+/*
+ * Ported by Alistair Johnson from
+ * https://android.googlesource.com/platform/libcore/+/master/luni/src/main/java/java/math/RoundingMode.java
+ * Original license copied below:
+ */
+
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package java.math
+
+import scala.annotation.switch
+
+enum RoundingMode extends Enum[RoundingMode]():
+  case UP extends RoundingMode
+  case DOWN extends RoundingMode
+  case CEILING extends RoundingMode
+  case FLOOR extends RoundingMode
+  case HALF_UP extends RoundingMode
+  case HALF_DOWN extends RoundingMode
+  case HALF_EVEN extends RoundingMode
+  case UNNECESSARY extends RoundingMode
+end RoundingMode
+
+object RoundingMode:
+  def valueOf(ordinal: Int): RoundingMode = RoundingMode.fromOrdinal(ordinal)

--- a/javalib/src/main/scala-3/java/math/RoundingMode.scala
+++ b/javalib/src/main/scala-3/java/math/RoundingMode.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+// Enums are not source-compatbile, make sure to sync this file with Scala 2 implementation
 
 /*
  * Ported by Alistair Johnson from

--- a/javalib/src/main/scala-3/java/nio/file/FileVisitOption.scala
+++ b/javalib/src/main/scala-3/java/nio/file/FileVisitOption.scala
@@ -1,0 +1,6 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+
+package java.nio.file
+
+enum FileVisitOption extends Enum[FileVisitOption]():
+  case FOLLOW_LINKS extends FileVisitOption

--- a/javalib/src/main/scala-3/java/nio/file/FileVisitOption.scala
+++ b/javalib/src/main/scala-3/java/nio/file/FileVisitOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+// Enums are not source-compatbile, make sure to sync this file with Scala 2 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-3/java/nio/file/FileVisitResult.scala
+++ b/javalib/src/main/scala-3/java/nio/file/FileVisitResult.scala
@@ -1,0 +1,9 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+
+package java.nio.file
+
+enum FileVisitResult extends Enum[FileVisitResult]():
+  case CONTINUE extends FileVisitResult
+  case TERMINATE extends FileVisitResult
+  case SKIP_SUBTREE extends FileVisitResult
+  case SKIP_SIBLINGS extends FileVisitResult

--- a/javalib/src/main/scala-3/java/nio/file/FileVisitResult.scala
+++ b/javalib/src/main/scala-3/java/nio/file/FileVisitResult.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+// Enums are not source-compatbile, make sure to sync this file with Scala 2 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-3/java/nio/file/LinkOption.scala
+++ b/javalib/src/main/scala-3/java/nio/file/LinkOption.scala
@@ -1,0 +1,6 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+
+package java.nio.file
+
+enum LinkOption extends Enum[LinkOption]() with OpenOption with CopyOption:
+  case NOFOLLOW_LINKS extends LinkOption

--- a/javalib/src/main/scala-3/java/nio/file/LinkOption.scala
+++ b/javalib/src/main/scala-3/java/nio/file/LinkOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+// Enums are not source-compatbile, make sure to sync this file with Scala 2 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-3/java/nio/file/StandardCopyOption.scala
+++ b/javalib/src/main/scala-3/java/nio/file/StandardCopyOption.scala
@@ -1,0 +1,8 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+
+package java.nio.file
+
+enum StandardCopyOption extends Enum[StandardCopyOption]() with CopyOption:
+  case REPLACE_EXISTING extends StandardCopyOption
+  case COPY_ATTRIBUTES extends StandardCopyOption
+  case ATOMIC_MOVE extends StandardCopyOption

--- a/javalib/src/main/scala-3/java/nio/file/StandardCopyOption.scala
+++ b/javalib/src/main/scala-3/java/nio/file/StandardCopyOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+// Enums are not source-compatbile, make sure to sync this file with Scala 2 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-3/java/nio/file/StandardOpenOption.scala
+++ b/javalib/src/main/scala-3/java/nio/file/StandardOpenOption.scala
@@ -1,0 +1,15 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+
+package java.nio.file
+
+enum StandardOpenOption extends Enum[StandardOpenOption]() with OpenOption:
+  case READ extends StandardOpenOption
+  case WRITE extends StandardOpenOption
+  case APPEND extends StandardOpenOption
+  case TRUNCATE_EXISTING extends StandardOpenOption
+  case CREATE extends StandardOpenOption
+  case CREATE_NEW extends StandardOpenOption
+  case DELETE_ON_CLOSE extends StandardOpenOption
+  case SPARSE extends StandardOpenOption
+  case SYNC extends StandardOpenOption
+  case DSYNC extends StandardOpenOption

--- a/javalib/src/main/scala-3/java/nio/file/StandardOpenOption.scala
+++ b/javalib/src/main/scala-3/java/nio/file/StandardOpenOption.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+// Enums are not source-compatbile, make sure to sync this file with Scala 2 implementation
 
 package java.nio.file
 

--- a/javalib/src/main/scala-3/java/nio/file/attribute/PosixFilePermission.scala
+++ b/javalib/src/main/scala-3/java/nio/file/attribute/PosixFilePermission.scala
@@ -1,4 +1,4 @@
-// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+// Enums are not source-compatbile, make sure to sync this file with Scala 2 implementation
 
 package java.nio.file.attribute
 

--- a/javalib/src/main/scala-3/java/nio/file/attribute/PosixFilePermission.scala
+++ b/javalib/src/main/scala-3/java/nio/file/attribute/PosixFilePermission.scala
@@ -1,0 +1,14 @@
+// Enums are not source-compatbile, make sure to sync this file Scala 2 implementation
+
+package java.nio.file.attribute
+
+enum PosixFilePermission extends Enum[PosixFilePermission]():
+  case OWNER_READ extends PosixFilePermission
+  case OWNER_WRITE extends PosixFilePermission
+  case OWNER_EXECUTE extends PosixFilePermission
+  case GROUP_READ extends PosixFilePermission
+  case GROUP_WRITE extends PosixFilePermission
+  case GROUP_EXECUTE extends PosixFilePermission
+  case OTHERS_READ extends PosixFilePermission
+  case OTHERS_WRITE extends PosixFilePermission
+  case OTHERS_EXECUTE extends PosixFilePermission

--- a/javalib/src/main/scala-3/java/util/Formatter.scala
+++ b/javalib/src/main/scala-3/java/util/Formatter.scala
@@ -1,0 +1,93 @@
+package java.util
+// Ported from Scala.js, commit: 0383e9f, dated: 2021-03-07
+
+import java.io._
+import java.lang.{
+  Double => JDouble,
+  Boolean => JBoolean,
+  StringBuilder => JStringBuilder
+}
+import java.math.{BigDecimal, BigInteger}
+import java.nio.CharBuffer
+import java.nio.charset.Charset
+import scala.annotation.{switch, tailrec}
+
+final class Formatter private (
+    dest: Appendable,
+    formatterLocaleInfo: Formatter.LocaleInfo
+) extends FormatterImpl(dest, formatterLocaleInfo) {
+  import Formatter._
+
+  def this() = this(new JStringBuilder(), Formatter.RootLocaleInfo)
+  def this(a: Appendable) = this(a, Formatter.RootLocaleInfo)
+  def this(l: Locale) =
+    this(new JStringBuilder(), new Formatter.LocaleLocaleInfo(l))
+
+  def this(a: Appendable, l: Locale) =
+    this(a, new Formatter.LocaleLocaleInfo(l))
+
+  private def this(
+      os: OutputStream,
+      csn: String,
+      localeInfo: Formatter.LocaleInfo
+  ) =
+    this(
+      new BufferedWriter(new OutputStreamWriter(os, csn)),
+      localeInfo
+    )
+  def this(os: OutputStream, csn: String, l: Locale) =
+    this(os, csn, new Formatter.LocaleLocaleInfo(l))
+  def this(os: OutputStream, csn: String) =
+    this(os, csn, Formatter.RootLocaleInfo)
+  def this(os: OutputStream) =
+    this(os, Charset.defaultCharset().name(), Formatter.RootLocaleInfo)
+
+  private def this(file: File, csn: String, l: Formatter.LocaleInfo) =
+    this(
+      {
+        var fout: FileOutputStream = null
+        try {
+          fout = new FileOutputStream(file)
+          val writer = new OutputStreamWriter(fout, csn)
+          new BufferedWriter(writer)
+        } catch {
+          case e @ (_: RuntimeException | _: UnsupportedEncodingException) =>
+            if (fout != null) {
+              try { fout.close() }
+              catch {
+                case _: IOException => () // silently
+              }
+            }
+            throw e
+        }
+      },
+      l
+    )
+
+  def this(file: File, csn: String, l: Locale) =
+    this(file, csn, new Formatter.LocaleLocaleInfo(l))
+  def this(file: File, csn: String) = this(file, csn, Formatter.RootLocaleInfo)
+
+  def this(file: File) = this(new FileOutputStream(file))
+  def this(ps: PrintStream) =
+    this(
+      {
+        if (null == ps)
+          throw new NullPointerException()
+        ps
+      },
+      Formatter.RootLocaleInfo
+    )
+
+  def this(fileName: String, csn: String, l: Locale) =
+    this(new File(fileName), csn, l)
+  def this(fileName: String, csn: String) = this(new File(fileName), csn)
+  def this(fileName: String) = this(new File(fileName))
+}
+
+object Formatter extends FormatterCompanionImpl {
+  enum BigDecimalLayoutForm extends Enum[BigDecimalLayoutForm]() {
+    case SCIENTIFIC extends BigDecimalLayoutForm
+    case DECIMAL_FLOAT extends BigDecimalLayoutForm
+  }
+}

--- a/javalib/src/main/scala-3/java/util/Formatter.scala
+++ b/javalib/src/main/scala-3/java/util/Formatter.scala
@@ -1,3 +1,9 @@
+// Make sure to sync this file with its Scala 2 counterpart.
+// Duo to problems with source-comaptibility of enums between Scala 2 and 3
+// main logic of Formatter was factored out to a shared `FormatterImpl` trait.
+// `Formatter` class should define only members that cannot be defined
+// in `FormatterImpl` like constructors and enums
+
 package java.util
 // Ported from Scala.js, commit: 0383e9f, dated: 2021-03-07
 

--- a/javalib/src/main/scala-3/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala-3/java/util/concurrent/TimeUnit.scala
@@ -1,0 +1,110 @@
+package java.util.concurrent
+
+import java.sql.Time
+
+// Ported from Scala.js
+
+enum TimeUnit extends Enum[TimeUnit] {
+  import TimeUnit._
+  case NANOSECONDS extends TimeUnit
+  case MICROSECONDS extends TimeUnit
+  case MILLISECONDS extends TimeUnit
+  case SECONDS extends TimeUnit
+  case MINUTES extends TimeUnit
+  case HOURS extends TimeUnit
+  case DAYS extends TimeUnit
+
+  def convert(a: Long, u: TimeUnit): Long = this match {
+    case TimeUnit.NANOSECONDS  => u.toNanos(a)
+    case TimeUnit.MICROSECONDS => u.toMicros(a)
+    case TimeUnit.MILLISECONDS => u.toMillis(a)
+    case TimeUnit.SECONDS      => u.toSeconds(a)
+    case TimeUnit.MINUTES      => u.toMinutes(a)
+    case TimeUnit.HOURS        => u.toHours(a)
+    case TimeUnit.DAYS         => u.toDays(a)
+  }
+  def toNanos(a: Long): Long = this match {
+    case TimeUnit.NANOSECONDS  => a
+    case TimeUnit.MICROSECONDS => x(a, C1 / C0, MAX / (C1 / C0))
+    case TimeUnit.MILLISECONDS => x(a, C2 / C0, MAX / (C2 / C0))
+    case TimeUnit.SECONDS      => x(a, C3 / C0, MAX / (C3 / C0))
+    case TimeUnit.MINUTES      => x(a, C4 / C0, MAX / (C4 / C0))
+    case TimeUnit.HOURS        => x(a, C5 / C0, MAX / (C5 / C0))
+    case TimeUnit.DAYS         => x(a, C6 / C0, MAX / (C6 / C0))
+  }
+
+  def toMicros(a: Long): Long = this match {
+    case TimeUnit.NANOSECONDS  => a / (C1 / C0)
+    case TimeUnit.MICROSECONDS => a
+    case TimeUnit.MILLISECONDS => x(a, C2 / C1, MAX / (C2 / C1))
+    case TimeUnit.SECONDS      => x(a, C3 / C1, MAX / (C3 / C1))
+    case TimeUnit.MINUTES      => x(a, C4 / C1, MAX / (C4 / C1))
+    case TimeUnit.HOURS        => x(a, C5 / C1, MAX / (C5 / C1))
+    case TimeUnit.DAYS         => x(a, C6 / C1, MAX / (C6 / C1))
+  }
+
+  def toMillis(a: Long): Long = this match {
+    case TimeUnit.NANOSECONDS  => a / (C2 / C0)
+    case TimeUnit.MICROSECONDS => a / (C2 / C1)
+    case TimeUnit.MILLISECONDS => a
+    case TimeUnit.SECONDS      => x(a, C3 / C2, MAX / (C3 / C2))
+    case TimeUnit.MINUTES      => x(a, C4 / C2, MAX / (C4 / C2))
+    case TimeUnit.HOURS        => x(a, C5 / C2, MAX / (C5 / C2))
+    case TimeUnit.DAYS         => x(a, C6 / C2, MAX / (C6 / C2))
+  }
+
+  def toSeconds(a: Long): Long = this match {
+    case TimeUnit.NANOSECONDS  => a / (C3 / C0)
+    case TimeUnit.MICROSECONDS => a / (C3 / C1)
+    case TimeUnit.MILLISECONDS => a / (C3 / C2)
+    case TimeUnit.SECONDS      => a
+    case TimeUnit.MINUTES      => x(a, C4 / C3, MAX / (C4 / C3))
+    case TimeUnit.HOURS        => x(a, C5 / C3, MAX / (C5 / C3))
+    case TimeUnit.DAYS         => x(a, C6 / C3, MAX / (C6 / C3))
+  }
+  def toMinutes(a: Long): Long = this match {
+    case TimeUnit.NANOSECONDS  => a / (C4 / C0)
+    case TimeUnit.MICROSECONDS => a / (C4 / C1)
+    case TimeUnit.MILLISECONDS => a / (C4 / C2)
+    case TimeUnit.SECONDS      => a / (C4 / C3)
+    case TimeUnit.MINUTES      => a
+    case TimeUnit.HOURS        => x(a, C5 / C4, MAX / (C5 / C4))
+    case TimeUnit.DAYS         => x(a, C6 / C4, MAX / (C6 / C4))
+  }
+  def toHours(a: Long): Long = this match {
+    case TimeUnit.NANOSECONDS  => a / (C5 / C0)
+    case TimeUnit.MICROSECONDS => a / (C5 / C1)
+    case TimeUnit.MILLISECONDS => a / (C5 / C2)
+    case TimeUnit.SECONDS      => a / (C5 / C3)
+    case TimeUnit.MINUTES      => a / (C5 / C4)
+    case TimeUnit.HOURS        => a
+    case TimeUnit.DAYS         => x(a, C6 / C5, MAX / (C6 / C5))
+  }
+  def toDays(a: Long): Long = this match {
+    case TimeUnit.NANOSECONDS  => a / (C6 / C0)
+    case TimeUnit.MICROSECONDS => a / (C6 / C1)
+    case TimeUnit.MILLISECONDS => a / (C6 / C2)
+    case TimeUnit.SECONDS      => a / (C6 / C3)
+    case TimeUnit.MINUTES      => a / (C6 / C4)
+    case TimeUnit.HOURS        => a / (C6 / C5)
+    case TimeUnit.DAYS         => a
+  }
+}
+
+object TimeUnit {
+  // deliberately without type ascription to make them compile-time constants
+  private final val C0 = 1L
+  private final val C1 = C0 * 1000L
+  private final val C2 = C1 * 1000L
+  private final val C3 = C2 * 1000L
+  private final val C4 = C3 * 60L
+  private final val C5 = C4 * 60L
+  private final val C6 = C5 * 24L
+  private final val MAX = Long.MaxValue
+
+  private def x(a: Long, b: Long, max: Long): Long = {
+    if (a > max) MAX
+    else if (a < -max) -MAX
+    else a * b
+  }
+}

--- a/javalib/src/main/scala-3/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala-3/java/util/concurrent/TimeUnit.scala
@@ -1,3 +1,5 @@
+// Enums are not source-compatible, make sure to sync this file with Scala 2 implementation
+
 package java.util.concurrent
 
 import java.sql.Time

--- a/javalib/src/main/scala-3/scala/scalanative/compat/ScalaStream.scala
+++ b/javalib/src/main/scala-3/scala/scalanative/compat/ScalaStream.scala
@@ -1,0 +1,21 @@
+package scala.scalanative.compat
+
+import java.util.stream.WrappedScalaStream
+import scala.collection.immutable
+import scala.language.implicitConversions
+
+private[scalanative] object ScalaStream {
+  type Underlying[T] = immutable.LazyList[T]
+  val Underlying = immutable.LazyList
+
+  implicit class ScalaStreamImpl[T](val underyling: Underlying[T])
+      extends AnyVal {
+    def wrappedStream(closeHanlder: Option[Runnable] = None) =
+      new WrappedScalaStream[T](underyling, closeHanlder)
+  }
+
+  implicit def seqToScalaStream[T](seq: Iterable[T]): Underlying[T] = {
+    seq.to(Underlying)
+  }
+
+}

--- a/javalib/src/main/scala-3/scala/scalanative/compat/ScalaStream.scala
+++ b/javalib/src/main/scala-3/scala/scalanative/compat/ScalaStream.scala
@@ -1,5 +1,5 @@
 // This file defines common wrapper for Scala streams
-// to allow for cross-compilation between Scala 2.12- and Scala 2.13+ 
+// to allow for cross-compilation between Scala 2.12- and Scala 2.13+
 // due to changes to collections API used in the javalib.
 package scala.scalanative.compat
 

--- a/javalib/src/main/scala-3/scala/scalanative/compat/ScalaStream.scala
+++ b/javalib/src/main/scala-3/scala/scalanative/compat/ScalaStream.scala
@@ -1,3 +1,6 @@
+// This file defines common wrapper for Scala streams
+// to allow for cross-compilation between Scala 2.12- and Scala 2.13+ 
+// due to changes to collections API used in the javalib.
 package scala.scalanative.compat
 
 import java.util.stream.WrappedScalaStream

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -178,7 +178,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
         if (ownerOnly) {
           withUserToken(TOKEN_QUERY) { userToken =>
             withTokenInformation(userToken, TokenInformationClass.TokenUser) {
-              data: Ptr[SidAndAttributes] =>
+              (data: Ptr[SidAndAttributes]) =>
                 ea.trustee.trusteeType = TrusteeType.TRUSTEE_IS_USER
                 ea.trustee.sid = data.sid
             }
@@ -717,14 +717,14 @@ object File {
     Zone { implicit z =>
       if (isWindows) {
         val buffSize = GetCurrentDirectoryW(0.toUInt, null)
-        val buff = alloc[windows.WChar](buffSize + 1.toUInt)
-        if (GetCurrentDirectoryW(buffSize, buff) == 0) {
+        val buff: Ptr[windows.WChar] = alloc[windows.WChar](buffSize + 1.toUInt)
+        if (GetCurrentDirectoryW(buffSize, buff) == 0.toUInt) {
           throw WindowsException("error in trying to get user directory")
         }
         fromCWideString(buff, StandardCharsets.UTF_16LE)
       } else {
         val buff: CString = alloc[CChar](4096.toUInt)
-        if (getcwd(buff, 4095.toUInt) == 0) {
+        if (getcwd(buff, 4095.toUInt) == 0.toUInt) {
           val errMsg = fromCString(string.strerror(errno.errno))
           throw new IOException(
             s"error in trying to get user directory - $errMsg"
@@ -924,7 +924,7 @@ object File {
           flags = finalPathFlags
         )
 
-        if (fileHandle == HandleApiExt.INVALID_HANDLE_VALUE || pathLength == 0)
+        if (fileHandle == HandleApiExt.INVALID_HANDLE_VALUE || pathLength == 0.toUInt)
           null
         else buffer
       }

--- a/javalib/src/main/scala/java/io/PushbackInputStream.scala
+++ b/javalib/src/main/scala/java/io/PushbackInputStream.scala
@@ -87,8 +87,7 @@ class PushbackInputStream(_in: InputStream, size: Int)
     } else {
       var numSkipped = 0L
       if (pos < buf.length) {
-        numSkipped += (if (count < buf.length - pos) count
-                       else buf.length - pos)
+        numSkipped += (buf.length - pos).toLong.min(count)
         pos += numSkipped.toInt
       }
       if (numSkipped < count) {

--- a/javalib/src/main/scala/java/io/RandomAccessFile.scala
+++ b/javalib/src/main/scala/java/io/RandomAccessFile.scala
@@ -154,7 +154,7 @@ class RandomAccessFile private (
       val fileLength = length()
       val toSkip =
         if (currentPosition + n > fileLength) fileLength - currentPosition
-        else n
+        else n.toLong
       seek(toSkip)
       toSkip.toInt
     }

--- a/javalib/src/main/scala/java/io/Serializable.scala
+++ b/javalib/src/main/scala/java/io/Serializable.scala
@@ -1,3 +1,0 @@
-package java.io
-
-trait Serializable

--- a/javalib/src/main/scala/java/lang/Cloneable.scala
+++ b/javalib/src/main/scala/java/lang/Cloneable.scala
@@ -1,3 +1,0 @@
-package java.lang
-
-trait Cloneable

--- a/javalib/src/main/scala/java/lang/Comparable.scala
+++ b/javalib/src/main/scala/java/lang/Comparable.scala
@@ -1,5 +1,0 @@
-package java.lang
-
-trait Comparable[A] {
-  def compareTo(o: A): scala.Int
-}

--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -385,11 +385,12 @@ object Integer {
       else 32 - numberOfLeadingZeros(i)
     val buffer = new Array[Char](count)
     var k = i
-    do {
+    while ({
       count -= 1
       buffer(count) = ((k & 1) + '0').toChar
       k >>>= 1
-    } while (count > 0)
+      count > 0
+    }) ()
 
     new String(buffer)
   }
@@ -400,7 +401,7 @@ object Integer {
       else ((32 - numberOfLeadingZeros(i)) + 3) / 4
     val buffer = new Array[Char](count)
     var k = i
-    do {
+    while ({
       var t = k & 15
       if (t > 9) {
         t = t - 10 + 'a'
@@ -410,7 +411,8 @@ object Integer {
       count -= 1
       buffer(count) = t.toChar
       k >>>= 4
-    } while (count > 0)
+      count > 0
+    }) ()
 
     new String(buffer)
   }
@@ -421,11 +423,12 @@ object Integer {
       else ((32 - numberOfLeadingZeros(i)) + 2) / 3
     val buffer = new Array[Char](count)
     var k = i
-    do {
+    while ({
       count -= 1
       buffer(count) = ((k & 7) + '0').toChar
       k >>>= 3
-    } while (count > 0)
+      count > 0
+    }) ()
 
     new String(buffer)
   }
@@ -449,24 +452,26 @@ object Integer {
 
         var last_digit = first_digit
         var quot = positive_value
-        do {
+        while ({
           val res = quot / 10
           var digit_value = quot - ((res << 3) + (res << 1))
           digit_value += '0'
           buffer(last_digit) = digit_value.toChar
           last_digit += 1
           quot = res
-        } while (quot != 0)
+          quot != 0
+        }) ()
 
         val count = last_digit
         last_digit -= 1
-        do {
+        while ({
           val tmp = buffer(last_digit)
           buffer(last_digit) = buffer(first_digit)
           last_digit -= 1
           buffer(first_digit) = tmp
           first_digit += 1
-        } while (first_digit < last_digit)
+          first_digit < last_digit
+        }) ()
 
         new String(buffer, 0, count)
       } else if (i == MIN_VALUE) {
@@ -561,7 +566,7 @@ object Integer {
       }
 
       val buffer = new Array[Char](count)
-      do {
+      while ({
         var ch = 0 - (j % radix)
         if (ch > 9) {
           ch = ch - 10 + 'a'
@@ -571,7 +576,8 @@ object Integer {
         count -= 1
         buffer(count) = ch.toChar
         j /= radix
-      } while (j != 0)
+        j != 0
+      }) ()
 
       if (negative) {
         buffer(0) = '-'
@@ -689,13 +695,14 @@ object Integer {
 
       // populate string with characters
       val buffer = new Array[Char](count)
-      do {
+      while ({
         val digit = remainderUnsigned(j, radix)
         val ch = Character.forDigit(digit.toInt, radix)
         count -= 1
         buffer(count) = ch
         j = divideUnsigned(j, radix)
-      } while (j != 0)
+        j != 0
+      }) ()
 
       new String(buffer)
     }

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -382,11 +382,12 @@ object Long {
       else 64 - numberOfLeadingZeros(l)
     val buffer = new Array[Char](count)
     var k = l
-    do {
+    while ({
       count -= 1
       buffer(count) = ((k & 1) + '0').toChar
       k >>= 1
-    } while (count > 0)
+      count > 0
+    }) ()
 
     new String(buffer)
   }
@@ -397,7 +398,7 @@ object Long {
       else ((64 - numberOfLeadingZeros(l)) + 3) / 4
     val buffer = new Array[Char](count)
     var k = l
-    do {
+    while ({
       var t = (k & 15).toInt
       if (t > 9) {
         t = t - 10 + 'a'
@@ -407,7 +408,8 @@ object Long {
       count -= 1
       buffer(count) = t.toChar
       k >>= 4
-    } while (count > 0)
+      count > 0
+    }) ()
 
     new String(buffer)
   }
@@ -418,11 +420,12 @@ object Long {
       else ((64 - numberOfLeadingZeros(l)) + 2) / 3
     val buffer = new Array[Char](count)
     var k = l
-    do {
+    while ({
       count -= 1
       buffer(count) = ((k & 7) + '0').toChar
       k >>>= 3
-    } while (count > 0)
+      count > 0
+    }) ()
 
     new String(buffer)
   }
@@ -453,7 +456,7 @@ object Long {
       }
 
       val buffer = new Array[Char](count)
-      do {
+      while ({
         var ch = 0 - (j % radix)
         if (ch > 9) {
           ch = ch - 10 + 'a'
@@ -463,7 +466,8 @@ object Long {
         count -= 1
         buffer(count) = ch.toChar
         j = j / radix
-      } while (j != 0)
+        j != 0
+      }) ()
 
       if (negative) {
         buffer(0) = '-'
@@ -579,13 +583,14 @@ object Long {
 
       // populate string with characters
       val buffer = new Array[Char](count)
-      do {
+      while ({
         val digit = remainderUnsigned(j, radix)
         val ch = Character.forDigit(digit.toInt, radix)
         count -= 1
         buffer(count) = ch
         j = divideUnsigned(j, radix)
-      } while (j != 0)
+        j != 0
+      }) ()
 
       new String(buffer)
     }

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -589,11 +589,12 @@ final class _String()
       val buffer = new Array[Char](count)
       System.arraycopy(value, offset, buffer, 0, count)
 
-      do {
+      while ({
         buffer(index) = newChar
         index += 1
         index = indexOf(oldChar, index)
-      } while (index != -1)
+        index != -1
+      }) ()
 
       new _String(0, count, buffer)
     }
@@ -630,12 +631,13 @@ final class _String()
       val buffer = new java.lang.StringBuilder(count + rs.length)
       val tl = target.length()
       var tail = 0
-      do {
+      while ({
         buffer.append(value, offset + tail, index - tail)
         buffer.append(rs)
         tail = index + tl
         index = indexOf(ts, tail)
-      } while (index != -1)
+        index != -1
+      }) ()
       buffer.append(value, offset + tail, count - tail)
 
       buffer.toString
@@ -1187,9 +1189,10 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
       if (separatorCount == count) {
         return Array.empty[String]
       }
-      do {
+      while ({
         begin -= 1
-      } while (charAt(begin - 1) == ch)
+        charAt(begin - 1) == ch
+      }) ()
       separatorCount -= count - begin
       begin
     } else {

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -11,6 +11,7 @@ import java.nio._
 import java.nio.charset._
 import java.util.Objects
 import scala.annotation.{switch, tailrec}
+import _String.{string2_string, _string2string}
 
 final class _String()
     extends Serializable
@@ -1329,8 +1330,8 @@ object _String {
     new Formatter(loc).format(fmt, args).toString()
 
   import scala.language.implicitConversions
-  @inline private implicit def _string2string(s: _String): String =
+  @inline private[lang] implicit def _string2string(s: _String): String =
     s.asInstanceOf[String]
-  @inline private implicit def string2_string(s: String): _String =
+  @inline private[lang] implicit def string2_string(s: String): _String =
     s.asInstanceOf[_String]
 }

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -770,14 +770,15 @@ final class _String()
       loop(i + 1)
     }
     val preprocessed = replaceCharsAtIndex { i =>
+      def ifMoreAboveOrNull(v: String) = if (moreAbove(i)) v else null
       (this.charAt(i): @switch) match {
-        case '\u0049' if moreAbove(i) => "\u0069\u0307"
-        case '\u004A' if moreAbove(i) => "\u006A\u0307"
-        case '\u012E' if moreAbove(i) => "\u012F\u0307"
-        case '\u00CC'                 => "\u0069\u0307\u0300"
-        case '\u00CD'                 => "\u0069\u0307\u0301"
-        case '\u0128'                 => "\u0069\u0307\u0303"
-        case _                        => null
+        case '\u0049' => ifMoreAboveOrNull("\u0069\u0307")
+        case '\u004A' => ifMoreAboveOrNull("\u006A\u0307")
+        case '\u012E' => ifMoreAboveOrNull("\u012F\u0307")
+        case '\u00CC' => "\u0069\u0307\u0300"
+        case '\u00CD' => "\u0069\u0307\u0301"
+        case '\u0128' => "\u0069\u0307\u0303"
+        case _        => null
       }
     }
 
@@ -833,10 +834,10 @@ final class _String()
 
     val preprocessed = replaceCharsAtIndex { i =>
       (this.charAt(i): @switch) match {
-        case '\u0130'                  => "\u0069"
-        case '\u0307' if afterI(i)     => ""
-        case '\u0049' if !beforeDot(i) => "\u0131"
-        case _                         => null
+        case '\u0130' => "\u0069"
+        case '\u0307' => if (afterI(i)) "" else null
+        case '\u0049' => if (!beforeDot(i)) "\u0131" else null
+        case _        => null
       }
     }
 

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -63,7 +63,7 @@ object System {
       sysProps.setProperty("path.separator", ";")
       sysProps.setProperty(
         "java.io.tmpdir", {
-          val buffer = stackalloc[scala.Byte](MAX_PATH)
+          val buffer: Ptr[scala.Byte] = stackalloc[scala.Byte](MAX_PATH)
           GetTempPathA(MAX_PATH, buffer)
           fromCString(buffer)
         }
@@ -133,7 +133,7 @@ object System {
         Some(fromCWideString(buf, StandardCharsets.UTF_16LE))
       else None
     } else {
-      val buf = stackalloc[scala.Byte](bufSize)
+      val buf: Ptr[scala.Byte] = stackalloc[scala.Byte](bufSize)
       val cwd = unistd.getcwd(buf, bufSize)
       Option(cwd).map(fromCString(_))
     }

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -473,10 +473,6 @@ class NoSuchMethodException(s: String) extends ReflectiveOperationException(s) {
   def this() = this(null)
 }
 
-class NullPointerException(s: String) extends RuntimeException(s) {
-  def this() = this(null)
-}
-
 class NumberFormatException(s: String) extends IllegalArgumentException(s) {
   def this() = this(null)
 }

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -14,7 +14,7 @@ private[lang] object StackTrace {
   ): StackTraceElement = {
     val nameMax = 1024
     val name: Ptr[CChar] = stackalloc[CChar](nameMax.toUInt)
-    val offset = stackalloc[scala.Byte](8.toUInt)
+    val offset: Ptr[scala.Byte] = stackalloc[scala.Byte](8.toUInt)
 
     unwind.get_proc_name(cursor, name, nameMax.toUInt, offset)
 
@@ -37,9 +37,9 @@ private[lang] object StackTrace {
     cache.getOrElseUpdate(ip, makeStackTraceElement(cursor))
 
   @noinline private[lang] def currentStackTrace(): Array[StackTraceElement] = {
-    val cursor = stackalloc[scala.Byte](2048.toUInt)
-    val context = stackalloc[scala.Byte](2048.toUInt)
-    val offset = stackalloc[scala.Byte](8.toUInt)
+    val cursor: Ptr[scala.Byte] = stackalloc[scala.Byte](2048.toUInt)
+    val context: Ptr[scala.Byte] = stackalloc[scala.Byte](2048.toUInt)
+    val offset: Ptr[scala.Byte] = stackalloc[scala.Byte](8.toUInt)
     val ip = stackalloc[CUnsignedLongLong]()
     var buffer = mutable.ArrayBuffer.empty[StackTraceElement]
 

--- a/javalib/src/main/scala/java/lang/process/PipeIO.scala
+++ b/javalib/src/main/scala/java/lang/process/PipeIO.scala
@@ -119,7 +119,7 @@ private[lang] object PipeIO {
       (_, fd) => new BufferedOutputStream(new FileOutputStream(fd))
     )
 
-  private final object NullInput extends Stream {
+  private object NullInput extends Stream {
     @stub
     override def process: GenericProcess = ???
     override def available(): Int = 0
@@ -127,7 +127,7 @@ private[lang] object PipeIO {
     override def read(): Int = 0
     override def read(buf: Array[scala.Byte], offset: Int, len: Int) = -1
   }
-  private final object NullOutput extends OutputStream {
+  private object NullOutput extends OutputStream {
     override def close(): Unit = {}
     override def write(b: Int): Unit = {}
   }

--- a/javalib/src/main/scala/java/lang/process/ProcessBuilderImpl.scala
+++ b/javalib/src/main/scala/java/lang/process/ProcessBuilderImpl.scala
@@ -18,7 +18,7 @@ import ProcessBuilder.Redirect
 
 private[lang] class ProcessBuilderImpl(private var _command: List[String]) {
   self: java.lang.ProcessBuilder =>
-    
+
   def command(): List[String] = _command
 
   def command(command: Array[String]): ProcessBuilder =

--- a/javalib/src/main/scala/java/lang/process/ProcessBuilderImpl.scala
+++ b/javalib/src/main/scala/java/lang/process/ProcessBuilderImpl.scala
@@ -1,0 +1,134 @@
+// Due to enums source-compatibility reasons `ProcessBuilder` was split into two
+// seperate files. `ProcessBuilder` contains constructors and Scala version specific
+// definition of enums. `ProcessBuilderImpl` defines actual logic of ProcessBuilder
+// that should be shared between both implementations
+
+package java.lang.process
+
+import java.util.{ArrayList, List}
+import java.util.Map
+import java.io.{File, IOException}
+import java.util
+import java.util.Arrays
+import scala.scalanative.unsafe._
+import scala.scalanative.posix.unistd
+import scala.scalanative.runtime.Platform
+import scala.scalanative.meta.LinktimeInfo.isWindows
+import ProcessBuilder.Redirect
+
+private[lang] class ProcessBuilderImpl(private var _command: List[String]) {
+  self: java.lang.ProcessBuilder =>
+    
+  def command(): List[String] = _command
+
+  def command(command: Array[String]): ProcessBuilder =
+    set { _command = Arrays.asList(command) }
+
+  def command(command: List[String]): ProcessBuilder = set {
+    _command = command
+  }
+
+  def environment(): Map[String, String] = _environment
+
+  def directory(): File = _directory
+
+  def directory(dir: File): ProcessBuilder =
+    set {
+      _directory = dir match {
+        case null => defaultDirectory
+        case _    => dir
+      }
+    }
+
+  def inheritIO(): ProcessBuilder = {
+    redirectInput(Redirect.INHERIT)
+    redirectOutput(Redirect.INHERIT)
+    redirectError(Redirect.INHERIT)
+  }
+
+  def redirectError(destination: Redirect): ProcessBuilder = destination match {
+    case null => set { _redirectOutput = Redirect.PIPE }
+    case d =>
+      d.`type`() match {
+        case Redirect.Type.READ =>
+          throw new IllegalArgumentException(
+            s"Redirect.READ cannot be used for error."
+          )
+        case _ =>
+          set { _redirectError = destination }
+      }
+  }
+
+  def redirectInput(source: Redirect): ProcessBuilder = source match {
+    case null => set { _redirectInput = Redirect.PIPE }
+    case s =>
+      s.`type`() match {
+        case Redirect.Type.WRITE | Redirect.Type.APPEND =>
+          throw new IllegalArgumentException(s"$s cannot be used for input.")
+        case _ =>
+          set { _redirectInput = source }
+      }
+  }
+
+  def redirectOutput(destination: Redirect): ProcessBuilder =
+    destination match {
+      case null => set { _redirectOutput = Redirect.PIPE }
+      case s =>
+        s.`type`() match {
+          case Redirect.Type.READ =>
+            throw new IllegalArgumentException(
+              s"Redirect.READ cannot be used for output."
+            )
+          case _ =>
+            set { _redirectOutput = destination }
+        }
+    }
+
+  def redirectInput(file: File): ProcessBuilder = {
+    redirectInput(Redirect.from(file))
+  }
+
+  def redirectOutput(file: File): ProcessBuilder = {
+    redirectOutput(Redirect.to(file))
+  }
+
+  def redirectError(file: File): ProcessBuilder = {
+    redirectError(Redirect.to(file))
+  }
+
+  def redirectInput(): Redirect = _redirectInput
+
+  def redirectOutput(): Redirect = _redirectOutput
+
+  def redirectError(): Redirect = _redirectError
+
+  def redirectErrorStream(): scala.Boolean = _redirectErrorStream
+
+  def redirectErrorStream(redirectErrorStream: scala.Boolean): ProcessBuilder =
+    set { _redirectErrorStream = redirectErrorStream }
+
+  def start(): Process = {
+    if (_command.isEmpty()) throw new IndexOutOfBoundsException()
+    if (_command.contains(null)) throw new NullPointerException()
+    if (isWindows) process.WindowsProcess(this)
+    else process.UnixProcess(this)
+  }
+
+  @inline private[this] def set(f: => Unit): ProcessBuilder = {
+    f
+    this
+  }
+  private def defaultDirectory = System.getenv("user.dir") match {
+    case null => new File(".")
+    case f    => new File(f)
+  }
+  private var _directory = defaultDirectory
+  private val _environment = {
+    val env = System.getenv()
+    new java.util.HashMap[String, String](env)
+  }
+  private var _redirectInput = Redirect.PIPE
+  private var _redirectOutput = Redirect.PIPE
+  private var _redirectError = Redirect.PIPE
+  private var _redirectErrorStream = false
+}

--- a/javalib/src/main/scala/java/lang/process/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcess.scala
@@ -85,9 +85,15 @@ private[lang] class UnixProcess private (
       case _ => true
     }
 
-  @inline private def waitImpl(f: () => Int) = {
+  @inline private def waitImpl(f: () => Int): Int = {
     var res = 1
-    do res = f() while (if (res == 0) _exitValue == -1 else res != ETIMEDOUT)
+    while ({
+      res = f()
+      res match {
+        case 0   => _exitValue == -1
+        case res => res != ETIMEDOUT
+      }
+    }) ()
     res
   }
 

--- a/javalib/src/main/scala/java/lang/ref/Reference.scala
+++ b/javalib/src/main/scala/java/lang/ref/Reference.scala
@@ -1,8 +1,8 @@
 package java.lang.ref
 
-abstract class Reference[T >: Null <: AnyRef](private[this] var referent: T) {
+abstract class Reference[T](private[this] var referent: T) {
   def get(): T = referent
-  def clear(): Unit = referent = null
+  def clear(): Unit = referent = null.asInstanceOf[T]
   def isEnqueued(): Boolean = false
   def enqueue(): Boolean = false
   private[ref] def dequeue(): Reference[T] = this

--- a/javalib/src/main/scala/java/lang/ref/ReferenceQueue.scala
+++ b/javalib/src/main/scala/java/lang/ref/ReferenceQueue.scala
@@ -3,20 +3,21 @@ package java.lang.ref
 import scalanative.annotation.stub
 import scala.collection.mutable
 
-class ReferenceQueue[T >: Null <: AnyRef] {
-  private val underlying = mutable.Queue[Reference[_ <: T]]()
-  private[ref] def enqueue(reference: Reference[_ <: T]): Unit =
+class ReferenceQueue[T] {
+  private val underlying = mutable.Queue[Reference[T]]()
+  private[ref] def enqueue(reference: Reference[T]): Unit =
     synchronized {
       underlying += reference
       notify()
     }
 
-  def poll(): Reference[_ <: T] = {
-    synchronized[Reference[_ <: T]] {
+  def poll(): Reference[T] = {
+    synchronized[Reference[T]] {
       underlying
         .dequeueFirst(_ => true)
         .map(_.dequeue())
         .orNull
+        .asInstanceOf[Reference[T]]
     }
   }
 

--- a/javalib/src/main/scala/java/lang/ref/WeakReference.scala
+++ b/javalib/src/main/scala/java/lang/ref/WeakReference.scala
@@ -5,10 +5,10 @@ package java.lang.ref
 // to register which fields shall not be marked by GC.
 // _gc_unmarked_ works like this only in the context of
 // the WeakReference class.
-class WeakReference[T >: Null <: AnyRef](
+class WeakReference[T](
     private var _gc_modified_referent: T,
-    queue: ReferenceQueue[_ >: T]
-) extends Reference[T](null) {
+    queue: ReferenceQueue[T]
+) extends Reference[T](null.asInstanceOf[T]) {
   // Since compiler generates _gc_modified_referent and referent
   // (of the Reference class) as two seperate fields and GC only
   // controls _gc_modified_ referent field, we pass null to the
@@ -36,7 +36,7 @@ class WeakReference[T >: Null <: AnyRef](
   override def isEnqueued(): Boolean = enqueued
 
   override def clear(): Unit = {
-    _gc_modified_referent = null
+    _gc_modified_referent = null.asInstanceOf[T]
     enqueue()
   }
 

--- a/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
+++ b/javalib/src/main/scala/java/lang/ref/WeakReferenceRegistry.scala
@@ -10,11 +10,11 @@ import scala.scalanative.runtime.GC
  * by the internals of the immix and commix GC.
  */
 private[java] object WeakReferenceRegistry {
-  private var weakRefList: immutable.List[WeakReference[_ >: Null <: AnyRef]] =
+  private var weakRefList: immutable.List[WeakReference[_]] =
     immutable.List()
 
   private val postGCHandlerMap
-      : mutable.HashMap[WeakReference[_ >: Null <: AnyRef], Function0[Unit]] =
+      : mutable.HashMap[WeakReference[_], Function0[Unit]] =
     new mutable.HashMap()
 
   if (isWeakReferenceSupported) {
@@ -39,13 +39,13 @@ private[java] object WeakReferenceRegistry {
       }
     }
 
-  private[ref] def add(weakRef: WeakReference[_ >: Null <: AnyRef]): Unit =
+  private[ref] def add(weakRef: WeakReference[_]): Unit =
     if (isWeakReferenceSupported) weakRefList = weakRefList ++ List(weakRef)
 
   // Scala Native javalib exclusive functionality.
   // Can be used to emulate finalize for javalib classes where necessary.
   private[java] def addHandler(
-      weakRef: WeakReference[_ >: Null <: AnyRef],
+      weakRef: WeakReference[_],
       handler: Function0[Unit]
   ): Unit =
     if (isWeakReferenceSupported) postGCHandlerMap += (weakRef -> handler)

--- a/javalib/src/main/scala/java/lang/reflect/Array.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Array.scala
@@ -45,14 +45,14 @@ object Array {
 
   def get(array: AnyRef, index: Int): AnyRef = array match {
     case array: Array[Object]  => array(index)
-    case array: Array[Boolean] => new java.lang.Boolean(array(index))
-    case array: Array[Char]    => new java.lang.Character(array(index))
-    case array: Array[Byte]    => new java.lang.Byte(array(index))
-    case array: Array[Short]   => new java.lang.Short(array(index))
-    case array: Array[Int]     => new java.lang.Integer(array(index))
-    case array: Array[Long]    => new java.lang.Long(array(index))
-    case array: Array[Float]   => new java.lang.Float(array(index))
-    case array: Array[Double]  => new java.lang.Double(array(index))
+    case array: Array[Boolean] => java.lang.Boolean.valueOf(array(index))
+    case array: Array[Char]    => java.lang.Character.valueOf(array(index))
+    case array: Array[Byte]    => java.lang.Byte.valueOf(array(index))
+    case array: Array[Short]   => java.lang.Short.valueOf(array(index))
+    case array: Array[Int]     => java.lang.Integer.valueOf(array(index))
+    case array: Array[Long]    => java.lang.Long.valueOf(array(index))
+    case array: Array[Float]   => java.lang.Float.valueOf(array(index))
+    case array: Array[Double]  => java.lang.Double.valueOf(array(index))
     case _ =>
       throw new IllegalArgumentException("argument type mismatch")
   }

--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -1024,7 +1024,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
             if (compRemDiv0 == 0) {
               val bi = qr.rem.multiply(powerOf10(exp2))
               val rem = bi.divide(divisor.getUnscaledValue())
-              Math.abs(rem.signum())
+              Math.abs(rem.signum()).toLong
             } else {
               compRemDiv0
             }

--- a/javalib/src/main/scala/java/math/Conversion.scala
+++ b/javalib/src/main/scala/java/math/Conversion.scala
@@ -177,20 +177,22 @@ private[math] object Conversion {
         val highDigit = digits(0)
         if (highDigit < 0) {
           var v: Long = highDigit & 0xffffffffL
-          do {
+          while ({
             val prev = v
             v /= 10
             currentChar -= 1
             result = (prev - v * 10).toString + result
-          } while (v != 0)
+            v != 0
+          }) ()
         } else {
           var v: Int = highDigit
-          do {
+          while ({
             val prev = v
             v /= 10
             currentChar -= 1
             result = (prev - v * 10).toString + result
-          } while (v != 0)
+            v != 0
+          }) ()
         }
       } else {
         val temp = new Array[Int](numberLength)
@@ -281,12 +283,13 @@ private[math] object Conversion {
       var currentChar = resLengthInChars
 
       var v: Long = if (negNumber) -value else value
-      do {
+      while ({
         val prev = v
         v /= 10
         currentChar -= 1
         result = (prev - v * 10).toString + result
-      } while (v != 0)
+        v != 0
+      }) ()
 
       val exponent: Long = resLengthInChars - currentChar - scale.toLong - 1
 

--- a/javalib/src/main/scala/java/math/Division.scala
+++ b/javalib/src/main/scala/java/math/Division.scala
@@ -477,10 +477,11 @@ private[math] object Division {
           }
         } else {
           // Use Knuth's algorithm of successive subtract and shifting
-          do {
+          while ({
             Elementary.inplaceSubtract(op2, op1)
             BitLevel.inplaceShiftRight(op2, op2.getLowestSetBit())
-          } while (op2.compareTo(op1) >= BigInteger.EQUALS)
+            op2.compareTo(op1) >= BigInteger.EQUALS
+          }) ()
         }
         // now op1 >= op2
         val swap: BigInteger = op2
@@ -521,7 +522,7 @@ private[math] object Division {
     if (lsb2 != 0)
       op2 >>>= lsb2
 
-    do {
+    while ({
       if (op1 >= op2) {
         op1 -= op2
         op1 >>>= java.lang.Integer.numberOfTrailingZeros(op1)
@@ -529,7 +530,8 @@ private[math] object Division {
         op2 -= op1
         op2 >>>= java.lang.Integer.numberOfTrailingZeros(op2)
       }
-    } while (op1 != 0)
+      op1 != 0
+    }) ()
     op2 << pow2Count
   }
 
@@ -1015,11 +1017,12 @@ private[math] object Division {
     val m0: Long = a.digits(0) & UINT_MAX
     var n2: Long = 1L
     var powerOfTwo: Long = 2L
-    do {
+    while ({
       if (((m0 * n2) & powerOfTwo) != 0)
         n2 |= powerOfTwo
       powerOfTwo <<= 1
-    } while (powerOfTwo < 0x100000000L)
+      powerOfTwo < 0x100000000L
+    }) ()
     n2 = -n2
     (n2 & UINT_MAX).toInt
   }
@@ -1028,7 +1031,7 @@ private[math] object Division {
    *  operation.
    *
    *  @param bi
-   *    @param n
+   *  @param n
    *  @return
    */
   private def howManyIterations(bi: BigInteger, n: Int): Int = {

--- a/javalib/src/main/scala/java/math/Division.scala
+++ b/javalib/src/main/scala/java/math/Division.scala
@@ -1031,7 +1031,7 @@ private[math] object Division {
    *  operation.
    *
    *  @param bi
-   *  @param n
+   *    @param n
    *  @return
    */
   private def howManyIterations(bi: BigInteger, n: Int): Int = {

--- a/javalib/src/main/scala/java/math/Primality.scala
+++ b/javalib/src/main/scala/java/math/Primality.scala
@@ -115,7 +115,7 @@ private[math] object Primality {
       val n = new BigInteger(1, count, new Array[Int](count))
 
       val last = count - 1
-      do {
+      while ({
         // To fill the array with random integers
         for (i <- 0 until n.numberLength) {
           n.digits(i) = rnd.nextInt()
@@ -124,7 +124,8 @@ private[math] object Primality {
         n.digits(last) = (n.digits(last) | 0x80000000) >>> shiftCount
         // To create an odd number
         n.digits(0) |= 1
-      } while (!isProbablePrime(n, certainty))
+        !isProbablePrime(n, certainty)
+      }) ()
       n
     }
   }
@@ -289,10 +290,12 @@ private[math] object Primality {
          * methods would call Miller-Rabin with t <= 50 so this part is only to
          * do more robust the algorithm
          */
-        do {
+        while ({
           x = new BigInteger(bitLength, rnd)
-        } while ((x.compareTo(n) >= BigInteger.EQUALS) || x.sign == 0 ||
+          (x.compareTo(n) >= BigInteger.EQUALS ||
+          x.sign == 0 ||
           x.isOne())
+        }) ()
       }
 
       y = x.modPow(q, n)

--- a/javalib/src/main/scala/java/net/SocketInputStream.scala
+++ b/javalib/src/main/scala/java/net/SocketInputStream.scala
@@ -20,10 +20,10 @@ private[net] class SocketInputStream(socket: AbstractPlainSocketImpl)
 
   override def read(buffer: Array[Byte]) = read(buffer, 0, buffer.length)
 
-  override def read(buffer: Array[Byte], offset: Int, count: Int) = {
+  override def read(buffer: Array[Byte], offset: Int, count: Int): Int = {
     if (buffer == null) throw new NullPointerException("Buffer is null")
 
-    if (count == 0) 0
+    if (count == 0) return 0
 
     if (offset < 0 || offset >= buffer.length)
       throw new ArrayIndexOutOfBoundsException(

--- a/javalib/src/main/scala/java/net/URIEncoderDecoder.scala
+++ b/javalib/src/main/scala/java/net/URIEncoderDecoder.scala
@@ -16,7 +16,7 @@ object URIEncoderDecoder {
       val ch: Char = s.charAt(i)
       if (ch == '%') {
         continue = true
-        do {
+        while ({
           if (i + 2 >= s.length) {
             throw new URISyntaxException(s, "Incomplete % sequence", i)
           }
@@ -30,7 +30,8 @@ object URIEncoderDecoder {
             )
           }
           i += 3
-        } while (i < s.length && s.charAt(i) == '%')
+          i < s.length && s.charAt(i) == '%'
+        }) ()
       } else if (!((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
             (ch >= '0' && ch <= '9') || legal.indexOf(ch) > -1 ||
             (ch > 127 && !java.lang.Character.isSpaceChar(ch) &&
@@ -101,7 +102,7 @@ object URIEncoderDecoder {
       val c: Char = s.charAt(i)
       if (c == '%') {
         out.reset()
-        do {
+        while ({
           if (i + 2 >= s.length) {
             throw new IllegalArgumentException("Incomplete % sequence at: " + i)
           }
@@ -114,7 +115,8 @@ object URIEncoderDecoder {
           }
           out.write(((d1 << 4) + d2).toByte)
           i += 3
-        } while (i < s.length && s.charAt(i) == '%')
+          i < s.length && s.charAt(i) == '%'
+        }) ()
         result.append(out.toString(encoding))
       }
       result.append(c)

--- a/javalib/src/main/scala/java/nio/ByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ByteBuffer.scala
@@ -27,7 +27,7 @@ abstract class ByteBuffer private[nio] (
 
   private[nio] type ElementType = Byte
   private[nio] type BufferType = ByteBuffer
-      
+
   private def genBuffer = GenBuffer[ByteBuffer](this)
 
   def this(_capacity: Int) = this(_capacity, null, null, -1)

--- a/javalib/src/main/scala/java/nio/ByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ByteBuffer.scala
@@ -27,6 +27,8 @@ abstract class ByteBuffer private[nio] (
 
   private[nio] type ElementType = Byte
   private[nio] type BufferType = ByteBuffer
+      
+  private def genBuffer = GenBuffer[ByteBuffer](this)
 
   def this(_capacity: Int) = this(_capacity, null, null, -1)
 
@@ -48,30 +50,30 @@ abstract class ByteBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Byte], offset: Int, length: Int): ByteBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   def get(dst: Array[Byte]): ByteBuffer =
     get(dst, 0, dst.length)
 
   @noinline
   def put(src: ByteBuffer): ByteBuffer =
-    GenBuffer(this).generic_put(src)
+    genBuffer.generic_put(src)
 
   @noinline
   def put(src: Array[Byte], offset: Int, length: Int): ByteBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   final def put(src: Array[Byte]): ByteBuffer =
     put(src, 0, src.length)
 
   @inline final def hasArray(): Boolean =
-    GenBuffer(this).generic_hasArray()
+    genBuffer.generic_hasArray()
 
   @inline final def array(): Array[Byte] =
-    GenBuffer(this).generic_array()
+    genBuffer.generic_array()
 
   @inline final def arrayOffset(): Int =
-    GenBuffer(this).generic_arrayOffset()
+    genBuffer.generic_arrayOffset()
 
   @inline override def position(newPosition: Int): ByteBuffer = {
     super.position(newPosition)
@@ -116,7 +118,7 @@ abstract class ByteBuffer private[nio] (
 
   @noinline
   override def hashCode(): Int =
-    GenBuffer(this).generic_hashCode(ByteBuffer.HashSeed)
+    genBuffer.generic_hashCode(ByteBuffer.HashSeed)
 
   override def equals(that: Any): Boolean = that match {
     case that: ByteBuffer => compareTo(that) == 0
@@ -125,7 +127,7 @@ abstract class ByteBuffer private[nio] (
 
   @noinline
   def compareTo(that: ByteBuffer): Int =
-    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+    genBuffer.generic_compareTo(that)(_.compareTo(_))
 
   final def order(): ByteOrder =
     if (_isBigEndian) ByteOrder.BIG_ENDIAN
@@ -196,7 +198,7 @@ abstract class ByteBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+    genBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(
@@ -205,5 +207,5 @@ abstract class ByteBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_store(startIndex, src, offset, length)
+    genBuffer.generic_store(startIndex, src, offset, length)
 }

--- a/javalib/src/main/scala/java/nio/CharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/CharBuffer.scala
@@ -33,6 +33,8 @@ abstract class CharBuffer private[nio] (
   private[nio] type ElementType = Char
   private[nio] type BufferType = CharBuffer
 
+  private def genBuffer = GenBuffer[CharBuffer](this)
+
   def this(_capacity: Int) = this(_capacity, null, null, -1)
 
   def read(target: CharBuffer): Int = {
@@ -41,7 +43,7 @@ abstract class CharBuffer private[nio] (
     if (n == 0) -1
     else if (_array != null) {
       // even if read-only
-      GenBuffer(target).generic_put(_array, _arrayOffset, n)
+      genBuffer.generic_put(_array, _arrayOffset, n)
       n
     } else {
       val savedPos = position()
@@ -67,18 +69,18 @@ abstract class CharBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   def get(dst: Array[Char]): CharBuffer =
     get(dst, 0, dst.length)
 
   @noinline
   def put(src: CharBuffer): CharBuffer =
-    GenBuffer(this).generic_put(src)
+    genBuffer.generic_put(src)
 
   @noinline
   def put(src: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   final def put(src: Array[Char]): CharBuffer =
     put(src, 0, src.length)
@@ -90,13 +92,13 @@ abstract class CharBuffer private[nio] (
     put(src, 0, src.length)
 
   @inline final def hasArray(): Boolean =
-    GenBuffer(this).generic_hasArray()
+    genBuffer.generic_hasArray()
 
   @inline final def array(): Array[Char] =
-    GenBuffer(this).generic_array()
+    genBuffer.generic_array()
 
   @inline final def arrayOffset(): Int =
-    GenBuffer(this).generic_arrayOffset()
+    genBuffer.generic_arrayOffset()
 
   @inline override def position(newPosition: Int): CharBuffer = {
     super.position(newPosition)
@@ -139,7 +141,7 @@ abstract class CharBuffer private[nio] (
 
   @noinline
   override def hashCode(): Int =
-    GenBuffer(this).generic_hashCode(CharBuffer.HashSeed)
+    genBuffer.generic_hashCode(CharBuffer.HashSeed)
 
   override def equals(that: Any): Boolean = that match {
     case that: CharBuffer => compareTo(that) == 0
@@ -148,7 +150,7 @@ abstract class CharBuffer private[nio] (
 
   @noinline
   def compareTo(that: CharBuffer): Int =
-    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+    genBuffer.generic_compareTo(that)(_.compareTo(_))
 
   override def toString(): String = {
     if (_array != null) {
@@ -193,7 +195,7 @@ abstract class CharBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+    genBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(
@@ -202,5 +204,5 @@ abstract class CharBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_store(startIndex, src, offset, length)
+    genBuffer.generic_store(startIndex, src, offset, length)
 }

--- a/javalib/src/main/scala/java/nio/DoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DoubleBuffer.scala
@@ -25,6 +25,8 @@ abstract class DoubleBuffer private[nio] (
   private[nio] type ElementType = Double
   private[nio] type BufferType = DoubleBuffer
 
+  private def genBuffer = GenBuffer[DoubleBuffer](this)
+
   def this(_capacity: Int) = this(_capacity, null, null, -1)
 
   def slice(): DoubleBuffer
@@ -43,30 +45,30 @@ abstract class DoubleBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   def get(dst: Array[Double]): DoubleBuffer =
     get(dst, 0, dst.length)
 
   @noinline
   def put(src: DoubleBuffer): DoubleBuffer =
-    GenBuffer(this).generic_put(src)
+    genBuffer.generic_put(src)
 
   @noinline
   def put(src: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   final def put(src: Array[Double]): DoubleBuffer =
     put(src, 0, src.length)
 
   @inline final def hasArray(): Boolean =
-    GenBuffer(this).generic_hasArray()
+    genBuffer.generic_hasArray()
 
   @inline final def array(): Array[Double] =
-    GenBuffer(this).generic_array()
+    genBuffer.generic_array()
 
   @inline final def arrayOffset(): Int =
-    GenBuffer(this).generic_arrayOffset()
+    genBuffer.generic_arrayOffset()
 
   @inline override def position(newPosition: Int): DoubleBuffer = {
     super.position(newPosition)
@@ -111,7 +113,7 @@ abstract class DoubleBuffer private[nio] (
 
   @noinline
   override def hashCode(): Int =
-    GenBuffer(this).generic_hashCode(DoubleBuffer.HashSeed)
+    genBuffer.generic_hashCode(DoubleBuffer.HashSeed)
 
   override def equals(that: Any): Boolean = that match {
     case that: DoubleBuffer => compareTo(that) == 0
@@ -120,7 +122,7 @@ abstract class DoubleBuffer private[nio] (
 
   @noinline
   def compareTo(that: DoubleBuffer): Int =
-    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+    genBuffer.generic_compareTo(that)(_.compareTo(_))
 
   def order(): ByteOrder
 
@@ -137,7 +139,7 @@ abstract class DoubleBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+    genBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(
@@ -146,5 +148,5 @@ abstract class DoubleBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_store(startIndex, src, offset, length)
+    genBuffer.generic_store(startIndex, src, offset, length)
 }

--- a/javalib/src/main/scala/java/nio/FloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/FloatBuffer.scala
@@ -25,6 +25,8 @@ abstract class FloatBuffer private[nio] (
   private[nio] type ElementType = Float
   private[nio] type BufferType = FloatBuffer
 
+  private def genBuffer = GenBuffer[FloatBuffer](this)
+
   def this(_capacity: Int) = this(_capacity, null, null, -1)
 
   def slice(): FloatBuffer
@@ -43,30 +45,30 @@ abstract class FloatBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   def get(dst: Array[Float]): FloatBuffer =
     get(dst, 0, dst.length)
 
   @noinline
   def put(src: FloatBuffer): FloatBuffer =
-    GenBuffer(this).generic_put(src)
+    genBuffer.generic_put(src)
 
   @noinline
   def put(src: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   final def put(src: Array[Float]): FloatBuffer =
     put(src, 0, src.length)
 
   @inline final def hasArray(): Boolean =
-    GenBuffer(this).generic_hasArray()
+    genBuffer.generic_hasArray()
 
   @inline final def array(): Array[Float] =
-    GenBuffer(this).generic_array()
+    genBuffer.generic_array()
 
   @inline final def arrayOffset(): Int =
-    GenBuffer(this).generic_arrayOffset()
+    genBuffer.generic_arrayOffset()
 
   @inline override def position(newPosition: Int): FloatBuffer = {
     super.position(newPosition)
@@ -111,7 +113,7 @@ abstract class FloatBuffer private[nio] (
 
   @noinline
   override def hashCode(): Int =
-    GenBuffer(this).generic_hashCode(FloatBuffer.HashSeed)
+    genBuffer.generic_hashCode(FloatBuffer.HashSeed)
 
   override def equals(that: Any): Boolean = that match {
     case that: FloatBuffer => compareTo(that) == 0
@@ -120,7 +122,7 @@ abstract class FloatBuffer private[nio] (
 
   @noinline
   def compareTo(that: FloatBuffer): Int =
-    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+    genBuffer.generic_compareTo(that)(_.compareTo(_))
 
   def order(): ByteOrder
 
@@ -137,7 +139,7 @@ abstract class FloatBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+    genBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(
@@ -146,5 +148,5 @@ abstract class FloatBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_store(startIndex, src, offset, length)
+    genBuffer.generic_store(startIndex, src, offset, length)
 }

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -12,7 +12,7 @@ private[nio] class HeapByteBuffer(
     _initialLimit: Int,
     _readOnly: Boolean
 ) extends ByteBuffer(_capacity, _array0, null, _arrayOffset0) {
-  
+
   position(_initialPosition)
   limit(_initialLimit)
 

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -12,11 +12,14 @@ private[nio] class HeapByteBuffer(
     _initialLimit: Int,
     _readOnly: Boolean
 ) extends ByteBuffer(_capacity, _array0, null, _arrayOffset0) {
-
+  
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapByteBuffer =
+  private def genBuffer = GenBuffer[ByteBuffer](this)
+  private def genHeapBuffer = GenHeapBuffer[ByteBuffer](this)
+  private implicit def newHeapByteBuffer
+      : GenHeapBuffer.NewHeapBuffer[ByteBuffer, Byte] =
     HeapByteBuffer.NewHeapByteBuffer
 
   def isReadOnly(): Boolean = _readOnly
@@ -25,43 +28,43 @@ private[nio] class HeapByteBuffer(
 
   @noinline
   def slice(): ByteBuffer =
-    GenHeapBuffer(this).generic_slice()
+    genHeapBuffer.generic_slice()
 
   @noinline
   def duplicate(): ByteBuffer =
-    GenHeapBuffer(this).generic_duplicate()
+    genHeapBuffer.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): ByteBuffer =
-    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+    genHeapBuffer.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Byte =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(b: Byte): ByteBuffer =
-    GenBuffer(this).generic_put(b)
+    genBuffer.generic_put(b)
 
   @noinline
   def get(index: Int): Byte =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, b: Byte): ByteBuffer =
-    GenBuffer(this).generic_put(index, b)
+    genBuffer.generic_put(index, b)
 
   @noinline
   override def get(dst: Array[Byte], offset: Int, length: Int): ByteBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Byte], offset: Int, length: Int): ByteBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): ByteBuffer =
-    GenHeapBuffer(this).generic_compact()
+    genHeapBuffer.generic_compact()
 
   // Here begins the stuff specific to ByteArrays
 
@@ -172,11 +175,11 @@ private[nio] class HeapByteBuffer(
 
   @inline
   private[nio] def load(index: Int): Byte =
-    GenHeapBuffer(this).generic_load(index)
+    genHeapBuffer.generic_load(index)
 
   @inline
   private[nio] def store(index: Int, elem: Byte): Unit =
-    GenHeapBuffer(this).generic_store(index, elem)
+    genHeapBuffer.generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -185,7 +188,7 @@ private[nio] class HeapByteBuffer(
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+    genHeapBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(
@@ -194,7 +197,7 @@ private[nio] class HeapByteBuffer(
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+    genHeapBuffer.generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapByteBuffer {

--- a/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
@@ -14,7 +14,10 @@ private[nio] final class HeapByteBufferCharView private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapCharBufferView =
+  private def genBuffer = GenBuffer[CharBuffer](this)
+  private def genHeapBufferView = GenHeapBufferView[CharBuffer](this)
+  private implicit def newHeapBufferView
+      : GenHeapBufferView.NewHeapBufferView[CharBuffer] =
     HeapByteBufferCharView.NewHeapByteBufferCharView
 
   def isReadOnly(): Boolean = _readOnly
@@ -23,15 +26,15 @@ private[nio] final class HeapByteBufferCharView private (
 
   @noinline
   def slice(): CharBuffer =
-    GenHeapBufferView(this).generic_slice()
+    genHeapBufferView.generic_slice()
 
   @noinline
   def duplicate(): CharBuffer =
-    GenHeapBufferView(this).generic_duplicate()
+    genHeapBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): CharBuffer =
-    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+    genHeapBufferView.generic_asReadOnlyBuffer()
 
   def subSequence(start: Int, end: Int): CharBuffer = {
     if (start < 0 || end < start || end > remaining())
@@ -49,45 +52,45 @@ private[nio] final class HeapByteBufferCharView private (
 
   @noinline
   def get(): Char =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Char): CharBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Char =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Char): CharBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): CharBuffer =
-    GenHeapBufferView(this).generic_compact()
+    genHeapBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenHeapBufferView(this).generic_order()
+    genHeapBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Char =
-    GenHeapBufferView(this).byteArrayBits.loadChar(index)
+    genHeapBufferView.byteArrayBits.loadChar(index)
 
   @inline
   private[nio] def store(index: Int, elem: Char): Unit =
-    GenHeapBufferView(this).byteArrayBits.storeChar(index, elem)
+    genHeapBufferView.byteArrayBits.storeChar(index, elem)
 }
 
 private[nio] object HeapByteBufferCharView {

--- a/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
@@ -13,7 +13,7 @@ private[nio] final class HeapByteBufferDoubleView private (
 
   position(_initialPosition)
   limit(_initialLimit)
-  
+
   private def genBuffer = GenBuffer[DoubleBuffer](this)
   private def genHeapBufferView = GenHeapBufferView[DoubleBuffer](this)
   private implicit def newHeapBufferView

--- a/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
@@ -13,8 +13,11 @@ private[nio] final class HeapByteBufferDoubleView private (
 
   position(_initialPosition)
   limit(_initialLimit)
-
-  private[this] implicit def newHeapDoubleBufferView =
+  
+  private def genBuffer = GenBuffer[DoubleBuffer](this)
+  private def genHeapBufferView = GenHeapBufferView[DoubleBuffer](this)
+  private implicit def newHeapBufferView
+      : GenHeapBufferView.NewHeapBufferView[DoubleBuffer] =
     HeapByteBufferDoubleView.NewHeapByteBufferDoubleView
 
   def isReadOnly(): Boolean = _readOnly
@@ -23,57 +26,57 @@ private[nio] final class HeapByteBufferDoubleView private (
 
   @noinline
   def slice(): DoubleBuffer =
-    GenHeapBufferView(this).generic_slice()
+    genHeapBufferView.generic_slice()
 
   @noinline
   def duplicate(): DoubleBuffer =
-    GenHeapBufferView(this).generic_duplicate()
+    genHeapBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): DoubleBuffer =
-    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+    genHeapBufferView.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Double =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Double): DoubleBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Double =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Double): DoubleBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): DoubleBuffer =
-    GenHeapBufferView(this).generic_compact()
+    genHeapBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenHeapBufferView(this).generic_order()
+    genHeapBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Double =
-    GenHeapBufferView(this).byteArrayBits.loadDouble(index)
+    genHeapBufferView.byteArrayBits.loadDouble(index)
 
   @inline
   private[nio] def store(index: Int, elem: Double): Unit =
-    GenHeapBufferView(this).byteArrayBits.storeDouble(index, elem)
+    genHeapBufferView.byteArrayBits.storeDouble(index, elem)
 }
 
 private[nio] object HeapByteBufferDoubleView {

--- a/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
@@ -14,7 +14,10 @@ private[nio] final class HeapByteBufferFloatView private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapFloatBufferView =
+  private def genBuffer = GenBuffer[FloatBuffer](this)
+  private def genHeapBufferView = GenHeapBufferView[FloatBuffer](this)
+  private implicit def newHeapBufferView
+      : GenHeapBufferView.NewHeapBufferView[FloatBuffer] =
     HeapByteBufferFloatView.NewHeapByteBufferFloatView
 
   def isReadOnly(): Boolean = _readOnly
@@ -23,57 +26,57 @@ private[nio] final class HeapByteBufferFloatView private (
 
   @noinline
   def slice(): FloatBuffer =
-    GenHeapBufferView(this).generic_slice()
+    genHeapBufferView.generic_slice()
 
   @noinline
   def duplicate(): FloatBuffer =
-    GenHeapBufferView(this).generic_duplicate()
+    genHeapBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): FloatBuffer =
-    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+    genHeapBufferView.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Float =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Float): FloatBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Float =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Float): FloatBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): FloatBuffer =
-    GenHeapBufferView(this).generic_compact()
+    genHeapBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenHeapBufferView(this).generic_order()
+    genHeapBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Float =
-    GenHeapBufferView(this).byteArrayBits.loadFloat(index)
+    genHeapBufferView.byteArrayBits.loadFloat(index)
 
   @inline
   private[nio] def store(index: Int, elem: Float): Unit =
-    GenHeapBufferView(this).byteArrayBits.storeFloat(index, elem)
+    genHeapBufferView.byteArrayBits.storeFloat(index, elem)
 }
 
 private[nio] object HeapByteBufferFloatView {

--- a/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
@@ -14,66 +14,69 @@ private[nio] final class HeapByteBufferIntView private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapIntBufferView =
+  private def genBuffer = GenBuffer[IntBuffer](this)
+  private def genHeapBufferView = GenHeapBufferView[IntBuffer](this)
+  private implicit def newHeapBufferView
+      : GenHeapBufferView.NewHeapBufferView[IntBuffer] =
     HeapByteBufferIntView.NewHeapByteBufferIntView
 
-  val isReadOnly: Boolean = _readOnly
+  override def isReadOnly(): Boolean = _readOnly
 
   def isDirect(): Boolean = true
 
   @noinline
   def slice(): IntBuffer =
-    GenHeapBufferView(this).generic_slice()
+    genHeapBufferView.generic_slice()
 
   @noinline
   def duplicate(): IntBuffer =
-    GenHeapBufferView(this).generic_duplicate()
+    genHeapBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): IntBuffer =
-    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+    genHeapBufferView.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Int =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Int): IntBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Int =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Int): IntBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): IntBuffer =
-    GenHeapBufferView(this).generic_compact()
+    genHeapBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenHeapBufferView(this).generic_order()
+    genHeapBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Int =
-    GenHeapBufferView(this).byteArrayBits.loadInt(index)
+    genHeapBufferView.byteArrayBits.loadInt(index)
 
   @inline
   private[nio] def store(index: Int, elem: Int): Unit =
-    GenHeapBufferView(this).byteArrayBits.storeInt(index, elem)
+    genHeapBufferView.byteArrayBits.storeInt(index, elem)
 }
 
 private[nio] object HeapByteBufferIntView {

--- a/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
@@ -14,7 +14,10 @@ private[nio] final class HeapByteBufferLongView private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapLongBufferView =
+  private def genBuffer = GenBuffer[LongBuffer](this)
+  private def genHeapBufferView = GenHeapBufferView[LongBuffer](this)
+  private implicit def newHeapBufferView
+      : GenHeapBufferView.NewHeapBufferView[LongBuffer] =
     HeapByteBufferLongView.NewHeapByteBufferLongView
 
   def isReadOnly(): Boolean = _readOnly
@@ -23,57 +26,57 @@ private[nio] final class HeapByteBufferLongView private (
 
   @noinline
   def slice(): LongBuffer =
-    GenHeapBufferView(this).generic_slice()
+    genHeapBufferView.generic_slice()
 
   @noinline
   def duplicate(): LongBuffer =
-    GenHeapBufferView(this).generic_duplicate()
+    genHeapBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): LongBuffer =
-    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+    genHeapBufferView.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Long =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Long): LongBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Long =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Long): LongBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): LongBuffer =
-    GenHeapBufferView(this).generic_compact()
+    genHeapBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenHeapBufferView(this).generic_order()
+    genHeapBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Long =
-    GenHeapBufferView(this).byteArrayBits.loadLong(index)
+    genHeapBufferView.byteArrayBits.loadLong(index)
 
   @inline
   private[nio] def store(index: Int, elem: Long): Unit =
-    GenHeapBufferView(this).byteArrayBits.storeLong(index, elem)
+    genHeapBufferView.byteArrayBits.storeLong(index, elem)
 }
 
 private[nio] object HeapByteBufferLongView {

--- a/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
@@ -14,7 +14,10 @@ private[nio] final class HeapByteBufferShortView private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapShortBufferView =
+  private def genBuffer = GenBuffer[ShortBuffer](this)
+  private def genHeapBufferView = GenHeapBufferView[ShortBuffer](this)
+  private implicit def newHeapBuffer
+      : GenHeapBufferView.NewHeapBufferView[ShortBuffer] =
     HeapByteBufferShortView.NewHeapByteBufferShortView
 
   def isReadOnly(): Boolean = _readOnly
@@ -23,57 +26,57 @@ private[nio] final class HeapByteBufferShortView private (
 
   @noinline
   def slice(): ShortBuffer =
-    GenHeapBufferView(this).generic_slice()
+    genHeapBufferView.generic_slice()
 
   @noinline
   def duplicate(): ShortBuffer =
-    GenHeapBufferView(this).generic_duplicate()
+    genHeapBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): ShortBuffer =
-    GenHeapBufferView(this).generic_asReadOnlyBuffer()
+    genHeapBufferView.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Short =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Short): ShortBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Short =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Short): ShortBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): ShortBuffer =
-    GenHeapBufferView(this).generic_compact()
+    genHeapBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenHeapBufferView(this).generic_order()
+    genHeapBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Short =
-    GenHeapBufferView(this).byteArrayBits.loadShort(index)
+    genHeapBufferView.byteArrayBits.loadShort(index)
 
   @inline
   private[nio] def store(index: Int, elem: Short): Unit =
-    GenHeapBufferView(this).byteArrayBits.storeShort(index, elem)
+    genHeapBufferView.byteArrayBits.storeShort(index, elem)
 }
 
 private[nio] object HeapByteBufferShortView {

--- a/javalib/src/main/scala/java/nio/HeapCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapCharBuffer.scala
@@ -10,12 +10,15 @@ private[nio] final class HeapCharBuffer private (
     _initialLimit: Int,
     _readOnly: Boolean
 ) extends CharBuffer(_capacity, _array0, null, _arrayOffset0) {
+  private implicit def newHeapBuffer
+      : GenHeapBuffer.NewHeapBuffer[CharBuffer, Char] =
+    HeapCharBuffer.NewHeapCharBuffer
 
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapCharBuffer =
-    HeapCharBuffer.NewHeapCharBuffer
+  private def genBuffer = GenBuffer[CharBuffer](this)
+  private def genHeapBuffer = GenHeapBuffer[CharBuffer](this)
 
   def isReadOnly(): Boolean = _readOnly
 
@@ -23,15 +26,15 @@ private[nio] final class HeapCharBuffer private (
 
   @noinline
   def slice(): CharBuffer =
-    GenHeapBuffer(this).generic_slice()
+    genHeapBuffer.generic_slice()
 
   @noinline
   def duplicate(): CharBuffer =
-    GenHeapBuffer(this).generic_duplicate()
+    genHeapBuffer.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): CharBuffer =
-    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+    genHeapBuffer.generic_asReadOnlyBuffer()
 
   def subSequence(start: Int, end: Int): CharBuffer = {
     if (start < 0 || end < start || end > remaining())
@@ -48,31 +51,31 @@ private[nio] final class HeapCharBuffer private (
 
   @noinline
   def get(): Char =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Char): CharBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Char =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Char): CharBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): CharBuffer =
-    GenHeapBuffer(this).generic_compact()
+    genHeapBuffer.generic_compact()
 
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
@@ -80,11 +83,11 @@ private[nio] final class HeapCharBuffer private (
 
   @inline
   private[nio] def load(index: Int): Char =
-    GenHeapBuffer(this).generic_load(index)
+    genHeapBuffer.generic_load(index)
 
   @inline
   private[nio] def store(index: Int, elem: Char): Unit =
-    GenHeapBuffer(this).generic_store(index, elem)
+    genHeapBuffer.generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -93,7 +96,7 @@ private[nio] final class HeapCharBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+    genHeapBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(
@@ -102,7 +105,7 @@ private[nio] final class HeapCharBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+    genHeapBuffer.generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapCharBuffer {

--- a/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
@@ -9,12 +9,15 @@ private[nio] final class HeapDoubleBuffer private (
     _initialLimit: Int,
     _readOnly: Boolean
 ) extends DoubleBuffer(_capacity, _array0, null, _arrayOffset0) {
+  private implicit def newHeapBuffer
+      : GenHeapBuffer.NewHeapBuffer[DoubleBuffer, Double] =
+    HeapDoubleBuffer.NewHeapDoubleBuffer
 
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapDoubleBuffer =
-    HeapDoubleBuffer.NewHeapDoubleBuffer
+  private def genBuffer = GenBuffer[DoubleBuffer](this)
+  private def genHeapBuffer = GenHeapBuffer[DoubleBuffer](this)
 
   def isReadOnly(): Boolean = _readOnly
 
@@ -22,43 +25,43 @@ private[nio] final class HeapDoubleBuffer private (
 
   @noinline
   def slice(): DoubleBuffer =
-    GenHeapBuffer(this).generic_slice()
+    genHeapBuffer.generic_slice()
 
   @noinline
   def duplicate(): DoubleBuffer =
-    GenHeapBuffer(this).generic_duplicate()
+    genHeapBuffer.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): DoubleBuffer =
-    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+    genHeapBuffer.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Double =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(d: Double): DoubleBuffer =
-    GenBuffer(this).generic_put(d)
+    genBuffer.generic_put(d)
 
   @noinline
   def get(index: Int): Double =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, d: Double): DoubleBuffer =
-    GenBuffer(this).generic_put(index, d)
+    genBuffer.generic_put(index, d)
 
   @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): DoubleBuffer =
-    GenHeapBuffer(this).generic_compact()
+    genHeapBuffer.generic_compact()
 
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
@@ -66,11 +69,11 @@ private[nio] final class HeapDoubleBuffer private (
 
   @inline
   private[nio] def load(index: Int): Double =
-    GenHeapBuffer(this).generic_load(index)
+    genHeapBuffer.generic_load(index)
 
   @inline
   private[nio] def store(index: Int, elem: Double): Unit =
-    GenHeapBuffer(this).generic_store(index, elem)
+    genHeapBuffer.generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -79,7 +82,7 @@ private[nio] final class HeapDoubleBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+    genHeapBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(
@@ -88,7 +91,7 @@ private[nio] final class HeapDoubleBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+    genHeapBuffer.generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapDoubleBuffer {

--- a/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
@@ -13,7 +13,11 @@ private[nio] final class HeapFloatBuffer private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapFloatBuffer =
+
+  private def genBuffer = GenBuffer[FloatBuffer](this)
+  private def genHeapBuffer = GenHeapBuffer[FloatBuffer](this)
+  private[this] implicit def newHeapFloatBuffer
+      : HeapFloatBuffer.NewHeapFloatBuffer.type =
     HeapFloatBuffer.NewHeapFloatBuffer
 
   def isReadOnly(): Boolean = _readOnly
@@ -22,43 +26,43 @@ private[nio] final class HeapFloatBuffer private (
 
   @noinline
   def slice(): FloatBuffer =
-    GenHeapBuffer(this).generic_slice()
+    genHeapBuffer.generic_slice()
 
   @noinline
   def duplicate(): FloatBuffer =
-    GenHeapBuffer(this).generic_duplicate()
+    genHeapBuffer.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): FloatBuffer =
-    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+    genHeapBuffer.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Float =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(f: Float): FloatBuffer =
-    GenBuffer(this).generic_put(f)
+    genBuffer.generic_put(f)
 
   @noinline
   def get(index: Int): Float =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, f: Float): FloatBuffer =
-    GenBuffer(this).generic_put(index, f)
+    genBuffer.generic_put(index, f)
 
   @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): FloatBuffer =
-    GenHeapBuffer(this).generic_compact()
+    genHeapBuffer.generic_compact()
 
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
@@ -66,11 +70,11 @@ private[nio] final class HeapFloatBuffer private (
 
   @inline
   private[nio] def load(index: Int): Float =
-    GenHeapBuffer(this).generic_load(index)
+    genHeapBuffer.generic_load(index)
 
   @inline
   private[nio] def store(index: Int, elem: Float): Unit =
-    GenHeapBuffer(this).generic_store(index, elem)
+    genHeapBuffer.generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -79,7 +83,7 @@ private[nio] final class HeapFloatBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+    genHeapBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(
@@ -88,7 +92,7 @@ private[nio] final class HeapFloatBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+    genHeapBuffer.generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapFloatBuffer {

--- a/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
@@ -13,7 +13,6 @@ private[nio] final class HeapFloatBuffer private (
   position(_initialPosition)
   limit(_initialLimit)
 
-
   private def genBuffer = GenBuffer[FloatBuffer](this)
   private def genHeapBuffer = GenHeapBuffer[FloatBuffer](this)
   private[this] implicit def newHeapFloatBuffer

--- a/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
@@ -13,7 +13,11 @@ private[nio] final class HeapIntBuffer private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapIntBuffer = HeapIntBuffer.NewHeapIntBuffer
+  private def genBuffer = GenBuffer[IntBuffer](this)
+  private def genHeapBuffer = GenHeapBuffer[IntBuffer](this)
+  private implicit def newHeapBuffer
+      : GenHeapBuffer.NewHeapBuffer[IntBuffer, Int] =
+    HeapIntBuffer.NewHeapIntBuffer
 
   def isReadOnly(): Boolean = _readOnly
 
@@ -21,43 +25,43 @@ private[nio] final class HeapIntBuffer private (
 
   @noinline
   def slice(): IntBuffer =
-    GenHeapBuffer(this).generic_slice()
+    genHeapBuffer.generic_slice()
 
   @noinline
   def duplicate(): IntBuffer =
-    GenHeapBuffer(this).generic_duplicate()
+    genHeapBuffer.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): IntBuffer =
-    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+    genHeapBuffer.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Int =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(i: Int): IntBuffer =
-    GenBuffer(this).generic_put(i)
+    genBuffer.generic_put(i)
 
   @noinline
   def get(index: Int): Int =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, i: Int): IntBuffer =
-    GenBuffer(this).generic_put(index, i)
+    genBuffer.generic_put(index, i)
 
   @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): IntBuffer =
-    GenHeapBuffer(this).generic_compact()
+    genHeapBuffer.generic_compact()
 
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
@@ -65,11 +69,11 @@ private[nio] final class HeapIntBuffer private (
 
   @inline
   private[nio] def load(index: Int): Int =
-    GenHeapBuffer(this).generic_load(index)
+    genHeapBuffer.generic_load(index)
 
   @inline
   private[nio] def store(index: Int, elem: Int): Unit =
-    GenHeapBuffer(this).generic_store(index, elem)
+    genHeapBuffer.generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -78,7 +82,7 @@ private[nio] final class HeapIntBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+    genHeapBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(
@@ -87,7 +91,7 @@ private[nio] final class HeapIntBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+    genHeapBuffer.generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapIntBuffer {

--- a/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
@@ -9,10 +9,10 @@ private[nio] final class HeapLongBuffer private (
     _initialLimit: Int,
     _readOnly: Boolean
 ) extends LongBuffer(_capacity, _array0, null, _arrayOffset0) {
-  
+
   position(_initialPosition)
   limit(_initialLimit)
-  
+
   private def genBuffer = GenBuffer[LongBuffer](this)
   private def genHeapBuffer = GenHeapBuffer[LongBuffer](this)
   private implicit def newHeapBuffer

--- a/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
@@ -9,11 +9,14 @@ private[nio] final class HeapLongBuffer private (
     _initialLimit: Int,
     _readOnly: Boolean
 ) extends LongBuffer(_capacity, _array0, null, _arrayOffset0) {
-
+  
   position(_initialPosition)
   limit(_initialLimit)
-
-  private[this] implicit def newHeapLongBuffer =
+  
+  private def genBuffer = GenBuffer[LongBuffer](this)
+  private def genHeapBuffer = GenHeapBuffer[LongBuffer](this)
+  private implicit def newHeapBuffer
+      : GenHeapBuffer.NewHeapBuffer[LongBuffer, Long] =
     HeapLongBuffer.NewHeapLongBuffer
 
   def isReadOnly(): Boolean = _readOnly
@@ -22,43 +25,43 @@ private[nio] final class HeapLongBuffer private (
 
   @noinline
   def slice(): LongBuffer =
-    GenHeapBuffer(this).generic_slice()
+    genHeapBuffer.generic_slice()
 
   @noinline
   def duplicate(): LongBuffer =
-    GenHeapBuffer(this).generic_duplicate()
+    genHeapBuffer.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): LongBuffer =
-    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+    genHeapBuffer.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Long =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(l: Long): LongBuffer =
-    GenBuffer(this).generic_put(l)
+    genBuffer.generic_put(l)
 
   @noinline
   def get(index: Int): Long =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, l: Long): LongBuffer =
-    GenBuffer(this).generic_put(index, l)
+    genBuffer.generic_put(index, l)
 
   @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): LongBuffer =
-    GenHeapBuffer(this).generic_compact()
+    genHeapBuffer.generic_compact()
 
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
@@ -66,11 +69,11 @@ private[nio] final class HeapLongBuffer private (
 
   @inline
   private[nio] def load(index: Int): Long =
-    GenHeapBuffer(this).generic_load(index)
+    genHeapBuffer.generic_load(index)
 
   @inline
   private[nio] def store(index: Int, elem: Long): Unit =
-    GenHeapBuffer(this).generic_store(index, elem)
+    genHeapBuffer.generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -79,7 +82,7 @@ private[nio] final class HeapLongBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+    genHeapBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(
@@ -88,7 +91,7 @@ private[nio] final class HeapLongBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+    genHeapBuffer.generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapLongBuffer {

--- a/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
@@ -9,11 +9,13 @@ private[nio] final class HeapShortBuffer private (
     _initialLimit: Int,
     _readOnly: Boolean
 ) extends ShortBuffer(_capacity, _array0, null, _arrayOffset0) {
-
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newHeapShortBuffer =
+  private def genBuffer = GenBuffer[ShortBuffer](this)
+  private def genHeapBuffer = GenHeapBuffer[ShortBuffer](this)
+  private implicit def newHeapByteBuffer
+      : GenHeapBuffer.NewHeapBuffer[ShortBuffer, Short] =
     HeapShortBuffer.NewHeapShortBuffer
 
   def isReadOnly(): Boolean = _readOnly
@@ -22,43 +24,43 @@ private[nio] final class HeapShortBuffer private (
 
   @noinline
   def slice(): ShortBuffer =
-    GenHeapBuffer(this).generic_slice()
+    genHeapBuffer.generic_slice()
 
   @noinline
   def duplicate(): ShortBuffer =
-    GenHeapBuffer(this).generic_duplicate()
+    genHeapBuffer.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): ShortBuffer =
-    GenHeapBuffer(this).generic_asReadOnlyBuffer()
+    genHeapBuffer.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Short =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(s: Short): ShortBuffer =
-    GenBuffer(this).generic_put(s)
+    genBuffer.generic_put(s)
 
   @noinline
   def get(index: Int): Short =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, s: Short): ShortBuffer =
-    GenBuffer(this).generic_put(index, s)
+    genBuffer.generic_put(index, s)
 
   @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): ShortBuffer =
-    GenHeapBuffer(this).generic_compact()
+    genHeapBuffer.generic_compact()
 
   def order(): ByteOrder = ByteOrder.nativeOrder()
 
@@ -66,11 +68,11 @@ private[nio] final class HeapShortBuffer private (
 
   @inline
   private[nio] def load(index: Int): Short =
-    GenHeapBuffer(this).generic_load(index)
+    genHeapBuffer.generic_load(index)
 
   @inline
   private[nio] def store(index: Int, elem: Short): Unit =
-    GenHeapBuffer(this).generic_store(index, elem)
+    genHeapBuffer.generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -79,7 +81,7 @@ private[nio] final class HeapShortBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_load(startIndex, dst, offset, length)
+    genHeapBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(
@@ -88,7 +90,7 @@ private[nio] final class HeapShortBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenHeapBuffer(this).generic_store(startIndex, src, offset, length)
+    genHeapBuffer.generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object HeapShortBuffer {

--- a/javalib/src/main/scala/java/nio/IntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/IntBuffer.scala
@@ -22,6 +22,7 @@ abstract class IntBuffer private[nio] (
 ) extends Buffer(_capacity)
     with Comparable[IntBuffer] {
 
+  private def genBuffer = GenBuffer[IntBuffer](this)
   private[nio] type ElementType = Int
   private[nio] type BufferType = IntBuffer
 
@@ -43,30 +44,30 @@ abstract class IntBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   def get(dst: Array[Int]): IntBuffer =
     get(dst, 0, dst.length)
 
   @noinline
   def put(src: IntBuffer): IntBuffer =
-    GenBuffer(this).generic_put(src)
+    genBuffer.generic_put(src)
 
   @noinline
   def put(src: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   final def put(src: Array[Int]): IntBuffer =
     put(src, 0, src.length)
 
   @inline final def hasArray(): Boolean =
-    GenBuffer(this).generic_hasArray()
+    genBuffer.generic_hasArray()
 
   @inline final def array(): Array[Int] =
-    GenBuffer(this).generic_array()
+    genBuffer.generic_array()
 
   @inline final def arrayOffset(): Int =
-    GenBuffer(this).generic_arrayOffset()
+    genBuffer.generic_arrayOffset()
 
   @inline override def position(newPosition: Int): IntBuffer = {
     super.position(newPosition)
@@ -114,7 +115,7 @@ abstract class IntBuffer private[nio] (
 
   @noinline
   override def hashCode(): Int =
-    GenBuffer(this).generic_hashCode(IntBuffer.HashSeed)
+    genBuffer.generic_hashCode(IntBuffer.HashSeed)
 
   override def equals(that: Any): Boolean = that match {
     case that: IntBuffer => compareTo(that) == 0
@@ -123,7 +124,7 @@ abstract class IntBuffer private[nio] (
 
   @noinline
   def compareTo(that: IntBuffer): Int =
-    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+    genBuffer.generic_compareTo(that)(_.compareTo(_))
 
   def order(): ByteOrder
 
@@ -140,7 +141,7 @@ abstract class IntBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+    genBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(
@@ -149,5 +150,5 @@ abstract class IntBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_store(startIndex, src, offset, length)
+    genBuffer.generic_store(startIndex, src, offset, length)
 }

--- a/javalib/src/main/scala/java/nio/LongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/LongBuffer.scala
@@ -25,6 +25,8 @@ abstract class LongBuffer private[nio] (
   private[nio] type ElementType = Long
   private[nio] type BufferType = LongBuffer
 
+  private def genBuffer = GenBuffer[LongBuffer](this)
+
   def this(_capacity: Int) = this(_capacity, null, null, -1)
 
   def slice(): LongBuffer
@@ -43,30 +45,30 @@ abstract class LongBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   def get(dst: Array[Long]): LongBuffer =
     get(dst, 0, dst.length)
 
   @noinline
   def put(src: LongBuffer): LongBuffer =
-    GenBuffer(this).generic_put(src)
+    genBuffer.generic_put(src)
 
   @noinline
   def put(src: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   final def put(src: Array[Long]): LongBuffer =
     put(src, 0, src.length)
 
   @inline final def hasArray(): Boolean =
-    GenBuffer(this).generic_hasArray()
+    genBuffer.generic_hasArray()
 
   @inline final def array(): Array[Long] =
-    GenBuffer(this).generic_array()
+    genBuffer.generic_array()
 
   @inline final def arrayOffset(): Int =
-    GenBuffer(this).generic_arrayOffset()
+    genBuffer.generic_arrayOffset()
 
   @inline override def position(newPosition: Int): LongBuffer = {
     super.position(newPosition)
@@ -111,7 +113,7 @@ abstract class LongBuffer private[nio] (
 
   @noinline
   override def hashCode(): Int =
-    GenBuffer(this).generic_hashCode(LongBuffer.HashSeed)
+    genBuffer.generic_hashCode(LongBuffer.HashSeed)
 
   override def equals(that: Any): Boolean = that match {
     case that: LongBuffer => compareTo(that) == 0
@@ -120,7 +122,7 @@ abstract class LongBuffer private[nio] (
 
   @noinline
   def compareTo(that: LongBuffer): Int =
-    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+    genBuffer.generic_compareTo(that)(_.compareTo(_))
 
   def order(): ByteOrder
 
@@ -137,7 +139,7 @@ abstract class LongBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+    genBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(
@@ -146,5 +148,5 @@ abstract class LongBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_store(startIndex, src, offset, length)
+    genBuffer.generic_store(startIndex, src, offset, length)
 }

--- a/javalib/src/main/scala/java/nio/MappedByteBufferCharView.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferCharView.scala
@@ -14,8 +14,11 @@ private[nio] final class MappedByteBufferCharView private (
 
   position(_initialPosition)
   limit(_initialLimit)
-
-  private[this] implicit def newMappedCharBufferView =
+  
+  private def genBuffer = GenBuffer[CharBuffer](this)
+  private def genHeapBufferView = GenMappedBufferView[CharBuffer](this)
+  private implicit def newMappedCharBufferView
+      : GenMappedBufferView.NewMappedBufferView[CharBuffer] =
     MappedByteBufferCharView.NewMappedByteBufferCharView
 
   def isReadOnly(): Boolean = _readOnly
@@ -24,15 +27,15 @@ private[nio] final class MappedByteBufferCharView private (
 
   @noinline
   def slice(): CharBuffer =
-    GenMappedBufferView(this).generic_slice()
+    genHeapBufferView.generic_slice()
 
   @noinline
   def duplicate(): CharBuffer =
-    GenMappedBufferView(this).generic_duplicate()
+    genHeapBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): CharBuffer =
-    GenMappedBufferView(this).generic_asReadOnlyBuffer()
+    genHeapBufferView.generic_asReadOnlyBuffer()
 
   def subSequence(start: Int, end: Int): CharBuffer = {
     if (start < 0 || end < start || end > remaining())
@@ -50,45 +53,45 @@ private[nio] final class MappedByteBufferCharView private (
 
   @noinline
   def get(): Char =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Char): CharBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Char =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Char): CharBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): CharBuffer =
-    GenMappedBufferView(this).generic_compact()
+    genHeapBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenMappedBufferView(this).generic_order()
+    genHeapBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Char =
-    GenMappedBufferView(this).byteArrayBits.loadChar(index)
+    genHeapBufferView.byteArrayBits.loadChar(index)
 
   @inline
   private[nio] def store(index: Int, elem: Char): Unit =
-    GenMappedBufferView(this).byteArrayBits.storeChar(index, elem)
+    genHeapBufferView.byteArrayBits.storeChar(index, elem)
 }
 
 private[nio] object MappedByteBufferCharView {

--- a/javalib/src/main/scala/java/nio/MappedByteBufferCharView.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferCharView.scala
@@ -14,7 +14,7 @@ private[nio] final class MappedByteBufferCharView private (
 
   position(_initialPosition)
   limit(_initialLimit)
-  
+
   private def genBuffer = GenBuffer[CharBuffer](this)
   private def genHeapBufferView = GenMappedBufferView[CharBuffer](this)
   private implicit def newMappedCharBufferView

--- a/javalib/src/main/scala/java/nio/MappedByteBufferDoubleView.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferDoubleView.scala
@@ -15,7 +15,11 @@ private[nio] final class MappedByteBufferDoubleView private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newMappedDoubleBufferView =
+  private def genBuffer = GenBuffer[DoubleBuffer](this)
+  protected def genMappedBufferView =
+    GenMappedBufferView[DoubleBuffer](this)
+  private[this] implicit def newMappedDoubleBufferView
+      : GenMappedBufferView.NewMappedBufferView[DoubleBuffer] =
     MappedByteBufferDoubleView.NewMappedByteBufferDoubleView
 
   def isReadOnly(): Boolean = _readOnly
@@ -24,57 +28,57 @@ private[nio] final class MappedByteBufferDoubleView private (
 
   @noinline
   def slice(): DoubleBuffer =
-    GenMappedBufferView(this).generic_slice()
+    genMappedBufferView.generic_slice()
 
   @noinline
   def duplicate(): DoubleBuffer =
-    GenMappedBufferView(this).generic_duplicate()
+    genMappedBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): DoubleBuffer =
-    GenMappedBufferView(this).generic_asReadOnlyBuffer()
+    genMappedBufferView.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Double =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Double): DoubleBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Double =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Double): DoubleBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Double], offset: Int, length: Int): DoubleBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): DoubleBuffer =
-    GenMappedBufferView(this).generic_compact()
+    genMappedBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenMappedBufferView(this).generic_order()
+    genMappedBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Double =
-    GenMappedBufferView(this).byteArrayBits.loadDouble(index)
+    genMappedBufferView.byteArrayBits.loadDouble(index)
 
   @inline
   private[nio] def store(index: Int, elem: Double): Unit =
-    GenMappedBufferView(this).byteArrayBits.storeDouble(index, elem)
+    genMappedBufferView.byteArrayBits.storeDouble(index, elem)
 }
 
 private[nio] object MappedByteBufferDoubleView {

--- a/javalib/src/main/scala/java/nio/MappedByteBufferFloatView.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferFloatView.scala
@@ -15,7 +15,10 @@ private[nio] final class MappedByteBufferFloatView private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newMappedFloatBufferView =
+  private def genBuffer = GenBuffer[FloatBuffer](this)
+  protected def genMappedBufferView = GenMappedBufferView[FloatBuffer](this)
+  private[this] implicit def newMappedFloatBufferView
+      : GenMappedBufferView.NewMappedBufferView[FloatBuffer] =
     MappedByteBufferFloatView.NewMappedByteBufferFloatView
 
   def isReadOnly(): Boolean = _readOnly
@@ -24,57 +27,57 @@ private[nio] final class MappedByteBufferFloatView private (
 
   @noinline
   def slice(): FloatBuffer =
-    GenMappedBufferView(this).generic_slice()
+    genMappedBufferView.generic_slice()
 
   @noinline
   def duplicate(): FloatBuffer =
-    GenMappedBufferView(this).generic_duplicate()
+    genMappedBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): FloatBuffer =
-    GenMappedBufferView(this).generic_asReadOnlyBuffer()
+    genMappedBufferView.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Float =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Float): FloatBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Float =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Float): FloatBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Float], offset: Int, length: Int): FloatBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): FloatBuffer =
-    GenMappedBufferView(this).generic_compact()
+    genMappedBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenMappedBufferView(this).generic_order()
+    genMappedBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Float =
-    GenMappedBufferView(this).byteArrayBits.loadFloat(index)
+    genMappedBufferView.byteArrayBits.loadFloat(index)
 
   @inline
   private[nio] def store(index: Int, elem: Float): Unit =
-    GenMappedBufferView(this).byteArrayBits.storeFloat(index, elem)
+    genMappedBufferView.byteArrayBits.storeFloat(index, elem)
 }
 
 private[nio] object MappedByteBufferFloatView {

--- a/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferImpl.scala
@@ -40,7 +40,10 @@ private class MappedByteBufferImpl(
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newMappedByteBuffer =
+  private def genBuffer = GenBuffer[ByteBuffer](this)
+  private def genMappedBuffer = GenMappedBuffer[ByteBuffer](this)
+  private[this] implicit def newMappedByteBuffer
+      : GenMappedBuffer.NewMappedBuffer[ByteBuffer, Byte] =
     MappedByteBufferImpl.NewMappedByteBuffer
 
   override def force(): MappedByteBuffer = {
@@ -58,43 +61,43 @@ private class MappedByteBufferImpl(
 
   @noinline
   def slice(): ByteBuffer =
-    GenMappedBuffer(this).generic_slice()
+    genMappedBuffer.generic_slice()
 
   @noinline
   def duplicate(): ByteBuffer =
-    GenMappedBuffer(this).generic_duplicate()
+    genMappedBuffer.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): ByteBuffer =
-    GenMappedBuffer(this).generic_asReadOnlyBuffer()
+    genMappedBuffer.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Byte =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(b: Byte): ByteBuffer =
-    GenBuffer(this).generic_put(b)
+    genBuffer.generic_put(b)
 
   @noinline
   def get(index: Int): Byte =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, b: Byte): ByteBuffer =
-    GenBuffer(this).generic_put(index, b)
+    genBuffer.generic_put(index, b)
 
   @noinline
   override def get(dst: Array[Byte], offset: Int, length: Int): ByteBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Byte], offset: Int, length: Int): ByteBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): ByteBuffer =
-    GenMappedBuffer(this).generic_compact()
+    genMappedBuffer.generic_compact()
 
   // Here begins the stuff specific to ByteArrays
 
@@ -201,11 +204,11 @@ private class MappedByteBufferImpl(
 
   @inline
   private[nio] def load(index: Int): Byte =
-    GenMappedBuffer(this).generic_load(index)
+    genMappedBuffer.generic_load(index)
 
   @inline
   private[nio] def store(index: Int, elem: Byte): Unit =
-    GenMappedBuffer(this).generic_store(index, elem)
+    genMappedBuffer.generic_store(index, elem)
 
   @inline
   override private[nio] def load(
@@ -214,7 +217,7 @@ private class MappedByteBufferImpl(
       offset: Int,
       length: Int
   ): Unit =
-    GenMappedBuffer(this).generic_load(startIndex, dst, offset, length)
+    genMappedBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(
@@ -223,7 +226,7 @@ private class MappedByteBufferImpl(
       offset: Int,
       length: Int
   ): Unit =
-    GenMappedBuffer(this).generic_store(startIndex, src, offset, length)
+    genMappedBuffer.generic_store(startIndex, src, offset, length)
 }
 
 private[nio] object MappedByteBufferImpl {
@@ -256,10 +259,12 @@ private[nio] object MappedByteBufferImpl {
       fd: FileDescriptor,
       mode: MapMode
   ): MappedByteBufferData = {
-    val (flProtect: DWord, dwDesiredAccess: DWord) =
-      if (mode eq MapMode.PRIVATE) (PAGE_WRITECOPY, FILE_MAP_COPY)
-      else if (mode eq MapMode.READ_ONLY) (PAGE_READONLY, FILE_MAP_READ)
-      else if (mode eq MapMode.READ_WRITE) (PAGE_READWRITE, FILE_MAP_WRITE)
+    val (flProtect: DWord, dwDesiredAccess: DWord) = mode match {
+      case MapMode.PRIVATE    => (PAGE_WRITECOPY, FILE_MAP_COPY)
+      case MapMode.READ_ONLY  => (PAGE_READONLY, FILE_MAP_READ)
+      case MapMode.READ_WRITE => (PAGE_READWRITE, FILE_MAP_WRITE)
+      case _ => throw new IllegalStateException("Unknown MapMode")
+    }
 
     val mappingHandle =
       CreateFileMappingA(
@@ -293,11 +298,12 @@ private[nio] object MappedByteBufferImpl {
       fd: FileDescriptor,
       mode: MapMode
   ): MappedByteBufferData = {
-    val (prot: Int, isPrivate: Int) =
-      if (mode eq MapMode.PRIVATE) (PROT_WRITE, MAP_PRIVATE)
-      else if (mode eq MapMode.READ_ONLY) (PROT_READ, MAP_SHARED)
-      else if (mode eq MapMode.READ_WRITE) (PROT_WRITE, MAP_SHARED)
-
+    val (prot: Int, isPrivate: Int) = mode match {
+      case MapMode.PRIVATE    => (PROT_WRITE, MAP_PRIVATE)
+      case MapMode.READ_ONLY  => (PROT_READ, MAP_SHARED)
+      case MapMode.READ_WRITE => (PROT_WRITE, MAP_SHARED)
+      case _ => throw new IllegalStateException("Unknown MapMode")
+    }
     val ptr = mmap(
       null,
       size.toUInt,

--- a/javalib/src/main/scala/java/nio/MappedByteBufferIntView.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferIntView.scala
@@ -15,7 +15,10 @@ private[nio] final class MappedByteBufferIntView private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newMappedIntBufferView =
+  private def genBuffer = GenBuffer[IntBuffer](this)
+  protected def genMappedBufferView = GenMappedBufferView[IntBuffer](this)
+  private implicit def newMappedIntBufferView
+      : GenMappedBufferView.NewMappedBufferView[IntBuffer] =
     MappedByteBufferIntView.NewMappedByteBufferIntView
 
   def isReadOnly(): Boolean = _readOnly
@@ -24,57 +27,57 @@ private[nio] final class MappedByteBufferIntView private (
 
   @noinline
   def slice(): IntBuffer =
-    GenMappedBufferView(this).generic_slice()
+    genMappedBufferView.generic_slice()
 
   @noinline
   def duplicate(): IntBuffer =
-    GenMappedBufferView(this).generic_duplicate()
+    genMappedBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): IntBuffer =
-    GenMappedBufferView(this).generic_asReadOnlyBuffer()
+    genMappedBufferView.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Int =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Int): IntBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Int =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Int): IntBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Int], offset: Int, length: Int): IntBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): IntBuffer =
-    GenMappedBufferView(this).generic_compact()
+    genMappedBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenMappedBufferView(this).generic_order()
+    genMappedBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Int =
-    GenMappedBufferView(this).byteArrayBits.loadInt(index)
+    genMappedBufferView.byteArrayBits.loadInt(index)
 
   @inline
   private[nio] def store(index: Int, elem: Int): Unit =
-    GenMappedBufferView(this).byteArrayBits.storeInt(index, elem)
+    genMappedBufferView.byteArrayBits.storeInt(index, elem)
 }
 
 private[nio] object MappedByteBufferIntView {

--- a/javalib/src/main/scala/java/nio/MappedByteBufferLongView.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferLongView.scala
@@ -15,7 +15,10 @@ private[nio] final class MappedByteBufferLongView private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newMappedLongBufferView =
+  private def genBuffer = GenBuffer[LongBuffer](this)
+  protected def genMappedBufferView = GenMappedBufferView[LongBuffer](this)
+  private[this] implicit def newMappedLongBufferView
+      : GenMappedBufferView.NewMappedBufferView[LongBuffer] =
     MappedByteBufferLongView.NewMappedByteBufferLongView
 
   def isReadOnly(): Boolean = _readOnly
@@ -23,58 +26,56 @@ private[nio] final class MappedByteBufferLongView private (
   def isDirect(): Boolean = true
 
   @noinline
-  def slice(): LongBuffer =
-    GenMappedBufferView(this).generic_slice()
+  def slice(): LongBuffer = genMappedBufferView.generic_slice()
 
   @noinline
-  def duplicate(): LongBuffer =
-    GenMappedBufferView(this).generic_duplicate()
+  def duplicate(): LongBuffer = genMappedBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): LongBuffer =
-    GenMappedBufferView(this).generic_asReadOnlyBuffer()
+    genMappedBufferView.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Long =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Long): LongBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Long =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Long): LongBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Long], offset: Int, length: Int): LongBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): LongBuffer =
-    GenMappedBufferView(this).generic_compact()
+    genMappedBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenMappedBufferView(this).generic_order()
+    genMappedBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Long =
-    GenMappedBufferView(this).byteArrayBits.loadLong(index)
+    genMappedBufferView.byteArrayBits.loadLong(index)
 
   @inline
   private[nio] def store(index: Int, elem: Long): Unit =
-    GenMappedBufferView(this).byteArrayBits.storeLong(index, elem)
+    genMappedBufferView.byteArrayBits.storeLong(index, elem)
 }
 
 private[nio] object MappedByteBufferLongView {

--- a/javalib/src/main/scala/java/nio/MappedByteBufferShortView.scala
+++ b/javalib/src/main/scala/java/nio/MappedByteBufferShortView.scala
@@ -15,7 +15,11 @@ private[nio] final class MappedByteBufferShortView private (
   position(_initialPosition)
   limit(_initialLimit)
 
-  private[this] implicit def newMappedShortBufferView =
+  private def genBuffer = GenBuffer[ShortBuffer](this)
+  protected def genMappedBufferView =
+    GenMappedBufferView[ShortBuffer](this)
+  private[this] implicit def newMappedShortBufferView
+      : GenMappedBufferView.NewMappedBufferView[ShortBuffer] =
     MappedByteBufferShortView.NewMappedByteBufferShortView
 
   def isReadOnly(): Boolean = _readOnly
@@ -24,57 +28,57 @@ private[nio] final class MappedByteBufferShortView private (
 
   @noinline
   def slice(): ShortBuffer =
-    GenMappedBufferView(this).generic_slice()
+    genMappedBufferView.generic_slice()
 
   @noinline
   def duplicate(): ShortBuffer =
-    GenMappedBufferView(this).generic_duplicate()
+    genMappedBufferView.generic_duplicate()
 
   @noinline
   def asReadOnlyBuffer(): ShortBuffer =
-    GenMappedBufferView(this).generic_asReadOnlyBuffer()
+    genMappedBufferView.generic_asReadOnlyBuffer()
 
   @noinline
   def get(): Short =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   @noinline
   def put(c: Short): ShortBuffer =
-    GenBuffer(this).generic_put(c)
+    genBuffer.generic_put(c)
 
   @noinline
   def get(index: Int): Short =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   @noinline
   def put(index: Int, c: Short): ShortBuffer =
-    GenBuffer(this).generic_put(index, c)
+    genBuffer.generic_put(index, c)
 
   @noinline
   override def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   @noinline
   override def put(src: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   @noinline
   def compact(): ShortBuffer =
-    GenMappedBufferView(this).generic_compact()
+    genMappedBufferView.generic_compact()
 
   @noinline
   def order(): ByteOrder =
-    GenMappedBufferView(this).generic_order()
+    genMappedBufferView.generic_order()
 
   // Private API
 
   @inline
   private[nio] def load(index: Int): Short =
-    GenMappedBufferView(this).byteArrayBits.loadShort(index)
+    genMappedBufferView.byteArrayBits.loadShort(index)
 
   @inline
   private[nio] def store(index: Int, elem: Short): Unit =
-    GenMappedBufferView(this).byteArrayBits.storeShort(index, elem)
+    genMappedBufferView.byteArrayBits.storeShort(index, elem)
 }
 
 private[nio] object MappedByteBufferShortView {

--- a/javalib/src/main/scala/java/nio/ShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ShortBuffer.scala
@@ -25,6 +25,8 @@ abstract class ShortBuffer private[nio] (
   private[nio] type ElementType = Short
   private[nio] type BufferType = ShortBuffer
 
+  private def genBuffer = GenBuffer[ShortBuffer](this)
+
   def this(_capacity: Int) = this(_capacity, null, null, -1)
 
   def slice(): ShortBuffer
@@ -43,30 +45,30 @@ abstract class ShortBuffer private[nio] (
 
   @noinline
   def get(dst: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   def get(dst: Array[Short]): ShortBuffer =
     get(dst, 0, dst.length)
 
   @noinline
   def put(src: ShortBuffer): ShortBuffer =
-    GenBuffer(this).generic_put(src)
+    genBuffer.generic_put(src)
 
   @noinline
   def put(src: Array[Short], offset: Int, length: Int): ShortBuffer =
-    GenBuffer(this).generic_put(src, offset, length)
+    genBuffer.generic_put(src, offset, length)
 
   final def put(src: Array[Short]): ShortBuffer =
     put(src, 0, src.length)
 
   @inline final def hasArray(): Boolean =
-    GenBuffer(this).generic_hasArray()
+    genBuffer.generic_hasArray()
 
   @inline final def array(): Array[Short] =
-    GenBuffer(this).generic_array()
+    genBuffer.generic_array()
 
   @inline final def arrayOffset(): Int =
-    GenBuffer(this).generic_arrayOffset()
+    genBuffer.generic_arrayOffset()
 
   @inline override def position(newPosition: Int): ShortBuffer = {
     super.position(newPosition)
@@ -111,7 +113,7 @@ abstract class ShortBuffer private[nio] (
 
   @noinline
   override def hashCode(): Int =
-    GenBuffer(this).generic_hashCode(ShortBuffer.HashSeed)
+    genBuffer.generic_hashCode(ShortBuffer.HashSeed)
 
   override def equals(that: Any): Boolean = that match {
     case that: ShortBuffer => compareTo(that) == 0
@@ -120,7 +122,7 @@ abstract class ShortBuffer private[nio] (
 
   @noinline
   def compareTo(that: ShortBuffer): Int =
-    GenBuffer(this).generic_compareTo(that)(_.compareTo(_))
+    genBuffer.generic_compareTo(that)(_.compareTo(_))
 
   def order(): ByteOrder
 
@@ -137,7 +139,7 @@ abstract class ShortBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+    genBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   private[nio] def store(
@@ -146,5 +148,5 @@ abstract class ShortBuffer private[nio] (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_store(startIndex, src, offset, length)
+    genBuffer.generic_store(startIndex, src, offset, length)
 }

--- a/javalib/src/main/scala/java/nio/StringCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/StringCharBuffer.scala
@@ -13,6 +13,8 @@ private[nio] final class StringCharBuffer private (
   position(_initialPosition)
   limit(_initialLimit)
 
+  private def genBuffer = GenBuffer[CharBuffer](this)
+
   def isReadOnly(): Boolean = true
 
   def isDirect(): Boolean = false
@@ -45,21 +47,21 @@ private[nio] final class StringCharBuffer private (
 
   @noinline
   def get(): Char =
-    GenBuffer(this).generic_get()
+    genBuffer.generic_get()
 
   def put(c: Char): CharBuffer =
     throw new ReadOnlyBufferException
 
   @noinline
   def get(index: Int): Char =
-    GenBuffer(this).generic_get(index)
+    genBuffer.generic_get(index)
 
   def put(index: Int, c: Char): CharBuffer =
     throw new ReadOnlyBufferException
 
   @noinline
   override def get(dst: Array[Char], offset: Int, length: Int): CharBuffer =
-    GenBuffer(this).generic_get(dst, offset, length)
+    genBuffer.generic_get(dst, offset, length)
 
   override def put(src: Array[Char], offset: Int, length: Int): CharBuffer =
     throw new ReadOnlyBufferException
@@ -91,7 +93,7 @@ private[nio] final class StringCharBuffer private (
       offset: Int,
       length: Int
   ): Unit =
-    GenBuffer(this).generic_load(startIndex, dst, offset, length)
+    genBuffer.generic_load(startIndex, dst, offset, length)
 
   @inline
   override private[nio] def store(

--- a/javalib/src/main/scala/java/nio/channels/FileLock.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileLock.scala
@@ -1,7 +1,7 @@
 package java.nio.channels
 
 abstract class FileLock private (
-    channel: Channel,
+    _channel: Channel,
     final val position: Long,
     final val size: Long,
     shared: Boolean
@@ -24,13 +24,13 @@ abstract class FileLock private (
   require(position >= 0 && size >= 0, "position and size must be non negative")
 
   final def channel(): FileChannel =
-    channel match {
+    _channel match {
       case fc: FileChannel => fc
       case _               => null
     }
 
   def acquiredBy(): Channel =
-    channel
+    _channel
 
   final def isShared(): Boolean =
     shared
@@ -46,6 +46,6 @@ abstract class FileLock private (
     release()
 
   override final def toString(): String =
-    s"FileLock($channel, $position, $size, $shared), isValid = ${isValid()}"
+    s"FileLock(${_channel}, $position, $size, $shared), isValid = ${isValid()}"
 
 }

--- a/javalib/src/main/scala/java/nio/file/DirectoryIteratorException.scala
+++ b/javalib/src/main/scala/java/nio/file/DirectoryIteratorException.scala
@@ -3,5 +3,5 @@ package java.nio.file
 import java.io.IOException
 import java.util.ConcurrentModificationException
 
-class DirectoryIteratorException(override val getCause: IOException)
-    extends ConcurrentModificationException(getCause)
+class DirectoryIteratorException(cause: IOException)
+    extends ConcurrentModificationException(cause)

--- a/javalib/src/main/scala/java/nio/file/StandardFileWatchEventKinds.scala
+++ b/javalib/src/main/scala/java/nio/file/StandardFileWatchEventKinds.scala
@@ -3,25 +3,25 @@ package java.nio.file
 object StandardWatchEventKinds {
   val ENTRY_CREATE =
     new WatchEvent.Kind[Path] {
-      override val name = "ENTRY_CREATE"
-      override val `type` = classOf[Path]
+      override def name() = "ENTRY_CREATE"
+      override def `type`() = classOf[Path]
     }
 
   val ENTRY_DELETE =
     new WatchEvent.Kind[Path] {
-      override val name = "ENTRY_DELETE"
-      override val `type` = classOf[Path]
+      override def name() = "ENTRY_DELETE"
+      override def `type`() = classOf[Path]
     }
 
   val ENTRY_MODIFY =
     new WatchEvent.Kind[Path] {
-      override val name = "ENTRY_MODIFY"
-      override val `type` = classOf[Path]
+      override def name() = "ENTRY_MODIFY"
+      override def `type`() = classOf[Path]
     }
 
   val OVERFLOW =
     new WatchEvent.Kind[Object] {
-      override val name = "OVERFLOW"
-      override val `type` = classOf[Object]
+      override def name() = "OVERFLOW"
+      override def `type`() = classOf[Object]
     }
 }

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -19,7 +19,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
   private def throwIOException() =
     throw PosixException(path.toString, errno.errno)
 
-  override val name: String = "posix"
+  override def name(): String = "posix"
 
   override def setTimes(
       lastModifiedTime: FileTime,
@@ -107,17 +107,17 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
 
       override def fileKey() = st_ino.asInstanceOf[Object]
 
-      override lazy val isDirectory =
-        stat.S_ISDIR(st_mode) == 1
+      private lazy val isDir = stat.S_ISDIR(st_mode) == 1
+      override def isDirectory() = isDir
 
-      override lazy val isRegularFile =
-        stat.S_ISREG(st_mode) == 1
+      private lazy val isRegular = stat.S_ISREG(st_mode) == 1
+      override def isRegularFile() = isRegular
 
-      override lazy val isSymbolicLink =
-        stat.S_ISLNK(st_mode) == 1
+      private lazy val isSymLink = stat.S_ISLNK(st_mode) == 1
+      override def isSymbolicLink() = isSymLink
 
-      override lazy val isOther =
-        !isDirectory && !isRegularFile && !isSymbolicLink
+      override def isOther() =
+        !isDirectory() && !isRegularFile() && !isSymbolicLink()
 
       override def lastAccessTime() =
         FileTime.from(st_atime, TimeUnit.SECONDS)
@@ -159,10 +159,10 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
         "lastAccessTime" -> attrs.lastAccessTime(),
         "creationTime" -> attrs.creationTime(),
         "size" -> Long.box(attrs.size()),
-        "isRegularFile" -> Boolean.box(attrs.isRegularFile),
-        "isDirectory" -> Boolean.box(attrs.isDirectory),
-        "isSymbolicLink" -> Boolean.box(attrs.isSymbolicLink),
-        "isOther" -> Boolean.box(attrs.isOther),
+        "isRegularFile" -> Boolean.box(attrs.isRegularFile()),
+        "isDirectory" -> Boolean.box(attrs.isDirectory()),
+        "isSymbolicLink" -> Boolean.box(attrs.isSymbolicLink()),
+        "isOther" -> Boolean.box(attrs.isOther()),
         "fileKey" -> attrs.fileKey(),
         "permissions" -> attrs.permissions(),
         "group" -> attrs.group()

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFilePermissions.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFilePermissions.scala
@@ -16,9 +16,10 @@ object PosixFilePermissions {
       val set = new HashSet[PosixFilePermission]()
       var i = 0
       while (i < 3) {
-        if (isR(perms, i)) set.add(PosixFilePermission.values()(3 * i))
-        if (isW(perms, i)) set.add(PosixFilePermission.values()(3 * i + 1))
-        if (isX(perms, i)) set.add(PosixFilePermission.values()(3 * i + 2))
+        val permissions = PosixFilePermission.values
+        if (isR(perms, i)) set.add(permissions(3 * i))
+        if (isW(perms, i)) set.add(permissions(3 * i + 1))
+        if (isX(perms, i)) set.add(permissions(3 * i + 2))
         i += 1
       }
       set

--- a/javalib/src/main/scala/java/util/AbstractList.scala
+++ b/javalib/src/main/scala/java/util/AbstractList.scala
@@ -223,7 +223,7 @@ private abstract class AbstractListView[E](
 private class BackedUpListIterator[E](
     innerIterator: ListIterator[E],
     fromIndex: Int,
-    override protected var end: Int
+    protected var end: Int
 ) extends ListIterator[E]
     with SizeChangeEvent {
 

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -226,7 +226,7 @@ class ArrayDeque[E] private (private val inner: ArrayList[E])
     inner.toArray()
   }
 
-  override def toArray[T](a: Array[T]): Array[T] = {
+  override def toArray[T <: AnyRef](a: Array[T]): Array[T] = {
     inner.toArray(a)
   }
 }

--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -85,7 +85,7 @@ class ArrayList[E] private (
   override def toArray(): Array[AnyRef] =
     inner.slice(0, _size).map(_.asInstanceOf[AnyRef])
 
-  override def toArray[T](a: Array[T]): Array[T] =
+  override def toArray[T <: AnyRef](a: Array[T]): Array[T] =
     if (a == null)
       throw new NullPointerException
     else if (a.length < size())

--- a/javalib/src/main/scala/java/util/HashMap.scala
+++ b/javalib/src/main/scala/java/util/HashMap.scala
@@ -93,7 +93,12 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Float)
         val iter = m.nodeIterator()
         while (iter.hasNext()) {
           val next = iter.next()
-          put0(next.key, next.value, next.hash, ifAbsent = false)
+          put0(
+            next.key.asInstanceOf[K],
+            next.value.asInstanceOf[V],
+            next.hash,
+            ifAbsent = false
+          )
         }
       case _ =>
         super.putAll(m)

--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -337,6 +337,13 @@ class Properties(protected val defaults: Properties)
 
     while (index < length) {
       val ch = string.charAt(index)
+      def fallback = {
+        if (toHex && (ch < 0x20 || ch > 0x7e)) {
+          buffer.append(unicodeToHexaDecimal(ch))
+        } else {
+          buffer.append(ch)
+        }
+      }
       (ch: @switch) match {
         case '\t' =>
           buffer.append("\\t")
@@ -349,14 +356,11 @@ class Properties(protected val defaults: Properties)
         case '\\' | '#' | '!' | '=' | ':' =>
           buffer.append('\\')
           buffer.append(ch)
-        case ' ' if isKey =>
-          buffer.append("\\ ")
+        case ' ' =>
+          if (isKey) buffer.append("\\ ")
+          else fallback
         case _ =>
-          if (toHex && (ch < 0x20 || ch > 0x7e)) {
-            buffer.append(unicodeToHexaDecimal(ch))
-          } else {
-            buffer.append(ch)
-          }
+          fallback
       }
       index += 1
     }

--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -94,11 +94,12 @@ class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
      * ones.
      * Rejection sampling throws away about 20% of the pairs.
      */
-    do {
+    while ({
       x = nextDouble() * 2 - 1
       y = nextDouble() * 2 - 1
       rds = x * x + y * y
-    } while (rds == 0 || rds > 1)
+      rds == 0 || rds > 1
+    }) ()
 
     val c = Math.sqrt(-2 * Math.log(rds) / rds)
 

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongArray.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongArray.scala
@@ -1,12 +1,12 @@
 package java.util.concurrent.atomic
 
-class AtomicLongArray(length: Int) extends Serializable {
+class AtomicLongArray(_length: Int) extends Serializable {
   def this(array: Array[Long]) = {
     this(array.size)
-    System.arraycopy(array, 0, inner, 0, length)
+    System.arraycopy(array, 0, inner, 0, _length)
   }
 
-  private val inner: Array[Long] = new Array[Long](length)
+  private val inner: Array[Long] = new Array[Long](_length)
 
   final def length(): Int =
     inner.length

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceArray.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceArray.scala
@@ -1,13 +1,13 @@
 package java.util.concurrent.atomic
 
-class AtomicReferenceArray[E <: AnyRef](length: Int) extends Serializable {
+class AtomicReferenceArray[E <: AnyRef](_length: Int) extends Serializable {
 
   def this(array: Array[E]) = {
     this(array.size)
-    System.arraycopy(array, 0, inner, 0, length)
+    System.arraycopy(array, 0, inner, 0, _length)
   }
 
-  private val inner: Array[AnyRef] = new Array[AnyRef](length)
+  private val inner: Array[AnyRef] = new Array[AnyRef](_length)
 
   final def length(): Int =
     inner.length

--- a/javalib/src/main/scala/java/util/zip/DeflaterOutputStream.scala
+++ b/javalib/src/main/scala/java/util/zip/DeflaterOutputStream.scala
@@ -31,10 +31,11 @@ class DeflaterOutputStream(
   def this(out: OutputStream) = this(out, false)
 
   protected def deflate(): Unit = {
-    do {
+    while ({
       val len = `def`.deflate(buf)
       out.write(buf, 0, len)
-    } while (!`def`.needsInput())
+      !`def`.needsInput()
+    }) ()
   }
 
   override def close(): Unit = {

--- a/javalib/src/main/scala/java/util/zip/InflaterInputStream.scala
+++ b/javalib/src/main/scala/java/util/zip/InflaterInputStream.scala
@@ -59,7 +59,7 @@ class InflaterInputStream private (
       throw new ArrayIndexOutOfBoundsException()
     }
 
-    do {
+    while ({
       if (inf.needsInput()) {
         fill()
       }
@@ -88,7 +88,8 @@ class InflaterInputStream private (
           }
           throw new IOException().initCause(e).asInstanceOf[IOException]
       }
-    } while (true)
+      true
+    }) ()
 
     throw new IllegalStateException()
   }

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -175,9 +175,10 @@ object FileHelpers {
       val tmpDir = Option(dir).fold(tempDir)(_.toString)
       val newSuffix = Option(suffix).getOrElse(".tmp")
       var result: File = null
-      do {
+      while ({
         result = genTempFile(prefix, newSuffix, tmpDir)
-      } while (!createNewFile(result.toString, throwOnError))
+        !createNewFile(result.toString, throwOnError)
+      }) ()
       result
     }
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
@@ -29,12 +29,13 @@ import scala.scalanative.posix.sys.statvfs
 import scalanative.annotation.stub
 
 class UnixFileSystem(
-    override val provider: FileSystemProvider,
+    fsProvider: FileSystemProvider,
     val root: String,
     val defaultDirectory: String
 ) extends FileSystem {
   private var closed: Boolean = false
 
+  override def provider(): FileSystemProvider = fsProvider
   override def close(): Unit =
     closed = true
 

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixPath.scala
@@ -106,7 +106,7 @@ class UnixPath(private val fs: UnixFileSystem, rawPath: String) extends Path {
     new UnixPath(fs, (beginIndex until endIndex).map(getName).mkString("/"))
 
   override def startsWith(other: Path): Boolean =
-    if (fs.provider == other.getFileSystem().provider()) {
+    if (fs.provider() == other.getFileSystem().provider()) {
       val otherLength = other.getNameCount()
       val thisLength = getNameCount()
 
@@ -123,7 +123,7 @@ class UnixPath(private val fs: UnixFileSystem, rawPath: String) extends Path {
     startsWith(new UnixPath(fs, other))
 
   override def endsWith(other: Path): Boolean =
-    if (fs.provider == other.getFileSystem().provider()) {
+    if (fs.provider() == other.getFileSystem().provider()) {
       val otherLength = other.getNameCount()
       val thisLength = getNameCount()
       if (otherLength > thisLength) false
@@ -210,7 +210,7 @@ class UnixPath(private val fs: UnixFileSystem, rawPath: String) extends Path {
     }
 
   override def compareTo(other: Path): Int =
-    if (fs.provider == other.getFileSystem().provider()) {
+    if (fs.provider() == other.getFileSystem().provider()) {
       this.toString().compareTo(other.toString)
     } else {
       throw new ClassCastException()

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixPath.scala
@@ -15,18 +15,20 @@ class UnixPath(private val fs: UnixFileSystem, rawPath: String) extends Path {
     else {
       var i = 0
       var count = 1
-      do {
+      while ({
         count += 1
         i = path.indexOf('/', i + 1)
-      } while (i != -1)
+        i != -1
+      }) ()
       val result = new Array[Int](count)
       i = if (path.charAt(0) == '/') 0 else -1
       var j = 0
-      do {
+      while ({
         result(j) = i
         i = path.indexOf('/', i + 1)
         j += 1
-      } while (i != -1)
+        i != -1
+      }) ()
       result(count - 1) = path.length
       result
     }

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
@@ -21,9 +21,10 @@ import scalanative.annotation.stub
 import scalanative.windows.FileApi._
 import scala.annotation.tailrec
 
-class WindowsFileSystem(override val provider: WindowsFileSystemProvider)
+class WindowsFileSystem(fsProvider: WindowsFileSystemProvider)
     extends FileSystem {
 
+  override def provider(): WindowsFileSystemProvider = fsProvider
   override def close(): Unit = throw new UnsupportedOperationException()
 
   @stub

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
@@ -95,7 +95,7 @@ class WindowsPath private[windows] (
     new WindowsPath(segments.slice(beginIndex, endIndex))
 
   override def startsWith(other: Path): Boolean =
-    if (fs.provider == other.getFileSystem().provider()) {
+    if (fs.provider() == other.getFileSystem().provider()) {
       val otherLength = other.getNameCount()
       val thisLength = getNameCount()
 
@@ -112,7 +112,7 @@ class WindowsPath private[windows] (
     startsWith(WindowsPathParser(other))
 
   override def endsWith(other: Path): Boolean =
-    if (fs.provider == other.getFileSystem().provider()) {
+    if (fs.provider() == other.getFileSystem().provider()) {
       val otherLength = other.getNameCount()
       val thisLength = getNameCount()
       if (otherLength > thisLength) false
@@ -223,7 +223,7 @@ class WindowsPath private[windows] (
     }
 
   override def compareTo(other: Path): Int =
-    if (fs.provider == other.getFileSystem().provider()) {
+    if (fs.provider() == other.getFileSystem().provider()) {
       this.toString().compareTo(other.toString)
     } else {
       throw new ClassCastException()

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipalLookupService.scala
@@ -17,8 +17,6 @@ object WindowsUserPrincipalLookupService extends UserPrincipalLookupService {
     lookupByName(name) match {
       case Success(user: WindowsUserPrincipal.User) => user
       case other =>
-        println(name)
-        println(other)
         throw new UserPrincipalNotFoundException(name)
     }
   }


### PR DESCRIPTION
This PR introduces a series of fixes allowing us to compile `javalib` project with Scala 3 compiler

* Replaced usages do-while loops with `while-do` 
* Ensured correct types (coercion)
* Ensure methods defined in Java stdlib are not defined as `val`s 
* Add explicit result types 
* Added required parenthesis for lambda parameters
* Fix no longer compliant usages of `@swtich` annotations
* Fixes to `java.nio` Buffers due to incorrectly resolved types of `GenBuffer[T](this)` method calls (needs explicit type)
* Update scalafmt config to handle Scala 3 sources
* Duplicate classes registered by Scala 3 compiler, renamed them in Scala 3 sources
* Duplicate enum definitions for Scala 2 / 3 projects
* Split `java.util.Formatter` into `Impl` class and standard class to allow for the definition of inner enums
* Duplicate `java.util.ProcessBuilder`  to allow for the definition of inner enums

# Additional explanations: 
## Renamed classes
 Some classes defined in `javalib` needs to be renamed, otherwise, Scala 3 compiler would complain about their usage "in the incorrect period" - this happens if for some reason in the compiler phase registered some symbol, for eg. using `getRequiredClass` method, but also finds the same symbol somewhere else when compiling sources. It leads to fatal error. This is why we need to rewrite some classes, eg. `java.lang.Serializable` to `java.lang._Serializable` (due to the same for `j.l.Object` in Scala 2). The names would be adjusted when encoding names in NIR. 

## Duplication of enums
Scala 3 does not allow us to define enums in the same way as we did in Scala 2, instead, we need to use new syntax using `enum X extends Enum[X]` (extending is needed to ensure they're Java-compatible). Because of that, we need to provide a separate implementation for defined enums for both Scala 2 / 3 in the separate directories

## Duplication of classes containing inner enums 
There were more problematic cases where enum was defined within the body of some classes. In such a case we had no other option but to duplicate the whole class definition. In the case of `java.util.Formatter` (1.6k LOC) it was not trivial, especially since we didn't want to sync such a big files. In that case common `FormatterImpl` class was extracted implementing the logic of formatted and created two `Formatter` implementations containing constructors and definitions of enums, one for each Scala epoch version. 
In the case of ProcessBuilder extracting common logic was not trivial, but due to the relatively small size, I've decided to duplicate the whole class body.

## Fixes to `java.nio` Buffers
It looks like in Scala 3 compiler has sometimes problems with deriving correct type for given class/method invocation. This is why we needed to help it and replace calls to `GenBuffer(this)` with calls containing explicit type eg `GenBuffer[ByteBuffer](this)`. To limit the amount of code changes in the future the inlined calls were replaced with factored out method, eg `private def genBuffer = GenBuffer[ByteBuffer](this)`. 
We do the same for other `Gen*` type classes

## Correct signatures
Scala 3 compiler is better at telling us what should be signature for given method defined in JDK. This is we had a lot of compiler errors when some method was defined as `val foo` instead of `def foo()`. This also means that we needed to factor out  rhs of such definitions, eg. create additional value that would store lazily computed value.  


