### PR TITLE
Port `java.util.BitSet`

### DIFF
--- a/javalib/src/main/scala/java/util/BitSet.scala
+++ b/javalib/src/main/scala/java/util/BitSet.scala
@@ -1,6 +1,6 @@
-package java.util
+// Ported from Scala.js commit: c0be6b6 dated: 2021-12-22
 
-// Ported from Scala.js
+package java.util
 
 import java.io.Serializable
 import java.lang.Long.bitCount

--- a/javalib/src/main/scala/java/util/BitSet.scala
+++ b/javalib/src/main/scala/java/util/BitSet.scala
@@ -52,7 +52,9 @@ private object BitSet {
   }
 }
 
-class BitSet private (private var bits: Array[Long]) extends Serializable with Cloneable {
+class BitSet private (private var bits: Array[Long])
+    extends Serializable
+    with Cloneable {
   import BitSet.{AddressBitsPerWord, ElementSize, RightBits}
 
   def this(nbits: Int) = {
@@ -453,7 +455,9 @@ class BitSet private (private var bits: Array[Long]) extends Serializable with C
     if (len == 0)
       0
     else
-      (len << AddressBitsPerWord) - java.lang.Long.numberOfLeadingZeros(bits(len - 1))
+      (len << AddressBitsPerWord) - java.lang.Long.numberOfLeadingZeros(
+        bits(len - 1)
+      )
   }
 
   def isEmpty(): Boolean = getActualArrayLength() == 0
@@ -576,9 +580,8 @@ class BitSet private (private var bits: Array[Long]) extends Serializable with C
 
   def size(): Int = bits.length << AddressBitsPerWord
 
-  /**
-   * If one of the BitSets is larger than the other, check to see if
-   * any of its extra bits are set. If so return false.
+  /** If one of the BitSets is larger than the other, check to see if any of its
+   *  extra bits are set. If so return false.
    */
   private def equalsImpl(other: BitSet): Boolean = {
     // scalastyle:off return
@@ -614,7 +617,7 @@ class BitSet private (private var bits: Array[Long]) extends Serializable with C
   override def equals(obj: Any): Boolean = {
     obj match {
       case bs: BitSet => equalsImpl(bs)
-      case _ => false
+      case _          => false
     }
   }
 
@@ -663,7 +666,9 @@ class BitSet private (private var bits: Array[Long]) extends Serializable with C
       throw new IndexOutOfBoundsException(s"toIndex < 0: $toIndex")
 
     if (toIndex < fromIndex)
-      throw new IndexOutOfBoundsException(s"fromIndex: $fromIndex > toIndex: $toIndex")
+      throw new IndexOutOfBoundsException(
+        s"fromIndex: $fromIndex > toIndex: $toIndex"
+      )
   }
 
   private def checkFromIndex(fromIndex: Int): Unit = {

--- a/javalib/src/main/scala/java/util/BitSet.scala
+++ b/javalib/src/main/scala/java/util/BitSet.scala
@@ -1,0 +1,678 @@
+package java.util
+
+// Ported from Scala.js
+
+import java.io.Serializable
+import java.lang.Long.bitCount
+import java.lang.Integer.toUnsignedLong
+import java.nio.{ByteBuffer, LongBuffer}
+import java.util
+
+private object BitSet {
+  private final val AddressBitsPerWord = 6 // Int Based 2^6 = 64
+  private final val ElementSize = 1 << AddressBitsPerWord
+  private final val RightBits = ElementSize - 1
+
+  def valueOf(longs: Array[Long]): util.BitSet = {
+    val bs = new util.BitSet
+
+    for (i <- 0 until longs.length * 64) {
+      val idx = i / 64
+      if ((longs(idx) & (1L << (i % 64))) != 0)
+        bs.set(i)
+    }
+
+    bs
+  }
+
+  def valueOf(lb: LongBuffer): BitSet = {
+    val arr = new Array[Long](lb.remaining())
+    lb.get(arr)
+    lb.position(lb.position() - arr.length) // Restores the buffer position
+    valueOf(arr)
+  }
+
+  def valueOf(bytes: Array[Byte]): BitSet = {
+    val bs = new BitSet
+
+    for (i <- 0 until bytes.length * 8) {
+      val idx = i / 8
+      if ((bytes(idx) & (1 << (i % 8))) != 0)
+        bs.set(i)
+    }
+
+    bs
+  }
+
+  def valueOf(bb: ByteBuffer): BitSet = {
+    val arr = new Array[Byte](bb.remaining())
+    bb.get(arr)
+    bb.position(bb.position() - arr.length) // Restores the buffer position
+    valueOf(arr)
+  }
+}
+
+class BitSet private (private var bits: Array[Long]) extends Serializable with Cloneable {
+  import BitSet.{AddressBitsPerWord, ElementSize, RightBits}
+
+  def this(nbits: Int) = {
+    this(
+      bits = {
+        if (nbits < 0)
+          throw new NegativeArraySizeException
+
+        val length = (nbits + BitSet.RightBits) >> BitSet.AddressBitsPerWord
+
+        new Array[Long](length)
+      }
+    )
+  }
+
+  def this() = {
+    this(64)
+  }
+
+  def toByteArray(): Array[Byte] = {
+    if (isEmpty()) {
+      new Array[Byte](0)
+    } else {
+      val l = (length() + 7) / 8
+      val array = new Array[Byte](l)
+
+      for (i <- 0 until length()) {
+        if (get(i))
+          array(i / 8) = (array(i / 8) | (1 << (i % 8))).toByte
+      }
+
+      array
+    }
+  }
+
+  def toLongArray(): Array[Long] = {
+    if (isEmpty()) {
+      new Array[Long](0)
+    } else {
+      val l = (length() + 63) / 64
+      val array = new Array[Long](l)
+
+      for (i <- 0 until length()) {
+        if (get(i))
+          array(i / 64) |= 1L << (i % 64)
+      }
+
+      array
+    }
+  }
+
+  def flip(bitIndex: Int): Unit = {
+    checkBitIndex(bitIndex)
+
+    val len = (bitIndex >> AddressBitsPerWord) + 1
+    ensureLength(len)
+
+    bits(len - 1) ^= 1L << (bitIndex & RightBits)
+  }
+
+  def flip(fromIndex: Int, toIndex: Int): Unit = {
+    checkToAndFromIndex(fromIndex, toIndex)
+
+    if (fromIndex != toIndex) {
+      val len2 = ((toIndex - 1) >> AddressBitsPerWord) + 1
+      ensureLength(len2)
+      val idx1 = fromIndex >> AddressBitsPerWord
+      val idx2 = (toIndex - 1) >> AddressBitsPerWord
+      val mask1 = (~0L) << (fromIndex & RightBits)
+      val mask2 = (~0L) >>> (ElementSize - (toIndex & RightBits))
+
+      if (idx1 == idx2) {
+        bits(idx1) ^= (mask1 & mask2)
+      } else {
+        bits(idx1) ^= mask1
+        bits(idx2) ^= mask2
+        for (i <- idx1 + 1 until idx2)
+          bits(i) ^= (~0L)
+      }
+    }
+  }
+
+  def set(bitIndex: Int): Unit = {
+    checkBitIndex(bitIndex)
+
+    val len = (bitIndex >> AddressBitsPerWord) + 1
+    ensureLength(len)
+
+    bits(len - 1) |= 1L << (bitIndex & RightBits)
+  }
+
+  def set(bitIndex: Int, value: Boolean): Unit =
+    if (value) set(bitIndex)
+    else clear(bitIndex)
+
+  // fromIndex is inclusive, toIndex is exclusive
+  def set(fromIndex: Int, toIndex: Int): Unit = {
+    checkToAndFromIndex(fromIndex, toIndex)
+
+    if (fromIndex != toIndex) {
+      val len2 = ((toIndex - 1) >> AddressBitsPerWord) + 1
+      ensureLength(len2)
+
+      val idx1 = fromIndex >> AddressBitsPerWord
+      val idx2 = (toIndex - 1) >> AddressBitsPerWord
+      val mask1 = (~0L) << (fromIndex & RightBits)
+      val mask2 = (~0L) >>> (ElementSize - (toIndex & RightBits))
+
+      if (idx1 == idx2) {
+        bits(idx1) |= (mask1 & mask2)
+      } else {
+        bits(idx1) |= mask1
+        bits(idx2) |= mask2
+
+        for (i <- idx1 + 1 until idx2)
+          bits(i) |= (~0)
+      }
+    }
+  }
+
+  def set(fromIndex: Int, toIndex: Int, value: Boolean): Unit =
+    if (value) set(fromIndex, toIndex)
+    else clear(fromIndex, toIndex)
+
+  def clear(bitIndex: Int): Unit = {
+    checkBitIndex(bitIndex)
+
+    val arrayPos = bitIndex >> AddressBitsPerWord
+
+    if (arrayPos < bits.length) {
+      bits(arrayPos) &= ~(1L << (bitIndex & RightBits))
+    }
+  }
+
+  def clear(fromIndex: Int, toIndex: Int): Unit = {
+    checkToAndFromIndex(fromIndex, toIndex)
+
+    val last = bits.length << AddressBitsPerWord
+    if (fromIndex >= last || fromIndex == toIndex)
+      return // scalastyle:ignore
+
+    val toIndexOrLast =
+      if (toIndex > last) last
+      else toIndex
+
+    val idx1 = fromIndex >> AddressBitsPerWord
+    val idx2 = (toIndexOrLast - 1) >> AddressBitsPerWord
+    val mask1 = (~0L) << (fromIndex & RightBits)
+    val mask2 = (~0L) >>> (ElementSize - (toIndexOrLast & RightBits))
+
+    if (idx1 == idx2) {
+      bits(idx1) &= ~(mask1 & mask2)
+    } else {
+      bits(idx1) &= ~mask1
+      bits(idx2) &= ~mask2
+
+      for (i <- idx1 + 1 until idx2)
+        bits(i) = 0
+    }
+  }
+
+  def clear(): Unit = {
+    for (i <- 0 until bits.length)
+      bits(i) = 0
+  }
+
+  def get(bitIndex: Int): Boolean = {
+    checkBitIndex(bitIndex)
+
+    val arrayPos = bitIndex >> AddressBitsPerWord
+
+    if (arrayPos < bits.length)
+      (bits(arrayPos) & (1L << (bitIndex & RightBits))) != 0
+    else
+      false
+  }
+
+  def get(fromIndex: Int, toIndex: Int): BitSet = {
+    // scalastyle:off return
+    checkToAndFromIndex(fromIndex, toIndex)
+
+    val last = bits.length << AddressBitsPerWord
+    if (fromIndex >= last || fromIndex == toIndex)
+      return new BitSet(0)
+
+    val toIndexOrLast =
+      if (toIndex > last) last
+      else toIndex
+
+    val idx1 = fromIndex >> AddressBitsPerWord
+    val idx2 = (toIndexOrLast - 1) >> AddressBitsPerWord
+    val mask1 = (~0L) << (fromIndex & RightBits)
+    val mask2 = (~0L) >>> (ElementSize - (toIndexOrLast & RightBits))
+
+    if (idx1 == idx2) {
+      val result = (bits(idx1) & (mask1 & mask2)) >>> (fromIndex % ElementSize)
+      if (result == 0)
+        return new BitSet(0)
+
+      new BitSet(Array[Long](result))
+    } else {
+      val newbits = new Array[Long](idx2 - idx1 + 1)
+      // first fill in the first and last indexes in the new bitset
+      newbits(0) = bits(idx1) & mask1
+      newbits(newbits.length - 1) = bits(idx2) & mask2
+      // fill in the in between elements of the new bitset
+      for (i <- 1 until idx2 - idx1)
+        newbits(i) = bits(idx1 + i)
+
+      val numBitsToShift = fromIndex & RightBits
+
+      if (numBitsToShift != 0) {
+        for (i <- 0 until newbits.length) {
+          // shift the current element to the right
+          newbits(i) = newbits(i) >>> numBitsToShift
+          // apply the last x bits of newbits[i+1] to the current
+          // element
+          if (i != newbits.length - 1)
+            newbits(i) |= newbits(i + 1) << (ElementSize - numBitsToShift)
+        }
+      }
+
+      new BitSet(newbits)
+    }
+    // scalastyle:on return
+  }
+
+  def nextSetBit(fromIndex: Int): Int = {
+    // scalastyle:off return
+    checkFromIndex(fromIndex)
+
+    if (fromIndex >= (bits.length << AddressBitsPerWord))
+      return -1
+
+    var idx = fromIndex >> AddressBitsPerWord
+
+    // first check in the same bit set element
+    if (bits(idx) != 0) {
+      var j = fromIndex & RightBits
+      while (j < ElementSize) {
+        if ((bits(idx) & (1L << j)) != 0)
+          return (idx << AddressBitsPerWord) + j
+        j += 1
+      }
+    }
+
+    idx += 1
+
+    while (idx < bits.length && bits(idx) == 0)
+      idx += 1
+
+    if (idx == bits.length)
+      return -1
+
+    // we know for sure there is a bit set to true in this element
+    // since the bitset value is not 0
+    var j = 0
+    while (j < ElementSize) {
+      if ((bits(idx) & (1L << j)) != 0)
+        return (idx << AddressBitsPerWord) + j
+      j += 1
+    }
+
+    -1
+    // scalastyle:on return
+  }
+
+  def nextClearBit(fromIndex: Int): Int = {
+    // scalastyle:off return
+    checkFromIndex(fromIndex)
+
+    val length = bits.length
+    val bssize = length << AddressBitsPerWord
+
+    if (fromIndex >= bssize)
+      return fromIndex
+
+    var idx = fromIndex >> AddressBitsPerWord
+
+    if (bits(idx) != (~0L)) {
+      var j = fromIndex % ElementSize
+      while (j < ElementSize) {
+        if ((bits(idx) & (1L << j)) == 0)
+          return idx * ElementSize + j
+        j += 1
+      }
+    }
+
+    idx += 1
+
+    while (idx < length && bits(idx) == (~0L))
+      idx += 1
+
+    if (idx == length)
+      return bssize
+
+    var j = 0
+    while (j < ElementSize) {
+      if ((bits(idx) & (1L << j)) == 0)
+        return (idx << AddressBitsPerWord) + j
+      j += 1
+    }
+
+    bssize
+    // scalastyle:on return
+  }
+
+  def previousSetBit(fromIndex: Int): Int = {
+    // scalastyle:off return
+    if (fromIndex == -1)
+      return -1
+
+    checkFromIndex(fromIndex)
+
+    val bssize = bits.length << AddressBitsPerWord
+    var idx = Math.min(bits.length - 1, fromIndex >> AddressBitsPerWord)
+
+    if (bits(idx) != 0) {
+      if (idx == bssize)
+        return idx
+
+      var j: Int = fromIndex % ElementSize
+      while (j >= 0) {
+        if ((bits(idx) & (1L << j)) != 0)
+          return idx * ElementSize + j
+
+        j -= 1
+      }
+    }
+
+    idx -= 1
+
+    while (idx >= 0 && bits(idx) == 0)
+      idx -= 1
+
+    if (idx == -1)
+      return -1
+
+    var j: Int = ElementSize - 1
+    while (j >= 0) {
+      if ((bits(idx) & (1L << j)) != 0)
+        return (idx << AddressBitsPerWord) + j
+
+      j -= 1
+    }
+
+    bssize
+    // scalastyle:on return
+  }
+
+  def previousClearBit(fromIndex: Int): Int = {
+    // scalastyle:off return
+    if (fromIndex == -1)
+      return -1
+
+    checkFromIndex(fromIndex)
+
+    val length = bits.length
+    val bssize = length << AddressBitsPerWord
+
+    if (fromIndex >= bssize)
+      return fromIndex
+
+    var idx = Math.min(bits.length - 1, fromIndex >> AddressBitsPerWord)
+
+    if (bits(idx) != (~0)) {
+      var j: Int = fromIndex % ElementSize
+      while (j >= 0) {
+        if ((bits(idx) & (1L << j)) == 0)
+          return idx * ElementSize + j
+
+        j -= 1
+      }
+    }
+
+    idx -= 1
+
+    while (idx >= 0 && bits(idx) == (~0))
+      idx -= 1
+
+    if (idx == -1)
+      return -1
+
+    var j: Int = ElementSize - 1
+    while (j >= 0) {
+      if ((bits(idx) & (1L << j)) == 0)
+        return (idx << AddressBitsPerWord) + j
+
+      j -= 1
+    }
+
+    bssize
+    // scalastyle:on return
+  }
+
+  def length(): Int = {
+    val len = getActualArrayLength()
+    if (len == 0)
+      0
+    else
+      (len << AddressBitsPerWord) - java.lang.Long.numberOfLeadingZeros(bits(len - 1))
+  }
+
+  def isEmpty(): Boolean = getActualArrayLength() == 0
+
+  def intersects(set: BitSet): Boolean = {
+    // scalastyle:off return
+    val bsBits = set.bits
+    val length1 = bits.length
+    val length2 = set.bits.length
+
+    if (length1 <= length2) {
+      var i: Int = 0
+      while (i < length1) {
+        if ((bits(i) & bsBits(i)) != 0)
+          return true
+
+        i += 1
+      }
+    } else {
+      var i: Int = 0
+      while (i < length2) {
+        if ((bits(i) & bsBits(i)) != 0)
+          return true
+
+        i += 1
+      }
+    }
+
+    false
+    // scalastyle:on return
+  }
+
+  def cardinality(): Int = {
+    var count = 0
+
+    val length = getActualArrayLength()
+
+    for (idx <- 0 until length) {
+      count += bitCount(bits(idx))
+    }
+
+    count
+  }
+
+  def and(set: BitSet): Unit = {
+    val bsBits = set.bits
+    val length1 = bits.length
+    val length2 = set.bits.length
+
+    if (length1 <= length2) {
+      for (i <- 0 until length1)
+        bits(i) &= bsBits(i)
+    } else {
+      for (i <- 0 until length2)
+        bits(i) &= bsBits(i)
+
+      for (i <- length2 until length1)
+        bits(i) = 0
+    }
+  }
+
+  def or(set: BitSet): Unit = {
+    val bsActualLen = set.getActualArrayLength()
+
+    if (bsActualLen > bits.length) {
+      val tempBits = Arrays.copyOf(set.bits, bsActualLen)
+
+      for (i <- 0 until bits.length)
+        tempBits(i) |= bits(i)
+
+      bits = tempBits
+    } else {
+      val bsBits = set.bits
+
+      for (i <- 0 until bsActualLen)
+        bits(i) |= bsBits(i)
+    }
+  }
+
+  def xor(set: BitSet): Unit = {
+    val bsActualLen = set.getActualArrayLength()
+
+    if (bsActualLen > bits.length) {
+      val tempBits = Arrays.copyOf(set.bits, bsActualLen)
+
+      for (i <- 0 until bits.length)
+        tempBits(i) ^= bits(i)
+
+      bits = tempBits
+    } else {
+      val bsBits = set.bits
+
+      for (i <- 0 until bsActualLen)
+        bits(i) ^= bsBits(i)
+    }
+  }
+
+  def andNot(set: BitSet): Unit = {
+    if (bits.length != 0) {
+      val bsBits = set.bits
+
+      val minLength = Math.min(bits.length, set.bits.length)
+
+      for (i <- 0 until minLength)
+        bits(i) &= ~bsBits(i)
+    }
+  }
+
+  override def hashCode(): Int = {
+    var x: Long = 1234L
+    var i: Int = 0
+
+    while (i < bits.length) {
+      x ^= bits(i) * (i + 1)
+      i += 1
+    }
+
+    ((x >> 32) ^ x).toInt
+  }
+
+  def size(): Int = bits.length << AddressBitsPerWord
+
+  /**
+   * If one of the BitSets is larger than the other, check to see if
+   * any of its extra bits are set. If so return false.
+   */
+  private def equalsImpl(other: BitSet): Boolean = {
+    // scalastyle:off return
+    val length1 = bits.length
+    val length2 = other.bits.length
+
+    val smallerBS: BitSet = if (length1 <= length2) this else other
+    val smallerLength: Int = if (length1 <= length2) length1 else length2
+
+    val largerBS: BitSet = if (length1 > length2) this else other
+    val largerLength: Int = if (length1 > length2) length1 else length2
+
+    var i: Int = 0
+    while (i < smallerLength) {
+      if (smallerBS.bits(i) != largerBS.bits(i))
+        return false
+
+      i += 1
+    }
+
+    // Check remainder bits, if they are zero these are equal
+    while (i < largerLength) {
+      if (largerBS.bits(i) != 0)
+        return false
+
+      i += 1
+    }
+    // scalastyle:on return
+
+    true
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case bs: BitSet => equalsImpl(bs)
+      case _ => false
+    }
+  }
+
+  override def clone(): AnyRef =
+    new BitSet(bits.clone())
+
+  override def toString(): String = {
+    var result: String = "{"
+    var comma: Boolean = false
+
+    for {
+      i <- 0 until getActualArrayLength()
+      j <- 0 until ElementSize
+    } {
+      if ((bits(i) & (1L << j)) != 0) {
+        if (comma)
+          result += ", "
+        else
+          comma = true
+        result += (i << AddressBitsPerWord) + j
+      }
+    }
+
+    result += "}"
+    result
+  }
+
+  final private def ensureLength(len: Int): Unit = {
+    if (len > bits.length)
+      bits = Arrays.copyOf(bits, Math.max(len, bits.length * 2))
+  }
+
+  final private def getActualArrayLength(): Int = {
+    var idx = bits.length - 1
+    while (idx >= 0 && bits(idx) == 0)
+      idx -= 1
+
+    idx + 1
+  }
+
+  private def checkToAndFromIndex(fromIndex: Int, toIndex: Int): Unit = {
+    if (fromIndex < 0)
+      throw new IndexOutOfBoundsException(s"fromIndex < 0: $fromIndex")
+
+    if (toIndex < 0)
+      throw new IndexOutOfBoundsException(s"toIndex < 0: $toIndex")
+
+    if (toIndex < fromIndex)
+      throw new IndexOutOfBoundsException(s"fromIndex: $fromIndex > toIndex: $toIndex")
+  }
+
+  private def checkFromIndex(fromIndex: Int): Unit = {
+    if (fromIndex < 0)
+      throw new IndexOutOfBoundsException(s"fromIndex < 0: $fromIndex")
+  }
+
+  private def checkBitIndex(bitIndex: Int): Unit = {
+    if (bitIndex < 0)
+      throw new IndexOutOfBoundsException(s"bitIndex < 0: $bitIndex")
+  }
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/BitSetTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/BitSetTest.scala
@@ -1,0 +1,1455 @@
+package javalib.util
+
+// Ported from Scala.js
+
+import java.nio.{ByteBuffer, LongBuffer}
+import java.util.BitSet
+import org.junit.Assert.{assertThrows => junitAssertThrows, _}
+import org.junit.Assume._
+import org.junit.Test
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
+// import org.scalajs.testsuite.utils.Platform._
+
+class BitSetTest {
+  @Test def test_Constructor_empty(): Unit = {
+    val bs = new BitSet
+
+    assertEquals("Create BitSet of incorrect size", 64, bs.size())
+    assertEquals("New BitSet had invalid string representation", "{}", bs.toString())
+  }
+
+  @Test def test_Constructor_Int(): Unit = {
+    var bs = new BitSet(128)
+
+    assertEquals("Create BitSet of incorrect size", 128, bs.size())
+    assertEquals("New BitSet had invalid string representation: " + bs.toString, "{}", bs.toString())
+
+    // All BitSets are created with elements of multiples of 64 on jvm, 32 in JS
+    bs = new BitSet(89)
+
+    assertEquals("Failed to round BitSet element size", 128, bs.size())
+
+    // "Failed to throw exception when creating a new BitSet with negative element value"
+    assertThrows(classOf[NegativeArraySizeException], new BitSet(-9))
+  }
+
+  @Test def test_clone(): Unit = {
+    val eightbs: BitSet = makeEightBS()
+    val bs: BitSet = eightbs.clone.asInstanceOf[BitSet]
+    assertEquals("clone failed to return equal BitSet", bs, eightbs)
+  }
+
+  @Test def test_equals(): Unit = {
+    val eightbs: BitSet = makeEightBS()
+    var bs: BitSet = makeEightBS()
+    assertEquals("Same BitSet returned false", eightbs, eightbs)
+    assertEquals("Identical BitSet returned false", bs, eightbs)
+    bs.clear(6)
+    assertFalse("Different BitSets returned true", eightbs == bs)
+
+    bs = makeEightBS()
+    bs.set(128)
+    assertFalse("Different sized BitSet with higher bit set returned true", eightbs == bs)
+    bs.clear(128)
+    assertTrue("Different sized BitSet with higher bits not set returned false", eightbs == bs)
+  }
+
+  @Test def test_hashCode(): Unit = {
+    val bs: BitSet = makeEightBS()
+    bs.clear(2)
+    bs.clear(6)
+    assertEquals("BitSet returns wrong hash value", 1129, bs.hashCode)
+    bs.set(10)
+    bs.clear(3)
+    assertEquals("BitSet returns wrong hash value", 97, bs.hashCode)
+  }
+
+  @Test def test_clear(): Unit = {
+    val eightbs = makeEightBS()
+    eightbs.clear()
+
+    for (i <- 0 until 8)
+      assertFalse("Clear didn't clear bit " + i, eightbs.get(i))
+
+    assertEquals("Test1: Wrong length", 0, eightbs.length())
+    val bs = new BitSet(3400)
+    bs.set(0, bs.size - 1) // ensure all bits are 1's
+
+    bs.set(bs.size - 1)
+    bs.clear()
+    assertEquals("Test2: Wrong length", 0, bs.length())
+    assertTrue("Test2: isEmpty() returned incorrect value", bs.isEmpty())
+    assertEquals("Test2: cardinality() returned incorrect value", 0, bs.cardinality())
+  }
+
+  @Test def test_clear_bitIndex(): Unit = {
+    val eightbs  = makeEightBS()
+    eightbs.clear(7)
+    assertFalse("Failed to clear bit", eightbs.get(7))
+
+    // Check to see all other bits are still set
+    for (i <- 0 until 7)
+      assertTrue("Clear cleared incorrect bits", eightbs.get(i))
+
+    eightbs.clear(165)
+    assertFalse("Failed to clear bit", eightbs.get(165))
+    // Try out of range
+    assertThrows(classOf[IndexOutOfBoundsException], eightbs.clear(-1))
+
+    val bs = new BitSet(0)
+    assertEquals("Test1: Wrong length,", 0, bs.length())
+    assertEquals("Test1: Wrong size,", 0, bs.size())
+    bs.clear(0)
+    assertEquals("Test2: Wrong length,", 0, bs.length())
+    assertEquals("Test2: Wrong size,", 0, bs.size())
+    bs.clear(60)
+    assertEquals("Test3: Wrong length,", 0, bs.length())
+    assertEquals("Test3: Wrong size,", 0, bs.size())
+    bs.clear(120)
+    assertEquals("Test4: Wrong size,", 0, bs.size())
+    assertEquals("Test4: Wrong length,", 0, bs.length())
+    bs.set(25)
+    assertEquals("Test5: Wrong size,", 64, bs.size())
+
+    assertEquals("Test5: Wrong length,", 26, bs.length())
+    bs.clear(80)
+
+    assertEquals("Test6: Wrong size,", 64, bs.size())
+
+    assertEquals("Test6: Wrong length,", 26, bs.length())
+    bs.clear(25)
+
+    assertEquals("Test7: Wrong size,", 64, bs.size())
+
+    assertEquals("Test7: Wrong length,", 0, bs.length())
+  }
+
+  @Test def test_clear_fromIndex_toIndex(): Unit = {
+    val bitset = new BitSet
+    for (i <- 0 until 20)
+      bitset.set(i)
+
+    bitset.clear(10, 10)
+    // Test for method void java.BitSet.clear(int, int)
+    // pos1 and pos2 are in the same bitset element
+    var bs = new BitSet(16)
+    var initialSize = bs.size
+    bs.set(0, initialSize)
+    bs.clear(5)
+    bs.clear(15)
+    bs.clear(7, 11)
+
+    for (i <- 0 until 7) {
+      if (i == 5)
+        assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+      else
+        assertTrue("Shouldn't have cleared bit " + i, bs.get(i))
+    }
+
+    for (i <- 7 until 11)
+      assertFalse("Failed to clear bit " + i, bs.get(i))
+
+    for (i <- 11 until initialSize) {
+      if (i == 15)
+        assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+      else
+        assertTrue("Shouldn't have cleared bit " + i, bs.get(i))
+    }
+
+    for (i <- initialSize until bs.size())
+      assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+
+    // pos1 and pos2 is in the same bitset element, boundry testing
+    bs = new BitSet(16)
+    initialSize = bs.size
+    bs.set(0, initialSize)
+    bs.clear(7, 64)
+
+    assertEquals("Failed to grow BitSet", 64, bs.size())
+
+    for (i <- 0 until 7)
+      assertTrue("Shouldn't have cleared bit " + i, bs.get(i))
+
+    for (i <- 7 until 64)
+      assertFalse("Failed to clear bit " + i, bs.get(i))
+
+    for (i <- 64 until bs.size())
+      assertTrue("Shouldn't have flipped bit " + i, !bs.get(i))
+
+    // more boundary testing
+    bs = new BitSet(32)
+    initialSize = bs.size
+    bs.set(0, initialSize)
+    bs.clear(0, 64)
+
+    for (i <- 0 until 64)
+      assertFalse("Failed to clear bit " + i, bs.get(i))
+
+    for (i <- 64 until bs.size())
+      assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+
+    bs = new BitSet(32)
+    initialSize = bs.size
+    bs.set(0, initialSize)
+    bs.clear(0, 65)
+
+    for (i <- 0 until 65)
+      assertFalse("Failed to clear bit " + i, bs.get(i))
+
+    for (i <- 65 until bs.size())
+      assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+
+    // pos1 and pos2 are in two sequential bitset elements
+    bs = new BitSet(128)
+    initialSize = bs.size
+    bs.set(0, initialSize)
+    bs.clear(7)
+    bs.clear(110)
+    bs.clear(9, 74)
+
+    for (i <- 0 until 9) {
+      if (i == 7)
+        assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+      else
+        assertTrue("Shouldn't have cleared bit " + i, bs.get(i))
+    }
+
+    for (i <- 9 until 74)
+      assertFalse("Failed to clear bit " + i, bs.get(i))
+
+    for (i <- 74 until initialSize) {
+      if (i == 110)
+        assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+      else
+        assertTrue("Shouldn't have cleared bit " + i, bs.get(i))
+    }
+
+    for (i <- initialSize until bs.size())
+      assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+
+    // pos1 and pos2 are in two non-sequential bitset elements
+    bs = new BitSet(256)
+    bs.set(0, 256)
+    bs.clear(7)
+    bs.clear(255)
+    bs.clear(9, 219)
+
+    for (i <- 0 until 9) {
+      if (i == 7)
+        assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+      else
+        assertTrue("Shouldn't have cleared bit " + i, bs.get(i))
+    }
+
+    for (i <- 9 until 219)
+      assertFalse("failed to clear bit " + i, bs.get(i))
+
+    for (i <- 219 until 255)
+      assertTrue("Shouldn't have cleared bit " + i, bs.get(i))
+
+    for (i <- 255 until bs.size())
+      assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+
+    // test illegal args
+    bs = new BitSet(10)
+    // "Test1: Attempt to flip with  negative index failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.clear(-1, 3))
+    // "Test2: Attempt to flip with negative index failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.clear(2, -1))
+
+    bs.set(2, 4)
+    bs.clear(2, 2)
+    assertTrue("Bit got cleared incorrectly ", bs.get(2))
+
+    // "Test4: Attempt to flip with illegal args failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.clear(4, 2))
+
+    bs = new BitSet(0)
+    assertEquals("Test1: Wrong length,", 0, bs.length())
+    assertEquals("Test1: Wrong size,", 0, bs.size())
+
+    bs.clear(0, 2)
+    assertEquals("Test2: Wrong length,", 0, bs.length())
+    assertEquals("Test2: Wrong size,", 0, bs.size())
+
+    bs.clear(60, 64)
+    assertEquals("Test3: Wrong length,", 0, bs.length())
+    assertEquals("Test3: Wrong size,", 0, bs.size())
+
+    bs.clear(64, 120)
+    assertEquals("Test4: Wrong length,", 0, bs.length())
+    assertEquals("Test4: Wrong size,", 0, bs.size())
+
+    bs.set(25)
+    assertEquals("Test5: Wrong length,", 26, bs.length())
+
+    assertEquals("Test5: Wrong size,", 64, bs.size())
+
+    bs.clear(60, 64)
+    assertEquals("Test6: Wrong length,", 26, bs.length())
+
+    assertEquals("Test6: Wrong size,", 64, bs.size())
+
+    bs.clear(64, 120)
+
+    assertEquals("Test7: Wrong size,", 64, bs.size())
+
+    assertEquals("Test7: Wrong length,", 26, bs.length())
+
+    bs.clear(80)
+
+    assertEquals("Test8: Wrong size,", 64, bs.size())
+
+    assertEquals("Test8: Wrong length,", 26, bs.length())
+
+    bs.clear(25)
+    assertEquals("Test9: Wrong size,", 64, bs.size())
+
+    assertEquals("Test9: Wrong length,", 0, bs.length())
+  }
+
+  @Test def test_get_bitIndex(): Unit = {
+    val eightbs = makeEightBS()
+    var bs = new BitSet
+    bs.set(8)
+    assertFalse("Get returned true for index out of range", eightbs.get(99))
+    assertTrue("Get returned false for set value", eightbs.get(3))
+    assertFalse("Get returned true for a non set value", bs.get(0))
+
+    // "Attempt to get at negative index failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.get(-1))
+
+    bs = new BitSet(1)
+    assertFalse("Access greater than size", bs.get(64))
+
+    bs = new BitSet
+    bs.set(63)
+    assertTrue("Test highest bit", bs.get(63))
+
+    bs = new BitSet(0)
+    assertEquals("Test1: Wrong length,", 0, bs.length())
+    assertEquals("Test1: Wrong size,", 0, bs.size())
+
+    bs.get(2)
+    assertEquals("Test2: Wrong length,", 0, bs.length())
+    assertEquals("Test2: Wrong size,", 0, bs.size())
+
+    bs.get(70)
+    assertEquals("Test3: Wrong length,", 0, bs.length())
+    assertEquals("Test3: Wrong size,", 0, bs.size())
+  }
+
+  @Test def test_get_fromIndex_toIndex(): Unit = {
+    val bitset = new BitSet(30)
+    bitset.get(3, 3)
+
+    var bs: BitSet = new BitSet(512)
+    var resultbs: BitSet = null
+    var correctbs: BitSet = null
+
+    bs.set(3, 9)
+    bs.set(10, 20)
+    bs.set(60, 75)
+    bs.set(121)
+    bs.set(130, 140)
+
+    // pos1 and pos2 are in the same bitset element, at index0
+    resultbs = bs.get(3, 6)
+    correctbs = new BitSet(3)
+    correctbs.set(0, 3)
+    assertEquals("Test1: Returned incorrect BitSet", correctbs, resultbs)
+    // pos1 and pos2 are in the same bitset element, at index 1
+    resultbs = bs.get(100, 125)
+    correctbs = new BitSet(25)
+    correctbs.set(21)
+    assertEquals("Test2: Returned incorrect BitSet", correctbs, resultbs)
+    // pos1 in bitset element at index 0, and pos2 in bitset element at
+    // index 1
+    resultbs = bs.get(15, 125)
+    correctbs = new BitSet(25)
+    correctbs.set(0, 5)
+    correctbs.set(45, 60)
+    correctbs.set(121 - 15)
+    assertEquals("Test3: Returned incorrect BitSet", correctbs, resultbs)
+    // pos1 in bitset element at index 1, and pos2 in bitset element at
+    // index 2
+    resultbs = bs.get(70, 145)
+    correctbs = new BitSet(75)
+    correctbs.set(0, 5)
+    correctbs.set(51)
+    correctbs.set(60, 70)
+    assertEquals("Test4: Returned incorrect BitSet", correctbs, resultbs)
+    resultbs = bs.get(5, 145)
+    correctbs = new BitSet(140)
+    correctbs.set(0, 4)
+    correctbs.set(5, 15)
+    correctbs.set(55, 70)
+    correctbs.set(116)
+    correctbs.set(125, 135)
+    assertEquals("Test5: Returned incorrect BitSet", correctbs, resultbs)
+    // index 3
+    resultbs = bs.get(5, 250)
+    correctbs = new BitSet(200)
+    correctbs.set(0, 4)
+    correctbs.set(5, 15)
+    correctbs.set(55, 70)
+    correctbs.set(116)
+    correctbs.set(125, 135)
+    assertEquals("Test6: Returned incorrect BitSet", correctbs, resultbs)
+    assertEquals("equality principle 1 ", bs.get(0, bs.size()), bs)
+    // more tests
+    var bs2 = new BitSet(129)
+    bs2.set(0, 20)
+    bs2.set(62, 65)
+    bs2.set(121, 123)
+    resultbs = bs2.get(1, 124)
+    correctbs = new BitSet(129)
+    correctbs.set(0, 19)
+    correctbs.set(61, 64)
+    correctbs.set(120, 122)
+    assertEquals("Test7: Returned incorrect BitSet", correctbs, resultbs)
+    // equality principle with some boundary conditions
+    bs2 = new BitSet(128)
+    bs2.set(2, 20)
+    bs2.set(62)
+    bs2.set(121, 123)
+    bs2.set(127)
+    resultbs = bs2.get(0, bs2.size())
+    assertEquals("equality principle 2 ", resultbs, bs2)
+    bs2 = new BitSet(128)
+    bs2.set(2, 20)
+    bs2.set(62)
+    bs2.set(121, 123)
+    bs2.set(127)
+    bs2.flip(0, 128)
+    resultbs = bs2.get(0, bs.size())
+    assertEquals("equality principle 3 ", resultbs, bs2)
+    bs = new BitSet(0)
+    assertEquals("Test1: Wrong length,", 0, bs.length())
+    assertEquals("Test1: Wrong size,", 0, bs.size())
+    bs.get(0, 2)
+    assertEquals("Test2: Wrong length,", 0, bs.length())
+    assertEquals("Test2: Wrong size,", 0, bs.size())
+    bs.get(60, 64)
+    assertEquals("Test3: Wrong length,", 0, bs.length())
+    assertEquals("Test3: Wrong size,", 0, bs.size())
+    bs.get(64, 120)
+    assertEquals("Test4: Wrong length,", 0, bs.length())
+    assertEquals("Test4: Wrong size,", 0, bs.size())
+    bs.set(25)
+    assertEquals("Test5: Wrong length,", 26, bs.length())
+
+    assertEquals("Test5: Wrong size,", 64, bs.size())
+
+    bs.get(60, 64)
+    assertEquals("Test6: Wrong length,", 26, bs.length())
+
+    assertEquals("Test6: Wrong size,", 64, bs.size())
+
+    bs.get(64, 120)
+
+    assertEquals("Test7: Wrong size,", 64, bs.size())
+
+    assertEquals("Test7: Wrong length,", 26, bs.length())
+    bs.get(80)
+
+    assertEquals("Test8: Wrong size,", 64, bs.size())
+
+    assertEquals("Test8: Wrong length,", 26, bs.length())
+    bs.get(25)
+
+    assertEquals("Test9: Wrong size,", 64, bs.size())
+
+    assertEquals("Test9: Wrong length,", 26, bs.length())
+  }
+
+  @Test def test_flip_bitIndex(): Unit = {
+    val eightbs = makeEightBS()
+    var bs = new BitSet
+    bs.clear(8)
+    bs.clear(9)
+    bs.set(10)
+    bs.flip(9)
+    assertFalse("Failed to flip bit", bs.get(8))
+    assertTrue("Failed to flip bit", bs.get(9))
+    assertTrue("Failed to flip bit", bs.get(10))
+    bs.set(8)
+    bs.set(9)
+    bs.clear(10)
+    bs.flip(9)
+    assertTrue("Failed to flip bit", bs.get(8))
+    assertFalse("Failed to flip bit", bs.get(9))
+    assertFalse("Failed to flip bit", bs.get(10))
+
+    // "Attempt to flip at negative index failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.flip(-1))
+
+    // Try setting a bit on a 64 boundary
+    bs.flip(128)
+
+    assertEquals("Failed to grow BitSet", 192, bs.size())
+
+    assertTrue("Failed to flip bit", bs.get(128))
+
+    bs = new BitSet(64)
+    var i = bs.size - 1
+    while (i >= 0) {
+      bs.flip(i)
+      assertTrue("Test1: Incorrectly flipped bit" + i, bs.get(i))
+      assertEquals("Incorrect length", i + 1, bs.length())
+      var j: Int = bs.size
+      while ({j -= 1; j} > i)
+        assertTrue("Test2: Incorrectly flipped bit" + j, !bs.get(j))
+
+      j = i
+      while ({j -= 1; j} >= 0)
+        assertTrue("Test3: Incorrectly flipped bit" + j, !bs.get(j))
+
+      bs.flip(i)
+      i -= 1
+    }
+
+    val bs0 = new BitSet(0)
+    assertEquals("Test1: Wrong size", 0, bs0.size())
+    assertEquals("Test1: Wrong length", 0, bs0.length())
+
+    bs0.flip(0)
+
+    assertEquals("Test2: Wrong size", 64, bs0.size())
+
+    assertEquals("Test2: Wrong length", 1, bs0.length())
+
+    bs0.flip(63)
+    assertEquals("Test3: Wrong size", 64, bs0.size())
+    assertEquals("Test3: Wrong length", 64, bs0.length())
+
+    eightbs.flip(7)
+    assertTrue("Failed to flip bit 7", !eightbs.get(7))
+
+    for (i <- 0 until 7)
+      assertTrue("Flip flipped incorrect bits", eightbs.get(i))
+
+    eightbs.flip(127)
+    assertTrue("Failed to flip bit 127", eightbs.get(127))
+
+    eightbs.flip(127)
+    assertTrue("Failed to flip bit 127", !eightbs.get(127))
+  }
+
+  @Test def test_flip_fromIndex_toIndex(): Unit = {
+    val bitset = new BitSet
+    for (i <- 0 until 20)
+      bitset.set(i)
+
+    bitset.flip(10, 10)
+    // Test for method void java.BitSet.flip(int, int)
+    var bs = new BitSet(16)
+    bs.set(7)
+    bs.set(10)
+    bs.flip(7, 11)
+
+    for (i <- 0 until 7)
+      assertTrue("Shouldn't have flipped bit " + i, !bs.get(i))
+
+    assertFalse("Failed to flip bit 7", bs.get(7))
+    assertTrue("Failed to flip bit 8", bs.get(8))
+    assertTrue("Failed to flip bit 9", bs.get(9))
+    assertFalse("Failed to flip bit 10", bs.get(10))
+
+    for (i <- 11 until bs.size())
+      assertTrue("Shouldn't have flipped bit " + i, !bs.get(i))
+
+    bs = new BitSet(16)
+    bs.set(7)
+    bs.set(10)
+    bs.flip(7, 64)
+    assertEquals("Failed to grow BitSet", 64, bs.size())
+
+    for (i <- 0 until 7)
+      assertTrue("Shouldn't have flipped bit " + i, !bs.get(i))
+
+    assertFalse("Failed to flip bit 7", bs.get(7))
+    assertTrue("Failed to flip bit 8", bs.get(8))
+    assertTrue("Failed to flip bit 9", bs.get(9))
+    assertFalse("Failed to flip bit 10", bs.get(10))
+
+    for (i <- 11 until 64)
+      assertTrue("failed to flip bit " + i, bs.get(i))
+
+    assertFalse("Shouldn't have flipped bit 64", bs.get(64))
+
+    bs = new BitSet(32)
+    bs.flip(0, 64)
+
+    for (i <- 0 until 64)
+      assertTrue("Failed to flip bit " + i, bs.get(i))
+
+    assertFalse("Shouldn't have flipped bit 64", bs.get(64))
+
+    bs = new BitSet(32)
+    bs.flip(0, 65)
+
+    for (i <- 0 until 65)
+      assertTrue("Failed to flip bit " + i, bs.get(i))
+
+    assertFalse("Shouldn't have flipped bit 65", bs.get(65))
+
+    bs = new BitSet(128)
+    bs.set(7)
+    bs.set(10)
+    bs.set(72)
+    bs.set(110)
+    bs.flip(9, 74)
+
+    for (i <- 0 until 7)
+      assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+
+    assertTrue("Shouldn't have flipped bit 7", bs.get(7))
+    assertFalse("Shouldn't have flipped bit 8", bs.get(8))
+    assertTrue("Failed to flip bit 9", bs.get(9))
+    assertFalse("Failed to flip bit 10", bs.get(10))
+
+    for (i <- 11 until 72)
+      assertTrue("failed to flip bit " + i, bs.get(i))
+
+    assertFalse("Failed to flip bit 72", bs.get(72))
+    assertTrue("Failed to flip bit 73", bs.get(73))
+
+    for (i <- 74 until 110)
+      assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+
+    assertTrue("Shouldn't have flipped bit 110", bs.get(110))
+
+    for (i <- 111 until bs.size())
+      assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+
+    bs = new BitSet(256)
+    bs.set(7)
+    bs.set(10)
+    bs.set(72)
+    bs.set(110)
+    bs.set(181)
+    bs.set(220)
+    bs.flip(9, 219)
+
+    for (i <- 0 until 7)
+      assertFalse("Shouldn't have flipped bit " + i, bs.get(i))
+
+    assertTrue("Shouldn't have flipped bit 7", bs.get(7))
+    assertFalse("Shouldn't have flipped bit 8", bs.get(8))
+    assertTrue("Failed to flip bit 9", bs.get(9))
+    assertFalse("Failed to flip bit 10", bs.get(10))
+
+    for (i <- 11 until 72)
+      assertTrue("failed to flip bit " + i, bs.get(i))
+
+    assertFalse("Failed to flip bit 72", bs.get(72))
+
+    for (i <- 73 until 110)
+      assertTrue("failed to flip bit " + i, bs.get(i))
+
+    assertFalse("Failed to flip bit 110", bs.get(110))
+
+    for (i <- 111 until 181)
+      assertTrue("failed to flip bit " + i, bs.get(i))
+
+    assertFalse("Failed to flip bit 181", bs.get(181))
+
+    for (i <- 182 until 219)
+      assertTrue("failed to flip bit " + i, bs.get(i))
+
+    assertFalse("Shouldn't have flipped bit 219", bs.get(219))
+    assertTrue("Shouldn't have flipped bit 220", bs.get(220))
+
+    for (i <- 221 until bs.size())
+      assertTrue("Shouldn't have flipped bit " + i, !bs.get(i))
+
+    bs = new BitSet(10)
+    // "Test1: Attempt to flip with  negative index failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.flip(-1, 3))
+
+    // "Test2: Attempt to flip with negative index failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.flip(2, -1))
+
+    // "Test4: Attempt to flip with illegal args failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.flip(4, 2))
+  }
+
+  @Test def test_set_bitIndex(): Unit = {
+    var bs = new BitSet
+    bs.set(8)
+    assertTrue("Failed to set bit", bs.get(8))
+
+    // "Attempt to set at negative index failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.set(-1))
+
+    bs.set(128)
+    assertEquals("Failed to grow BitSet", 192, bs.size())
+
+    assertTrue("Failed to set bit", bs.get(128))
+
+    bs = new BitSet(64)
+    var i = bs.size
+    while ({i -= 1; i} >= 0) {
+      bs.set(i)
+      assertTrue("Incorrectly set", bs.get(i))
+      assertEquals("Incorrect length", i + 1, bs.length())
+
+      var j = bs.size
+      while ({j -= 1; j} > i)
+        assertFalse("Incorrectly set bit " + j, bs.get(j))
+
+      var k = i
+      while ({k -= 1; k} >= 0)
+        assertFalse("Incorrectly set bit " + k, bs.get(k))
+
+      bs.clear(i)
+    }
+
+    bs = new BitSet(0)
+    assertEquals("Test1: Wrong length", 0, bs.length())
+
+    bs.set(0)
+    assertEquals("Test2: Wrong length", 1, bs.length())
+  }
+
+  @Test def set_bitIndex_bool(): Unit = {
+    val eightbs = makeEightBS()
+
+    eightbs.set(5, false)
+    assertFalse("Should have set bit 5 to true", eightbs.get(5))
+
+    eightbs.set(5, true)
+    assertTrue("Should have set bit 5 to false", eightbs.get(5))
+  }
+
+  @Test def set_fromIndex_toIndex(): Unit = {
+    val bitset = new BitSet(30)
+    bitset.set(29, 29)
+
+    var bs = new BitSet(16)
+    bs.set(5)
+    bs.set(15)
+    bs.set(7, 11)
+
+    for (i <- 0 until 7) {
+      if (i == 5)
+        assertTrue("Shouldn't have flipped bit " + i, bs.get(i))
+      else
+        assertFalse("Shouldn't have set bit " + i, bs.get(i))
+    }
+
+    for (i <- 7 until 11)
+      assertTrue("Failed to set bit " + i, bs.get(i))
+
+    for (i <- 11 until bs.size()) {
+      if (i == 15)
+        assertTrue("Shouldn't have flipped bit " + i, bs.get(i))
+      else
+        assertFalse("Shouldn't have set bit " + i, bs.get(i))
+    }
+
+    bs = new BitSet(16)
+    bs.set(7, 64)
+    assertEquals("Failed to grow BitSet", 64, bs.size())
+
+    for (i <- 0 until 7)
+      assertFalse("Shouldn't have set bit " + i, bs.get(i))
+
+    for (i <- 7 until 64)
+      assertTrue("Failed to set bit " + i, bs.get(i))
+
+    assertFalse("Shouldn't have set bit 64", bs.get(64))
+
+    bs = new BitSet(32)
+    bs.set(0, 64)
+
+    for (i <- 0 until 64)
+      assertTrue("Failed to set bit " + i, bs.get(i))
+
+    assertFalse("Shouldn't have set bit 64", bs.get(64))
+
+    bs = new BitSet(32)
+    bs.set(0, 65)
+
+    for (i <- 0 until 65)
+      assertTrue("Failed to set bit " + i, bs.get(i))
+
+    assertFalse("Shouldn't have set bit 65", bs.get(65))
+
+    bs = new BitSet(128)
+    bs.set(7)
+    bs.set(110)
+    bs.set(9, 74)
+
+    for (i <- 0 until 9) {
+      if (i == 7)
+        assertTrue("Shouldn't have flipped bit " + i, bs.get(i))
+      else
+        assertFalse("Shouldn't have set bit " + i, bs.get(i))
+    }
+
+    for (i <- 9 until 74)
+      assertTrue("Failed to set bit " + i, bs.get(i))
+
+    for (i <- 74 until bs.size()) {
+      if (i == 110)
+        assertTrue("Shouldn't have flipped bit " + i, bs.get(i))
+      else
+        assertFalse("Shouldn't have set bit " + i, bs.get(i))
+    }
+
+    bs = new BitSet(256)
+    bs.set(7)
+    bs.set(255)
+    bs.set(9, 219)
+
+    for (i <- 0 until 9) {
+      if (i == 7)
+        assertTrue("Shouldn't have set flipped " + i, bs.get(i))
+      else
+        assertFalse("Shouldn't have set bit " + i, bs.get(i))
+    }
+
+    for (i <- 9 until 219)
+      assertTrue("failed to set bit " + i, bs.get(i))
+
+    for (i <- 219 until 255)
+      assertFalse("Shouldn't have set bit " + i, bs.get(i))
+
+    assertTrue("Shouldn't have flipped bit 255", bs.get(255))
+
+    bs = new BitSet(10)
+    // "Test1: Attempt to flip with  negative index failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.set(-1, 3))
+
+    // "Test2: Attempt to flip with negative index failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.set(2, -1))
+
+    bs.set(2, 2)
+    assertFalse("Bit got set incorrectly ", bs.get(2))
+
+    // "Test4: Attempt to flip with illegal args failed to generate exception"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.set(4, 2))
+  }
+
+  @Test def set_fromIndex_toIndex_bool(): Unit = {
+    val eightbs = makeEightBS()
+
+    eightbs.set(3, 6, false)
+    assertTrue("Should have set bits 3, 4, and 5 to false",
+        !eightbs.get(3) && !eightbs.get(4) && !eightbs.get(5))
+    eightbs.set(3, 6, true)
+    assertTrue("Should have set bits 3, 4, and 5 to true",
+        eightbs.get(3) && eightbs.get(4) && eightbs.get(5))
+  }
+
+  @Test def intersects(): Unit = {
+    val bs = new BitSet(500)
+    bs.set(5)
+    bs.set(63)
+    bs.set(64)
+    bs.set(71, 110)
+    bs.set(127, 130)
+    bs.set(192)
+    bs.set(450)
+    val bs2 = new BitSet(8)
+    assertFalse(bs.intersects(bs2))
+    assertFalse(bs2.intersects(bs))
+
+    bs2.set(4)
+    assertFalse(bs.intersects(bs2))
+    assertFalse(bs2.intersects(bs))
+
+    bs2.clear()
+    bs2.set(5)
+    assertTrue(bs.intersects(bs2))
+    assertTrue(bs2.intersects(bs))
+
+    bs2.clear()
+    bs2.set(63)
+    assertTrue(bs.intersects(bs2))
+    assertTrue(bs2.intersects(bs))
+
+    bs2.clear()
+    bs2.set(80)
+    assertTrue(bs.intersects(bs2))
+    assertTrue(bs2.intersects(bs))
+
+    bs2.clear()
+    bs2.set(127)
+    assertTrue(bs.intersects(bs2))
+    assertTrue(bs2.intersects(bs))
+
+    bs2.clear()
+    bs2.set(192)
+    assertTrue(bs.intersects(bs2))
+    assertTrue(bs2.intersects(bs))
+
+    bs2.clear()
+    bs2.set(450)
+    assertTrue(bs.intersects(bs2))
+    assertTrue(bs2.intersects(bs))
+
+    bs2.clear()
+    bs2.set(500)
+    assertFalse(bs.intersects(bs2))
+    assertFalse(bs2.intersects(bs))
+  }
+
+  @Test def and(): Unit = {
+    val eightbs = makeEightBS()
+    val bs = new BitSet(128)
+
+    // Initialize the bottom half of the BitSet
+    for (i <- 64 until 128)
+      bs.set(i)
+
+    eightbs.and(bs)
+    assertFalse(eightbs == bs)
+    eightbs.set(3)
+    bs.set(3)
+    eightbs.and(bs)
+    assertTrue(bs.get(3))
+    bs.and(eightbs)
+
+    for (i <- 64 until 128)
+      assertFalse(bs.get(i))
+  }
+
+  def andNot(): Unit = {
+    var bs = makeEightBS()
+    bs.clear(5)
+    val bs2 = new BitSet
+    bs2.set(2)
+    bs2.set(3)
+    bs.andNot(bs2)
+    assertEquals("{0, 1, 4, 6, 7}", bs.toString())
+    bs = new BitSet(0)
+    bs.andNot(bs2)
+    assertEquals(0, bs.size())
+  }
+
+  @Test def or(): Unit = {
+    val eightbs = makeEightBS()
+    var bs = new BitSet(128)
+    bs.or(eightbs)
+
+    for (i <- 0 until 8)
+      assertTrue("OR failed to set bits", bs.get(i))
+
+    bs = new BitSet(0)
+    bs.or(eightbs)
+
+    for (i <- 0 until 8)
+      assertTrue(bs.get(i))
+
+    eightbs.clear(5)
+    bs = new BitSet(128)
+    bs.or(eightbs)
+    assertFalse(bs.get(5))
+  }
+
+  @Test def xor(): Unit = {
+    val eightbs = makeEightBS()
+    var bs = makeEightBS()
+    bs.xor(eightbs)
+
+    for (i <- 0 until 8)
+      assertFalse(bs.get(i))
+
+    bs.xor(eightbs)
+
+    for (i <- 0 until 8)
+      assertTrue(bs.get(i))
+
+    bs = new BitSet(0)
+    bs.xor(eightbs)
+
+    for (i <- 0 until 8)
+      assertTrue(bs.get(i))
+
+    bs = new BitSet
+    bs.set(63)
+    assertEquals("{63}", bs.toString())
+  }
+
+  @Test def size(): Unit = {
+    val eightbs = makeEightBS()
+    assertEquals(64, eightbs.size())
+    eightbs.set(129)
+    assertTrue(eightbs.size >= 129)
+  }
+
+  @Test def toStringTest(): Unit = {
+    val bs = new BitSet
+    assertEquals("{}", bs.toString())
+
+    bs.set(0)
+    assertEquals("{0}", bs.toString())
+
+    bs.clear(0)
+    assertEquals("{}", bs.toString())
+
+    bs.set(0)
+    bs.set(100)
+    bs.set(200)
+    bs.set(400)
+    assertEquals("{0, 100, 200, 400}", bs.toString())
+
+    bs.clear(200)
+    assertEquals("{0, 100, 400}", bs.toString())
+
+    bs.set(500)
+    assertEquals("{0, 100, 400, 500}", bs.toString())
+  }
+
+  @Test def length(): Unit = {
+    val bs = new BitSet
+    assertEquals(0, bs.length())
+    bs.set(5)
+    assertEquals(6, bs.length())
+    bs.set(10)
+    assertEquals(11, bs.length())
+    bs.set(432)
+    assertEquals(433, bs.length())
+    bs.set(300)
+    assertEquals(433, bs.length())
+  }
+
+  @Test def previousClearBit(): Unit = {
+    val bs = new BitSet(500)
+    bs.set(5)
+    bs.set(32)
+    bs.set(63)
+    bs.set(64)
+    bs.set(71, 110)
+    bs.set(127, 130)
+    bs.set(193)
+    bs.set(450)
+
+    assertEquals(-1, bs.previousClearBit(-1))
+    assertThrows(classOf[IndexOutOfBoundsException], bs.previousClearBit(-2))
+
+    assertEquals(0, bs.previousClearBit(0))
+    assertEquals(4, bs.previousClearBit(4))
+    assertEquals(4, bs.previousClearBit(5))
+    assertEquals(6, bs.previousClearBit(6))
+
+    assertEquals(31, bs.previousClearBit(31))
+    assertEquals(31, bs.previousClearBit(32))
+    assertEquals(33, bs.previousClearBit(33))
+
+    assertEquals(62, bs.previousClearBit(62))
+    assertEquals(62, bs.previousClearBit(63))
+    assertEquals(62, bs.previousClearBit(64))
+    assertEquals(65, bs.previousClearBit(65))
+
+    assertEquals(70, bs.previousClearBit(70))
+    assertEquals(70, bs.previousClearBit(71))
+    assertEquals(70, bs.previousClearBit(80))
+    assertEquals(70, bs.previousClearBit(109))
+    assertEquals(110, bs.previousClearBit(110))
+    assertEquals(111, bs.previousClearBit(111))
+
+    assertEquals(126, bs.previousClearBit(126))
+    assertEquals(126, bs.previousClearBit(127))
+    assertEquals(126, bs.previousClearBit(128))
+    assertEquals(126, bs.previousClearBit(129))
+    assertEquals(130, bs.previousClearBit(130))
+
+    assertEquals(192, bs.previousClearBit(192))
+    assertEquals(192, bs.previousClearBit(193))
+    assertEquals(194, bs.previousClearBit(194))
+
+    assertEquals(255, bs.previousClearBit(255))
+    assertEquals(256, bs.previousClearBit(256))
+
+    assertEquals(449, bs.previousClearBit(449))
+    assertEquals(449, bs.previousClearBit(450))
+    assertEquals(451, bs.previousClearBit(451))
+
+    assertEquals(500, bs.previousClearBit(500))
+    assertEquals(800, bs.previousClearBit(800))
+  }
+
+  @Test def previousSetBit(): Unit = {
+    val bs = new BitSet(500)
+    bs.set(5)
+    bs.set(32)
+    bs.set(63)
+    bs.set(64)
+    bs.set(71, 110)
+    bs.set(127, 130)
+    bs.set(193)
+    bs.set(450)
+
+    assertEquals(-1, bs.previousSetBit(-1))
+    assertThrows(classOf[IndexOutOfBoundsException], bs.previousSetBit(-2))
+
+    assertEquals(-1, bs.previousSetBit(0))
+    assertEquals(-1, bs.previousSetBit(4))
+    assertEquals(5, bs.previousSetBit(5))
+    assertEquals(5, bs.previousSetBit(6))
+
+    assertEquals(5, bs.previousSetBit(31))
+    assertEquals(32, bs.previousSetBit(32))
+    assertEquals(32, bs.previousSetBit(33))
+
+    assertEquals(32, bs.previousSetBit(62))
+    assertEquals(63, bs.previousSetBit(63))
+    assertEquals(64, bs.previousSetBit(64))
+    assertEquals(64, bs.previousSetBit(65))
+
+    assertEquals(64, bs.previousSetBit(70))
+    assertEquals(71, bs.previousSetBit(71))
+    assertEquals(72, bs.previousSetBit(72))
+    assertEquals(80, bs.previousSetBit(80))
+    assertEquals(109, bs.previousSetBit(109))
+    assertEquals(109, bs.previousSetBit(110))
+    assertEquals(109, bs.previousSetBit(111))
+
+    assertEquals(109, bs.previousSetBit(126))
+    assertEquals(127, bs.previousSetBit(127))
+    assertEquals(128, bs.previousSetBit(128))
+    assertEquals(129, bs.previousSetBit(129))
+    assertEquals(129, bs.previousSetBit(130))
+    assertEquals(129, bs.previousSetBit(131))
+
+    assertEquals(129, bs.previousSetBit(191))
+    assertEquals(129, bs.previousSetBit(192))
+    assertEquals(193, bs.previousSetBit(193))
+    assertEquals(193, bs.previousSetBit(194))
+
+    assertEquals(193, bs.previousSetBit(255))
+    assertEquals(193, bs.previousSetBit(256))
+
+    assertEquals(450, bs.previousSetBit(450))
+    assertEquals(450, bs.previousSetBit(500))
+    assertEquals(450, bs.previousSetBit(800))
+  }
+
+  @Test def nextSetBit(): Unit = {
+    val bs = new BitSet(500)
+    bs.set(5)
+    bs.set(32)
+    bs.set(63)
+    bs.set(64)
+    bs.set(71, 110)
+    bs.set(127, 130)
+    bs.set(193)
+    bs.set(450)
+
+    // "Expected IndexOutOfBoundsException for negative index"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.nextSetBit(-1))
+
+    assertEquals(5, bs.nextSetBit(0))
+    assertEquals(5, bs.nextSetBit(5))
+    assertEquals(32, bs.nextSetBit(6))
+    assertEquals(32, bs.nextSetBit(32))
+    assertEquals(63, bs.nextSetBit(33))
+
+    // boundary tests
+    assertEquals(63, bs.nextSetBit(63))
+    assertEquals(64, bs.nextSetBit(64))
+
+    // at bitset element 1
+    assertEquals(71, bs.nextSetBit(65))
+    assertEquals(71, bs.nextSetBit(71))
+    assertEquals(72, bs.nextSetBit(72))
+    assertEquals(127, bs.nextSetBit(110))
+    assertEquals(127, bs.nextSetBit(127))
+    assertEquals(128, bs.nextSetBit(128))
+
+    // at bitset element 2
+    assertEquals(193, bs.nextSetBit(130))
+    assertEquals(193, bs.nextSetBit(191))
+    assertEquals(193, bs.nextSetBit(192))
+    assertEquals(193, bs.nextSetBit(193))
+    assertEquals(450, bs.nextSetBit(194))
+    assertEquals(450, bs.nextSetBit(255))
+    assertEquals(450, bs.nextSetBit(256))
+    assertEquals(450, bs.nextSetBit(450))
+    assertEquals(-1, bs.nextSetBit(451))
+    assertEquals(-1, bs.nextSetBit(511))
+    assertEquals(-1, bs.nextSetBit(512))
+    assertEquals(-1, bs.nextSetBit(800))
+  }
+
+  @Test def test_nextClearBit_bitIndex(): Unit = {
+    val bs = new BitSet(500)
+    bs.set(0, bs.size - 1) // ensure all the bits from 0 to bs.size()
+
+    // -1
+    bs.set(bs.size - 1) // are set to true
+
+    bs.clear(5)
+    bs.clear(32)
+    bs.clear(63)
+    bs.clear(64)
+    bs.clear(71, 110)
+    bs.clear(127, 130)
+    bs.clear(193)
+    bs.clear(450)
+
+    // "Expected IndexOutOfBoundsException for negative index"
+    assertThrows(classOf[IndexOutOfBoundsException], bs.nextClearBit(-1))
+
+    assertEquals(5, bs.nextClearBit(0))
+    assertEquals(5, bs.nextClearBit(5))
+    assertEquals(32, bs.nextClearBit(6))
+    assertEquals(32, bs.nextClearBit(32))
+    assertEquals(63, bs.nextClearBit(33))
+    assertEquals(63, bs.nextClearBit(63))
+    assertEquals(64, bs.nextClearBit(64))
+    assertEquals(71, bs.nextClearBit(65))
+    assertEquals(71, bs.nextClearBit(71))
+    assertEquals(72, bs.nextClearBit(72))
+    assertEquals(127, bs.nextClearBit(110))
+    assertEquals(127, bs.nextClearBit(127))
+    assertEquals(128, bs.nextClearBit(128))
+    assertEquals(193, bs.nextClearBit(130))
+    assertEquals(193, bs.nextClearBit(191))
+    assertEquals(193, bs.nextClearBit(192))
+    assertEquals(193, bs.nextClearBit(193))
+    assertEquals(450, bs.nextClearBit(194))
+    assertEquals(450, bs.nextClearBit(255))
+    assertEquals(450, bs.nextClearBit(256))
+    assertEquals(450, bs.nextClearBit(450))
+
+    // bitset has 1 still the end of bs.size() -1, but calling nextClearBit with any index value
+    // after the last true bit should return bs.size(),
+    assertEquals(512, bs.nextClearBit(451))
+    assertEquals(512, bs.nextClearBit(511))
+    assertEquals(512, bs.nextClearBit(512))
+
+    // if the index is larger than bs.size(), nextClearBit should return index;
+    assertEquals(513, bs.nextClearBit(513))
+    assertEquals(800, bs.nextClearBit(800))
+  }
+
+  @Test def isEmpty(): Unit = {
+    val bs = new BitSet(500)
+    assertTrue(bs.isEmpty())
+
+    bs.set(3)
+    assertFalse(bs.isEmpty())
+
+    bs.clear()
+    bs.set(12)
+    assertFalse(bs.isEmpty())
+
+    bs.clear()
+    bs.set(128)
+    assertFalse(bs.isEmpty())
+
+    bs.clear()
+    bs.set(459)
+    assertFalse(bs.isEmpty())
+
+    bs.clear()
+    bs.set(511)
+    assertFalse(bs.isEmpty())
+  }
+
+  @Test def cardinality(): Unit = {
+    val bs = new BitSet(500)
+    bs.set(5)
+    bs.set(32)
+    bs.set(63)
+    bs.set(64)
+    bs.set(71, 110)
+    bs.set(127, 130)
+    bs.set(193)
+    bs.set(450)
+    assertEquals(48, bs.cardinality())
+
+    bs.flip(0, 500)
+    assertEquals(452, bs.cardinality())
+
+    bs.clear()
+    assertEquals(0, bs.cardinality())
+
+    bs.set(0, 500)
+    assertEquals(500, bs.cardinality())
+  }
+
+  @Test def toByteArray(): Unit = {
+    val bs = new BitSet(500)
+    assertArrayEquals(Array[Byte](), bs.toByteArray())
+    bs.set(5)
+    assertArrayEquals(Array[Byte](32), bs.toByteArray())
+    bs.set(32)
+    assertArrayEquals(Array[Byte](32, 0, 0, 0, 1), bs.toByteArray())
+    bs.set(63)
+    assertArrayEquals(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128), bs.toByteArray())
+    bs.set(64)
+    assertArrayEquals(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, 1), bs.toByteArray())
+    bs.set(71, 110)
+    assertArrayEquals(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63), bs.toByteArray())
+    bs.set(127, 130)
+    assertArrayEquals(
+        Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0, -128, 3), bs.toByteArray())
+    bs.set(193)
+    assertArrayEquals(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0,
+        -128, 3, 0, 0, 0, 0, 0, 0, 0, 2), bs.toByteArray())
+    bs.set(450)
+    assertArrayEquals(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0,
+        -128, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4), bs.toByteArray())
+  }
+
+  @Test def toLongArray(): Unit = {
+    val bs = new BitSet(500)
+    assertArrayEquals(Array[Long](), bs.toLongArray())
+    bs.set(5)
+    assertArrayEquals(Array[Long](32L), bs.toLongArray())
+    bs.set(32)
+    assertArrayEquals(Array[Long](4294967328L), bs.toLongArray())
+    bs.set(63)
+    assertArrayEquals(Array[Long](-9223372032559808480L), bs.toLongArray())
+    bs.set(64)
+    assertArrayEquals(Array[Long](-9223372032559808480L, 1L), bs.toLongArray())
+    bs.set(71, 110)
+    assertArrayEquals(Array[Long](-9223372032559808480L, 70368744177537L), bs.toLongArray())
+    bs.set(127, 130)
+    assertArrayEquals(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L), bs.toLongArray())
+    bs.set(193)
+    assertArrayEquals(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L), bs.toLongArray())
+    bs.set(450)
+    assertArrayEquals(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L,
+        0L, 0L, 0L, 4L), bs.toLongArray())
+  }
+
+  @Test def valueOf_ByteArray(): Unit = {
+    val bs = new BitSet(500)
+    assertEquals(bs, BitSet.valueOf(Array[Byte]()))
+    bs.set(5)
+    assertEquals(bs, BitSet.valueOf(Array[Byte](32)))
+    bs.set(32)
+    assertEquals(bs, BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1)))
+    bs.set(63)
+    assertEquals(bs, BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128)))
+    bs.set(64)
+    assertEquals(bs, BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, 1)))
+    bs.set(71, 110)
+    assertEquals(bs, BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63)))
+    bs.set(127, 130)
+    assertEquals(bs,
+      BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0, -128, 3)))
+    bs.set(193)
+    assertEquals(bs, BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0,
+      -128, 3, 0, 0, 0, 0, 0, 0, 0, 2)))
+    bs.set(450)
+    assertEquals(bs, BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0,
+      -128, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4)))
+  }
+
+  @Test def valueOf_LongArray(): Unit = {
+    val bs = new BitSet(500)
+    assertEquals(bs, BitSet.valueOf(Array[Long]()))
+    bs.set(5)
+    assertEquals(bs, BitSet.valueOf(Array[Long](32L)))
+    bs.set(32)
+    assertEquals(bs, BitSet.valueOf(Array[Long](4294967328L)))
+    bs.set(63)
+    assertEquals(bs, BitSet.valueOf(Array[Long](-9223372032559808480L)))
+    bs.set(64)
+    assertEquals(bs, BitSet.valueOf(Array[Long](-9223372032559808480L, 1L)))
+    bs.set(71, 110)
+    assertEquals(bs, BitSet.valueOf(Array[Long](-9223372032559808480L, 70368744177537L)))
+    bs.set(127, 130)
+    assertEquals(bs, BitSet.valueOf(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L)))
+    bs.set(193)
+    assertEquals(bs, BitSet.valueOf(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L)))
+    bs.set(450)
+    assertEquals(bs, BitSet.valueOf(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L,
+      0L, 0L, 0L, 4L)))
+  }
+
+  @Test def valueOf_ByteBuffer(): Unit = {
+    // Array-wrapped ByteBuffer
+    val emptyBS = new BitSet
+    val emptyBytes = emptyBS.toByteArray()
+
+    assertEquals(emptyBS, BitSet.valueOf(ByteBuffer.wrap(emptyBytes)))
+
+    val eightBS = makeEightBS()
+    val eightBytes = eightBS.toByteArray()
+    assertEquals(eightBS, BitSet.valueOf(ByteBuffer.wrap(eightBytes)))
+
+    val bbWithPosition = ByteBuffer.wrap(192.toByte +: eightBytes)
+    assertEquals(192.toByte, bbWithPosition.get()) // extra byte
+    assertEquals(1, bbWithPosition.position())
+    assertEquals(eightBS, BitSet.valueOf(bbWithPosition))
+    assertEquals(1, bbWithPosition.position())
+
+    // ByteBuffer.allocate()ed
+    assertEquals(emptyBS, BitSet.valueOf(ByteBuffer.allocate(0)))
+
+    val allocateByteBuffer = ByteBuffer.allocate(eightBytes.length + 1)
+    allocateByteBuffer.put(192.toByte) // extra byte
+    allocateByteBuffer.put(eightBytes)
+    allocateByteBuffer.rewind()
+    assertEquals(192.toByte, allocateByteBuffer.get()) // extra byte
+    assertEquals(1, allocateByteBuffer.position())
+    assertEquals(eightBS, BitSet.valueOf(allocateByteBuffer))
+    assertEquals(1, allocateByteBuffer.position())
+  }
+
+  @Test def valueOf_ByteBuffer_typedArrays(): Unit = {
+
+    val eightBS = makeEightBS()
+    val eightBytes = eightBS.toByteArray()
+
+    // ByteBuffer.allocateDirect()ed
+    assertEquals(new BitSet, BitSet.valueOf(ByteBuffer.allocateDirect(0)))
+
+    val directByteBuffer = ByteBuffer.allocateDirect(eightBytes.length + 1)
+    directByteBuffer.put(192.toByte) // extra byte
+    directByteBuffer.put(eightBytes)
+    directByteBuffer.rewind()
+    assertEquals(192.toByte, directByteBuffer.get()) // extra byte
+    assertEquals(1, directByteBuffer.position())
+    assertEquals(eightBS, BitSet.valueOf(directByteBuffer))
+    assertEquals(1, directByteBuffer.position())
+  }
+
+  @Test def valueOf_LongBuffer(): Unit = {
+    // Array-wrapped LongBuffer
+    val emptyBS = new BitSet
+    val emptyBSArray = emptyBS.toLongArray()
+    assertEquals(emptyBS, BitSet.valueOf(LongBuffer.wrap(emptyBSArray)))
+
+    val eightBS = makeEightBS()
+    val eightBSArray = eightBS.toLongArray()
+    assertEquals(eightBS, BitSet.valueOf(LongBuffer.wrap(eightBSArray)))
+
+    val lbWithPosition = LongBuffer.wrap(192L +: eightBSArray)
+    assertEquals(192L, lbWithPosition.get()) // extra byte
+    assertEquals(1, lbWithPosition.position())
+    assertEquals(eightBS, BitSet.valueOf(lbWithPosition))
+    assertEquals(1, lbWithPosition.position())
+
+    // LongBuffer.allocate()ed
+    assertEquals(emptyBS, BitSet.valueOf(LongBuffer.allocate(0)))
+
+    val allocateLongBuffer = LongBuffer.allocate(eightBSArray.length + 1)
+    allocateLongBuffer.put(192L) // extra byte
+    allocateLongBuffer.put(eightBSArray)
+    allocateLongBuffer.rewind()
+    assertEquals(192L, allocateLongBuffer.get()) // extra byte
+    assertEquals(1, allocateLongBuffer.position())
+    assertEquals(eightBS, BitSet.valueOf(allocateLongBuffer))
+    assertEquals(1, allocateLongBuffer.position())
+  }
+
+  private def makeEightBS(): BitSet = {
+    val eightbs = new BitSet
+    for (i <- 0 until 8) {
+      eightbs.set(i)
+    }
+    eightbs
+  }
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/BitSetTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/BitSetTest.scala
@@ -1,6 +1,6 @@
-package javalib.util
+// Ported from Scala.js commit: c0be6b6 dated: 2021-12-22
 
