### PR TITLE
Allow to define top-level extern definitons in Scala 3

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -43,7 +43,11 @@ trait NirGenType(using Context) {
     def isStaticInNIR: Boolean =
       sym.is(JavaStatic) || sym.isScalaStatic || sym.isExtern
 
-    def isExtern: Boolean = sym.owner.isExternModule
+    def isExtern: Boolean = sym.exists && {
+      sym.owner.isExternModule ||
+      sym.hasAnnotation(defnNir.ExternClass) ||
+      (sym.is(Accessor) && sym.field.isExtern)
+    }
 
     def isExternModule: Boolean =
       isScalaModule && sym.hasAnnotation(defnNir.ExternClass)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -11,6 +11,7 @@ import core.Symbols._
 import core.Types._
 import core.StdNames._
 import core.Constants.Constant
+import NirGenUtil.ContextCached
 
 /** This phase does:
  *    - Rewrite calls to scala.Enumeration.Value (include name string) (Ported
@@ -27,11 +28,24 @@ class PrepNativeInterop extends PluginPhase {
   override def description: String = "prepare ASTs for Native interop"
 
   def defn(using Context): Definitions = ctx.definitions
+  def defnNir(using Context): NirDefinitions = NirDefinitions.get
+
+  private def isTopLevelExtern(dd: ValOrDefDef)(using Context) = {
+    dd.rhs.symbol == defnNir.UnsafePackage_extern &&
+    dd.symbol.isWrappedToplevelDef
+  }
+
+  override def transformDefDef(dd: DefDef)(using Context): Tree = {
+    // Set `@extern` annotation for top-level extern functions
+    if (isTopLevelExtern(dd) && !dd.symbol.hasAnnotation(defnNir.ExternClass)) {
+      dd.symbol.addAnnotation(defnNir.ExternClass)
+    }
+    dd
+  }
 
   override def transformValDef(vd: ValDef)(using Context): Tree = {
-    val enumsCtx = EnumerationsContext.cached
+    val enumsCtx = EnumerationsContext.get
     import enumsCtx._
-
     val sym = vd.symbol
     vd match {
       case ValDef(_, tpt, ScalaEnumValue.NoName(optIntParam)) =>
@@ -42,21 +56,21 @@ class PrepNativeInterop extends PluginPhase {
         val nrhs = scalaEnumValName(sym.owner.asClass, sym, optIntParam)
         cpy.ValDef(vd)(tpt = transformAllDeep(tpt), nrhs)
 
-      case _ => vd
+      case _ =>
+        // Set `@extern` annotation for top-level extern variables
+        if (isTopLevelExtern(vd) &&
+            !sym.hasAnnotation(defnNir.ExternClass)) {
+          sym.addAnnotation(defnNir.ExternClass)
+          sym.setter.addAnnotation(defnNir.ExternClass)
+        }
+
+        vd
     }
   }
 
   private object EnumerationsContext {
-    private var lastDotcCtx: Option[Context] = None
-    private var lastValue: EnumerationsContext = _
-    def cached(using ctx: Context): EnumerationsContext = {
-      if (lastDotcCtx.contains(ctx)) lastValue
-      else {
-        lastDotcCtx = Some(ctx)
-        lastValue = EnumerationsContext()
-        lastValue
-      }
-    }
+    private val cached = ContextCached(EnumerationsContext())
+    def get(using Context): EnumerationsContext = cached.get
   }
   private class EnumerationsContext(using Context) {
     abstract class ScalaEnumFctExtractors(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -4,6 +4,7 @@ import dotty.tools.dotc.plugins.PluginPhase
 import dotty.tools._
 import dotc._
 import dotc.ast.tpd._
+import dotc.transform.SymUtils.setter
 import core.Contexts._
 import core.Definitions
 import core.Names._

--- a/tools/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
+++ b/tools/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
@@ -1,0 +1,56 @@
+package scala.scalanative
+
+import java.nio.file.Files
+
+import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.scalanative.api.CompilationFailedException
+
+class NIRCompilerTest3 extends AnyFlatSpec with Matchers with Inspectors {
+  def nativeCompilation(source: String): Unit = {
+    try scalanative.NIRCompiler(_.compile(source))
+    catch {
+      case ex: CompilationFailedException =>
+        fail(s"Failed to compile source: ${ex.getMessage}", ex)
+    }
+  }
+
+  "The compiler" should "allow to define top level extern methods" in nativeCompilation(
+    """
+      |import scala.scalanative.unsafe.extern
+      |
+      |def foo(): Int = extern
+      |""".stripMargin
+  )
+
+  it should "report error for top-level extern method without result type" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(_.compile("""
+        |import scala.scalanative.unsafe.extern
+        |
+        |def foo() = extern
+        |""".stripMargin))
+    }.getMessage should include("extern method foo needs result type")
+  }
+
+  it should "allow to define top level extern variable" in nativeCompilation(
+    """
+      |import scala.scalanative.unsafe.extern
+      |
+      |var foo: Int = extern
+      |""".stripMargin
+  )
+
+  it should "report error for top-level extern variable without result type" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(_.compile("""
+        |import scala.scalanative.unsafe.extern
+        |
+        |var foo = extern
+        |""".stripMargin))
+    }.getMessage should include("extern field foo needs result type")
+  }
+
+}

--- a/unit-tests/native/src/test/resources/scala-native/top-level-externs.c
+++ b/unit-tests/native/src/test/resources/scala-native/top-level-externs.c
@@ -1,0 +1,3 @@
+int topLevelExternVariable = 42;
+int topLevelExternFunction() { return 42; }
+int topLevelExternFunction2(int n) { return n * 42; }

--- a/unit-tests/native/src/test/scala-3/scala/scala/scalnative/TopLevelExternsTest.scala
+++ b/unit-tests/native/src/test/scala-3/scala/scala/scalnative/TopLevelExternsTest.scala
@@ -1,0 +1,32 @@
+package scala.scalanative
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scalanative.unsafe._
+
+var topLevelExternVariable: Int = extern
+def topLevelExternFunction: Int = extern
+@name("topLevelExternFunction2")
+def topLevelExternFunction(n: Int): Int = extern
+
+class TopLevelExternsTest {
+  @Test def canAccessExternFunciton(): Unit = {
+    assertEquals(42, topLevelExternFunction)
+    assertEquals(84, topLevelExternFunction(2))
+  }
+
+  @Test def canAccessExternVariable(): Unit = {
+    assertEquals(42, topLevelExternVariable)
+  }
+
+  @Test def canMutateExternVariable(): Unit = {
+    val previousValue = topLevelExternVariable
+    try {
+      topLevelExternVariable = previousValue * 10
+      assertEquals(previousValue * 10, topLevelExternVariable)
+    } finally {
+      topLevelExternVariable = previousValue
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new feature to Scala 3 compiler plugin allowing to define use use `extern` definitions defined in the top-level of a given file. This allows for an easier definition of externs in Scala 3 and makes it more similar to the ones defined in C. 

* Added runtime tests checking for correct behaviour of top-level defined extern variables and functions
* Added compilation tests checking for cases of non-explicit return type for top-level externs
* Added transformation of top-level externs in `PrepNativeInterop` phase - it would add `@extern` annotation to methods and fields defined with `extern` at rhs, but not having explicit `@extern` annotation
* Adapted detection of extern symbols to handle top-level definitions
* Replaced caching mechanism in `PrepNativeInterop` with `ContextCached` wrapper used in other phases. 
* Added fixes to class constructors to allow definition of extern fields.