### PR TITLE
Fix #2504 - Use correct self value when generating Apply trees

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -57,8 +57,7 @@ trait GenReflectiveInstantisation(using Context) {
         curClassSym := sym,
         curFresh := Fresh(),
         curUnwindHandler := None,
-        curMethodThis := None,
-        curMethodOuterSym := None
+        curMethodThis := None
       ) {
         registerReflectiveInstantiation(td)
       }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -33,7 +33,6 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   protected val curClassFresh = new util.ScopedVar[nir.Fresh]
 
   protected val curMethodSym = new util.ScopedVar[Symbol]
-  protected val curMethodOuterSym = new util.ScopedVar[Option[Symbol]]
   protected val curMethodSig = new util.ScopedVar[nir.Type]
   protected val curMethodInfo = new util.ScopedVar[CollectMethodInfo]
   protected val curMethodEnv = new util.ScopedVar[MethodEnv]

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -297,7 +297,6 @@ trait NirGenStat(using Context) {
       else
         scoped(
           curMethodThis := thisParam,
-          curMethodOuterSym := outerParam,
           curMethodIsExtern := isExtern
         ) {
           buf.genReturn(withOptSynchronized(_.genExpr(bodyp)) match {
@@ -557,8 +556,7 @@ trait NirGenStat(using Context) {
           val fresh = curFresh.get
           scoped(
             curUnwindHandler := None,
-            curMethodThis := None,
-            curMethodOuterSym := None
+            curMethodThis := None
           ) {
             val entryParams = forwarderParamTypes.map(Val.Local(fresh(), _))
             val args = entryParams.map(ValTree(_))

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -437,7 +437,7 @@ class IssuesTest {
     val singletonMap = Collections.singletonMap(value, value)
     val singletonSet = Collections.singleton(value)
     val singletonList = Collections.singletonList(value)
-    val unmodifiableMap = Collections.unmodifiableMap(singletonMap)
+    val unmodifiableMap = Collections.unmodifiableMap[String, String](singletonMap)
     val unmodifiableSet = Collections.unmodifiableSet(singletonSet)
     val unmodifiableList = Collections.unmodifiableList(singletonList)
     val unmodifiableCollection =

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -416,6 +416,58 @@ class IssuesTest {
     assertNotNull(res)
   }
 
+  @Test def test_Issue2504(): Unit = {
+    // In issue 2504 accessing iterator of immutable Java collection, would lead to
+    // infinite loop and segmentation fault.
+    import java.util.Collections
+    import java.util.Map.Entry
+    Seq(
+      Collections.EMPTY_MAP.entrySet().iterator(),
+      Collections.EMPTY_MAP.keySet().iterator(),
+      Collections.EMPTY_MAP.values().iterator(),
+      Collections.EMPTY_SET.iterator(),
+      Collections.EMPTY_LIST.iterator()
+    ).zipWithIndex.foreach {
+      case (iterator, idx) =>
+        assertNotNull(idx.toString, iterator)
+        assertFalse(idx.toString(), iterator.hasNext())
+    }
+
+    val value = "foo"
+    val singletonMap = Collections.singletonMap(value, value)
+    val singletonSet = Collections.singleton(value)
+    val singletonList = Collections.singletonList(value)
+    val unmodifiableMap = Collections.unmodifiableMap(singletonMap)
+    val unmodifiableSet = Collections.unmodifiableSet(singletonSet)
+    val unmodifiableList = Collections.unmodifiableList(singletonList)
+    val unmodifiableCollection =
+      Collections.unmodifiableCollection(singletonList)
+
+    Seq(
+      singletonMap.entrySet().iterator(),
+      singletonMap.keySet().iterator(),
+      singletonMap.values().iterator(),
+      singletonSet.iterator(),
+      singletonList.iterator(),
+      unmodifiableMap.entrySet().iterator(),
+      unmodifiableMap.keySet().iterator(),
+      unmodifiableMap.values().iterator(),
+      unmodifiableSet.iterator(),
+      unmodifiableList.iterator(),
+      unmodifiableCollection.iterator()
+    ).zipWithIndex.foreach {
+      case (iterator, idx) =>
+        assertNotNull(idx.toString, iterator)
+        assertTrue(idx.toString(), iterator.hasNext())
+        iterator.next() match {
+          case entry: Entry[String, String] @unchecked =>
+            assertEquals(s"$idx key", value, entry.getKey())
+            assertEquals(s"$idx value", value, entry.getValue())
+          case v => assertEquals(idx.toString(), value, v)
+        }
+    }
+  }
+
 }
 
 package issue1090 {

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -437,7 +437,8 @@ class IssuesTest {
     val singletonMap = Collections.singletonMap(value, value)
     val singletonSet = Collections.singleton(value)
     val singletonList = Collections.singletonList(value)
-    val unmodifiableMap = Collections.unmodifiableMap[String, String](singletonMap)
+    val unmodifiableMap =
+      Collections.unmodifiableMap[String, String](singletonMap)
     val unmodifiableSet = Collections.unmodifiableSet(singletonSet)
     val unmodifiableList = Collections.unmodifiableList(singletonList)
     val unmodifiableCollection =


### PR DESCRIPTION
This PR fixes #2504 leading to segmentation faults in the runtime. 
The problem was caused by incorrect resolving of self-value for dynamic method dispatch and self-value for the method call. In the past, we had cases where we needed to resolve self-value based on outer symbols or it's accessor method, mostly in same cases of static calls. After merging #2472 this is no longer the case, and we can remove this mechanism, in which we tried to out-smart the scalac compiler. It did also contained a bug, where have not validated if the outer accessor **should** be used, rather than it just can be used.  

* Added runtime test cases for calls leading to a segmentation fault
* Removed no longer needed mechanism for using an outer symbol or its an accessor to generate calls to static methods