-// Ported from Scala.js
+package javalib.util
 
 import java.nio.{ByteBuffer, LongBuffer}
 import java.util.BitSet
@@ -8,7 +8,6 @@ import org.junit.Assert.{assertThrows => junitAssertThrows, _}
 import org.junit.Assume._
 import org.junit.Test
 import scala.scalanative.junit.utils.AssertThrows.assertThrows
-// import org.scalajs.testsuite.utils.Platform._
 
 class BitSetTest {
   @Test def test_Constructor_empty(): Unit = {

--- a/unit-tests/shared/src/test/scala/javalib/util/BitSetTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/BitSetTest.scala
@@ -14,14 +14,22 @@ class BitSetTest {
     val bs = new BitSet
 
     assertEquals("Create BitSet of incorrect size", 64, bs.size())
-    assertEquals("New BitSet had invalid string representation", "{}", bs.toString())
+    assertEquals(
+      "New BitSet had invalid string representation",
+      "{}",
+      bs.toString()
+    )
   }
 
   @Test def test_Constructor_Int(): Unit = {
     var bs = new BitSet(128)
 
     assertEquals("Create BitSet of incorrect size", 128, bs.size())
-    assertEquals("New BitSet had invalid string representation: " + bs.toString, "{}", bs.toString())
+    assertEquals(
+      "New BitSet had invalid string representation: " + bs.toString,
+      "{}",
+      bs.toString()
+    )
 
     // All BitSets are created with elements of multiples of 64 on jvm, 32 in JS
     bs = new BitSet(89)
@@ -48,9 +56,15 @@ class BitSetTest {
 
     bs = makeEightBS()
     bs.set(128)
-    assertFalse("Different sized BitSet with higher bit set returned true", eightbs == bs)
+    assertFalse(
+      "Different sized BitSet with higher bit set returned true",
+      eightbs == bs
+    )
     bs.clear(128)
-    assertTrue("Different sized BitSet with higher bits not set returned false", eightbs == bs)
+    assertTrue(
+      "Different sized BitSet with higher bits not set returned false",
+      eightbs == bs
+    )
   }
 
   @Test def test_hashCode(): Unit = {
@@ -78,11 +92,15 @@ class BitSetTest {
     bs.clear()
     assertEquals("Test2: Wrong length", 0, bs.length())
     assertTrue("Test2: isEmpty() returned incorrect value", bs.isEmpty())
-    assertEquals("Test2: cardinality() returned incorrect value", 0, bs.cardinality())
+    assertEquals(
+      "Test2: cardinality() returned incorrect value",
+      0,
+      bs.cardinality()
+    )
   }
 
   @Test def test_clear_bitIndex(): Unit = {
-    val eightbs  = makeEightBS()
+    val eightbs = makeEightBS()
     eightbs.clear(7)
     assertFalse("Failed to clear bit", eightbs.get(7))
 
@@ -497,11 +515,11 @@ class BitSetTest {
       assertTrue("Test1: Incorrectly flipped bit" + i, bs.get(i))
       assertEquals("Incorrect length", i + 1, bs.length())
       var j: Int = bs.size
-      while ({j -= 1; j} > i)
+      while ({ j -= 1; j } > i)
         assertTrue("Test2: Incorrectly flipped bit" + j, !bs.get(j))
 
       j = i
-      while ({j -= 1; j} >= 0)
+      while ({ j -= 1; j } >= 0)
         assertTrue("Test3: Incorrectly flipped bit" + j, !bs.get(j))
 
       bs.flip(i)
@@ -689,17 +707,17 @@ class BitSetTest {
 
     bs = new BitSet(64)
     var i = bs.size
-    while ({i -= 1; i} >= 0) {
+    while ({ i -= 1; i } >= 0) {
       bs.set(i)
       assertTrue("Incorrectly set", bs.get(i))
       assertEquals("Incorrect length", i + 1, bs.length())
 
       var j = bs.size
-      while ({j -= 1; j} > i)
+      while ({ j -= 1; j } > i)
         assertFalse("Incorrectly set bit " + j, bs.get(j))
 
       var k = i
-      while ({k -= 1; k} >= 0)
+      while ({ k -= 1; k } >= 0)
         assertFalse("Incorrectly set bit " + k, bs.get(k))
 
       bs.clear(i)
@@ -836,11 +854,15 @@ class BitSetTest {
     val eightbs = makeEightBS()
 
     eightbs.set(3, 6, false)
-    assertTrue("Should have set bits 3, 4, and 5 to false",
-        !eightbs.get(3) && !eightbs.get(4) && !eightbs.get(5))
+    assertTrue(
+      "Should have set bits 3, 4, and 5 to false",
+      !eightbs.get(3) && !eightbs.get(4) && !eightbs.get(5)
+    )
     eightbs.set(3, 6, true)
-    assertTrue("Should have set bits 3, 4, and 5 to true",
-        eightbs.get(3) && eightbs.get(4) && eightbs.get(5))
+    assertTrue(
+      "Should have set bits 3, 4, and 5 to true",
+      eightbs.get(3) && eightbs.get(4) && eightbs.get(5)
+    )
   }
 
   @Test def intersects(): Unit = {
@@ -1283,19 +1305,34 @@ class BitSetTest {
     bs.set(63)
     assertArrayEquals(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128), bs.toByteArray())
     bs.set(64)
-    assertArrayEquals(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, 1), bs.toByteArray())
+    assertArrayEquals(
+      Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, 1),
+      bs.toByteArray()
+    )
     bs.set(71, 110)
-    assertArrayEquals(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63), bs.toByteArray())
+    assertArrayEquals(
+      Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63),
+      bs.toByteArray()
+    )
     bs.set(127, 130)
     assertArrayEquals(
-        Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0, -128, 3), bs.toByteArray())
+      Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0, -128,
+        3),
+      bs.toByteArray()
+    )
     bs.set(193)
-    assertArrayEquals(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0,
-        -128, 3, 0, 0, 0, 0, 0, 0, 0, 2), bs.toByteArray())
+    assertArrayEquals(
+      Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0, -128,
+        3, 0, 0, 0, 0, 0, 0, 0, 2),
+      bs.toByteArray()
+    )
     bs.set(450)
-    assertArrayEquals(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0,
-        -128, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4), bs.toByteArray())
+    assertArrayEquals(
+      Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0, -128,
+        3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4),
+      bs.toByteArray()
+    )
   }
 
   @Test def toLongArray(): Unit = {
@@ -1310,14 +1347,26 @@ class BitSetTest {
     bs.set(64)
     assertArrayEquals(Array[Long](-9223372032559808480L, 1L), bs.toLongArray())
     bs.set(71, 110)
-    assertArrayEquals(Array[Long](-9223372032559808480L, 70368744177537L), bs.toLongArray())
+    assertArrayEquals(
+      Array[Long](-9223372032559808480L, 70368744177537L),
+      bs.toLongArray()
+    )
     bs.set(127, 130)
-    assertArrayEquals(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L), bs.toLongArray())
+    assertArrayEquals(
+      Array[Long](-9223372032559808480L, -9223301668110598271L, 3L),
+      bs.toLongArray()
+    )
     bs.set(193)
-    assertArrayEquals(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L), bs.toLongArray())
+    assertArrayEquals(
+      Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L),
+      bs.toLongArray()
+    )
     bs.set(450)
