### PR TITLE
Add missing java.io.channels.Channels methods

### DIFF
--- a/javalib/src/main/scala/java/nio/channels/Channels.scala
+++ b/javalib/src/main/scala/java/nio/channels/Channels.scala
@@ -46,23 +46,168 @@ object Channels {
 
   // def newInputStream(ch: AsynchronousByteChannel): InputStream
   // def newOutputStream(ch: AsynchronousByteChannel): OutputStream
-  // def newChannel(in: InputStream): ReadableByteChannel
-  // def newChannel(out: OutputStream): WritableByteChannel
 
-  // def newReader(
-  //     ch: ReadableByteChannel,
-  //     dec: CharsetDecoder,
-  //     minBufferCap: Int
-  // ): Reader
-  // def newReader(ch: ReadableByteChannel, csName: String): Reader
-  // def newReader(ch: ReadableByteChannel, charset: Charset): Reader
+  def newChannel(in: InputStream): ReadableByteChannel = {
+    Objects.requireNonNull(in, "in")
+    new ReadableByteChannel {
+      var closed = false
+      override def read(dst: ByteBuffer): Int = synchronized {
+        if (closed) throw new ClosedChannelException()
 
-  // def newWriter(
-  //     ch: WritableByteChannel,
-  //     enc: CharsetEncoder,
-  //     minBufferCap: Int
-  // ): Writer
-  // def newWriter(ch: WritableByteChannel, csName: String): Writer
-  // def newWriter(ch: WritableByteChannel, charset: Charset): Writer
+        var written = 0
+        val capacity = dst.capacity()
+        while ({
+          val readByte = in.read()
+          if (readByte != -1) {
+            dst.put(readByte.toByte)
+            written += 1
+            capacity > written
+          } else false
+        }) ()
+
+        written
+      }
+      override def close(): Unit = synchronized {
+        in.close()
+        closed = true
+      }
+      override def isOpen(): Boolean = synchronized { !closed }
+    }
+  }
+
+  def newChannel(out: OutputStream): WritableByteChannel = {
+    Objects.requireNonNull(out, "out")
+    new WritableByteChannel {
+      var closed = false
+      override def write(src: ByteBuffer): Int = synchronized {
+        if (closed) throw new ClosedChannelException()
+
+        val array = Array.ofDim[Byte](src.remaining())
+        var i = 0
+        while (src.hasRemaining()) {
+          array(i) = src.get()
+          i += 1
+        }
+        out.write(array)
+        i
+      }
+      override def close(): Unit = synchronized {
+        out.close()
+        closed = true
+      }
+      override def isOpen(): Boolean = synchronized { !closed }
+    }
+  }
+
+  def newReader(
+      ch: ReadableByteChannel,
+      dec: CharsetDecoder,
+      minBufferCap: Int
+  ): Reader = {
+    Objects.requireNonNull(ch, "ch")
+    new Reader {
+      private val capacity =
+        if (minBufferCap == -1) 1024 else minBufferCap.max(1024)
+      private lazy val byteBuffer = {
+        val buffer = ByteBuffer.allocate(capacity)
+        buffer.limit(0)
+        buffer
+      }
+      private lazy val charBuffer = {
+        val buffer = CharBuffer.allocate(capacity)
+        buffer.limit(0)
+        buffer
+      }
+
+      private def fillBuffers() = {
+        if (!byteBuffer.hasRemaining()) {
+          byteBuffer.clear()
+          ch.read(byteBuffer)
+          byteBuffer.limit(byteBuffer.position())
+          byteBuffer.rewind()
+        }
+        if (!charBuffer.hasRemaining()) {
+          charBuffer.clear()
+          dec.decode(byteBuffer, charBuffer, false)
+          charBuffer.limit(charBuffer.position())
+          charBuffer.rewind()
+        }
+      }
+      override def read(cbuf: Array[Char], off: Int, len: Int): Int = {
+        if (len < 0 || len < 0 || cbuf.length < off + len)
+          throw new IndexOutOfBoundsException()
+
+        var read = 0
+        while (read < len) {
+          fillBuffers()
+
+          while (charBuffer.hasRemaining() && read < len) {
+            cbuf(off + read) = charBuffer.get()
+            read += 1
+          }
+        }
+        read
+      }
+      override def read(): Int = {
+        fillBuffers()
+        charBuffer.get()
+      }
+      override def close(): Unit = {
+        ch.close()
+      }
+    }
+  }
+
+  def newReader(ch: ReadableByteChannel, csName: String): Reader =
+    newReader(ch, Charset.forName(csName).newDecoder(), -1);
+
+  def newReader(ch: ReadableByteChannel, charset: Charset): Reader =
+    newReader(ch, charset.newDecoder(), -1);
+
+  def newWriter(
+      ch: WritableByteChannel,
+      enc: CharsetEncoder,
+      minBufferCap: Int
+  ): Writer = {
+    Objects.requireNonNull(ch, "ch")
+    new Writer {
+      private val capacity =
+        if (minBufferCap == -1) 1028 else minBufferCap.max(1028)
+      private lazy val charBuffer = CharBuffer.allocate(capacity)
+
+      override def write(cbuf: Array[Char], off: Int, len: Int): Unit = {
+        if (len < 0 || len < 0 || cbuf.length < off + len)
+          throw new IndexOutOfBoundsException()
+
+        synchronized {
+          var written = 0
+          while (written < len) {
+            val toPut = capacity.min(len - written)
+            charBuffer.put(cbuf, off + written, toPut)
+            if (!charBuffer.hasRemaining()) flush()
+            written += toPut
+          }
+        }
+      }
+      override def write(c: Int): Unit = synchronized {
+        charBuffer.put(c.toChar)
+        if (!charBuffer.hasRemaining()) flush()
+      }
+      override def flush() = synchronized {
+        charBuffer.limit(charBuffer.position())
+        charBuffer.position(0)
+        val encoded = enc.encode(charBuffer)
+        ch.write(encoded)
+        charBuffer.clear()
+      }
+      override def close() = ch.close()
+    }
+  }
+
+  def newWriter(ch: WritableByteChannel, csName: String): Writer =
+    newWriter(ch, Charset.forName(csName).newEncoder(), -1)
+
+  def newWriter(ch: WritableByteChannel, charset: Charset): Writer =
+    newWriter(ch, charset.newEncoder(), -1)
 
 }

