### PR TITLE
Fix conflicting cross version suffixes when using `Cross.for3Use_2.13`

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -166,30 +166,40 @@ object Build {
                 CrossVersion.binaryScalaVersion(scalaVersion)
               }
 
-              Def
-                .task(())
+              def publishLocalVersion(ver: String) = {
+                Def
+                  .task(())
+                  .dependsOn(
+                    // Compiler plugins
+                    nscPlugin.forBinaryVersion(ver) / publishLocal,
+                    junitPlugin.forBinaryVersion(ver) / publishLocal,
+                    // Native libraries
+                    nativelib.forBinaryVersion(ver) / publishLocal,
+                    clib.forBinaryVersion(ver) / publishLocal,
+                    posixlib.forBinaryVersion(ver) / publishLocal,
+                    windowslib.forBinaryVersion(ver) / publishLocal,
+                    // Standard language libraries
+                    javalib.forBinaryVersion(ver) / publishLocal,
+                    auxlib.forBinaryVersion(ver) / publishLocal,
+                    scalalib.forBinaryVersion(ver) / publishLocal,
+                    // Testing infrastructure
+                    testInterfaceSbtDefs.forBinaryVersion(ver) / publishLocal,
+                    testInterface.forBinaryVersion(ver) / publishLocal,
+                    junitRuntime.forBinaryVersion(ver) / publishLocal,
+                    // JVM libraries
+                    util.forBinaryVersion(ver) / publishLocal,
+                    nir.forBinaryVersion(ver) / publishLocal,
+                    tools.forBinaryVersion(ver) / publishLocal,
+                    testRunner.forBinaryVersion(ver) / publishLocal
+                  )
+              }
+
+              publishLocalVersion(ver)
                 .dependsOn(
-                  // Compiler plugins
-                  nscPlugin.forBinaryVersion(ver) / publishLocal,
-                  junitPlugin.forBinaryVersion(ver) / publishLocal,
-                  // Native libraries
-                  nativelib.forBinaryVersion(ver) / publishLocal,
-                  clib.forBinaryVersion(ver) / publishLocal,
-                  posixlib.forBinaryVersion(ver) / publishLocal,
-                  windowslib.forBinaryVersion(ver) / publishLocal,
-                  // Standard language libraries
-                  javalib.forBinaryVersion(ver) / publishLocal,
-                  auxlib.forBinaryVersion(ver) / publishLocal,
-                  scalalib.forBinaryVersion(ver) / publishLocal,
-                  // Testing infrastructure
-                  testInterfaceSbtDefs.forBinaryVersion(ver) / publishLocal,
-                  testInterface.forBinaryVersion(ver) / publishLocal,
-                  junitRuntime.forBinaryVersion(ver) / publishLocal,
-                  // JVM libraries
-                  util.forBinaryVersion(ver) / publishLocal,
-                  nir.forBinaryVersion(ver) / publishLocal,
-                  tools.forBinaryVersion(ver) / publishLocal,
-                  testRunner.forBinaryVersion(ver) / publishLocal
+                  // Scala 3 needs 2.13 deps for it's cross version compat tests
+                  if (scalaVersion.value.startsWith("3."))
+                    publishLocalVersion("2.13")
+                  else Def.task(())
                 )
             })
             .value

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -197,8 +197,7 @@ object Build {
               publishLocalVersion(ver)
                 .dependsOn(
                   // Scala 3 needs 2.13 deps for it's cross version compat tests
-                  if (scalaVersion.value.startsWith("3."))
-                    publishLocalVersion("2.13")
+                  if (ver == "3") publishLocalVersion("2.13")
                   else Def.task(())
                 )
             })

