### PR TITLE
Allow to resolve `unsafe.Tag` introduced via `given`

### DIFF
--- a/unit-tests/native/src/test/scala-3/scala/scala/scalnative/IssuesTestScala3.scala
+++ b/unit-tests/native/src/test/scala-3/scala/scala/scalnative/IssuesTestScala3.scala
@@ -7,38 +7,20 @@ import scala.scalanative.junit.utils.AssertThrows.assertThrows
 import scalanative.unsigned._
 import scalanative.unsafe._
 
-class IssuesTestScala2 {
+class IssuesTestScala3 {
+  @Test def issue2485(): Unit = {
+    import scala.scalanative.issue2485.*
+    import types.MyEnum
 
-  @Test def test_Issue803(): Unit = {
-    val x1: String = null
-    var x2: String = "right"
-    assertTrue(x1 + x2 == "nullright")
-
-    val x3: String = "left"
-    val x4: String = null
-    assertTrue(x3 + x4 == "leftnull")
-
-    val x5: AnyRef = new { override def toString = "custom" }
-    val x6: String = null
-    assertEquals("customnull", x5.toString + x6)
-
-    val x7: String = null
-    val x8: AnyRef = new { override def toString = "custom" }
-    assertEquals("nullcustom", x7 + x8)
-
-    val x9: String = null
-    val x10: String = null
-    assertEquals("nullnull", x9 + x10)
-
-    // This syntax operation does not compile in Scala 3
-    // When using `toString` on null it might throw NullPointerException
-    // val x11: AnyRef = null
-    // val x12: String = null
-    // assertEquals("nullnull", x11 + x12)
-
-    val x13: String = null
-    val x14: AnyRef = null
-    assertEquals("nullnull", x13 + x14)
+    assertEquals(Tag.materializeIntTag, summon[Tag[MyEnum]])
+    // Check if compiles
+    CFuncPtr1.fromScalaFunction[MyEnum, MyEnum] { a => a }
   }
-
 }
+
+object issue2485:
+  object types:
+    opaque type MyEnum = Int
+    object MyEnum:
+      given Tag[MyEnum] = Tag.materializeIntTag
+end issue2485

--- a/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
+++ b/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
@@ -2,7 +2,6 @@ package scala.issues
 
 import org.junit.Test
 import org.junit.Assert._
-import scala.scalanative.unsafe._
 
 class Scala3IssuesTest:
 

--- a/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
+++ b/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
@@ -13,18 +13,36 @@ class Scala3IssuesTest:
     assertEquals(List(1, 2, 3), result)
   }
 
-  @Test def issue2485(): Unit = {
-    object testing:
-      object types:
-        opaque type MyEnum = Int
-        object MyEnum:
-          given Tag[MyEnum] = Tag.materializeIntTag
-      import types.MyEnum
+  @Test def test_Issue803(): Unit = {
+    val x1: String = null
+    var x2: String = "right"
+    assertTrue(x1 + x2 == "nullright")
 
-      assertEquals(Tag.materializeIntTag, summon[Tag[MyEnum]])
-      // Check if compiles
-      CFuncPtr1.fromScalaFunction[MyEnum, MyEnum] { a =>
-        a
-      }
-    end testing
+    val x3: String = "left"
+    val x4: String = null
+    assertTrue(x3 + x4 == "leftnull")
+
+    val x5: AnyRef = new { override def toString = "custom" }
+    val x6: String = null
+    assertEquals("customnull", x5.toString + x6)
+
+    val x7: String = null
+    val x8: AnyRef = new { override def toString = "custom" }
+    assertEquals("nullcustom", x7 + x8)
+
+    val x9: String = null
+    val x10: String = null
+    assertEquals("nullnull", x9 + x10)
+
+    // This syntax operation does not compile in Scala 3
+    // When using `toString` on null it might throw NullPointerException
+    // val x11: AnyRef = null
+    // val x12: String = null
+    // assertEquals("nullnull", x11 + x12)
+
+    val x13: String = null
+    val x14: AnyRef = null
+    assertEquals("nullnull", x13 + x14)
   }
+
+end Scala3IssuesTest

--- a/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
+++ b/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
@@ -2,6 +2,7 @@ package scala.issues
 
 import org.junit.Test
 import org.junit.Assert._
+import scala.scalanative.unsafe._
 
 class Scala3IssuesTest:
 
@@ -10,4 +11,20 @@ class Scala3IssuesTest:
   @Test def canUseMacros(): Unit = {
     val result = Macros.test("foo")
     assertEquals(List(1, 2, 3), result)
+  }
+
+  @Test def issue2485(): Unit = {
+    object testing:
+      object types:
+        opaque type MyEnum = Int
+        object MyEnum:
+          given Tag[MyEnum] = Tag.materializeIntTag
+      import types.MyEnum
+
+      asserEquals(Tag.materializeIntTag, summon[Tag[MyEnum]])
+      // Check if compiles
+      CFuncPtr1.fromScalaFunction[MyEnum, MyEnum] { a =>
+        a
+      }
+    end testing
   }

--- a/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
+++ b/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
@@ -21,7 +21,7 @@ class Scala3IssuesTest:
           given Tag[MyEnum] = Tag.materializeIntTag
       import types.MyEnum
 
-      asserEquals(Tag.materializeIntTag, summon[Tag[MyEnum]])
+      assertEquals(Tag.materializeIntTag, summon[Tag[MyEnum]])
       // Check if compiles
       CFuncPtr1.fromScalaFunction[MyEnum, MyEnum] { a =>
         a


### PR DESCRIPTION
This PR fixes #2485 compile-time errors when trying to resolve correct `unsafe.Tag[_]` which was introduced in the scope by `given` keyworkd