--- a/unit-tests/shared/src/test/scala/javalib/nio/channels/ChannelsTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/channels/ChannelsTest.scala
@@ -1,0 +1,133 @@
+package javalib.nio.channels
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import scalanative.junit.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.nio.{ByteBuffer, CharBuffer}
+import java.nio.charset.StandardCharsets
+
+import java.nio.channels.{Channels, ClosedChannelException}
+
+class ChannelsTest {
+  @Test def newChannelInputStreamReads(): Unit = {
+    val expected = Array[Byte](1, 2, 3)
+    val in = new ByteArrayInputStream(expected, 0, 3)
+    val channel = Channels.newChannel(in)
+
+    val byteBuffer = ByteBuffer.allocate(3)
+
+    channel.read(byteBuffer)
+    assertArrayEquals(expected, byteBuffer.array())
+  }
+
+  @Test def newChannelInputStreamThrows(): Unit = {
+    assumeFalse(
+      "Bug in the JVM, works for later versions than java 8",
+      Platform.executingInJVMOnJDK8OrLower
+    )
+
+    val in = new ByteArrayInputStream(Array(0), 0, 1)
+    val channel = Channels.newChannel(in)
+    val byteBuffer = ByteBuffer.wrap(Array(1))
+
+    channel.close()
+    assertThrows(classOf[ClosedChannelException], channel.read(byteBuffer))
+  }
+
+  @Test def newChannelOutputStreamWrites(): Unit = {
+    val expected = Array[Byte](1, 2, 3)
+    val out = new ByteArrayOutputStream(3)
+    val channel = Channels.newChannel(out)
+
+    val byteBuffer = ByteBuffer.wrap(expected)
+
+    channel.write(byteBuffer)
+    assertArrayEquals(expected, out.toByteArray())
+  }
+
+  @Test def newChannelOutputStreamThrows(): Unit = {
+    assumeFalse(
+      "Bug in the JVM, works for later versions than java 8",
+      Platform.executingInJVMOnJDK8OrLower
+    )
+
+    val out = new ByteArrayOutputStream(2)
+    val channel = Channels.newChannel(out)
+    val byteBuffer = ByteBuffer.wrap(Array(0, 0))
+
+    channel.close()
+    assertThrows(classOf[ClosedChannelException], channel.write(byteBuffer))
+  }
+
+  // Example from javalib.lang.StringTest
+  val utf8Array = "\u0000\t\nAZaz09@~\u00DF\u4E66\u1F50A".toCharArray
+  val utf8Decoded =
+    Seq[Byte](0, 9, 10, 65, 90, 97, 122, 48, 57, 64, 126, // one byte unicode
+      -61, -97, // two byte unicode
+      -28, -71, -90, // three byte unicode
+      -31, -67, -112, 65 // four byte unicode
+    )
+
+  @Test def newReaderReadMultiple(): Unit = {
+    val in = new ByteArrayInputStream(utf8Decoded.toArray)
+    val channel = Channels.newChannel(in)
+    val reader =
+      Channels.newReader(channel, StandardCharsets.UTF_8.newDecoder, -1)
+
+    val obtained = Array.ofDim[Char](utf8Array.length)
+    reader.read(obtained)
+
+    assertArrayEquals(utf8Array, obtained)
+  }
+
+  @Test def newReaderReadSingle(): Unit = {
+    val in = new ByteArrayInputStream(utf8Decoded.toArray)
+    val channel = Channels.newChannel(in)
+    val reader =
+      Channels.newReader(channel, StandardCharsets.UTF_8.newDecoder, -1)
+
+    for (i <- 0 to 10) { // only the first 11 characters should be equal
+      assertEquals(s"Char #$i", utf8Decoded(i), reader.read())
+    }
+    assertNotEquals("Char #11", utf8Decoded(10), reader.read())
+  }
+
+  @Test def newWriterWriteMultiple(): Unit = {
+    val out = new ByteArrayOutputStream(10)
+    val channel = Channels.newChannel(out)
+
+    val writer = Channels.newWriter(
+      channel,
+      StandardCharsets.UTF_8.newEncoder,
+      utf8Decoded.length
+    )
+
+    writer.write(utf8Array)
+    writer.flush()
+
+    assertArrayEquals(utf8Decoded.toArray, out.toByteArray())
+  }
+
+  @Test def newWriterWriteSingle(): Unit = {
+    val out = new ByteArrayOutputStream(10)
+    val channel = Channels.newChannel(out)
+    val writer = Channels.newWriter(
+      channel,
+      StandardCharsets.UTF_8.newEncoder,
+      utf8Decoded.length
+    )
+
+    for (i <- 0 until utf8Array.length) {
+      writer.write(utf8Array(i))
+    }
+    writer.flush()
+
+    assertArrayEquals(utf8Decoded.toArray, out.toByteArray())
+  }
+
+}


### PR DESCRIPTION
Missing Channels methods were added, along with some newly prepared tests. `newInputStream(ch: AsynchronousByteChannel)` and `newOutputStream(ch: AsynchronousByteChannel)` were omitted for now, as `AsynchronousByteChannel`s are not implemented as well - perhaps it is better to wait for multithreading with both.

All tests worked with java 17 jvm, but two failed on java 8 despite them following the java documentation, so they were assumed-out. 

Inspired by reports about missing methods used in os-lib on scala-native discord.