--- a/project/Commands.scala
+++ b/project/Commands.scala
@@ -76,7 +76,7 @@ object Commands {
       val version = args.headOption
         .orElse(state.getSetting(scalaVersion))
         .getOrElse(
-          "Used command needs explicit Scala binary version as an argument"
+          "Used command needs explicit Scala version as an argument"
         )
       val setScriptedLaunchOpts =
         s"""set sbtScalaNative/scriptedLaunchOpts := {
@@ -86,14 +86,18 @@ object Commands {
             |}""".stripMargin
       // Scala 3 is supported since sbt 1.5.0
       // Older versions set incorrect binary version
+      val isScala3 = version.startsWith("3.")
       val overrideSbtVersion =
-        if (version.startsWith("3."))
-          """set sbtScalaNative/sbtVersion := "1.5.0"""" :: Nil
+        if (isScala3)
+          """set sbtScalaNative/sbtVersion := "1.5.0" """ :: Nil
         else Nil
+      val scalaVersionTests =
+        if (isScala3) "scala3/*"
+        else ""
 
       setScriptedLaunchOpts ::
         overrideSbtVersion :::
-        "sbtScalaNative/scripted" ::
+        s"sbtScalaNative/scripted ${scalaVersionTests} run/*" ::
         state
   }
 

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativeCrossVersion.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativeCrossVersion.scala
@@ -7,15 +7,7 @@ import sbt._
 import scala.scalanative.nir.Versions
 
 object ScalaNativeCrossVersion {
-  private final val ReleaseVersion =
-    raw"""(\d+)\.(\d+)\.(\d+)""".r
-
-  val currentBinaryVersion = binaryVersion(Versions.current)
-
-  def binaryVersion(full: String): String = full match {
-    case ReleaseVersion(major, minor, _) => s"$major.$minor"
-    case _                               => full
-  }
+  val currentBinaryVersion = Versions.currentBinaryVersion
 
   private[this] def crossVersionAddPlatformPart(
       cross: CrossVersion,

--- a/scripted-tests/scala3/cross-version-compat/base/src/main/scala/Base.scala
+++ b/scripted-tests/scala3/cross-version-compat/base/src/main/scala/Base.scala
@@ -1,0 +1,8 @@
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+object Base {
+  def foo(n: Int): Unit = {
+        val _ = stackalloc[Byte](n.toUInt)
+  }
+}

--- a/scripted-tests/scala3/cross-version-compat/base/src/main/scala/Base.scala
+++ b/scripted-tests/scala3/cross-version-compat/base/src/main/scala/Base.scala
@@ -3,6 +3,6 @@ import scalanative.unsigned._
 
 object Base {
   def foo(n: Int): Unit = {
-        val _ = stackalloc[Byte](n.toUInt)
+    val _ = stackalloc[Byte](n.toUInt)
   }
 }

--- a/scripted-tests/scala3/cross-version-compat/build.sbt
+++ b/scripted-tests/scala3/cross-version-compat/build.sbt
@@ -1,0 +1,97 @@
+inThisBuild(
+  Seq(
+    scalaVersion := "3.1.1",
+    crossScalaVersions := Seq("3.1.1", "2.13.8"),
+    version := "0.1.0-SNAPSHOT",
+    organization := "org.scala-native.test",
+    publishMavenStyle := true
+  )
+)
+
+def commonScala213Settigns = Def.settings(
+  scalacOptions ++= {
+    if ((scalaVersion.value).startsWith("2.13."))
+      Seq(
+        // Needed to use Scala 3 dependencies from Scala 2.13
+        "-Ytasty-reader"
+      )
+    else Nil
+  }
+)
+
+lazy val base = project
+  .in(file("base"))
+  .enablePlugins(ScalaNativePlugin)
+
+lazy val projectA = project
+  .in(file("project-A"))
+  .enablePlugins(ScalaNativePlugin)
+  .settings(
+    libraryDependencies += organization.value %%% (base / normalizedName).value % version.value
+  )
+
+lazy val projectB = project
+  .in(file("project-B"))
+  .enablePlugins(ScalaNativePlugin)
+  .settings(
+    commonScala213Settigns,
+    libraryDependencies += (organization.value %%% (base / normalizedName).value % version.value)
+      .cross(CrossVersion.for3Use2_13)
+  )
+
+lazy val projectC = project
+  .in(file("project-C"))
+  .enablePlugins(ScalaNativePlugin)
+  .settings(
+    commonScala213Settigns,
+    libraryDependencies += (organization.value %%% (base / normalizedName).value % version.value)
+      .cross(CrossVersion.for2_13Use3)
+  )
+
+lazy val projectD = project
+  .in(file("project-D"))
+  .enablePlugins(ScalaNativePlugin)
+  .settings(
+    commonScala213Settigns,
+    libraryDependencies ++= Seq(
+      organization.value %%% (projectA / normalizedName).value % version.value,
+      organization.value %%% (projectB / normalizedName).value % version.value,
+      organization.value %%% (projectC / normalizedName).value % version.value
+    ),
+    excludeDependencies += ExclusionRule(
+      organization.value,
+      s"${(base / normalizedName).value}_native${ScalaNativeCrossVersion.currentBinaryVersion}_2.13"
+    )
+  )
+
+lazy val projectE = project
+  .in(file("project-E"))
+  .enablePlugins(ScalaNativePlugin)
+  .settings(
+    commonScala213Settigns,
+    libraryDependencies ++= Seq(
+      organization.value %%% (projectA / normalizedName).value % version.value,
+      organization.value %%% (projectB / normalizedName).value % version.value,
+      organization.value %%% (projectC / normalizedName).value % version.value
+    ).map(_.cross(CrossVersion.for3Use2_13)),
+    excludeDependencies += ExclusionRule(
+      organization.value,
+      s"${(base / normalizedName).value}_native${ScalaNativeCrossVersion.currentBinaryVersion}_3"
+    )
+  )
+
+lazy val projectF = project
+  .in(file("project-F"))
+  .enablePlugins(ScalaNativePlugin)
+  .settings(
+    commonScala213Settigns,
+    libraryDependencies ++= Seq(
+      organization.value %%% (projectA / normalizedName).value % version.value,
+      organization.value %%% (projectB / normalizedName).value % version.value,
+      organization.value %%% (projectC / normalizedName).value % version.value
+    ).map(_.cross(CrossVersion.for2_13Use3)),
+    excludeDependencies += ExclusionRule(
+      organization.value,
+      s"${(base / normalizedName).value}_native${ScalaNativeCrossVersion.currentBinaryVersion}_2.13"
+    )
+  )

--- a/scripted-tests/scala3/cross-version-compat/project-A/src/main/scala/ProjectA.scala
+++ b/scripted-tests/scala3/cross-version-compat/project-A/src/main/scala/ProjectA.scala
@@ -1,0 +1,9 @@
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+object ProjectA {
+  def foo(n: Int): Unit = {
+    Base.foo(n)
+    val _ = stackalloc[Byte](n.toUInt)
+  }
+}

--- a/scripted-tests/scala3/cross-version-compat/project-B/ProjectB.scala
+++ b/scripted-tests/scala3/cross-version-compat/project-B/ProjectB.scala
@@ -1,0 +1,9 @@
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+object ProjectB {
+  def foo(n: Int): Unit = {
+    Base.foo(n)
+    val _ = stackalloc[Byte](n.toUInt)
+  }
+}

--- a/scripted-tests/scala3/cross-version-compat/project-C/src/main/scala/ProjectC.scala
+++ b/scripted-tests/scala3/cross-version-compat/project-C/src/main/scala/ProjectC.scala
@@ -1,0 +1,9 @@
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+object ProjectC {
+  def foo(n: Int): Unit = {
+    Base.foo(n)
+    val _ = stackalloc[Byte](n.toUInt)
+  }
+}

--- a/scripted-tests/scala3/cross-version-compat/project-D/src/main/scala/ProjectD.scala
+++ b/scripted-tests/scala3/cross-version-compat/project-D/src/main/scala/ProjectD.scala
@@ -1,0 +1,12 @@
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+object ProjectD {
+  def foo(n: Int): Unit = {
+    Base.foo(n)
+    ProjectA.foo(n)
+    ProjectB.foo(n)
+    ProjectC.foo(n)
+    val _ = stackalloc[Byte](n.toUInt)
+  }
+}

--- a/scripted-tests/scala3/cross-version-compat/project-F/src/main/scala/ProjectF.scala
+++ b/scripted-tests/scala3/cross-version-compat/project-F/src/main/scala/ProjectF.scala
@@ -1,0 +1,12 @@
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+object ProjectF {
+  def foo(n: Int): Unit = {
+    Base.foo(n)
+    ProjectA.foo(n)
+    ProjectB.foo(n)
+    ProjectC.foo(n)
+    val _ = stackalloc[Byte](n.toUInt)
+  }
+}

--- a/scripted-tests/scala3/cross-version-compat/project/build.properties
+++ b/scripted-tests/scala3/cross-version-compat/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/scripted-tests/scala3/cross-version-compat/project/scala-native.sbt
+++ b/scripted-tests/scala3/cross-version-compat/project/scala-native.sbt
@@ -1,0 +1,9 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+  else addSbtPlugin("org.scala-native" % "sbt-scala-native" % pluginVersion)
+}

--- a/scripted-tests/scala3/cross-version-compat/test
+++ b/scripted-tests/scala3/cross-version-compat/test
@@ -1,0 +1,27 @@
+> +base/publishLocal
+
+# Publish projects using crossVersion
+## No CrossVerison
+> +projectA/publishLocal
+> +projectA/test
+
+## Use CrossVersion.for3use2_13
+> +projectB/publishLocal
+> +projectB/test
+
+## Use CrossVersion.for2_13use3
+> +projectC/publishLocal
+> +projectC/test
+
+# Use published projects
+## No CrossVersion
+> +projectD/compile
+> +projectD/test
+
+## Use CrossVersion.for3use2_13
+> +projectE/compile
+> +projectE/test
+
+## Use CrossVersion.for2_13use3
+> +projectF/compile
+> +projectF/test

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -70,10 +70,12 @@ object CodeGen {
         Impl(config, env, sorted).gen(id = "out", workdir) :: Nil
       }
 
+      // For some reason in the CI matching for `case _: build.Mode.Relese` throws compile time erros
+      import build.Mode._
       (config.mode, config.LTO) match {
-        case (build.Mode.Debug, _)                   => separate()
-        case (_: build.Mode.Release, build.LTO.None) => single()
-        case (_: build.Mode.Release, _)              => separate()
+        case (Debug, _)                                  => separate()
+        case (ReleaseFast | ReleaseFull, build.LTO.None) => single()
+        case (ReleaseFast | ReleaseFull, _)              => separate()
       }
     }
 


