### PR TITLE
Define `Field` operation in NIR

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -139,4 +139,8 @@ object Intrinsics {
 
   /** Intrinsified cast that reinterprets long as a raw pointer. */
   def castLongToRawPtr(int: Long): RawPtr = intrinsic
+
+  /** Intrinsified resolving of class field as a raw pointer */
+  def classFieldRawPtr[T <: AnyRef](obj: T, fieldName: String): RawPtr =
+    intrinsic
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Buffer.scala
@@ -97,6 +97,8 @@ class Buffer(implicit fresh: Fresh) {
       implicit pos: Position
   ): Val =
     let(Op.Fieldstore(ty, obj, name, value), unwind)
+  def field(obj: Val, name: Global, unwind: Next)(implicit pos: Position) =
+    let(Op.Field(obj, name), unwind)
   def method(obj: Val, sig: Sig, unwind: Next)(implicit pos: Position): Val =
     let(Op.Method(obj, sig), unwind)
   def dynmethod(obj: Val, sig: Sig, unwind: Next)(implicit pos: Position): Val =

--- a/nir/src/main/scala/scala/scalanative/nir/Ops.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Ops.scala
@@ -24,6 +24,7 @@ sealed abstract class Op {
     case Op.Classalloc(n)       => Type.Ref(n, exact = true, nullable = false)
     case Op.Fieldload(ty, _, _) => ty
     case Op.Fieldstore(ty, _, _, _) => Type.Unit
+    case Op.Field(_, _)             => Type.Ptr
     case Op.Method(_, _)            => Type.Ptr
     case Op.Dynmethod(_, _)         => Type.Ptr
     case Op.Module(n) => Type.Ref(n, exact = true, nullable = false)
@@ -84,8 +85,8 @@ sealed abstract class Op {
     // Division and modulo are non-pure but idempotent.
     case op: Op.Bin =>
       true
-    case _: Op.Method | _: Op.Dynmethod | _: Op.Module | _: Op.Box |
-        _: Op.Unbox | _: Op.Arraylength =>
+    case _: Op.Field | _: Op.Method | _: Op.Dynmethod | _: Op.Module |
+        _: Op.Box | _: Op.Unbox | _: Op.Arraylength =>
       true
     case _ =>
       false
@@ -129,6 +130,7 @@ object Op {
   final case class Fieldload(ty: Type, obj: Val, name: Global) extends Op
   final case class Fieldstore(ty: Type, obj: Val, name: Global, value: Val)
       extends Op
+  final case class Field(obj: Val, name: Global) extends Op
   final case class Method(obj: Val, sig: Sig) extends Op
   final case class Dynmethod(obj: Val, sig: Sig) extends Op
   final case class Module(name: Global) extends Op

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -276,6 +276,11 @@ object Show {
         global_(name)
         str(", ")
         val_(value)
+      case Op.Field(value, name) =>
+        str("field ")
+        val_(value)
+        str(", ")
+        global_(name)
       case Op.Method(value, sig) =>
         str("method ")
         val_(value)

--- a/nir/src/main/scala/scala/scalanative/nir/Transform.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Transform.scala
@@ -83,6 +83,8 @@ trait Transform {
       Op.Fieldload(onType(ty), onVal(v), n)
     case Op.Fieldstore(ty, v1, n, v2) =>
       Op.Fieldstore(onType(ty), onVal(v1), n, onVal(v2))
+    case Op.Field(v, n) =>
+      Op.Field(onVal(v), n)
     case Op.Method(v, n) =>
       Op.Method(onVal(v), n)
     case Op.Dynmethod(obj, signature) =>

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -231,6 +231,7 @@ final class BinaryDeserializer(buffer: ByteBuffer, bufferName: String) {
     case T.FieldloadOp  => Op.Fieldload(getType(), getVal(), getGlobal())
     case T.FieldstoreOp =>
       Op.Fieldstore(getType(), getVal(), getGlobal(), getVal())
+    case T.FieldOp      => Op.Field(getVal(), getGlobal())
     case T.MethodOp     => Op.Method(getVal(), getSig())
     case T.DynmethodOp  => Op.Dynmethod(getVal(), getSig())
     case T.ModuleOp     => Op.Module(getGlobal())

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -385,6 +385,11 @@ final class BinarySerializer {
       putGlobal(name)
       putVal(value)
 
+    case Op.Field(v, name) =>
+      putInt(T.FieldOp)
+      putVal(v)
+      putGlobal(name)
+
     case Op.Method(v, sig) =>
       putInt(T.MethodOp)
       putVal(v)

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -160,7 +160,8 @@ object Tags {
   final val CompOp = 1 + BinOp
   final val ConvOp = 1 + CompOp
   final val ClassallocOp = 1 + ConvOp
-  final val FieldloadOp = 1 + ClassallocOp
+  final val FieldOp = 1 + ClassallocOp
+  final val FieldloadOp = 1 + FieldOp
   final val FieldstoreOp = 1 + FieldloadOp
   final val MethodOp = 1 + FieldstoreOp
   final val ModuleOp = 1 + MethodOp

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -160,8 +160,7 @@ object Tags {
   final val CompOp = 1 + BinOp
   final val ConvOp = 1 + CompOp
   final val ClassallocOp = 1 + ConvOp
-  final val FieldOp = 1 + ClassallocOp
-  final val FieldloadOp = 1 + FieldOp
+  final val FieldloadOp = 1 + ClassallocOp
   final val FieldstoreOp = 1 + FieldloadOp
   final val MethodOp = 1 + FieldstoreOp
   final val ModuleOp = 1 + MethodOp
@@ -179,6 +178,7 @@ object Tags {
   final val ArrayloadOp = 1 + ArrayallocOp
   final val ArraystoreOp = 1 + ArrayloadOp
   final val ArraylengthOp = 1 + ArraystoreOp
+  final val FieldOp = 1 + ArraylengthOp
 
   // Types
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -223,6 +223,8 @@ trait NirDefinitions {
       getMember(IntrinsicsModule, TermName("castLongToRawPtr"))
     lazy val StackallocMethod =
       getMember(IntrinsicsModule, TermName("stackalloc"))
+    lazy val ClassFieldRawPtrMethod =
+      getMember(IntrinsicsModule, TermName("classFieldRawPtr"))
 
     lazy val CFuncPtrApplyMethods = CFuncPtrNClass.map(
       getMember(_, TermName("apply"))

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1998,7 +1998,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         (classInfo.decls ++ classInfoSym.parentSymbols.flatMap(_.info.decls))
           .filter(f => f.isField && matchesName(f))
 
-      candidates.find(!_.isVariable).foreach { f =>
+      candidates.find(!_.isVar).foreach { f =>
         reporter.error(
           app.pos,
           s"Resolving pointer of immutable field ${fieldNameId} in ${f.owner} is not allowed"

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirPrimitives.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirPrimitives.scala
@@ -64,6 +64,7 @@ object NirPrimitives {
 
   final val CFUNCPTR_FROM_FUNCTION = 1 + CAST_LONG_TO_RAWPTR
   final val CFUNCPTR_APPLY = 1 + CFUNCPTR_FROM_FUNCTION
+  final val CLASS_FIELD_RAWPTR = 1 + CFUNCPTR_APPLY
 }
 
 abstract class NirPrimitives {
@@ -172,5 +173,6 @@ abstract class NirPrimitives {
     addPrimitive(CastLongToRawPtrMethod, CAST_LONG_TO_RAWPTR)
     CFuncPtrApplyMethods.foreach(addPrimitive(_, CFUNCPTR_APPLY))
     CFuncPtrFromFunctionMethods.foreach(addPrimitive(_, CFUNCPTR_FROM_FUNCTION))
+    addPrimitive(ClassFieldRawPtrMethod, CLASS_FIELD_RAWPTR)
   }
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -205,6 +205,7 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val Intrinsics_castIntToRawPtrR = IntrinsicsModule.requiredMethodRef("castIntToRawPtr")
   @tu lazy val Intrinsics_castLongToRawPtrR = IntrinsicsModule.requiredMethodRef("castLongToRawPtr")
   @tu lazy val Intrinsics_stackallocR = IntrinsicsModule.requiredMethodRef("stackalloc")
+  @tu lazy val Intrinsics_classFieldRawPtrR = IntrinsicsModule.requiredMethodRef("classFieldRawPtr")
 
   def Intrinsics_divUInt(using Context) = Intrinsics_divUIntR.symbol
   def Intrinsics_divULong(using Context) = Intrinsics_divULongR.symbol
@@ -251,6 +252,7 @@ final class NirDefinitions()(using ctx: Context) {
   def Intrinsics_castIntToRawPtr(using Context) = Intrinsics_castIntToRawPtrR.symbol
   def Intrinsics_castLongToRawPtr(using Context) = Intrinsics_castLongToRawPtrR.symbol
   def Intrinsics_stackalloc(using Context) = Intrinsics_stackallocR.symbol
+  def Intrinsics_classFieldRawPtr(using Context) = Intrinsics_classFieldRawPtrR.symbol
 
   // Runtime types
   @tu lazy val RuntimePrimitive: Map[Char, Symbol] = Map(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPrimitives.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPrimitives.scala
@@ -77,7 +77,9 @@ object NirPrimitives {
   final val CFUNCPTR_FROM_FUNCTION = 1 + CAST_LONG_TO_RAWPTR
   final val CFUNCPTR_APPLY = 1 + CFUNCPTR_FROM_FUNCTION
 
-  final val LastNirPrimitiveCode = CFUNCPTR_APPLY
+  final val CLASS_FIELD_RAWPTR = 1 + CFUNCPTR_APPLY
+
+  final val LastNirPrimitiveCode = CLASS_FIELD_RAWPTR
 
   def isNirPrimitive(code: Int): Boolean =
     code >= FirstNirPrimitiveCode && code <= LastNirPrimitiveCode
@@ -178,6 +180,7 @@ class NirPrimitives(using ctx: Context) extends DottyPrimitives(ctx) {
     defnNir.CFuncPtr_fromScalaFunction.foreach(
       addPrimitive(_, CFUNCPTR_FROM_FUNCTION)
     )
+    addPrimitive(defnNir.Intrinsics_classFieldRawPtr, CLASS_FIELD_RAWPTR)
     primitives
   }
 }

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -196,6 +196,16 @@ final class Check(implicit linked: linker.Result) {
       checkFieldOp(ty, obj, name, None)
     case Op.Fieldstore(ty, obj, name, value) =>
       checkFieldOp(ty, obj, name, Some(value))
+    case Op.Field(obj, name) =>
+      obj.ty match {
+        case ScopeRef(scope) =>
+          scope.implementors.foreach { cls =>
+            if (cls.fields.exists(_.name == name)) ok
+            else error(s"can't acces field '${name.show}' in ${cls.name.show}")
+          }
+        case ty =>
+          error(s"can't access fields of a non-class type ${ty.show}")
+      }
     case Op.Method(obj, sig) =>
       expect(Rt.Object, obj)
       sig match {

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -454,6 +454,14 @@ object Lower {
       genStoreOp(buf, n, Op.Store(ty, elem, value))
     }
 
+    def genFieldOp(buf: Buffer, n: Local, op: Op)(implicit
+        pos: Position
+    ) = {
+      val Op.Field(obj, name) = op
+      val elem = genFieldElemOp(buf, obj, name)
+      buf.let(n, Op.Copy(elem), unwind)
+    }
+
     def genStoreOp(buf: Buffer, n: Local, op: Op.Store)(implicit
         pos: Position
     ) = {

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -336,6 +336,8 @@ object Lower {
 
     def genOp(buf: Buffer, n: Local, op: Op)(implicit pos: Position): Unit = {
       op match {
+        case op: Op.Field =>
+          genFieldOp(buf, n, op)
         case op: Op.Fieldload =>
           genFieldloadOp(buf, n, op)
         case op: Op.Fieldstore =>

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -242,6 +242,12 @@ trait Eval { self: Interflow =>
                 )
             )
         }
+
+      case Op.Field(rawObj, name) =>
+        val obj = eval(rawObj)
+        visitRoot(name)
+        delay(Op.Field(materialize(obj), name))
+
       case Op.Method(rawObj, sig) =>
         val obj = eval(rawObj)
         val objty = {

--- a/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/NoOpt.scala
@@ -82,6 +82,9 @@ trait NoOpt { self: Interflow =>
       noOptVal(v1)
       noOptGlobal(n)
       noOptVal(v2)
+    case Op.Field(obj, n) =>
+      noOptVal(obj)
+      noOptGlobal(n)
     case Op.Method(obj, sig) =>
       noOptVal(obj)
       obj.ty match {

--- a/tools/src/main/scala/scala/scalanative/interflow/State.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/State.scala
@@ -193,6 +193,7 @@ final class State(block: Local) {
       case _: Op.Classalloc            => ()
       case Op.Fieldload(_, v, _)       => reachVal(v)
       case Op.Fieldstore(_, v1, _, v2) => reachVal(v1); reachVal(v2)
+      case Op.Field(v, _)              => reachVal(v)
       case Op.Method(v, _)             => reachVal(v)
       case Op.Dynmethod(v, _)          => reachVal(v)
       case _: Op.Module                => ()
@@ -352,6 +353,7 @@ final class State(block: Local) {
       case _: Op.Classalloc            => ()
       case Op.Fieldload(_, v, _)       => reachVal(v)
       case Op.Fieldstore(_, v1, _, v2) => reachVal(v1); reachVal(v2)
+      case Op.Field(v, _)              => reachVal(v)
       case Op.Method(v, _)             => reachVal(v)
       case Op.Dynmethod(v, _)          => reachVal(v)
       case _: Op.Module                => ()
@@ -406,6 +408,8 @@ final class State(block: Local) {
         Op.Fieldload(ty, escapedVal(v), n)
       case Op.Fieldstore(ty, v1, n, v2) =>
         Op.Fieldstore(ty, escapedVal(v1), n, escapedVal(v2))
+      case Op.Field(v, n) =>
+        Op.Field(escapedVal(v), n)
       case Op.Method(v, n) =>
         Op.Method(escapedVal(v), n)
       case Op.Dynmethod(v, n) =>

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -703,6 +703,9 @@ class Reach(
       reachVal(v1)
       reachGlobal(n)
       reachVal(v2)
+    case Op.Field(obj, name) =>
+      reachVal(obj)
+      reachGlobal(name)
     case Op.Method(obj, sig) =>
       reachVal(obj)
       reachMethodTargets(obj.ty, sig)

--- a/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -84,4 +84,66 @@ class NIRCompilerTest extends AnyFlatSpec with Matchers with Inspectors {
     caught.getMessage should include("extern method foo needs result type")
   }
 
+  it should "report error for intrinsic resolving of not existing field" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(
+        _.compile(
+          """import scala.scalanative.runtime.Intrinsics
+          |class Foo {
+          | val fieldRawPtr =  Intrinsics.classFieldRawPtr(this, "myField")
+          |}""".stripMargin
+        )
+      )
+    }.getMessage should include("class Foo does not contain field myField")
+  }
+
+  it should "report error for intrinsic resolving of immutable field" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(
+        _.compile(
+          """import scala.scalanative.runtime.Intrinsics
+           |class Foo {
+           | val myField = 42
+           | val fieldRawPtr =  Intrinsics.classFieldRawPtr(this, "myField")
+           |}""".stripMargin
+        )
+      )
+    }.getMessage should include(
+      "Resolving pointer of immutable field myField in class Foo is not allowed"
+    )
+  }
+
+  it should "report error for intrinsic resolving of immutable field introduced by trait" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(
+        _.compile(
+          """import scala.scalanative.runtime.Intrinsics
+            |trait Foo { val myField = 42}
+            |class Bar extends Foo {
+            | val fieldRawPtr =  Intrinsics.classFieldRawPtr(this, "myField")
+            |}""".stripMargin
+        )
+      )
+    }.getMessage should include(
+      // In Scala 3 trait would be inlined into class
+      "Resolving pointer of immutable field myField in "
+    ) //trait Foo is not allowed")
+  }
+
+  it should "report error for intrinsic resolving of immutable field introduced by inheritence" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(
+        _.compile(
+          """import scala.scalanative.runtime.Intrinsics
+             |abstract class Foo { val myField = 42}
+             |class Bar extends Foo {
+             | val fieldRawPtr =  Intrinsics.classFieldRawPtr(this, "myField")
+             |}""".stripMargin
+        )
+      )
+    }.getMessage should include(
+      "Resolving pointer of immutable field myField in class Foo is not allowed"
+    )
+  }
+
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/IntrinsicsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/IntrinsicsTest.scala
@@ -1,0 +1,76 @@
+package scala.scalanative.runtime
+
+import org.junit.Test
+import org.junit.Assert._
+
+class IntrinsicsTest {
+
+  @Test
+  def allowsToAccessFieldPtr(): Unit = {
+    class Foo(
+        var longField: Long,
+        var shortField: Short,
+        var intField: Int,
+        var byteField: Byte
+    )
+
+    val foo = new Foo(1L, 2.toShort, 42, 4.toByte)
+    val fieldPtr = fromRawPtr[Int](Intrinsics.classFieldRawPtr(foo, "intField"))
+    assertEquals(42, !fieldPtr)
+    !fieldPtr = 13
+    assertEquals(13, foo.intField)
+    // Ensure other fields were not mutated
+    assertEquals(1L, foo.longField)
+    assertEquals(2.toShort, foo.shortField)
+    assertEquals(4.toByte, foo.byteField)
+  }
+
+  @Test
+  def allowsToAccessInheritedFieldPtr(): Unit = {
+    class Bar {
+      var bar = 42
+    }
+    class Foo(
+        var longField: Long,
+        var shortField: Short,
+        var intField: Int,
+        var byteField: Byte
+    ) extends Bar
+
+    val foo = new Foo(1L, 2.toShort, 3, 4.toByte)
+    val fieldPtr = fromRawPtr[Int](Intrinsics.classFieldRawPtr(foo, "bar"))
+    assertEquals(42, !fieldPtr)
+    !fieldPtr = 13
+    assertEquals(13, foo.bar)
+    // Ensure other fields were not mutated
+    assertEquals(1L, foo.longField)
+    assertEquals(2.toShort, foo.shortField)
+    assertEquals(3, foo.intField)
+    assertEquals(4.toByte, foo.byteField)
+  }
+
+  @Test
+  def allowsToAccessInheritedFromTraitFieldPtr(): Unit = {
+    trait Bar {
+      var bar = 42
+    }
+    class Foo(
+        var longField: Long,
+        var shortField: Short,
+        var intField: Int,
+        var byteField: Byte
+    ) extends Bar
+
+    val foo = new Foo(1L, 2.toShort, 3, 4.toByte)
+    val fieldPtr = fromRawPtr[Int](Intrinsics.classFieldRawPtr(foo, "bar"))
+    assertEquals(42, !fieldPtr)
+    !fieldPtr = 13
+    assertEquals(13, foo.bar)
+    // Ensure other fields were not mutated
+    assertEquals(1L, foo.longField)
+    assertEquals(2.toShort, foo.shortField)
+    assertEquals(3, foo.intField)
+    assertEquals(4.toByte, foo.byteField)
+  }
+
+}


### PR DESCRIPTION
This PR adds a new kind of operation to the NIR allowing to resolve pointer to pointer of the field in a given instance of an object.
Similarly to `Op.Method` this operation is being replaced with resolved value while performing lowering. 

Additionally, a new intrinsic method was added `def classFieldRawPtr(obj: AnyRef, classField: String)` - it would be registered as a primitive operation and replaced with `Op.Field` while generating NIR. Even though we pass classField as a string this method is user safe as we check at compile time if a field with a given name is defined for the instance of given class. Also to make it more secure compiler plugin would not allow to use this method on immutable fields - it could lead to breaking a language contract by introducing mutation to immutable `val`. 

Handling of the newly introduced field was added to our static reachability phase and optimizer to make sure that the referenced field would be included and hopefully its usages would be optimized

Currently, there are two places where this operation would be used inside Scala Native: 
1. Adaption of Lazy Vals - Scala 3 compiler defines a new, thread-safe initialization of lazy vals, using JDK `unsafe` mechanism to calculate offsets to fields containing bitmap of initialization states for lazy fields. In Scala 3 Native we want to get rid of standard calls to LazyVals methods using calculated offsets. Instead, we would rewrite these calls to Scala Native specific variants of these methods taking direct `Ptr[Long]` to given bitmap. Pointer would be resolved using an intrinsic call to `classFieldRawPtr` and known at compile time name of bitmap field.
2. Implementation of `java.util.concurrent.Atomic*` - to use C/LLVM atomics, we need to use pointers to a given variable. Currently, there is no mechanism in Scala Native that would allow us to create pointers bound to a given object instance and handled by the GC. To work around this issue I've been trying to use [unsafe hacks in order to calculate the correct offset](https://github.com/WojciechMazur/scala-native/blob/aa663c88581b6bda3c379bc23bcf0ee1057a6cfd/javalib/src/main/scala/java/util/concurrent/atomic/AtomicInteger.scala#L32) which are very fragile to the memory layout of the given class. 


