### PR TITLE
Allow to init arrays using constant values in Scala 3

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -103,7 +103,7 @@ trait NirGenExpr(using Context) {
           ) = args
           if (dimensions.size == 1)
             val length = genExpr(dimensions.head)
-            buf.arrayalloc(genType(componentType), length, unwind)
+            buf.arrayalloc(genType(componentType.typeValue), length, unwind)
           else genApplyMethod(sym, statically = isStatic, qualifier, args)
         case _ =>
           if (nirPrimitives.isPrimitive(fun)) genApplyPrimitive(app)


### PR DESCRIPTION
This PR fixes bug in the Scala 3 compiler plugin. In Scala 2 it is possible to allocate array using constant literals - thanks to that we would not have to iterate over all values and assign them to array slots.  This PR ports this fix to Scala 3.