### PR TITLE
Port JUnit Plugin to Scala 3

### DIFF
--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -311,8 +311,5 @@ jobs:
           sbt "++ ${{ matrix.scala }} -v"
           "-no-colors"
           "-J-Xmx3G"
-          tools3/test
-          testRunner3/test
-          testsJVM3/test
-          testsExtJVM3/test
-          sandbox3/run
+          test-tools 3
+          test-runtime 3

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -286,26 +286,6 @@ jobs:
         with:
           scala-version: ${{matrix.scala}}
 
-        # Ensure that our codebase is source compatible with Scala 3
-        # Skip transitive dependencies in the build
-      - name: Compile sources with Scala 3
-        run: >
-          sbt "++ ${{ matrix.scala }} -v" 
-          "-no-colors" 
-          "-J-Xmx3G" 
-          nscplugin3/compile
-          tools3/compile
-          tools3/Test/compile
-          posixlib3/compile
-          windowslib3/compile
-          auxlib3/compile
-          javalib3/compile
-          scalalib3/compile
-          junitRuntime3/compile
-          testInterfaceSbtDefs3/compile
-          testInterface3/compile
-          testingCompiler3/compile
-
       - name: Run Scala 3 tsts
         run: >
           sbt "++ ${{ matrix.scala }} -v"

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -286,10 +286,10 @@ jobs:
         with:
           scala-version: ${{matrix.scala}}
 
-      - name: Run Scala 3 tsts
+      - name: Run Scala 3 tests
         run: >
           sbt "++ ${{ matrix.scala }} -v"
           "-no-colors"
           "-J-Xmx3G"
-          test-tools 3
-          test-runtime 3
+          "test-tools 3"
+          "test-runtime 3"

--- a/junit-plugin/src/main/resources/plugin.properties
+++ b/junit-plugin/src/main/resources/plugin.properties
@@ -1,0 +1,1 @@
+pluginClass=scala.scalanative.junit.plugin.ScalaNativeJUnitPlugin

--- a/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/JUnitDefinitions.scala
+++ b/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/JUnitDefinitions.scala
@@ -1,0 +1,64 @@
+package scala.scalanative.junit.plugin
+
+import dotty.tools.dotc.core
+import core.Symbols._
+import core.Symbols.given
+import core.Contexts._
+import core.Types._
+import core.StdNames._
+import scala.annotation.threadUnsafe
+
+object JUnitDefinitions {
+  private var cached: JUnitDefinitions = _
+  private var lastContext = Option.empty[Context]
+  def defnJUnit(using ctx: Context): JUnitDefinitions = {
+    if (!lastContext.contains(ctx)) {
+      cached = JUnitDefinitions()
+    }
+    cached
+  }
+}
+
+/** Definitions required by JUnit plugin
+ *
+ *  Scala.js port based on dotty.tools.backend.sjs.JSDefinitions#junit from
+ *  Scala release 3.1.0 Contains the same definitions as original class which
+ *  cannot be used directly in Scala Native plugin
+ */
+final class JUnitDefinitions()(using ctx: Context) {
+  // scalafmt: { maxColumn = 120}
+  @threadUnsafe lazy val TestAnnotType: TypeRef = requiredClassRef("org.junit.Test")
+  def TestAnnotClass(using Context): ClassSymbol = TestAnnotType.symbol.asClass
+
+  @threadUnsafe lazy val BeforeAnnotType: TypeRef = requiredClassRef("org.junit.Before")
+  def BeforeAnnotClass(using Context): ClassSymbol = BeforeAnnotType.symbol.asClass
+
+  @threadUnsafe lazy val AfterAnnotType: TypeRef = requiredClassRef("org.junit.After")
+  def AfterAnnotClass(using Context): ClassSymbol = AfterAnnotType.symbol.asClass
+
+  @threadUnsafe lazy val BeforeClassAnnotType: TypeRef = requiredClassRef("org.junit.BeforeClass")
+  def BeforeClassAnnotClass(using Context): ClassSymbol = BeforeClassAnnotType.symbol.asClass
+
+  @threadUnsafe lazy val AfterClassAnnotType: TypeRef = requiredClassRef("org.junit.AfterClass")
+  def AfterClassAnnotClass(using Context): ClassSymbol = AfterClassAnnotType.symbol.asClass
+
+  @threadUnsafe lazy val IgnoreAnnotType: TypeRef = requiredClassRef("org.junit.Ignore")
+  def IgnoreAnnotClass(using Context): ClassSymbol = IgnoreAnnotType.symbol.asClass
+
+  @threadUnsafe lazy val BootstrapperType: TypeRef = requiredClassRef("scala.scalanative.junit.Bootstrapper")
+  @threadUnsafe lazy val TestMetadataType: TypeRef = requiredClassRef("scala.scalanative.junit.TestMetadata")
+  @threadUnsafe lazy val TestClassMetadataType: TypeRef = requiredClassRef("scala.scalanative.junit.TestClassMetadata")
+
+  @threadUnsafe lazy val NoSuchMethodExceptionType: TypeRef = requiredClassRef("java.lang.NoSuchMethodException")
+
+  @threadUnsafe lazy val FutureType: TypeRef = requiredClassRef("scala.concurrent.Future")
+  def FutureClass(using Context): ClassSymbol = FutureType.symbol.asClass
+
+  @threadUnsafe private lazy val FutureModule_successfulR = requiredModule("scala.concurrent.Future")
+    .requiredMethodRef("successful")
+  def FutureModule_successful(using Context): Symbol = FutureModule_successfulR.symbol
+
+  @threadUnsafe private lazy val SuccessModule_applyR = requiredModule("scala.util.Success")
+    .requiredMethodRef(nme.apply)
+  def SuccessModule_apply(using Context): Symbol = SuccessModule_applyR.symbol
+}

