### PR TITLE
Store config cached fingerprints seperetly for each version of Scala

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -145,8 +145,14 @@ object ScalaNativePluginInternal {
         import NativeLinkCacheImplicits._
         import collection.JavaConverters._
 
+        // Products of compilation for Scala 2 are always defined in `target/scala-<scalaBinaryVersion` directory,
+        // but in case of Scala 3 there is always a dedicated directory for each (minor) Scala version.
+        // This allows us to cache binaries for each Scala version instead of each binary Scala version.
+        val scalaVersionDir =
+          if (scalaVersion.value.startsWith("2.")) scalaBinaryVersion.value
+          else scalaVersion.value
         val cacheFactory =
-          streams.value.cacheStoreFactory / "fileInfo" / s"scala-${scalaBinaryVersion.value}"
+          streams.value.cacheStoreFactory / "fileInfo" / s"scala-${scalaVersionDir}"
         val classpathTracker =
           Tracked.inputChanged[
             (Seq[HashFileInfo], build.Config),

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -145,7 +145,8 @@ object ScalaNativePluginInternal {
         import NativeLinkCacheImplicits._
         import collection.JavaConverters._
 
-        val cacheFactory = streams.value.cacheStoreFactory / "fileInfo"
+        val cacheFactory =
+          streams.value.cacheStoreFactory / "fileInfo" / s"scala-${scalaBinaryVersion.value}"
         val classpathTracker =
           Tracked.inputChanged[
             (Seq[HashFileInfo], build.Config),


### PR DESCRIPTION
This PR fixes #2514 
Currently, files containing metadata used in caching mechanism were kept in a single directory. In case if we would define `crossScalaVersions := Seq("2.11.12", "2.12.13", "2.13.7", "3.1.0")` (single version for each binary version of Scala) and use `+ compile` the Scala compiler would compile each binary version only once and would skip subsequent calls to compile if sources have not changed. However, if we would use `+ nativeLink` (or another task dependent on `nativeLink`) our linker would re-link executables each time, even if sources or config have not changed. 
This bug was happening because we have been using a single global directory for storing cached metadata, so after switching to another Scala version the previously computed hashes (for the previous binary version) would not match with the current ones and linking would be triggered. 
To fix this issue we've changed the layout of nativeLink cache directory, to use a dedicated Scala binary version specific directory.  

What's worth mentioning, in case if `crossScalaVersions` contains two minor versions of the same binary Scala version, eg. "2.13.6" and "2.13.7,  running `+ compile` would always trigger a new compilation. The same applies to `+ nativeLink`, because compilation products are always stored in the "target/scala-<scalaBinaryVersion>" directory. This does not apply however to Scala 3 which specifies a separate target directory for each minor version of Scala. In both cases current behaviour of `+ nativeLink` should be now compliant with `+ compile`