### PR TITLE
Implement time zone offset

### DIFF
--- a/nativelib/src/main/resources/scala-native/time_zone_offset.c
+++ b/nativelib/src/main/resources/scala-native/time_zone_offset.c
@@ -1,11 +1,11 @@
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
-    #include <windows.h>
-    #include <wchar.h>
+#include <windows.h>
+#include <wchar.h>
 #else
-    // #define _GNU_SOURCE /* for tm_gmtoff and tm_zone */
-    #include <stdio.h>
-    #include <time.h>
+// #define _GNU_SOURCE /* for tm_gmtoff and tm_zone */
+#include <stdio.h>
+#include <time.h>
 #endif
 
 long long scalanative_time_zone_offset() {

--- a/nativelib/src/main/resources/scala-native/time_zone_offset.c
+++ b/nativelib/src/main/resources/scala-native/time_zone_offset.c
@@ -1,0 +1,38 @@
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#else
+#include <stdio.h>
+#include <sys/time.h>
+#endif
+
+long long scalanative_time_zone_offset() {
+    long long current_time_millis;
+
+#if defined(_WIN32)
+    // January 1, 1970 (start of Unix epoch) in "ticks"
+    long long UNIX_TIME_START = 0x019DB1DED53E8000;
+    long long TICKS_PER_MILLIS = 10000; // a tick is 100ns
+
+    FILETIME filetime;
+    GetSystemTimeAsFileTime(&filetime); // returns ticks in UTC
+
+    // Copy the low and high parts of FILETIME into a LARGE_INTEGER
+    // This is so we can access the full 64-bits as an Int64 without causing
+    // an alignment fault
+    LARGE_INTEGER li;
+    li.LowPart = filetime.dwLowDateTime;
+    li.HighPart = filetime.dwHighDateTime;
+
+    current_time_millis = (li.QuadPart - UNIX_TIME_START) / TICKS_PER_MILLIS;
+#else
+#define MILLIS_PER_SEC 1000LL
+#define MICROS_PER_MILLI 1000LL
+
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    current_time_millis =
+        tv.tv_sec * MILLIS_PER_SEC + tv.tv_usec / MICROS_PER_MILLI;
+#endif
+    return current_time_millis;
+}

--- a/nativelib/src/main/resources/scala-native/time_zone_offset.c
+++ b/nativelib/src/main/resources/scala-native/time_zone_offset.c
@@ -3,7 +3,7 @@
 #include <windows.h>
 #include <wchar.h>
 #else
-// #define _GNU_SOURCE /* for tm_gmtoff and tm_zone */
+// #define _GNU_SOURCE /* for tm_gmtoff and tm_zone if needed */
 #include <stdio.h>
 #include <time.h>
 #endif
@@ -13,9 +13,7 @@ long long scalanative_time_zone_offset() {
 
 #if defined(_WIN32)
     TIME_ZONE_INFORMATION tzi = {0};
-   
     int r = GetTimeZoneInformation(&tzi);
-
     if (r == TIME_ZONE_ID_INVALID) {
         // If failed return 0 - default for UTC
         time_zone_offset_secs = 0L;
@@ -26,9 +24,7 @@ long long scalanative_time_zone_offset() {
 #else
     time_t t = time(NULL);
     struct tm lt = {0};
-
     localtime_r(&t, &lt);
-
     time_zone_offset_secs = lt.tm_gmtoff;
 #endif
     return time_zone_offset_secs;

--- a/nativelib/src/main/scala/scala/scalanative/runtime/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/time.scala
@@ -7,5 +7,11 @@ import scala.scalanative.unsafe.{CLongLong, extern}
 object time {
   def scalanative_nano_time: CLongLong = extern
   def scalanative_current_time_millis: CLongLong = extern
-  def scalanative_time_zone_offset: CLongLong = extern
+
+  /** Time zone offset in seconds
+   *
+   *  @return
+   *    offset in seconds from UTC
+   */
+  def scalanative_time_zone_offset(): CLongLong = extern
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/time.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/time.scala
@@ -7,4 +7,5 @@ import scala.scalanative.unsafe.{CLongLong, extern}
 object time {
   def scalanative_nano_time: CLongLong = extern
   def scalanative_current_time_millis: CLongLong = extern
+  def scalanative_time_zone_offset: CLongLong = extern
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/TimeTest.scala
@@ -8,9 +8,8 @@ import scalanative.runtime.time.scalanative_time_zone_offset
 class TimeTest {
   @Test def testTimeZoneOffset(): Unit = {
     val offset = scalanative_time_zone_offset()
-    // Max 12 hours +- in seconds
-    // Offset is 0s (UTC) in CI
-    println(s"Time zone offset: ${offset}s")
+    // Max 12 hours +- in seconds. Offset is 0s (UTC) in CI
+    // println(s"Time zone offset: ${offset}s")
     assertTrue("time_zone_offset >= -43200", offset >= -43200)
     assertTrue("time_zone_offset <= 43200", offset <= 43200)
   }

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/TimeTest.scala
@@ -1,0 +1,16 @@
+package scala.scalanative.runtime
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scalanative.runtime.time.scalanative_time_zone_offset
+
+class TimeTest {
+  @Test def testTimeZoneOffset(): Unit = {
+    val offset = scalanative_time_zone_offset()
+    // max 12 hours +- in seconds
+    println(s"Time zone offset: ${offset}s")
+    assertTrue("time_zone_offset >= -43200", offset >= -43200)
+    assertTrue("time_zone_offset <= 43200", offset <= 43200)
+  }
+}

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/TimeTest.scala
@@ -10,7 +10,7 @@ class TimeTest {
     val offset = scalanative_time_zone_offset()
     // Max 12 hours +- in seconds
     // Offset is 0s (UTC) in CI
-    //println(s"Time zone offset: ${offset}s")
+    println(s"Time zone offset: ${offset}s")
     assertTrue("time_zone_offset >= -43200", offset >= -43200)
     assertTrue("time_zone_offset <= 43200", offset <= 43200)
   }

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/TimeTest.scala
@@ -8,8 +8,9 @@ import scalanative.runtime.time.scalanative_time_zone_offset
 class TimeTest {
   @Test def testTimeZoneOffset(): Unit = {
     val offset = scalanative_time_zone_offset()
-    // max 12 hours +- in seconds
-    println(s"Time zone offset: ${offset}s")
+    // Max 12 hours +- in seconds
+    // Offset is 0s (UTC) in CI
+    //println(s"Time zone offset: ${offset}s")
     assertTrue("time_zone_offset >= -43200", offset >= -43200)
     assertTrue("time_zone_offset <= 43200", offset <= 43200)
   }

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/TimeTest.scala
@@ -8,9 +8,9 @@ import scalanative.runtime.time.scalanative_time_zone_offset
 class TimeTest {
   @Test def testTimeZoneOffset(): Unit = {
     val offset = scalanative_time_zone_offset()
-    // Max 12 hours +- in seconds. Offset is 0s (UTC) in CI
+    // Between -12 and +14 hrs in seconds. Offset is 0s (UTC) in CI
     // println(s"Time zone offset: ${offset}s")
     assertTrue("time_zone_offset >= -43200", offset >= -43200)
-    assertTrue("time_zone_offset <= 43200", offset <= 43200)
+    assertTrue("time_zone_offset <= 50400", offset <= 50400)
   }
 }


### PR DESCRIPTION
This PR allows us to get time zone offset which is needed for `java.util.Date` and downstream for `java.time`. We probably would also need to get Time Zone itself as that is needed for `Date` as well but since `Date` is mostly deprecated there is no much need right now. Time Zone could also be used for a lightweight `Locale` type implementation. A full blown `Locale` implementation is already support as a 3rd party package.

There are a few rationale for this addition. 

- Scala.js can provide `java.util.Date` because it has JS `Date`.
- Downstream `java.time` can use this to provide `LocalDate` and `LocalDateTime`
- Scala Native has the cross platform CI that allows for testing on Windows and Unix type platforms.

Currently, there is not a good place for this so it is in runtime so technically private and subject to change. We could in the future provide a `util` package for a few fundamental functions such as this. Windows is supported and the Unix C functions are well supported GNU extensions.