### PR TITLE
Use encoded names for methods and fields in NIR

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Rt.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Rt.scala
@@ -17,8 +17,8 @@ object Rt {
   val GetClassSig = Sig.Method("getClass", Seq(Rt.Class)).mangled
   val JavaEqualsSig = Sig.Method("equals", Seq(Object, Bool)).mangled
   val JavaHashCodeSig = Sig.Method("hashCode", Seq(Int)).mangled
-  val ScalaEqualsSig = Sig.Method("scala_==", Seq(Object, Bool)).mangled
-  val ScalaHashCodeSig = Sig.Method("scala_##", Seq(Int)).mangled
+  val ScalaEqualsSig = Sig.Method("scala_$eq$eq", Seq(Object, Bool)).mangled
+  val ScalaHashCodeSig = Sig.Method("scala_$hash$hash", Seq(Int)).mangled
   val ScalaMainSig = Sig.Method("main", Seq(Array(Rt.String), Unit))
   val IsArraySig = Sig.Method("isArray", Seq(Bool)).mangled
   val IsAssignableFromSig =

--- a/nir/src/main/scala/scala/scalanative/nir/Versions.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Versions.scala
@@ -21,8 +21,8 @@ object Versions {
    * when 2.3-based release happens all of the code needs to recompiled with
    * new version of the toolchain.
    */
-  final val compat: Int = 5 // a.k.a. MAJOR version
-  final val revision: Int = 8 // a.k.a. MINOR version
+  final val compat: Int = 6 // a.k.a. MAJOR version
+  final val revision: Int = 9 // a.k.a. MINOR version
 
   /* Current public release version of Scala Native. */
   final val current: String = "0.5.0-SNAPSHOT"

--- a/nir/src/main/scala/scala/scalanative/nir/Versions.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Versions.scala
@@ -21,7 +21,7 @@ object Versions {
    * when 2.3-based release happens all of the code needs to recompiled with
    * new version of the toolchain.
    */
-  final val compat: Int = 6 // a.k.a. MAJOR version
+  final val compat: Int = 5 // a.k.a. MAJOR version
   final val revision: Int = 9 // a.k.a. MINOR version
 
   /* Current public release version of Scala Native. */

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -26,6 +26,8 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
     (prelude, pairs, files)
   }
 
+  private val usesEncodedMemberNames = prelude.revision >= 9
+
   final def deserialize(): Seq[Defn] = {
     val allDefns = mutable.UnrolledBuffer.empty[Defn]
     header.foreach {
@@ -190,8 +192,16 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
       Global.Member(Global.Top(getUTF8String()), getSig())
   }
 
-  private def getSig(): Sig =
-    new Sig(getUTF8String())
+  private def getSig(): Sig = {
+    val sig = new Sig(getUTF8String())
+    if (usesEncodedMemberNames) sig
+    else
+      sig.unmangled match {
+        case s: Sig.Field  => s.copy(id = NameTransformer.encode(s.id))
+        case s: Sig.Method => s.copy(id = NameTransformer.encode(s.id))
+        case sig           => sig
+      }
+  }
 
   private def getLocal(): Local =
     Local(getLong)
@@ -362,4 +372,73 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
 
     readPosition()
   }
+
+  // Copy pasted from Scala 3.1.0 compiler
+  // Used to encode names from NIR versions <= 5.8 produced with decoded names
+  private object NameTransformer {
+
+    private val nops = 128
+
+    private val op2code = new Array[String](nops)
+    private def enterOp(op: Char, code: String) = {
+      op2code(op.toInt) = code
+    }
+
+    /* Note: decoding assumes opcodes are only ever lowercase. */
+    enterOp('~', "$tilde")
+    enterOp('=', "$eq")
+    enterOp('<', "$less")
+    enterOp('>', "$greater")
+    enterOp('!', "$bang")
+    enterOp('#', "$hash")
+    enterOp('%', "$percent")
+    enterOp('^', "$up")
+    enterOp('&', "$amp")
+    enterOp('|', "$bar")
+    enterOp('*', "$times")
+    enterOp('/', "$div")
+    enterOp('+', "$plus")
+    enterOp('-', "$minus")
+    enterOp(':', "$colon")
+    enterOp('\\', "$bslash")
+    enterOp('?', "$qmark")
+    enterOp('@', "$at")
+
+    /** Replace operator symbols by corresponding expansion strings, and replace
+     *  characters that are not valid Java identifiers by "$u" followed by the
+     *  character's unicode expansion. Note that no attempt is made to escape
+     *  the use of '$' in `name`: blindly escaping them might make it impossible
+     *  to call some platform APIs. This unfortunately means that
+     *  `decode(encode(name))` might not be equal to `name`, this is considered
+     *  acceptable since '$' is a reserved character in the Scala spec as well
+     *  as the Java spec.
+     */
+    def encode(name: String): String = {
+      var buf: StringBuilder = null
+      val len = name.length
+      var i = 0
+      while (i < len) {
+        val c = name(i)
+        if (c < nops && (op2code(c.toInt) ne null)) {
+          if (buf eq null) {
+            buf = new StringBuilder()
+            buf.append(name.slice(0, i))
+          }
+          buf.append(op2code(c.toInt))
+          /* Handle glyphs that are not valid Java/JVM identifiers */
+        } else if (!Character.isJavaIdentifierPart(c)) {
+          if (buf eq null) {
+            buf = new StringBuilder()
+            buf.append(name.slice(0, i))
+          }
+          buf.append("$u%04X".format(c.toInt))
+        } else if (buf ne null) {
+          buf.append(c)
+        }
+        i += 1
+      }
+      if (buf eq null) name else buf.toString
+    }
+  }
+
 }

--- a/tools/src/test/scala/scala/scalanative/linker/ClassReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ClassReachabilitySuite.scala
@@ -14,7 +14,7 @@ class ClassReachabilitySuite extends ReachabilitySuite {
   val ParentFoo = g(ParentClsName, Sig.Method("foo", Seq(Type.Unit)))
   val ParentBar = g(ParentClsName, Sig.Field("bar"))
   val ParentBarSet =
-    g(ParentClsName, Sig.Method("bar_=", Seq(Type.Int, Type.Unit)))
+    g(ParentClsName, Sig.Method("bar_$eq", Seq(Type.Int, Type.Unit)))
   val ParentBarGet = g(ParentClsName, Sig.Method("bar", Seq(Type.Int)))
   val ParentMain = g(ParentClsName, Rt.ScalaMainSig)
   val Child = g(ChildClsName)

--- a/tools/src/test/scala/scala/scalanative/linker/ModuleReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ModuleReachabilitySuite.scala
@@ -23,7 +23,7 @@ class ModuleReachabilitySuite extends ReachabilitySuite {
   val ModuleFoo = g(ModuleClsName, Sig.Method("foo", Seq(Type.Unit)))
   val ModuleBar = g(ModuleClsName, Sig.Field("bar"))
   val ModuleBarSet =
-    g(ModuleClsName, Sig.Method("bar_=", Seq(Type.Int, Type.Unit)))
+    g(ModuleClsName, Sig.Method("bar_$eq", Seq(Type.Int, Type.Unit)))
   val ModuleBarGet = g(ModuleClsName, Sig.Method("bar", Seq(Type.Int)))
   val Parent = g(ParentClsName)
   val ParentInit = g(ParentClsName, Sig.Ctor(Seq.empty))


### PR DESCRIPTION
This PR changes the way names of methods and fields are stored in NIR format. Currently, names are always stored in decoded form, eg. `def foo_=(v: Int)` would have the name `foo_=` in NIR 
This behaviour however might lead to causing problems in Scala 3. In some cases, it can produce names containing partially encoded names, leading to missing definitions while linking. 
To make sure this would not happen we now store names primarily in encoded form, eg. `foo_$eq` with exceptions for extern members which needs to be always decoded (eg. if the native name contains special characters like dots in some of the LLVM intrinsic methods).

This change is binarily incompatible in NIR, so its version was bumped up. 