### PR TITLE
Fix incorrect self type of closures 

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -228,7 +228,7 @@ trait NirGenExpr(using Context) {
         for
           (tree, idx) <- allCaptureValues.zipWithIndex
           tpe = tree match {
-            case This(iden) => genType(curClassSym.get)
+            case This(iden) => genType(fun.symbol.owner)
             case _          => genType(tree.tpe)
           }
           name = anonClassName.member(nir.Sig.Field(s"capture$idx"))

--- a/scalalib/overrides-3/scala/reflect/Selectable.scala.patch
+++ b/scalalib/overrides-3/scala/reflect/Selectable.scala.patch
@@ -4,7 +4,7 @@
     */
    protected def selectedValue: Any = this
  
-+  private def unreachable(methodName: String): Nothing = 
++  private def unreachable(methodName: String): Nothing =
 +    throw new IllegalStateException(
 +      "Reflection is not fully supported in Scala Native. " +
 +      s"Call to method scala.reflect.Selectable.$methodName should have been " +
@@ -34,7 +34,7 @@
 -    val mth = rcls.getMethod(name, paramTypes: _*)
 -    ensureAccessible(mth)
 -    mth.invoke(selectedValue, args.asInstanceOf[Seq[AnyRef]]: _*)
-+  final def applyDynamic(name: String, paramTypes: Class[_]*)(args: Any*): Any = 
++  final def applyDynamic(name: String, paramTypes: Class[_]*)(args: Any*): Any =
 +    unreachable("applyDynamic")
  
  object Selectable:

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -541,6 +541,14 @@ class IssuesTest {
     assertEquals(n, func3(stub, n))
   }
 
+  @Test def test_Issue2552() = {
+    import issue2552._
+    // Test that methods (lambdas) as reachable, issue reported missing symbols
+    assertEquals("case 0", 0, issue2552.foo(0))
+    assertEquals("case 1", 0, baz())
+    assertEquals("case 2", 0, Bar.bar())
+  }
+
 }
 
 package issue1090 {
@@ -629,5 +637,13 @@ package issue2520 {
     }
 
     def law: Law = new Law {}
+  }
+}
+
+package object issue2552 {
+  def foo(a: Int, b: Int = 0): Int = 0
+  val baz = () => foo(1)
+  object Bar {
+    val bar = () => foo(0)
   }
 }


### PR DESCRIPTION
This PR fixes #2552 and its reachability errors. The problem with the mentioned issue was caused by usage of incorrect self type for the object containing closure ( SN synthetic Lambda class) and was partially introduced due to changes of how symbols ownership is perceived in Scala 3 or due to the fact that `genNir` phase is executed after `flatten` scalac phase. 
When generating the closure symbol of the current class saved in `curClassSym` in the outer scope of AST traversal was different the owner of function passed to the `Closure`. 
 
 ```
 object example {
   val foo = () => println("foo") // curClassSym = `example$`; closure.fun.owner = `example$` 
   object inner {
     val foo = () => println("inner foo") // curClassSym = `example$`; closure.fun.owner = `example$foo$`
   }
 }
 ```
 
 We cannot change the naming of the Scala Native synthetic Lambda class at this point because it might lead to binary incompatibility with 0.4.3 release. Luckily, this is not needed. Reachability errors that we could have observed were caused by method dispatch which was using incorrect self type. Using `closure.fun.owner` for self type instead of `curClassStm` fixes the problem. 
 
 * Added reproducer tests for issue 2552
 * Changed self type used for closure inner structure
 
 Additional fix: 
 * I've observed warning when compiling scalalib, removing tail whitespace from patches fixed that issue