### PR TITLE
Fix rare `WeakReferenceTest` failures

### DIFF
--- a/unit-tests/native/src/test/scala/java/lang/ref/WeakReferenceTest.scala
+++ b/unit-tests/native/src/test/scala/java/lang/ref/WeakReferenceTest.scala
@@ -33,6 +33,28 @@ class WeakReferenceTest {
   }
 
   @nooptimize @Test def addsToReferenceQueueAfterGC(): Unit = {
+    def assertEventuallyIsCollected(
+        clue: String,
+        ref: WeakReference[_],
+        retries: Int
+    ): Unit = {
+      ref.get() match {
+        case null =>
+          assertTrue("collected but not enqueded", ref.isEnqueued())
+        case v =>
+          if (retries > 0) {
+            // Give GC something to collect
+            System.err.println(s"$clue - not yet collected $ref ($retries)")
+            GC.collect()
+            assertEventuallyIsCollected(clue, ref, retries - 1)
+          } else {
+            fail(
+              s"$clue - expected that WeakReference would be collected, but it contains value ${v}"
+            )
+          }
+      }
+    }
+
     gcAssumption()
     val refQueue = new ReferenceQueue[A]()
     val weakRef1 = allocWeakRef(refQueue)
@@ -40,11 +62,15 @@ class WeakReferenceTest {
     val weakRefList = List(weakRef1, weakRef2)
 
     GC.collect()
+    assertEventuallyIsCollected("weakRef1", weakRef1, retries = 3)
+    assertEventuallyIsCollected("weakRef2", weakRef2, retries = 3)
 
     assertEquals("weakRef1", null, weakRef1.get())
     assertEquals("weakRef2", null, weakRef2.get())
     val a = refQueue.poll()
+    assertNotNull("a was null", a)
     val b = refQueue.poll()
+    assertNotNull("b was null", b)
     assertTrue("!contains a", weakRefList.contains(a))
     assertTrue("!contains b", weakRefList.contains(b))
     assertNotEquals(a, b)


### PR DESCRIPTION
This introduces a fix to the `WeakRerenerceTest` which spuriously fails in the CI and can be always observed frequently when Scala 3 build https://github.com/scala-native/scala-native/runs/4624454757

* Check for eventual collection of `WeakReference` target, by introducing retries with additional `GC.collect` calls 
* Fix condidition in `WeakReferenceRegistry` for filtering `weakRefList`
