### PR TITLE
Fix certain absolute file paths being shown as relative on Windows

### DIFF
--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
@@ -42,6 +42,7 @@ class WindowsPath private[windows] (
         }
       case (PathType.Absolute, Some(root))          => root
       case (PathType.DirectoryRelative, Some(root)) => root + "\\"
+      case (PathType.DriveRelative, _)              => "\\"
       case _                                        => ""
     }
     drivePrefix + segments.mkString(seperator)

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/PathsTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/PathsTest.scala
@@ -64,6 +64,15 @@ class PathsTest {
     assertEquals(expected2, path2.toString)
   }
 
+  @Test def driveRelativePathToStringShownAsAbsolute() = {
+    val absolutePath = "/absolute/file"
+    val expected = if (isWindows) "\\absolute\\file" else "/absolute/file"
+
+    val path = Paths.get(absolutePath)
+
+    assertEquals(expected, path.toString)
+  }
+
   // issue #2433
   @Test def spaceAllowedInPath() = {
     val withSpaces = "space dir/space file"


### PR DESCRIPTION
Previously, certain file paths on Windows like "\absolute\path" would be parsed and shown in toString as "absolute\path", which would not happen on JVM, despite the file actually being drive relative.
This commit fixes that issue and adds a test, bringing Scala Native closer to JVM.