### PR TITLE
Make reachablity phase more user friendly

### DIFF
--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -849,12 +849,14 @@ class Reach(
   }
 
   protected def addMissing(global: Global, pos: Position): Unit = {
-    val prev = missing.getOrElse(global, Set.empty)
-    val position = NonReachablePosition(
-      path = Paths.get(pos.source),
-      line = pos.line + 1
-    )
-    missing(global) = prev + position
+    val prev = missing.getOrElseUpdate(global, Set.empty)
+    if (pos != nir.Position.NoPosition) {
+      val position = NonReachablePosition(
+        path = Paths.get(pos.source),
+        line = pos.line + 1
+      )
+      missing(global) = prev + position
+    }
   }
 
   private def reportMissing(): Unit = {


### PR DESCRIPTION
This PR includes some improvements to `Reach`, by providing better logging of missing definitions and fixes frequently observed issues. 

* Fix frequent class cast exception (Unavailable -> ScopeInfo) 
* Fix `IllegalArgumentException` when trying to report missing definition using `nir.Position.NoPostion` 
* Throw verbose exception when required definition (ex. Scala hashCode) is missing
* Include unavailable definitions in while reporting missing defns