### PR TITLE
Add `-test` suffix to artifact path of test executables

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -89,10 +89,10 @@ object ScalaNativePluginInternal {
     }
   )
 
-  lazy val scalaNativeConfigSettings: Seq[Setting[_]] = Seq(
+  def scalaNativeConfigSettings(nameSuffix: String): Seq[Setting[_]] = Seq(
     nativeLink / artifactPath := {
       val ext = if (Platform.isWindows) ".exe" else ""
-      crossTarget.value / (moduleName.value + "-out" + ext)
+      crossTarget.value / s"${moduleName.value}${nameSuffix}-out${ext}"
     },
     nativeWorkdir := {
       val workdir = crossTarget.value / "native"
@@ -218,10 +218,10 @@ object ScalaNativePluginInternal {
   )
 
   lazy val scalaNativeCompileSettings: Seq[Setting[_]] =
-    scalaNativeConfigSettings
+    scalaNativeConfigSettings(nameSuffix = "")
 
   lazy val scalaNativeTestSettings: Seq[Setting[_]] =
-    scalaNativeConfigSettings ++
+    scalaNativeConfigSettings(nameSuffix = "-test") ++
       Seq(
         mainClass := Some("scala.scalanative.testinterface.TestMain"),
         loadedTestFrameworks := {

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -92,10 +92,10 @@ object ScalaNativePluginInternal {
   def scalaNativeConfigSettings(nameSuffix: String): Seq[Setting[_]] = Seq(
     nativeLink / artifactPath := {
       val ext = if (Platform.isWindows) ".exe" else ""
-      crossTarget.value / s"${moduleName.value}${nameSuffix}-out${ext}"
+      crossTarget.value / s"${moduleName.value}$nameSuffix-out$ext"
     },
     nativeWorkdir := {
-      val workdir = crossTarget.value / s"native${nameSuffix}"
+      val workdir = crossTarget.value / s"native$nameSuffix"
       if (!workdir.exists) {
         IO.createDirectory(workdir)
       }

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -95,7 +95,7 @@ object ScalaNativePluginInternal {
       crossTarget.value / s"${moduleName.value}${nameSuffix}-out${ext}"
     },
     nativeWorkdir := {
-      val workdir = crossTarget.value / "native"
+      val workdir = crossTarget.value / s"native${nameSuffix}"
       if (!workdir.exists) {
         IO.createDirectory(workdir)
       }


### PR DESCRIPTION
This PR fixes artefact paths of `nativeLink` task to be distinguishable depending on whether we are in the `Compile` or `Test` scope. 
Currently, both `artifactPaths` were giving the same result, because they're using a common `crossTarget` path. Now test artefacts contain an additional `-test` suffix allowing us to distinguish both paths. 

This fix would improve our caching mechanism. Previously switching between `run` and `test` commands would override created binary. Now,  the paths of both targets are different and we would only overwrite executable for which scopes sources have changed. 

Additionally we now also create a separate working directory for tests suffix the same suffix. It would be not used now, but keeping NIR files separately might be helpful in the future if we would like to introduce better incremental compilation. 