### PR TITLE
Enforce usage of empty parens variant of `stackalloc[T]` and `alloc[T]` in Scala 3

### DIFF
--- a/docs/changelog/0.4.1.md
+++ b/docs/changelog/0.4.1.md
@@ -82,7 +82,7 @@ def isDirectory(path: CString): Boolean = {
     val flag = FILE_ATTRIBUTE_DIRECTORY
     GetFileAttributesA(path) & FILE_ATTRIBUTE_DIRECTORY != 0 
   } else {
-    val buf = alloc[stat.stat]
+    val buf = alloc[stat.stat]()
     stat.stat(path, buf)
     stat.S_ISDIR(buf._13) != 0
   }

--- a/docs/contrib/nir.rst
+++ b/docs/contrib/nir.rst
@@ -418,7 +418,7 @@ stackalloc
 ``````````
 .. code-block:: text
 
-    stackalloc[$type]
+    stackalloc[$type]()
 
 Stack allocate a slot of memory big enough to store given type.
 Corresponds to LLVM's

--- a/docs/user/interop.rst
+++ b/docs/user/interop.rst
@@ -333,7 +333,7 @@ pointers and do not have a corresponding first-class values backing them.
 
   .. code-block:: scala
 
-      val ptr = unsafe.stackalloc[unsafe.CStruct2[Int, Int]]
+      val ptr = unsafe.stackalloc[unsafe.CStruct2[Int, Int]]()
       ptr._1 = 10
       ptr._2 = 20
       println(s"first ${ptr._1}, second ${ptr._2}")
@@ -365,7 +365,7 @@ pointers and do not have a corresponding first-class values backing them.
 
   Once you have a natural for the length, it can be used as an array length::
 
-      val arrptr = unsafe.stackalloc[CArray[Byte, _1024]]
+      val arrptr = unsafe.stackalloc[CArray[Byte, _1024]]()
 
   You can find an address of n-th array element via ``arrptr.at(n)``.
 

