### PR TITLE
Better error messages for `CFuncPtr.fromScalaFunction`

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2244,6 +2244,13 @@ trait NirGenExpr(using Context) {
           )
           fnRef
 
+        case ref: RefTree =>
+          report.error(
+            s"Function passed to ${app.symbol.show} needs to be inlined",
+            tree.sourcePos
+          )
+          Val.Null
+
         case _ =>
           report.error(
             "Failed to resolve function ref for extern forwarder",

--- a/tools/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
+++ b/tools/src/test/scala-3/scala/scalanative/NIRCompilerTest3.scala
@@ -53,4 +53,47 @@ class NIRCompilerTest3 extends AnyFlatSpec with Matchers with Inspectors {
     }.getMessage should include("extern field foo needs result type")
   }
 
+  it should "allow to inline function passed to CFuncPtr.fromScalaFunction" in nativeCompilation(
+    """
+        |import scala.scalanative.unsafe.*
+        |
+        |opaque type Visitor = CFuncPtr1[Int, Int]
+        |object Visitor:
+        |  inline def apply(inline f: Int => Int): Visitor = f
+        |
+        |@extern def useVisitor(x: Visitor): Unit = extern
+        |
+        |@main def test(n: Int): Unit = 
+        |  def callback(x: Int) = x*x + 2*n*n
+        |  val visitor: Visitor = (n: Int) => n * 10
+        |  useVisitor(Visitor(callback))
+        |  useVisitor(Visitor(_ * 10))
+        |  useVisitor(visitor)
+        | 
+        |""".stripMargin
+  )
+
+  it should "allow to report error if function passed to CFuncPtr.fromScalaFunction is not inlineable" in {
+    intercept[CompilationFailedException] {
+      NIRCompiler(_.compile("""
+        |import scala.scalanative.unsafe.*
+        |
+        |opaque type Visitor = CFuncPtr1[Int, Int]
+        |object Visitor:
+        |  def apply(f: Int => Int): Visitor = f
+        |
+        |@extern def useVisitor(x: Visitor): Unit = extern
+        |
+        |@main def test(n: Int): Unit = 
+        |  def callback(x: Int) = x*x + 2*n*n
+        |  val visitor: Visitor = (n: Int) => n * 10
+        |  useVisitor(Visitor(callback))
+        |  useVisitor(Visitor(_ * 10))
+        |  useVisitor(visitor)
+        | 
+        |""".stripMargin))
+    }.getMessage should include(
+      "Function passed to method fromScalaFunction needs to be inlined"
+    )
+  }
 }


### PR DESCRIPTION
In Scala 2 it was not possible to use `CFuncPtr.fromScalaFunction` conversion using arbitrary function passed as a parameter - it always needed to be inlined in the form of lambda or using an exact reference to the function, it couldn't be generic. 
With Scala 3 we have an easy mechanism for inlining function, which allows us to work around this limitation, as pointed out in #2486. 

* Add explicit error was trying to pass non-inlinable function to `CFuncPtr.fromScalaFunction`
* Add compilation tests for the usage of inlined functions to check they can be used