### PR TITLE
Increase timeout for frequently failing `ProcessTest`

### DIFF
--- a/unit-tests/shared/src/test/scala/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/ProcessTest.scala
@@ -140,7 +140,7 @@ class ProcessTest {
 
     assertTrue(
       "process should have exited but timed out",
-      proc.waitFor(2, TimeUnit.SECONDS)
+      proc.waitFor(4, TimeUnit.SECONDS)
     )
     assertEquals(0, proc.exitValue)
   }


### PR DESCRIPTION
This PR does increase the timeout for the test frequently failing in the CI. It can be only observed in Windows CI workflows running with None GC. While trying to reproduce it locally failures were very rare and were only observed heavy load created by external processes. 