### PR TITLE
Add support for `scala.reflect.Selectable`

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -361,6 +361,15 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val NothingClassTag = ClasstagModule.requiredMethod("Nothing")
   @tu lazy val NullClassTag = ClasstagModule.requiredMethod("Null")
 
+  @tu lazy val ReflectSelectableType: TypeRef = requiredClassRef("scala.reflect.Selectable")
+  @tu lazy val ReflectSelectable_selectDynamicR = ReflectSelectableClass.requiredMethodRef("selectDynamic")
+  @tu lazy val ReflectSelectable_applyDynamicR = ReflectSelectableClass.requiredMethodRef("applyDynamic")
+  @tu lazy val ReflectSelectable_selectedValueR = ReflectSelectableClass.requiredMethodRef("selectedValue")
+  def ReflectSelectableClass(using Context) = ReflectSelectableType.symbol.asClass
+  def ReflectSelectable_selectDynamic(using Context) = ReflectSelectable_selectDynamicR.symbol
+  def ReflectSelectable_applyDynamic(using Context) = ReflectSelectable_applyDynamicR.symbol
+  def ReflectSelectable_selectedValue(using Context) = ReflectSelectable_selectedValueR.symbol
+
   // Java library
   @tu lazy val NObjectType = requiredClassRef("java.lang._Object")
   def NObjectClass(using Context) = NObjectType.symbol.asClass

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1028,6 +1028,12 @@ trait NirGenExpr(using Context) {
       else if (code == STACKALLOC) genStackalloc(app)
       else if (code == CQUOTE) genCQuoteOp(app)
       else if (code == CLASS_FIELD_RAWPTR) genClassFieldRawPtr(app)
+      else if (code == REFLECT_SELECTABLE_SELECTDYN)
+        // scala.reflect.Selectable.selectDynamic
+        genReflectiveCall(app, isSelectDynamic = true)
+      else if (code == REFLECT_SELECTABLE_APPLYDYN)
+        // scala.reflect.Selectable.applyDynamic
+        genReflectiveCall(app, isSelectDynamic = false)
       else {
         report.error(
           s"Unknown primitive operation: ${sym.fullName}(${fun.symbol.showName})",
@@ -2343,6 +2349,115 @@ trait NirGenExpr(using Context) {
         buf.toSeq
       }
       Defn.Define(attrs, forwarderName, forwarderSig, forwarderBody)
+    }
+
+    private object WrapArray {
+      lazy val isWrapArray: Set[Symbol] = {
+        val names = defn
+          .ScalaValueClasses()
+          .map(sym => nme.wrapXArray(sym.name))
+          .concat(Set(nme.wrapRefArray, nme.genericWrapArray))
+        val symsInPredef = names.map(defn.ScalaPredefModule.requiredMethod(_))
+        val symsInScalaRunTime =
+          names.map(defn.ScalaRuntimeModule.requiredMethod(_))
+        (symsInPredef ++ symsInScalaRunTime).toSet
+      }
+
+      def unapply(tree: Apply): Option[Tree] = tree match {
+        case Apply(wrapArray_?, List(wrapped))
+            if isWrapArray(wrapArray_?.symbol) =>
+          Some(wrapped)
+        case _ =>
+          None
+      }
+    }
+
+    private def genReflectiveCall(
+        tree: Apply,
+        isSelectDynamic: Boolean
+    ): Val = {
+      given nir.Position = tree.span
+      val Apply(fun @ Select(receiver, _), args) = tree
+
+      val selectedValue = genApplyMethod(
+        defnNir.ReflectSelectable_selectedValue,
+        statically = false,
+        genExpr(receiver),
+        Seq()
+      )
+
+      // Extract the method name as a String
+      val methodNameStr = args.head match {
+        case Literal(Constants.Constant(name: String)) => name
+        case _ =>
+          report.error(
+            "The method name given to Selectable.selectDynamic or Selectable.applyDynamic " +
+              "must be a literal string. " +
+              "Other uses are not supported in Scala Native.",
+            args.head.sourcePos
+          )
+          "erroneous"
+      }
+
+      val (formalParamTypeRefs, actualArgs) =
+        if (isSelectDynamic) (Nil, Nil)
+        else
+          args.tail match {
+            // Extract the param type refs and actual args from the 2nd and 3rd argument to applyDynamic
+            case WrapArray(classOfsArray: JavaSeqLiteral) ::
+                WrapArray(actualArgsAnyArray: JavaSeqLiteral) :: Nil =>
+              // Extract nir.Type's from the classOf[_] trees
+              val formalParamTypes = classOfsArray.elems.map {
+                // classOf[tp] -> tp
+                case Literal(const) if const.tag == Constants.ClazzTag =>
+                  genType(const.typeValue)
+
+                // Anything else is invalid
+                case otherTree =>
+                  report.error(
+                    "The java.lang.Class[_] arguments passed to Selectable.applyDynamic must be " +
+                      "literal classOf[T] expressions (typically compiler-generated). " +
+                      "Other uses are not supported in Scala Native.",
+                    otherTree.sourcePos
+                  )
+                  Rt.Object
+              }
+
+              // Gen the actual args, downcasting them to the formal param types
+              val actualArgs =
+                actualArgsAnyArray.elems
+                  .zip(formalParamTypes)
+                  .map { (actualArgAny, formalParamType) =>
+                    val genActualArgAny = genExpr(actualArgAny)
+                    buf.as(
+                      formalParamType,
+                      genActualArgAny,
+                      unwind
+                    )
+                  }
+
+              (formalParamTypes, actualArgs)
+
+            case _ =>
+              report.error(
+                "Passing the varargs of Selectable.applyDynamic with `: _*` " +
+                  "is not supported in Scala Native.",
+                tree.sourcePos
+              )
+              (Nil, Nil)
+          }
+
+      val dynMethod = buf.dynmethod(
+        selectedValue,
+        Sig.Proxy(methodNameStr, formalParamTypeRefs),
+        unwind
+      )
+      buf.call(
+        Type.Function(selectedValue.ty :: formalParamTypeRefs, Rt.Object),
+        dynMethod,
+        selectedValue :: actualArgs,
+        unwind
+      )
     }
 
     private object LinktimeProperty {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPrimitives.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPrimitives.scala
@@ -79,7 +79,10 @@ object NirPrimitives {
 
   final val CLASS_FIELD_RAWPTR = 1 + CFUNCPTR_APPLY
 
-  final val LastNirPrimitiveCode = CLASS_FIELD_RAWPTR
+  final val REFLECT_SELECTABLE_SELECTDYN = CLASS_FIELD_RAWPTR + 1
+  final val REFLECT_SELECTABLE_APPLYDYN = REFLECT_SELECTABLE_SELECTDYN + 1
+
+  final val LastNirPrimitiveCode = REFLECT_SELECTABLE_APPLYDYN
 
   def isNirPrimitive(code: Int): Boolean =
     code >= FirstNirPrimitiveCode && code <= LastNirPrimitiveCode
@@ -181,6 +184,14 @@ class NirPrimitives(using ctx: Context) extends DottyPrimitives(ctx) {
       addPrimitive(_, CFUNCPTR_FROM_FUNCTION)
     )
     addPrimitive(defnNir.Intrinsics_classFieldRawPtr, CLASS_FIELD_RAWPTR)
+    addPrimitive(
+      defnNir.ReflectSelectable_selectDynamic,
+      REFLECT_SELECTABLE_SELECTDYN
+    )
+    addPrimitive(
+      defnNir.ReflectSelectable_applyDynamic,
+      REFLECT_SELECTABLE_APPLYDYN
+    )
     primitives
   }
 }

--- a/scalalib/overrides-3/scala/reflect/Selectable.scala.patch
+++ b/scalalib/overrides-3/scala/reflect/Selectable.scala.patch
@@ -1,0 +1,41 @@
+--- 3.1.1/scala/reflect/Selectable.scala
++++ overrides-3/scala/reflect/Selectable.scala
+@@ -16,16 +16,16 @@
+    */
+   protected def selectedValue: Any = this
+ 
++  private def unreachable(methodName: String): Nothing = 
++    throw new IllegalStateException(
++      "Reflection is not fully supported in Scala Native. " +
++      s"Call to method scala.reflect.Selectable.$methodName should have been " +
++      "replaced by Scala Native. Please report it to the Scala Native team."
++    )
++
+   // The Scala.js codegen relies on this method being final for correctness
+   /** Select member with given name */
+-  final def selectDynamic(name: String): Any =
+-    val rcls = selectedValue.getClass
+-    try
+-      val fld = rcls.getField(name)
+-      ensureAccessible(fld)
+-      fld.get(selectedValue)
+-    catch case ex: NoSuchFieldException =>
+-      applyDynamic(name)()
++  final def selectDynamic(name: String): Any = unreachable("selectDynamic")
+ 
+   // The Scala.js codegen relies on this method being final for correctness
+   /** Select method and apply to arguments.
+@@ -33,11 +33,8 @@
+    *  @param paramTypes The class tags of the selected method's formal parameter types
+    *  @param args       The arguments to pass to the selected method
+    */
+-  final def applyDynamic(name: String, paramTypes: Class[_]*)(args: Any*): Any =
+-    val rcls = selectedValue.getClass
+-    val mth = rcls.getMethod(name, paramTypes: _*)
+-    ensureAccessible(mth)
+-    mth.invoke(selectedValue, args.asInstanceOf[Seq[AnyRef]]: _*)
++  final def applyDynamic(name: String, paramTypes: Class[_]*)(args: Any*): Any = 
++    unreachable("applyDynamic")
+ 
+ object Selectable:
+ 

--- a/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
+++ b/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
@@ -51,6 +51,15 @@ class Scala3IssuesTest:
       CallByNeed.instance.map(CallByNeed(2))(_ + 3).value
     )
   }
