### PR TITLE
Fix off by 1 `nir.Positions` produced in Scala 3

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Position.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Position.scala
@@ -8,7 +8,11 @@ final case class Position(
     /** Zero-based column number. */
     column: Int
 ) {
-  def show: String = s"$line:$column"
+  /** One-based line number */
+  def sourceLine: Int = line + 1
+  /** One-based column number */
+  def sourceColumn: Int = column + 1
+  def show: String = s"$source:$sourceLine:$sourceColumn"
 
   def isEmpty: Boolean = {
     def isEmptySlowPath(): Boolean = {

--- a/nir/src/main/scala/scala/scalanative/nir/Position.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Position.scala
@@ -8,8 +8,10 @@ final case class Position(
     /** Zero-based column number. */
     column: Int
 ) {
+
   /** One-based line number */
   def sourceLine: Int = line + 1
+
   /** One-based column number */
   def sourceColumn: Int = column + 1
   def show: String = s"$source:$sourceLine:$sourceColumn"

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPositions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPositions.scala
@@ -22,10 +22,9 @@ class NirPositions()(using Context) {
   ): nir.Position = {
     def nirSource = conversionCache.toNIRSource(source)
     if (span.exists && source.exists)
-      // dotty positions are 1-based but NIR positions are 0-based
       val point = span.point
-      val line = source.offsetToLine(point) - 1
-      val column = source.column(point) - 1
+      val line = source.offsetToLine(point) 
+      val column = source.column(point)
       nir.Position(nirSource, line, column)
     else if (source.exists) nir.Position(nirSource, 0, 0)
     else nir.Position.NoPosition

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPositions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPositions.scala
@@ -23,7 +23,7 @@ class NirPositions()(using Context) {
     def nirSource = conversionCache.toNIRSource(source)
     if (span.exists && source.exists)
       val point = span.point
-      val line = source.offsetToLine(point) 
+      val line = source.offsetToLine(point)
       val column = source.column(point)
       nir.Position(nirSource, line, column)
     else if (source.exists) nir.Position(nirSource, 0, 0)

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -614,12 +614,14 @@ class Reach(
           //  special case for lifted methods
           .orElse(findRewriteCandidate(inModule = false))
           .getOrElse {
-            throw new LinkingException(
-              s"Found a call to not defined static method ${methodName} that could not be rewritten. " +
+            config.logger.warn(
+              s"Found a call to not defined static method ${methodName}. " +
                 "Static methods are generated since Scala Native 0.4.3, " +
                 "report this bug in the Scala Native issues. " +
-                s"Call defined at ${inst.pos.source}:${inst.pos.line}:${inst.pos.column}"
+                s"Call defined at ${inst.pos.show}"
             )
+            addMissing(methodName, inst.pos)
+            inst :: Nil
           }
 
       case inst =>

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -945,7 +945,7 @@ class Reach(
     if (pos != nir.Position.NoPosition) {
       val position = NonReachablePosition(
         path = Paths.get(pos.source),
-        line = pos.line + 1
+        line = pos.sourceLine
       )
       missing(global) = prev + position
     }


### PR DESCRIPTION
`nir.Postions` in Scala 3 are based on `SourceFile::offsetToLine` method which does already return zero-based position. Until now we were decrementing both `line` and `collumn` by 1, leading to producing `-1` based positions. This lead to incorrect reporting of positions in Reach and would cause problems in the future when we would try to introduce debug support. 

* Fixed generation of nir.Position in compiler plugin
* Define `sourceLine` and `sourceColumn` helper methods returning 1-based offsets in nir.Position
* Fix reporting positions in Reach