### PR TITLE
When enabling reflective instantiation check base classess instead of parents

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/GenReflectiveInstantisation.scala
@@ -47,7 +47,7 @@ trait GenReflectiveInstantisation(using Context) {
   def genReflectiveInstantiation(td: TypeDef): Unit = {
     val sym = td.symbol.asClass
     val enableReflectiveInstantiation =
-      (sym :: sym.info.parents.map(_.typeSymbol))
+      sym.baseClasses
         .exists(
           _.hasAnnotation(defnNir.EnableReflectiveInstantiationAnnotationClass)
         )

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -467,6 +467,35 @@ class IssuesTest {
           case v => assertEquals(idx.toString(), value, v)
         }
     }
+
+  @Test def test_Issue2519(): Unit = {
+    import scala.scalanative.reflect.Reflect
+
+    def isInstantiatableClass(fqcn: String) =
+      Reflect.lookupInstantiatableClass(fqcn).isDefined
+    def isLoadableModule(fqcn: String) =
+      Reflect.lookupLoadableModuleClass(fqcn).isDefined
+
+    assertTrue(
+      "A should be instantiatable",
+      isInstantiatableClass("scala.scalanative.issue2519.A")
+    )
+    assertFalse(
+      "B should be not instantiatable",
+      isInstantiatableClass("scala.scalanative.issue2519.B")
+    )
+    assertTrue(
+      "C should be instantiatable",
+      isInstantiatableClass("scala.scalanative.issue2519.C")
+    )
+    assertTrue(
+      "D should be loadable",
+      isLoadableModule("scala.scalanative.issue2519.D$")
+    )
+    assertTrue(
+      "E should be loadable",
+      isLoadableModule("scala.scalanative.issue2519.E$")
+    )
   }
 
 }
@@ -518,4 +547,15 @@ package issue1909 {
 package issue1950 {
   final class ValueClass(val value: Float) extends AnyVal
   final case class ValueClass2(string: String) extends AnyVal
+}
+
+package issue2519 {
+  import scala.scalanative.reflect.Reflect
+
+  @scala.scalanative.reflect.annotation.EnableReflectiveInstantiation
+  class A
+  abstract class B extends A
+  class C extends B
+  object D extends A
+  object E extends B
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -467,6 +467,7 @@ class IssuesTest {
           case v => assertEquals(idx.toString(), value, v)
         }
     }
+  }
 
   @Test def test_Issue2519(): Unit = {
     import scala.scalanative.reflect.Reflect


### PR DESCRIPTION
This PR fixes #2519, currently then checking wherever we should enable reflective instantiation for given class we were checking for special annotation in class or it's parents. `symbol.info.parents` does not include all classes that given symbol derives from. To fix this issue we use `symbol.info.baseClasses` instead 

* Added runtime checks for issue 2519
* Replaced usage of `info.parents` with `info.baseClassess` when checking should reflective instantiation should be enabled 