### PR TITLE
Adapt LazyVals to work in Scala Native

### DIFF
--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -315,3 +315,4 @@ jobs:
           testRunner3/test
           testsJVM3/test
           testsExtJVM3/test
+          sandbox3/run

--- a/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/runtime/LazyVals.scala
@@ -1,0 +1,47 @@
+package scala.scalanative.runtime
+
+import scala.scalanative.annotation._
+import scala.runtime.LazyVals.{BITS_PER_LAZY_VAL, STATE}
+
+/** Helper methods used in thread-safe lazy vals adapted for Scala Native usage
+ *  Make sure to sync them with the logic defined in Scala 3
+ *  scala.runtime.LazyVals
+ */
+private object LazyVals {
+
+  private final val LAZY_VAL_MASK = 3L
+
+  /* ------------- Start of public API ------------- */
+
+  @`inline`
+  def CAS(bitmap: RawPtr, e: Long, v: Int, ord: Int): Boolean = {
+    val mask = ~(LAZY_VAL_MASK << ord * BITS_PER_LAZY_VAL)
+    val n = (e & mask) | (v.toLong << (ord * BITS_PER_LAZY_VAL))
+    // Todo: with multithreading use atomic cas
+    if (get(bitmap) != e) false
+    else {
+      Intrinsics.storeLong(bitmap, n)
+      true
+    }
+  }
+
+  @`inline`
+  def setFlag(bitmap: RawPtr, v: Int, ord: Int): Unit = {
+    val cur = get(bitmap)
+    // TODO: with multithreading add waiting for notifications
+    CAS(bitmap, cur, v, ord)
+  }
+
+  def wait4Notification(bitmap: RawPtr, cur: Long, ord: Int): Unit = {
+    throw new IllegalStateException(
+      "wait4Notification not supported in single-threaded Scala Native runtime"
+    )
+  }
+
+  @alwaysinline
+  def get(bitmap: RawPtr): Long = {
+    // Todo: make it volatile read with multithreading
+    Intrinsics.loadLong(bitmap)
+  }
+
+}

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -1,0 +1,132 @@
+package scala.scalanative.nscplugin
+
+import dotty.tools._
+import dotc._
+import dotc.transform.{LazyVals, MoveStatics}
+import dotc.ast.tpd._
+import plugins._
+import core.Flags._
+import core.Contexts._
+import core.Names._
+import core.Symbols._
+import core.StdNames._
+import scala.annotation.{threadUnsafe => tu}
+
+// This phase is responsible for rewriting calls to scala.runtime.LazyVals with
+// its scala native specific counter-part. This is needed, becouse LazyVals are
+// using JVM unsafe API and static class constructors which are not supported
+// in Scala Native.
+object AdaptLazyVals extends PluginPhase {
+  val phaseName = "scalanative-adaptLazyVals"
+
+  override val runsAfter = Set(LazyVals.name, MoveStatics.name)
+  override val runsBefore = Set(GenNIR.phaseName)
+
+  def defn(using Context) = LazyValsDefns.get
+  def defnNir(using Context) = NirDefinitions.defnNir
+
+  private def isLazyFieldOffset(name: Name) =
+    name.startsWith(nme.LAZY_FIELD_OFFSET.toString)
+
+  // Map of field symbols for LazyVals offsets and literals
+  // with the name of referenced bitmap fields within given TypeDef
+  private val bitmapFieldNames = collection.mutable.Map.empty[Symbol, Literal]
+
+  override def prepareForUnit(tree: Tree)(using Context): Context = {
+    bitmapFieldNames.clear()
+    super.prepareForUnit(tree)
+  }
+
+  // Collect informations about offset fields
+  override def prepareForTypeDef(td: TypeDef)(using Context): Context = {
+    val sym = td.symbol
+    val hasLazyFields = sym.denot.info.fields
+      .exists(f => isLazyFieldOffset(f.name))
+
+    if (hasLazyFields) {
+      val template @ Template(_, _, _, _) = td.rhs
+      bitmapFieldNames ++= template.body.collect {
+        case vd: ValDef if isLazyFieldOffset(vd.name) =>
+          val Apply(_, List(cls: Literal, fieldname: Literal)) = vd.rhs
+          vd.symbol -> fieldname
+      }.toMap
+    }
+
+    ctx
+  }
+
+  // Replace all usages of all unsuportted LazyVals methods with their
+  // Scala Native specific implementation (taking Ptr intead of object + offset)
+  override def transformApply(tree: Apply)(using Context): Tree = {
+    // Create call to SN intrinsic methods returning pointer to bitmap field
+    def classFieldPtr(target: Tree, fieldRef: Tree): Tree = {
+      val fieldName = bitmapFieldNames(fieldRef.symbol)
+      cpy.Apply(tree)(
+        fun = ref(defnNir.Intrinsics_classFieldRawPtr),
+        args = List(target, fieldName)
+      )
+    }
+
+    val Apply(fun, args) = tree
+    val sym = fun.symbol
+
+    if bitmapFieldNames.isEmpty then tree // No LazyVals in TypeDef, fast path
+    else if sym == defn.LazyVals_get then
+      val List(target, fieldRef) = args
+      cpy.Apply(tree)(
+        fun = ref(defn.NativeLazyVals_get),
+        args = List(classFieldPtr(target, fieldRef))
+      )
+    else if sym == defn.LazyVals_setFlag then
+      val List(target, fieldRef, value, ord) = args
+      cpy.Apply(tree)(
+        fun = ref(defn.NativeLazyVals_setFlag),
+        args = List(classFieldPtr(target, fieldRef), value, ord)
+      )
+    else if sym == defn.LazyVals_CAS then
+      val List(target, fieldRef, expected, value, ord) = args
+      cpy.Apply(tree)(
+        fun = ref(defn.NativeLazyVals_CAS),
+        args = List(classFieldPtr(target, fieldRef), expected, value, ord)
+      )
+    else if sym == defn.LazyVals_wait4Notification then
+      val List(target, fieldRef, value, ord) = args
+      cpy.Apply(tree)(
+        fun = ref(defn.NativeLazyVals_wait4Notification),
+        args = List(classFieldPtr(target, fieldRef), value, ord)
+      )
+    else tree
+  }
+
+  object LazyValsDefns {
+    var lastCtx: Option[Context] = None
+    var lastDefns: LazyValsDefns = _
+
+    def get(using Context): LazyValsDefns = {
+      if (!lastCtx.contains(ctx)) {
+        lastDefns = LazyValsDefns()
+        lastCtx = Some(ctx)
+      }
+      lastDefns
+    }
+  }
+  class LazyValsDefns(using Context) {
+    @tu lazy val NativeLazyValsModule = requiredModule(
+      "scala.scalanative.runtime.LazyVals"
+    )
+    @tu lazy val NativeLazyVals_get = NativeLazyValsModule.requiredMethod("get")
+    @tu lazy val NativeLazyVals_setFlag =
+      NativeLazyValsModule.requiredMethod("setFlag")
+    @tu lazy val NativeLazyVals_CAS = NativeLazyValsModule.requiredMethod("CAS")
+    @tu lazy val NativeLazyVals_wait4Notification =
+      NativeLazyValsModule.requiredMethod("wait4Notification")
+
+    @tu lazy val LazyValsModule = requiredModule("scala.runtime.LazyVals")
+    @tu lazy val LazyVals_get = LazyValsModule.requiredMethod("get")
+    @tu lazy val LazyVals_setFlag = LazyValsModule.requiredMethod("setFlag")
+    @tu lazy val LazyVals_CAS = LazyValsModule.requiredMethod("CAS")
+    @tu lazy val LazyVals_wait4Notification =
+      LazyValsModule.requiredMethod("wait4Notification")
+  }
+
+}

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -13,7 +13,7 @@ import core.StdNames._
 import scala.annotation.{threadUnsafe => tu}
 
 // This phase is responsible for rewriting calls to scala.runtime.LazyVals with
