### PR TITLE
Fix failing to link `CFuncPtr` created from adapted function

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2156,6 +2156,7 @@ trait NirGenExpr(using Context) {
 
     def toExtern(expectedTy: nir.Type, value: Val)(using nir.Position): Val =
       (expectedTy, value.ty) match {
+        case (Type.Unit, _) => Val.Unit
         case (_, refty: Type.Ref)
             if Type.boxClasses.contains(refty.name)
               && Type.unbox(Type.Ref(refty.name)) == expectedTy =>

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2325,8 +2325,8 @@ trait NirGenExpr(using Context) {
 
         val params = paramtys.map(ty => Val.Local(fresh(), ty))
         buf.label(fresh(), params)
-
-        val origTypes = if (funSym.isStaticInNIR) origtys else origtys.tail
+        val origTypes =
+          if (funSym.isStaticInNIR || isAdapted) origtys else origtys.tail
         val boxedParams = origTypes.zip(params).map(buf.fromExtern(_, _))
         val argsp = boxedParams.map(ValTree(_))
         val res =

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -516,6 +516,31 @@ class IssuesTest {
     }
   }
 
+  @Test def test_Issue2550(): Unit = {
+    // The code was failing to link
+    // There were 2 reasons:
+    // 1. Incorrect number of arguments (tested in all cases)
+    // 2. Incorrect return type j.l.Object instead of nir Unit (tested in Func)
+    type Func = CFuncPtr2[Ptr[Byte], Int, Unit]
+    type Func1 = CFuncPtr2[Ptr[Byte], Int, Ptr[Byte]]
+    type Func2 = CFuncPtr2[Ptr[Byte], Int, Int]
+    type Func3 = CFuncPtr2[Ptr[Byte], Int, java.lang.Integer]
+
+    val func0: Func = (handle: Ptr[Byte], i: Int) => ()
+    val func1: Func1 = (handle: Ptr[Byte], i: Int) => handle
+    val func2: Func2 = (handle: Ptr[Byte], i: Int) => i
+    val func3: Func3 = (handle: Ptr[Byte], i: Int) =>
+      java.lang.Integer.valueOf(i)
+
+    val stub = stackalloc[Byte]()
+    val n = 10
+
+    assertEquals((), func0(stub, n))
+    assertEquals(stub, func1(stub, n))
+    assertEquals(n, func2(stub, n))
+    assertEquals(n, func3(stub, n))
+  }
+
 }
 
 package issue1090 {


### PR DESCRIPTION
This PR fixes #2550 describing link-time errors. The main reason for that was the unhandled case in the conversion of `scala.Function to `scalanative.unsafe.CFuncPtr` in the case when the adapted function was being used. Adapted functions are special type of synthetic methods which at the point of our compilation have already erased types. These lead to two errors: 
1. Since adapted function was not treated as static call we we're always missing it's first argument value
2. Since the result of this function is also erased in case if we would expect the function to return Unit it would return `j.l.Object` instead. 

* Added reproducer tests for issue 2550 extended with additional cases 
* Fixed incorrect number of arguments when using adapted function
* Handle Type.Unit in `toExtern` method, return Val.Unit if Type.Unit is expected
* Add compiler error to detect incorrect number of functions argument at compile time
 