--- a/javalib/src/main/scala/java/io/File.scala
+++ b/javalib/src/main/scala/java/io/File.scala
@@ -147,9 +147,9 @@ class File(_path: String) extends Serializable with Comparable[File] {
   ): Boolean =
     Zone { implicit z =>
       val filename = toCWideStringUTF16LE(properPath)
-      val securityDescriptorPtr = alloc[Ptr[SecurityDescriptor]]
-      val previousDacl, newDacl = alloc[ACLPtr]
-      val usersGroupSid = alloc[SIDPtr]
+      val securityDescriptorPtr = alloc[Ptr[SecurityDescriptor]]()
+      val previousDacl, newDacl = alloc[ACLPtr]()
+      val usersGroupSid = alloc[SIDPtr]()
 
       val accessMode: AccessMode =
         if (grant) AccessMode.GRANT_ACCESS
@@ -169,7 +169,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
 
       def setupNewAclEntry() = {
         import accctrl.ops._
-        val ea = alloc[ExplicitAccessW]
+        val ea = alloc[ExplicitAccessW]()
         ea.accessPermisions = accessRights
         ea.accessMode = accessMode
         ea.inheritence = NO_PROPAGATE_INHERIT_ACE
@@ -413,7 +413,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
             MinWinBaseApiOps.FileTimeOps.toUnixEpochMillis(!lastModified)
         }
       } else {
-        val buf = alloc[stat.stat]
+        val buf = alloc[stat.stat]()
         if (stat.stat(toCString(path), buf) == 0) {
           buf._8 * 1000L
         } else {
@@ -423,7 +423,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
     }
 
   private def accessMode()(implicit z: Zone): stat.mode_t = {
-    val buf = alloc[stat.stat]
+    val buf = alloc[stat.stat]()
     if (stat.stat(toCString(path), buf) == 0) {
       buf._13
     } else {
@@ -470,9 +470,9 @@ class File(_path: String) extends Serializable with Comparable[File] {
               )
           }
         } else {
-          val statbuf = alloc[stat.stat]
+          val statbuf = alloc[stat.stat]()
           if (stat.stat(toCString(path), statbuf) == 0) {
-            val timebuf = alloc[utime.utimbuf]
+            val timebuf = alloc[utime.utimbuf]()
             timebuf._1 = statbuf._8
             timebuf._2 = time / 1000L
             utime.utime(toCString(path), timebuf) == 0
@@ -516,12 +516,12 @@ class File(_path: String) extends Serializable with Comparable[File] {
       ) {
         case INVALID_HANDLE_VALUE => 0L
         case handle =>
-          val size = stackalloc[windows.LargeInteger]
+          val size = stackalloc[windows.LargeInteger]()
           if (GetFileSizeEx(handle, size)) (!size).toLong
           else 0L
       }
     } else {
-      val buf = alloc[stat.stat]
+      val buf = alloc[stat.stat]()
       if (stat.stat(toCString(path), buf) == 0) {
         buf._6
       } else {
@@ -633,7 +633,7 @@ class File(_path: String) extends Serializable with Comparable[File] {
     def withFileSecurityDescriptor(
         fn: Ptr[SecurityDescriptor] => Unit
     ): Unit = {
-      val securityDescriptorPtr = stackalloc[Ptr[SecurityDescriptor]]
+      val securityDescriptorPtr = stackalloc[Ptr[SecurityDescriptor]]()
       val filename = toCWideStringUTF16LE(properPath)
       val securityInfo =
         OWNER_SECURITY_INFORMATION |
@@ -671,16 +671,16 @@ class File(_path: String) extends Serializable with Comparable[File] {
           genericMapping.genericExecute = FILE_GENERIC_EXECUTE
           genericMapping.genericAll = FILE_GENERIC_ALL
 
-          val accessMask = stackalloc[windows.DWord]
+          val accessMask = stackalloc[windows.DWord]()
           !accessMask = access
 
-          val privilegeSetLength = stackalloc[windows.DWord]
+          val privilegeSetLength = stackalloc[windows.DWord]()
           !privilegeSetLength = emptyPriviligesSize.toUInt
 
           val privilegeSet: Ptr[Byte] = stackalloc[Byte](!privilegeSetLength)
           memset(privilegeSet, 0, !privilegeSetLength)
 
-          val grantedAcccess = stackalloc[windows.DWord]
+          val grantedAcccess = stackalloc[windows.DWord]()
           !grantedAcccess = 0.toUInt
 
           MapGenericMask(accessMask, genericMapping)

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -150,7 +150,7 @@ object System {
         else None
       }
     } else {
-      val buf = stackalloc[pwd.passwd]
+      val buf = stackalloc[pwd.passwd]()
       val uid = unistd.getuid()
       val res = pwd.getpwuid(uid, buf)
       if (res == 0 && buf.pw_dir != null)

--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -57,9 +57,9 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
   }
 
   private def fetchLocalPort(family: Int): Option[Int] = {
-    val len = stackalloc[socket.socklen_t]
+    val len = stackalloc[socket.socklen_t]()
     val portOpt = if (family == socket.AF_INET) {
-      val sin = stackalloc[in.sockaddr_in]
+      val sin = stackalloc[in.sockaddr_in]()
       !len = sizeof[in.sockaddr_in].toUInt
 
       if (socket.getsockname(
@@ -72,7 +72,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
         Some(sin.sin_port)
       }
     } else {
-      val sin = stackalloc[in.sockaddr_in6]
+      val sin = stackalloc[in.sockaddr_in6]()
       !len = sizeof[in.sockaddr_in6].toUInt
 
       if (socket.getsockname(
@@ -91,7 +91,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
 
   override def bind(addr: InetAddress, port: Int): Unit = {
     val hints = stackalloc[addrinfo]()
-    val ret = stackalloc[Ptr[addrinfo]]
+    val ret = stackalloc[Ptr[addrinfo]]()
     hints.ai_family = socket.AF_UNSPEC
     hints.ai_flags = AI_NUMERICHOST
     hints.ai_socktype = socket.SOCK_STREAM
@@ -134,7 +134,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     }
 
     val storage: Ptr[Byte] = stackalloc[Byte](sizeof[in.sockaddr_in6])
-    val len = stackalloc[socket.socklen_t]
+    val len = stackalloc[socket.socklen_t]()
     !len = sizeof[in.sockaddr_in6].toUInt
 
     val newFd =
@@ -187,7 +187,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
 
     val inetAddr = address.asInstanceOf[InetSocketAddress]
     val hints = stackalloc[addrinfo]()
-    val ret = stackalloc[Ptr[addrinfo]]
+    val ret = stackalloc[Ptr[addrinfo]]()
     hints.ai_family = socket.AF_UNSPEC
     hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV
     hints.ai_socktype = socket.SOCK_STREAM
@@ -386,12 +386,12 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     val optValue = nativeValueFromOption(optID)
 
     val opt = if (optID == SocketOptions.SO_LINGER) {
-      stackalloc[socket.linger].asInstanceOf[Ptr[Byte]]
+      stackalloc[socket.linger]().asInstanceOf[Ptr[Byte]]
     } else {
-      stackalloc[CInt].asInstanceOf[Ptr[Byte]]
+      stackalloc[CInt]().asInstanceOf[Ptr[Byte]]
     }
 
-    val len = stackalloc[socket.socklen_t]
+    val len = stackalloc[socket.socklen_t]()
     !len = if (optID == SocketOptions.SO_LINGER) {
       sizeof[socket.linger].toUInt
     } else {
@@ -457,7 +457,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
         !ptr = if (value.asInstanceOf[Boolean]) 1 else 0
         ptr.asInstanceOf[Ptr[Byte]]
       case SocketOptions.SO_LINGER =>
-        val ptr = stackalloc[socket.linger]
+        val ptr = stackalloc[socket.linger]()
         val linger = value.asInstanceOf[Int]
         if (linger == -1) {
           ptr.l_onoff = 0

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -32,7 +32,7 @@ object SocketHelpers {
 
   private def setSocketNonBlocking(socket: CInt)(implicit z: Zone): CInt = {
     if (isWindows) {
-      val mode = alloc[CInt]
+      val mode = alloc[CInt]()
       !mode = 0
       ioctlSocket(socket.toPtr[Byte], FIONBIO, mode)
     } else {
@@ -44,7 +44,7 @@ object SocketHelpers {
     Zone { implicit z =>
       val cIP = toCString(ip)
       val hints = stackalloc[addrinfo]()
-      val ret = stackalloc[Ptr[addrinfo]]
+      val ret = stackalloc[Ptr[addrinfo]]()
 
       hints.ai_family = AF_UNSPEC
       hints.ai_protocol = 0
@@ -83,7 +83,7 @@ object SocketHelpers {
         }
 
         if (select(sock + 1, null, fdsetPtr, null, time) == 1) {
-          val so_error = stackalloc[CInt].asInstanceOf[Ptr[Byte]]
+          val so_error = stackalloc[CInt]().asInstanceOf[Ptr[Byte]]
           val len = stackalloc[socklen_t]()
           !len = sizeof[CInt].toUInt
           getsockopt(sock, SOL_SOCKET, SO_ERROR, so_error, len)
@@ -127,7 +127,7 @@ object SocketHelpers {
   def hostToIp(host: String): Option[String] =
     Zone { implicit z =>
       val hints = stackalloc[addrinfo]()
-      val ret = stackalloc[Ptr[addrinfo]]
+      val ret = stackalloc[Ptr[addrinfo]]()
 
       val ipstr: Ptr[CChar] = stackalloc[CChar]((INET6_ADDRSTRLEN + 1).toUInt)
       hints.ai_family = AF_UNSPEC
@@ -161,7 +161,7 @@ object SocketHelpers {
   def hostToIpArray(host: String): scala.Array[String] =
     Zone { implicit z =>
       val hints = stackalloc[addrinfo]()
-      val ret = stackalloc[Ptr[addrinfo]]
+      val ret = stackalloc[Ptr[addrinfo]]()
 
       hints.ai_family = AF_UNSPEC
       hints.ai_socktype = SOCK_STREAM

--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -218,7 +218,7 @@ private[java] final class FileChannelImpl(
       def fail() = throw WindowsException.onPath(file.fold("")(_.toString))
 
       def tryRead(count: Int)(fallback: => Int) = {
-        val readBytes = stackalloc[windows.DWord]
+        val readBytes = stackalloc[windows.DWord]()
         if (ReadFile(fd.handle, buf, count.toUInt, readBytes, null)) {
           (!readBytes).toInt match {
             case 0     => -1 // EOF
@@ -258,7 +258,7 @@ private[java] final class FileChannelImpl(
 
   override def size(): Long = {
     if (isWindows) {
-      val size = stackalloc[windows.LargeInteger]
+      val size = stackalloc[windows.LargeInteger]()
       if (GetFileSizeEx(fd.handle, size)) (!size).toLong
       else 0L
     } else {
@@ -387,7 +387,7 @@ private[java] final class FileChannelImpl(
 
   def available(): Int = {
     if (isWindows) {
-      val currentPosition, lastPosition = stackalloc[windows.LargeInteger]
+      val currentPosition, lastPosition = stackalloc[windows.LargeInteger]()
       SetFilePointerEx(
         fd.handle,
         distanceToMove = 0,

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -438,7 +438,7 @@ object Files {
       getAttribute(path, "basic:isRegularFile", options).asInstanceOf[Boolean]
     } else
       Zone { implicit z =>
-        val buf = alloc[stat.stat]
+        val buf = alloc[stat.stat]()
         val err =
           if (options.contains(LinkOption.NOFOLLOW_LINKS)) {
             stat.lstat(toCString(path.toFile().getPath()), buf)
@@ -462,7 +462,7 @@ object Files {
       exists & isReparsePoint
     } else {
       val filename = toCString(path.toFile().getPath())
-      val buf = alloc[stat.stat]
+      val buf = alloc[stat.stat]()
       if (stat.lstat(filename, buf) == 0) {
         stat.S_ISLNK(buf._13) == 1
       } else {

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -28,7 +28,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
   ): Unit = Zone { implicit z =>
     val sb = getStat()
 
-    val buf = alloc[utime.utimbuf]
+    val buf = alloc[utime.utimbuf]()
     buf._1 =
       if (lastAccessTime != null) lastAccessTime.to(TimeUnit.SECONDS)
       else sb._7
@@ -190,7 +190,7 @@ final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
     }
 
   private def getStat()(implicit z: Zone): Ptr[stat.stat] = {
-    val buf = alloc[stat.stat]
+    val buf = alloc[stat.stat]()
     val err =
       if (options.contains(LinkOption.NOFOLLOW_LINKS)) {
         stat.lstat(toCString(path.toString), buf)

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixUserPrincipalLookupService.scala
@@ -38,7 +38,7 @@ object PosixUserPrincipalLookupService extends UserPrincipalLookupService {
 
   private[attribute] def getGroupName(gid: stat.gid_t): String = Zone {
     implicit z =>
-      val buf = alloc[grp.group]
+      val buf = alloc[grp.group]()
 
       errno.errno = 0
       val err = grp.getgrgid(gid, buf)
@@ -54,7 +54,7 @@ object PosixUserPrincipalLookupService extends UserPrincipalLookupService {
 
   private[attribute] def getUsername(uid: stat.uid_t): String = Zone {
     implicit z =>
-      val buf = alloc[pwd.passwd]
+      val buf = alloc[pwd.passwd]()
 
       errno.errno = 0
       val err = pwd.getpwuid(uid, buf)
@@ -71,7 +71,7 @@ object PosixUserPrincipalLookupService extends UserPrincipalLookupService {
   private def getGroup(
       name: CString
   )(implicit z: Zone): Option[Ptr[grp.group]] = {
-    val buf = alloc[grp.group]
+    val buf = alloc[grp.group]()
 
     errno.errno = 0
     val err = grp.getgrnam(name, buf)
@@ -102,7 +102,7 @@ object PosixUserPrincipalLookupService extends UserPrincipalLookupService {
   private def getPasswd(
       name: CString
   )(implicit z: Zone): Option[Ptr[pwd.passwd]] = {
-    val buf = alloc[pwd.passwd]
+    val buf = alloc[pwd.passwd]()
 
     errno.errno = 0
     val err = pwd.getpwnam(name, buf)

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -60,10 +60,10 @@ object Date {
 
   private def secondsToString(seconds: Long, default: => String): String =
     Zone { implicit z =>
-      val ttPtr = alloc[time_t]
+      val ttPtr = alloc[time_t]()
       !ttPtr = seconds
 
-      val tmPtr = alloc[tm]
+      val tmPtr = alloc[tm]()
       def getLocalTime() =
         if (isWindows) winTime.localtime_s(tmPtr, ttPtr) != 0
         else localtime_r(ttPtr, tmPtr) == null

--- a/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
+++ b/javalib/src/main/scala/java/util/WindowsHelperMethods.scala
@@ -64,7 +64,7 @@ object WindowsHelperMethods {
       token: Handle,
       informationClass: TokenInformationClass
   )(fn: Ptr[T] => R)(implicit z: Zone): R = {
-    val dataSize = alloc[DWord]
+    val dataSize = alloc[DWord]()
     !dataSize = 0.toUInt
 
     if (!GetTokenInformation(

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -70,7 +70,7 @@ object FileHelpers {
         null
       } else {
         Zone { implicit z =>
-          var elem = alloc[dirent]
+          var elem = alloc[dirent]()
           var res = 0
           while ({ res = readdir(dir, elem); res == 0 }) {
             val name = fromCString(elem._2.at(0))

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
@@ -64,7 +64,7 @@ class UnixFileSystem(
     closed == false
 
   override def isReadOnly(): Boolean = Zone { implicit z =>
-    val stat = alloc[statvfs.statvfs]
+    val stat = alloc[statvfs.statvfs]()
     val err = statvfs.statvfs(toCString(root), stat)
     if (err != 0) {
       throw new IOException()

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsDosFileAttributeView.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsDosFileAttributeView.scala
@@ -107,7 +107,7 @@ final class WindowsDosFileAttributeView(path: Path, options: Array[LinkOption])
   def readAttributes(): DosFileAttributes = attributes
 
   private lazy val attributes: DosFileAttributes = Zone { implicit z: Zone =>
-    val fileInfo = alloc[ByHandleFileInformation]
+    val fileInfo = alloc[ByHandleFileInformation]()
 
     withFileOpen(
       pathAbs,

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsUserPrincipalLookupService.scala
@@ -37,7 +37,7 @@ object WindowsUserPrincipalLookupService extends UserPrincipalLookupService {
       !cbSid = 0.toUInt
       !domainSize = 0.toUInt
 
-      val useRef = alloc[SidNameUse]
+      val useRef = alloc[SidNameUse]()
       val accountName = toCWideStringUTF16LE(name).asInstanceOf[CWString]
       LookupAccountNameW(
         systemName = null,

--- a/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
+++ b/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
@@ -79,6 +79,19 @@ private object MacroImpl {
   import scala.reflect.macros.blackbox.Context
 
   def alloc1[T: c.WeakTypeTag](c: Context)(tag: c.Tree, z: c.Tree): c.Tree = {
+    c.warning(
+      c.enclosingPosition,
+      s"Empty param method `alloc[T]` is deprecated, " +
+        "in Scala 3 `alloc[T](n)` can be interpretted as " +
+        "`alloc[T].apply(n)` leading to runtime erros, " +
+        "use `alloc[T]()` instead "
+    )
+    alloc1Impl(c)(tag, z)
+  }
+
+  private def alloc1Impl[T: c.WeakTypeTag](
+      c: Context
+  )(tag: c.Tree, z: c.Tree): c.Tree = {
     import c.universe._
     val T = weakTypeOf[T]
 
@@ -97,7 +110,7 @@ private object MacroImpl {
 
   def allocSingle[T: c.WeakTypeTag](
       c: Context
-  )()(tag: c.Tree, z: c.Tree): c.Tree = alloc1(c)(tag, z)
+  )()(tag: c.Tree, z: c.Tree): c.Tree = alloc1Impl(c)(tag, z)
 
   def allocN[T: c.WeakTypeTag](
       c: Context
@@ -121,9 +134,21 @@ private object MacroImpl {
   }
 
   def stackallocSingle[T: c.WeakTypeTag](c: Context)()(tag: c.Tree): c.Tree =
-    stackalloc1(c)(tag)
+    stackalloc1Impl(c)(tag)
 
   def stackalloc1[T: c.WeakTypeTag](c: Context)(tag: c.Tree): c.Tree = {
+    c.warning(
+      c.enclosingPosition,
+      s"Empty param method `stackalloc[T]` is deprecated, " +
+        "in Scala 3 `stackalloc[T](n)` can be interpretted as " +
+        "`stackalloc[T].apply(n)` leading to runtime erros, " +
+        "use `stackalloc[T]()` instead "
+    )
+    stackalloc1Impl(c)(tag)
+  }
+
+  private def stackalloc1Impl[T: c.WeakTypeTag](c: Context)(tag: c.Tree): c.Tree = {
+
     import c.universe._
 
     val T = weakTypeOf[T]

--- a/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
+++ b/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
@@ -81,7 +81,7 @@ private object MacroImpl {
   def alloc1[T: c.WeakTypeTag](c: Context)(tag: c.Tree, z: c.Tree): c.Tree = {
     c.warning(
       c.enclosingPosition,
-      s"Empty param method `alloc[T]` is deprecated, " +
+      s"Scala Native method `alloc[T]` is deprecated, " +
         "in Scala 3 `alloc[T](n)` can be interpretted as " +
         "`alloc[T].apply(n)` leading to runtime erros, " +
         "use `alloc[T]()` instead "
@@ -139,7 +139,7 @@ private object MacroImpl {
   def stackalloc1[T: c.WeakTypeTag](c: Context)(tag: c.Tree): c.Tree = {
     c.warning(
       c.enclosingPosition,
-      s"Empty param method `stackalloc[T]` is deprecated, " +
+      s"Scala Native method `stackalloc[T]` is deprecated, " +
         "in Scala 3 `stackalloc[T](n)` can be interpretted as " +
         "`stackalloc[T].apply(n)` leading to runtime erros, " +
         "use `stackalloc[T]()` instead "
@@ -147,7 +147,9 @@ private object MacroImpl {
     stackalloc1Impl(c)(tag)
   }
 
-  private def stackalloc1Impl[T: c.WeakTypeTag](c: Context)(tag: c.Tree): c.Tree = {
+  private def stackalloc1Impl[T: c.WeakTypeTag](
+      c: Context
+  )(tag: c.Tree): c.Tree = {
 
     import c.universe._
 

--- a/nativelib/src/main/scala-3/scala/scalanative/unsafe/UnsafePackageCompat.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/unsafe/UnsafePackageCompat.scala
@@ -7,17 +7,6 @@ private[scalanative] trait UnsafePackageCompat {
   private[scalanative] given reflect.ClassTag[Array[?]] =
     reflect.classTag[Array[AnyRef]].asInstanceOf[reflect.ClassTag[Array[?]]]
 
-  /** Heap allocate and zero-initialize a value using current implicit
-   *  allocator.
-   */
-  @deprecated(
-    "In Scala 3 alloc[T](n) can be confused with alloc[T].apply(n) leading to runtime erros, use alloc[T]() instead",
-    since = "0.5.0"
-  )
-  inline def alloc[T](using tag: Tag[T], zone: Zone): Ptr[T] = {
-    alloc[T](1.toULong)
-  }
-
   /** Heap allocate and zero-initialize n values using current implicit
    *  allocator.
    */
@@ -41,13 +30,6 @@ private[scalanative] trait UnsafePackageCompat {
   )
   inline def alloc[T](inline n: CSSize)(using Tag[T], Zone): Ptr[T] =
     alloc[T](n.toUInt)
-
-  @deprecated(
-    "In Scala 3 stackalloc[T](n) can be confused with stackalloc[T].apply(n) leading to runtime erros, use stackalloc[T]() instead",
-    since = "0.5.0"
-  )
-  inline def stackalloc[T](implicit tag: Tag[T]): Ptr[T] =
-    stackalloc[T](1.toULong)
 
   /** Stack allocate n values of given type */
   inline def stackalloc[T](

--- a/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
@@ -344,7 +344,7 @@ object signalOps {
       !p.asInstanceOf[Ptr[Ptr[Byte]]] = value
   }
 
-  def union_sigval()(implicit z: Zone): Ptr[sigval] = alloc[sigval]
+  def union_sigval()(implicit z: Zone): Ptr[sigval] = alloc[sigval]()
 
   implicit class sigaction_ops(val p: Ptr[sigaction]) extends AnyVal {
     def sa_handler: CFuncPtr1[CInt, Unit] = p._1
@@ -360,7 +360,7 @@ object signalOps {
       p._4 = value
   }
 
-  def struct_sigaction()(implicit z: Zone): Ptr[sigaction] = alloc[sigaction]
+  def struct_sigaction()(implicit z: Zone): Ptr[sigaction] = alloc[sigaction]()
 
   // mcontext_t - platform specific
 
@@ -375,7 +375,8 @@ object signalOps {
     def uc_mcontext_=(value: mcontext_t): Unit = !p._4
   }
 
-  def struct_ucontext_t()(implicit z: Zone): Ptr[ucontext_t] = alloc[ucontext_t]
+  def struct_ucontext_t()(implicit z: Zone): Ptr[ucontext_t] =
+    alloc[ucontext_t]()
 
   implicit class stack_t_ops(val p: Ptr[stack_t]) extends AnyVal {
     def ss_sp: Ptr[Byte] = p._1
@@ -386,7 +387,7 @@ object signalOps {
     def ss_flags_=(value: CInt): Unit = p._3 = value
   }
 
-  def struct_stack_t()(implicit z: Zone): Ptr[stack_t] = alloc[stack_t]
+  def struct_stack_t()(implicit z: Zone): Ptr[stack_t] = alloc[stack_t]()
 
   implicit class siginfo_t_ops(val p: Ptr[siginfo_t]) extends AnyVal {
     def si_signo: CInt = p._1

--- a/unit-tests/native/src/test/scala/java/net/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/java/net/UdpSocketTest.scala
@@ -80,7 +80,7 @@ class UdpSocketTest {
     val inSocket: CInt = createAndCheckUdpSocket()
 
     try {
-      val inAddr = alloc[sockaddr]
+      val inAddr = alloc[sockaddr]()
       val inAddrInPtr = inAddr.asInstanceOf[Ptr[sockaddr_in]]
 
       inAddrInPtr.sin_family = AF_INET.toUShort
@@ -93,8 +93,8 @@ class UdpSocketTest {
       val bindStatus = bind(inSocket, inAddr, sizeof[sockaddr].toUInt)
       assertNotEquals("bind", -1, bindStatus)
 
-      val inAddrInfo = alloc[sockaddr]
-      val gsnAddrLen = alloc[socklen_t]
+      val inAddrInfo = alloc[sockaddr]()
+      val gsnAddrLen = alloc[socklen_t]()
       !gsnAddrLen = sizeof[sockaddr].toUInt
 
       val gsnStatus = getsockname(inSocket, inAddrInfo, gsnAddrLen)
@@ -104,7 +104,7 @@ class UdpSocketTest {
       val outSocket = createAndCheckUdpSocket()
 
       try {
-        val outAddr = alloc[sockaddr]
+        val outAddr = alloc[sockaddr]()
         val outAddrInPtr = outAddr.asInstanceOf[Ptr[sockaddr_in]]
         outAddrInPtr.sin_family = AF_INET.toUShort
         outAddrInPtr.sin_addr.s_addr = localhostInetAddr
@@ -177,8 +177,8 @@ class UdpSocketTest {
         assertEquals("recvfrom_1 length", nBytesSent, nBytesPeekedAt)
 
         // Test retrieving remote address.
-        val srcAddr = alloc[sockaddr]
-        val srcAddrLen = alloc[socklen_t]
+        val srcAddr = alloc[sockaddr]()
+        val srcAddrLen = alloc[socklen_t]()
         !srcAddrLen = sizeof[sockaddr].toUInt
         val nBytesRecvd =
           recvfrom(inSocket, inData, maxInData.toUInt, 0, srcAddr, srcAddrLen)

--- a/unit-tests/native/src/test/scala/scala/scalanative/libc/CComplexTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/libc/CComplexTest.scala
@@ -60,10 +60,10 @@ class CComplexTest {
 
   def tf(implicit z: Zone) = res(real.toFloat, imag.toFloat)
 
-  def buff(implicit z: Zone) = alloc[CFloatComplex]
+  def buff(implicit z: Zone) = alloc[CFloatComplex]()
 
   def res(real: Float, imag: Float)(implicit z: Zone) =
-    alloc[CFloatComplex].init(real.toFloat, imag.toFloat)
+    alloc[CFloatComplex]().init(real.toFloat, imag.toFloat)
 
   @Test def testCacosf(): Unit = {
     Zone { implicit z =>
@@ -267,10 +267,10 @@ class CComplexTest {
 
   def td(implicit z: Zone) = res(real, imag)
 
-  def buf(implicit z: Zone) = alloc[CDoubleComplex]
+  def buf(implicit z: Zone) = alloc[CDoubleComplex]()
 
   def res(real: Double, imag: Double)(implicit z: Zone) =
-    alloc[CDoubleComplex].init(real, imag)
+    alloc[CDoubleComplex]().init(real, imag)
 
   @Test def testCacos(): Unit = {
     Zone { implicit z =>

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/ResourceTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/ResourceTest.scala
@@ -89,7 +89,7 @@ class ResourceTest {
   @Test def getrlimitInvalidArgResource() = if (!isWindows) {
     Zone { implicit z =>
       errno.errno = 0
-      val rlimPtr = alloc[rlimit]
+      val rlimPtr = alloc[rlimit]()
 
       getrlimit(Integer.MAX_VALUE, rlimPtr)
 
@@ -143,7 +143,7 @@ class ResourceTest {
   @Test def getrusageInvalidArgWho() = if (!isWindows) {
     Zone { implicit z =>
       errno.errno = 0
-      val rusagePtr = alloc[rusage]
+      val rusagePtr = alloc[rusage]()
 
       getrusage(Integer.MIN_VALUE, rusagePtr)
 
@@ -154,7 +154,7 @@ class ResourceTest {
   @Test def getrusageSelf() = if (!isWindows) {
     Zone { implicit z =>
       errno.errno = 0
-      val rusagePtr = alloc[rusage]
+      val rusagePtr = alloc[rusage]()
 
       val result = getrusage(RUSAGE_SELF, rusagePtr)
 
@@ -186,7 +186,7 @@ class ResourceTest {
   @Test def getrusageChildren() = if (!isWindows) {
     Zone { implicit z =>
       errno.errno = 0
-      val rusagePtr = alloc[rusage]
+      val rusagePtr = alloc[rusage]()
 
       val result = getrusage(RUSAGE_CHILDREN, rusagePtr)
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -41,7 +41,7 @@ class TimeTest {
       Zone { implicit z =>
         val time_ptr = stackalloc[time_t]()
         !time_ptr = now_time_t
-        val localtime: Ptr[tm] = localtime_r(time_ptr, alloc[tm])
+        val localtime: Ptr[tm] = localtime_r(time_ptr, alloc[tm]())
 
         localtime.tm_isdst == 0
       }
@@ -50,7 +50,7 @@ class TimeTest {
   @Test def asctimeWithGivenKnownStateShouldMatchItsRepresentation(): Unit =
     if (!isWindows) {
       Zone { implicit z =>
-        val anno_zero_ptr = alloc[tm]
+        val anno_zero_ptr = alloc[tm]()
         anno_zero_ptr.tm_mday = 1
         anno_zero_ptr.tm_wday = 1
         val cstr: CString = asctime(anno_zero_ptr)
@@ -62,7 +62,7 @@ class TimeTest {
   @Test def asctime_rWithGivenKnownStateShouldMatchItsRepresentation(): Unit =
     if (!isWindows) {
       Zone { implicit z =>
-        val anno_zero_ptr = alloc[tm]
+        val anno_zero_ptr = alloc[tm]()
         anno_zero_ptr.tm_mday = 1
         anno_zero_ptr.tm_wday = 1
         val cstr: CString = asctime_r(anno_zero_ptr, alloc[Byte](26))
@@ -99,7 +99,7 @@ class TimeTest {
         )
         val time_ptr = stackalloc[time_t]()
         !time_ptr = epoch + timezone()
-        val time: Ptr[tm] = localtime_r(time_ptr, alloc[tm])
+        val time: Ptr[tm] = localtime_r(time_ptr, alloc[tm]())
         val cstr: CString = asctime_r(time, alloc[Byte](26))
         val str: String = fromCString(cstr)
 
@@ -146,7 +146,7 @@ class TimeTest {
         36.toULong
       )
 
-      val ttPtr = alloc[time_t]
+      val ttPtr = alloc[time_t]()
       !ttPtr = 1490986064740L / 1000L // Fri Mar 31 14:47:44 EDT 2017
 
       // This code is testing for reading past the end of a "short"
@@ -197,7 +197,7 @@ class TimeTest {
   @Test def strftimeForJanOne1900ZeroZulu(): Unit = if (!isWindows) {
     Zone { implicit z =>
       val isoDatePtr: Ptr[CChar] = alloc[CChar](70)
-      val timePtr = alloc[tm]
+      val timePtr = alloc[tm]()
 
       timePtr.tm_mday = 1
 
@@ -211,7 +211,7 @@ class TimeTest {
 
   @Test def strftimeForMondayJanOne1990ZeroTime(): Unit = if (!isWindows) {
     Zone { implicit z =>
-      val timePtr = alloc[tm]
+      val timePtr = alloc[tm]()
       val datePtr: Ptr[CChar] = alloc[CChar](70)
 
       timePtr.tm_mday = 1
@@ -226,7 +226,7 @@ class TimeTest {
 
   @Test def strptimeDetectsGrosslyInvalidFormat(): Unit = if (!isWindows) {
     Zone { implicit z =>
-      val tmPtr = alloc[tm]
+      val tmPtr = alloc[tm]()
 
       // As described in the Scala Native time.c implementation,
       // the format string is passed, unchecked, to the underlying
@@ -246,7 +246,7 @@ class TimeTest {
 
   @Test def strptimeDetectsInvalidString(): Unit = if (!isWindows) {
     Zone { implicit z =>
-      val tmPtr = alloc[tm]
+      val tmPtr = alloc[tm]()
 
       // 32 in string is invalid
       val result =
@@ -258,7 +258,7 @@ class TimeTest {
 
   @Test def strptimeDetectsStringShorterThanFormat(): Unit = if (!isWindows) {
     Zone { implicit z =>
-      val tmPtr = alloc[tm]
+      val tmPtr = alloc[tm]()
 
       val result =
         strptime(c"December 32, 2016 23:59", c"%B %d, %Y %T", tmPtr)
@@ -386,7 +386,7 @@ class TimeTest {
 
   @Test def strptimeFor31December2016Time235960(): Unit = if (!isWindows) {
     Zone { implicit z =>
-      val tmPtr = alloc[tm]
+      val tmPtr = alloc[tm]()
 
       // A leap second was added at this time
       val result =
@@ -436,7 +436,7 @@ class TimeTest {
 
   @Test def strptimeExtraTextAfterDateStringIsOK(): Unit = if (!isWindows) {
     Zone { implicit z =>
-      val tmPtr = alloc[tm]
+      val tmPtr = alloc[tm]()
 
       val result =
         strptime(c"December 31, 2016 23:59:60 UTC", c"%B %d, %Y %T ", tmPtr)

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CArrayOpsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CArrayOpsTest.scala
@@ -11,7 +11,7 @@ import scalanative.unsafe.Ptr.ptrToCArray
 class CArrayOpsTest {
 
   @Test def atN(): Unit = {
-    val alloc = stackalloc[CArray[Int, Digit2[_3, _2]]]
+    val alloc = stackalloc[CArray[Int, Digit2[_3, _2]]]()
     val carr = !alloc
     val ptr = alloc.asInstanceOf[Ptr[Int]]
 
@@ -20,7 +20,7 @@ class CArrayOpsTest {
   }
 
   @Test def applyUpdate(): Unit = {
-    val alloc = stackalloc[CArray[Int, Digit2[_3, _2]]]
+    val alloc = stackalloc[CArray[Int, Digit2[_3, _2]]]()
     val carr = !alloc
     val ptr = alloc.asInstanceOf[Ptr[Int]]
 
@@ -35,21 +35,21 @@ class CArrayOpsTest {
   }
 
   @Test def testLength(): Unit = {
-    val carr0 = stackalloc[CArray[Int, _0]]
+    val carr0 = stackalloc[CArray[Int, _0]]()
     assertTrue(carr0.length == 0)
-    val carr8 = stackalloc[CArray[Int, _8]]
+    val carr8 = stackalloc[CArray[Int, _8]]()
     assertTrue(carr8.length == 8)
-    val carr16 = stackalloc[CArray[Int, Digit2[_1, _6]]]
+    val carr16 = stackalloc[CArray[Int, Digit2[_1, _6]]]()
     assertTrue(carr16.length == 16)
-    val carr32 = stackalloc[CArray[Int, Digit2[_3, _2]]]
+    val carr32 = stackalloc[CArray[Int, Digit2[_3, _2]]]()
     assertTrue(carr32.length == 32)
-    val carr128 = stackalloc[CArray[Int, Digit3[_1, _2, _8]]]
+    val carr128 = stackalloc[CArray[Int, Digit3[_1, _2, _8]]]()
     assertTrue(carr128.length == 128)
-    val carr256 = stackalloc[CArray[Int, Digit3[_2, _5, _6]]]
+    val carr256 = stackalloc[CArray[Int, Digit3[_2, _5, _6]]]()
     assertTrue(carr256.length == 256)
-    val carr1024 = stackalloc[CArray[Int, Digit4[_1, _0, _2, _4]]]
+    val carr1024 = stackalloc[CArray[Int, Digit4[_1, _0, _2, _4]]]()
     assertTrue(carr1024.length == 1024)
-    val carr4096 = stackalloc[CArray[Int, Digit4[_4, _0, _9, _6]]]
+    val carr4096 = stackalloc[CArray[Int, Digit4[_4, _0, _9, _6]]]()
     assertTrue(carr4096.length == 4096)
   }
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStringTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStringTest.scala
@@ -116,7 +116,7 @@ class CStringTest {
   @Test def toFromCString(): Unit = {
     Zone { implicit z =>
       type _11 = Nat.Digit2[Nat._1, Nat._1]
-      val arr = unsafe.stackalloc[CArray[Byte, _11]]
+      val arr = unsafe.stackalloc[CArray[Byte, _11]]()
 
       val jstr1 = "a\b\\c\u0064"
       val cstr1 = c"a\b\\c\x64"

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStructOpsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/CStructOpsTest.scala
@@ -7,7 +7,7 @@ import org.junit.Assert._
 class CStructOpsTest {
 
   @Test def atN(): Unit = {
-    val alloc = stackalloc[CStruct4[Byte, Short, Int, Long]]
+    val alloc = stackalloc[CStruct4[Byte, Short, Int, Long]]()
     val struct = !alloc
     val ptr = alloc.asInstanceOf[Ptr[Byte]]
 
@@ -18,7 +18,7 @@ class CStructOpsTest {
   }
 
   @Test def applyUpdate(): Unit = {
-    val alloc = stackalloc[CStruct4[Int, Int, Int, Int]]
+    val alloc = stackalloc[CStruct4[Int, Int, Int, Int]]()
     val struct = !alloc
     val ptr = alloc.asInstanceOf[Ptr[Int]]
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrBoxingTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrBoxingTest.scala
@@ -172,7 +172,7 @@ class PtrBoxingTest {
     type Cons = CStruct2[Int, Ptr[Byte]]
 
     def cons(value: Int, next: Ptr[Cons])(implicit z: Zone): Ptr[Cons] = {
-      val v = alloc[Cons]
+      val v = alloc[Cons]()
       v._1 = value
       v._2 = next.asInstanceOf[Ptr[Byte]]
       v

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrOpsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/PtrOpsTest.scala
@@ -79,7 +79,7 @@ class PtrOpsTest {
 
     def test(fn: CFuncPtr2[CString, StructA, StructA]): Unit = Zone {
       implicit z =>
-        val str = alloc[StructA]
+        val str = alloc[StructA]()
         val charset = java.nio.charset.StandardCharsets.UTF_8
 
         str._1 = 1
@@ -107,7 +107,7 @@ class PtrOpsTest {
   @Test def castedCFuncPtrHandlesArrays(): Unit = {
     def test(fn: CFuncPtr3[CInt, CUnsignedLongLong, LLArr, LLArr]) = Zone {
       implicit z =>
-        val arr = alloc[LLArr]
+        val arr = alloc[LLArr]()
 
         val value = ULong.MaxValue
         val idx = 5

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/StackallocTest.scala
@@ -31,7 +31,7 @@ class StackallocTest {
   }
 
   @Test def stackallocCStruct2IntInt(): Unit = {
-    val ptr = stackalloc[CStruct2[Int, Int]]
+    val ptr = stackalloc[CStruct2[Int, Int]]()
 
     ptr._1 = 1
     ptr._2 = 2
@@ -41,7 +41,7 @@ class StackallocTest {
   }
 
   @Test def stackallocCArrayIntNat4(): Unit = {
-    val ptr = stackalloc[CArray[Int, Nat._4]]
+    val ptr = stackalloc[CArray[Int, Nat._4]]()
     val arr = !ptr
 
     arr(0) = 1
@@ -77,7 +77,7 @@ class StackallocTest {
     var i = 0
     var head: Ptr[Node] = null
     while (i < 4) {
-      head = stackalloc[Node].init(i, head)
+      head = stackalloc[Node]().init(i, head)
       i += 1
     }
     assertTrue(head.sum == 6)


### PR DESCRIPTION
This PR does remove empty-parens variants of methods `alloc[T]` and `stackalloc[T]` from Scala 3 unsafe package.
Even though this change is not source compatible with Scala 2 it does prevent users from getting runtime errors when `stackalloc[T](n)` would be interpreted as `stackalloc[T].apply(n)` - instead of allocation memory of size `n*sizeOf(T)` it would allocate `1*sizeOf(T)` and would try to access received pointer at offset `n` leading to undefined behaviour.  

Additionally, since deprecation annotations are ignored in methods defined as macros, a deprecation warning is now a part of the `stackalloc[T]` and `alloc[T]` definition.  

* Removed no-parens `stackalloc[T]` and `alloc[T]` methods from Scala 3 unsafe package
* Added warning in no-parens `stackalloc[T]` and `alloc[T]` methods in Scala 2 
* Fixed all remaining usages of no parens variants of mentioned method in Scala Native