### PR TITLE
Remove redundant coversion of `CharSequence` into `Array` in `Character.codePoint{at, before}` methods

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -264,8 +264,16 @@ object Character {
     }
   }
 
-  def codePointAt(seq: CharSequence, _index: scala.Int): scala.Int = {
-    codePointAt(seq.toString.toArray[scala.Char], _index)
+  def codePointAt(seq: CharSequence, index: scala.Int): scala.Int = {
+    val high = seq.charAt(index)
+    val nextIndex = index + 1
+
+    if (nextIndex >= seq.length()) high
+    else {
+      val low = seq.charAt(nextIndex)
+      if (isSurrogatePair(high, low)) toCodePoint(high, low)
+      else high
+    }
   }
 
   def codePointBefore(seq: Array[scala.Char], index: scala.Int): scala.Int = {
@@ -299,7 +307,16 @@ object Character {
   }
 
   def codePointBefore(seq: CharSequence, index: scala.Int): scala.Int = {
-    codePointBefore(seq.toString.toArray[scala.Char], index)
+    val indexMinus1 = index - 1
+    val indexMinus2 = index - 2
+    val low = seq.charAt(indexMinus1)
+
+    if (indexMinus2 < 0) low
+    else {
+      val high = seq.charAt(indexMinus2)
+      if (isSurrogatePair(high, low)) toCodePoint(high, low)
+      else low
+    }
   }
 
   def codePointCount(


### PR DESCRIPTION
This PR does fix a performance-related bug in Scala Native. Currently a call to `Character.codePointAt` method using `CharSequence` would lead to transforming `CharSequence` to `String` (which maybe be cheap) and then into `Array[Char]`. This leads to redundant class alocations, and time penalty would scale with sequence length. When testing on the local machine difference between calling `codePointAt` with `Array[Char]`  would be at least 1000x faster than a call to the same array represented as a `String`.  

Quick comparison of the same program: 
```
  def check(length: Int): Unit = {
    val chars = Random.alphanumeric.take(length)
    val asCharSeq: CharSequence = chars.mkString
    val asArray: Array[Char] = chars.toArray
    val iterations = 0 until 1000
    time(s"asArray $length") { iterations.foreach(idx => Character.codePointAt(asArray, idx % length)) }
    time(s"asChSeq $length") { iterations.foreach(idx => Character.codePointAt(asCharSeq, idx % length)) }
  }

```
Before 
```
Took 0 ms (asArray 10)
Took 1 ms (asChSeq 10)
Took 0 ms (asArray 100)
Took 1 ms (asChSeq 100)
Took 0 ms (asArray 1000)
Took 2 ms (asChSeq 1000)
Took 0 ms (asArray 10000)
Took 17 ms (asChSeq 10000)
Took 0 ms (asArray 100000)
Took 137 ms (asChSeq 100000)
Took 1 ms (asArray 1000000)
Took 1234 ms (asChSeq 1000000)
```

After (but measured with nanosenconds)
```
Took 106349 ns (asArray 10)
Took 112220 ns (asChSeq 10)
Took 139848 ns (asArray 100)
Took 121542 ns (asChSeq 100)
Took 83092 ns (asArray 1000)
Took 107492 ns (asChSeq 1000)
Took 64195 ns (asArray 10000)
Took 62654 ns (asChSeq 10000)
Took 93650 ns (asArray 100000)
Took 118258 ns (asChSeq 100000)
Took 82363 ns (asArray 1000000)
Took 89485 ns (asChSeq 1000000)
```
