### PR TITLE
Synchronise names of compiler plugins and phases between Scala 2 and 3

### DIFF
--- a/junit-plugin/src/main/scala-2/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala-2/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
@@ -20,14 +20,13 @@ import scala.tools.nsc.plugins.{
  */
 class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
 
-  val name: String = "Scala Native JUnit plugin"
+  val name: String = "scalanative-junit"
+  val description: String = "Makes JUnit test classes invokable in Scala Native"
 
   val components: List[NscPluginComponent] = global match {
     case _: doc.ScaladocGlobal => Nil
     case _                     => List(ScalaNativeJUnitPluginComponent)
   }
-
-  val description: String = "Makes JUnit test classes invokable in Scala Native"
 
   object ScalaNativeJUnitPluginComponent
       extends plugins.PluginComponent
@@ -38,9 +37,9 @@ class ScalaNativeJUnitPlugin(val global: Global) extends NscPlugin {
     import definitions._
     import rootMirror.getRequiredClass
 
-    val phaseName: String = "junit-inject"
+    val phaseName: String = "scalanative-junitBootstrappers"
     val runsAfter: List[String] = List("mixin")
-    override val runsBefore: List[String] = List("nir")
+    override val runsBefore: List[String] = List("scalanative-genNIR")
 
     protected def newTransformer(unit: CompilationUnit): Transformer =
       new ScalaNativeJUnitPluginTransformer

--- a/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala-3/scala/scalanative/junit/plugin/ScalaNativeJUnitPlugin.scala
@@ -17,7 +17,7 @@ import core.Contexts._
  */
 
 class ScalaNativeJUnitPlugin extends StandardPlugin {
-  val name: String = "Scala Native JUnit plugin"
+  val name: String = "scalanative-junit"
   val description: String = "Makes JUnit test classes invokable in Scala Native"
 
   def init(options: List[String]): List[PluginPhase] =

--- a/nscplugin/src/main/resources/plugin.properties
+++ b/nscplugin/src/main/resources/plugin.properties
@@ -1,1 +1,1 @@
-pluginClass=scala.scalanative.nscplugin.NirPlugin
+pluginClass=scala.scalanative.nscplugin.ScalaNativePlugin

--- a/nscplugin/src/main/resources/scalac-plugin.xml
+++ b/nscplugin/src/main/resources/scalac-plugin.xml
@@ -1,4 +1,4 @@
 <plugin>
   <name>nir</name>
-  <classname>scala.scalanative.nscplugin.NirPlugin</classname>
+  <classname>scala.scalanative.nscplugin.ScalaNativePlugin</classname>
 </plugin>

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -25,7 +25,7 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
   import definitions._
   import nirAddons._
 
-  val phaseName = "nir"
+  val phaseName = "scalanative-genNIR"
 
   protected val curClassSym = new util.ScopedVar[Symbol]
   protected val curClassFresh = new util.ScopedVar[nir.Fresh]

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -21,7 +21,7 @@ abstract class PrepNativeInterop[G <: Global with Singleton](
   import definitions._
   import nirAddons.nirDefinitions._
 
-  val phaseName: String = "nativeinterop"
+  val phaseName: String = "scalanative-prepareInterop"
   override def description: String = "prepare ASTs for Native interop"
 
   override def newPhase(p: nsc.Phase): StdPhase = new NativeInteropPhase(p)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -4,8 +4,8 @@ package nscplugin
 import scala.tools.nsc._
 import scala.tools.nsc.plugins._
 
-class NirPlugin(val global: Global) extends Plugin {
-  val name = "nir"
+class ScalaNativePlugin(val global: Global) extends Plugin {
+  val name = "scalanative"
   val description = "Compile to Scala Native IR (NIR)"
   val components: List[PluginComponent] = global match {
     case _: doc.ScaladocGlobal => List(prepNativeInterop)
@@ -22,13 +22,15 @@ class NirPlugin(val global: Global) extends Plugin {
   object nirAddons extends NirGlobalAddonsEarlyInit[global.type](global)
 
   object prepNativeInterop extends PrepNativeInterop[global.type](global) {
-    val nirAddons: NirPlugin.this.nirAddons.type = NirPlugin.this.nirAddons
+    val nirAddons: ScalaNativePlugin.this.nirAddons.type =
+      ScalaNativePlugin.this.nirAddons
     override val runsAfter = List("typer")
     override val runsBefore = List("pickler")
   }
 
   object nirGen extends NirGenPhase[global.type](global) {
-    val nirAddons: NirPlugin.this.nirAddons.type = NirPlugin.this.nirAddons
+    val nirAddons: ScalaNativePlugin.this.nirAddons.type =
+      ScalaNativePlugin.this.nirAddons
     override val runsAfter = List("mixin")
     override val runsBefore = List("delambdafy", "cleanup", "terminal")
   }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -2,7 +2,7 @@ package scala.scalanative.nscplugin
 
 import dotty.tools.dotc.plugins._
 
-class NirPlugin extends StandardPlugin:
+class ScalaNativePlugin extends StandardPlugin:
   val name: String = "scalanative"
   val description: String = "Scala Native compiler plugin"
 

--- a/scala-partest/src/main/scala/scala/tools/partest/scalanative/ScalaNativeDirectCompiler.scala
+++ b/scala-partest/src/main/scala/scala/tools/partest/scalanative/ScalaNativeDirectCompiler.scala
@@ -1,6 +1,6 @@
 package scala.tools.partest.scalanative
 
-import scala.scalanative.nscplugin.NirPlugin
+import scala.scalanative.nscplugin.ScalaNativePlugin
 import scala.tools.nsc.Settings
 import scala.tools.nsc.plugins.Plugin
 import scala.tools.nsc.reporters.Reporter
@@ -14,7 +14,7 @@ trait ScalaNativeDirectCompiler extends DirectCompiler {
     new PartestGlobal(settings, reporter) {
       override protected def loadRoughPluginsList(): List[Plugin] = {
         super.loadRoughPluginsList() :+
-          Plugin.instantiate(classOf[NirPlugin], this)
+          Plugin.instantiate(classOf[ScalaNativePlugin], this)
       }
     }
   }


### PR DESCRIPTION
This PR does not introduce any new features, but it does make it easier to introduce new options in Scala 2 / 3 compiler plugins. 

* Set the same names for compiler plugins in Scala 2/3 to allow for easy passing of options
* Make sure that corresponding phases in Scala 2/3 has the same names
* Rename `NirPlugin` to `ScalaNativePlugin` - it's more accurate and uses the same naming schema as Scala.js (ScalaJsPlugin)