### PR TITLE
Fix compilation errors when using lazy vals in quoted macros

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -16,7 +16,7 @@ import scala.annotation.{threadUnsafe => tu}
 // its scala native specific counter-part. This is needed, because LazyVals are
 // using JVM unsafe API and static class constructors which are not supported
 // in Scala Native.
-// In theory it could be defined as seperate compilation phase (it was in the past), but
+// In theory it could be defined as separate compilation phase (it was in the past), but
 // it would lead to the problems when using macros - rewritten lazy fields method would
 // be inlined and evaluated at compile time, however modified AST contains Scala Native
 // specific calls to Intrinsic methods. This would lead to throwing exception while compiling.

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/AdaptLazyVals.scala
@@ -12,22 +12,16 @@ import core.Symbols._
 import core.StdNames._
 import scala.annotation.{threadUnsafe => tu}
 
-// This phase is responsible for rewriting calls to scala.runtime.LazyVals with
+// This helper class is responsible for rewriting calls to scala.runtime.LazyVals with
 // its scala native specific counter-part. This is needed, because LazyVals are
 // using JVM unsafe API and static class constructors which are not supported
 // in Scala Native.
-object AdaptLazyVals {
-  val name = "scalanative-adaptLazyVals"
-}
-
-class AdaptLazyVals extends PluginPhase {
-  val phaseName = AdaptLazyVals.name
-
-  override val runsAfter = Set(LazyVals.name, MoveStatics.name)
-  override val runsBefore = Set(GenNIR.name)
-
+// In theory it could be defined as seperate compilation phase (it was in the past), but
+// it would lead to the problems when using macros - rewritten lazy fields method would
+// be inlined and evaluated at compile time, however modified AST contains Scala Native
+// specific calls to Intrinsic methods. This would lead to throwing exception while compiling.
+class AdaptLazyVals(defnNir: NirDefinitions) {
   def defn(using Context) = LazyValsDefns.get
-  def defnNir(using Context) = NirDefinitions.get
 
   private def isLazyFieldOffset(name: Name) =
     name.startsWith(nme.LAZY_FIELD_OFFSET.toString)
@@ -36,13 +30,12 @@ class AdaptLazyVals extends PluginPhase {
   // with the name of referenced bitmap fields within given TypeDef
   private val bitmapFieldNames = collection.mutable.Map.empty[Symbol, Literal]
 
-  override def prepareForUnit(tree: Tree)(using Context): Context = {
+  def clean(): Unit = {
     bitmapFieldNames.clear()
-    super.prepareForUnit(tree)
   }
 
   // Collect informations about offset fields
-  override def prepareForTypeDef(td: TypeDef)(using Context): Context = {
+  def prepareForTypeDef(td: TypeDef)(using Context): Unit = {
     val sym = td.symbol
     val hasLazyFields = sym.denot.info.fields
       .exists(f => isLazyFieldOffset(f.name))
@@ -55,11 +48,9 @@ class AdaptLazyVals extends PluginPhase {
           vd.symbol -> fieldname
       }.toMap
     }
-
-    ctx
   }
 
-  override def transformDefDef(dd: DefDef)(using Context): Tree = {
+  def transformDefDef(dd: DefDef)(using Context): DefDef | Thicket = {
     val hasLazyFields = dd.symbol.owner.denot.info.fields
       .exists(f => isLazyFieldOffset(f.name))
 
@@ -84,7 +75,7 @@ class AdaptLazyVals extends PluginPhase {
 
   // Replace all usages of all unsupported LazyVals methods with their
   // Scala Native specific implementation (taking Ptr instead of object + offset)
-  override def transformApply(tree: Apply)(using Context): Tree = {
+  def transformApply(tree: Apply)(using Context): Apply = {
     // Create call to SN intrinsic methods returning pointer to bitmap field
     def classFieldPtr(target: Tree, fieldRef: Tree): Tree = {
       val fieldName = bitmapFieldNames(fieldRef.symbol)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -44,7 +44,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   protected val curFresh = new util.ScopedVar[nir.Fresh]
   protected val curUnwindHandler = new util.ScopedVar[Option[nir.Local]]
 
-  protected val LazyValsAdapter = AdaptLazyVals(defnNir)
+  protected val lazyValsAdapter = AdaptLazyVals(defnNir)
 
   protected def unwind(implicit fresh: Fresh): Next =
     curUnwindHandler.get
@@ -64,7 +64,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   }
 
   private def genCompilationUnit(cunit: CompilationUnit): Unit = {
-    LazyValsAdapter.clean()
+    lazyValsAdapter.clean()
     def collectTypeDefs(tree: Tree): List[TypeDef] = {
       tree match {
         case EmptyTree            => Nil

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -44,6 +44,8 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   protected val curFresh = new util.ScopedVar[nir.Fresh]
   protected val curUnwindHandler = new util.ScopedVar[Option[nir.Local]]
 
+  protected val LazyValsAdapter = AdaptLazyVals(defnNir)
+
   protected def unwind(implicit fresh: Fresh): Next =
     curUnwindHandler.get
       .fold[Next](Next.None) { handler =>
@@ -62,6 +64,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
   }
 
   private def genCompilationUnit(cunit: CompilationUnit): Unit = {
+    LazyValsAdapter.clean()
     def collectTypeDefs(tree: Tree): List[TypeDef] = {
       tree match {
         case EmptyTree            => Nil

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -45,10 +45,12 @@ trait NirGenExpr(using Context) {
     buf =>
     def genExpr(tree: Tree): Val = {
       tree match {
-        case EmptyTree            => Val.Unit
-        case ValTree(value)       => value
-        case ContTree(f)          => f()
-        case tree: Apply          => genApply(tree)
+        case EmptyTree      => Val.Unit
+        case ValTree(value) => value
+        case ContTree(f)    => f()
+        case tree: Apply =>
+          val updatedTree = LazyValsAdapter.transformApply(tree)
+          genApply(updatedTree)
         case tree: Assign         => genAssign(tree)
         case tree: Block          => genBlock(tree)
         case tree: Closure        => genClosure(tree)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -49,7 +49,7 @@ trait NirGenExpr(using Context) {
         case ValTree(value) => value
         case ContTree(f)    => f()
         case tree: Apply =>
-          val updatedTree = LazyValsAdapter.transformApply(tree)
+          val updatedTree = lazyValsAdapter.transformApply(tree)
           genApply(updatedTree)
         case tree: Assign         => genAssign(tree)
         case tree: Block          => genBlock(tree)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -20,7 +20,6 @@ import scala.scalanative.util.ScopedVar.{scoped, toValue}
 import scala.scalanative.util.unsupported
 import dotty.tools.FatalError
 import dotty.tools.dotc.report
-import dotty.tools.dotc.transform.LazyVals
 
 trait NirGenStat(using Context) {
   self: NirCodeGen =>
@@ -47,7 +46,7 @@ trait NirGenStat(using Context) {
   }
 
   private def genNormalClass(td: TypeDef): Unit = {
-    LazyValsAdapter.prepareForTypeDef(td)
+    lazyValsAdapter.prepareForTypeDef(td)
     implicit val pos: nir.Position = td.span
     val sym = td.symbol.asClass
     val attrs = genClassAttrs(td)
@@ -145,7 +144,7 @@ trait NirGenStat(using Context) {
       case _: ValDef  => Nil // handled in genClassFields
       case _: TypeDef => Nil
       case dd: DefDef =>
-        LazyValsAdapter.transformDefDef(dd) match {
+        lazyValsAdapter.transformDefDef(dd) match {
           case dd: DefDef => genMethod(dd)
           case _          => Nil // erased
         }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -228,7 +228,7 @@ trait NirGenType(using Context) {
       sym: Symbol,
       isExtern: Boolean
   ): nir.Type.Function = {
-    require(sym.is(Method) || sym.isStatic, "symbol is not a method")
+    require(sym.is(Method) || sym.isStatic, s"symbol ${sym.owner} $sym is not a method")
 
     val owner = sym.owner
     val paramtys = genMethodSigParamsImpl(sym, isExtern)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenType.scala
@@ -228,7 +228,10 @@ trait NirGenType(using Context) {
       sym: Symbol,
       isExtern: Boolean
   ): nir.Type.Function = {
-    require(sym.is(Method) || sym.isStatic, s"symbol ${sym.owner} $sym is not a method")
+    require(
+      sym.is(Method) || sym.isStatic,
+      s"symbol ${sym.owner} $sym is not a method"
+    )
 
     val owner = sym.owner
     val paramtys = genMethodSigParamsImpl(sym, isExtern)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/ScalaNativePlugin.scala
@@ -13,5 +13,5 @@ class ScalaNativePlugin extends StandardPlugin:
           config.copy(genStaticForwardersForNonTopLevelObjects = true)
         case (config, _) => config
       }
-    List(PrepNativeInterop(), AdaptLazyVals(), GenNIR(genNirSettings))
+    List(PrepNativeInterop(), GenNIR(genNirSettings))
   }

--- a/tools/src/test/scala-3/scala/NativeCompilerTest.scala
+++ b/tools/src/test/scala-3/scala/NativeCompilerTest.scala
@@ -4,6 +4,9 @@ import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.scalanative.api._
+import scala.scalanative.util.Scope
+import scala.scalanative.io.VirtualDirectory
+import java.nio.file.Files
 
 class NativeCompilerTest extends AnyFlatSpec:
 
@@ -12,6 +15,21 @@ class NativeCompilerTest extends AnyFlatSpec:
     catch {
       case ex: CompilationFailedException =>
         fail(s"Failed to compile source: ${ex.getMessage}", ex)
+    }
+  }
+
+  def compileAll(sources: (String, String)*): Unit = {
+    Scope { implicit in =>
+      val outDir = Files.createTempDirectory("native-test-out")
+      val compiler = scalanative.NIRCompiler.getCompiler(outDir)
+      val sourcesDir = scalanative.NIRCompiler.writeSources(sources.toMap)
+      val dir = VirtualDirectory.real(outDir)
+
+      try scalanative.NIRCompiler(_.compile(sourcesDir))
+      catch {
+        case ex: CompilationFailedException =>
+          fail(s"Failed to compile source: ${ex.getMessage}", ex)
+      }
     }
   }
 
@@ -54,3 +72,32 @@ class NativeCompilerTest extends AnyFlatSpec:
   |  }
   |}
   """.stripMargin)
+
+  // Reproducer for https://github.com/typelevel/shapeless-3/pull/61#discussion_r779376350
+  it should "allow to compile inlined macros with lazy vals" in {
+    compileAll(
+      "Test.scala" -> "@main def run(): Unit = Macros.foo()",
+      "Macros.scala" -> """
+        |import scala.quoted.*
+        |object Macros:
+        |  def foo_impl()(using q: Quotes): Expr[Unit] = '{
+        |     ${val x = ReflectionUtils(quotes).Mirror(); '{()} }
+        |     println()
+        |   }
+        |
+        |  inline def foo(): Unit = ${foo_impl()}
+        |end Macros
+        |
+        |class ReflectionUtils[Q <: Quotes](val q: Q) {
+        |  given q.type = q
+        |  import q.reflect._
+        |
+        |  case class Mirror(arg: String)
+        |  object Mirror{
+        |    def apply(): Mirror = 
+        |      println("Mirror.apply")
+        |      Mirror("foo")
+        |  }
+        |}""".stripMargin
+    )
+  }

--- a/tools/src/test/scala-3/scala/NativeCompilerTest.scala
+++ b/tools/src/test/scala-3/scala/NativeCompilerTest.scala
@@ -89,14 +89,12 @@ class NativeCompilerTest extends AnyFlatSpec:
         |end Macros
         |
         |class ReflectionUtils[Q <: Quotes](val q: Q) {
-        |  given q.type = q
+        |  given q.type = q // Internally defined as lazy val, leading to problems
         |  import q.reflect._
         |
         |  case class Mirror(arg: String)
         |  object Mirror{
-        |    def apply(): Mirror = 
-        |      println("Mirror.apply")
-        |      Mirror("foo")
+        |    def apply(): Mirror = Mirror("foo")
         |  }
         |}""".stripMargin
     )


### PR DESCRIPTION
This PR resolves an issue with the compilation of Scala 3 macros using lazy vals, based on a bug found in shapeless3 https://github.com/typelevel/shapeless-3/pull/61#discussion_r779376350 

The problem was caused by trying to inline and evaluate code that was modified in the `AdaptLazyVals` phase. When Scala 3 `Inliner` phase would try to invoke the modified code it would try to invoke Scala Native Intrinsic method (eg. `Intrinsic.classFieldRawPtr`) on the JVM, which would lead to throwing `UndefinedBehaviourException` and resulting in failure of the compiler. 

To mitigate this issue global rewrites performed in the `AdaptLazyVals` (that would be propagated to produce ByteCode or Tasty) phase were replaced with local transformations performed when generating NIR. This way products of compilation other than NIR files would not be affected by our specific rewrites.

* Added test case for macro leading to compilation error 
* Rewritten `AdaptLazyVals` phase to be defined as a helper class, instead of compiler plugin phase
* Updated NIR generation to locally transform AST using `AdaptLAzyVals` instance