-// its scala native specific counter-part. This is needed, becouse LazyVals are
+// its scala native specific counter-part. This is needed, because LazyVals are
 // using JVM unsafe API and static class constructors which are not supported
 // in Scala Native.
 object AdaptLazyVals extends PluginPhase {
@@ -55,8 +55,8 @@ object AdaptLazyVals extends PluginPhase {
     ctx
   }
 
-  // Replace all usages of all unsuportted LazyVals methods with their
-  // Scala Native specific implementation (taking Ptr intead of object + offset)
+  // Replace all usages of all unsupported LazyVals methods with their
+  // Scala Native specific implementation (taking Ptr instead of object + offset)
   override def transformApply(tree: Apply)(using Context): Tree = {
     // Create call to SN intrinsic methods returning pointer to bitmap field
     def classFieldPtr(target: Tree, fieldRef: Tree): Tree = {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPlugin.scala
@@ -7,4 +7,4 @@ class NirPlugin extends StandardPlugin:
   val description: String = "Scala Native compiler plugin"
 
   def init(options: List[String]): List[PluginPhase] =
-    List(PrepNativeInterop, GenNIR)
+    List(PrepNativeInterop, AdaptLazyVals, GenNIR)

--- a/scalalib/overrides-3/scala/runtime/LazyVals.scala.patch
+++ b/scalalib/overrides-3/scala/runtime/LazyVals.scala.patch
@@ -1,0 +1,128 @@
+--- 3.1.0/scala/runtime/LazyVals.scala
++++ overrides-3/scala/runtime/LazyVals.scala
+@@ -1,111 +1,48 @@
+ package scala.runtime
+ 
++import scala.scalanative.runtime.*
++
+ /**
+  * Helper methods used in thread-safe lazy vals.
+  */
+ object LazyVals {
+-  private[this] val unsafe: sun.misc.Unsafe =
+-      classOf[sun.misc.Unsafe].getDeclaredFields.find { field =>
+-        field.getType == classOf[sun.misc.Unsafe] && {
+-          field.setAccessible(true)
+-          true
+-        }
+-      }
+-      .map(_.get(null).asInstanceOf[sun.misc.Unsafe])
+-      .getOrElse {
+-        throw new ExceptionInInitializerError {
+-          new IllegalStateException("Can't find instance of sun.misc.Unsafe")
+-        }
+-      }
+-
+-  private[this] val base: Int = {
+-    val processors = java.lang.Runtime.getRuntime.availableProcessors()
+-    8 * processors * processors
+-  }
+-  private[this] val monitors: Array[Object] =
+-    Array.tabulate(base)(_ => new Object)
+-
+-  private def getMonitor(obj: Object, fieldId: Int = 0) = {
+-    var id = (java.lang.System.identityHashCode(obj) + fieldId) % base
+-
+-    if (id < 0) id += base
+-    monitors(id)
+-  }
+-
+   private final val LAZY_VAL_MASK = 3L
+-  private final val debug = false
+ 
+   /* ------------- Start of public API ------------- */
+ 
+   final val BITS_PER_LAZY_VAL = 2L
+-
+   def STATE(cur: Long, ord: Int): Long = {
+     val r = (cur >> (ord * BITS_PER_LAZY_VAL)) & LAZY_VAL_MASK
+-    if (debug)
+-      println(s"STATE($cur, $ord) = $r")
+     r
+   }
+ 
+   def CAS(t: Object, offset: Long, e: Long, v: Int, ord: Int): Boolean = {
+-    if (debug)
+-      println(s"CAS($t, $offset, $e, $v, $ord)")
+-    val mask = ~(LAZY_VAL_MASK << ord * BITS_PER_LAZY_VAL)
+-    val n = (e & mask) | (v.toLong << (ord * BITS_PER_LAZY_VAL))
+-    unsafe.compareAndSwapLong(t, offset, e, n)
++    unexpectedUsage()
+   }
+ 
+   def setFlag(t: Object, offset: Long, v: Int, ord: Int): Unit = {
+-    if (debug)
+-      println(s"setFlag($t, $offset, $v, $ord)")
+-    var retry = true
+-    while (retry) {
+-      val cur = get(t, offset)
+-      if (STATE(cur, ord) == 1) retry = !CAS(t, offset, cur, v, ord)
+-      else {
+-        // cur == 2, somebody is waiting on monitor
+-        if (CAS(t, offset, cur, v, ord)) {
+-          val monitor = getMonitor(t, ord)
+-          monitor.synchronized {
+-            monitor.notifyAll()
+-          }
+-          retry = false
+-        }
+-      }
+-    }
++    unexpectedUsage()
+   }
+ 
+   def wait4Notification(t: Object, offset: Long, cur: Long, ord: Int): Unit = {
+-    if (debug)
+-      println(s"wait4Notification($t, $offset, $cur, $ord)")
+-    var retry = true
+-    while (retry) {
+-      val cur = get(t, offset)
+-      val state = STATE(cur, ord)
+-      if (state == 1) CAS(t, offset, cur, 2, ord)
+-      else if (state == 2) {
+-        val monitor = getMonitor(t, ord)
+-        monitor.synchronized {
+-          if (STATE(get(t, offset), ord) == 2) // make sure notification did not happen yet.
+-            monitor.wait()
+-        }
+-      }
+-      else retry = false
+-    }
++    unexpectedUsage()
+   }
+ 
+   def get(t: Object, off: Long): Long = {
+-    if (debug)
+-      println(s"get($t, $off)")
+-    unsafe.getLongVolatile(t, off)
++    unexpectedUsage()
+   }
+ 
+   def getOffset(clz: Class[_], name: String): Long = {
+-    val r = unsafe.objectFieldOffset(clz.getDeclaredField(name))
+-    if (debug)
+-      println(s"getOffset($clz, $name) = $r")
+-    r
++    unexpectedUsage()
+   }
+ 
++  private def unexpectedUsage() = {
++    throw new IllegalStateException(
++      "Unexpected usage of scala.runtime.LazyVals method, " +
++      "in Scala Native lazy vals use overriden version of this class"
++    )
++  }
++
+   object Names {
+     final val state = "STATE"
+     final val cas = "CAS"

--- a/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
@@ -37,32 +37,7 @@ abstract class LinkerSpec extends AnyFlatSpec {
       val entries = ScalaNative.entries(config)
       val result = ScalaNative.link(config, entries)
 
-      val filteredResult = {
-        import scalanative.nir.Global._
-        import scalanative.nir.Sig
-
-        // Until proper support for Scala 3 LazyVals is established
-        val ignoredNames = List(
-          Top("sun.misc.Unsafe"),
-          Member(
-            Top("java.lang.Class"),
-            new Sig("D17getDeclaredFieldsLAL23java.lang.reflect.Field_EO")
-          )
-        )
-        new linker.Result(
-          infos = result.infos,
-          entries = result.entries,
-          unavailable = result.unavailable.diff(ignoredNames),
-          referencedFrom = result.referencedFrom,
-          links = result.links,
-          defns = result.defns,
-          dynsigs = result.dynsigs,
-          dynimpls = result.dynimpls,
-          resolvedVals = result.resolvedVals
-        )
-      }
-
-      fn(config, filteredResult)
+      fn(config, result)
     }
 
   private def makeClasspath(outDir: Path)(implicit in: Scope) = {

--- a/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/LinktimeConditionsSpec.scala
@@ -382,15 +382,6 @@ class LinktimeConditionsSpec extends OptimizerSpec with Matchers {
   }
 
   it should "allow to inline linktime property" in {
-    val isScala3 = util
-      .Try(java.lang.Class.forName("scala.runtime.LazyVals"))
-      .map(_ => true)
-      .getOrElse(false)
-    assume(
-      !isScala3,
-      "Would fail due to problems with lazy vals in the optimizer"
-    )
-
     optimizeWithProps(
       "props.scala" ->
         """package scala.scalanative


### PR DESCRIPTION
This PR does add a new plugin phase which is responsible for rewriting calls to `scala.runtime.LazyVals` which cannot be supported in Scala Native because we do not support static class constructors and we don't provide access to JDK `unsafe` methods, like `getFieldOffset`. 

* Added override for `scala.runtime.LazyVals`
* Added `scala.scalanative.runtime.LazyVals` which are used instead of Scala implementation - they're using the same algorithm, however, are using a pointer to resolved field instead of calculating it using offset (we we're not able to get offsets correctly) 
* Added `AdaptLazyVals` phase which does: 
  * collect references to bitmap fields used by LazyVals within compilation unit
  * rewrites usages of internal `OFFSET` fields with intrinsic `classFieldRawPtr` function call based on trees collected in previous step 
  * rewrites all not-compliant calls to Scala LazyVals methods with their Scala Native counter parts
* Reverted mitigations for failing tests due to LazyVals issues
* Added building and running sandbox in the CI 
