### PR TITLE
Introduce static scope and generate static method forwarders in Scala 3

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Mangle.scala
@@ -1,6 +1,6 @@
 package scala.scalanative
 package nir
-import scala.scalanative.nir.Sig.Scope.{Private, Public}
+import scala.scalanative.nir.Sig.Scope._
 import scala.scalanative.util.ShowBuilder.InMemoryShowBuilder
 
 object Mangle {
@@ -45,9 +45,13 @@ object Mangle {
     def mangleSig(sig: Sig): Unit =
       str(sig.mangle)
 
-    def mangleSigScope(scope: Sig.Scope): Unit = scope match {
-      case Public      => str("O")
-      case Private(in) => str("P"); mangleGlobal(in)
+    def mangleSigScope(scope: Sig.Scope): Unit = {
+      scope match {
+        case Public            => str("O")
+        case PublicStatic      => str("o")
+        case Private(in)       => str("P"); mangleGlobal(in)
+        case PrivateStatic(in) => str("p"); mangleGlobal(in)
+      }
     }
 
     def mangleUnmangledSig(sig: Sig.Unmangled): Unit = sig match {

--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -3,10 +3,6 @@ package nir
 
 import scala.annotation.tailrec
 import scala.language.implicitConversions
-import scala.scalanative.nir.Sig.Scope.Public
-import scala.scalanative.nir.Sig.Scope.Private
-import scala.scalanative.nir.Sig.Scope.PublicStatic
-import scala.scalanative.nir.Sig.Scope.PrivateStatic
 
 final class Sig(val mangle: String) {
   final def toProxy: Sig =
@@ -29,14 +25,7 @@ final class Sig(val mangle: String) {
     mangle.##
   final override def toString: String =
     mangle
-  final def unmangled: Sig.Unmangled = try {
-    Unmangle.unmangleSig(mangle)
-  } catch {
-    case ex: scala.MatchError =>
-      throw new Exception(
-        s"Failed to unmangle signature `${mangle}`, unknown tag found ${ex.getMessage()}"
-      )
-  }
+  final def unmangled: Sig.Unmangled = Unmangle.unmangleSig(mangle)
 
   final def isField: Boolean = mangle(0) == 'F'
   final def isCtor: Boolean = mangle(0) == 'R'

--- a/nir/src/main/scala/scala/scalanative/nir/Sig.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Sig.scala
@@ -3,6 +3,10 @@ package nir
 
 import scala.annotation.tailrec
 import scala.language.implicitConversions
+import scala.scalanative.nir.Sig.Scope.Public
+import scala.scalanative.nir.Sig.Scope.Private
+import scala.scalanative.nir.Sig.Scope.PublicStatic
+import scala.scalanative.nir.Sig.Scope.PrivateStatic
 
 final class Sig(val mangle: String) {
   final def toProxy: Sig =
@@ -25,7 +29,14 @@ final class Sig(val mangle: String) {
     mangle.##
   final override def toString: String =
     mangle
-  final def unmangled: Sig.Unmangled = Unmangle.unmangleSig(mangle)
+  final def unmangled: Sig.Unmangled = try {
+    Unmangle.unmangleSig(mangle)
+  } catch {
+    case ex: scala.MatchError =>
+      throw new Exception(
+        s"Failed to unmangle signature `${mangle}`, unknown tag found ${ex.getMessage()}"
+      )
+  }
 
   final def isField: Boolean = mangle(0) == 'F'
   final def isCtor: Boolean = mangle(0) == 'R'
@@ -39,18 +50,23 @@ final class Sig(val mangle: String) {
 
   final def isVirtual = !(isCtor || isClinit || isImplCtor || isExtern)
   final def isPrivate: Boolean = privateIn.isDefined
+  final def isStatic: Boolean = unmangled.sigScope.isStatic
   final lazy val privateIn: Option[Global.Top] = {
-    unmangled.sigScope match {
-      case Sig.Scope.Private(in: Global.Top) => Some(in)
-      case _                                 => None
-    }
+    unmangled.sigScope.privateIn.map(_.top)
   }
 }
 object Sig {
-  sealed trait Scope
+  sealed abstract class Scope(
+      val isStatic: Boolean,
+      val privateIn: Option[Global]
+  ) {
+    def isPublic: Boolean = privateIn.isEmpty
+  }
   object Scope {
-    case object Public extends Scope
-    case class Private(in: Global) extends Scope
+    case object Public extends Scope(false, None)
+    case object PublicStatic extends Scope(true, None)
+    final case class Private(in: Global) extends Scope(false, Some(in))
+    final case class PrivateStatic(in: Global) extends Scope(true, Some(in))
   }
 
   sealed abstract class Unmangled {

--- a/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
@@ -21,7 +21,9 @@ object Unmangle {
 
     def readSigScope(): Sig.Scope = read() match {
       case 'O' => Sig.Scope.Public
+      case 'o' => Sig.Scope.PublicStatic
       case 'P' => Sig.Scope.Private(readGlobal())
+      case 'p' => Sig.Scope.PrivateStatic(readGlobal())
     }
 
     def readUnmangledSig(): Sig.Unmangled = read() match {

--- a/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Unmangle.scala
@@ -2,9 +2,18 @@ package scala.scalanative
 package nir
 
 object Unmangle {
-  def unmangleGlobal(s: String): Global = (new Impl(s)).readGlobal()
-  def unmangleType(s: String): Type = (new Impl(s)).readType()
-  def unmangleSig(s: String): Sig.Unmangled = (new Impl(s)).readUnmangledSig()
+  def unmangleGlobal(s: String): Global = unmangle(s)(_.readGlobal())
+  def unmangleType(s: String): Type = unmangle(s)(_.readType())
+  def unmangleSig(s: String): Sig.Unmangled = unmangle(s)(_.readUnmangledSig())
+
+  private def unmangle[T](s: String)(fn: Impl => T) =
+    try fn(new Impl(s))
+    catch {
+      case ex: scala.MatchError =>
+        throw new Exception(
+          s"Failed to unmangle signature `${s}`, unknown symbol found ${ex.getMessage()}"
+        )
+    }
 
   private class Impl(s: String) {
     val chars = s.toArray

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -20,7 +20,7 @@ object AdaptLazyVals extends PluginPhase {
   val phaseName = "scalanative-adaptLazyVals"
 
   override val runsAfter = Set(LazyVals.name, MoveStatics.name)
-  override val runsBefore = Set(GenNIR.phaseName)
+  override val runsBefore = Set(GenNIR.name)
 
   def defn(using Context) = LazyValsDefns.get
   def defnNir(using Context) = NirDefinitions.defnNir

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenNIR.scala
@@ -6,13 +6,18 @@ import plugins._
 import core._
 import Contexts._
 
-object GenNIR extends PluginPhase {
-  val phaseName = "scalanative-genNIR"
+class GenNIR(settings: GenNIR.Settings) extends PluginPhase {
+  val phaseName = GenNIR.name
 
   override val runsAfter = Set(transform.MoveStatics.name)
   override val runsBefore = Set(backend.jvm.GenBCode.name)
 
   override def run(using Context): Unit = {
-    NirCodeGen().run()
+    NirCodeGen(settings).run()
   }
+}
+
+object GenNIR {
+  val name = "scalanative-genNIR"
+  case class Settings(genStaticForwardersForNonTopLevelObjects: Boolean = false)
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -389,6 +389,4 @@ trait GenReflectiveInstantisation(using Context) {
     ctorsInfo
   }
 
-
-
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -389,13 +389,6 @@ trait GenReflectiveInstantisation(using Context) {
     ctorsInfo
   }
 
-  private def withFreshExprBuffer[R](f: ExprBuffer ?=> R): R = {
-    scoped(
-      curFresh := Fresh()
-    ) {
-      val buffer = new ExprBuffer(using curFresh)
-      f(using buffer)
-    }
-  }
+
 
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -15,7 +15,7 @@ import dotty.tools.FatalError
 import scala.collection.mutable
 import scala.language.implicitConversions
 
-class NirCodeGen()(using ctx: Context)
+class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
     extends NirGenStat
     with NirGenExpr
     with NirGenType
@@ -56,6 +56,7 @@ class NirCodeGen()(using ctx: Context)
       genCompilationUnit(ctx.compilationUnit)
     } finally {
       generatedDefns.clear()
+      generatedStaticForwarderClasses.clear()
       reflectiveInstantiationBuffers.clear()
     }
   }
@@ -80,6 +81,47 @@ class NirCodeGen()(using ctx: Context)
     reflectiveInstantiationBuffers
       .groupMapReduce(buf => getFileFor(cunit, buf.name.top))(_.toSeq)(_ ++ _)
       .foreach(genIRFile(_, _))
+
+    if (generatedStaticForwarderClasses.nonEmpty) {
+      // Ported from Scala.js
+      /* #4148 Add generated static forwarder classes, except those that
+       * would collide with regular classes on case insensitive file systems.
+       */
+
+      /* I could not find any reference anywhere about what locale is used
+       * by case insensitive file systems to compare case-insensitively.
+       * In doubt, force the English locale, which is probably going to do
+       * the right thing in virtually all cases (especially if users stick
+       * to ASCII class names), and it has the merit of being deterministic,
+       * as opposed to using the OS' default locale.
+       * The JVM backend performs a similar test to emit a warning for
+       * conflicting top-level classes. However, it uses `toLowerCase()`
+       * without argument, which is not deterministic.
+       */
+      def caseInsensitiveNameOf(classDef: nir.Defn.Class): String =
+        classDef.name.mangle.toLowerCase(java.util.Locale.ENGLISH)
+
+      val generatedCaseInsensitiveNames =
+        generatedDefns.collect {
+          case cls: Defn.Class => caseInsensitiveNameOf(cls)
+        }.toSet
+
+      for ((site, staticCls) <- generatedStaticForwarderClasses) {
+        val StaticForwarderClass(classDef, forwarders) = staticCls
+        val caseInsensitiveName = caseInsensitiveNameOf(classDef)
+        if (!generatedCaseInsensitiveNames.contains(caseInsensitiveName)) {
+          val file = getFileFor(cunit, classDef.name)
+          val defs = classDef +: forwarders
+          genIRFile(file, defs)
+        } else {
+          report.warning(
+            s"Not generating the static forwarders of ${classDef.name} " +
+              "because its name differs only in case from the name of another class or trait in this compilation unit.",
+            site.srcPos
+          )
+        }
+      }
+    }
   }
 
   private def genIRFile(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -119,23 +119,18 @@ trait NirGenExpr(using Context) {
       val Assign(lhsp, rhsp) = tree
       given nir.Position = tree.span
 
-      val sym = lhsp.symbol
-      if (sym.is(JavaStaticTerm) && sym.source != ctx.compilationUnit.source) {
-        report.error(
-          s"Assignment to static member ${sym.fullName} is not supported",
-          tree.sourcePos
-        )
-      }
-
       desugarTree(lhsp) match {
         case sel @ Select(qualp, _) =>
-          val qual = genExpr(qualp)
           val rhs = genExpr(rhsp)
-          val name = genFieldName(sel.symbol)
-          if (sel.symbol.owner.isExternModule) {
+          val sym = sel.symbol
+          val name = genFieldName(sym)
+          if (sym.owner.isExternModule) {
             val externTy = genExternType(sel.tpe)
-            genStoreExtern(externTy, sel.symbol, rhs)
+            genStoreExtern(externTy, sym, rhs)
           } else {
+            val qual =
+              if (sym.isStaticMember) genModule(qualp.symbol)
+              else genExpr(qualp)
             val ty = genType(sel.tpe)
             buf.fieldstore(ty, qual, name, rhs, unwind)
           }
@@ -646,7 +641,7 @@ trait NirGenExpr(using Context) {
 
     def genModule(sym: Symbol)(using nir.Position): Val = {
       val moduleSym = if (sym.isTerm) sym.moduleClass else sym
-      buf.module(genTypeName(moduleSym), unwind)
+      buf.module(genModuleName(moduleSym), unwind)
     }
 
     def genReturn(tree: Return): Val = {
@@ -693,7 +688,9 @@ trait NirGenExpr(using Context) {
         buf.extract(qual, Seq(index), unwind)
       } else {
         val ty = genType(tree.tpe)
-        val qual = genExpr(qualp)
+        val qual =
+          if (sym.isStaticMember) genModule(owner)
+          else genExpr(qualp)
         val name = genFieldName(tree.symbol)
         if (sym.isExtern) {
           val externTy = genExternType(tree.tpe)
@@ -1182,20 +1179,13 @@ trait NirGenExpr(using Context) {
         sym: Symbol,
         argsp: Seq[Tree]
     )(using nir.Position): Val = {
-      val owner = sym.owner.asClass
-      val module = genModuleName(owner)
-
-      val name = {
-        val nir.Global.Member(_, sig) = genMethodName(sym)
-        module.member(sig)
-      }
+      val name = genStaticMemberName(sym)
       val method = Val.Global(name, nir.Type.Ptr)
 
       val Type.Function(_ +: argTypes, retty) = genMethodSig(sym)
-      val sig = Type.Function(Type.Ref(module) +: argTypes, retty)
+      val sig = Type.Function(Type.Ref(name.owner) +: argTypes, retty)
       val args = genMethodArgs(sym, argsp)
-      val self = buf.module(module, unwind)
-      val values = self +: args
+      val values = Val.Null +: args
       buf.call(sig, method, values, unwind)
     }
 
@@ -1576,11 +1566,15 @@ trait NirGenExpr(using Context) {
     private def genStaticMember(
         sym: Symbol
     )(using nir.Position): Val = {
-      def ty = genType(sym.info.resultType)
-      def module = genModule(sym.owner)
+      /* Actually, there is no static member in Scala Native. If we come here, that
+       * is because we found the symbol in a Java-emitted .class in the
+       * classpath. But the corresponding implementation in Scala Native will
+       * actually be a val in the companion module.
+       */
 
       if (sym == defn.BoxedUnit_UNIT) Val.Unit
-      else genApplyMethod(sym, statically = true, module, Seq())
+      else if (sym == defn.BoxedUnit_TYPE) Val.Unit
+      else genApplyStaticMethod(sym, Seq())
     }
 
     private def genSynchronized(receiverp: Tree, bodyp: Tree)(using

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1183,7 +1183,7 @@ trait NirGenExpr(using Context) {
       val method = Val.Global(name, nir.Type.Ptr)
 
       val Type.Function(_ +: argTypes, retty) = genMethodSig(sym)
-      val sig = Type.Function(Type.Ref(name.owner) +: argTypes, retty)
+      val sig = Type.Function(Type.Ref(name.top) +: argTypes, retty)
       val args = genMethodArgs(sym, argsp)
       val values = Val.Null +: args
       buf.call(sig, method, values, unwind)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -49,7 +49,9 @@ trait NirGenName(using Context) {
   }
 
   def genFieldName(sym: Symbol): nir.Global = {
-    val owner = genTypeName(sym.owner)
+    val owner =
+      if (sym.isScalaStatic) genModuleName(sym.owner)
+      else genTypeName(sym.owner)
     val id = nativeIdOf(sym)
     val scope = {
       /* Variables are internally private, but with public setter/getter.
@@ -95,9 +97,8 @@ trait NirGenName(using Context) {
   }
 
   def genStaticMemberName(sym: Symbol): Global = {
-    require(sym.is(JavaStatic),
-        "genStaticMemberName called with non-static symbol: " + sym + " " + sym.flagsString)
-    val owner = genTypeName(sym.owner)
+    val typeName = genTypeName(sym.owner)
+    val owner = Global.Top(typeName.id.stripSuffix("$"))
     val id = nativeIdOf(sym)
     val scope =
       if (sym.isPrivate) nir.Sig.Scope.PrivateStatic(owner)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -89,6 +89,7 @@ trait NirGenName(using Context) {
         owner.member(nir.Sig.Extern(id))
       else owner.member(nir.Sig.Extern(id))
     else if (sym.isClassConstructor) owner.member(nir.Sig.Ctor(paramTypes))
+    else if (sym.isStaticConstructor) owner.member(nir.Sig.Clinit())
     else if (sym.name == nme.TRAIT_CONSTRUCTOR)
       owner.member(nir.Sig.Method(id, Seq(nir.Type.Unit), scope))
     else

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -88,7 +88,8 @@ trait NirGenName(using Context) {
         val id = nativeIdOf(sym.getter)
         owner.member(nir.Sig.Extern(id))
       else owner.member(nir.Sig.Extern(id))
-    else if (sym.name == nme.CONSTRUCTOR) owner.member(nir.Sig.Ctor(paramTypes))
+    else if (sym.isClassConstructor) owner.member(nir.Sig.Ctor(paramTypes))
+    else if (sym.isStaticConstructor) owner.member(nir.Sig.Clinit())
     else if (sym.name == nme.TRAIT_CONSTRUCTOR)
       owner.member(nir.Sig.Method(id, Seq(nir.Type.Unit), scope))
     else

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -89,7 +89,6 @@ trait NirGenName(using Context) {
         owner.member(nir.Sig.Extern(id))
       else owner.member(nir.Sig.Extern(id))
     else if (sym.isClassConstructor) owner.member(nir.Sig.Ctor(paramTypes))
-    else if (sym.isStaticConstructor) owner.member(nir.Sig.Clinit())
     else if (sym.name == nme.TRAIT_CONSTRUCTOR)
       owner.member(nir.Sig.Method(id, Seq(nir.Type.Unit), scope))
     else

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -547,7 +547,7 @@ trait NirGenStat(using Context) {
 
       val methodName = genMethodName(sym)
       val forwarderName = genStaticMemberName(sym)
-      
+
       val Type.Function(_ +: paramTypes, retType) = genMethodSig(sym)
       val forwarderParamTypes = Type.Ref(forwarderName.top) +: paramTypes
       val forwarderType = Type.Function(forwarderParamTypes, retType)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -535,9 +535,8 @@ trait NirGenStat(using Context) {
 
     def isExcluded(m: Symbol): Boolean = {
       def hasAccessBoundary = m.accessBoundary(defn.RootClass) ne defn.RootClass
-      m.isExtern ||
-      m.is(Deferred) || m.isConstructor ||
-      hasAccessBoundary ||
+      m.isExtern || m.isConstructor ||
+      m.is(Deferred) || hasAccessBoundary ||
       (m.owner eq defn.ObjectClass)
     }
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -9,6 +9,7 @@ import core.Symbols._
 import core.Constants._
 import core.StdNames._
 import core.Flags._
+import core.Phases._
 import dotty.tools.dotc.transform.SymUtils._
 
 import scala.collection.mutable
@@ -25,6 +26,13 @@ trait NirGenStat(using Context) {
   import positionsConversions.fromSpan
 
   protected val generatedDefns = mutable.UnrolledBuffer.empty[nir.Defn]
+  protected val generatedStaticForwarderClasses =
+    mutable.Map.empty[Symbol, StaticForwarderClass]
+
+  protected case class StaticForwarderClass(
+      defn: nir.Defn.Class,
+      forwarders: Seq[nir.Defn.Define]
+  )
 
   def genClass(td: TypeDef)(using Context): Unit = {
     val sym = td.symbol.asClass
@@ -99,29 +107,26 @@ trait NirGenStat(using Context) {
     do
       given nir.Position = f.span
 
-      val isStaticField =
-        f.is(JavaStatic) || f.hasAnnotation(defn.StaticAnnotationClass)
-      val mutable = isStaticField || f.is(Mutable)
+      val isJavaStatic = f.is(JavaStatic)
+      val mutable = isJavaStatic || f.is(Mutable)
       val isExternModule = classSym.isExternModule
       val attrs = nir.Attrs(isExtern = isExternModule)
       val ty = genType(f.info.resultType)
-      val fieldName @ Global.Member(owner, sig) = genName(f)
+      val fieldName @ Global.Member(owner, sig) = genFieldName(f)
       generatedDefns += Defn.Var(attrs, fieldName, ty, Val.Zero(ty))
 
-      if (isStaticField) {
+      if (isJavaStatic) {
         // Here we are generating a public static getter for the static field,
         // this is its API for other units. This is necessary for singleton
         // enum values, which are backed by static fields.
         generatedDefns += Defn.Define(
           attrs = Attrs(inlineHint = nir.Attr.InlineHint),
-          name = genMethodName(f),
+          name = genStaticMemberName(f),
           ty = Type.Function(Nil, ty),
-          insts = {
-            given fresh: Fresh = Fresh()
-            given buf: ExprBuffer = ExprBuffer()
-
+          insts = withFreshExprBuffer { buf ?=>
+            val fresh = curFresh.get
             buf.label(fresh())
-            val module = buf.module(owner, Next.None)
+            val module = buf.module(genModuleName(classSym), Next.None)
             val value = buf.fieldload(ty, module, fieldName, Next.None)
             buf.ret(value)
 
@@ -133,85 +138,21 @@ trait NirGenStat(using Context) {
 
   private def genMethods(td: TypeDef): Unit = {
     val tpl = td.rhs.asInstanceOf[Template]
-    (tpl.constr :: tpl.body).foreach {
-      case EmptyTree  => ()
-      case _: ValDef  => () // handled in genClassFields
-      case _: TypeDef => ()
+    val methods = (tpl.constr :: tpl.body).flatMap {
+      case EmptyTree  => Nil
+      case _: ValDef  => Nil // handled in genClassFields
+      case _: TypeDef => Nil
       case dd: DefDef => genMethod(dd)
       case tree =>
         throw new FatalError("Illegal tree in body of genMethods():" + tree)
     }
 
-    scoped(
-      curUnwindHandler := None
-    ) {
-      genStaticMethodForwarders(td)
-    }
+    val forwarders = genStaticMethodForwarders(td, methods)
+    generatedDefns ++= methods
+    generatedDefns ++= forwarders
   }
 
-  // In Scala Native we don't have a limited access for static members.
-  // Make sure that we can always call static methods, by generating a forwarder
-  // inside a companion module. It is need to handle methods created by compiler
-  // with JavaStatic flag, eg main method using @main annotation
-  private def genStaticMethodForwarders(td: TypeDef): Unit = {
-    val sym = td.symbol.asClass
-    val moduleName = genModuleName(sym)
-    val staticMethods =
-      sym.info.allMembers
-        .map(_.symbol)
-        .filter(_.isStaticMethod)
-
-    if (!sym.isStaticModule && staticMethods.nonEmpty) {
-      val module = sym.companionModule
-      if (!module.exists) {
-        given nir.Position = td.span
-        generatedDefns += Defn.Module(
-          attrs = Attrs.None,
-          name = moduleName,
-          parent = Some(Rt.Object.name),
-          traits = Nil
-        )
-      }
-
-      staticMethods.foreach { sym =>
-        given nir.Position = sym.span
-
-        val methodName @ Global.Member(_, methodSig) = genMethodName(sym)
-        val methodType @ Type.Function(origOwner +: paramTypes, retType) =
-          genMethodSig(sym)
-
-        val selfType = Type.Ref(moduleName)
-        val forwarderName = moduleName.member(methodSig)
-        val forwarderParamTypes = selfType +: paramTypes
-        val forwarderSig = Type.Function(forwarderParamTypes, retType)
-
-        generatedDefns += Defn.Define(
-          attrs = Attrs(inlineHint = nir.Attr.InlineHint),
-          name = forwarderName,
-          ty = forwarderSig,
-          insts = {
-            given fresh: Fresh = Fresh()
-            given buf: ExprBuffer = ExprBuffer()
-
-            val entryParams @ (self +: params) =
-              forwarderParamTypes.map(Val.Local(fresh(), _))
-            buf.label(fresh(), entryParams)
-            val result = buf.call(
-              methodType,
-              Val.Global(methodName, Type.Ptr),
-              Val.Null +: params,
-              Next.None
-            )
-            buf.ret(result)
-
-            buf.toSeq
-          }
-        )
-      }
-    }
-  }
-
-  private def genMethod(dd: DefDef): Unit = {
+  private def genMethod(dd: DefDef): Option[Defn] = {
     implicit val pos: nir.Position = dd.span
     val fresh = Fresh()
 
@@ -232,13 +173,13 @@ trait NirGenStat(using Context) {
       val isStatic = sym.isExtern
 
       dd.rhs match {
-        case EmptyTree =>
-          generatedDefns += Defn.Declare(attrs, name, sig)
+        case EmptyTree => Some(Defn.Declare(attrs, name, sig))
         case _ if sym.isClassConstructor && sym.isExtern =>
           validateExternCtor(dd.rhs)
-          ()
+          None
 
-        case _ if sym.isClassConstructor && owner.isStruct => ()
+        case _ if sym.isClassConstructor && owner.isStruct =>
+          None
 
         case rhs if sym.isExtern =>
           checkExplicitReturnTypeAnnotation(dd, "extern method")
@@ -251,12 +192,13 @@ trait NirGenStat(using Context) {
           scoped(
             curMethodSig := sig
           ) {
-            generatedDefns += Defn.Define(
+            val defn = Defn.Define(
               attrs,
               name,
               sig,
               genMethodBody(dd, rhs, isStatic, isExtern = false)
             )
+            Some(defn)
           }
       }
     }
@@ -411,7 +353,7 @@ trait NirGenStat(using Context) {
 
   protected def genLinktimeResolved(dd: DefDef, name: Global)(using
       nir.Position
-  ): Unit = {
+  ): Option[Defn] = {
     if (dd.symbol.isField) {
       report.error(
         "Link-time property cannot be constant value, it would be inlined by scalac compiler",
@@ -424,15 +366,17 @@ trait NirGenStat(using Context) {
       dd match {
         case LinktimeProperty(propertyName, _) =>
           val retty = genType(dd.tpt.tpe)
-          genLinktimeResolvedMethod(retty, propertyName, name)
-
-        case _ => () // no-op
+          val defn = genLinktimeResolvedMethod(retty, propertyName, name)
+          Some(defn)
+        case _ => None
       }
-    } else
+    } else {
       report.error(
         s"Link-time resolved property must have ${defnNir.UnsafePackage_resolved.fullName} as body",
         dd.sourcePos
       )
+      None
+    }
   }
 
   /* Generate stub method that can be used to get value of link-time property at runtime */
@@ -440,7 +384,7 @@ trait NirGenStat(using Context) {
       retty: nir.Type,
       propertyName: String,
       methodName: nir.Global
-  )(using nir.Position): Unit = {
+  )(using nir.Position): Defn = {
     given fresh: Fresh = Fresh()
     val buf = new ExprBuffer()
 
@@ -453,7 +397,7 @@ trait NirGenStat(using Context) {
     )
     buf.ret(value)
 
-    generatedDefns += Defn.Define(
+    Defn.Define(
       Attrs(inlineHint = Attr.AlwaysInline),
       methodName,
       Type.Function(Seq(), retty),
@@ -466,7 +410,7 @@ trait NirGenStat(using Context) {
       name: nir.Global,
       origSig: nir.Type,
       rhs: Tree
-  ): Unit = {
+  ): Option[Defn] = {
     given nir.Position = rhs.span
     rhs match {
       case Apply(ref: RefTree, Seq())
@@ -474,14 +418,15 @@ trait NirGenStat(using Context) {
         val moduleName = genTypeName(curClassSym)
         val externAttrs = Attrs(isExtern = true)
         val externSig = genExternMethodSig(curMethodSym)
-        generatedDefns += Defn.Declare(externAttrs, name, externSig)
+        Some(Defn.Declare(externAttrs, name, externSig))
       case _ if curMethodSym.get.isOneOf(Accessor | Synthetic) =>
-        () // no-op
+        None
       case rhs =>
         report.error(
           s"methods in extern objects must have extern body  - ${rhs}",
           rhs.sourcePos
         )
+        None
     }
   }
 
@@ -504,6 +449,168 @@ trait NirGenStat(using Context) {
       "extern objects may only contain extern fields",
       f.sourcePos
     )
+  }
+
+  // Static forwarders -------------------------------------------------------
+
+  // Ported from Scala.js
+  /* It is important that we always emit forwarders, because some Java APIs
+   * actually have a public static method and a public instance method with
+   * the same name. For example the class `Integer` has a
+   * `def hashCode(): Int` and a `static def hashCode(Int): Int`. The JVM
+   * back-end considers them as colliding because they have the same name,
+   * but we must not.
+   *
+   * By default, we only emit forwarders for top-level objects, like the JVM
+   * back-end. However, if requested via a compiler option, we enable them
+   * for all static objects. This is important so we can implement static
+   * methods of nested static classes of JDK APIs (see scala-js/#3950).
+   */
+
+  /** Is the given Scala class, interface or module class a candidate for static
+   *  forwarders?
+   *
+   *    - the flag `-XnoForwarders` is not set to true, and
+   *    - the symbol is static, and
+   *    - either of both of the following is true:
+   *      - the plugin setting `GenStaticForwardersForNonTopLevelObjects` is set
+   *        to true, or
+   *      - the symbol was originally at the package level
+   *
+   *  Other than the the fact that we also consider interfaces, this performs
+   *  the same tests as the JVM back-end.
+   */
+  private def isCandidateForForwarders(sym: Symbol): Boolean = {
+    !ctx.settings.XnoForwarders.value && sym.isStatic && {
+      settings.genStaticForwardersForNonTopLevelObjects ||
+      atPhase(flattenPhase) {
+        toDenot(sym).owner.is(PackageClass)
+      }
+    }
+  }
+
+  /** Gen the static forwarders to the members of a class or interface for
+   *  methods of its companion object.
+   *
+   *  This is only done if there exists a companion object and it is not a JS
+   *  type.
+   *
+   *  Precondition: `isCandidateForForwarders(sym)` is true
+   */
+  private def genStaticForwardersForClassOrInterface(
+      existingMembers: Seq[Defn],
+      sym: Symbol
+  ): Seq[Defn.Define] = {
+    val module = sym.companionModule
+    if (!module.exists) Nil
+    else {
+      val moduleClass = module.moduleClass
+      if (moduleClass.isExternModule) Nil
+      else genStaticForwardersFromModuleClass(existingMembers, moduleClass)
+    }
+  }
+
+  /** Gen the static forwarders for the methods of a module class.
+   *
+   *  Precondition: `isCandidateForForwarders(moduleClass)` is true
+   */
+  private def genStaticForwardersFromModuleClass(
+      existingMembers: Seq[Defn],
+      moduleClass: Symbol
+  ): Seq[Defn.Define] = {
+    assert(moduleClass.is(ModuleClass), moduleClass)
+
+    val existingStaticMethodNames: Set[Global] = existingMembers.collect {
+      case Defn.Define(_, name @ Global.Member(_, sig), _, _) if sig.isStatic =>
+        name
+    }.toSet
+    val members = {
+      moduleClass.info
+        .membersBasedOnFlags(
+          required = Method,
+          excluded = ExcludedForwarder
+        )
+        .map(_.symbol)
+    }
+
+    def isExcluded(m: Symbol): Boolean = {
+      def hasAccessBoundary = m.accessBoundary(defn.RootClass) ne defn.RootClass
+      m.isExtern ||
+      m.is(Deferred) || m.isConstructor ||
+      hasAccessBoundary ||
+      (m.owner eq defn.ObjectClass)
+    }
+
+    for {
+      sym <- members if !isExcluded(sym)
+    } yield {
+      given nir.Position = sym.span
+
+      val methodName = genMethodName(sym)
+      val forwarderName = genStaticMemberName(sym)
+      
+      val Type.Function(_ +: paramTypes, retType) = genMethodSig(sym)
+      val forwarderParamTypes = Type.Ref(forwarderName.top) +: paramTypes
+      val forwarderType = Type.Function(forwarderParamTypes, retType)
+
+      if (existingStaticMethodNames.contains(forwarderName)) {
+        report.error(
+          "Unexpected situation: found existing public static method " +
+            s"${sym.show} in the companion class of " +
+            s"${moduleClass.fullName}; cannot generate a static forwarder " +
+            "the method of the same name in the object." +
+            "Please report this as a bug in the Scala Native support.",
+          curClassSym.get.sourcePos
+        )
+      }
+
+      Defn.Define(
+        attrs = Attrs(inlineHint = nir.Attr.InlineHint),
+        name = forwarderName,
+        ty = forwarderType,
+        insts = withFreshExprBuffer { buf ?=>
+          val fresh = curFresh.get
+          scoped(
+            curUnwindHandler := None,
+            curMethodThis := None,
+            curMethodOuterSym := None
+          ) {
+            val entryParams @ (_ +: params) = forwarderParamTypes
+              .map(Val.Local(fresh(), _))
+            buf.label(fresh(), entryParams)
+            val res =
+              buf.genApplyModuleMethod(sym.owner, sym, params.map(ValTree(_)))
+            buf.ret(res)
+          }
+          buf.toSeq
+        }
+      )
+    }
+  }
+
+  private def genStaticMethodForwarders(
+      td: TypeDef,
+      existingMethods: Seq[Defn]
+  ): Seq[Defn] = {
+    val sym = td.symbol
+    if !isCandidateForForwarders(sym) then Nil
+    else if sym.isStaticModule then {
+      if !sym.linkedClass.exists then {
+        val forwarders = genStaticForwardersFromModuleClass(Nil, sym)
+        if (forwarders.nonEmpty) {
+          given pos: nir.Position = td.span
+          val classDefn = Defn.Class(
+            attrs = Attrs.None,
+            name = Global.Top(genName(sym).top.id.stripSuffix("$")),
+            parent = Some(Rt.Object.name),
+            traits = Nil
+          )
+          val forwarderClass = StaticForwarderClass(classDefn, forwarders)
+          generatedStaticForwarderClasses += sym -> forwarderClass
+        }
+      }
+      Nil
+    } else genStaticForwardersForClassOrInterface(existingMethods, sym)
   }
 
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -36,7 +36,9 @@ trait NirGenType(using Context) {
       sym.is(Module) && sym.isStatic
 
     def isStaticMethod: Boolean =
-      sym.isAllOf(Method | JavaStatic)
+      sym.is(Method) && {
+        sym.is(JavaStatic) || sym.isScalaStatic
+      }
 
     def isExtern: Boolean = sym.owner.isExternModule
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenUtil.scala
@@ -7,7 +7,8 @@ import core.Symbols._
 import core.Contexts._
 import core.Types._
 import scalanative.util.unsupported
-
+import scalanative.util.ScopedVar.scoped
+import scalanative.nir.Fresh
 trait NirGenUtil(using Context) { self: NirCodeGen =>
 
   private lazy val materializeClassTagTypes: Map[Symbol, Symbol] = Map(
@@ -130,4 +131,13 @@ trait NirGenUtil(using Context) { self: NirCodeGen =>
     unwrapClassTagOption(tree).getOrElse {
       unsupported(s"can't recover runtime class tag from $tree")
     }
+
+  protected def withFreshExprBuffer[R](f: ExprBuffer ?=> R): R = {
+    scoped(
+      curFresh := Fresh()
+    ) {
+      val buffer = new ExprBuffer(using curFresh)
+      f(using buffer)
+    }
+  }
 }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPlugin.scala
@@ -3,13 +3,13 @@ package scala.scalanative.nscplugin
 import dotty.tools.dotc.plugins._
 
 class NirPlugin extends StandardPlugin:
-  val name: String = "NirPlugin"
+  val name: String = "scalanative"
   val description: String = "Scala Native compiler plugin"
 
   def init(options: List[String]): List[PluginPhase] = {
     val genNirSettings = options
       .foldLeft(GenNIR.Settings()) {
-        case (config, "GenStaticForwardersForNonTopLevelObjects") =>
+        case (config, "genStaticForwardersForNonTopLevelObjects") =>
           config.copy(genStaticForwardersForNonTopLevelObjects = true)
         case (config, _) => config
       }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPlugin.scala
@@ -6,5 +6,12 @@ class NirPlugin extends StandardPlugin:
   val name: String = "NirPlugin"
   val description: String = "Scala Native compiler plugin"
 
-  def init(options: List[String]): List[PluginPhase] =
-    List(PrepNativeInterop, AdaptLazyVals, GenNIR)
+  def init(options: List[String]): List[PluginPhase] = {
+    val genNirSettings = options
+      .foldLeft(GenNIR.Settings()) {
+        case (config, "GenStaticForwardersForNonTopLevelObjects") =>
+          config.copy(genStaticForwardersForNonTopLevelObjects = true)
+        case (config, _) => config
+      }
+    List(PrepNativeInterop, AdaptLazyVals, GenNIR(genNirSettings))
+  }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -38,19 +38,8 @@ object PrepNativeInterop extends PluginPhase {
         val nrhs = scalaEnumValName(sym.owner.asClass, sym, optIntParam)
         cpy.ValDef(vd)(tpt = transformAllDeep(tpt), nrhs)
 
-      case _ =>
-        // Scala Native expectes static methods to be defined in companion object
-        // Remove scala.static annotations that would move them to linked class
-        vd.symbol.removeAnnotation(defn.ScalaStaticAnnot)
-        vd
+      case _ => vd
     }
-  }
-
-  override def transformDefDef(dd: DefDef)(using Context): Tree = {
-    // Scala Native expectes static fields to be defined in companion object
-    // Remove scala.static annotations that would move them to linked class
-    dd.symbol.removeAnnotation(defn.ScalaStaticAnnot)
-    dd
   }
 
   private object EnumerationsContext {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -405,9 +405,15 @@ object Settings {
       val separator = sys.props("path.separator")
       "-javabootclasspath" +: s"$classDir$separator$javaBootClasspath" +: previous
     },
-    Compile / scalacOptions ++= scalaNativeCompilerOptions(
-      "GenStaticForwardersForNonTopLevelObjects"
-    ),
+    Compile / scalacOptions ++= {
+      scalaBinaryVersion.value match {
+        case "3" =>
+          scalaNativeCompilerOptions(
+            "GenStaticForwardersForNonTopLevelObjects"
+          )
+        case _ => Nil
+      }
+    },
     // Don't include classfiles for javalib in the packaged jar.
     Compile / packageBin / mappings := {
       val previous = (Compile / packageBin / mappings).value

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -409,7 +409,7 @@ object Settings {
       scalaBinaryVersion.value match {
         case "3" =>
           scalaNativeCompilerOptions(
-            "GenStaticForwardersForNonTopLevelObjects"
+            "genStaticForwardersForNonTopLevelObjects"
           )
         case _ => Nil
       }
@@ -687,7 +687,7 @@ object Settings {
   )
 
   def scalaNativeCompilerOptions(options: String*): Seq[String] = {
-    options.map(opt => s"-P:NirPlugin:$opt")
+    options.map(opt => s"-P:scalanative:$opt")
   }
 
   def scalaVersionsDependendent[T](scalaVersion: String)(default: T)(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -405,6 +405,9 @@ object Settings {
       val separator = sys.props("path.separator")
       "-javabootclasspath" +: s"$classDir$separator$javaBootClasspath" +: previous
     },
+    Compile / scalacOptions ++= scalaNativeCompilerOptions(
+      "GenStaticForwardersForNonTopLevelObjects"
+    ),
     // Don't include classfiles for javalib in the packaged jar.
     Compile / packageBin / mappings := {
       val previous = (Compile / packageBin / mappings).value
@@ -676,6 +679,10 @@ object Settings {
       }
     }
   )
+
+  def scalaNativeCompilerOptions(options: String*): Seq[String] = {
+    options.map(opt => s"-P:NirPlugin:$opt")
+  }
 
   def scalaVersionsDependendent[T](scalaVersion: String)(default: T)(
       matching: PartialFunction[(Long, Long), T]

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -423,23 +423,22 @@ final class Check(implicit linked: linker.Result) {
     obj.ty match {
       case ScopeRef(scope) =>
         scope.implementors.foreach { cls =>
-          cls.fields
-            .collectFirst {
-              case fld: Field if fld.name == name =>
-                in("field declared type") {
-                  expect(ty, fld.ty)
+          val field = cls.fields.collectFirst {
+            case fld: Field if fld.name == name =>
+              in("field declared type") {
+                expect(ty, fld.ty)
+              }
+              value.foreach { v =>
+                in("stored value") {
+                  expect(fld.ty, v)
                 }
-                value.foreach { v =>
-                  in("stored value") {
-                    expect(fld.ty, v)
-                  }
-                }
-            }
-            .getOrElse(
-              error(
-                s"class ${scope.name.show} does not define field ${name.show}"
-              )
+              }
+          }
+          if (field.isEmpty) {
+            error(
+              s"class ${scope.name.show} does not define field ${name.show}"
             )
+          }
         }
       case ty =>
         error(s"can't access fields of a non-class type ${ty.show}")

--- a/tools/src/main/scala/scala/scalanative/checker/Check.scala
+++ b/tools/src/main/scala/scala/scalanative/checker/Check.scala
@@ -423,17 +423,23 @@ final class Check(implicit linked: linker.Result) {
     obj.ty match {
       case ScopeRef(scope) =>
         scope.implementors.foreach { cls =>
-          cls.fields.collectFirst {
-            case fld: Field if fld.name == name =>
-              in("field declared type") {
-                expect(ty, fld.ty)
-              }
-              value.foreach { v =>
-                in("stored value") {
-                  expect(fld.ty, v)
+          cls.fields
+            .collectFirst {
+              case fld: Field if fld.name == name =>
+                in("field declared type") {
+                  expect(ty, fld.ty)
                 }
-              }
-          }
+                value.foreach { v =>
+                  in("stored value") {
+                    expect(fld.ty, v)
+                  }
+                }
+            }
+            .getOrElse(
+              error(
+                s"class ${scope.name.show} does not define field ${name.show}"
+              )
+            )
         }
       case ty =>
         error(s"can't access fields of a non-class type ${ty.show}")

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -32,16 +32,7 @@ class Reach(
   private val delayedMethods = mutable.Set.empty[DelayedMethod]
 
   entries.foreach(reachEntry)
-
-  // Internal hack used inside linker tests, for more information
-  // check out comment in scala.scalanative.linker.ReachabilitySuite
-  val reachStaticConstructors = sys.props
-    .get("scala.scalanative.linker.reachStaticConstructors")
-    .flatMap(v => scala.util.Try(v.toBoolean).toOption)
-    .forall(_ == true)
-  if (reachStaticConstructors) {
-    loader.classesWithEntryPoints.foreach(reachClinit)
-  }
+  loader.classesWithEntryPoints.foreach(reachClinit)
 
   def result(): Result = {
     reportMissing()

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -32,7 +32,16 @@ class Reach(
   private val delayedMethods = mutable.Set.empty[DelayedMethod]
 
   entries.foreach(reachEntry)
-  loader.classesWithEntryPoints.foreach(reachClinit)
+
+  // Internal hack used inside linker tests, for more information
+  // check out comment in scala.scalanative.linker.ReachabilitySuite
+  val reachStaticConstructors = sys.props
+    .get("scala.scalanative.linker.reachStaticConstructors")
+    .flatMap(v => scala.util.Try(v.toBoolean).toOption)
+    .forall(_ == true)
+  if (reachStaticConstructors) {
+    loader.classesWithEntryPoints.foreach(reachClinit)
+  }
 
   def result(): Result = {
     reportMissing()

--- a/tools/src/test/scala-3/scala/scalanative/linker/StaticForwardersSuite.scala
+++ b/tools/src/test/scala-3/scala/scalanative/linker/StaticForwardersSuite.scala
@@ -25,10 +25,10 @@ class StaticForwardersSuite extends LinkerSpec {
           Sig.Method("main", Rt.ScalaMainSig.types, Sig.Scope.PublicStatic)
         ),
         Package.member(
-          Sig.Method("myMainFunction", Nil, Sig.Scope.PublicStatic)
+          Sig.Method("myMainFunction", Seq(Type.Unit), Sig.Scope.PublicStatic)
         ),
         PackageModule.member(Sig.Ctor(Nil)),
-        PackageModule.member(Sig.Method("myMainFunction", Nil))
+        PackageModule.member(Sig.Method("myMainFunction", Seq(Type.Unit)))
       )
       val names = defns.map(_.name)
       assert(expected.diff(names).isEmpty)

--- a/tools/src/test/scala-3/scala/scalanative/linker/StaticForwardersSuite.scala
+++ b/tools/src/test/scala-3/scala/scalanative/linker/StaticForwardersSuite.scala
@@ -3,30 +3,124 @@ package scala.scalanative.linker
 import org.scalatest._
 import scala.scalanative.LinkerSpec
 import scala.scalanative.nir._
+import scala.scalanative.util.Scope
+import scala.scalanative.io._
+import scala.scalanative.NIRCompiler
+import org.scalatest.flatspec.AnyFlatSpec
+import java.nio.file.{Files, Path, Paths}
 
 class StaticForwardersSuite extends LinkerSpec {
   "Static forwarder methods" should "be generated for @main annotated method" in {
     val MainClass = Global.Top("myMainFunction")
-    val MainModule = Global.Top("myMainFunction$")
-    val mainMethod = Sig.Method("main", Seq(Type.Array(Rt.String), Type.Unit))
+    val Package = Global.Top("Main$package")
+    val PackageModule = Global.Top("Main$package$")
 
-    link(
-      entry = MainModule.id,
-      sources = Map(
-        "Main.scala" -> "@main def myMainFunction(): Unit = ()"
-      )
-    ) { (cfg, result) =>
-      assert(cfg.mainClass == MainModule.id)
-      assert(result.unavailable.isEmpty)
-
-      Seq(
+    compileAndLoad(
+      "Main.scala" -> "@main def myMainFunction(): Unit = ()"
+    ) { defns =>
+      val expected = Seq(
         MainClass,
-        MainClass.member(mainMethod),
-        MainModule,
-        MainModule.member(mainMethod)
-      ).foreach { name =>
-        assert(result.infos.contains(name))
-      }
+        MainClass.member(Sig.Ctor(Nil)),
+        MainClass.member(
+          Sig.Method("main", Rt.ScalaMainSig.types, Sig.Scope.PublicStatic)
+        ),
+        Package.member(
+          Sig.Method("myMainFunction", Nil, Sig.Scope.PublicStatic)
+        ),
+        PackageModule.member(Sig.Ctor(Nil)),
+        PackageModule.member(Sig.Method("myMainFunction", Nil))
+      )
+      val names = defns.map(_.name)
+      assert(expected.diff(names).isEmpty)
+    }
+  }
+  it should "generate static members for methods defined in companion object" in {
+    compileAndLoad(
+      "Test.scala" ->
+        """ 
+          |class Foo() {
+          |  def foo(): String = {
+          |    Foo.bar() + Foo.fooBar
+          |  }
+          |}
+          |object Foo {
+          |  def main(args: Array[String]): Unit  = {
+          |    val x = new Foo().foo()
+          |  }
+          |  def bar(): String = "bar"
+          |  def fooBar: String = "foo" + bar()
+          |}
+          """.stripMargin
+    ) { defns =>
+      val Class = Global.Top("Foo")
+      val Module = Global.Top("Foo$")
+      val expected = Seq(
+        Class.member(Sig.Ctor(Nil)),
+        Class.member(Sig.Method("foo", Seq(Rt.String))),
+        Class.member(Sig.Method("bar", Seq(Rt.String), Sig.Scope.PublicStatic)),
+        Class.member(
+          Sig.Method("fooBar", Seq(Rt.String), Sig.Scope.PublicStatic)
+        ),
+        Class.member(
+          Sig.Method(
+            Rt.ScalaMainSig.id,
+            Rt.ScalaMainSig.types,
+            Sig.Scope.PublicStatic
+          )
+        ),
+        Module.member(Sig.Ctor(Nil)),
+        Module.member(Rt.ScalaMainSig),
+        Module.member(Sig.Method("bar", Seq(Rt.String))),
+        Module.member(Sig.Method("fooBar", Seq(Rt.String)))
+      )
+
+      assert(expected.diff(defns.map(_.name)).isEmpty)
+    }
+  }
+  it should "generate static accessors to fields defined in compation object" in {
+    compileAndLoad(
+      "Test.scala" ->
+        """ 
+          |class Foo() {
+          |  val foo = "foo"
+          |}
+          |object Foo {
+          |  val bar = "bar"
+          |}
+          """.stripMargin
+    ) { defns =>
+      val Class = Global.Top("Foo")
+      val Module = Global.Top("Foo$")
+      val expected = Seq(
+        Class.member(Sig.Field("foo", Sig.Scope.Private(Class))),
+        Class.member(Sig.Method("foo", Seq(Rt.String))),
+        Class.member(Sig.Method("bar", Seq(Rt.String), Sig.Scope.PublicStatic)),
+        Module.member(Sig.Field("bar", Sig.Scope.Private(Module))),
+        Module.member(Sig.Method("bar", Seq(Rt.String)))
+      )
+      assert(expected.diff(defns.map(_.name)).isEmpty)
+    }
+  }
+
+  def compileAndLoad(
+      sources: (String, String)*
+  )(fn: Seq[Defn] => Unit): Unit = {
+    Scope { implicit in =>
+      val outDir = Files.createTempDirectory("native-test-out")
+      val compiler = NIRCompiler.getCompiler(outDir)
+      val sourcesDir = NIRCompiler.writeSources(sources.toMap)
+      val dir = VirtualDirectory.real(outDir)
+
+      val defns = compiler
+        .compile(sourcesDir)
+        .toSeq
+        .filter(_.toString.endsWith(".nir"))
+        .map(outDir.relativize(_))
+        .flatMap { path =>
+          val buffer = dir.read(path)
+          serialization.deserializeBinary(buffer, path.toString)
+        }
+      fn(defns)
     }
   }
 }

--- a/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
@@ -27,25 +27,12 @@ trait ReachabilitySuite extends AnyFunSuite {
   def testReachable(label: String)(f: => (String, Global, Seq[Global])) =
     test(label) {
       val (source, entry, expected) = f
-      // When running reachability tests disable loading static constructors
-      // ReachabilitySuite tests are designed to check that exactly given group
-      // of symbols is reachable. By default we always try to load all static
-      // constructrs - this mechanism is used by junit-plugin to mitigate lack
-      // of reflection. We need to disable it, otherwise we would be swarmed
-      // with definitions introduced by static constructors
-      val reachStaticConstructorsKey =
-        "scala.scalanative.linker.reachStaticConstructors"
-      sys.props += reachStaticConstructorsKey -> false.toString()
-      try {
-        link(Seq(entry), Seq(source), entry.top.id) { res =>
-          val left = res.defns.map(_.name).toSet
-          val right = expected.toSet ++ MainMethodDependencies
-          assert(res.unavailable.isEmpty, "unavailable")
-          assert((left -- right).isEmpty, "underapproximation")
-          assert((right -- left).isEmpty, "overapproximation")
-        }
-      } finally {
-        sys.props -= reachStaticConstructorsKey
+      link(Seq(entry), Seq(source), entry.top.id) { res =>
+        val left = res.defns.map(_.name).toSet
+        val right = expected.toSet ++ MainMethodDependencies
+        assert(res.unavailable.isEmpty, "unavailable")
+        assert((left -- right).isEmpty, "underapproximation")
+        assert((right -- left).isEmpty, "overapproximation")
       }
     }
 


### PR DESCRIPTION
This PR does introduce 2 new scopes for methods and fields - `PublicStatic` and `PrivateStatic`. Based on that are now able to generate static method forwarders inside the class to methods defined in its companion object - it's the same behaviour as on the JVM or in the Scala.js. Currently, the generation of static forwarders is limited to Scala 3 compiler plugin but would be backported to Scala 2 in the follow-up PR. 
This change would allow us to correctly discover the main entry method in the future and would allow us to use `@main` annotation in Scala 3 
Additionally now Scala 3 compiler plugin does generate proper static constructors for classes that would be invoked on startup, similarly as it is done in case of reflective instantiation. Static constructors are needed eg. to make enums work properly. 

* Reverted changes introduced in #2468 
* Added new scopes `PublicStatic` and `PrivateStatic` to NIR
* Ported logic for generating of static forwarders for Scala.js 
* Fixed our expression generation to correctly call methods defined as static or accessing static fields
* Fixed Check that was not failing in case if a given field was not defined in it's defined, owner
* Added tests for checking that static forwarders are being generated 
* Added generation of static constructors needed by fields annotated with `@scala.static` 
* Introduced system property-based option to disable reaching static constructors, to allow for accurate testing in `ReachabilitySuite`s