### PR TITLE
Improvements to generation and invocation of static methods

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2386,7 +2386,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           buf.method(self, sig, unwind)
         }
       val values =
-        if (sym.isStaticInIR) args
+        if (sym.isStaticInNIR) args
         else self +: args
 
       val res = buf.call(sig, method, values, unwind)

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2294,19 +2294,13 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         receiver: Tree,
         argsp: Seq[Tree]
     )(implicit pos: nir.Position): Val = {
-      require(!isImplClass(sym.owner), sym.owner)
-      val name = genStaticMemberName(
-        sym,
-        Option(receiver.symbol).filter(_.exists)
-      )
+      require(!isImplClass(sym.owner) && !sym.owner.isExternModule, sym.owner)
+      val name = genStaticMemberName(sym, receiver.symbol)
       val method = Val.Global(name, nir.Type.Ptr)
 
       val sig = genMethodSig(sym)
       val args = genMethodArgs(sym, argsp)
-      val values =
-        if (isImplClass(sym.owner)) args
-        else Val.Null +: args
-      buf.call(sig, method, values, unwind)
+      buf.call(sig, method, args, unwind)
     }
 
     def genApplyExternAccessor(sym: Symbol, argsp: Seq[Tree])(implicit
@@ -2392,10 +2386,8 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           buf.method(self, sig, unwind)
         }
       val values =