-    assertArrayEquals(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L,
-        0L, 0L, 0L, 4L), bs.toLongArray())
+    assertArrayEquals(
+      Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L, 0L, 0L,
+        0L, 4L),
+      bs.toLongArray()
+    )
   }
 
   @Test def valueOf_ByteArray(): Unit = {
@@ -1332,17 +1381,37 @@ class BitSetTest {
     bs.set(64)
     assertEquals(bs, BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, 1)))
     bs.set(71, 110)
-    assertEquals(bs, BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63)))
+    assertEquals(
+      bs,
+      BitSet.valueOf(
+        Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63)
+      )
+    )
     bs.set(127, 130)
-    assertEquals(bs,
-      BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0, -128, 3)))
+    assertEquals(
+      bs,
+      BitSet.valueOf(
+        Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0,
+          -128, 3)
+      )
+    )
     bs.set(193)
-    assertEquals(bs, BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0,
-      -128, 3, 0, 0, 0, 0, 0, 0, 0, 2)))
+    assertEquals(
+      bs,
+      BitSet.valueOf(
+        Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0,
+          -128, 3, 0, 0, 0, 0, 0, 0, 0, 2)
+      )
+    )
     bs.set(450)
-    assertEquals(bs, BitSet.valueOf(Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0,
-      -128, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4)))
+    assertEquals(
+      bs,
+      BitSet.valueOf(
+        Array[Byte](32, 0, 0, 0, 1, 0, 0, -128, -127, -1, -1, -1, -1, 63, 0,
+          -128, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4)
+      )
+    )
   }
 
   @Test def valueOf_LongArray(): Unit = {
@@ -1357,14 +1426,32 @@ class BitSetTest {
     bs.set(64)
     assertEquals(bs, BitSet.valueOf(Array[Long](-9223372032559808480L, 1L)))
     bs.set(71, 110)
-    assertEquals(bs, BitSet.valueOf(Array[Long](-9223372032559808480L, 70368744177537L)))
+    assertEquals(
+      bs,
+      BitSet.valueOf(Array[Long](-9223372032559808480L, 70368744177537L))
+    )
     bs.set(127, 130)
-    assertEquals(bs, BitSet.valueOf(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L)))
+    assertEquals(
+      bs,
+      BitSet.valueOf(
+        Array[Long](-9223372032559808480L, -9223301668110598271L, 3L)
+      )
+    )
     bs.set(193)
-    assertEquals(bs, BitSet.valueOf(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L)))
+    assertEquals(
+      bs,
+      BitSet.valueOf(
+        Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L)
+      )
+    )
     bs.set(450)
-    assertEquals(bs, BitSet.valueOf(Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L,
-      0L, 0L, 0L, 4L)))
+    assertEquals(
+      bs,
+      BitSet.valueOf(
+        Array[Long](-9223372032559808480L, -9223301668110598271L, 3L, 2L, 0L,
+          0L, 0L, 4L)
+      )
+    )
   }
 
   @Test def valueOf_ByteBuffer(): Unit = {


### PR DESCRIPTION
All credit to @er1c for the effort in https://github.com/scala-js/scala-js/pull/4217.

The changes I made were to use 64-bit words and related adjustments.