### PR DESCRIPTION
This PR fixes #2546 

The problem exists because we do publish standard native libraries for both Scala 2.13 and Scala 3. Scala.js does not have this problem, because it does only use Scala 2.13 js library. In the case of Scala Native, using the same solution would not as easy:
* `nativelib` uses macros for multiple common operations, eg. `stackalloc[T]()`, `alloc[T]()`, we cannot use Scala 2 macros in Scala 3. We can make alloc implemented as a normal function, but stackalloc needs to be implemented as a macro (needs to be inlined) **< blocker >**
* Scala 3 Compiler Plugin needs `scala.scalanative.runtime.LazyVals` implementation at compile-time, we would need to ship it with both Scala 2.13 and Scala3 nativelib

The proposed solution is based using sbt `excludeDependencies`, we would use it to exclude Scala 3 native stdlib when using Scala 2.13, or to exclude 2.13 artifacts when using Scala 3. It works fine with sbt, but it's not an universal solution - similar changes would need to be applied in other build tools

Changes:
* Added scripted tests to reproduce conflicting cross-version suffixes in Scala 3 and 2.13 artifacts
* Fixed `currentBinaryVersion` in ScalaNativeCrossVersion, now it delegates to correct `nir.Versions` implementation 
* Added exclusion rules for project settings in ScalaNativePlugin
* Removed redundant explicit library dependencies for Scala Native standard library, they would be pulled tranistivelly from scalalib. 
* Fixed pattern match failing in Scala 2.13 - resolves #2538 