### PR TITLE
Make unit tests JDK 11 compliant

### DIFF
--- a/.github/workflows/run-jdk-compliance-tests.yml
+++ b/.github/workflows/run-jdk-compliance-tests.yml
@@ -1,0 +1,66 @@
+name: Run tests JDK compliance tests
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+concurrency:
+  group: jdk-compliance-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Compile and run tests against given version of the JDK to check compliance
+  # We test against Java 8 as default in other CI jobs 
+  tests-unix-jdk-compliance:
+    name: Test JDK compliance
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, macos-10.15]
+        scala: [3.1.1]
+        java: [11] 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "temurin"
+          java-version: ${{matrix.java}}
+
+      - uses: ./.github/actions/macos-setup-env
+        if: ${{ startsWith(matrix.os, 'macos'}}
+        with:
+          scala-version: ${{matrix.scala}}
+      - uses: ./.github/actions/linux-setup-env
+        if: ${{ startsWith(matrix.os, 'ubuntu'}}
+        with:
+          scala-version: ${{matrix.scala}}
+
+      - name: Test runtime
+        run: sbt "++ ${{ matrix.scala }} -v" "-no-colors" "-J-Xmx3G" "test-runtime ${{matrix.scala}}"
+
+  tests-windows-jdk-compliance:
+    name: Test Windows JDK compliance
+    runs-on: windows-2019
+    strategy:
+      fail-fast: false
+      matrix:
+        scala: [3.1.1]
+        java: [11]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "temurin"
+          java-version: ${{matrix.java}}
+      - uses: ./.github/actions/windows-setup-env
+        with:
+          scala-version: ${{matrix.scala}}
+
+      - name: Test runtime
+        run: >
+          set SCALANATIVE_INCLUDE_DIRS=${{steps.setup.outputs.vcpkg-dir}}\include&
+          set SCALANATIVE_LIB_DIRS=${{steps.setup.outputs.vcpkg-dir}}\lib&
+          set SCALANATIVE &
+          sbt ++${{matrix.scala}}
+          "test-runtime ${{matrix.scala}}"

--- a/javalib/src/main/scala/java/nio/channels/FileLock.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileLock.scala
@@ -1,5 +1,7 @@
 package java.nio.channels
 
+import java.util.Objects
+
 abstract class FileLock private (
     _channel: Channel,
     final val position: Long,
@@ -22,6 +24,7 @@ abstract class FileLock private (
     this(channel: Channel, position, size, shared)
 
   require(position >= 0 && size >= 0, "position and size must be non negative")
+  Objects.requireNonNull(_channel, "Null channel")
 
   final def channel(): FileChannel =
     _channel match {


### PR DESCRIPTION
This PR fixes the last remaining non-JDK 11 compliant unit test and sets up a CI workflow to test compliance for other versions in the future. 
Resolves #2541 

* Added CI workflow for checking JDK compliance in our unit-tests 
* Fix FileLockTest to be JDK 11 compliant 
* File FileLock impl to be JDK 11 compliant