+
+  @Test def issue2543(): Unit = {
+    import scala.reflect.Selectable.reflectiveSelectable
+    def collectionClassName(i: Iterable[_]): String =
+      i.asInstanceOf[{ def collectionClassName: String }].collectionClassName
+
+    assertEquals("List", collectionClassName(List(1, 2, 3)))
+  }
+
 end Scala3IssuesTest
 
 private object issue2484 {

--- a/unit-tests/shared/src/test/scala-3/scala/reflect/StructuralTest.scala
+++ b/unit-tests/shared/src/test/scala-3/scala/reflect/StructuralTest.scala
@@ -1,0 +1,112 @@
+// Ported from Dotty repo (test 'i4496b')
+
+package scala.reflect
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.reflect.Selectable.reflectiveSelectable
+
+trait Foo1 { val a: Int }
+trait Foo2 { def a: Int }
+trait Foo3 { var a: Int }
+
+private class FooBar1 extends Foo1 { val a: Int = 10 }
+private class FooBar2 extends Foo2 { def a: Int = 10 }
+private class FooBar3 extends Foo3 { var a: Int = 10 }
+
+private class Bar1 { val a: Int = 10 }
+private class Bar2 { def a: Int = 10 }
+private class Bar3 { var a: Int = 10 }
+
+class StructuralTest() {
+  // This test is also an (abstracted) motivating example.
+
+  @Test def testStructuralVal(): Unit = {
+    // Consider one module upcasting all these instances to T. These casts are clearly well-typed.
+    type T = { val a: Int }
+    def upcast1(v: Foo1): T = v
+    def upcast2(v: Foo2): T = v
+    def upcast3(v: Foo3): T = v
+
+    // These accesses are also clearly well-typed
+    def consume(v: T) = v.a
+    inline def consumeInl(v: T) = v.a
+    def verify(v: T) = {
+      assert(consume(v) == 10)
+      assert(consumeInl(v) == 10)
+      assert(v.a == 10)
+    }
+
+    // These calls are also clearly well-typed, hence can't be rejected.
+    verify(upcast1(new Foo1 { val a = 10 }))
+    verify(upcast2(new Foo2 { val a = 10 }))
+    verify(upcast3(new Foo3 { var a = 10 }))
+    // Ditto, so we must override access control to the class.
+    verify(upcast1(new FooBar1))
+    verify(upcast2(new FooBar2))
+    verify(upcast3(new FooBar3))
+
+    // Other testcases
+    verify(new { val a = 10 }: T)
+    verify(new { var a = 10 }: T)
+    verify(new { def a = 10 }: T)
+
+    verify(new Bar1: T)
+    verify(new Bar2: T)
+    verify(new Bar3: T)
+  }
+
+  @Test def testStructuralDef(): Unit = {
+    type T = { def a: Int }
+    def upcast1(v: Foo1): T = v
+    def upcast2(v: Foo2): T = v
+    def upcast3(v: Foo3): T = v
+    def consume(v: T) = v.a
+    inline def consumeInl(v: T) = v.a
+    def verify(v: T) = {
+      assert(consume(v) == 10)
+      assert(consumeInl(v) == 10)
+      assert(v.a == 10)
+    }
+
+    verify(upcast1(new Foo1 { val a = 10 }))
+    verify(upcast2(new Foo2 { val a = 10 }))
+    verify(upcast3(new Foo3 { var a = 10 }))
+
+    verify(upcast1(new FooBar1))
+    verify(upcast2(new FooBar2))
+    verify(upcast3(new FooBar3))
+
+    verify(new { val a = 10 }: T)
+    verify(new { var a = 10 }: T)
+    verify(new { def a = 10 }: T)
+
+    verify(new Bar1: T)
+    verify(new Bar2: T)
+    verify(new Bar3: T)
+  }
+
+  @Test def testStructuralVar(): Unit = {
+    type T = { val a: Int; def a_=(x: Int): Unit }
+    def upcast3(v: Foo3): T = v
+    def consume(v: T) = v.a
+    inline def consumeInl(v: T) = v.a
+    def verify(v: T) = {
+      assert(consume(v) == 10)
+      assert(consumeInl(v) == 10)
+      assert(v.a == 10)
+      // Pending, per https://github.com/lampepfl/dotty/issues/4528.
+      // v.a = 11
+      // assert(consume(v) == 11)
+      // assert(consumeInl(v) == 11)
+      // assert(v.a == 11)
+    }
+
+    verify(upcast3(new Foo3 { var a = 10 }))
+    verify(upcast3(new FooBar3))
+    verify(new { var a = 10 }: T)
+    verify(new Bar3: T)
+  }
+
+}


### PR DESCRIPTION
This PR port support for `scala.reflect.Selectable` from Scala.js (inside Dotty compiler) and allows to use structural types in Scala Native. It fixes #2543 

* Add runtime tests using structural types 
* Add reproducer test for #2543
* Register primitives for `Selectable.selectDynamic` and `Selectable.applyDynamic` 
* Handle dynamic calls using port of Scala.js logic 
* Add override to scala3 library to allow for compilation of `Selectable` sources