--- a/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/JUnitDefinitions.scala
+++ b/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/JUnitDefinitions.scala
@@ -22,8 +22,8 @@ object JUnitDefinitions {
 /** Definitions required by JUnit plugin
  *
  *  Scala.js port based on dotty.tools.backend.sjs.JSDefinitions#junit from
- *  Scala release 3.1.0. It contains the same definitions as original class which
- *  cannot be used directly in Scala Native plugin
+ *  Scala release 3.1.0. It contains the same definitions as original class
+ *  which cannot be used directly in Scala Native plugin
  */
 final class JUnitDefinitions()(using ctx: Context) {
   // scalafmt: { maxColumn = 120}

--- a/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/JUnitDefinitions.scala
+++ b/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/JUnitDefinitions.scala
@@ -22,7 +22,7 @@ object JUnitDefinitions {
 /** Definitions required by JUnit plugin
  *
  *  Scala.js port based on dotty.tools.backend.sjs.JSDefinitions#junit from
- *  Scala release 3.1.0 Contains the same definitions as original class which
+ *  Scala release 3.1.0. It contains the same definitions as original class which
  *  cannot be used directly in Scala Native plugin
  */
 final class JUnitDefinitions()(using ctx: Context) {

--- a/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/ScalaNativeJUnitBootstrappers.scala
+++ b/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/ScalaNativeJUnitBootstrappers.scala
@@ -30,6 +30,9 @@ import dotty.tools.dotc.sbt
  *  Unfortunately we cannot use sjs implementation directly, because
  *  JsDefinitions assumes usage of JsPlatform which is absent in SN compiler
  *  plugin.
+ *
+ *  Additionally this port differs from Scala.js implementation by supporting
+ *  test suite wide ignore (ported from Scala 2 Native compiler plugin)
  */
 object ScalaNativeJUnitBootstrappers extends PluginPhase {
   def phaseName: String = "scalanative-junitBootstrappers"

--- a/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/ScalaNativeJUnitBootstrappers.scala
+++ b/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/ScalaNativeJUnitBootstrappers.scala
@@ -1,0 +1,403 @@
+package scala.scalanative.junit.plugin
+
+import scala.annotation.tailrec
+
+import dotty.tools.dotc.ast.tpd._
+import dotty.tools.dotc.core
+import core.Constants._
+import core.Contexts._
+import core.Decorators._
+import core.Flags._
+import core.Names._
+import core.NameOps._
+import core.Phases._
+import core.Scopes._
+import core.Symbols._
+import core.StdNames._
+import core.Types._
+import dotty.tools.dotc.plugins.PluginPhase
+import dotty.tools.dotc.transform
+import dotty.tools.dotc.report
+import dotty.tools.dotc.sbt
+
+/** Generates JUnit bootstrapper objects for Scala Native
+ *
+ *  Scala Native similarly as Scala.js cannot use reflection to invoke JUnit
+ *  tests, instead it injects bootstrapper classes responsible for running them.
+ *
+ *  This phase is a port of dotty.tools.dotc.transform.sjs.JUnitBootstrappers
+ *  based on release 3.1.0. Actual transformation logic is the same.
+ *  Unfortunately we cannot use sjs implementation directly, because
+ *  JsDefinitions assumes usage of JsPlatform which is absent in SN compiler
+ *  plugin.
+ */
+object ScalaNativeJUnitBootstrappers extends PluginPhase {
+  def phaseName: String = "scalanative-junitBootstrappers"
+  override val runsAfter = Set(transform.Mixin.name)
+  override val runsBefore = Set("scalanative-genNIR")
+
+  // Make sure to sync it the one used in JUnitTask
+  final val bootstrapperSuffix = "$scalanative$junit$bootstrapper"
+
+  // The actual transform -------------------------------
+  override def transformPackageDef(tree: PackageDef)(using Context): Tree = {
+    val junitdefn = JUnitDefinitions.defnJUnit
+
+    @tailrec
+    def hasTests(sym: ClassSymbol): Boolean = {
+      sym.info.decls.exists(m =>
+        m.is(Method) && m.hasAnnotation(junitdefn.TestAnnotClass)
+      ) ||
+      sym.superClass.exists && hasTests(sym.superClass.asClass)
+    }
+
+    def isTestClass(sym: Symbol): Boolean = {
+      sym.isClass &&
+      !sym.isOneOf(ModuleClass | Abstract | Trait) &&
+      hasTests(sym.asClass)
+    }
+
+    val bootstrappers = tree.stats.collect {
+      case clDef: TypeDef if isTestClass(clDef.symbol) =>
+        genBootstrapper(clDef.symbol.asClass)
+    }
+
+    if (bootstrappers.isEmpty) tree
+    else cpy.PackageDef(tree)(tree.pid, tree.stats ::: bootstrappers)
+  }
+
+  private def genBootstrapper(
+      testClass: ClassSymbol
+  )(using Context): TypeDef = {
+    val junitdefn = JUnitDefinitions.defnJUnit
+
+    /* The name of the bootstrapper module. It is derived from the test class name by
+     * appending a specific suffix string mandated "by spec". It will indeed also be
+     * computed as such at run-time by the Scala.js JUnit Runtime support. Therefore,
+     * it must *not* be a dotc semantic name.
+     */
+    val bootstrapperName =
+      (testClass.name ++ bootstrapperSuffix).toTermName
+
+    val owner = testClass.owner
+    val moduleSym = newCompleteModuleSymbol(
+      owner,
+      bootstrapperName,
+      Synthetic,
+      Synthetic,
+      List(defn.ObjectType, junitdefn.BootstrapperType),
+      newScope,
+      coord = testClass.span,
+      assocFile = testClass.assocFile
+    ).entered
+    val classSym = moduleSym.moduleClass.asClass
+
+    val constr = genConstructor(classSym)
+
+    val testMethods = annotatedMethods(testClass, junitdefn.TestAnnotClass)
+
+    val defs = List(
+      genCallOnModule(
+        classSym,
+        junitNme.beforeClass,
+        testClass.companionModule,
+        junitdefn.BeforeClassAnnotClass
+      ),
+      genCallOnModule(
+        classSym,
+        junitNme.afterClass,
+        testClass.companionModule,
+        junitdefn.AfterClassAnnotClass
+      ),
+      genCallOnParam(
+        classSym,
+        junitNme.before,
+        testClass,
+        junitdefn.BeforeAnnotClass
+      ),
+      genCallOnParam(
+        classSym,
+        junitNme.after,
+        testClass,
+        junitdefn.AfterAnnotClass
+      ),
+      genTestMetadata(classSym, testClass),
+      genTests(classSym, testMethods),
+      genInvokeTest(classSym, testClass, testMethods),
+      genNewInstance(classSym, testClass)
+    )
+
+    sbt.APIUtils.registerDummyClass(classSym)
+
+    ClassDef(classSym, constr, defs)
+  }
+
+  private def genConstructor(owner: ClassSymbol)(using Context): DefDef = {
+    val sym = newDefaultConstructor(owner).entered
+    DefDef(
+      sym, {
+        Block(
+          Super(This(owner), tpnme.EMPTY)
+            .select(defn.ObjectClass.primaryConstructor)
+            .appliedToNone :: Nil,
+          unitLiteral
+        )
+      }
+    )
+  }
+
+  private def genCallOnModule(
+      owner: ClassSymbol,
+      name: TermName,
+      module: Symbol,
+      annot: Symbol
+  )(using Context): DefDef = {
+    val sym = newSymbol(
+      owner,
+      name,
+      Synthetic | Method,
+      MethodType(Nil, Nil, defn.UnitType)
+    ).entered
+
+    DefDef(
+      sym, {
+        if (module.exists) {
+          val calls = annotatedMethods(module.moduleClass.asClass, annot)
+            .map(m => Apply(ref(module).select(m), Nil))
+          Block(calls, unitLiteral)
+        } else {
+          unitLiteral
+        }
+      }
+    )
+  }
+
+  private def genCallOnParam(
+      owner: ClassSymbol,
+      name: TermName,
+      testClass: ClassSymbol,
+      annot: Symbol
+  )(using Context): DefDef = {
+    val sym = newSymbol(
+      owner,
+      name,
+      Synthetic | Method,
+      MethodType(
+        junitNme.instance :: Nil,
+        defn.ObjectType :: Nil,
+        defn.UnitType
+      )
+    ).entered
+
+    DefDef(
+      sym,
+      { (paramRefss: List[List[Tree]]) =>
+        val List(List(instanceParamRef)) = paramRefss
+        val calls = annotatedMethods(testClass, annot)
+          .map(m =>
+            Apply(instanceParamRef.cast(testClass.typeRef).select(m), Nil)
+          )
+        Block(calls, unitLiteral)
+      }
+    )
+  }
+
+  // This method is not part of Scala 3/Scala.js bootstrappers implementation
+  private def genTestMetadata(
+      owner: ClassSymbol,
+      testClass: ClassSymbol
+  )(using Context): DefDef = {
+    val junitdefn = JUnitDefinitions.defnJUnit
+
+    val sym = newSymbol(
+      owner,
+      junitNme.testClassMetadata,
+      Synthetic | Method,
+      MethodType(Nil, junitdefn.TestClassMetadataType)
+    ).entered
+
+    DefDef(
+      sym, {
+        val hasIgnoreAnnot = testClass.hasAnnotation(junitdefn.IgnoreAnnotClass)
+        val isIgnored = Literal(Constant(hasIgnoreAnnot))
+
+        New(junitdefn.TestClassMetadataType, List(isIgnored))
+      }
+    )
+  }
+
+  private def genTests(owner: ClassSymbol, tests: List[Symbol])(using
+      Context
+  ): DefDef = {
+    val junitdefn = JUnitDefinitions.defnJUnit
+
+    val sym = newSymbol(
+      owner,
+      junitNme.tests,
+      Synthetic | Method,
+      MethodType(Nil, defn.ArrayOf(junitdefn.TestMetadataType))
+    ).entered
+
+    DefDef(
+      sym, {
+        val metadata = for (test <- tests) yield {
+          val name = Literal(Constant(test.name.mangledString))
+          val ignored =
+            Literal(Constant(test.hasAnnotation(junitdefn.IgnoreAnnotClass)))
+          val testAnnot = test.getAnnotation(junitdefn.TestAnnotClass).get
+
+          val mappedArguments = testAnnot.arguments.flatMap {
+            // Since classOf[...] in annotations would not be transformed, grab the resulting class constant here
+            case NamedArg(
+                  expectedName: SimpleName,
+                  TypeApply(Ident(nme.classOf), fstArg :: _)
+                ) if expectedName.toString == "expected" =>
+              Some(clsOf(fstArg.tpe))
+            // The only other valid argument to @Test annotations is timeout
+            case NamedArg(timeoutName: TermName, timeoutLiteral: Literal)
+                if timeoutName.toString == "timeout" =>
+              Some(timeoutLiteral)
+            case other => {
+              val shownName = other match {
+                case NamedArg(name, _) => name.show(using ctx)
+                case other             => other.show(using ctx)
+              }
+              report.error(
+                s"$shownName is an unsupported argument for the JUnit @Test annotation in this position",
+                other.sourcePos
+              )
+              None
+            }
+          }
+
+          val reifiedAnnot =
+            resolveConstructor(junitdefn.TestAnnotType, mappedArguments)
+          New(junitdefn.TestMetadataType, List(name, ignored, reifiedAnnot))
+        }
+        JavaSeqLiteral(metadata, TypeTree(junitdefn.TestMetadataType))
+      }
+    )
+  }
+
+  private def genInvokeTest(
+      owner: ClassSymbol,
+      testClass: ClassSymbol,
+      tests: List[Symbol]
+  )(using Context): DefDef = {
+    val junitdefn = JUnitDefinitions.defnJUnit
+
+    val sym = newSymbol(
+      owner,
+      junitNme.invokeTest,
+      Synthetic | Method,
+      MethodType(
+        List(junitNme.instance, junitNme.name),
+        List(defn.ObjectType, defn.StringType),
+        junitdefn.FutureType
+      )
+    ).entered
+
+    DefDef(
+      sym,
+      { (paramRefss: List[List[Tree]]) =>
+        val List(List(instanceParamRef, nameParamRef)) = paramRefss
+        val castInstanceSym = newSymbol(
+          sym,
+          junitNme.castInstance,
+          Synthetic,
+          testClass.typeRef,
+          coord = owner.span
+        )
+        Block(
+          ValDef(
+            castInstanceSym,
+            instanceParamRef.cast(testClass.typeRef)
+          ) :: Nil,
+          tests.foldRight[Tree] {
+            val tp = junitdefn.NoSuchMethodExceptionType
+            Throw(resolveConstructor(tp, nameParamRef :: Nil))
+          } { (test, next) =>
+            If(
+              Literal(Constant(test.name.mangledString))
+                .select(defn.Any_equals)
+                .appliedTo(nameParamRef),
+              genTestInvocation(testClass, test, ref(castInstanceSym)),
+              next
+            )
+          }
+        )
+      }
+    )
+  }
+
+  private def genTestInvocation(
+      testClass: ClassSymbol,
+      testMethod: Symbol,
+      instance: Tree
+  )(using Context): Tree = {
+    val junitdefn = JUnitDefinitions.defnJUnit
+
+    val resultType = testMethod.info.resultType
+    def returnsUnit =
+      resultType.isRef(defn.UnitClass) || resultType.isRef(defn.BoxedUnitClass)
+    def returnsFuture = resultType.isRef(junitdefn.FutureClass)
+
+    if (returnsUnit) {
+      val newSuccess =
+        ref(junitdefn.SuccessModule_apply).appliedTo(ref(defn.BoxedUnit_UNIT))
+      Block(
+        instance.select(testMethod).appliedToNone :: Nil,
+        ref(junitdefn.FutureModule_successful).appliedTo(newSuccess)
+      )
+    } else if (returnsFuture) {
+      instance.select(testMethod).appliedToNone
+    } else {
+      // We lie in the error message to not expose that we support async testing.
+      report.error(
+        s"JUnit test must have Unit return type, but got $resultType",
+        testMethod.sourcePos
+      )
+      EmptyTree
+    }
+  }
+
+  private def genNewInstance(owner: ClassSymbol, testClass: ClassSymbol)(using
+      Context
+  ): DefDef = {
+    val sym = newSymbol(
+      owner,
+      junitNme.newInstance,
+      Synthetic | Method,
+      MethodType(Nil, defn.ObjectType)
+    ).entered
+
+    DefDef(sym, New(testClass.typeRef, Nil))
+  }
+
+  private def castParam(param: Symbol, clazz: Symbol)(using Context): Tree =
+    ref(param).cast(clazz.typeRef)
+
+  private def annotatedMethods(owner: ClassSymbol, annot: Symbol)(using
+      Context
+  ): List[Symbol] =
+    owner.info
+      .membersBasedOnFlags(Method, EmptyFlags)
+      .filter(_.symbol.hasAnnotation(annot))
+      .map(_.symbol)
+      .toList
+
+  private object junitNme {
+    val beforeClass: TermName = termName("beforeClass")
+    val afterClass: TermName = termName("afterClass")
+    val before: TermName = termName("before")
+    val after: TermName = termName("after")
+    val testClassMetadata: TermName = termName("testClassMetadata")
+    val tests: TermName = termName("tests")
+    val invokeTest: TermName = termName("invokeTest")
+    val newInstance: TermName = termName("newInstance")
+
+    val instance: TermName = termName("instance")
+    val name: TermName = termName("name")
+    val castInstance: TermName = termName("castInstance")
+  }
+}

--- a/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
@@ -1,0 +1,25 @@
+package scala.scalanative.junit.plugin
+
+import dotty.tools.dotc
+import dotc.plugins._
+import dotc.transform
+import dotc.core
+import core.Contexts._
+
+/** The Scala Native JUnit plugin replaces reflection based test lookup.
+ *
+ *  For each JUnit test `my.pkg.X`, it generates a bootstrapper module/object
+ *  `my.pkg.X\$scalanative\$junit\$bootstrapper` implementing
+ *  `scala.scalanative.junit.Bootstrapper`.
+ *
+ *  The test runner uses these objects to obtain test metadata and dispatch to
+ *  relevant methods.
+ */
+
+class ScalaNativeJUnitPlugin extends StandardPlugin {
+  val name: String = "Scala Native JUnit plugin"
+  val description: String = "Makes JUnit test classes invokable in Scala Native"
+
+  def init(options: List[String]): List[PluginPhase] =
+    ScalaNativeJUnitBootstrappers :: Nil
+}

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -24,7 +24,7 @@ object BinaryIncompatibilities {
   final val PosixLib: Filters = Nil
   final val WindowsLib: Filters = Nil
 
-  final val AuxLib, JavaLib, ScalaLib: Filters = Nil
+  final val AuxLib, JavaLib, ScalaLib, Scala3Lib: Filters = Nil
   final val TestRunner: Filters = Nil
   final val TestInterface: Filters = Nil
   final val TestInterfaceSbtDefs: Filters = Nil
@@ -41,6 +41,7 @@ object BinaryIncompatibilities {
     "auxlib" -> AuxLib,
     "javalib" -> JavaLib,
     "scalalib" -> ScalaLib,
+    "scala3lib" -> Scala3Lib,
     "test-runner" -> TestRunner,
     "test-interface" -> TestInterface,
     "test-interface-sbt-defs" -> TestInterfaceSbtDefs,


### PR DESCRIPTION
This PR ports Scala.js JUnit plugin for Scala 3 to Scala Native, and additionally it combines changes from Scala 2 Native compiler plugin allowing for test-suite wide `Ignore` annotations. 

Most of the plugin was copy-pasted from Scala 3.1.0 compiler, because we cannot use it directly in Scala Native (phase uses `JsPlatform` which is not available in the compiler plugin). 
Adding JUnit plugin allows us to run our unit tests, and we now run all tools and runtime tests in the CI