-        if (owner.isExternModule || isImplClass(owner))
-          args
-        else
-          self +: args
+        if (sym.isStaticInIR) args
+        else self +: args
 
       val res = buf.call(sig, method, values, unwind)
 

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
@@ -115,10 +115,15 @@ trait NirGenName[G <: Global with Singleton] {
 
   def genStaticMemberName(
       sym: Symbol,
-      explicitOwner: Option[Symbol]
+      explicitOwner: Symbol
   ): nir.Global = {
+    // Use explicit owner in case if forwarder target was defined in the trait/interface
+    // or was abstract. In Scala 2 `sym.owner` would always point to original owner.
+    // To resolve correct owner use optional explicit owner containing symbol of implementing class
     require(!isImplClass(sym.owner), sym.owner)
-    val typeName = genTypeName(explicitOwner.getOrElse(sym.owner))
+    val typeName = genTypeName(
+      Option(explicitOwner).filter(_.exists).getOrElse(sym.owner)
+    )
     val owner = nir.Global.Top(typeName.id.stripSuffix("$"))
     val id = nativeIdOf(sym)
     val scope =

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -802,7 +802,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       val fresh = curFresh.get
       val buf = new ExprBuffer()(fresh)
       val isSynchronized = dd.symbol.hasFlag(SYNCHRONIZED)
-      val isStatic = dd.symbol.isStaticInIR || isImplClass(dd.symbol.owner)
+      val isStatic = dd.symbol.isStaticInNIR || isImplClass(dd.symbol.owner)
       val isExtern = dd.symbol.owner.isExternModule
 
       implicit val pos: nir.Position = bodyp.pos

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -619,7 +619,6 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         val attrs = genMethodAttrs(sym)
         val name = genMethodName(sym)
         val sig = genMethodSig(sym)
-        val isStatic = owner.isExternModule || isImplClass(owner)
 
         dd.rhs match {
           case EmptyTree
@@ -666,7 +665,7 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             scoped(
               curMethodSig := sig
             ) {
-              val body = genMethodBody(dd, rhs, isStatic, isExtern = false)
+              val body = genMethodBody(dd, rhs)
               Some(Defn.Define(attrs, name, sig, body))
             }
         }
@@ -798,12 +797,13 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
 
     def genMethodBody(
         dd: DefDef,
-        bodyp: Tree,
-        isStatic: Boolean,
-        isExtern: Boolean
+        bodyp: Tree
     ): Seq[nir.Inst] = {
       val fresh = curFresh.get
       val buf = new ExprBuffer()(fresh)
+      val isSynchronized = dd.symbol.hasFlag(SYNCHRONIZED)
+      val isStatic = dd.symbol.isStaticInIR || isImplClass(dd.symbol.owner)
+      val isExtern = dd.symbol.owner.isExternModule
 
       implicit val pos: nir.Position = bodyp.pos
 
@@ -813,27 +813,14 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
           val ty = genType(curClassSym.tpe)
           Val.Local(fresh(), ty)
         case Some(sym) =>
-          val ty = if (isExtern) genExternType(sym.tpe) else genType(sym.tpe)
+          val ty = genType(sym.tpe)
           val param = Val.Local(fresh(), ty)
           curMethodEnv.enter(sym, param)
           param
       }
 
-      val isSynchronized = dd.symbol.hasFlag(SYNCHRONIZED)
-
       def genEntry(): Unit = {
         buf.label(fresh(), params)
-
-        if (isExtern) {
-          paramSyms.zip(params).foreach {
-            case (Some(sym), param) if isExtern =>
-              val ty = genType(sym.tpe)
-              val value = buf.fromExtern(ty, param)
-              curMethodEnv.enter(sym, value)
-            case _ =>
-              ()
-          }
-        }
       }
 
       def genVars(): Unit = {
@@ -1036,9 +1023,9 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
       implicit val pos: nir.Position = sym.pos
 
       val methodName = genMethodName(sym)
-      val forwarderName = genStaticMemberName(sym, Some(moduleClass))
+      val forwarderName = genStaticMemberName(sym, moduleClass)
       val Type.Function(_ +: paramTypes, retType) = genMethodSig(sym)
-      val forwarderParamTypes = Type.Ref(forwarderName.top) +: paramTypes
+      val forwarderParamTypes = paramTypes
       val forwarderType = Type.Function(forwarderParamTypes, retType)
 
       if (existingStaticMethodNames.contains(forwarderName)) {
@@ -1063,14 +1050,13 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
               curUnwindHandler := None,
               curMethodThis := None
             ) {
-              val entryParams @ (_ +: params) = forwarderParamTypes
-                .map(Val.Local(fresh(), _))
+              val entryParams = forwarderParamTypes.map(Val.Local(fresh(), _))
               buf.label(fresh(), entryParams)
               val res =
                 buf.genApplyModuleMethod(
                   moduleClass,
                   sym,
-                  params.map(ValTree(_))
+                  entryParams.map(ValTree(_))
                 )
               buf.ret(res)
             }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
@@ -19,6 +19,9 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
     def isScalaModule: Boolean =
       sym.isModuleClass && !isImplClass(sym) && !sym.isLifted
 
+    def isStaticInIR: Boolean =
+      sym.owner.isExternModule || sym.isStaticMember || isImplClass(sym.owner)
+
     def isExternModule: Boolean =
       isScalaModule && sym.annotations.exists(_.symbol == ExternClass)
 
@@ -167,7 +170,7 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
     val owner = sym.owner
     val paramtys = genMethodSigParamsImpl(sym, isExtern)
     val selfty =
-      if (isExtern || owner.isExternModule || isImplClass(owner)) None
+      if (isExtern || sym.isStaticInIR) None
       else Some(genType(owner.tpe))
     val retty =
       if (sym.isClassConstructor) nir.Type.Unit

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenType.scala
@@ -19,7 +19,7 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
     def isScalaModule: Boolean =
       sym.isModuleClass && !isImplClass(sym) && !sym.isLifted
 
-    def isStaticInIR: Boolean =
+    def isStaticInNIR: Boolean =
       sym.owner.isExternModule || sym.isStaticMember || isImplClass(sym.owner)
 
     def isExternModule: Boolean =
@@ -170,7 +170,7 @@ trait NirGenType[G <: Global with Singleton] { self: NirGenPhase[G] =>
     val owner = sym.owner
     val paramtys = genMethodSigParamsImpl(sym, isExtern)
     val selfty =
-      if (isExtern || sym.isStaticInIR) None
+      if (isExtern || sym.isStaticInNIR) None
       else Some(genType(owner.tpe))
     val retty =
       if (sym.isClassConstructor) nir.Type.Unit

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -334,7 +334,11 @@ trait NirGenExpr(using Context) {
             val allVals = (captureVals ++ paramVals).toList.map(ValTree(_))
             val res = if (isStaticCall) {
               scoped(curMethodThis := None) {
-                buf.genApplyStaticMethod(funSym, qualifierOf(fun).symbol, allVals)
+                buf.genApplyStaticMethod(
+                  funSym,
+                  qualifierOf(fun).symbol,
+                  allVals
+                )
               }
             } else {
               val thisVal :: argVals = allVals

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -101,11 +101,6 @@ trait NirGenName(using Context) {
       if (ownerIsScalaModule && haveNoForwarders) typeName
       else Global.Top(typeName.id.stripSuffix("$"))
     }
-    val sig = genStaticMemberSig(sym)
-    owner.member(sig)
-  }
-
-  def genStaticMemberSig(sym: Symbol): nir.Sig = {
     val id = nativeIdOf(sym)
     val scope =
       if (sym.isPrivate) nir.Sig.Scope.PrivateStatic(genTypeName(sym.owner))
@@ -116,9 +111,8 @@ trait NirGenName(using Context) {
       .map(genType)
     val retType = genType(fromType(sym.info.resultType))
 
-    val name = sym.name
     val sig = nir.Sig.Method(id, paramTypes :+ retType, scope)
-    sig
+    owner.member(sig)
   }
 
   private def nativeIdOf(sym: Symbol): String = {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -121,7 +121,7 @@ trait NirGenStat(using Context) {
         // enum values, which are backed by static fields.
         generatedDefns += Defn.Define(
           attrs = Attrs(inlineHint = nir.Attr.InlineHint),
-          name = genStaticMemberName(f),
+          name = genStaticMemberName(f, classSym),
           ty = Type.Function(Nil, ty),
           insts = withFreshExprBuffer { buf ?=>
             val fresh = curFresh.get
@@ -533,7 +533,7 @@ trait NirGenStat(using Context) {
       given nir.Position = sym.span
 
       val methodName = genMethodName(sym)
-      val forwarderName = genStaticMemberName(sym)
+      val forwarderName = genStaticMemberName(sym, moduleClass)
       val Type.Function(_ +: paramTypes, retType) = genMethodSig(sym)
       val forwarderParamTypes = paramTypes
       val forwarderType = Type.Function(forwarderParamTypes, retType)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -241,7 +241,7 @@ trait NirGenStat(using Context) {
     given fresh: nir.Fresh = curFresh.get
     val buf = ExprBuffer()
     val isExtern = dd.symbol.owner.isExternModule
-    val isStatic = dd.symbol.isStaticInIR
+    val isStatic = dd.symbol.isStaticInNIR
     val isSynchronized = dd.symbol.is(Synchronized)
 
     val sym = curMethodSym.get

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -40,6 +40,9 @@ trait NirGenType(using Context) {
         sym.is(JavaStatic) || sym.isScalaStatic
       }
 
+    def isStaticInIR: Boolean =
+      sym.is(JavaStatic) || sym.isScalaStatic || sym.isExtern
+
     def isExtern: Boolean = sym.owner.isExternModule
 
     def isExternModule: Boolean =
@@ -225,9 +228,9 @@ trait NirGenType(using Context) {
 
     val owner = sym.owner
     val paramtys = genMethodSigParamsImpl(sym, isExtern)
-    val selfty =
-      if (isExtern || owner.isExternModule) None
-      else Some(genType(owner))
+    val selfty = Option.unless(isExtern || sym.isStaticInIR) {
+      genType(owner)
+    }
     val resultType = sym.info.resultType
     val retty =
       if (sym.isConstructor) nir.Type.Unit

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -40,7 +40,7 @@ trait NirGenType(using Context) {
         sym.is(JavaStatic) || sym.isScalaStatic
       }
 
-    def isStaticInIR: Boolean =
+    def isStaticInNIR: Boolean =
       sym.is(JavaStatic) || sym.isScalaStatic || sym.isExtern
 
     def isExtern: Boolean = sym.owner.isExternModule
@@ -228,7 +228,7 @@ trait NirGenType(using Context) {
 
     val owner = sym.owner
     val paramtys = genMethodSigParamsImpl(sym, isExtern)
-    val selfty = Option.unless(isExtern || sym.isStaticInIR) {
+    val selfty = Option.unless(isExtern || sym.isStaticInNIR) {
       genType(owner)
     }
     val resultType = sym.info.resultType

--- a/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Generate.scala
@@ -132,10 +132,8 @@ object Generate {
       validateMainEntry()
 
       implicit val fresh = Fresh()
-      val entryMainTy =
-        Type.Function(Seq(Type.Ref(entry.top), ObjectArray), Type.Unit)
-      val entryMainMethod =
-        Val.Global(entry.member(Rt.ScalaMainSig), Type.Ptr)
+      val entryMainTy = Type.Function(Seq(ObjectArray), Type.Unit)
+      val entryMainMethod = Val.Global(entry.member(Rt.ScalaMainSig), Type.Ptr)
 
       val stackBottom = Val.Local(fresh(), Type.Ptr)
       val argc = Val.Local(fresh(), Type.Int)
@@ -189,7 +187,7 @@ object Generate {
               unwind
             ),
             Inst.Let(
-              Op.Call(entryMainTy, entryMainMethod, Seq(Val.Null, arr)),
+              Op.Call(entryMainTy, entryMainMethod, Seq(arr)),
               unwind
             ),
             Inst.Let(Op.Call(RuntimeLoopSig, RuntimeLoop, Seq(rt)), unwind),

--- a/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/GenerateReflectiveProxies.scala
@@ -112,7 +112,7 @@ object GenerateReflectiveProxies {
     val toProxy =
       dynimpls
         .foldLeft(Map[(Global, Sig), Global]()) {
-          case (acc, g @ Global.Member(owner, sig)) =>
+          case (acc, g @ Global.Member(owner, sig)) if !sig.isStatic =>
             val proxySig = sig.toProxy
             if (!acc.contains((owner, proxySig))) {
               acc + ((owner, proxySig) -> g)

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -617,7 +617,8 @@ class Reach(
             throw new LinkingException(
               s"Found a call to not defined static method ${methodName} that could not be rewritten. " +
                 "Static methods are generated since Scala Native 0.4.3, " +
-                "report this bug in the Scala Native issues."
+                "report this bug in the Scala Native issues. " +
+                s"Call defined at ${inst.pos.source}:${inst.pos.line}:${inst.pos.column}"
             )
           }
 


### PR DESCRIPTION
This PR does introduce a series of fixes and improvements to static methods in Scala Native and make their behaviour more compliant with the JVM

* Don't use dummy self (this) value in static methods - remove it from signature and body 
 It changes signatures off all static methods, eg for `object foo { @static def bar(arg: Int): Unit }` previously we in the NIR would create signature equal to  `(foo$, int) => Unit`, where `self: foo$` argument would never be used. Now NIR representation would match the signature `(int) => Unit `. This change makes it more compliant with the JVM and additionally allows to easier spot errors when trying to call static methods using arguments for the non-static calls. 
 * Adapt generation of `main` entry point to make a static call
 * Don't create `RefleciveProxies` for static methods
 * Fix generation of static calls when given class does not have defined a static forwarder (Scala 3 only)
 * Explain why we need to use explicit owner to generate static method name
 * Don't unmangle`Sig` to check if name is static/private, analyse mangled name string instead
 * Add `isStaticInNIR` helper method (based on Scala.js `isStaticInIR` helper method) to check if given symbol should be interpreted as static
 * Remove never used code in compiler plugin
 * Fix #2484 
 