### PR TITLE
Add missing `Show` implementation for `Inst.LinktimeIf`

### DIFF
--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -161,6 +161,13 @@ object Show {
         next_(thenp)
         str(" else ")
         next_(elsep)
+      case Inst.LinktimeIf(cond, thenp, elsep) =>
+        str("linktime if ")
+        linktimeCondition(cond)
+        str(" then ")
+        next_(thenp)
+        str(" else ")
+        next_(elsep)
       case Inst.Switch(scrut, default, cases) =>
         str("switch ")
         val_(scrut)
@@ -185,7 +192,7 @@ object Show {
           str(" ")
           next_(unwind)
         }
-      case _ => util.unsupported(s"Show does not support ${inst}")
+      case null | _ => util.unsupported(s"Show does not support ${inst}")
     }
 
     def op_(op: Op): Unit = op match {
@@ -631,6 +638,23 @@ object Show {
     def local_(local: Local): Unit = {
       str("%")
       str(local.id)
+    }
+
+    def linktimeCondition(cond: LinktimeCondition): Unit = {
+      import LinktimeCondition._
+      cond match {
+        case SimpleCondition(propertyName, comparison, value) =>
+          str(propertyName + " ")
+          comp_(comparison)
+          str(" ")
+          val_(value)
+        case ComplexCondition(op, left, right) =>
+          linktimeCondition(left)
+          str(" ")
+          bin_(op)
+          str(" ")
+          linktimeCondition(right)
+      }
     }
 
     private def escapeNewLine(s: String): String =

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -192,7 +192,6 @@ object Show {
           str(" ")
           next_(unwind)
         }
-      case null | _ => util.unsupported(s"Show does not support ${inst}")
     }
 
     def op_(op: Op): Unit = op match {


### PR DESCRIPTION
This PR adds a missing Show handling for `Inst.LinktimeIf`, currently it was never needed because `Show` was used only after the static reachability phase and evaluation of `LinktimeIf` which would replace them with other trees. However, if we would try to show NIR in a raw form it would fail with an exception.