### PR TITLE
Support PathMatching via Globs

### DIFF
--- a/javalib/src/main/scala/java/nio/file/PathMatcherImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/PathMatcherImpl.scala
@@ -27,6 +27,5 @@ private class RegexPathMatcher(pattern: Pattern) extends PathMatcher {
 private class GlobPathMatcher(pattern: String) extends PathMatcher {
   val globPattern = GlobPattern.compile(pattern)
   override def matches(p: Path): Boolean =
-    globPattern.matcher().matches(p)
-
+    globPattern.matcher(p.toString).matches()
 }

--- a/javalib/src/main/scala/java/nio/file/PathMatcherImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/PathMatcherImpl.scala
@@ -21,11 +21,12 @@ object PathMatcherImpl {
 
 private class RegexPathMatcher(pattern: Pattern) extends PathMatcher {
   override def matches(p: Path): Boolean =
-    pattern.matcher(p.toString).matches()
+    pattern.matcher(p.toString).matches() // does it work on windows ???
 }
 
 private class GlobPathMatcher(pattern: String) extends PathMatcher {
   val globPattern = GlobPattern.compile(pattern)
   override def matches(p: Path): Boolean =
     globPattern.matcher().matches(p)
+
 }

--- a/javalib/src/main/scala/java/nio/file/PathMatcherImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/PathMatcherImpl.scala
@@ -1,6 +1,7 @@
 package java.nio.file
 
 import java.util.regex.Pattern
+import java.nio.file.glob.GlobPattern
 
 object PathMatcherImpl {
   def apply(syntaxAndPattern: String): PathMatcher = {
@@ -13,6 +14,7 @@ object PathMatcherImpl {
       syntaxAndPattern.substring(colonIndex + 1, syntaxAndPattern.length())
 
     if (syntax == "regex") new RegexPathMatcher(Pattern.compile(pattern))
+    else if (syntax == "glob") new GlobPathMatcher(pattern)
     else throw new UnsupportedOperationException()
   }
 }
@@ -20,4 +22,10 @@ object PathMatcherImpl {
 private class RegexPathMatcher(pattern: Pattern) extends PathMatcher {
   override def matches(p: Path): Boolean =
     pattern.matcher(p.toString).matches()
+}
+
+private class GlobPathMatcher(pattern: String) extends PathMatcher {
+  val globPattern = GlobPattern.compile(pattern)
+  override def matches(p: Path): Boolean =
+    globPattern.matcher().matches(p)
 }

--- a/javalib/src/main/scala/java/nio/file/PathMatcherImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/PathMatcherImpl.scala
@@ -21,7 +21,7 @@ object PathMatcherImpl {
 
 private class RegexPathMatcher(pattern: Pattern) extends PathMatcher {
   override def matches(p: Path): Boolean =
-    pattern.matcher(p.toString).matches() // does it work on windows ???
+    pattern.matcher(p.toString).matches()
 }
 
 private class GlobPathMatcher(pattern: String) extends PathMatcher {

--- a/javalib/src/main/scala/java/nio/file/glob/GlobMatcher.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobMatcher.scala
@@ -1,0 +1,74 @@
+package java.nio.file.glob
+
+import java.nio.file.{PathMatcher, Path}
+import scala.util.matching.Regex
+import scala.annotation.tailrec
+
+class GlobMatcher(pattern: GlobPattern) extends PathMatcher {
+
+  def matches(path: java.nio.file.Path): Boolean = {
+    val input = path.toString() // TODO change dividers (?)
+    val glob = pattern.globSpecification
+
+    // Finds states reachable after using one inputChar
+    def reachableStates(
+        inputChar: Char,
+        node: GlobNode,
+        previous: GlobNode
+    ): List[GlobNode] =
+      if (!node.isFinal) {
+        node.globSpec match {
+          case Divider if inputChar == '/' => List(node)
+          case NonCrossingName if inputChar != '/' =>
+            List(node, previous) ++ node.next.flatMap(
+              reachableStates(inputChar, _, node)
+            ) // skip
+          case NonCrossingName if inputChar == '/' =>
+            node.next.flatMap(reachableStates(inputChar, _, node))
+          case CrossingName =>
+            List(node, previous) ++ node.next.flatMap(
+              reachableStates(inputChar, _, node)
+            ) // skip
+          case AnyChar if inputChar != '/'                      => List(node)
+          case GlobChar(char) if char == inputChar              => List(node)
+          case Bracket(set) if set.contains(inputChar)          => List(node)
+          case NegationBracket(set) if !set.contains(inputChar) => List(node)
+          case Groups(_) =>
+            node.next.flatMap(reachableStates(inputChar, _, node))
+          case _ => Nil
+        }
+      } else {
+        Nil
+      }
+
+    // @tailrec
+    def isEndReachable(node: GlobNode): Boolean =
+      if (!node.isFinal) {
+        node.globSpec match {
+          case NonCrossingName => node.next.exists(isEndReachable(_))
+          case CrossingName    => node.next.exists(isEndReachable(_))
+          case Groups(_)       => node.next.exists(isEndReachable(_))
+          case _               => false
+        }
+      } else true
+
+    // Matches against one string
+    @tailrec
+    def matchesInternal(inputIdx: Int, states: List[GlobNode]): Boolean = { /// return if not found
+      val inputChar = input.charAt(inputIdx)
+      val newStates = states.flatMap { node =>
+        val nextList = node.next.flatMap { nextNode =>
+          reachableStates(inputChar, nextNode, node)
+        }
+        nextList
+      }
+
+      if (inputIdx == input.length() - 1)
+        newStates.exists(_.next.exists(isEndReachable(_)))
+      else matchesInternal(inputIdx + 1, newStates)
+    }
+
+    matchesInternal(0, List(glob))
+
+  }
+}

--- a/javalib/src/main/scala/java/nio/file/glob/GlobMatcher.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobMatcher.scala
@@ -5,17 +5,12 @@ import scala.util.matching.Regex
 import scala.annotation.tailrec
 import scala.scalanative.meta.LinktimeInfo.isWindows
 
-class GlobMatcher(pattern: GlobPattern) extends PathMatcher {
+class GlobMatcher(glob: GlobNode, inputPath: String) {
 
-  def matches(path: Path): Boolean = {
+  def matches(): Boolean = {
     val input =
-      if (isWindows) {
-        path.toString.replace("\\", "/")
-      } else {
-        path.toString()
-      }
-
-    val glob = pattern.globSpecification
+      if (isWindows) inputPath.replace("\\", "/")
+      else inputPath
 
     // Finds states reachable after using one input character
     def reachableStates(

--- a/javalib/src/main/scala/java/nio/file/glob/GlobNode.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobNode.scala
@@ -1,7 +1,14 @@
 package java.nio.file.glob
 
-case class GlobNode( // add divs and chars left
+private[glob] sealed abstract class GlobNode(
+    val minCharsLeft: Int,
+    val minDivsLeft: Int
+)
+private[glob] case class StartNode(nextNode: GlobNode) extends GlobNode(0, 0)
+private[glob] case object EndNode extends GlobNode(0, 0)
+private[glob] case class TransitionNode(
     globSpec: GlobSpecification,
     next: List[GlobNode],
-    isFinal: Boolean
-)
+    override val minCharsLeft: Int,
+    override val minDivsLeft: Int
+) extends GlobNode(minCharsLeft, minDivsLeft)

--- a/javalib/src/main/scala/java/nio/file/glob/GlobNode.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobNode.scala
@@ -1,0 +1,7 @@
+package java.nio.file.glob
+
+case class GlobNode( // add divs and chars left
+    globSpec: GlobSpecification,
+    next: List[GlobNode],
+    isFinal: Boolean
+)

--- a/javalib/src/main/scala/java/nio/file/glob/GlobNode.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobNode.scala
@@ -2,7 +2,7 @@ package java.nio.file.glob
 
 private[glob] sealed abstract class GlobNode(
     val minCharsLeft: Int,
-    val minDivsLeft: Int
+    val minSepsLeft: Int
 )
 private[glob] case class StartNode(nextNode: GlobNode) extends GlobNode(0, 0)
 private[glob] case object EndNode extends GlobNode(0, 0)
@@ -10,5 +10,5 @@ private[glob] case class TransitionNode(
     globSpec: GlobSpecification,
     next: List[GlobNode],
     override val minCharsLeft: Int,
-    override val minDivsLeft: Int
-) extends GlobNode(minCharsLeft, minDivsLeft)
+    override val minSepsLeft: Int
+) extends GlobNode(minCharsLeft, minSepsLeft)

--- a/javalib/src/main/scala/java/nio/file/glob/GlobPattern.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobPattern.scala
@@ -8,9 +8,10 @@ import scala.scalanative.annotation.alwaysinline
 
 class GlobPattern(pattern: String) {
 
-  def matcher(): GlobMatcher = new GlobMatcher(this)
+  def matcher(pathString: String): GlobMatcher =
+    new GlobMatcher(globNFA, pathString)
 
-  private[glob] val globSpecification = compileGlobNFA()
+  private val globNFA = compileGlobNFA()
 
   private def compileGlobNFA(): GlobNode = {
 

--- a/javalib/src/main/scala/java/nio/file/glob/GlobPattern.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobPattern.scala
@@ -1,0 +1,210 @@
+package java.nio.file.glob
+
+import java.util.regex.PatternSyntaxException
+
+import scala.collection.mutable
+import scala.annotation.tailrec
+import scala.scalanative.annotation.alwaysinline
+
+class GlobPattern(pattern: String) {
+
+  def matcher(): GlobMatcher = new GlobMatcher(this)
+
+  private[glob] val minDividerAmount = 0 // todo set maybe
+  private[glob] val minCharAmount = 0 // TODO set maybe
+
+  private[glob] lazy val globSpecification = { // Map[(Int, Char), Int] = { // (state, char) -> state, produces NFA
+
+    // Parse input
+    val length = pattern.length
+    val parsingList = mutable.ArrayBuffer[GlobSpecification]()
+
+    var i = 0
+    var escaping = false
+    var inParentheses = false
+    var inBrackets = false
+
+    @alwaysinline def nextTwo(): (Char, Option[Char]) = {
+      val first = pattern.charAt(i)
+      val second =
+        if (i + 1 < length) Some(pattern.charAt(i + 1))
+        else None
+      (first, second)
+    }
+
+    @alwaysinline def nextThree(): (Char, Option[Char], Option[Char]) = {
+      val (first, second) = nextTwo()
+      val third =
+        if (i + 2 < length) Some(pattern.charAt(i + 2))
+        else None
+
+      (first, second, third)
+    }
+
+    def parseBracketSet() = {
+      val set = mutable.TreeSet[Char]()
+      while ({
+        val closedBracket =
+          nextThree() match {
+            case (']', _, _) =>
+              true
+            case ('/', _, _) =>
+              throw new PatternSyntaxException(
+                "Explicit 'name separator' in class",
+                pattern,
+                i
+              )
+            case (startingChar, Some('-'), Some('/')) =>
+              throw new PatternSyntaxException("Invalid range", pattern, i)
+            case (startingChar, Some('-'), Some(endingChar))
+                if (endingChar < startingChar && endingChar != ']') =>
+              throw new PatternSyntaxException("Invalid range", pattern, i)
+            case (startingChar, Some('-'), Some(endingChar)) if endingChar != ']' =>
+              for (j <- startingChar to endingChar) set.add(j)
+              i += 2
+              false
+            case (otherChar, _, _) =>
+              set.add(otherChar)
+              false
+          }
+
+        i += 1
+
+        if (!closedBracket && i >= length) throw new PatternSyntaxException("Missing ']'", pattern, i-1)
+
+        !closedBracket
+      }) ()
+
+      set.toSet
+    }
+
+    def parseGroups() = {
+      i += 1
+      def parseGroupElement() = {
+        val groupBuffer = mutable.ArrayBuffer[GlobSpecification]()
+        var toLeave = false
+        var toNext = false
+        while (!toLeave && !toNext) {
+          nextTwo() match {
+            case ('?', _) =>
+              groupBuffer.append(AnyChar)
+            case ('*', Some('*')) =>
+              groupBuffer.append(CrossingName)
+              i += 1
+            case ('*', _) =>
+              groupBuffer.append(NonCrossingName)
+            case ('[', Some('!')) =>
+              i += 1
+              groupBuffer.append(NegationBracket(parseBracketSet()))
+              i -= 1
+            case ('[', _) =>
+              groupBuffer.append(Bracket(parseBracketSet()))
+              i -= 1
+            case ('{', _) =>
+              throw new PatternSyntaxException(
+                s"Cannot nest groups",
+                pattern,
+                i
+              )
+            case ('}', _) =>
+              toLeave = true // TODO maybe return/reconsider
+            case (',', _) =>
+              toNext = true
+            case ('\\', Some(char)) =>
+              groupBuffer.append(GlobChar(char))
+              i += 1
+            case (char, _) =>
+              groupBuffer.append(GlobChar(char))
+          }
+
+          i += 1
+          if(i >= length && !toLeave) throw new PatternSyntaxException("Missing '}'", pattern, i)
+        }
+
+        (groupBuffer.toList, toLeave)
+      }
+
+      val buffer = mutable.ArrayBuffer[List[GlobSpecification]]()
+      var leaving = false // todo redo loop
+      while (i < length && !leaving) { // todo check incorrect todo redo loop
+        val (parsingList, toLeave) = parseGroupElement()
+        leaving = toLeave
+        buffer.append(parsingList)
+      }
+      Groups(buffer.toList)
+    }
+
+    while (i < length) {
+      nextTwo() match {
+        case ('?', _) =>
+          parsingList.append(AnyChar)
+        case ('{', _) =>
+          parsingList.append(parseGroups())
+          i -= 1
+        case ('*', Some('*')) =>
+          parsingList.append(CrossingName)
+          i += 1
+        case ('*', _) =>
+          parsingList.append(NonCrossingName)
+        case ('[', Some('!')) =>
+          i += 2
+          parsingList.append(NegationBracket(parseBracketSet()))
+          i -= 1
+        case ('[', _) =>
+          i += 1
+          parsingList.append(Bracket(parseBracketSet()))
+          i -= 1
+        case ('/', _) =>
+          parsingList.append(Divider)
+        case ('\\', Some(char)) =>
+          parsingList.append(GlobChar(char))
+          i += 1
+        case (char, _) =>
+          parsingList.append(GlobChar(char))
+      }
+
+      i += 1
+    }
+
+    // Parse to NFA(-like)
+    // @tailrec todo
+    def specListToGlobNodes(
+        specList: List[GlobSpecification],
+        next: GlobNode
+    ): GlobNode =
+      specList match {
+        case (head @ Groups(lists)) :: tail =>
+          val nextGroupNodes =
+            lists.map(list => specListToGlobNodes(list.reverse, next))
+          val newNext = GlobNode(head, nextGroupNodes, isFinal = false)
+          specListToGlobNodes(tail, newNext)
+        case head :: Nil => // TODO check if NIL is a list
+          val newNext = GlobNode(head, List(next), isFinal = false)
+          newNext
+        case head :: tail => // TODO reconsider where is specification parsed
+          val newNext = GlobNode(head, List(next), isFinal = false)
+          specListToGlobNodes(tail, newNext)
+        case Nil => next
+      }
+
+    val reversedSpecification = parsingList.toList.reverse
+    GlobNode(
+      null,
+      List(
+        specListToGlobNodes(
+          reversedSpecification,
+          GlobNode(null, Nil, isFinal = true)
+        )
+      ),
+      false
+    ) // todo rethink final
+  }
+}
+
+object GlobPattern {
+  def compile(pattern: String): GlobPattern = {
+    val a = new GlobPattern(pattern)
+    a.globSpecification
+    a
+  }
+}

--- a/javalib/src/main/scala/java/nio/file/glob/GlobPattern.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobPattern.scala
@@ -87,10 +87,10 @@ class GlobPattern(pattern: String) {
               groupBuffer.append(AnyChar)
               i += 1
             case ('*', Some('*')) =>
-              groupBuffer.append(DoubleStar)
+              groupBuffer.append(DoubleAsterisk)
               i += 2
             case ('*', _) =>
-              groupBuffer.append(Star)
+              groupBuffer.append(Asterisk)
               i += 1
             case ('[', Some('!')) =>
               i += 1
@@ -143,10 +143,10 @@ class GlobPattern(pattern: String) {
           i += 1
           parsingList.append(parseGroups())
         case ('*', Some('*')) =>
-          parsingList.append(DoubleStar)
+          parsingList.append(DoubleAsterisk)
           i += 2
         case ('*', _) =>
-          parsingList.append(Star)
+          parsingList.append(Asterisk)
           i += 1
         case ('[', Some('!')) =>
           i += 2
@@ -155,7 +155,7 @@ class GlobPattern(pattern: String) {
           i += 1
           parsingList.append(Bracket(parseBracketSet()))
         case ('/', _) =>
-          parsingList.append(Divider)
+          parsingList.append(Separator)
           i += 1
         case ('\\', Some(char)) =>
           parsingList.append(GlobChar(char))
@@ -168,9 +168,9 @@ class GlobPattern(pattern: String) {
 
     def charsTaken(spec: GlobSpecification): (Int, Int) =
       spec match {
-        case Divider                                                 => (1, 1)
+        case Separator                                               => (1, 1)
         case AnyChar | GlobChar(_) | Bracket(_) | NegationBracket(_) => (1, 0)
-        case Groups(_) | Star | DoubleStar                           => (0, 0)
+        case Groups(_) | Asterisk | DoubleAsterisk                   => (0, 0)
       }
 
     def specListToGlobNodes(
@@ -181,17 +181,17 @@ class GlobPattern(pattern: String) {
         case (head @ Groups(lists)) :: tail =>
           val nextGroupNodes =
             lists.map(list => specListToGlobNodes(list.reverse, next))
-          val minChars = nextGroupNodes.minBy(_.minDivsLeft).minDivsLeft
-          val minDivs = nextGroupNodes.minBy(_.minCharsLeft).minCharsLeft
-          val newNext = TransitionNode(head, nextGroupNodes, minChars, minDivs)
+          val minChars = nextGroupNodes.minBy(_.minSepsLeft).minSepsLeft
+          val minSeps = nextGroupNodes.minBy(_.minCharsLeft).minCharsLeft
+          val newNext = TransitionNode(head, nextGroupNodes, minChars, minSeps)
           specListToGlobNodes(tail, newNext)
         case head :: tail =>
-          val (chars, divs) = charsTaken(head)
+          val (chars, seps) = charsTaken(head)
           val newNext = TransitionNode(
             head,
             List(next),
             next.minCharsLeft + chars,
-            next.minDivsLeft + divs
+            next.minSepsLeft + seps
           )
           specListToGlobNodes(tail, newNext)
         case Nil => next

--- a/javalib/src/main/scala/java/nio/file/glob/GlobSpecification.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobSpecification.scala
@@ -1,13 +1,14 @@
 package java.nio.file.glob
 
-trait GlobSpecification
-case class GlobChar(c: Char) extends GlobSpecification // char
-case object AnyChar extends GlobSpecification // `?`
-case object NonCrossingName extends GlobSpecification // `*`
-case object CrossingName extends GlobSpecification // `**`
-case object Divider extends GlobSpecification // `/`
-case class NegationBracket(excluded: Set[Char])
+private[glob] sealed trait GlobSpecification
+private[glob] case class GlobChar(c: Char) extends GlobSpecification // char
+private[glob] case object AnyChar extends GlobSpecification // `?`
+private[glob] case object Star extends GlobSpecification // `*`
+private[glob] case object DoubleStar extends GlobSpecification // `**`
+private[glob] case object Divider extends GlobSpecification // `/`
+private[glob] case class NegationBracket(excluded: Set[Char])
     extends GlobSpecification // `[!(...)]`
-case class Bracket(included: Set[Char]) extends GlobSpecification // `[(...)]`
-case class Groups(elements: List[List[GlobSpecification]])
-    extends GlobSpecification // requires optimization // `{(...)}`
+private[glob] case class Bracket(included: Set[Char])
+    extends GlobSpecification // `[(...)]`
+private[glob] case class Groups(elements: List[List[GlobSpecification]])
+    extends GlobSpecification // `{(...)}`

--- a/javalib/src/main/scala/java/nio/file/glob/GlobSpecification.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobSpecification.scala
@@ -1,0 +1,13 @@
+package java.nio.file.glob
+
+trait GlobSpecification
+case class GlobChar(c: Char) extends GlobSpecification // char
+case object AnyChar extends GlobSpecification // `?`
+case object NonCrossingName extends GlobSpecification // `*`
+case object CrossingName extends GlobSpecification // `**`
+case object Divider extends GlobSpecification // `/`
+case class NegationBracket(excluded: Set[Char])
+    extends GlobSpecification // `[!(...)]`
+case class Bracket(included: Set[Char]) extends GlobSpecification // `[(...)]`
+case class Groups(elements: List[List[GlobSpecification]])
+    extends GlobSpecification // requires optimization // `{(...)}`

--- a/javalib/src/main/scala/java/nio/file/glob/GlobSpecification.scala
+++ b/javalib/src/main/scala/java/nio/file/glob/GlobSpecification.scala
@@ -3,9 +3,9 @@ package java.nio.file.glob
 private[glob] sealed trait GlobSpecification
 private[glob] case class GlobChar(c: Char) extends GlobSpecification // char
 private[glob] case object AnyChar extends GlobSpecification // `?`
-private[glob] case object Star extends GlobSpecification // `*`
-private[glob] case object DoubleStar extends GlobSpecification // `**`
-private[glob] case object Divider extends GlobSpecification // `/`
+private[glob] case object Asterisk extends GlobSpecification // `*`
+private[glob] case object DoubleAsterisk extends GlobSpecification // `**`
+private[glob] case object Separator extends GlobSpecification // `/`
 private[glob] case class NegationBracket(excluded: Set[Char])
     extends GlobSpecification // `[!(...)]`
 private[glob] case class Bracket(included: Set[Char])

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/PathMatcherGlobTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/PathMatcherGlobTest.scala
@@ -121,9 +121,8 @@ class PathMatcherGlobTest {
     fail("b{an,ana,nana}", "ba")
     fail("b{an,ana,nana}", "nan")
   }
-  // TODO what if space
-  @Test def incorrectPattern(): Unit = {
 
+  @Test def incorrectPattern(): Unit = {
     throws("{ba,{na{na}},{na}}", "nested groups")
 
     throws("[c-a]", "incorrect class definition")
@@ -167,7 +166,7 @@ class PathMatcherGlobTest {
     pass("**/*", "a/b")
     pass("**/*", "a/b/c")
     fail("**/*", "ab")
-    // fail("**/*", "") TODO fix
+    fail("**/*", "")
 
     pass("**??/*", "a/aa/a")
     pass("**??/*", "aa/a")
@@ -184,8 +183,8 @@ class PathMatcherGlobTest {
     fail("**/????*/*.ext", "/dir/file.ext")
     fail("**/????*/*.ext", "/dir/file.ext")
 
-    fail("**/{*ab*,*ba*}/", "dir/0ab0/") // why
-    fail("**/{*ab*,*ba*}/", "dir/ba/") // why
+    fail("**/{*ab*,*ba*}/", "dir/0ab0/")
+    fail("**/{*ab*,*ba*}/", "dir/ba/")
     fail("**/{*ab*,*ba*}/", "dir/0a0b0/")
 
     // Standard examples
@@ -195,6 +194,11 @@ class PathMatcherGlobTest {
     fail("**/*/*{.zip,.gz}", "dir/dir2/file.ext")
   }
 
-  // TODO test windows things
+  @Test def emptyGlob(): Unit = {
+    pass("", "")
+    fail("", "a")
+    fail("a", "")
+    pass("*", "")
+  }
 
 }

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/PathMatcherGlobTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/PathMatcherGlobTest.scala
@@ -4,6 +4,7 @@ import java.nio.file._
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import java.util.regex.PatternSyntaxException
 
@@ -13,33 +14,31 @@ import org.scalanative.testsuite.utils.Platform.isWindows
 class PathMatcherGlobTest {
 
   @inline def pass(glob: String, path: String, onWindows: Boolean = true) = {
-    if (isWindows && !onWindows) {
-      // incompatible on windows
-      println("Skipping pass($glob, $path) on Windows")
-    } else {
-      val pattern = s"glob:$glob"
-      val matched = Paths.get(path)
-      val matcher = FileSystems.getDefault().getPathMatcher(pattern)
-      assertTrue(
-        s"glob: $glob, path: $path should be matched",
-        matcher.matches(matched)
-      )
-    }
+    assumeFalse(
+      s"Skipping pass($glob, $path) on Windows",
+      isWindows && !onWindows
+    )
+    val pattern = s"glob:$glob"
+    val matched = Paths.get(path)
+    val matcher = FileSystems.getDefault().getPathMatcher(pattern)
+    assertTrue(
+      s"glob: $glob, path: $path should be matched",
+      matcher.matches(matched)
+    )
   }
 
   @inline def fail(glob: String, path: String, onWindows: Boolean = true) = {
-    if (isWindows && !onWindows) {
-      // incompatible on windows
-      println("Skipping pass($glob, $path) on Windows")
-    } else {
-      val pattern = s"glob:$glob"
-      val matched = Paths.get(path)
-      val matcher = FileSystems.getDefault().getPathMatcher(pattern)
-      assertFalse(
-        s"glob: $glob, path: $path should not be matched",
-        matcher.matches(matched)
-      )
-    }
+    assumeFalse(
+      s"Skipping fail($glob, $path) on Windows",
+      isWindows && !onWindows
+    )
+    val pattern = s"glob:$glob"
+    val matched = Paths.get(path)
+    val matcher = FileSystems.getDefault().getPathMatcher(pattern)
+    assertFalse(
+      s"glob: $glob, path: $path should not be matched",
+      matcher.matches(matched)
+    )
   }
 
   @inline def throws[T <: Throwable](glob: String, message: String) = {
@@ -147,7 +146,7 @@ class PathMatcherGlobTest {
     fail("*.?", "any.")
   }
 
-  @Test def correctMatchingOfStar(): Unit = {
+  @Test def correctMatchingOfAsterisk(): Unit = {
     pass("*.ext", "banana.ext")
     pass("*.ext", ".ext")
     fail("*.ext", "/banana.ext")
@@ -160,7 +159,7 @@ class PathMatcherGlobTest {
     fail("*/*", "banana/")
   }
 
-  @Test def correctMatchingOfDoubleStar(): Unit = {
+  @Test def correctMatchingOfDoubleAsterisk(): Unit = {
     pass("**/*", "/a")
     fail("**/*", "a/")
     pass("**/*", "a/b")

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/PathMatcherGlobTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/PathMatcherGlobTest.scala
@@ -1,0 +1,189 @@
+package javalib.nio.file
+
+import java.nio.file._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.util.regex.PatternSyntaxException
+
+import scalanative.junit.utils.AssertThrows.assertThrows
+
+class PathMatcherGlobTest {
+
+  @inline def pass(glob: String, path: String) = {
+    // println(glob + " " + path)
+    val pattern = s"glob:$glob"
+    val matched = Paths.get(path)
+    val matcher = FileSystems.getDefault().getPathMatcher(pattern)
+    assertTrue(
+      s"glob: $glob, path: $path should be matched", 
+      matcher.matches(matched)
+    )
+  }
+
+  @inline def fail(glob: String, path: String) = {
+    // println(glob + " " + path)
+    val pattern    = s"glob:$glob"
+    val matched    = Paths.get(path)
+    val matcher = FileSystems.getDefault().getPathMatcher(pattern)
+    assertFalse(
+      s"glob: $glob, path: $path should not be matched",
+      matcher.matches(matched)
+    )
+  }
+
+  @inline def throws[T <: Throwable](glob: String, message: String) = {
+    val pattern = s"glob:$glob"
+    assertThrows(message, classOf[PatternSyntaxException], FileSystems.getDefault().getPathMatcher(pattern))
+  }
+
+  @Test def correctMatcherOfClass(): Unit = {
+    pass("ab[c-c].ext", "abc.ext")
+    fail("ab[c-c].ext", "abd.ext")
+    pass("ab[c-d].ext", "abd.ext")
+    fail("ab[c-d].ext", "abb.ext")
+    pass("ab[c-e].ext", "abe.ext")
+    fail("ab[c-e].ext", "abf.ext")
+    
+    pass("[a-c].ext", "b.ext")
+    fail("[a-c].ext", ".ext")
+
+    pass("prefix[a-c]", "prefixb")
+    fail("prefix[a-c]", "prefix")
+    fail("prefix[a-c]", "prefixd")
+
+    // mixed
+    pass("[abf-i]", "a")
+    pass("[abf-i]", "b")
+    pass("[abf-i]", "f")
+    pass("[abf-i]", "h")
+    pass("[abf-i]", "i")
+    pass("[abf-i]", "a")
+
+    // special characters
+    pass("a[-]b", "a-b")
+    fail("a[-]b", "ab")
+
+    pass("a[-a]b", "a-b")
+    pass("a[a-]b", "a-b")
+
+    pass("a[\\]b", "a\\b")
+    fail("a[\\]b", "ab")
+
+    pass("a[?]b", "a?b")
+    fail("a[?]b", "ab")
+
+    pass("a[*]b", "a*b")
+    fail("a[*]b", "ab")
+  }
+
+  @Test def correctMatcherOfExclusionClass(): Unit = {
+    pass("ab[!d].ext", "abe.ext")
+    fail("ab[!d].ext", "abd.ext")
+  }
+
+  @Test def correctMatcherOfGroups(): Unit = {
+    // prefix group
+    pass("{ba,na}na", "bana")
+    pass("{ba,na}na", "nana")
+    fail("{ba,na}na", "na")
+    fail("{ba,na}na", "ba")
+
+    // infix, differing length 
+    pass("b{ana,n}a", "banaa")
+    pass("b{ana,n}a", "bna")
+    fail("b{ana,n}a", "banana")
+    
+    // infix, with empty
+    pass("ba{na,}na", "bana")
+    pass("ba{na,}na", "banana")
+    fail("ba{na,}na", "ba")
+    fail("ba{na,}na", "na")
+
+    // suffix
+    pass("b{an,ana,nana}", "ban")
+    pass("b{an,ana,nana}", "bana")
+    pass("b{an,ana,nana}", "bnana")
+    fail("b{an,ana,nana}", "ba")
+    fail("b{an,ana,nana}", "nan")
+  }
+ // TODO what if space
+  @Test def incorrectPattern(): Unit = {
+
+    throws("{ba,{na{na}},{na}}", "nested groups")
+
+    throws("[c-a]", "incorrect class definition")
+
+    throws("a[b", "class does not end")
+
+    throws("a[!b", "exclusion class does not end")
+    
+    throws("a{b,c", "group does not end")
+  }
+
+  @Test def correctMatchingOfQuestionMark(): Unit = {
+    pass("?.ext", "a.ext")
+    fail("?.ext", "/.ext")
+    fail("?.ext", ".ext")
+
+    pass("??.ext", "ba.ext")
+    fail("??.ext", ".ext")
+
+    pass("*.?", "any.c")
+    pass("*.?", ".c")
+    fail("*.?", "any.")
+  }
+
+  @Test def correctMatchingOfStar(): Unit = {
+    pass("*.ext", "banana.ext")
+    pass("*.ext", ".ext")
+    fail("*.ext", "/banana.ext")
+    fail("*.ext", "/.ext")
+
+    pass("*/*", "bana/na")
+    pass("*/*", "/banana")
+    fail("*/*", "banana/")
+    fail("*/*", "ba/na/na")
+    fail("*/*", "banana/")
+  }
+
+  @Test def correctMatchingOfDoubleStar(): Unit = {
+    pass("**/*", "/a")
+    fail("**/*", "a/")
+    pass("**/*", "a/b")
+    pass("**/*", "a/b/c")
+    fail("**/*", "ab")
+    // fail("**/*", "") TODO fix
+
+    pass("**??/*", "a/aa/a")
+    pass("**??/*", "aa/a")
+    pass("**??/*", "a/aa/a")
+    pass("**??/*", "aa/a")
+    fail("**??/*", "aa/")
+    fail("**??/*", "a/a")
+    fail("**??/*", "a/a/a")
+  }
+
+  @Test def allConstructs(): Unit = {
+    pass("**/*/*.ext", "/file/file.ext")
+    pass("**/????*/*.ext", "/file/file.ext")
+    fail("**/????*/*.ext", "/dir/file.ext")
+    fail("**/????*/*.ext", "/dir/file.ext")
+
+    fail("**/{*ab*,*ba*}/", "dir/0ab0/") // why
+    fail("**/{*ab*,*ba*}/", "dir/ba/") // why
+    fail("**/{*ab*,*ba*}/", "dir/0a0b0/")
+
+    // Standard examples
+    pass("**/*/*{.zip,.gz}", "dir/dir2/file.zip")
+    pass("**/*/*{.zip,.gz}", "dir/dir2/file.gz")
+    fail("**/*/*{.zip,.gz}", "dir2/file.gz")
+    fail("**/*/*{.zip,.gz}", "dir/dir2/file.ext")
+
+  }
+
+
+  // TODO test windows things
+
+}

--- a/unit-tests/shared/src/test/scala/utils/AssertThrows.scala
+++ b/unit-tests/shared/src/test/scala/utils/AssertThrows.scala
@@ -27,4 +27,18 @@ object AssertThrows {
       }
     )
   }
+
+  def assertThrows[T <: Throwable, U](
+      message: String,
+      expectedThrowable: Class[T],
+      code: => U
+  ): T = {
+    Assert.assertThrows(
+      message,
+      expectedThrowable,
+      new ThrowingRunnable {
+        def run(): Unit = code
+      }
+    )
+  }
 }


### PR DESCRIPTION
Implements FileSystems.getDefault().getPathMatcher(pattern), with pattern of type "glob:...".

Instead of translating to regex, Glob matching was implemented from scratch. This is for multiple reasons - for one I believe it will be easier to understand and maintain, than doing a character based translation to regex. Additionally glob exclusive optimizations could be introduced - here we count characters and dividers (‚/’) left, more easily filtering out the states when we know we will not be able to fulfill globs.

We start by compiling glob pattern:
1. We translate to a list of syntax tokens, throwing regex.PatternSyntaxException if necessary.
2. We create NFA, with the additional information about minimum characters and dividers necessary in every state.

To match we simply travel the resulting NFA one character at a time, keeping a list of possible reachable states for path’s substring ending with that character.

A number of unit-tests has also been added.