### PR TITLE
ProcessMonitor should not busy wait if there are no active processess

### DIFF
--- a/javalib/src/main/scala/java/lang/process/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcess.scala
@@ -142,6 +142,8 @@ object UnixProcess {
   @link("pthread")
   @extern
   private[this] object ProcessMonitor {
+    @name("scalanative_process_monitor_notify")
+    def notifyMonitor(): Unit = extern
     @name("scalanative_process_monitor_check_result")
     def checkResult(pid: Int): CInt = extern
     @name("scalanative_process_monitor_init")
@@ -198,6 +200,7 @@ object UnixProcess {
          * to run on the child before execve inside of a method.
          */
         def invokeChildProcess(): Process = {
+          ProcessMonitor.notifyMonitor()
           if (dir != null) unistd.chdir(toCString(dir.toString))
           setupChildFDS(!infds, builder.redirectInput(), unistd.STDIN_FILENO)
           setupChildFDS(

--- a/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
+++ b/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
@@ -28,6 +28,8 @@ struct Monitor {
         delete cond;
     }
 };
+volatile int32_t active_subprocs_count = 0;
+static pthread_cond_t has_active_subprocs;
 static pthread_mutex_t shared_mutex;
 static std::unordered_map<int, std::shared_ptr<Monitor>> waiting_procs;
 static std::unordered_map<int, int> finished_procs;
@@ -35,15 +37,24 @@ static std::unordered_map<int, int> finished_procs;
 static void *wait_loop(void *arg) {
     while (1) {
         int status;
+        pthread_mutex_lock(&shared_mutex);
+        while (active_subprocs_count == 0) {
+            pthread_cond_wait(&has_active_subprocs, &shared_mutex);
+        }
+        // Release mutex to allow for starting new processes while waiting
+        // until any process finishes.
+        pthread_mutex_unlock(&shared_mutex);
+
         const int pid = waitpid(-1, &status, 0);
         if (pid != -1) {
             pthread_mutex_lock(&shared_mutex);
+            active_subprocs_count -= 1;
             const int last_result =
                 WIFSIGNALED(status) ? 0x80 + status : status;
             const auto monitor = waiting_procs.find(pid);
             if (monitor != waiting_procs.end()) {
-                waiting_procs.erase(monitor);
                 auto m = monitor->second;
+                waiting_procs.erase(monitor);
                 *m->res = last_result;
                 pthread_cond_broadcast(m->cond);
             } else {
@@ -60,13 +71,21 @@ static void *wait_loop(void *arg) {
 static int check_result(const int pid, pthread_mutex_t *lock) {
     const auto result = finished_procs.find(pid);
     if (result != finished_procs.end()) {
+        const auto exit_code = result->second;
         finished_procs.erase(result);
-        return result->second;
+        return exit_code;
     }
     return -1;
 }
 
 extern "C" {
+void scalanative_process_monitor_notify() {
+    pthread_mutex_lock(&shared_mutex);
+    active_subprocs_count += 1;
+    pthread_cond_signal(&has_active_subprocs);
+    pthread_mutex_unlock(&shared_mutex);
+}
+
 int scalanative_process_monitor_check_result(const int pid) {
     pthread_mutex_lock(&shared_mutex);
     const int res = check_result(pid, &shared_mutex);
@@ -100,6 +119,7 @@ int scalanative_process_monitor_wait_for_pid(const int pid, timespec *ts,
 void scalanative_process_monitor_init() {
     pthread_t thread;
     pthread_mutex_init(&shared_mutex, NULL);
+    pthread_cond_init(&has_active_subprocs, NULL);
     pthread_create(&thread, NULL, wait_loop, NULL);
     pthread_detach(thread);
 }

--- a/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
+++ b/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
@@ -29,9 +29,13 @@ struct Monitor {
 };
 
 static pthread_mutex_t shared_mutex;
-static sem_t active_procs;
 static std::unordered_map<int, std::shared_ptr<Monitor>> waiting_procs;
 static std::unordered_map<int, int> finished_procs;
+#ifdef __APPLE__
+static dispatch_semaphore_t active_procs;
+#else
+static sem_t active_procs;
+#endif
 
 static void *wait_loop(void *arg) {
     while (1) {

--- a/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
+++ b/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
@@ -14,13 +14,6 @@
 #include <semaphore.h>
 #endif
 
-#define RETURN_ON_ERROR(f)                                                     \
-    do {                                                                       \
-        int res = f;                                                           \
-        if (res != 0)                                                          \
-            return res;                                                        \
-    } while (0)
-
 struct Monitor {
   public:
     pthread_cond_t *cond;

--- a/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
+++ b/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
@@ -12,6 +12,7 @@
 #include <dispatch/dispatch.h>
 #else
 #include <semaphore.h>
+#include <errno.h>
 #endif
 
 struct Monitor {


### PR DESCRIPTION
This PR fixes #2501 by limiting the amount of busy waiting in the background thread. Previously, spawning any processes would lead to creating a thread that would constantly busy-wait in the background - this happens because in case if there are no active subprocesses, call to `waitpid(-1, $status, 0)` would return immediately. 
To fix this issue a condition and a counter of active processes were introduced. Each freshly created subprocess starts it's execution by notifying ProcessMonitor incrementing the counter and signalling the condition. When there would be no active processes the background ProcessMonitor thread would wait until the condition would be signalled. 