### PR TITLE
Synchronise generation of gyb templates and remove line directive

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -7,7 +7,9 @@ version = "3.4.0"
 docstrings.style = AsteriskSpace
 project.git = true
 project.excludePaths = [
-  "glob:**/scalalib/**"
+  "glob:**/scalalib/**",
+  # Files to big to disable formating using directive // format: off
+  "glob:**/nativelib/**/unsafe/Tag.scala"
 ]
 # Default runner.dialect is deprecated now, needs to be explicitly set
 runner.dialect = scala213

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -1,5 +1,3 @@
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 1)
-
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -29,8 +27,6 @@ package runtime
 import scalanative.unsafe._
 import scalanative.unsigned._
 import scalanative.runtime.Intrinsics._
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 34)
 
 sealed abstract class Array[T]
     extends java.io.Serializable
@@ -165,12 +161,6 @@ object Array {
   }
 }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 168)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
-
 final class BooleanArray private () extends Array[Boolean] {
 
   @inline def stride: CSize =
@@ -232,9 +222,6 @@ object BooleanArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
 
 final class CharArray private () extends Array[Char] {
 
@@ -297,9 +284,6 @@ object CharArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
 
 final class ByteArray private () extends Array[Byte] {
 
@@ -362,9 +346,6 @@ object ByteArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
 
 final class ShortArray private () extends Array[Short] {
 
@@ -427,9 +408,6 @@ object ShortArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
 
 final class IntArray private () extends Array[Int] {
 
@@ -492,9 +470,6 @@ object IntArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
 
 final class LongArray private () extends Array[Long] {
 
@@ -557,9 +532,6 @@ object LongArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
 
 final class FloatArray private () extends Array[Float] {
 
@@ -622,9 +594,6 @@ object FloatArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
 
 final class DoubleArray private () extends Array[Double] {
 
@@ -687,9 +656,6 @@ object DoubleArray {
     arr
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 170)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb", line: 174)
 
 final class ObjectArray private () extends Array[Object] {
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
@@ -1,3 +1,5 @@
+// format: off
+
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -9,6 +11,7 @@
 //
 //   scripts/gyb.py \
 //     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb \
+//     --line-directive '' \
 //     -o /nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
 //
 //  After executing the script, you may want to edit this file to remove
@@ -59,13 +62,11 @@ sealed abstract class Array[T]
 }
 
 object Array {
-  def copy(
-      from: AnyRef,
-      fromPos: Int,
-      to: AnyRef,
-      toPos: Int,
-      len: Int
-  ): Unit = {
+  def copy(from: AnyRef,
+           fromPos: Int,
+           to: AnyRef,
+           toPos: Int,
+           len: Int): Unit = {
     if (from == null || to == null) {
       throw new NullPointerException()
     } else if (!from.isInstanceOf[Array[_]]) {
@@ -73,23 +74,19 @@ object Array {
     } else if (!to.isInstanceOf[Array[_]]) {
       throw new IllegalArgumentException("to argument must be an array")
     } else {
-      copy(
-        from.asInstanceOf[Array[_]],
-        fromPos,
-        to.asInstanceOf[Array[_]],
-        toPos,
-        len
-      )
+      copy(from.asInstanceOf[Array[_]],
+           fromPos,
+           to.asInstanceOf[Array[_]],
+           toPos,
+           len)
     }
   }
 
-  def copy(
-      from: Array[_],
-      fromPos: Int,
-      to: Array[_],
-      toPos: Int,
-      len: Int
-  ): Unit = {
+  def copy(from: Array[_],
+           fromPos: Int,
+           to: Array[_],
+           toPos: Int,
+           len: Int): Unit = {
     if (from == null || to == null) {
       throw new NullPointerException()
     } else if (from.getClass != to.getClass) {
@@ -104,19 +101,17 @@ object Array {
       ()
     } else {
       val fromPtr = from.atRaw(fromPos)
-      val toPtr = to.atRaw(toPos)
-      val size = to.stride * len.toULong
+      val toPtr   = to.atRaw(toPos)
+      val size    = to.stride * len.toULong
       libc.memmove(toPtr, fromPtr, size)
     }
   }
 
-  def compare(
-      left: AnyRef,
-      leftPos: Int,
-      right: AnyRef,
-      rightPos: Int,
-      len: Int
-  ): Int = {
+  def compare(left: AnyRef,
+              leftPos: Int,
+              right: AnyRef,
+              rightPos: Int,
+              len: Int): Int = {
     if (left == null || right == null) {
       throw new NullPointerException()
     } else if (!left.isInstanceOf[Array[_]]) {
@@ -124,23 +119,19 @@ object Array {
     } else if (!right.isInstanceOf[Array[_]]) {
       throw new IllegalArgumentException("right argument must be an array")
     } else {
-      compare(
-        left.asInstanceOf[Array[_]],
-        leftPos,
-        right.asInstanceOf[Array[_]],
-        rightPos,
-        len
-      )
+      compare(left.asInstanceOf[Array[_]],
+              leftPos,
+              right.asInstanceOf[Array[_]],
+              rightPos,
+              len)
     }
   }
 
-  def compare(
-      left: Array[_],
-      leftPos: Int,
-      right: Array[_],
-      rightPos: Int,
-      len: Int
-  ): Int = {
+  def compare(left: Array[_],
+              leftPos: Int,
+              right: Array[_],
+              rightPos: Int,
+              len: Int): Int = {
     if (left == null || right == null) {
       throw new NullPointerException()
     } else if (left.getClass != right.getClass) {
@@ -154,12 +145,13 @@ object Array {
     } else if (len == 0) {
       0
     } else {
-      val leftPtr = left.atRaw(leftPos)
+      val leftPtr  = left.atRaw(leftPos)
       val rightPtr = right.atRaw(rightPos)
       libc.memcmp(leftPtr, rightPtr, len.toULong * left.stride)
     }
   }
 }
+
 
 final class BooleanArray private () extends Array[Boolean] {
 
@@ -179,7 +171,7 @@ final class BooleanArray private () extends Array[Boolean] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 1 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 1 * i)
       loadBoolean(ith)
     }
 
@@ -188,15 +180,15 @@ final class BooleanArray private () extends Array[Boolean] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 1 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 1 * i)
       storeBoolean(ith, value)
     }
 
   @inline override def clone(): BooleanArray = {
-    val arrcls = classOf[BooleanArray]
+    val arrcls  = classOf[BooleanArray]
     val arrsize = (16 + 1 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
-    val src = castObjectToRawPtr(this)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
+    val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[BooleanArray]
   }
@@ -205,18 +197,18 @@ final class BooleanArray private () extends Array[Boolean] {
 object BooleanArray {
 
   @inline def alloc(length: Int): BooleanArray = {
-    val arrcls = classOf[BooleanArray]
+    val arrcls  = classOf[BooleanArray]
     val arrsize = (16 + 1 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), 1.toInt)
     castRawPtrToObject(arr).asInstanceOf[BooleanArray]
   }
 
   @inline def snapshot(length: Int, data: RawPtr): BooleanArray = {
-    val arr = alloc(length)
-    val dst = arr.atRaw(0)
-    val src = data
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
     val size = (1 * length).toULong
     libc.memcpy(dst, src, size)
     arr
@@ -241,7 +233,7 @@ final class CharArray private () extends Array[Char] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 2 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 2 * i)
       loadChar(ith)
     }
 
@@ -250,15 +242,15 @@ final class CharArray private () extends Array[Char] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 2 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 2 * i)
       storeChar(ith, value)
     }
 
   @inline override def clone(): CharArray = {
-    val arrcls = classOf[CharArray]
+    val arrcls  = classOf[CharArray]
     val arrsize = (16 + 2 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
-    val src = castObjectToRawPtr(this)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
+    val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[CharArray]
   }
@@ -267,18 +259,18 @@ final class CharArray private () extends Array[Char] {
 object CharArray {
 
   @inline def alloc(length: Int): CharArray = {
-    val arrcls = classOf[CharArray]
+    val arrcls  = classOf[CharArray]
     val arrsize = (16 + 2 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), 2.toInt)
     castRawPtrToObject(arr).asInstanceOf[CharArray]
   }
 
   @inline def snapshot(length: Int, data: RawPtr): CharArray = {
-    val arr = alloc(length)
-    val dst = arr.atRaw(0)
-    val src = data
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
     val size = (2 * length).toULong
     libc.memcpy(dst, src, size)
     arr
@@ -303,7 +295,7 @@ final class ByteArray private () extends Array[Byte] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 1 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 1 * i)
       loadByte(ith)
     }
 
@@ -312,15 +304,15 @@ final class ByteArray private () extends Array[Byte] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 1 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 1 * i)
       storeByte(ith, value)
     }
 
   @inline override def clone(): ByteArray = {
-    val arrcls = classOf[ByteArray]
+    val arrcls  = classOf[ByteArray]
     val arrsize = (16 + 1 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
-    val src = castObjectToRawPtr(this)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
+    val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[ByteArray]
   }
@@ -329,18 +321,18 @@ final class ByteArray private () extends Array[Byte] {
 object ByteArray {
 
   @inline def alloc(length: Int): ByteArray = {
-    val arrcls = classOf[ByteArray]
+    val arrcls  = classOf[ByteArray]
     val arrsize = (16 + 1 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), 1.toInt)
     castRawPtrToObject(arr).asInstanceOf[ByteArray]
   }
 
   @inline def snapshot(length: Int, data: RawPtr): ByteArray = {
-    val arr = alloc(length)
-    val dst = arr.atRaw(0)
-    val src = data
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
     val size = (1 * length).toULong
     libc.memcpy(dst, src, size)
     arr
@@ -365,7 +357,7 @@ final class ShortArray private () extends Array[Short] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 2 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 2 * i)
       loadShort(ith)
     }
 
@@ -374,15 +366,15 @@ final class ShortArray private () extends Array[Short] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 2 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 2 * i)
       storeShort(ith, value)
     }
 
   @inline override def clone(): ShortArray = {
-    val arrcls = classOf[ShortArray]
+    val arrcls  = classOf[ShortArray]
     val arrsize = (16 + 2 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
-    val src = castObjectToRawPtr(this)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
+    val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[ShortArray]
   }
@@ -391,18 +383,18 @@ final class ShortArray private () extends Array[Short] {
 object ShortArray {
 
   @inline def alloc(length: Int): ShortArray = {
-    val arrcls = classOf[ShortArray]
+    val arrcls  = classOf[ShortArray]
     val arrsize = (16 + 2 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), 2.toInt)
     castRawPtrToObject(arr).asInstanceOf[ShortArray]
   }
 
   @inline def snapshot(length: Int, data: RawPtr): ShortArray = {
-    val arr = alloc(length)
-    val dst = arr.atRaw(0)
-    val src = data
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
     val size = (2 * length).toULong
     libc.memcpy(dst, src, size)
     arr
@@ -427,7 +419,7 @@ final class IntArray private () extends Array[Int] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 4 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 4 * i)
       loadInt(ith)
     }
 
@@ -436,15 +428,15 @@ final class IntArray private () extends Array[Int] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 4 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 4 * i)
       storeInt(ith, value)
     }
 
   @inline override def clone(): IntArray = {
-    val arrcls = classOf[IntArray]
+    val arrcls  = classOf[IntArray]
     val arrsize = (16 + 4 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
-    val src = castObjectToRawPtr(this)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
+    val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[IntArray]
   }
@@ -453,18 +445,18 @@ final class IntArray private () extends Array[Int] {
 object IntArray {
 
   @inline def alloc(length: Int): IntArray = {
-    val arrcls = classOf[IntArray]
+    val arrcls  = classOf[IntArray]
     val arrsize = (16 + 4 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), 4.toInt)
     castRawPtrToObject(arr).asInstanceOf[IntArray]
   }
 
   @inline def snapshot(length: Int, data: RawPtr): IntArray = {
-    val arr = alloc(length)
-    val dst = arr.atRaw(0)
-    val src = data
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
     val size = (4 * length).toULong
     libc.memcpy(dst, src, size)
     arr
@@ -489,7 +481,7 @@ final class LongArray private () extends Array[Long] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 8 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
       loadLong(ith)
     }
 
@@ -498,15 +490,15 @@ final class LongArray private () extends Array[Long] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 8 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
       storeLong(ith, value)
     }
 
   @inline override def clone(): LongArray = {
-    val arrcls = classOf[LongArray]
+    val arrcls  = classOf[LongArray]
     val arrsize = (16 + 8 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
-    val src = castObjectToRawPtr(this)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
+    val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[LongArray]
   }
@@ -515,18 +507,18 @@ final class LongArray private () extends Array[Long] {
 object LongArray {
 
   @inline def alloc(length: Int): LongArray = {
-    val arrcls = classOf[LongArray]
+    val arrcls  = classOf[LongArray]
     val arrsize = (16 + 8 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), 8.toInt)
     castRawPtrToObject(arr).asInstanceOf[LongArray]
   }
 
   @inline def snapshot(length: Int, data: RawPtr): LongArray = {
-    val arr = alloc(length)
-    val dst = arr.atRaw(0)
-    val src = data
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
     val size = (8 * length).toULong
     libc.memcpy(dst, src, size)
     arr
@@ -551,7 +543,7 @@ final class FloatArray private () extends Array[Float] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 4 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 4 * i)
       loadFloat(ith)
     }
 
@@ -560,15 +552,15 @@ final class FloatArray private () extends Array[Float] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 4 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 4 * i)
       storeFloat(ith, value)
     }
 
   @inline override def clone(): FloatArray = {
-    val arrcls = classOf[FloatArray]
+    val arrcls  = classOf[FloatArray]
     val arrsize = (16 + 4 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
-    val src = castObjectToRawPtr(this)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
+    val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[FloatArray]
   }
@@ -577,18 +569,18 @@ final class FloatArray private () extends Array[Float] {
 object FloatArray {
 
   @inline def alloc(length: Int): FloatArray = {
-    val arrcls = classOf[FloatArray]
+    val arrcls  = classOf[FloatArray]
     val arrsize = (16 + 4 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), 4.toInt)
     castRawPtrToObject(arr).asInstanceOf[FloatArray]
   }
 
   @inline def snapshot(length: Int, data: RawPtr): FloatArray = {
-    val arr = alloc(length)
-    val dst = arr.atRaw(0)
-    val src = data
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
     val size = (4 * length).toULong
     libc.memcpy(dst, src, size)
     arr
@@ -613,7 +605,7 @@ final class DoubleArray private () extends Array[Double] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 8 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
       loadDouble(ith)
     }
 
@@ -622,15 +614,15 @@ final class DoubleArray private () extends Array[Double] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 8 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
       storeDouble(ith, value)
     }
 
   @inline override def clone(): DoubleArray = {
-    val arrcls = classOf[DoubleArray]
+    val arrcls  = classOf[DoubleArray]
     val arrsize = (16 + 8 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
-    val src = castObjectToRawPtr(this)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
+    val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[DoubleArray]
   }
@@ -639,18 +631,18 @@ final class DoubleArray private () extends Array[Double] {
 object DoubleArray {
 
   @inline def alloc(length: Int): DoubleArray = {
-    val arrcls = classOf[DoubleArray]
+    val arrcls  = classOf[DoubleArray]
     val arrsize = (16 + 8 * length).toULong
-    val arr = GC.alloc_atomic(arrcls, arrsize)
+    val arr     = GC.alloc_atomic(arrcls, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), 8.toInt)
     castRawPtrToObject(arr).asInstanceOf[DoubleArray]
   }
 
   @inline def snapshot(length: Int, data: RawPtr): DoubleArray = {
-    val arr = alloc(length)
-    val dst = arr.atRaw(0)
-    val src = data
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
     val size = (8 * length).toULong
     libc.memcpy(dst, src, size)
     arr
@@ -675,7 +667,7 @@ final class ObjectArray private () extends Array[Object] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 8 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
       loadObject(ith)
     }
 
@@ -684,15 +676,15 @@ final class ObjectArray private () extends Array[Object] {
       throwOutOfBounds(i)
     } else {
       val rawptr = castObjectToRawPtr(this)
-      val ith = elemRawPtr(rawptr, 16 + 8 * i)
+      val ith    = elemRawPtr(rawptr, 16 + 8 * i)
       storeObject(ith, value)
     }
 
   @inline override def clone(): ObjectArray = {
-    val arrcls = classOf[ObjectArray]
+    val arrcls  = classOf[ObjectArray]
     val arrsize = (16 + 8 * length).toULong
-    val arr = GC.alloc(arrcls, arrsize)
-    val src = castObjectToRawPtr(this)
+    val arr     = GC.alloc(arrcls, arrsize)
+    val src     = castObjectToRawPtr(this)
     libc.memcpy(arr, src, arrsize)
     castRawPtrToObject(arr).asInstanceOf[ObjectArray]
   }
@@ -701,18 +693,18 @@ final class ObjectArray private () extends Array[Object] {
 object ObjectArray {
 
   @inline def alloc(length: Int): ObjectArray = {
-    val arrcls = classOf[ObjectArray]
+    val arrcls  = classOf[ObjectArray]
     val arrsize = (16 + 8 * length).toULong
-    val arr = GC.alloc(arrcls, arrsize)
+    val arr     = GC.alloc(arrcls, arrsize)
     storeInt(elemRawPtr(arr, 8), length)
     storeInt(elemRawPtr(arr, 12), 8.toInt)
     castRawPtrToObject(arr).asInstanceOf[ObjectArray]
   }
 
   @inline def snapshot(length: Int, data: RawPtr): ObjectArray = {
-    val arr = alloc(length)
-    val dst = arr.atRaw(0)
-    val src = data
+    val arr  = alloc(length)
+    val dst  = arr.atRaw(0)
+    val src  = data
     val size = (8 * length).toULong
     libc.memcpy(dst, src, size)
     arr

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb
@@ -1,3 +1,4 @@
+// format: off
 
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
@@ -10,6 +11,7 @@
 //
 //   scripts/gyb.py \
 //     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb \
+//     --line-directive '' \
 //     -o /nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
 //
 //  After executing the script, you may want to edit this file to remove
@@ -31,7 +33,6 @@ import scalanative.runtime.Intrinsics._
 
 % sizePtr = 8
 % sizeHeader = 16
-
 sealed abstract class Array[T]
     extends java.io.Serializable
     with java.lang.Cloneable {
@@ -165,9 +166,7 @@ object Array {
 % #         
 % #	    To reduce time consuming git differences, python >= 3.6 should be
 % #         used to run this script.
-
 % for T, sizeT in types.items():
-
 %{
    alloc = 'GC.alloc_atomic' if T != 'Object' else 'GC.alloc'
 }%

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala
@@ -1,4 +1,3 @@
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 1)
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -30,167 +29,130 @@ import scalanative.unsafe._
 
 object Boxes {
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 41)
   @inline def boxToUByte(v: Byte): UByte = new UByte(v)
-
   @inline def unboxToUByte(o: java.lang.Object): Byte =
     if (o == null) 0.toByte else o.asInstanceOf[UByte].underlying
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 41)
   @inline def boxToUShort(v: Short): UShort = new UShort(v)
-
   @inline def unboxToUShort(o: java.lang.Object): Short =
     if (o == null) 0.toShort else o.asInstanceOf[UShort].underlying
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 41)
   @inline def boxToUInt(v: Int): UInt = new UInt(v)
-
   @inline def unboxToUInt(o: java.lang.Object): Int =
     if (o == null) 0.toInt else o.asInstanceOf[UInt].underlying
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 41)
   @inline def boxToULong(v: Long): ULong = new ULong(v)
-
   @inline def unboxToULong(o: java.lang.Object): Long =
     if (o == null) 0.toLong else o.asInstanceOf[ULong].underlying
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 46)
-
   @inline def boxToPtr[T](v: RawPtr): Ptr[T] =
     if (v == null) null else new Ptr[T](v)
-
   @inline def unboxToPtr(o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[Ptr[_]].rawptr
 
   @inline def boxToCArray[T, N <: Nat](v: RawPtr): CArray[T, N] =
     if (v == null) null else new CArray[T, N](v)
-
   @inline def unboxToCArray(o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CArray[_, _]].rawptr
 
   @inline def boxToCVarArgList(v: RawPtr): CVarArgList =
     if (v == null) null else new CVarArgList(v)
-
   @inline def unboxToCVarArgList(o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CVarArgList].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr0[R](v: RawPtr): CFuncPtr0[R] =
     if (v == null) null else CFuncPtr0.fromRawPtr[R](v)
-
   @inline def unboxToCFuncPtr0[R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr1[T1, R](v: RawPtr): CFuncPtr1[T1, R] =
     if (v == null) null else CFuncPtr1.fromRawPtr[T1, R](v)
-
   @inline def unboxToCFuncPtr1[T1, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr2[T1, T2, R](v: RawPtr): CFuncPtr2[T1, T2, R] =
     if (v == null) null else CFuncPtr2.fromRawPtr[T1, T2, R](v)
-
   @inline def unboxToCFuncPtr2[T1, T2, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr3[T1, T2, T3, R](
       v: RawPtr
   ): CFuncPtr3[T1, T2, T3, R] =
     if (v == null) null else CFuncPtr3.fromRawPtr[T1, T2, T3, R](v)
-
   @inline def unboxToCFuncPtr3[T1, T2, T3, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr4[T1, T2, T3, T4, R](
       v: RawPtr
   ): CFuncPtr4[T1, T2, T3, T4, R] =
     if (v == null) null else CFuncPtr4.fromRawPtr[T1, T2, T3, T4, R](v)
-
   @inline def unboxToCFuncPtr4[T1, T2, T3, T4, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr5[T1, T2, T3, T4, T5, R](
       v: RawPtr
   ): CFuncPtr5[T1, T2, T3, T4, T5, R] =
     if (v == null) null else CFuncPtr5.fromRawPtr[T1, T2, T3, T4, T5, R](v)
-
   @inline def unboxToCFuncPtr5[T1, T2, T3, T4, T5, R](
       o: java.lang.Object
   ): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr6[T1, T2, T3, T4, T5, T6, R](
       v: RawPtr
   ): CFuncPtr6[T1, T2, T3, T4, T5, T6, R] =
     if (v == null) null else CFuncPtr6.fromRawPtr[T1, T2, T3, T4, T5, T6, R](v)
-
   @inline def unboxToCFuncPtr6[T1, T2, T3, T4, T5, T6, R](
       o: java.lang.Object
   ): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R](
       v: RawPtr
   ): CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] =
     if (v == null) null
     else CFuncPtr7.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, R](v)
-
   @inline def unboxToCFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R](
       o: java.lang.Object
   ): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R](
       v: RawPtr
   ): CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] =
     if (v == null) null
     else CFuncPtr8.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, R](v)
-
   @inline def unboxToCFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R](
       o: java.lang.Object
   ): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](
       v: RawPtr
   ): CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] =
     if (v == null) null
     else CFuncPtr9.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](v)
-
   @inline def unboxToCFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](
       o: java.lang.Object
   ): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](
       v: RawPtr
   ): CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] =
     if (v == null) null
     else CFuncPtr10.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](v)
-
   @inline def unboxToCFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](
       o: java.lang.Object
   ): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](
       v: RawPtr
   ): CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] =
     if (v == null) null
     else
       CFuncPtr11.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](v)
-
   @inline def unboxToCFuncPtr11[
       T1,
       T2,
@@ -207,7 +169,6 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr12[
       T1,
       T2,
@@ -229,7 +190,6 @@ object Boxes {
     else
       CFuncPtr12
         .fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](v)
-
   @inline def unboxToCFuncPtr12[
       T1,
       T2,
@@ -247,7 +207,6 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr13[
       T1,
       T2,
@@ -272,7 +231,6 @@ object Boxes {
         .fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](
           v
         )
-
   @inline def unboxToCFuncPtr13[
       T1,
       T2,
@@ -291,7 +249,6 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr14[
       T1,
       T2,
@@ -344,7 +301,6 @@ object Boxes {
         T14,
         R
       ](v)
-
   @inline def unboxToCFuncPtr14[
       T1,
       T2,
@@ -364,7 +320,6 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr15[
       T1,
       T2,
@@ -420,7 +375,6 @@ object Boxes {
         T15,
         R
       ](v)
-
   @inline def unboxToCFuncPtr15[
       T1,
       T2,
@@ -441,7 +395,6 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr16[
       T1,
       T2,
@@ -500,7 +453,6 @@ object Boxes {
         T16,
         R
       ](v)
-
   @inline def unboxToCFuncPtr16[
       T1,
       T2,
@@ -522,7 +474,6 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr17[
       T1,
       T2,
@@ -584,7 +535,6 @@ object Boxes {
         T17,
         R
       ](v)
-
   @inline def unboxToCFuncPtr17[
       T1,
       T2,
@@ -607,7 +557,6 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr18[
       T1,
       T2,
@@ -672,7 +621,6 @@ object Boxes {
         T18,
         R
       ](v)
-
   @inline def unboxToCFuncPtr18[
       T1,
       T2,
@@ -696,7 +644,6 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr19[
       T1,
       T2,
@@ -764,7 +711,6 @@ object Boxes {
         T19,
         R
       ](v)
-
   @inline def unboxToCFuncPtr19[
       T1,
       T2,
@@ -789,7 +735,6 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr20[
       T1,
       T2,
@@ -860,7 +805,6 @@ object Boxes {
         T20,
         R
       ](v)
-
   @inline def unboxToCFuncPtr20[
       T1,
       T2,
@@ -886,7 +830,6 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr21[
       T1,
       T2,
@@ -960,7 +903,6 @@ object Boxes {
         T21,
         R
       ](v)
-
   @inline def unboxToCFuncPtr21[
       T1,
       T2,
@@ -987,7 +929,6 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 67)
   @inline def boxToCFuncPtr22[
       T1,
       T2,
@@ -1064,7 +1005,6 @@ object Boxes {
         T22,
         R
       ](v)
-
   @inline def unboxToCFuncPtr22[
       T1,
       T2,
@@ -1092,5 +1032,4 @@ object Boxes {
   ](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  // ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb", line: 73)
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala
@@ -1,3 +1,5 @@
+// format: off
+
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -9,6 +11,7 @@
 //
 //   scripts/gyb.py \
 //     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb \
+//     --line-directive '' \
 //     -o /nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
 //
 //  After executing the script, you may want to edit this file to remove
@@ -75,961 +78,104 @@ object Boxes {
   @inline def unboxToCFuncPtr2[T1, T2, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr3[T1, T2, T3, R](
-      v: RawPtr
-  ): CFuncPtr3[T1, T2, T3, R] =
+  @inline def boxToCFuncPtr3[T1, T2, T3, R](v: RawPtr): CFuncPtr3[T1, T2, T3, R] =
     if (v == null) null else CFuncPtr3.fromRawPtr[T1, T2, T3, R](v)
   @inline def unboxToCFuncPtr3[T1, T2, T3, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr4[T1, T2, T3, T4, R](
-      v: RawPtr
-  ): CFuncPtr4[T1, T2, T3, T4, R] =
+  @inline def boxToCFuncPtr4[T1, T2, T3, T4, R](v: RawPtr): CFuncPtr4[T1, T2, T3, T4, R] =
     if (v == null) null else CFuncPtr4.fromRawPtr[T1, T2, T3, T4, R](v)
   @inline def unboxToCFuncPtr4[T1, T2, T3, T4, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr5[T1, T2, T3, T4, T5, R](
-      v: RawPtr
-  ): CFuncPtr5[T1, T2, T3, T4, T5, R] =
+  @inline def boxToCFuncPtr5[T1, T2, T3, T4, T5, R](v: RawPtr): CFuncPtr5[T1, T2, T3, T4, T5, R] =
     if (v == null) null else CFuncPtr5.fromRawPtr[T1, T2, T3, T4, T5, R](v)
-  @inline def unboxToCFuncPtr5[T1, T2, T3, T4, T5, R](
-      o: java.lang.Object
-  ): RawPtr =
+  @inline def unboxToCFuncPtr5[T1, T2, T3, T4, T5, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr6[T1, T2, T3, T4, T5, T6, R](
-      v: RawPtr
-  ): CFuncPtr6[T1, T2, T3, T4, T5, T6, R] =
+  @inline def boxToCFuncPtr6[T1, T2, T3, T4, T5, T6, R](v: RawPtr): CFuncPtr6[T1, T2, T3, T4, T5, T6, R] =
     if (v == null) null else CFuncPtr6.fromRawPtr[T1, T2, T3, T4, T5, T6, R](v)
-  @inline def unboxToCFuncPtr6[T1, T2, T3, T4, T5, T6, R](
-      o: java.lang.Object
-  ): RawPtr =
+  @inline def unboxToCFuncPtr6[T1, T2, T3, T4, T5, T6, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R](
-      v: RawPtr
-  ): CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] =
-    if (v == null) null
-    else CFuncPtr7.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, R](v)
-  @inline def unboxToCFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R](
-      o: java.lang.Object
-  ): RawPtr =
+  @inline def boxToCFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R](v: RawPtr): CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] =
+    if (v == null) null else CFuncPtr7.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, R](v)
+  @inline def unboxToCFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R](
-      v: RawPtr
-  ): CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] =
-    if (v == null) null
-    else CFuncPtr8.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, R](v)
-  @inline def unboxToCFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R](
-      o: java.lang.Object
-  ): RawPtr =
+  @inline def boxToCFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R](v: RawPtr): CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] =
+    if (v == null) null else CFuncPtr8.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, R](v)
+  @inline def unboxToCFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](
-      v: RawPtr
-  ): CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] =
-    if (v == null) null
-    else CFuncPtr9.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](v)
-  @inline def unboxToCFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](
-      o: java.lang.Object
-  ): RawPtr =
+  @inline def boxToCFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](v: RawPtr): CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] =
+    if (v == null) null else CFuncPtr9.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](v)
+  @inline def unboxToCFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](
-      v: RawPtr
-  ): CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] =
-    if (v == null) null
-    else CFuncPtr10.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](v)
-  @inline def unboxToCFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](
-      o: java.lang.Object
-  ): RawPtr =
+  @inline def boxToCFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](v: RawPtr): CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] =
+    if (v == null) null else CFuncPtr10.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](v)
+  @inline def unboxToCFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](
-      v: RawPtr
-  ): CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] =
-    if (v == null) null
-    else
-      CFuncPtr11.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](v)
-  @inline def unboxToCFuncPtr11[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](v: RawPtr): CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] =
+    if (v == null) null else CFuncPtr11.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](v)
+  @inline def unboxToCFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr12[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      R
-  ](
-      v: RawPtr
-  ): CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] =
-    if (v == null) null
-    else
-      CFuncPtr12
-        .fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](v)
-  @inline def unboxToCFuncPtr12[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](v: RawPtr): CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] =
+    if (v == null) null else CFuncPtr12.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](v)
+  @inline def unboxToCFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr13[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      R
-  ](
-      v: RawPtr
-  ): CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] =
-    if (v == null) null
-    else
-      CFuncPtr13
-        .fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](
-          v
-        )
-  @inline def unboxToCFuncPtr13[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](v: RawPtr): CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] =
+    if (v == null) null else CFuncPtr13.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](v)
+  @inline def unboxToCFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr14[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      R
-  ](v: RawPtr): CFuncPtr14[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    R
-  ] =
-    if (v == null) null
-    else
-      CFuncPtr14.fromRawPtr[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        R
-      ](v)
-  @inline def unboxToCFuncPtr14[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R](v: RawPtr): CFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R] =
+    if (v == null) null else CFuncPtr14.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R](v)
+  @inline def unboxToCFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr15[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      R
-  ](v: RawPtr): CFuncPtr15[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    R
-  ] =
-    if (v == null) null
-    else
-      CFuncPtr15.fromRawPtr[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        R
-      ](v)
-  @inline def unboxToCFuncPtr15[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R](v: RawPtr): CFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R] =
+    if (v == null) null else CFuncPtr15.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R](v)
+  @inline def unboxToCFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr16[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      R
-  ](v: RawPtr): CFuncPtr16[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    R
-  ] =
-    if (v == null) null
-    else
-      CFuncPtr16.fromRawPtr[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        R
-      ](v)
-  @inline def unboxToCFuncPtr16[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R](v: RawPtr): CFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R] =
+    if (v == null) null else CFuncPtr16.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R](v)
+  @inline def unboxToCFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr17[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      R
-  ](v: RawPtr): CFuncPtr17[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    R
-  ] =
-    if (v == null) null
-    else
-      CFuncPtr17.fromRawPtr[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        R
-      ](v)
-  @inline def unboxToCFuncPtr17[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R](v: RawPtr): CFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] =
+    if (v == null) null else CFuncPtr17.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R](v)
+  @inline def unboxToCFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr18[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      R
-  ](v: RawPtr): CFuncPtr18[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    R
-  ] =
-    if (v == null) null
-    else
-      CFuncPtr18.fromRawPtr[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        R
-      ](v)
-  @inline def unboxToCFuncPtr18[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R](v: RawPtr): CFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R] =
+    if (v == null) null else CFuncPtr18.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R](v)
+  @inline def unboxToCFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr19[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      R
-  ](v: RawPtr): CFuncPtr19[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    R
-  ] =
-    if (v == null) null
-    else
-      CFuncPtr19.fromRawPtr[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        R
-      ](v)
-  @inline def unboxToCFuncPtr19[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R](v: RawPtr): CFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R] =
+    if (v == null) null else CFuncPtr19.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R](v)
+  @inline def unboxToCFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr20[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      R
-  ](v: RawPtr): CFuncPtr20[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    R
-  ] =
-    if (v == null) null
-    else
-      CFuncPtr20.fromRawPtr[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        R
-      ](v)
-  @inline def unboxToCFuncPtr20[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R](v: RawPtr): CFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R] =
+    if (v == null) null else CFuncPtr20.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R](v)
+  @inline def unboxToCFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr21[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      R
-  ](v: RawPtr): CFuncPtr21[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    R
-  ] =
-    if (v == null) null
-    else
-      CFuncPtr21.fromRawPtr[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        R
-      ](v)
-  @inline def unboxToCFuncPtr21[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R](v: RawPtr): CFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] =
+    if (v == null) null else CFuncPtr21.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R](v)
+  @inline def unboxToCFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
-  @inline def boxToCFuncPtr22[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      T22,
-      R
-  ](v: RawPtr): CFuncPtr22[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    R
-  ] =
-    if (v == null) null
-    else
-      CFuncPtr22.fromRawPtr[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        R
-      ](v)
-  @inline def unboxToCFuncPtr22[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      T22,
-      R
-  ](o: java.lang.Object): RawPtr =
+  @inline def boxToCFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](v: RawPtr): CFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] =
+    if (v == null) null else CFuncPtr22.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](v)
+  @inline def unboxToCFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](o: java.lang.Object): RawPtr =
     if (o == null) null else o.asInstanceOf[CFuncPtr].rawptr
 
 }

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Boxes.scala.gyb
@@ -1,3 +1,5 @@
+// format: off
+
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -9,6 +11,7 @@
 //
 //   scripts/gyb.py \
 //     nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala.gyb \
+//     --line-directive '' \
 //     -o /nativelib/src/main/scala/scala/scalanative/runtime/Arrays.scala
 //
 //  After executing the script, you may want to edit this file to remove
@@ -43,7 +46,6 @@ object Boxes {
     if (o == null) 0.to${P} else o.asInstanceOf[${U}].underlying
 
 % end
-
   @inline def boxToPtr[T](v: RawPtr): Ptr[T] =
     if (v == null) null else new Ptr[T](v)
   @inline def unboxToPtr(o: java.lang.Object): RawPtr =

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala
@@ -1,3 +1,5 @@
+// format: off
+
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala
@@ -1,5 +1,3 @@
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb", line: 1)
-
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -11,40 +9,20 @@
 package scala.scalanative
 package runtime
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb", line: 17)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb", line: 19)
-
 final abstract class PrimitiveBoolean
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb", line: 19)
 
 final abstract class PrimitiveChar
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb", line: 19)
-
 final abstract class PrimitiveByte
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb", line: 19)
 
 final abstract class PrimitiveShort
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb", line: 19)
-
 final abstract class PrimitiveInt
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb", line: 19)
 
 final abstract class PrimitiveLong
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb", line: 19)
-
 final abstract class PrimitiveFloat
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb", line: 19)
-
 final abstract class PrimitiveDouble
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb", line: 19)
 
 final abstract class PrimitiveUnit

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Primitives.scala.gyb
@@ -1,3 +1,4 @@
+// format: off
 
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
@@ -9,14 +10,11 @@
 
 package scala.scalanative
 package runtime
-
 %{
     primitives = ['Boolean', 'Char', 'Byte', 'Short',
                   'Int', 'Long', 'Float', 'Double', 'Unit']
 }%
-
 % for T in primitives:
 
 final abstract class Primitive${T}
-
 % end

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala
@@ -1,3 +1,5 @@
+// format: off
+
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -14,14 +16,10 @@ import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.runtime.Boxes._
 import scala.scalanative.runtime.{RawPtr, intrinsic}
 
-sealed abstract class CFuncPtr private[unsafe] (
-    private[scalanative] val rawptr: RawPtr
-)
+sealed abstract class CFuncPtr private[unsafe] (private[scalanative] val rawptr: RawPtr)
 
 object CFuncPtr {
-  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: Ptr[Byte])(implicit
-      tag: Tag.CFuncPtrTag[F]
-  ): F =
+  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: Ptr[Byte])(implicit tag: Tag.CFuncPtrTag[F]): F =
     tag.fromRawPtr(ptr.rawptr)
 
   @alwaysinline def toPtr(ptr: CFuncPtr): Ptr[Byte] = {
@@ -34,9 +32,7 @@ final class CFuncPtr0[R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
 }
 
 object CFuncPtr0 {
-  implicit def fromScalaFunction[R](fn: Function0[R])(implicit
-      evRet: Tag[R]
-  ): CFuncPtr0[R] = intrinsic
+  implicit def fromScalaFunction[R](fn: Function0[R])(implicit evRet: Tag[R]): CFuncPtr0[R] = intrinsic
 
   private[scalanative] def fromRawPtr[R](ptr: RawPtr): CFuncPtr0[R] = {
     new CFuncPtr0[R](ptr)
@@ -48,2584 +44,261 @@ final class CFuncPtr1[T1, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
 }
 
 object CFuncPtr1 {
-  implicit def fromScalaFunction[T1, R](
-      fn: Function1[T1, R]
-  )(implicit ev1: Tag[T1], evRet: Tag[R]): CFuncPtr1[T1, R] = intrinsic
+  implicit def fromScalaFunction[T1, R](fn: Function1[T1, R])(implicit ev1: Tag[T1], evRet: Tag[R]): CFuncPtr1[T1, R] = intrinsic
 
   private[scalanative] def fromRawPtr[T1, R](ptr: RawPtr): CFuncPtr1[T1, R] = {
     new CFuncPtr1[T1, R](ptr)
   }
 }
 
-final class CFuncPtr2[T1, T2, R] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(arg1: T1, arg2: T2)(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr2[T1, T2, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2)(implicit ev1: Tag[T1], ev2: Tag[T2], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr2 {
-  implicit def fromScalaFunction[T1, T2, R](
-      fn: Function2[T1, T2, R]
-  )(implicit ev1: Tag[T1], ev2: Tag[T2], evRet: Tag[R]): CFuncPtr2[T1, T2, R] =
-    intrinsic
+  implicit def fromScalaFunction[T1, T2, R](fn: Function2[T1, T2, R])(implicit ev1: Tag[T1], ev2: Tag[T2], evRet: Tag[R]): CFuncPtr2[T1, T2, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[T1, T2, R](
-      ptr: RawPtr
-  ): CFuncPtr2[T1, T2, R] = {
+  private[scalanative] def fromRawPtr[T1, T2, R](ptr: RawPtr): CFuncPtr2[T1, T2, R] = {
     new CFuncPtr2[T1, T2, R](ptr)
   }
 }
 
-final class CFuncPtr3[T1, T2, T3, R] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(arg1: T1, arg2: T2, arg3: T3)(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr3[T1, T2, T3, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr3 {
-  implicit def fromScalaFunction[T1, T2, T3, R](
-      fn: Function3[T1, T2, T3, R]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      evRet: Tag[R]
-  ): CFuncPtr3[T1, T2, T3, R] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, R](fn: Function3[T1, T2, T3, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], evRet: Tag[R]): CFuncPtr3[T1, T2, T3, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[T1, T2, T3, R](
-      ptr: RawPtr
-  ): CFuncPtr3[T1, T2, T3, R] = {
+  private[scalanative] def fromRawPtr[T1, T2, T3, R](ptr: RawPtr): CFuncPtr3[T1, T2, T3, R] = {
     new CFuncPtr3[T1, T2, T3, R](ptr)
   }
 }
 
-final class CFuncPtr4[T1, T2, T3, T4, R] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4)(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr4[T1, T2, T3, T4, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr4 {
-  implicit def fromScalaFunction[T1, T2, T3, T4, R](
-      fn: Function4[T1, T2, T3, T4, R]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      evRet: Tag[R]
-  ): CFuncPtr4[T1, T2, T3, T4, R] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, R](fn: Function4[T1, T2, T3, T4, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], evRet: Tag[R]): CFuncPtr4[T1, T2, T3, T4, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[T1, T2, T3, T4, R](
-      ptr: RawPtr
-  ): CFuncPtr4[T1, T2, T3, T4, R] = {
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, R](ptr: RawPtr): CFuncPtr4[T1, T2, T3, T4, R] = {
     new CFuncPtr4[T1, T2, T3, T4, R](ptr)
   }
 }
 
-final class CFuncPtr5[T1, T2, T3, T4, T5, R] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5)(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr5[T1, T2, T3, T4, T5, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr5 {
-  implicit def fromScalaFunction[T1, T2, T3, T4, T5, R](
-      fn: Function5[T1, T2, T3, T4, T5, R]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      evRet: Tag[R]
-  ): CFuncPtr5[T1, T2, T3, T4, T5, R] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, R](fn: Function5[T1, T2, T3, T4, T5, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], evRet: Tag[R]): CFuncPtr5[T1, T2, T3, T4, T5, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, R](
-      ptr: RawPtr
-  ): CFuncPtr5[T1, T2, T3, T4, T5, R] = {
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, R](ptr: RawPtr): CFuncPtr5[T1, T2, T3, T4, T5, R] = {
     new CFuncPtr5[T1, T2, T3, T4, T5, R](ptr)
   }
 }
 
-final class CFuncPtr6[T1, T2, T3, T4, T5, T6, R] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6)(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr6[T1, T2, T3, T4, T5, T6, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr6 {
-  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, R](
-      fn: Function6[T1, T2, T3, T4, T5, T6, R]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      evRet: Tag[R]
-  ): CFuncPtr6[T1, T2, T3, T4, T5, T6, R] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, R](fn: Function6[T1, T2, T3, T4, T5, T6, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], evRet: Tag[R]): CFuncPtr6[T1, T2, T3, T4, T5, T6, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, R](
-      ptr: RawPtr
-  ): CFuncPtr6[T1, T2, T3, T4, T5, T6, R] = {
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, R](ptr: RawPtr): CFuncPtr6[T1, T2, T3, T4, T5, T6, R] = {
     new CFuncPtr6[T1, T2, T3, T4, T5, T6, R](ptr)
   }
 }
 
-final class CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr7 {
-  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, R](
-      fn: Function7[T1, T2, T3, T4, T5, T6, T7, R]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      evRet: Tag[R]
-  ): CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, R](fn: Function7[T1, T2, T3, T4, T5, T6, T7, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], evRet: Tag[R]): CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, R](
-      ptr: RawPtr
-  ): CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] = {
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, R](ptr: RawPtr): CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] = {
     new CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R](ptr)
   }
 }
 
-final class CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] private (
-    rawptr: RawPtr
-) extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr8 {
-  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, R](
-      fn: Function8[T1, T2, T3, T4, T5, T6, T7, T8, R]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      evRet: Tag[R]
-  ): CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, R](fn: Function8[T1, T2, T3, T4, T5, T6, T7, T8, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], evRet: Tag[R]): CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, R](
-      ptr: RawPtr
-  ): CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] = {
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, R](ptr: RawPtr): CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] = {
     new CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R](ptr)
   }
 }
 
-final class CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] private (
-    rawptr: RawPtr
-) extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr9 {
-  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](
-      fn: Function9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      evRet: Tag[R]
-  ): CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](fn: Function9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], evRet: Tag[R]): CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](
-      ptr: RawPtr
-  ): CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = {
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](ptr: RawPtr): CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = {
     new CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](ptr)
   }
 }
 
-final class CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] private (
-    rawptr: RawPtr
-) extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr10 {
-  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](
-      fn: Function10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      evRet: Tag[R]
-  ): CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](fn: Function10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], evRet: Tag[R]): CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      R
-  ](ptr: RawPtr): CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = {
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](ptr: RawPtr): CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = {
     new CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](ptr)
   }
 }
 
-final class CFuncPtr11[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr11 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      R
-  ](fn: Function11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R])(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      evRet: Tag[R]
-  ): CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](fn: Function11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], evRet: Tag[R]): CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      R
-  ](
-      ptr: RawPtr
-  ): CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] = {
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](ptr: RawPtr): CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] = {
     new CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](ptr)
   }
 }
 
-final class CFuncPtr12[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11,
-      arg12: T12
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr12 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      R
-  ](
-      fn: Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      evRet: Tag[R]
-  ): CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] =
-    intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](fn: Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], evRet: Tag[R]): CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      R
-  ](
-      ptr: RawPtr
-  ): CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] = {
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](ptr: RawPtr): CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] = {
     new CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](ptr)
   }
 }
 
-final class CFuncPtr13[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11,
-      arg12: T12,
-      arg13: T13
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr13 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      R
-  ](
-      fn: Function13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      evRet: Tag[R]
-  ): CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] =
-    intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](fn: Function13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], evRet: Tag[R]): CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      R
-  ](
-      ptr: RawPtr
-  ): CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] = {
-    new CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](
-      ptr
-    )
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](ptr: RawPtr): CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] = {
+    new CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](ptr)
   }
 }
 
-final class CFuncPtr14[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11,
-      arg12: T12,
-      arg13: T13,
-      arg14: T14
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr14 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      R
-  ](
-      fn: Function14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        R
-      ]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      evRet: Tag[R]
-  ): CFuncPtr14[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    R
-  ] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R](fn: Function14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], evRet: Tag[R]): CFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      R
-  ](ptr: RawPtr): CFuncPtr14[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    R
-  ] = {
-    new CFuncPtr14[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      R
-    ](ptr)
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R](ptr: RawPtr): CFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R] = {
+    new CFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R](ptr)
   }
 }
 
-final class CFuncPtr15[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11,
-      arg12: T12,
-      arg13: T13,
-      arg14: T14,
-      arg15: T15
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr15 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      R
-  ](
-      fn: Function15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        R
-      ]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      evRet: Tag[R]
-  ): CFuncPtr15[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    R
-  ] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R](fn: Function15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], evRet: Tag[R]): CFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      R
-  ](ptr: RawPtr): CFuncPtr15[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    R
-  ] = {
-    new CFuncPtr15[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      R
-    ](ptr)
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R](ptr: RawPtr): CFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R] = {
+    new CFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R](ptr)
   }
 }
 
-final class CFuncPtr16[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11,
-      arg12: T12,
-      arg13: T13,
-      arg14: T14,
-      arg15: T15,
-      arg16: T16
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr16 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      R
-  ](
-      fn: Function16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        R
-      ]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      evRet: Tag[R]
-  ): CFuncPtr16[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    R
-  ] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R](fn: Function16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], evRet: Tag[R]): CFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      R
-  ](ptr: RawPtr): CFuncPtr16[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    R
-  ] = {
-    new CFuncPtr16[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      R
-    ](ptr)
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R](ptr: RawPtr): CFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R] = {
+    new CFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R](ptr)
   }
 }
 
-final class CFuncPtr17[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11,
-      arg12: T12,
-      arg13: T13,
-      arg14: T14,
-      arg15: T15,
-      arg16: T16,
-      arg17: T17
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr17 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      R
-  ](
-      fn: Function17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        R
-      ]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      evRet: Tag[R]
-  ): CFuncPtr17[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    R
-  ] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R](fn: Function17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], evRet: Tag[R]): CFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      R
-  ](ptr: RawPtr): CFuncPtr17[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    R
-  ] = {
-    new CFuncPtr17[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      R
-    ](ptr)
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R](ptr: RawPtr): CFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] = {
+    new CFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R](ptr)
   }
 }
 
-final class CFuncPtr18[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11,
-      arg12: T12,
-      arg13: T13,
-      arg14: T14,
-      arg15: T15,
-      arg16: T16,
-      arg17: T17,
-      arg18: T18
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      ev18: Tag[T18],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], ev18: Tag[T18], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr18 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      R
-  ](
-      fn: Function18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        R
-      ]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      ev18: Tag[T18],
-      evRet: Tag[R]
-  ): CFuncPtr18[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    R
-  ] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R](fn: Function18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], ev18: Tag[T18], evRet: Tag[R]): CFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      R
-  ](ptr: RawPtr): CFuncPtr18[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    R
-  ] = {
-    new CFuncPtr18[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      R
-    ](ptr)
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R](ptr: RawPtr): CFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R] = {
+    new CFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R](ptr)
   }
 }
 
-final class CFuncPtr19[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11,
-      arg12: T12,
-      arg13: T13,
-      arg14: T14,
-      arg15: T15,
-      arg16: T16,
-      arg17: T17,
-      arg18: T18,
-      arg19: T19
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      ev18: Tag[T18],
-      ev19: Tag[T19],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], ev18: Tag[T18], ev19: Tag[T19], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr19 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      R
-  ](
-      fn: Function19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        R
-      ]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      ev18: Tag[T18],
-      ev19: Tag[T19],
-      evRet: Tag[R]
-  ): CFuncPtr19[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    R
-  ] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R](fn: Function19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], ev18: Tag[T18], ev19: Tag[T19], evRet: Tag[R]): CFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      R
-  ](ptr: RawPtr): CFuncPtr19[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    R
-  ] = {
-    new CFuncPtr19[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      R
-    ](ptr)
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R](ptr: RawPtr): CFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R] = {
+    new CFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R](ptr)
   }
 }
 
-final class CFuncPtr20[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11,
-      arg12: T12,
-      arg13: T13,
-      arg14: T14,
-      arg15: T15,
-      arg16: T16,
-      arg17: T17,
-      arg18: T18,
-      arg19: T19,
-      arg20: T20
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      ev18: Tag[T18],
-      ev19: Tag[T19],
-      ev20: Tag[T20],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], ev18: Tag[T18], ev19: Tag[T19], ev20: Tag[T20], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr20 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      R
-  ](
-      fn: Function20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        R
-      ]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      ev18: Tag[T18],
-      ev19: Tag[T19],
-      ev20: Tag[T20],
-      evRet: Tag[R]
-  ): CFuncPtr20[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    R
-  ] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R](fn: Function20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], ev18: Tag[T18], ev19: Tag[T19], ev20: Tag[T20], evRet: Tag[R]): CFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      R
-  ](ptr: RawPtr): CFuncPtr20[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    R
-  ] = {
-    new CFuncPtr20[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      R
-    ](ptr)
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R](ptr: RawPtr): CFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R] = {
+    new CFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R](ptr)
   }
 }
 
-final class CFuncPtr21[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11,
-      arg12: T12,
-      arg13: T13,
-      arg14: T14,
-      arg15: T15,
-      arg16: T16,
-      arg17: T17,
-      arg18: T18,
-      arg19: T19,
-      arg20: T20,
-      arg21: T21
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      ev18: Tag[T18],
-      ev19: Tag[T19],
-      ev20: Tag[T20],
-      ev21: Tag[T21],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20, arg21: T21)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], ev18: Tag[T18], ev19: Tag[T19], ev20: Tag[T20], ev21: Tag[T21], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr21 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      R
-  ](
-      fn: Function21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        R
-      ]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      ev18: Tag[T18],
-      ev19: Tag[T19],
-      ev20: Tag[T20],
-      ev21: Tag[T21],
-      evRet: Tag[R]
-  ): CFuncPtr21[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    R
-  ] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R](fn: Function21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], ev18: Tag[T18], ev19: Tag[T19], ev20: Tag[T20], ev21: Tag[T21], evRet: Tag[R]): CFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      R
-  ](ptr: RawPtr): CFuncPtr21[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    R
-  ] = {
-    new CFuncPtr21[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      R
-    ](ptr)
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R](ptr: RawPtr): CFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] = {
+    new CFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R](ptr)
   }
 }
 
-final class CFuncPtr22[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    R
-] private (rawptr: RawPtr)
-    extends CFuncPtr(rawptr) {
-  def apply(
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      arg7: T7,
-      arg8: T8,
-      arg9: T9,
-      arg10: T10,
-      arg11: T11,
-      arg12: T12,
-      arg13: T13,
-      arg14: T14,
-      arg15: T15,
-      arg16: T16,
-      arg17: T17,
-      arg18: T18,
-      arg19: T19,
-      arg20: T20,
-      arg21: T21,
-      arg22: T22
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      ev18: Tag[T18],
-      ev19: Tag[T19],
-      ev20: Tag[T20],
-      ev21: Tag[T21],
-      ev22: Tag[T22],
-      evRet: Tag[R]
-  ): R = intrinsic
+final class CFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
+  def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20, arg21: T21, arg22: T22)(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], ev18: Tag[T18], ev19: Tag[T19], ev20: Tag[T20], ev21: Tag[T21], ev22: Tag[T22], evRet: Tag[R]): R = intrinsic
 }
 
 object CFuncPtr22 {
-  implicit def fromScalaFunction[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      T22,
-      R
-  ](
-      fn: Function22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        R
-      ]
-  )(implicit
-      ev1: Tag[T1],
-      ev2: Tag[T2],
-      ev3: Tag[T3],
-      ev4: Tag[T4],
-      ev5: Tag[T5],
-      ev6: Tag[T6],
-      ev7: Tag[T7],
-      ev8: Tag[T8],
-      ev9: Tag[T9],
-      ev10: Tag[T10],
-      ev11: Tag[T11],
-      ev12: Tag[T12],
-      ev13: Tag[T13],
-      ev14: Tag[T14],
-      ev15: Tag[T15],
-      ev16: Tag[T16],
-      ev17: Tag[T17],
-      ev18: Tag[T18],
-      ev19: Tag[T19],
-      ev20: Tag[T20],
-      ev21: Tag[T21],
-      ev22: Tag[T22],
-      evRet: Tag[R]
-  ): CFuncPtr22[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    R
-  ] = intrinsic
+  implicit def fromScalaFunction[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](fn: Function22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R])(implicit ev1: Tag[T1], ev2: Tag[T2], ev3: Tag[T3], ev4: Tag[T4], ev5: Tag[T5], ev6: Tag[T6], ev7: Tag[T7], ev8: Tag[T8], ev9: Tag[T9], ev10: Tag[T10], ev11: Tag[T11], ev12: Tag[T12], ev13: Tag[T13], ev14: Tag[T14], ev15: Tag[T15], ev16: Tag[T16], ev17: Tag[T17], ev18: Tag[T18], ev19: Tag[T19], ev20: Tag[T20], ev21: Tag[T21], ev22: Tag[T22], evRet: Tag[R]): CFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] = intrinsic
 
-  private[scalanative] def fromRawPtr[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      T22,
-      R
-  ](ptr: RawPtr): CFuncPtr22[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    R
-  ] = {
-    new CFuncPtr22[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      T22,
-      R
-    ](ptr)
+  private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](ptr: RawPtr): CFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] = {
+    new CFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](ptr)
   }
 }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala
@@ -1,5 +1,3 @@
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 1)
-
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -31,8 +29,6 @@ object CFuncPtr {
   }
 }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
-
 final class CFuncPtr0[R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
   def apply()(implicit evRet: Tag[R]): R = intrinsic
 }
@@ -46,7 +42,6 @@ object CFuncPtr0 {
     new CFuncPtr0[R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr1[T1, R] private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
   def apply(arg1: T1)(implicit ev1: Tag[T1], evRet: Tag[R]): R = intrinsic
@@ -61,7 +56,6 @@ object CFuncPtr1 {
     new CFuncPtr1[T1, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr2[T1, T2, R] private (rawptr: RawPtr)
     extends CFuncPtr(rawptr) {
@@ -69,8 +63,7 @@ final class CFuncPtr2[T1, T2, R] private (rawptr: RawPtr)
       ev1: Tag[T1],
       ev2: Tag[T2],
       evRet: Tag[R]
-  ): R =
-    intrinsic
+  ): R = intrinsic
 }
 
 object CFuncPtr2 {
@@ -85,7 +78,6 @@ object CFuncPtr2 {
     new CFuncPtr2[T1, T2, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr3[T1, T2, T3, R] private (rawptr: RawPtr)
     extends CFuncPtr(rawptr) {
@@ -113,7 +105,6 @@ object CFuncPtr3 {
     new CFuncPtr3[T1, T2, T3, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr4[T1, T2, T3, T4, R] private (rawptr: RawPtr)
     extends CFuncPtr(rawptr) {
@@ -123,8 +114,7 @@ final class CFuncPtr4[T1, T2, T3, T4, R] private (rawptr: RawPtr)
       ev3: Tag[T3],
       ev4: Tag[T4],
       evRet: Tag[R]
-  ): R =
-    intrinsic
+  ): R = intrinsic
 }
 
 object CFuncPtr4 {
@@ -144,7 +134,6 @@ object CFuncPtr4 {
     new CFuncPtr4[T1, T2, T3, T4, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr5[T1, T2, T3, T4, T5, R] private (rawptr: RawPtr)
     extends CFuncPtr(rawptr) {
@@ -176,7 +165,6 @@ object CFuncPtr5 {
     new CFuncPtr5[T1, T2, T3, T4, T5, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr6[T1, T2, T3, T4, T5, T6, R] private (rawptr: RawPtr)
     extends CFuncPtr(rawptr) {
@@ -210,7 +198,6 @@ object CFuncPtr6 {
     new CFuncPtr6[T1, T2, T3, T4, T5, T6, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] private (rawptr: RawPtr)
     extends CFuncPtr(rawptr) {
@@ -254,7 +241,6 @@ object CFuncPtr7 {
     new CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] private (
     rawptr: RawPtr
@@ -302,7 +288,6 @@ object CFuncPtr8 {
     new CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] private (
     rawptr: RawPtr
@@ -345,8 +330,7 @@ object CFuncPtr9 {
       ev8: Tag[T8],
       ev9: Tag[T9],
       evRet: Tag[R]
-  ): CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] =
-    intrinsic
+  ): CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = intrinsic
 
   private[scalanative] def fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](
       ptr: RawPtr
@@ -354,7 +338,6 @@ object CFuncPtr9 {
     new CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] private (
     rawptr: RawPtr
@@ -400,8 +383,7 @@ object CFuncPtr10 {
       ev9: Tag[T9],
       ev10: Tag[T10],
       evRet: Tag[R]
-  ): CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] =
-    intrinsic
+  ): CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = intrinsic
 
   private[scalanative] def fromRawPtr[
       T1,
@@ -419,7 +401,6 @@ object CFuncPtr10 {
     new CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr11[
     T1,
@@ -512,7 +493,6 @@ object CFuncPtr11 {
     new CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr12[
     T1,
@@ -614,7 +594,6 @@ object CFuncPtr12 {
     new CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr13[
     T1,
@@ -724,7 +703,6 @@ object CFuncPtr13 {
     )
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr14[
     T1,
@@ -899,7 +877,6 @@ object CFuncPtr14 {
     ](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr15[
     T1,
@@ -1084,7 +1061,6 @@ object CFuncPtr15 {
     ](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr16[
     T1,
@@ -1279,7 +1255,6 @@ object CFuncPtr16 {
     ](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr17[
     T1,
@@ -1484,7 +1459,6 @@ object CFuncPtr17 {
     ](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr18[
     T1,
@@ -1699,7 +1673,6 @@ object CFuncPtr18 {
     ](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr19[
     T1,
@@ -1924,7 +1897,6 @@ object CFuncPtr19 {
     ](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr20[
     T1,
@@ -2159,7 +2131,6 @@ object CFuncPtr20 {
     ](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr21[
     T1,
@@ -2404,7 +2375,6 @@ object CFuncPtr21 {
     ](ptr)
   }
 }
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb", line: 36)
 
 final class CFuncPtr22[
     T1,

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CFuncPtr.scala.gyb
@@ -1,3 +1,4 @@
+// format: off
 
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
@@ -18,15 +19,13 @@ import scala.scalanative.runtime.{RawPtr, intrinsic}
 sealed abstract class CFuncPtr private[unsafe] (private[scalanative] val rawptr: RawPtr)
 
 object CFuncPtr {
-  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: Ptr[Byte])(
-      implicit tag: Tag.CFuncPtrTag[F]): F =
+  @alwaysinline def fromPtr[F <: CFuncPtr](ptr: Ptr[Byte])(implicit tag: Tag.CFuncPtrTag[F]): F =
     tag.fromRawPtr(ptr.rawptr)
 
   @alwaysinline def toPtr(ptr: CFuncPtr): Ptr[Byte] = {
     boxToPtr[Byte](ptr.rawptr)
   }
 }
-
 % for N in range(0, 23):
 %   args      = ", ".join("arg" + str(i) + ": T" + str(i) for i in range(1, N+1))
 %   allTps    = ", ".join(["T" + str(i) for i in range(1, N+1)] + ["R"])
@@ -38,7 +37,7 @@ final class ${CFuncPtrN} private (rawptr: RawPtr) extends CFuncPtr(rawptr) {
   def apply(${args})(implicit ${evidences}): R = intrinsic
 }
 
-object CFuncPtr${N}{
+object CFuncPtr${N} {
   implicit def fromScalaFunction[${allTps}](fn: ${FunctionN})(implicit ${evidences}): ${CFuncPtrN} = intrinsic
 
   private[scalanative] def fromRawPtr[${allTps}](ptr: RawPtr): ${CFuncPtrN} = {

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala
@@ -1,5 +1,3 @@
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 1)
-
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -17,8 +15,6 @@ import scalanative.runtime.Intrinsics._
 import scalanative.unsigned._
 
 sealed abstract class CStruct
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct0 private[scalanative] (
     private[scalanative] val rawptr: RawPtr
@@ -40,10 +36,7 @@ final class CStruct0 private[scalanative] (
   @alwaysinline def toPtr: Ptr[CStruct0] =
     fromRawPtr[CStruct0](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct1[T1] private[scalanative] (
     private[scalanative] val rawptr: RawPtr
@@ -65,8 +58,6 @@ final class CStruct1[T1] private[scalanative] (
   @alwaysinline def toPtr: Ptr[CStruct1[T1]] =
     fromRawPtr[CStruct1[T1]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct1[T1]): Ptr[T1] =
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
@@ -83,10 +74,7 @@ final class CStruct1[T1] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._1)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct2[T1, T2] private[scalanative] (
     private[scalanative] val rawptr: RawPtr
@@ -108,8 +96,6 @@ final class CStruct2[T1, T2] private[scalanative] (
   @alwaysinline def toPtr: Ptr[CStruct2[T1, T2]] =
     fromRawPtr[CStruct2[T1, T2]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct2[T1, T2]): Ptr[T1] =
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
@@ -127,8 +113,6 @@ final class CStruct2[T1, T2] private[scalanative] (
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct2[T1, T2]): Ptr[T2] =
@@ -148,10 +132,7 @@ final class CStruct2[T1, T2] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct3[T1, T2, T3] private[scalanative] (
     private[scalanative] val rawptr: RawPtr
@@ -173,8 +154,6 @@ final class CStruct3[T1, T2, T3] private[scalanative] (
   @alwaysinline def toPtr: Ptr[CStruct3[T1, T2, T3]] =
     fromRawPtr[CStruct3[T1, T2, T3]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T1] =
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
@@ -192,8 +171,6 @@ final class CStruct3[T1, T2, T3] private[scalanative] (
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T2] =
@@ -213,8 +190,6 @@ final class CStruct3[T1, T2, T3] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T3] =
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
@@ -233,10 +208,7 @@ final class CStruct3[T1, T2, T3] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._3)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct4[T1, T2, T3, T4] private[scalanative] (
     private[scalanative] val rawptr: RawPtr
@@ -258,8 +230,6 @@ final class CStruct4[T1, T2, T3, T4] private[scalanative] (
   @alwaysinline def toPtr: Ptr[CStruct4[T1, T2, T3, T4]] =
     fromRawPtr[CStruct4[T1, T2, T3, T4]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T1] =
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
@@ -277,8 +247,6 @@ final class CStruct4[T1, T2, T3, T4] private[scalanative] (
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T2] =
@@ -298,8 +266,6 @@ final class CStruct4[T1, T2, T3, T4] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T3] =
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
@@ -317,8 +283,6 @@ final class CStruct4[T1, T2, T3, T4] private[scalanative] (
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T4] =
@@ -338,10 +302,7 @@ final class CStruct4[T1, T2, T3, T4] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
     private[scalanative] val rawptr: RawPtr
@@ -363,8 +324,6 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
   @alwaysinline def toPtr: Ptr[CStruct5[T1, T2, T3, T4, T5]] =
     fromRawPtr[CStruct5[T1, T2, T3, T4, T5]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct5[T1, T2, T3, T4, T5]
@@ -384,8 +343,6 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -407,8 +364,6 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct5[T1, T2, T3, T4, T5]
@@ -428,8 +383,6 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -451,8 +404,6 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct5[T1, T2, T3, T4, T5]
@@ -473,10 +424,7 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._5)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (
     private[scalanative] val rawptr: RawPtr
@@ -498,8 +446,6 @@ final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (
   @alwaysinline def toPtr: Ptr[CStruct6[T1, T2, T3, T4, T5, T6]] =
     fromRawPtr[CStruct6[T1, T2, T3, T4, T5, T6]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
@@ -521,8 +467,6 @@ final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -546,8 +490,6 @@ final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
@@ -569,8 +511,6 @@ final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -594,8 +534,6 @@ final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
@@ -617,8 +555,6 @@ final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -642,10 +578,7 @@ final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (
     private[scalanative] val rawptr: RawPtr
@@ -667,8 +600,6 @@ final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (
   @alwaysinline def toPtr: Ptr[CStruct7[T1, T2, T3, T4, T5, T6, T7]] =
     fromRawPtr[CStruct7[T1, T2, T3, T4, T5, T6, T7]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
@@ -690,8 +621,6 @@ final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -715,8 +644,6 @@ final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
@@ -738,8 +665,6 @@ final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -763,8 +688,6 @@ final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
@@ -786,8 +709,6 @@ final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -811,8 +732,6 @@ final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
@@ -835,10 +754,7 @@ final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._7)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
     private[scalanative] val rawptr: RawPtr
@@ -860,8 +776,6 @@ final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
   @alwaysinline def toPtr: Ptr[CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]] =
     fromRawPtr[CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
@@ -883,8 +797,6 @@ final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -908,8 +820,6 @@ final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
@@ -931,8 +841,6 @@ final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -956,8 +864,6 @@ final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
@@ -979,8 +885,6 @@ final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -1004,8 +908,6 @@ final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
@@ -1027,8 +929,6 @@ final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -1052,10 +952,7 @@ final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
     private[scalanative] val rawptr: RawPtr
@@ -1077,8 +974,6 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
   @alwaysinline def toPtr: Ptr[CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] =
     fromRawPtr[CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
@@ -1100,8 +995,6 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -1125,8 +1018,6 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
@@ -1148,8 +1039,6 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -1173,8 +1062,6 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
@@ -1196,8 +1083,6 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -1221,8 +1106,6 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
@@ -1245,8 +1128,6 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._7)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
       tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
@@ -1268,8 +1149,6 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
@@ -1293,10 +1172,7 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
     ptr.`unary_!_=`(value)(tag._9)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct10[
     T1,
@@ -1329,8 +1205,6 @@ final class CStruct10[
       : Ptr[CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] =
     fromRawPtr[CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
@@ -1352,8 +1226,6 @@ final class CStruct10[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -1377,8 +1249,6 @@ final class CStruct10[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
@@ -1400,8 +1270,6 @@ final class CStruct10[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -1425,8 +1293,6 @@ final class CStruct10[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
@@ -1448,8 +1314,6 @@ final class CStruct10[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -1473,8 +1337,6 @@ final class CStruct10[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
@@ -1496,8 +1358,6 @@ final class CStruct10[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -1521,8 +1381,6 @@ final class CStruct10[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
@@ -1544,8 +1402,6 @@ final class CStruct10[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -1569,10 +1425,7 @@ final class CStruct10[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct11[
     T1,
@@ -1606,8 +1459,6 @@ final class CStruct11[
       : Ptr[CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] =
     fromRawPtr[CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
@@ -1629,8 +1480,6 @@ final class CStruct11[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -1654,8 +1503,6 @@ final class CStruct11[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
@@ -1677,8 +1524,6 @@ final class CStruct11[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -1702,8 +1547,6 @@ final class CStruct11[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
@@ -1725,8 +1568,6 @@ final class CStruct11[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -1750,8 +1591,6 @@ final class CStruct11[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
@@ -1773,8 +1612,6 @@ final class CStruct11[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -1798,8 +1635,6 @@ final class CStruct11[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
@@ -1821,8 +1656,6 @@ final class CStruct11[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -1846,8 +1679,6 @@ final class CStruct11[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
@@ -1870,10 +1701,7 @@ final class CStruct11[
     ptr.`unary_!_=`(value)(tag._11)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct12[
     T1,
@@ -1910,8 +1738,6 @@ final class CStruct12[
       rawptr
     )
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
@@ -1933,8 +1759,6 @@ final class CStruct12[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -1958,8 +1782,6 @@ final class CStruct12[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
@@ -1981,8 +1803,6 @@ final class CStruct12[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -2006,8 +1826,6 @@ final class CStruct12[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
@@ -2029,8 +1847,6 @@ final class CStruct12[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -2054,8 +1870,6 @@ final class CStruct12[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
@@ -2077,8 +1891,6 @@ final class CStruct12[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -2102,8 +1914,6 @@ final class CStruct12[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
@@ -2125,8 +1935,6 @@ final class CStruct12[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -2150,8 +1958,6 @@ final class CStruct12[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
@@ -2173,8 +1979,6 @@ final class CStruct12[
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit
@@ -2198,10 +2002,7 @@ final class CStruct12[
     ptr.`unary_!_=`(value)(tag._12)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct13[
     T1,
@@ -2239,8 +2040,6 @@ final class CStruct13[
       CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
     ](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
@@ -2262,8 +2061,6 @@ final class CStruct13[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -2287,8 +2084,6 @@ final class CStruct13[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
@@ -2310,8 +2105,6 @@ final class CStruct13[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -2335,8 +2128,6 @@ final class CStruct13[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
@@ -2358,8 +2149,6 @@ final class CStruct13[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -2383,8 +2172,6 @@ final class CStruct13[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
@@ -2406,8 +2193,6 @@ final class CStruct13[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -2431,8 +2216,6 @@ final class CStruct13[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
@@ -2454,8 +2237,6 @@ final class CStruct13[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -2479,8 +2260,6 @@ final class CStruct13[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
@@ -2502,8 +2281,6 @@ final class CStruct13[
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit
@@ -2527,8 +2304,6 @@ final class CStruct13[
     ptr.`unary_!_=`(value)(tag._12)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit
       tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
@@ -2551,10 +2326,7 @@ final class CStruct13[
     ptr.`unary_!_=`(value)(tag._13)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct14[
     T1,
@@ -2594,8 +2366,6 @@ final class CStruct14[
       CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]
     ](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct14[
@@ -2662,8 +2432,6 @@ final class CStruct14[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -2732,8 +2500,6 @@ final class CStruct14[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct14[
@@ -2800,8 +2566,6 @@ final class CStruct14[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -2870,8 +2634,6 @@ final class CStruct14[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct14[
@@ -2938,8 +2700,6 @@ final class CStruct14[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -3008,8 +2768,6 @@ final class CStruct14[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct14[
@@ -3076,8 +2834,6 @@ final class CStruct14[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -3146,8 +2902,6 @@ final class CStruct14[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct14[
@@ -3214,8 +2968,6 @@ final class CStruct14[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -3284,8 +3036,6 @@ final class CStruct14[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct14[
@@ -3352,8 +3102,6 @@ final class CStruct14[
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit
@@ -3422,8 +3170,6 @@ final class CStruct14[
     ptr.`unary_!_=`(value)(tag._12)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit
       tag: Tag.CStruct14[
@@ -3490,8 +3236,6 @@ final class CStruct14[
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit
@@ -3560,10 +3304,7 @@ final class CStruct14[
     ptr.`unary_!_=`(value)(tag._14)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct15[
     T1,
@@ -3618,8 +3359,6 @@ final class CStruct15[
       T15
     ]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct15[
@@ -3689,8 +3428,6 @@ final class CStruct15[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -3762,8 +3499,6 @@ final class CStruct15[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct15[
@@ -3833,8 +3568,6 @@ final class CStruct15[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -3906,8 +3639,6 @@ final class CStruct15[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct15[
@@ -3977,8 +3708,6 @@ final class CStruct15[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -4050,8 +3779,6 @@ final class CStruct15[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct15[
@@ -4121,8 +3848,6 @@ final class CStruct15[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -4194,8 +3919,6 @@ final class CStruct15[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct15[
@@ -4265,8 +3988,6 @@ final class CStruct15[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -4338,8 +4059,6 @@ final class CStruct15[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct15[
@@ -4409,8 +4128,6 @@ final class CStruct15[
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit
@@ -4482,8 +4199,6 @@ final class CStruct15[
     ptr.`unary_!_=`(value)(tag._12)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit
       tag: Tag.CStruct15[
@@ -4554,8 +4269,6 @@ final class CStruct15[
     ptr.`unary_!_=`(value)(tag._13)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit
       tag: Tag.CStruct15[
@@ -4625,8 +4338,6 @@ final class CStruct15[
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._14)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit
@@ -4698,10 +4409,7 @@ final class CStruct15[
     ptr.`unary_!_=`(value)(tag._15)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct16[
     T1,
@@ -4773,8 +4481,6 @@ final class CStruct16[
       T16
     ]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct16[
@@ -4847,8 +4553,6 @@ final class CStruct16[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -4923,8 +4627,6 @@ final class CStruct16[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct16[
@@ -4997,8 +4699,6 @@ final class CStruct16[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -5073,8 +4773,6 @@ final class CStruct16[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct16[
@@ -5147,8 +4845,6 @@ final class CStruct16[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -5223,8 +4919,6 @@ final class CStruct16[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct16[
@@ -5297,8 +4991,6 @@ final class CStruct16[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -5373,8 +5065,6 @@ final class CStruct16[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct16[
@@ -5447,8 +5137,6 @@ final class CStruct16[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -5523,8 +5211,6 @@ final class CStruct16[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct16[
@@ -5597,8 +5283,6 @@ final class CStruct16[
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit
@@ -5673,8 +5357,6 @@ final class CStruct16[
     ptr.`unary_!_=`(value)(tag._12)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit
       tag: Tag.CStruct16[
@@ -5747,8 +5429,6 @@ final class CStruct16[
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit
@@ -5823,8 +5503,6 @@ final class CStruct16[
     ptr.`unary_!_=`(value)(tag._14)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit
       tag: Tag.CStruct16[
@@ -5897,8 +5575,6 @@ final class CStruct16[
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit
@@ -5973,10 +5649,7 @@ final class CStruct16[
     ptr.`unary_!_=`(value)(tag._16)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct17[
     T1,
@@ -6069,8 +5742,6 @@ final class CStruct17[
       T17
     ]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct17[
@@ -6146,8 +5817,6 @@ final class CStruct17[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -6225,8 +5894,6 @@ final class CStruct17[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct17[
@@ -6302,8 +5969,6 @@ final class CStruct17[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -6381,8 +6046,6 @@ final class CStruct17[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct17[
@@ -6458,8 +6121,6 @@ final class CStruct17[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -6537,8 +6198,6 @@ final class CStruct17[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct17[
@@ -6614,8 +6273,6 @@ final class CStruct17[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -6693,8 +6350,6 @@ final class CStruct17[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct17[
@@ -6770,8 +6425,6 @@ final class CStruct17[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -6849,8 +6502,6 @@ final class CStruct17[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct17[
@@ -6926,8 +6577,6 @@ final class CStruct17[
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit
@@ -7005,8 +6654,6 @@ final class CStruct17[
     ptr.`unary_!_=`(value)(tag._12)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit
       tag: Tag.CStruct17[
@@ -7082,8 +6729,6 @@ final class CStruct17[
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit
@@ -7161,8 +6806,6 @@ final class CStruct17[
     ptr.`unary_!_=`(value)(tag._14)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit
       tag: Tag.CStruct17[
@@ -7238,8 +6881,6 @@ final class CStruct17[
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit
@@ -7317,8 +6958,6 @@ final class CStruct17[
     ptr.`unary_!_=`(value)(tag._16)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit
       tag: Tag.CStruct17[
@@ -7395,10 +7034,7 @@ final class CStruct17[
     ptr.`unary_!_=`(value)(tag._17)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct18[
     T1,
@@ -7495,8 +7131,6 @@ final class CStruct18[
       T18
     ]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct18[
@@ -7575,8 +7209,6 @@ final class CStruct18[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -7657,8 +7289,6 @@ final class CStruct18[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct18[
@@ -7737,8 +7367,6 @@ final class CStruct18[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -7819,8 +7447,6 @@ final class CStruct18[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct18[
@@ -7899,8 +7525,6 @@ final class CStruct18[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -7981,8 +7605,6 @@ final class CStruct18[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct18[
@@ -8061,8 +7683,6 @@ final class CStruct18[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -8143,8 +7763,6 @@ final class CStruct18[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct18[
@@ -8223,8 +7841,6 @@ final class CStruct18[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -8305,8 +7921,6 @@ final class CStruct18[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct18[
@@ -8385,8 +7999,6 @@ final class CStruct18[
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit
@@ -8467,8 +8079,6 @@ final class CStruct18[
     ptr.`unary_!_=`(value)(tag._12)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit
       tag: Tag.CStruct18[
@@ -8547,8 +8157,6 @@ final class CStruct18[
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit
@@ -8629,8 +8237,6 @@ final class CStruct18[
     ptr.`unary_!_=`(value)(tag._14)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit
       tag: Tag.CStruct18[
@@ -8709,8 +8315,6 @@ final class CStruct18[
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit
@@ -8791,8 +8395,6 @@ final class CStruct18[
     ptr.`unary_!_=`(value)(tag._16)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit
       tag: Tag.CStruct18[
@@ -8871,8 +8473,6 @@ final class CStruct18[
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._17)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 18. */
   @alwaysinline def at18(implicit
@@ -8953,10 +8553,7 @@ final class CStruct18[
     ptr.`unary_!_=`(value)(tag._18)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct19[
     T1,
@@ -9057,8 +8654,6 @@ final class CStruct19[
       T19
     ]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct19[
@@ -9140,8 +8735,6 @@ final class CStruct19[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -9225,8 +8818,6 @@ final class CStruct19[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct19[
@@ -9308,8 +8899,6 @@ final class CStruct19[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -9393,8 +8982,6 @@ final class CStruct19[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct19[
@@ -9476,8 +9063,6 @@ final class CStruct19[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -9561,8 +9146,6 @@ final class CStruct19[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct19[
@@ -9644,8 +9227,6 @@ final class CStruct19[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -9729,8 +9310,6 @@ final class CStruct19[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct19[
@@ -9812,8 +9391,6 @@ final class CStruct19[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -9897,8 +9474,6 @@ final class CStruct19[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct19[
@@ -9980,8 +9555,6 @@ final class CStruct19[
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit
@@ -10065,8 +9638,6 @@ final class CStruct19[
     ptr.`unary_!_=`(value)(tag._12)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit
       tag: Tag.CStruct19[
@@ -10148,8 +9719,6 @@ final class CStruct19[
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit
@@ -10233,8 +9802,6 @@ final class CStruct19[
     ptr.`unary_!_=`(value)(tag._14)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit
       tag: Tag.CStruct19[
@@ -10316,8 +9883,6 @@ final class CStruct19[
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit
@@ -10401,8 +9966,6 @@ final class CStruct19[
     ptr.`unary_!_=`(value)(tag._16)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit
       tag: Tag.CStruct19[
@@ -10484,8 +10047,6 @@ final class CStruct19[
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._17)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 18. */
   @alwaysinline def at18(implicit
@@ -10569,8 +10130,6 @@ final class CStruct19[
     ptr.`unary_!_=`(value)(tag._18)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 19. */
   @alwaysinline def at19(implicit
       tag: Tag.CStruct19[
@@ -10653,10 +10212,7 @@ final class CStruct19[
     ptr.`unary_!_=`(value)(tag._19)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct20[
     T1,
@@ -10761,8 +10317,6 @@ final class CStruct20[
       T20
     ]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct20[
@@ -10847,8 +10401,6 @@ final class CStruct20[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -10935,8 +10487,6 @@ final class CStruct20[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct20[
@@ -11021,8 +10571,6 @@ final class CStruct20[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -11109,8 +10657,6 @@ final class CStruct20[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct20[
@@ -11195,8 +10741,6 @@ final class CStruct20[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -11283,8 +10827,6 @@ final class CStruct20[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct20[
@@ -11369,8 +10911,6 @@ final class CStruct20[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -11457,8 +10997,6 @@ final class CStruct20[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct20[
@@ -11543,8 +11081,6 @@ final class CStruct20[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -11631,8 +11167,6 @@ final class CStruct20[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct20[
@@ -11717,8 +11251,6 @@ final class CStruct20[
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit
@@ -11805,8 +11337,6 @@ final class CStruct20[
     ptr.`unary_!_=`(value)(tag._12)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit
       tag: Tag.CStruct20[
@@ -11891,8 +11421,6 @@ final class CStruct20[
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit
@@ -11979,8 +11507,6 @@ final class CStruct20[
     ptr.`unary_!_=`(value)(tag._14)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit
       tag: Tag.CStruct20[
@@ -12065,8 +11591,6 @@ final class CStruct20[
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit
@@ -12153,8 +11677,6 @@ final class CStruct20[
     ptr.`unary_!_=`(value)(tag._16)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit
       tag: Tag.CStruct20[
@@ -12239,8 +11761,6 @@ final class CStruct20[
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._17)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 18. */
   @alwaysinline def at18(implicit
@@ -12327,8 +11847,6 @@ final class CStruct20[
     ptr.`unary_!_=`(value)(tag._18)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 19. */
   @alwaysinline def at19(implicit
       tag: Tag.CStruct20[
@@ -12413,8 +11931,6 @@ final class CStruct20[
     val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._19)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 20. */
   @alwaysinline def at20(implicit
@@ -12501,10 +12017,7 @@ final class CStruct20[
     ptr.`unary_!_=`(value)(tag._20)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct21[
     T1,
@@ -12613,8 +12126,6 @@ final class CStruct21[
       T21
     ]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct21[
@@ -12702,8 +12213,6 @@ final class CStruct21[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -12793,8 +12302,6 @@ final class CStruct21[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct21[
@@ -12882,8 +12389,6 @@ final class CStruct21[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -12973,8 +12478,6 @@ final class CStruct21[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct21[
@@ -13062,8 +12565,6 @@ final class CStruct21[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -13153,8 +12654,6 @@ final class CStruct21[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct21[
@@ -13242,8 +12741,6 @@ final class CStruct21[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -13333,8 +12830,6 @@ final class CStruct21[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct21[
@@ -13422,8 +12917,6 @@ final class CStruct21[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -13513,8 +13006,6 @@ final class CStruct21[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct21[
@@ -13602,8 +13093,6 @@ final class CStruct21[
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit
@@ -13693,8 +13182,6 @@ final class CStruct21[
     ptr.`unary_!_=`(value)(tag._12)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit
       tag: Tag.CStruct21[
@@ -13782,8 +13269,6 @@ final class CStruct21[
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit
@@ -13873,8 +13358,6 @@ final class CStruct21[
     ptr.`unary_!_=`(value)(tag._14)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit
       tag: Tag.CStruct21[
@@ -13962,8 +13445,6 @@ final class CStruct21[
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit
@@ -14053,8 +13534,6 @@ final class CStruct21[
     ptr.`unary_!_=`(value)(tag._16)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit
       tag: Tag.CStruct21[
@@ -14142,8 +13621,6 @@ final class CStruct21[
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._17)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 18. */
   @alwaysinline def at18(implicit
@@ -14233,8 +13710,6 @@ final class CStruct21[
     ptr.`unary_!_=`(value)(tag._18)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 19. */
   @alwaysinline def at19(implicit
       tag: Tag.CStruct21[
@@ -14322,8 +13797,6 @@ final class CStruct21[
     val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._19)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 20. */
   @alwaysinline def at20(implicit
@@ -14413,8 +13886,6 @@ final class CStruct21[
     ptr.`unary_!_=`(value)(tag._20)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 21. */
   @alwaysinline def at21(implicit
       tag: Tag.CStruct21[
@@ -14503,10 +13974,7 @@ final class CStruct21[
     ptr.`unary_!_=`(value)(tag._21)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 23)
 
 final class CStruct22[
     T1,
@@ -14619,8 +14087,6 @@ final class CStruct22[
       T22
     ]](rawptr)
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 1. */
   @alwaysinline def at1(implicit
       tag: Tag.CStruct22[
@@ -14711,8 +14177,6 @@ final class CStruct22[
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 2. */
   @alwaysinline def at2(implicit
@@ -14805,8 +14269,6 @@ final class CStruct22[
     ptr.`unary_!_=`(value)(tag._2)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 3. */
   @alwaysinline def at3(implicit
       tag: Tag.CStruct22[
@@ -14897,8 +14359,6 @@ final class CStruct22[
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 4. */
   @alwaysinline def at4(implicit
@@ -14991,8 +14451,6 @@ final class CStruct22[
     ptr.`unary_!_=`(value)(tag._4)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 5. */
   @alwaysinline def at5(implicit
       tag: Tag.CStruct22[
@@ -15083,8 +14541,6 @@ final class CStruct22[
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 6. */
   @alwaysinline def at6(implicit
@@ -15177,8 +14633,6 @@ final class CStruct22[
     ptr.`unary_!_=`(value)(tag._6)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 7. */
   @alwaysinline def at7(implicit
       tag: Tag.CStruct22[
@@ -15269,8 +14723,6 @@ final class CStruct22[
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 8. */
   @alwaysinline def at8(implicit
@@ -15363,8 +14815,6 @@ final class CStruct22[
     ptr.`unary_!_=`(value)(tag._8)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 9. */
   @alwaysinline def at9(implicit
       tag: Tag.CStruct22[
@@ -15455,8 +14905,6 @@ final class CStruct22[
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 10. */
   @alwaysinline def at10(implicit
@@ -15549,8 +14997,6 @@ final class CStruct22[
     ptr.`unary_!_=`(value)(tag._10)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 11. */
   @alwaysinline def at11(implicit
       tag: Tag.CStruct22[
@@ -15641,8 +15087,6 @@ final class CStruct22[
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 12. */
   @alwaysinline def at12(implicit
@@ -15735,8 +15179,6 @@ final class CStruct22[
     ptr.`unary_!_=`(value)(tag._12)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 13. */
   @alwaysinline def at13(implicit
       tag: Tag.CStruct22[
@@ -15827,8 +15269,6 @@ final class CStruct22[
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 14. */
   @alwaysinline def at14(implicit
@@ -15921,8 +15361,6 @@ final class CStruct22[
     ptr.`unary_!_=`(value)(tag._14)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 15. */
   @alwaysinline def at15(implicit
       tag: Tag.CStruct22[
@@ -16013,8 +15451,6 @@ final class CStruct22[
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 16. */
   @alwaysinline def at16(implicit
@@ -16107,8 +15543,6 @@ final class CStruct22[
     ptr.`unary_!_=`(value)(tag._16)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 17. */
   @alwaysinline def at17(implicit
       tag: Tag.CStruct22[
@@ -16199,8 +15633,6 @@ final class CStruct22[
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._17)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 18. */
   @alwaysinline def at18(implicit
@@ -16293,8 +15725,6 @@ final class CStruct22[
     ptr.`unary_!_=`(value)(tag._18)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 19. */
   @alwaysinline def at19(implicit
       tag: Tag.CStruct22[
@@ -16385,8 +15815,6 @@ final class CStruct22[
     val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._19)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 20. */
   @alwaysinline def at20(implicit
@@ -16479,8 +15907,6 @@ final class CStruct22[
     ptr.`unary_!_=`(value)(tag._20)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
-
   /** Load a value of a field number 21. */
   @alwaysinline def at21(implicit
       tag: Tag.CStruct22[
@@ -16571,8 +15997,6 @@ final class CStruct22[
     val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset(20.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._21)
   }
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 43)
 
   /** Load a value of a field number 22. */
   @alwaysinline def at22(implicit
@@ -16665,5 +16089,4 @@ final class CStruct22[
     ptr.`unary_!_=`(value)(tag._22)
   }
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb", line: 61)
 }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala
@@ -1,3 +1,5 @@
+// format: off
+
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -16,9 +18,7 @@ import scalanative.unsigned._
 
 sealed abstract class CStruct
 
-final class CStruct0 private[scalanative] (
-    private[scalanative] val rawptr: RawPtr
-) extends CStruct {
+final class CStruct0 private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct0 =>
@@ -38,9 +38,7 @@ final class CStruct0 private[scalanative] (
 
 }
 
-final class CStruct1[T1] private[scalanative] (
-    private[scalanative] val rawptr: RawPtr
-) extends CStruct {
+final class CStruct1[T1] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct1[_] =>
@@ -59,7 +57,7 @@ final class CStruct1[T1] private[scalanative] (
     fromRawPtr[CStruct1[T1]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit tag: Tag.CStruct1[T1]): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct1[T1]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
@@ -76,9 +74,7 @@ final class CStruct1[T1] private[scalanative] (
 
 }
 
-final class CStruct2[T1, T2] private[scalanative] (
-    private[scalanative] val rawptr: RawPtr
-) extends CStruct {
+final class CStruct2[T1, T2] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct2[_, _] =>
@@ -97,7 +93,7 @@ final class CStruct2[T1, T2] private[scalanative] (
     fromRawPtr[CStruct2[T1, T2]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit tag: Tag.CStruct2[T1, T2]): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct2[T1, T2]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
@@ -107,15 +103,13 @@ final class CStruct2[T1, T2] private[scalanative] (
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(
-      value: T1
-  )(implicit tag: Tag.CStruct2[T1, T2]): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct2[T1, T2]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit tag: Tag.CStruct2[T1, T2]): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct2[T1, T2]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
@@ -125,18 +119,14 @@ final class CStruct2[T1, T2] private[scalanative] (
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(
-      value: T2
-  )(implicit tag: Tag.CStruct2[T1, T2]): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct2[T1, T2]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
 }
 
-final class CStruct3[T1, T2, T3] private[scalanative] (
-    private[scalanative] val rawptr: RawPtr
-) extends CStruct {
+final class CStruct3[T1, T2, T3] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct3[_, _, _] =>
@@ -155,7 +145,7 @@ final class CStruct3[T1, T2, T3] private[scalanative] (
     fromRawPtr[CStruct3[T1, T2, T3]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
@@ -165,15 +155,13 @@ final class CStruct3[T1, T2, T3] private[scalanative] (
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(
-      value: T1
-  )(implicit tag: Tag.CStruct3[T1, T2, T3]): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct3[T1, T2, T3]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
@@ -183,15 +171,13 @@ final class CStruct3[T1, T2, T3] private[scalanative] (
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(
-      value: T2
-  )(implicit tag: Tag.CStruct3[T1, T2, T3]): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct3[T1, T2, T3]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct3[T1, T2, T3]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
@@ -201,18 +187,14 @@ final class CStruct3[T1, T2, T3] private[scalanative] (
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(
-      value: T3
-  )(implicit tag: Tag.CStruct3[T1, T2, T3]): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct3[T1, T2, T3]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
 }
 
-final class CStruct4[T1, T2, T3, T4] private[scalanative] (
-    private[scalanative] val rawptr: RawPtr
-) extends CStruct {
+final class CStruct4[T1, T2, T3, T4] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct4[_, _, _, _] =>
@@ -231,7 +213,7 @@ final class CStruct4[T1, T2, T3, T4] private[scalanative] (
     fromRawPtr[CStruct4[T1, T2, T3, T4]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
@@ -241,15 +223,13 @@ final class CStruct4[T1, T2, T3, T4] private[scalanative] (
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(
-      value: T1
-  )(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
@@ -259,15 +239,13 @@ final class CStruct4[T1, T2, T3, T4] private[scalanative] (
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(
-      value: T2
-  )(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
@@ -277,15 +255,13 @@ final class CStruct4[T1, T2, T3, T4] private[scalanative] (
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(
-      value: T3
-  )(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
@@ -295,18 +271,14 @@ final class CStruct4[T1, T2, T3, T4] private[scalanative] (
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(
-      value: T4
-  )(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct4[T1, T2, T3, T4]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
 }
 
-final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
-    private[scalanative] val rawptr: RawPtr
-) extends CStruct {
+final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct5[_, _, _, _, _] =>
@@ -325,9 +297,7 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
     fromRawPtr[CStruct5[T1, T2, T3, T4, T5]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct5[T1, T2, T3, T4, T5]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
@@ -337,17 +307,13 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(
-      value: T1
-  )(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct5[T1, T2, T3, T4, T5]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
@@ -357,17 +323,13 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(
-      value: T2
-  )(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct5[T1, T2, T3, T4, T5]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
@@ -377,17 +339,13 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(
-      value: T3
-  )(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct5[T1, T2, T3, T4, T5]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
@@ -397,17 +355,13 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(
-      value: T4
-  )(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct5[T1, T2, T3, T4, T5]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
@@ -417,18 +371,14 @@ final class CStruct5[T1, T2, T3, T4, T5] private[scalanative] (
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(
-      value: T5
-  )(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct5[T1, T2, T3, T4, T5]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
 }
 
-final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (
-    private[scalanative] val rawptr: RawPtr
-) extends CStruct {
+final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct6[_, _, _, _, _, _] =>
@@ -447,142 +397,104 @@ final class CStruct6[T1, T2, T3, T4, T5, T6] private[scalanative] (
     fromRawPtr[CStruct6[T1, T2, T3, T4, T5, T6]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(
-      value: T1
-  )(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(
-      value: T2
-  )(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(
-      value: T3
-  )(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(
-      value: T4
-  )(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(
-      value: T5
-  )(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(
-      value: T6
-  )(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
 }
 
-final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (
-    private[scalanative] val rawptr: RawPtr
-) extends CStruct {
+final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct7[_, _, _, _, _, _, _] =>
@@ -601,164 +513,120 @@ final class CStruct7[T1, T2, T3, T4, T5, T6, T7] private[scalanative] (
     fromRawPtr[CStruct7[T1, T2, T3, T4, T5, T6, T7]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(
-      value: T1
-  )(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(
-      value: T2
-  )(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(
-      value: T3
-  )(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(
-      value: T4
-  )(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(
-      value: T5
-  )(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(
-      value: T6
-  )(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(
-      value: T7
-  )(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
 }
 
-final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
-    private[scalanative] val rawptr: RawPtr
-) extends CStruct {
+final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct8[_, _, _, _, _, _, _, _] =>
@@ -777,186 +645,136 @@ final class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] private[scalanative] (
     fromRawPtr[CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(
-      value: T1
-  )(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(
-      value: T2
-  )(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(
-      value: T3
-  )(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(
-      value: T4
-  )(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(
-      value: T5
-  )(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(
-      value: T6
-  )(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(
-      value: T7
-  )(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(
-      value: T8
-  )(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
 }
 
-final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
-    private[scalanative] val rawptr: RawPtr
-) extends CStruct {
+final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct9[_, _, _, _, _, _, _, _, _] =>
@@ -975,218 +793,152 @@ final class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] private[scalanative] (
     fromRawPtr[CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(
-      value: T1
-  )(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(
-      value: T2
-  )(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(
-      value: T3
-  )(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(
-      value: T4
-  )(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(
-      value: T5
-  )(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(
-      value: T6
-  )(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(
-      value: T7
-  )(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(
-      value: T8
-  )(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(
-      value: T9
-  )(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
 }
 
-final class CStruct10[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct10[_, _, _, _, _, _, _, _, _, _] =>
@@ -1201,246 +953,172 @@ final class CStruct10[
   @alwaysinline override def toString: String =
     "CStruct10@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr
-      : Ptr[CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] =
+  @alwaysinline def toPtr: Ptr[CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] =
     fromRawPtr[CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
 }
 
-final class CStruct11[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct11[_, _, _, _, _, _, _, _, _, _, _] =>
@@ -1455,269 +1133,188 @@ final class CStruct11[
   @alwaysinline override def toString: String =
     "CStruct11@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr
-      : Ptr[CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] =
+  @alwaysinline def toPtr: Ptr[CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] =
     fromRawPtr[CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
 }
 
-final class CStruct12[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct12[_, _, _, _, _, _, _, _, _, _, _, _] =>
@@ -1732,294 +1329,204 @@ final class CStruct12[
   @alwaysinline override def toString: String =
     "CStruct12@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr
-      : Ptr[CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] =
-    fromRawPtr[CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]](
-      rawptr
-    )
+  @alwaysinline def toPtr: Ptr[CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] =
+    fromRawPtr[CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
-  @alwaysinline def at12(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Ptr[T12] =
+  @alwaysinline def at12(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Ptr[T12] = 
     new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
 
   /** Load a value of a field number 12. */
-  @alwaysinline def _12(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): T12 = {
+  @alwaysinline def _12(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): T12 = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
-  @alwaysinline def _12_=(value: T12)(implicit
-      tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-  ): Unit = {
+  @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
 }
 
-final class CStruct13[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct13[_, _, _, _, _, _, _, _, _, _, _, _, _] =>
@@ -2034,317 +1541,220 @@ final class CStruct13[
   @alwaysinline override def toString: String =
     "CStruct13@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr
-      : Ptr[CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] =
-    fromRawPtr[
-      CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-    ](rawptr)
+  @alwaysinline def toPtr: Ptr[CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] =
+    fromRawPtr[CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
-  @alwaysinline def at12(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T12] =
+  @alwaysinline def at12(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T12] = 
     new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
 
   /** Load a value of a field number 12. */
-  @alwaysinline def _12(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T12 = {
+  @alwaysinline def _12(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T12 = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
-  @alwaysinline def _12_=(value: T12)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
-  @alwaysinline def at13(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Ptr[T13] =
+  @alwaysinline def at13(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Ptr[T13] = 
     new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
 
   /** Load a value of a field number 13. */
-  @alwaysinline def _13(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): T13 = {
+  @alwaysinline def _13(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): T13 = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
-  @alwaysinline def _13_=(value: T13)(implicit
-      tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-  ): Unit = {
+  @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
 }
 
-final class CStruct14[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct14[_, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
@@ -2359,971 +1769,236 @@ final class CStruct14[
   @alwaysinline override def toString: String =
     "CStruct14@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr: Ptr[
-    CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]
-  ] =
-    fromRawPtr[
-      CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]
-    ](rawptr)
+  @alwaysinline def toPtr: Ptr[CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]] =
+    fromRawPtr[CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
-  @alwaysinline def at12(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T12] =
+  @alwaysinline def at12(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T12] = 
     new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
 
   /** Load a value of a field number 12. */
-  @alwaysinline def _12(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T12 = {
+  @alwaysinline def _12(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T12 = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
-  @alwaysinline def _12_=(value: T12)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
-  @alwaysinline def at13(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T13] =
+  @alwaysinline def at13(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T13] = 
     new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
 
   /** Load a value of a field number 13. */
-  @alwaysinline def _13(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T13 = {
+  @alwaysinline def _13(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T13 = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
-  @alwaysinline def _13_=(value: T13)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
-  @alwaysinline def at14(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Ptr[T14] =
+  @alwaysinline def at14(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Ptr[T14] = 
     new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
 
   /** Load a value of a field number 14. */
-  @alwaysinline def _14(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): T14 = {
+  @alwaysinline def _14(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): T14 = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
-  @alwaysinline def _14_=(value: T14)(implicit
-      tag: Tag.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]
-  ): Unit = {
+  @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
 }
 
-final class CStruct15[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct15[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
@@ -3338,1098 +2013,252 @@ final class CStruct15[
   @alwaysinline override def toString: String =
     "CStruct15@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr: Ptr[
-    CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]
-  ] =
-    fromRawPtr[CStruct15[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15
-    ]](rawptr)
+  @alwaysinline def toPtr: Ptr[CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]] =
+    fromRawPtr[CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
-  @alwaysinline def at12(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T12] =
+  @alwaysinline def at12(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T12] = 
     new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
 
   /** Load a value of a field number 12. */
-  @alwaysinline def _12(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T12 = {
+  @alwaysinline def _12(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T12 = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
-  @alwaysinline def _12_=(value: T12)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
-  @alwaysinline def at13(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T13] =
+  @alwaysinline def at13(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T13] = 
     new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
 
   /** Load a value of a field number 13. */
-  @alwaysinline def _13(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T13 = {
+  @alwaysinline def _13(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T13 = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
-  @alwaysinline def _13_=(value: T13)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
-  @alwaysinline def at14(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T14] =
+  @alwaysinline def at14(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T14] = 
     new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
 
   /** Load a value of a field number 14. */
-  @alwaysinline def _14(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T14 = {
+  @alwaysinline def _14(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T14 = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
-  @alwaysinline def _14_=(value: T14)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
-  @alwaysinline def at15(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Ptr[T15] =
+  @alwaysinline def at15(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Ptr[T15] = 
     new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
 
   /** Load a value of a field number 15. */
-  @alwaysinline def _15(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): T15 = {
+  @alwaysinline def _15(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): T15 = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
-  @alwaysinline def _15_=(value: T15)(implicit
-      tag: Tag.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]
-  ): Unit = {
+  @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
 }
 
-final class CStruct16[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
       case other: CStruct16[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
@@ -4444,1254 +2273,271 @@ final class CStruct16[
   @alwaysinline override def toString: String =
     "CStruct16@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr: Ptr[CStruct16[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16
-  ]] =
-    fromRawPtr[CStruct16[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16
-    ]](rawptr)
+  @alwaysinline def toPtr: Ptr[CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]] =
+    fromRawPtr[CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
-  @alwaysinline def at12(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T12] =
+  @alwaysinline def at12(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T12] = 
     new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
 
   /** Load a value of a field number 12. */
-  @alwaysinline def _12(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T12 = {
+  @alwaysinline def _12(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T12 = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
-  @alwaysinline def _12_=(value: T12)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
-  @alwaysinline def at13(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T13] =
+  @alwaysinline def at13(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T13] = 
     new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
 
   /** Load a value of a field number 13. */
-  @alwaysinline def _13(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T13 = {
+  @alwaysinline def _13(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T13 = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
-  @alwaysinline def _13_=(value: T13)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
-  @alwaysinline def at14(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T14] =
+  @alwaysinline def at14(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T14] = 
     new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
 
   /** Load a value of a field number 14. */
-  @alwaysinline def _14(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T14 = {
+  @alwaysinline def _14(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T14 = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
-  @alwaysinline def _14_=(value: T14)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
-  @alwaysinline def at15(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T15] =
+  @alwaysinline def at15(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T15] = 
     new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
 
   /** Load a value of a field number 15. */
-  @alwaysinline def _15(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T15 = {
+  @alwaysinline def _15(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T15 = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
-  @alwaysinline def _15_=(value: T15)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
-  @alwaysinline def at16(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Ptr[T16] =
+  @alwaysinline def at16(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Ptr[T16] = 
     new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
 
   /** Load a value of a field number 16. */
-  @alwaysinline def _16(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): T16 = {
+  @alwaysinline def _16(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): T16 = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
-  @alwaysinline def _16_=(value: T16)(implicit
-      tag: Tag.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]
-  ): Unit = {
+  @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
 }
 
-final class CStruct17[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
-      case other: CStruct17[
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _
-          ] =>
+      case other: CStruct17[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         other.rawptr == rawptr
       case _ =>
         false
@@ -5703,1382 +2549,287 @@ final class CStruct17[
   @alwaysinline override def toString: String =
     "CStruct17@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr: Ptr[CStruct17[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17
-  ]] =
-    fromRawPtr[CStruct17[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17
-    ]](rawptr)
+  @alwaysinline def toPtr: Ptr[CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]] =
+    fromRawPtr[CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
-  @alwaysinline def at12(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T12] =
+  @alwaysinline def at12(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T12] = 
     new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
 
   /** Load a value of a field number 12. */
-  @alwaysinline def _12(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T12 = {
+  @alwaysinline def _12(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T12 = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
-  @alwaysinline def _12_=(value: T12)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
-  @alwaysinline def at13(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T13] =
+  @alwaysinline def at13(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T13] = 
     new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
 
   /** Load a value of a field number 13. */
-  @alwaysinline def _13(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T13 = {
+  @alwaysinline def _13(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T13 = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
-  @alwaysinline def _13_=(value: T13)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
-  @alwaysinline def at14(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T14] =
+  @alwaysinline def at14(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T14] = 
     new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
 
   /** Load a value of a field number 14. */
-  @alwaysinline def _14(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T14 = {
+  @alwaysinline def _14(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T14 = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
-  @alwaysinline def _14_=(value: T14)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
-  @alwaysinline def at15(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T15] =
+  @alwaysinline def at15(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T15] = 
     new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
 
   /** Load a value of a field number 15. */
-  @alwaysinline def _15(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T15 = {
+  @alwaysinline def _15(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T15 = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
-  @alwaysinline def _15_=(value: T15)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
-  @alwaysinline def at16(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T16] =
+  @alwaysinline def at16(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T16] = 
     new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
 
   /** Load a value of a field number 16. */
-  @alwaysinline def _16(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T16 = {
+  @alwaysinline def _16(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T16 = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
-  @alwaysinline def _16_=(value: T16)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
-  @alwaysinline def at17(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Ptr[T17] =
+  @alwaysinline def at17(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Ptr[T17] = 
     new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
 
   /** Load a value of a field number 17. */
-  @alwaysinline def _17(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): T17 = {
+  @alwaysinline def _17(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): T17 = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
-  @alwaysinline def _17_=(value: T17)(implicit
-      tag: Tag.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]
-  ): Unit = {
+  @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
 }
 
-final class CStruct18[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
-      case other: CStruct18[
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _
-          ] =>
+      case other: CStruct18[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         other.rawptr == rawptr
       case _ =>
         false
@@ -7090,1516 +2841,303 @@ final class CStruct18[
   @alwaysinline override def toString: String =
     "CStruct18@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr: Ptr[CStruct18[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18
-  ]] =
-    fromRawPtr[CStruct18[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18
-    ]](rawptr)
+  @alwaysinline def toPtr: Ptr[CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]] =
+    fromRawPtr[CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
-  @alwaysinline def at12(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T12] =
+  @alwaysinline def at12(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T12] = 
     new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
 
   /** Load a value of a field number 12. */
-  @alwaysinline def _12(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T12 = {
+  @alwaysinline def _12(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T12 = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
-  @alwaysinline def _12_=(value: T12)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
-  @alwaysinline def at13(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T13] =
+  @alwaysinline def at13(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T13] = 
     new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
 
   /** Load a value of a field number 13. */
-  @alwaysinline def _13(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T13 = {
+  @alwaysinline def _13(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T13 = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
-  @alwaysinline def _13_=(value: T13)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
-  @alwaysinline def at14(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T14] =
+  @alwaysinline def at14(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T14] = 
     new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
 
   /** Load a value of a field number 14. */
-  @alwaysinline def _14(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T14 = {
+  @alwaysinline def _14(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T14 = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
-  @alwaysinline def _14_=(value: T14)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
-  @alwaysinline def at15(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T15] =
+  @alwaysinline def at15(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T15] = 
     new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
 
   /** Load a value of a field number 15. */
-  @alwaysinline def _15(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T15 = {
+  @alwaysinline def _15(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T15 = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
-  @alwaysinline def _15_=(value: T15)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
-  @alwaysinline def at16(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T16] =
+  @alwaysinline def at16(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T16] = 
     new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
 
   /** Load a value of a field number 16. */
-  @alwaysinline def _16(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T16 = {
+  @alwaysinline def _16(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T16 = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
-  @alwaysinline def _16_=(value: T16)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
-  @alwaysinline def at17(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T17] =
+  @alwaysinline def at17(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T17] = 
     new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
 
   /** Load a value of a field number 17. */
-  @alwaysinline def _17(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T17 = {
+  @alwaysinline def _17(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T17 = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
-  @alwaysinline def _17_=(value: T17)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
   /** Load a value of a field number 18. */
-  @alwaysinline def at18(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Ptr[T18] =
+  @alwaysinline def at18(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Ptr[T18] = 
     new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
 
   /** Load a value of a field number 18. */
-  @alwaysinline def _18(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): T18 = {
+  @alwaysinline def _18(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): T18 = {
     val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
     ptr.unary_!(tag._18)
   }
 
   /** Store a value to a field number 18. */
-  @alwaysinline def _18_=(value: T18)(implicit
-      tag: Tag.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]
-  ): Unit = {
+  @alwaysinline def _18_=(value: T18)(implicit tag: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
     val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._18)
   }
 
 }
 
-final class CStruct19[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
-      case other: CStruct19[
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _
-          ] =>
+      case other: CStruct19[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         other.rawptr == rawptr
       case _ =>
         false
@@ -8611,1656 +3149,319 @@ final class CStruct19[
   @alwaysinline override def toString: String =
     "CStruct19@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr: Ptr[CStruct19[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19
-  ]] =
-    fromRawPtr[CStruct19[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19
-    ]](rawptr)
+  @alwaysinline def toPtr: Ptr[CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]] =
+    fromRawPtr[CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
-  @alwaysinline def at12(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T12] =
+  @alwaysinline def at12(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T12] = 
     new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
 
   /** Load a value of a field number 12. */
-  @alwaysinline def _12(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T12 = {
+  @alwaysinline def _12(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T12 = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
-  @alwaysinline def _12_=(value: T12)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
-  @alwaysinline def at13(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T13] =
+  @alwaysinline def at13(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T13] = 
     new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
 
   /** Load a value of a field number 13. */
-  @alwaysinline def _13(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T13 = {
+  @alwaysinline def _13(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T13 = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
-  @alwaysinline def _13_=(value: T13)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
-  @alwaysinline def at14(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T14] =
+  @alwaysinline def at14(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T14] = 
     new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
 
   /** Load a value of a field number 14. */
-  @alwaysinline def _14(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T14 = {
+  @alwaysinline def _14(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T14 = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
-  @alwaysinline def _14_=(value: T14)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
-  @alwaysinline def at15(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T15] =
+  @alwaysinline def at15(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T15] = 
     new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
 
   /** Load a value of a field number 15. */
-  @alwaysinline def _15(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T15 = {
+  @alwaysinline def _15(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T15 = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
-  @alwaysinline def _15_=(value: T15)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
-  @alwaysinline def at16(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T16] =
+  @alwaysinline def at16(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T16] = 
     new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
 
   /** Load a value of a field number 16. */
-  @alwaysinline def _16(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T16 = {
+  @alwaysinline def _16(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T16 = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
-  @alwaysinline def _16_=(value: T16)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
-  @alwaysinline def at17(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T17] =
+  @alwaysinline def at17(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T17] = 
     new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
 
   /** Load a value of a field number 17. */
-  @alwaysinline def _17(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T17 = {
+  @alwaysinline def _17(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T17 = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
-  @alwaysinline def _17_=(value: T17)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
   /** Load a value of a field number 18. */
-  @alwaysinline def at18(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T18] =
+  @alwaysinline def at18(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T18] = 
     new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
 
   /** Load a value of a field number 18. */
-  @alwaysinline def _18(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T18 = {
+  @alwaysinline def _18(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T18 = {
     val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
     ptr.unary_!(tag._18)
   }
 
   /** Store a value to a field number 18. */
-  @alwaysinline def _18_=(value: T18)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _18_=(value: T18)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._18)
   }
 
   /** Load a value of a field number 19. */
-  @alwaysinline def at19(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Ptr[T19] =
+  @alwaysinline def at19(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Ptr[T19] = 
     new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
 
   /** Load a value of a field number 19. */
-  @alwaysinline def _19(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): T19 = {
+  @alwaysinline def _19(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): T19 = {
     val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
     ptr.unary_!(tag._19)
   }
 
   /** Store a value to a field number 19. */
-  @alwaysinline def _19_=(value: T19)(implicit
-      tag: Tag.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]
-  ): Unit = {
+  @alwaysinline def _19_=(value: T19)(implicit tag: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
     val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._19)
   }
 
 }
 
-final class CStruct20[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
-      case other: CStruct20[
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _
-          ] =>
+      case other: CStruct20[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         other.rawptr == rawptr
       case _ =>
         false
@@ -10272,1802 +3473,335 @@ final class CStruct20[
   @alwaysinline override def toString: String =
     "CStruct20@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr: Ptr[CStruct20[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20
-  ]] =
-    fromRawPtr[CStruct20[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20
-    ]](rawptr)
+  @alwaysinline def toPtr: Ptr[CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]] =
+    fromRawPtr[CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
-  @alwaysinline def at12(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T12] =
+  @alwaysinline def at12(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T12] = 
     new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
 
   /** Load a value of a field number 12. */
-  @alwaysinline def _12(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T12 = {
+  @alwaysinline def _12(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T12 = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
-  @alwaysinline def _12_=(value: T12)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
-  @alwaysinline def at13(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T13] =
+  @alwaysinline def at13(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T13] = 
     new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
 
   /** Load a value of a field number 13. */
-  @alwaysinline def _13(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T13 = {
+  @alwaysinline def _13(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T13 = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
-  @alwaysinline def _13_=(value: T13)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
-  @alwaysinline def at14(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T14] =
+  @alwaysinline def at14(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T14] = 
     new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
 
   /** Load a value of a field number 14. */
-  @alwaysinline def _14(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T14 = {
+  @alwaysinline def _14(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T14 = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
-  @alwaysinline def _14_=(value: T14)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
-  @alwaysinline def at15(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T15] =
+  @alwaysinline def at15(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T15] = 
     new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
 
   /** Load a value of a field number 15. */
-  @alwaysinline def _15(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T15 = {
+  @alwaysinline def _15(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T15 = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
-  @alwaysinline def _15_=(value: T15)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
-  @alwaysinline def at16(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T16] =
+  @alwaysinline def at16(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T16] = 
     new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
 
   /** Load a value of a field number 16. */
-  @alwaysinline def _16(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T16 = {
+  @alwaysinline def _16(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T16 = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
-  @alwaysinline def _16_=(value: T16)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
-  @alwaysinline def at17(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T17] =
+  @alwaysinline def at17(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T17] = 
     new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
 
   /** Load a value of a field number 17. */
-  @alwaysinline def _17(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T17 = {
+  @alwaysinline def _17(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T17 = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
-  @alwaysinline def _17_=(value: T17)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
   /** Load a value of a field number 18. */
-  @alwaysinline def at18(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T18] =
+  @alwaysinline def at18(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T18] = 
     new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
 
   /** Load a value of a field number 18. */
-  @alwaysinline def _18(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T18 = {
+  @alwaysinline def _18(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T18 = {
     val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
     ptr.unary_!(tag._18)
   }
 
   /** Store a value to a field number 18. */
-  @alwaysinline def _18_=(value: T18)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _18_=(value: T18)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._18)
   }
 
   /** Load a value of a field number 19. */
-  @alwaysinline def at19(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T19] =
+  @alwaysinline def at19(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T19] = 
     new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
 
   /** Load a value of a field number 19. */
-  @alwaysinline def _19(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T19 = {
+  @alwaysinline def _19(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T19 = {
     val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
     ptr.unary_!(tag._19)
   }
 
   /** Store a value to a field number 19. */
-  @alwaysinline def _19_=(value: T19)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _19_=(value: T19)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._19)
   }
 
   /** Load a value of a field number 20. */
-  @alwaysinline def at20(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Ptr[T20] =
+  @alwaysinline def at20(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Ptr[T20] = 
     new Ptr[T20](elemRawPtr(rawptr, tag.offset(19.toULong).toLong))
 
   /** Load a value of a field number 20. */
-  @alwaysinline def _20(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): T20 = {
+  @alwaysinline def _20(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): T20 = {
     val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19.toULong).toLong))
     ptr.unary_!(tag._20)
   }
 
   /** Store a value to a field number 20. */
-  @alwaysinline def _20_=(value: T20)(implicit
-      tag: Tag.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]
-  ): Unit = {
+  @alwaysinline def _20_=(value: T20)(implicit tag: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
     val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._20)
   }
 
 }
 
-final class CStruct21[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
-      case other: CStruct21[
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _
-          ] =>
+      case other: CStruct21[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         other.rawptr == rawptr
       case _ =>
         false
@@ -12079,1954 +3813,351 @@ final class CStruct21[
   @alwaysinline override def toString: String =
     "CStruct21@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr: Ptr[CStruct21[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21
-  ]] =
-    fromRawPtr[CStruct21[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21
-    ]](rawptr)
+  @alwaysinline def toPtr: Ptr[CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]] =
+    fromRawPtr[CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
-  @alwaysinline def at12(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T12] =
+  @alwaysinline def at12(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T12] = 
     new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
 
   /** Load a value of a field number 12. */
-  @alwaysinline def _12(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T12 = {
+  @alwaysinline def _12(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T12 = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
-  @alwaysinline def _12_=(value: T12)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
-  @alwaysinline def at13(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T13] =
+  @alwaysinline def at13(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T13] = 
     new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
 
   /** Load a value of a field number 13. */
-  @alwaysinline def _13(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T13 = {
+  @alwaysinline def _13(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T13 = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
-  @alwaysinline def _13_=(value: T13)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
-  @alwaysinline def at14(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T14] =
+  @alwaysinline def at14(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T14] = 
     new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
 
   /** Load a value of a field number 14. */
-  @alwaysinline def _14(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T14 = {
+  @alwaysinline def _14(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T14 = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
-  @alwaysinline def _14_=(value: T14)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
-  @alwaysinline def at15(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T15] =
+  @alwaysinline def at15(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T15] = 
     new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
 
   /** Load a value of a field number 15. */
-  @alwaysinline def _15(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T15 = {
+  @alwaysinline def _15(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T15 = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
-  @alwaysinline def _15_=(value: T15)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
-  @alwaysinline def at16(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T16] =
+  @alwaysinline def at16(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T16] = 
     new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
 
   /** Load a value of a field number 16. */
-  @alwaysinline def _16(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T16 = {
+  @alwaysinline def _16(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T16 = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
-  @alwaysinline def _16_=(value: T16)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
-  @alwaysinline def at17(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T17] =
+  @alwaysinline def at17(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T17] = 
     new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
 
   /** Load a value of a field number 17. */
-  @alwaysinline def _17(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T17 = {
+  @alwaysinline def _17(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T17 = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
-  @alwaysinline def _17_=(value: T17)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
   /** Load a value of a field number 18. */
-  @alwaysinline def at18(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T18] =
+  @alwaysinline def at18(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T18] = 
     new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
 
   /** Load a value of a field number 18. */
-  @alwaysinline def _18(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T18 = {
+  @alwaysinline def _18(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T18 = {
     val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
     ptr.unary_!(tag._18)
   }
 
   /** Store a value to a field number 18. */
-  @alwaysinline def _18_=(value: T18)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _18_=(value: T18)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._18)
   }
 
   /** Load a value of a field number 19. */
-  @alwaysinline def at19(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T19] =
+  @alwaysinline def at19(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T19] = 
     new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
 
   /** Load a value of a field number 19. */
-  @alwaysinline def _19(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T19 = {
+  @alwaysinline def _19(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T19 = {
     val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
     ptr.unary_!(tag._19)
   }
 
   /** Store a value to a field number 19. */
-  @alwaysinline def _19_=(value: T19)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _19_=(value: T19)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._19)
   }
 
   /** Load a value of a field number 20. */
-  @alwaysinline def at20(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T20] =
+  @alwaysinline def at20(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T20] = 
     new Ptr[T20](elemRawPtr(rawptr, tag.offset(19.toULong).toLong))
 
   /** Load a value of a field number 20. */
-  @alwaysinline def _20(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T20 = {
+  @alwaysinline def _20(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T20 = {
     val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19.toULong).toLong))
     ptr.unary_!(tag._20)
   }
 
   /** Store a value to a field number 20. */
-  @alwaysinline def _20_=(value: T20)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _20_=(value: T20)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._20)
   }
 
   /** Load a value of a field number 21. */
-  @alwaysinline def at21(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Ptr[T21] =
+  @alwaysinline def at21(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Ptr[T21] = 
     new Ptr[T21](elemRawPtr(rawptr, tag.offset(20.toULong).toLong))
 
   /** Load a value of a field number 21. */
-  @alwaysinline def _21(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): T21 = {
+  @alwaysinline def _21(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): T21 = {
     val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset(20.toULong).toLong))
     ptr.unary_!(tag._21)
   }
 
   /** Store a value to a field number 21. */
-  @alwaysinline def _21_=(value: T21)(implicit
-      tag: Tag.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]
-  ): Unit = {
+  @alwaysinline def _21_=(value: T21)(implicit tag: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
     val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset(20.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._21)
   }
 
 }
 
-final class CStruct22[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22
-] private[scalanative] (private[scalanative] val rawptr: RawPtr)
-    extends CStruct {
+final class CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22] private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
-      case other: CStruct22[
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _
-          ] =>
+      case other: CStruct22[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         other.rawptr == rawptr
       case _ =>
         false
@@ -14038,2055 +4169,360 @@ final class CStruct22[
   @alwaysinline override def toString: String =
     "CStruct22@" + java.lang.Long.toHexString(castRawPtrToLong(rawptr))
 
-  @alwaysinline def toPtr: Ptr[CStruct22[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22
-  ]] =
-    fromRawPtr[CStruct22[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      T22
-    ]](rawptr)
+  @alwaysinline def toPtr: Ptr[CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]] =
+    fromRawPtr[CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]](rawptr)
 
   /** Load a value of a field number 1. */
-  @alwaysinline def at1(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T1] =
+  @alwaysinline def at1(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T1] = 
     new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
 
   /** Load a value of a field number 1. */
-  @alwaysinline def _1(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T1 = {
+  @alwaysinline def _1(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T1 = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.unary_!(tag._1)
   }
 
   /** Store a value to a field number 1. */
-  @alwaysinline def _1_=(value: T1)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _1_=(value: T1)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T1](elemRawPtr(rawptr, tag.offset(0.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._1)
   }
 
   /** Load a value of a field number 2. */
-  @alwaysinline def at2(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T2] =
+  @alwaysinline def at2(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T2] = 
     new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
 
   /** Load a value of a field number 2. */
-  @alwaysinline def _2(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T2 = {
+  @alwaysinline def _2(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T2 = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.unary_!(tag._2)
   }
 
   /** Store a value to a field number 2. */
-  @alwaysinline def _2_=(value: T2)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _2_=(value: T2)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T2](elemRawPtr(rawptr, tag.offset(1.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._2)
   }
 
   /** Load a value of a field number 3. */
-  @alwaysinline def at3(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T3] =
+  @alwaysinline def at3(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T3] = 
     new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
 
   /** Load a value of a field number 3. */
-  @alwaysinline def _3(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T3 = {
+  @alwaysinline def _3(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T3 = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.unary_!(tag._3)
   }
 
   /** Store a value to a field number 3. */
-  @alwaysinline def _3_=(value: T3)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _3_=(value: T3)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T3](elemRawPtr(rawptr, tag.offset(2.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._3)
   }
 
   /** Load a value of a field number 4. */
-  @alwaysinline def at4(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T4] =
+  @alwaysinline def at4(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T4] = 
     new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
 
   /** Load a value of a field number 4. */
-  @alwaysinline def _4(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T4 = {
+  @alwaysinline def _4(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T4 = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.unary_!(tag._4)
   }
 
   /** Store a value to a field number 4. */
-  @alwaysinline def _4_=(value: T4)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _4_=(value: T4)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T4](elemRawPtr(rawptr, tag.offset(3.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._4)
   }
 
   /** Load a value of a field number 5. */
-  @alwaysinline def at5(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T5] =
+  @alwaysinline def at5(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T5] = 
     new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
 
   /** Load a value of a field number 5. */
-  @alwaysinline def _5(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T5 = {
+  @alwaysinline def _5(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T5 = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.unary_!(tag._5)
   }
 
   /** Store a value to a field number 5. */
-  @alwaysinline def _5_=(value: T5)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _5_=(value: T5)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T5](elemRawPtr(rawptr, tag.offset(4.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._5)
   }
 
   /** Load a value of a field number 6. */
-  @alwaysinline def at6(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T6] =
+  @alwaysinline def at6(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T6] = 
     new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
 
   /** Load a value of a field number 6. */
-  @alwaysinline def _6(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T6 = {
+  @alwaysinline def _6(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T6 = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.unary_!(tag._6)
   }
 
   /** Store a value to a field number 6. */
-  @alwaysinline def _6_=(value: T6)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _6_=(value: T6)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T6](elemRawPtr(rawptr, tag.offset(5.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._6)
   }
 
   /** Load a value of a field number 7. */
-  @alwaysinline def at7(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T7] =
+  @alwaysinline def at7(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T7] = 
     new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
 
   /** Load a value of a field number 7. */
-  @alwaysinline def _7(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T7 = {
+  @alwaysinline def _7(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T7 = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.unary_!(tag._7)
   }
 
   /** Store a value to a field number 7. */
-  @alwaysinline def _7_=(value: T7)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _7_=(value: T7)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T7](elemRawPtr(rawptr, tag.offset(6.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._7)
   }
 
   /** Load a value of a field number 8. */
-  @alwaysinline def at8(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T8] =
+  @alwaysinline def at8(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T8] = 
     new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
 
   /** Load a value of a field number 8. */
-  @alwaysinline def _8(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T8 = {
+  @alwaysinline def _8(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T8 = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.unary_!(tag._8)
   }
 
   /** Store a value to a field number 8. */
-  @alwaysinline def _8_=(value: T8)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _8_=(value: T8)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T8](elemRawPtr(rawptr, tag.offset(7.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._8)
   }
 
   /** Load a value of a field number 9. */
-  @alwaysinline def at9(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T9] =
+  @alwaysinline def at9(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T9] = 
     new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
 
   /** Load a value of a field number 9. */
-  @alwaysinline def _9(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T9 = {
+  @alwaysinline def _9(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T9 = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.unary_!(tag._9)
   }
 
   /** Store a value to a field number 9. */
-  @alwaysinline def _9_=(value: T9)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _9_=(value: T9)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T9](elemRawPtr(rawptr, tag.offset(8.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._9)
   }
 
   /** Load a value of a field number 10. */
-  @alwaysinline def at10(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T10] =
+  @alwaysinline def at10(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T10] = 
     new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
 
   /** Load a value of a field number 10. */
-  @alwaysinline def _10(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T10 = {
+  @alwaysinline def _10(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T10 = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.unary_!(tag._10)
   }
 
   /** Store a value to a field number 10. */
-  @alwaysinline def _10_=(value: T10)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _10_=(value: T10)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T10](elemRawPtr(rawptr, tag.offset(9.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._10)
   }
 
   /** Load a value of a field number 11. */
-  @alwaysinline def at11(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T11] =
+  @alwaysinline def at11(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T11] = 
     new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
 
   /** Load a value of a field number 11. */
-  @alwaysinline def _11(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T11 = {
+  @alwaysinline def _11(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T11 = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.unary_!(tag._11)
   }
 
   /** Store a value to a field number 11. */
-  @alwaysinline def _11_=(value: T11)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _11_=(value: T11)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T11](elemRawPtr(rawptr, tag.offset(10.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._11)
   }
 
   /** Load a value of a field number 12. */
-  @alwaysinline def at12(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T12] =
+  @alwaysinline def at12(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T12] = 
     new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
 
   /** Load a value of a field number 12. */
-  @alwaysinline def _12(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T12 = {
+  @alwaysinline def _12(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T12 = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.unary_!(tag._12)
   }
 
   /** Store a value to a field number 12. */
-  @alwaysinline def _12_=(value: T12)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _12_=(value: T12)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T12](elemRawPtr(rawptr, tag.offset(11.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._12)
   }
 
   /** Load a value of a field number 13. */
-  @alwaysinline def at13(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T13] =
+  @alwaysinline def at13(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T13] = 
     new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
 
   /** Load a value of a field number 13. */
-  @alwaysinline def _13(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T13 = {
+  @alwaysinline def _13(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T13 = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.unary_!(tag._13)
   }
 
   /** Store a value to a field number 13. */
-  @alwaysinline def _13_=(value: T13)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _13_=(value: T13)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T13](elemRawPtr(rawptr, tag.offset(12.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._13)
   }
 
   /** Load a value of a field number 14. */
-  @alwaysinline def at14(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T14] =
+  @alwaysinline def at14(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T14] = 
     new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
 
   /** Load a value of a field number 14. */
-  @alwaysinline def _14(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T14 = {
+  @alwaysinline def _14(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T14 = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.unary_!(tag._14)
   }
 
   /** Store a value to a field number 14. */
-  @alwaysinline def _14_=(value: T14)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _14_=(value: T14)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T14](elemRawPtr(rawptr, tag.offset(13.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._14)
   }
 
   /** Load a value of a field number 15. */
-  @alwaysinline def at15(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T15] =
+  @alwaysinline def at15(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T15] = 
     new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
 
   /** Load a value of a field number 15. */
-  @alwaysinline def _15(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T15 = {
+  @alwaysinline def _15(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T15 = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.unary_!(tag._15)
   }
 
   /** Store a value to a field number 15. */
-  @alwaysinline def _15_=(value: T15)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _15_=(value: T15)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T15](elemRawPtr(rawptr, tag.offset(14.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._15)
   }
 
   /** Load a value of a field number 16. */
-  @alwaysinline def at16(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T16] =
+  @alwaysinline def at16(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T16] = 
     new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
 
   /** Load a value of a field number 16. */
-  @alwaysinline def _16(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T16 = {
+  @alwaysinline def _16(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T16 = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.unary_!(tag._16)
   }
 
   /** Store a value to a field number 16. */
-  @alwaysinline def _16_=(value: T16)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _16_=(value: T16)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T16](elemRawPtr(rawptr, tag.offset(15.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._16)
   }
 
   /** Load a value of a field number 17. */
-  @alwaysinline def at17(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T17] =
+  @alwaysinline def at17(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T17] = 
     new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
 
   /** Load a value of a field number 17. */
-  @alwaysinline def _17(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T17 = {
+  @alwaysinline def _17(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T17 = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.unary_!(tag._17)
   }
 
   /** Store a value to a field number 17. */
-  @alwaysinline def _17_=(value: T17)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _17_=(value: T17)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T17](elemRawPtr(rawptr, tag.offset(16.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._17)
   }
 
   /** Load a value of a field number 18. */
-  @alwaysinline def at18(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T18] =
+  @alwaysinline def at18(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T18] = 
     new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
 
   /** Load a value of a field number 18. */
-  @alwaysinline def _18(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T18 = {
+  @alwaysinline def _18(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T18 = {
     val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
     ptr.unary_!(tag._18)
   }
 
   /** Store a value to a field number 18. */
-  @alwaysinline def _18_=(value: T18)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _18_=(value: T18)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T18](elemRawPtr(rawptr, tag.offset(17.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._18)
   }
 
   /** Load a value of a field number 19. */
-  @alwaysinline def at19(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T19] =
+  @alwaysinline def at19(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T19] = 
     new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
 
   /** Load a value of a field number 19. */
-  @alwaysinline def _19(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T19 = {
+  @alwaysinline def _19(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T19 = {
     val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
     ptr.unary_!(tag._19)
   }
 
   /** Store a value to a field number 19. */
-  @alwaysinline def _19_=(value: T19)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _19_=(value: T19)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T19](elemRawPtr(rawptr, tag.offset(18.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._19)
   }
 
   /** Load a value of a field number 20. */
-  @alwaysinline def at20(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T20] =
+  @alwaysinline def at20(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T20] = 
     new Ptr[T20](elemRawPtr(rawptr, tag.offset(19.toULong).toLong))
 
   /** Load a value of a field number 20. */
-  @alwaysinline def _20(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T20 = {
+  @alwaysinline def _20(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T20 = {
     val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19.toULong).toLong))
     ptr.unary_!(tag._20)
   }
 
   /** Store a value to a field number 20. */
-  @alwaysinline def _20_=(value: T20)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _20_=(value: T20)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T20](elemRawPtr(rawptr, tag.offset(19.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._20)
   }
 
   /** Load a value of a field number 21. */
-  @alwaysinline def at21(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T21] =
+  @alwaysinline def at21(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T21] = 
     new Ptr[T21](elemRawPtr(rawptr, tag.offset(20.toULong).toLong))
 
   /** Load a value of a field number 21. */
-  @alwaysinline def _21(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T21 = {
+  @alwaysinline def _21(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T21 = {
     val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset(20.toULong).toLong))
     ptr.unary_!(tag._21)
   }
 
   /** Store a value to a field number 21. */
-  @alwaysinline def _21_=(value: T21)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _21_=(value: T21)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T21](elemRawPtr(rawptr, tag.offset(20.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._21)
   }
 
   /** Load a value of a field number 22. */
-  @alwaysinline def at22(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Ptr[T22] =
+  @alwaysinline def at22(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Ptr[T22] = 
     new Ptr[T22](elemRawPtr(rawptr, tag.offset(21.toULong).toLong))
 
   /** Load a value of a field number 22. */
-  @alwaysinline def _22(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): T22 = {
+  @alwaysinline def _22(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): T22 = {
     val ptr = new Ptr[T22](elemRawPtr(rawptr, tag.offset(21.toULong).toLong))
     ptr.unary_!(tag._22)
   }
 
   /** Store a value to a field number 22. */
-  @alwaysinline def _22_=(value: T22)(implicit
-      tag: Tag.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]
-  ): Unit = {
+  @alwaysinline def _22_=(value: T22)(implicit tag: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
     val ptr = new Ptr[T22](elemRawPtr(rawptr, tag.offset(21.toULong).toLong))
     ptr.`unary_!_=`(value)(tag._22)
   }
 
 }
+

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CStruct.scala.gyb
@@ -1,3 +1,4 @@
+// format: off
 
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
@@ -20,7 +21,6 @@ sealed abstract class CStruct
 % for N in range(0, 23):
 %    Ts = "" if N == 0 else "[" + ", ".join("T" + str(i) for i in range(1, N + 1)) + "]"
 %    underscores = "" if N == 0 else "[" + ", ".join("_" for i in range(0, N)) + "]"
-
 final class CStruct${N}${Ts} private[scalanative] (private[scalanative] val rawptr: RawPtr) extends CStruct {
   @alwaysinline override def equals(other: Any): Boolean =
     (this eq other.asInstanceOf[AnyRef]) || (other match {
@@ -40,7 +40,6 @@ final class CStruct${N}${Ts} private[scalanative] (private[scalanative] val rawp
     fromRawPtr[CStruct${N}${Ts}](rawptr)
 
   % for F in range(1, N + 1):
-
   /** Load a value of a field number ${F}. */
   @alwaysinline def at${F}(implicit tag: Tag.CStruct${N}${Ts}): Ptr[T${F}] = 
     new Ptr[T${F}](elemRawPtr(rawptr, tag.offset(${F - 1}.toULong).toLong))

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala
@@ -1,3 +1,5 @@
+// format: off
+
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -36,64 +38,18 @@ object Nat {
 
   final abstract class Digit2[N1 <: Nat.Base, N2 <: Nat.Base] extends Nat
 
-  final abstract class Digit3[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base]
-      extends Nat
+  final abstract class Digit3[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base] extends Nat
 
-  final abstract class Digit4[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base
-  ] extends Nat
+  final abstract class Digit4[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base] extends Nat
 
-  final abstract class Digit5[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base,
-      N5 <: Nat.Base
-  ] extends Nat
+  final abstract class Digit5[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base] extends Nat
 
-  final abstract class Digit6[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base,
-      N5 <: Nat.Base,
-      N6 <: Nat.Base
-  ] extends Nat
+  final abstract class Digit6[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base] extends Nat
 
-  final abstract class Digit7[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base,
-      N5 <: Nat.Base,
-      N6 <: Nat.Base,
-      N7 <: Nat.Base
-  ] extends Nat
+  final abstract class Digit7[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base, N7 <: Nat.Base] extends Nat
 
-  final abstract class Digit8[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base,
-      N5 <: Nat.Base,
-      N6 <: Nat.Base,
-      N7 <: Nat.Base,
-      N8 <: Nat.Base
-  ] extends Nat
+  final abstract class Digit8[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base, N7 <: Nat.Base, N8 <: Nat.Base] extends Nat
 
-  final abstract class Digit9[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base,
-      N5 <: Nat.Base,
-      N6 <: Nat.Base,
-      N7 <: Nat.Base,
-      N8 <: Nat.Base,
-      N9 <: Nat.Base
-  ] extends Nat
+  final abstract class Digit9[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base, N7 <: Nat.Base, N8 <: Nat.Base, N9 <: Nat.Base] extends Nat
 
 }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala
@@ -1,5 +1,3 @@
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 1)
-
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -16,58 +14,30 @@ sealed abstract class Nat
 object Nat {
   sealed abstract class Base extends Nat
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 19)
-
   final abstract class _0 extends Base
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 19)
 
   final abstract class _1 extends Base
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 19)
-
   final abstract class _2 extends Base
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 19)
 
   final abstract class _3 extends Base
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 19)
-
   final abstract class _4 extends Base
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 19)
 
   final abstract class _5 extends Base
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 19)
-
   final abstract class _6 extends Base
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 19)
 
   final abstract class _7 extends Base
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 19)
-
   final abstract class _8 extends Base
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 19)
 
   final abstract class _9 extends Base
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 23)
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 26)
-
   final abstract class Digit2[N1 <: Nat.Base, N2 <: Nat.Base] extends Nat
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 26)
 
   final abstract class Digit3[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base]
       extends Nat
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 26)
 
   final abstract class Digit4[
       N1 <: Nat.Base,
@@ -75,8 +45,6 @@ object Nat {
       N3 <: Nat.Base,
       N4 <: Nat.Base
   ] extends Nat
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 26)
 
   final abstract class Digit5[
       N1 <: Nat.Base,
@@ -86,8 +54,6 @@ object Nat {
       N5 <: Nat.Base
   ] extends Nat
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 26)
-
   final abstract class Digit6[
       N1 <: Nat.Base,
       N2 <: Nat.Base,
@@ -96,8 +62,6 @@ object Nat {
       N5 <: Nat.Base,
       N6 <: Nat.Base
   ] extends Nat
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 26)
 
   final abstract class Digit7[
       N1 <: Nat.Base,
@@ -109,8 +73,6 @@ object Nat {
       N7 <: Nat.Base
   ] extends Nat
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 26)
-
   final abstract class Digit8[
       N1 <: Nat.Base,
       N2 <: Nat.Base,
@@ -121,8 +83,6 @@ object Nat {
       N7 <: Nat.Base,
       N8 <: Nat.Base
   ] extends Nat
-
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 26)
 
   final abstract class Digit9[
       N1 <: Nat.Base,
@@ -136,5 +96,4 @@ object Nat {
       N9 <: Nat.Base
   ] extends Nat
 
-// ###sourceLocation(file: "nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb", line: 30)
 }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Nat.scala.gyb
@@ -1,3 +1,4 @@
+// format: off
 
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
@@ -16,14 +17,11 @@ object Nat {
   sealed abstract class Base extends Nat
 
   % for N in range(0, 10):
-
   final abstract class _${N} extends Base
 
   % end
-
   % for N in range(2, 10):
   %   Ns = ", ".join("N{} <: Nat.Base".format(i) for i in range(1, N + 1))
-
   final abstract class Digit${N}[${Ns}] extends Nat
 
   % end 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
@@ -1,3 +1,5 @@
+// format: off 
+
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -24,21 +26,18 @@ sealed abstract class Tag[T] {
 }
 
 object Tag {
-  final case class Ptr[T](of: Tag[T]) extends Tag[unsafe.Ptr[T]] {
+  final case class Ptr[T](of: Tag[T])
+      extends Tag[unsafe.Ptr[T]] {
     @alwaysinline def size: CSize = 8.toULong
     @alwaysinline def alignment: CSize = 8.toULong
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.Ptr[T]]
-    ): unsafe.Ptr[T] =
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.Ptr[T]]): unsafe.Ptr[T] =
       fromRawPtr[T](loadRawPtr(toRawPtr(ptr)))
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.Ptr[T]],
-        value: unsafe.Ptr[T]
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.Ptr[T]], value: unsafe.Ptr[T]): Unit =
       storeRawPtr(toRawPtr(ptr), toRawPtr(value))
   }
 
-  final case class Class[T <: AnyRef](of: java.lang.Class[T]) extends Tag[T] {
+  final case class Class[T <: AnyRef](of: java.lang.Class[T])
+      extends Tag[T] {
     @alwaysinline def size: CSize = 8.toULong
     @alwaysinline def alignment: CSize = 8.toULong
     @alwaysinline override def load(ptr: unsafe.Ptr[T]): T =
@@ -52,24 +51,16 @@ object Tag {
     @alwaysinline def alignment: CSize = 8.toULong
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Unit]): scala.Unit =
       loadObject(toRawPtr(ptr)).asInstanceOf[Unit]
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[scala.Unit],
-        value: scala.Unit
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Unit], value: scala.Unit): Unit =
       storeObject(toRawPtr(ptr), value.asInstanceOf[Object])
   }
 
   object Boolean extends Tag[scala.Boolean] {
     @alwaysinline def size: CSize = 1.toULong
     @alwaysinline def alignment: CSize = 1.toULong
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[scala.Boolean]
-    ): scala.Boolean =
+    @alwaysinline override def load(ptr: unsafe.Ptr[scala.Boolean]): scala.Boolean =
       loadBoolean(toRawPtr(ptr))
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[scala.Boolean],
-        value: scala.Boolean
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Boolean], value: scala.Boolean): Unit =
       storeBoolean(toRawPtr(ptr), value)
   }
 
@@ -78,10 +69,7 @@ object Tag {
     @alwaysinline def alignment: CSize = 2.toULong
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Char]): scala.Char =
       loadChar(toRawPtr(ptr))
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[scala.Char],
-        value: scala.Char
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Char], value: scala.Char): Unit =
       storeChar(toRawPtr(ptr), value)
   }
 
@@ -90,24 +78,16 @@ object Tag {
     @alwaysinline def alignment: CSize = 1.toULong
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Byte]): scala.Byte =
       loadByte(toRawPtr(ptr))
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[scala.Byte],
-        value: scala.Byte
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Byte], value: scala.Byte): Unit =
       storeByte(toRawPtr(ptr), value)
   }
 
   object UByte extends Tag[unsigned.UByte] {
     @alwaysinline def size: CSize = 1.toULong
     @alwaysinline def alignment: CSize = 1.toULong
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsigned.UByte]
-    ): unsigned.UByte =
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsigned.UByte]): unsigned.UByte =
       loadByte(toRawPtr(ptr)).toUByte
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsigned.UByte],
-        value: unsigned.UByte
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsigned.UByte], value: unsigned.UByte): Unit =
       storeByte(toRawPtr(ptr), value.toByte)
   }
 
@@ -116,24 +96,16 @@ object Tag {
     @alwaysinline def alignment: CSize = 2.toULong
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Short]): scala.Short =
       loadShort(toRawPtr(ptr))
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[scala.Short],
-        value: scala.Short
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Short], value: scala.Short): Unit =
       storeShort(toRawPtr(ptr), value)
   }
 
   object UShort extends Tag[unsigned.UShort] {
     @alwaysinline def size: CSize = 2.toULong
     @alwaysinline def alignment: CSize = 2.toULong
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsigned.UShort]
-    ): unsigned.UShort =
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsigned.UShort]): unsigned.UShort =
       loadShort(toRawPtr(ptr)).toUShort
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsigned.UShort],
-        value: unsigned.UShort
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsigned.UShort], value: unsigned.UShort): Unit =
       storeShort(toRawPtr(ptr), value.toShort)
   }
 
@@ -142,24 +114,16 @@ object Tag {
     @alwaysinline def alignment: CSize = 4.toULong
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Int]): scala.Int =
       loadInt(toRawPtr(ptr))
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[scala.Int],
-        value: scala.Int
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Int], value: scala.Int): Unit =
       storeInt(toRawPtr(ptr), value)
   }
 
   object UInt extends Tag[unsigned.UInt] {
     @alwaysinline def size: CSize = 4.toULong
     @alwaysinline def alignment: CSize = 4.toULong
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsigned.UInt]
-    ): unsigned.UInt =
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsigned.UInt]): unsigned.UInt =
       loadInt(toRawPtr(ptr)).toUInt
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsigned.UInt],
-        value: unsigned.UInt
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsigned.UInt], value: unsigned.UInt): Unit =
       storeInt(toRawPtr(ptr), value.toInt)
   }
 
@@ -168,24 +132,16 @@ object Tag {
     @alwaysinline def alignment: CSize = 8.toULong
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Long]): scala.Long =
       loadLong(toRawPtr(ptr))
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[scala.Long],
-        value: scala.Long
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Long], value: scala.Long): Unit =
       storeLong(toRawPtr(ptr), value)
   }
 
   object ULong extends Tag[unsigned.ULong] {
     @alwaysinline def size: CSize = 8.toULong
     @alwaysinline def alignment: CSize = 8.toULong
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsigned.ULong]
-    ): unsigned.ULong =
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsigned.ULong]): unsigned.ULong =
       loadLong(toRawPtr(ptr)).toULong
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsigned.ULong],
-        value: unsigned.ULong
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsigned.ULong], value: unsigned.ULong): Unit =
       storeLong(toRawPtr(ptr), value.toLong)
   }
 
@@ -194,26 +150,19 @@ object Tag {
     @alwaysinline def alignment: CSize = 4.toULong
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Float]): scala.Float =
       loadFloat(toRawPtr(ptr))
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[scala.Float],
-        value: scala.Float
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Float], value: scala.Float): Unit =
       storeFloat(toRawPtr(ptr), value)
   }
 
   object Double extends Tag[scala.Double] {
     @alwaysinline def size: CSize = 8.toULong
     @alwaysinline def alignment: CSize = 8.toULong
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[scala.Double]
-    ): scala.Double =
+    @alwaysinline override def load(ptr: unsafe.Ptr[scala.Double]): scala.Double =
       loadDouble(toRawPtr(ptr))
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[scala.Double],
-        value: scala.Double
-    ): Unit =
+    @alwaysinline override def store(ptr: unsafe.Ptr[scala.Double], value: scala.Double): Unit =
       storeDouble(toRawPtr(ptr), value)
   }
+
 
   private[scalanative] sealed trait NatTag {
     def toInt: Int
@@ -280,10 +229,8 @@ object Tag {
     @alwaysinline def toInt: Int = 9
   }
 
-  final case class Digit2[N1 <: Nat.Base, N2 <: Nat.Base](
-      _1: Tag[N1],
-      _2: Tag[N2]
-  ) extends Tag[unsafe.Nat.Digit2[N1, N2]]
+  final case class Digit2[N1 <: Nat.Base, N2 <: Nat.Base](_1: Tag[N1], _2: Tag[N2])
+      extends Tag[unsafe.Nat.Digit2[N1, N2]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
     @alwaysinline def alignment: CSize = throwUndefined()
@@ -295,11 +242,8 @@ object Tag {
     }
   }
 
-  final case class Digit3[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base](
-      _1: Tag[N1],
-      _2: Tag[N2],
-      _3: Tag[N3]
-  ) extends Tag[unsafe.Nat.Digit3[N1, N2, N3]]
+  final case class Digit3[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3])
+      extends Tag[unsafe.Nat.Digit3[N1, N2, N3]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
     @alwaysinline def alignment: CSize = throwUndefined()
@@ -312,12 +256,7 @@ object Tag {
     }
   }
 
-  final case class Digit4[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base
-  ](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4])
+  final case class Digit4[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4])
       extends Tag[unsafe.Nat.Digit4[N1, N2, N3, N4]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
@@ -332,13 +271,7 @@ object Tag {
     }
   }
 
-  final case class Digit5[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base,
-      N5 <: Nat.Base
-  ](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4], _5: Tag[N5])
+  final case class Digit5[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4], _5: Tag[N5])
       extends Tag[unsafe.Nat.Digit5[N1, N2, N3, N4, N5]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
@@ -354,21 +287,8 @@ object Tag {
     }
   }
 
-  final case class Digit6[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base,
-      N5 <: Nat.Base,
-      N6 <: Nat.Base
-  ](
-      _1: Tag[N1],
-      _2: Tag[N2],
-      _3: Tag[N3],
-      _4: Tag[N4],
-      _5: Tag[N5],
-      _6: Tag[N6]
-  ) extends Tag[unsafe.Nat.Digit6[N1, N2, N3, N4, N5, N6]]
+  final case class Digit6[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4], _5: Tag[N5], _6: Tag[N6])
+      extends Tag[unsafe.Nat.Digit6[N1, N2, N3, N4, N5, N6]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
     @alwaysinline def alignment: CSize = throwUndefined()
@@ -384,23 +304,8 @@ object Tag {
     }
   }
 
-  final case class Digit7[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base,
-      N5 <: Nat.Base,
-      N6 <: Nat.Base,
-      N7 <: Nat.Base
-  ](
-      _1: Tag[N1],
-      _2: Tag[N2],
-      _3: Tag[N3],
-      _4: Tag[N4],
-      _5: Tag[N5],
-      _6: Tag[N6],
-      _7: Tag[N7]
-  ) extends Tag[unsafe.Nat.Digit7[N1, N2, N3, N4, N5, N6, N7]]
+  final case class Digit7[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base, N7 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4], _5: Tag[N5], _6: Tag[N6], _7: Tag[N7])
+      extends Tag[unsafe.Nat.Digit7[N1, N2, N3, N4, N5, N6, N7]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
     @alwaysinline def alignment: CSize = throwUndefined()
@@ -417,25 +322,8 @@ object Tag {
     }
   }
 
-  final case class Digit8[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base,
-      N5 <: Nat.Base,
-      N6 <: Nat.Base,
-      N7 <: Nat.Base,
-      N8 <: Nat.Base
-  ](
-      _1: Tag[N1],
-      _2: Tag[N2],
-      _3: Tag[N3],
-      _4: Tag[N4],
-      _5: Tag[N5],
-      _6: Tag[N6],
-      _7: Tag[N7],
-      _8: Tag[N8]
-  ) extends Tag[unsafe.Nat.Digit8[N1, N2, N3, N4, N5, N6, N7, N8]]
+  final case class Digit8[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base, N7 <: Nat.Base, N8 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4], _5: Tag[N5], _6: Tag[N6], _7: Tag[N7], _8: Tag[N8])
+      extends Tag[unsafe.Nat.Digit8[N1, N2, N3, N4, N5, N6, N7, N8]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
     @alwaysinline def alignment: CSize = throwUndefined()
@@ -453,27 +341,8 @@ object Tag {
     }
   }
 
-  final case class Digit9[
-      N1 <: Nat.Base,
-      N2 <: Nat.Base,
-      N3 <: Nat.Base,
-      N4 <: Nat.Base,
-      N5 <: Nat.Base,
-      N6 <: Nat.Base,
-      N7 <: Nat.Base,
-      N8 <: Nat.Base,
-      N9 <: Nat.Base
-  ](
-      _1: Tag[N1],
-      _2: Tag[N2],
-      _3: Tag[N3],
-      _4: Tag[N4],
-      _5: Tag[N5],
-      _6: Tag[N6],
-      _7: Tag[N7],
-      _8: Tag[N8],
-      _9: Tag[N9]
-  ) extends Tag[unsafe.Nat.Digit9[N1, N2, N3, N4, N5, N6, N7, N8, N9]]
+  final case class Digit9[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base, N4 <: Nat.Base, N5 <: Nat.Base, N6 <: Nat.Base, N7 <: Nat.Base, N8 <: Nat.Base, N9 <: Nat.Base](_1: Tag[N1], _2: Tag[N2], _3: Tag[N3], _4: Tag[N4], _5: Tag[N5], _6: Tag[N6], _7: Tag[N7], _8: Tag[N8], _9: Tag[N9])
+      extends Tag[unsafe.Nat.Digit9[N1, N2, N3, N4, N5, N6, N7, N8, N9]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
     @alwaysinline def alignment: CSize = throwUndefined()
@@ -492,32 +361,26 @@ object Tag {
     }
   }
 
+
   final case class CArray[T, N <: unsafe.Nat](of: Tag[T], n: Tag[N])
-      extends Tag[unsafe.CArray[T, N]] {
+      extends Tag[unsafe.CArray[T, N]]
+  {
     @alwaysinline def size: CSize = of.size * n.asInstanceOf[NatTag].toUInt
     @alwaysinline def alignment: CSize = of.alignment
     @alwaysinline override def offset(idx: CSize): CSize = of.size * idx.toUInt
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CArray[T, N]]
-    ): unsafe.CArray[T, N] = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CArray[T, N]]): unsafe.CArray[T, N] = {
       new unsafe.CArray[T, N](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CArray[T, N]],
-        value: unsafe.CArray[T, N]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CArray[T, N]], value: unsafe.CArray[T, N]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size)
     }
   }
-
+  
   private[scalanative] sealed trait StructTag
 
-  @alwaysinline private[scalanative] def align(
-      offset: CSize,
-      alignment: CSize
-  ) = {
+  @alwaysinline private[scalanative] def align(offset: CSize, alignment: CSize) = {
     val alignmentMask = alignment - 1.toULong
     val zeroUL = 0.toULong
     val padding =
@@ -526,7 +389,10 @@ object Tag {
     offset + padding
   }
 
-  final case class CStruct0() extends Tag[unsafe.CStruct0] with StructTag {
+
+  final case class CStruct0()
+    extends Tag[unsafe.CStruct0]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       align(res, alignment)
@@ -539,24 +405,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct0]
-    ): unsafe.CStruct0 = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct0]): unsafe.CStruct0 = {
       new unsafe.CStruct0(ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct0],
-        value: unsafe.CStruct0
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct0], value: unsafe.CStruct0): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
+
   final case class CStruct1[T1](_1: Tag[T1])
-      extends Tag[unsafe.CStruct1[T1]]
-      with StructTag {
+    extends Tag[unsafe.CStruct1[T1]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -574,24 +436,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct1[T1]]
-    ): unsafe.CStruct1[T1] = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct1[T1]]): unsafe.CStruct1[T1] = {
       new unsafe.CStruct1[T1](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct1[T1]],
-        value: unsafe.CStruct1[T1]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct1[T1]], value: unsafe.CStruct1[T1]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
+
   final case class CStruct2[T1, T2](_1: Tag[T1], _2: Tag[T2])
-      extends Tag[unsafe.CStruct2[T1, T2]]
-      with StructTag {
+    extends Tag[unsafe.CStruct2[T1, T2]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -615,24 +473,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct2[T1, T2]]
-    ): unsafe.CStruct2[T1, T2] = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct2[T1, T2]]): unsafe.CStruct2[T1, T2] = {
       new unsafe.CStruct2[T1, T2](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct2[T1, T2]],
-        value: unsafe.CStruct2[T1, T2]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct2[T1, T2]], value: unsafe.CStruct2[T1, T2]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
+
   final case class CStruct3[T1, T2, T3](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3])
-      extends Tag[unsafe.CStruct3[T1, T2, T3]]
-      with StructTag {
+    extends Tag[unsafe.CStruct3[T1, T2, T3]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -663,28 +517,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct3[T1, T2, T3]]
-    ): unsafe.CStruct3[T1, T2, T3] = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct3[T1, T2, T3]]): unsafe.CStruct3[T1, T2, T3] = {
       new unsafe.CStruct3[T1, T2, T3](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct3[T1, T2, T3]],
-        value: unsafe.CStruct3[T1, T2, T3]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct3[T1, T2, T3]], value: unsafe.CStruct3[T1, T2, T3]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct4[T1, T2, T3, T4](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4]
-  ) extends Tag[unsafe.CStruct4[T1, T2, T3, T4]]
-      with StructTag {
+
+  final case class CStruct4[T1, T2, T3, T4](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4])
+    extends Tag[unsafe.CStruct4[T1, T2, T3, T4]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -723,29 +569,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct4[T1, T2, T3, T4]]
-    ): unsafe.CStruct4[T1, T2, T3, T4] = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct4[T1, T2, T3, T4]]): unsafe.CStruct4[T1, T2, T3, T4] = {
       new unsafe.CStruct4[T1, T2, T3, T4](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct4[T1, T2, T3, T4]],
-        value: unsafe.CStruct4[T1, T2, T3, T4]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct4[T1, T2, T3, T4]], value: unsafe.CStruct4[T1, T2, T3, T4]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct5[T1, T2, T3, T4, T5](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5]
-  ) extends Tag[unsafe.CStruct5[T1, T2, T3, T4, T5]]
-      with StructTag {
+
+  final case class CStruct5[T1, T2, T3, T4, T5](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5])
+    extends Tag[unsafe.CStruct5[T1, T2, T3, T4, T5]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -793,30 +630,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct5[T1, T2, T3, T4, T5]]
-    ): unsafe.CStruct5[T1, T2, T3, T4, T5] = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct5[T1, T2, T3, T4, T5]]): unsafe.CStruct5[T1, T2, T3, T4, T5] = {
       new unsafe.CStruct5[T1, T2, T3, T4, T5](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct5[T1, T2, T3, T4, T5]],
-        value: unsafe.CStruct5[T1, T2, T3, T4, T5]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct5[T1, T2, T3, T4, T5]], value: unsafe.CStruct5[T1, T2, T3, T4, T5]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct6[T1, T2, T3, T4, T5, T6](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6]
-  ) extends Tag[unsafe.CStruct6[T1, T2, T3, T4, T5, T6]]
-      with StructTag {
+
+  final case class CStruct6[T1, T2, T3, T4, T5, T6](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6])
+    extends Tag[unsafe.CStruct6[T1, T2, T3, T4, T5, T6]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -874,31 +701,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct6[T1, T2, T3, T4, T5, T6]]
-    ): unsafe.CStruct6[T1, T2, T3, T4, T5, T6] = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct6[T1, T2, T3, T4, T5, T6]]): unsafe.CStruct6[T1, T2, T3, T4, T5, T6] = {
       new unsafe.CStruct6[T1, T2, T3, T4, T5, T6](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct6[T1, T2, T3, T4, T5, T6]],
-        value: unsafe.CStruct6[T1, T2, T3, T4, T5, T6]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct6[T1, T2, T3, T4, T5, T6]], value: unsafe.CStruct6[T1, T2, T3, T4, T5, T6]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct7[T1, T2, T3, T4, T5, T6, T7](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7]
-  ) extends Tag[unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]]
-      with StructTag {
+
+  final case class CStruct7[T1, T2, T3, T4, T5, T6, T7](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7])
+    extends Tag[unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -967,32 +783,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]]
-    ): unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7] = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]]): unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7] = {
       new unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]],
-        value: unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]], value: unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8]
-  ) extends Tag[unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]]
-      with StructTag {
+
+  final case class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8])
+    extends Tag[unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -1073,33 +877,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]]
-    ): unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]]): unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] = {
       new unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]],
-        value: unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]], value: unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9]
-  ) extends Tag[unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]]
-      with StructTag {
+
+  final case class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9])
+    extends Tag[unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -1193,34 +984,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]]
-    ): unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]]): unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] = {
       new unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]],
-        value: unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]], value: unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10]
-  ) extends Tag[unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]]
-      with StructTag {
+
+  final case class CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10])
+    extends Tag[unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -1328,39 +1105,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[
-          unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-        ]
-    ): unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] = {
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]]): unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] = {
       new unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[
-          unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-        ],
-        value: unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]], value: unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11]
-  ) extends Tag[unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]]
-      with StructTag {
+
+  final case class CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11])
+    extends Tag[unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -1483,44 +1241,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[
-          unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-        ]
-    ): unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11] = {
-      new unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](
-        ptr.rawptr
-      )
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]]): unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11] = {
+      new unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[
-          unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-        ],
-        value: unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]], value: unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11],
-      _12: Tag[T12]
-  ) extends Tag[
-        unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-      ]
-      with StructTag {
+
+  final case class CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11], _12: Tag[T12])
+    extends Tag[unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -1659,72 +1393,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[
-          unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-        ]
-    ): unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12] = {
-      new unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](
-        ptr.rawptr
-      )
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]]): unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12] = {
+      new unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[
-          unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-        ],
-        value: unsafe.CStruct12[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12
-        ]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]], value: unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct13[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13
-  ](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11],
-      _12: Tag[T12],
-      _13: Tag[T13]
-  ) extends Tag[
-        unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-      ]
-      with StructTag {
+
+  final case class CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11], _12: Tag[T12], _13: Tag[T13])
+    extends Tag[unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -1880,138 +1562,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct13[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13
-        ]]
-    ): unsafe.CStruct13[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13
-    ] = {
-      new unsafe.CStruct13[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13
-      ](ptr.rawptr)
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]]): unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13] = {
+      new unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct13[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13
-        ]],
-        value: unsafe.CStruct13[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13
-        ]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]], value: unsafe.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct14[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14
-  ](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11],
-      _12: Tag[T12],
-      _13: Tag[T13],
-      _14: Tag[T14]
-  ) extends Tag[unsafe.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ]]
-      with StructTag {
+
+  final case class CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11], _12: Tag[T12], _13: Tag[T13], _14: Tag[T14])
+    extends Tag[unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -2185,146 +1749,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct14[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14
-        ]]
-    ): unsafe.CStruct14[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14
-    ] = {
-      new unsafe.CStruct14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14
-      ](ptr.rawptr)
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]]): unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14] = {
+      new unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct14[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14
-        ]],
-        value: unsafe.CStruct14[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14
-        ]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]], value: unsafe.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct15[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15
-  ](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11],
-      _12: Tag[T12],
-      _13: Tag[T13],
-      _14: Tag[T14],
-      _15: Tag[T15]
-  ) extends Tag[unsafe.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ]]
-      with StructTag {
+
+  final case class CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11], _12: Tag[T12], _13: Tag[T13], _14: Tag[T14], _15: Tag[T15])
+    extends Tag[unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -2517,154 +1955,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct15[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15
-        ]]
-    ): unsafe.CStruct15[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15
-    ] = {
-      new unsafe.CStruct15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15
-      ](ptr.rawptr)
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]]): unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15] = {
+      new unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct15[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15
-        ]],
-        value: unsafe.CStruct15[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15
-        ]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]], value: unsafe.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct16[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16
-  ](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11],
-      _12: Tag[T12],
-      _13: Tag[T13],
-      _14: Tag[T14],
-      _15: Tag[T15],
-      _16: Tag[T16]
-  ) extends Tag[unsafe.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ]]
-      with StructTag {
+
+  final case class CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11], _12: Tag[T12], _13: Tag[T13], _14: Tag[T14], _15: Tag[T15], _16: Tag[T16])
+    extends Tag[unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -2877,162 +2181,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct16[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16
-        ]]
-    ): unsafe.CStruct16[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16
-    ] = {
-      new unsafe.CStruct16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16
-      ](ptr.rawptr)
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]]): unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16] = {
+      new unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct16[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16
-        ]],
-        value: unsafe.CStruct16[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16
-        ]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]], value: unsafe.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct17[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17
-  ](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11],
-      _12: Tag[T12],
-      _13: Tag[T13],
-      _14: Tag[T14],
-      _15: Tag[T15],
-      _16: Tag[T16],
-      _17: Tag[T17]
-  ) extends Tag[unsafe.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ]]
-      with StructTag {
+
+  final case class CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11], _12: Tag[T12], _13: Tag[T13], _14: Tag[T14], _15: Tag[T15], _16: Tag[T16], _17: Tag[T17])
+    extends Tag[unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -3266,170 +2428,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct17[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17
-        ]]
-    ): unsafe.CStruct17[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17
-    ] = {
-      new unsafe.CStruct17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17
-      ](ptr.rawptr)
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]]): unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17] = {
+      new unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct17[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17
-        ]],
-        value: unsafe.CStruct17[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17
-        ]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]], value: unsafe.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct18[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18
-  ](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11],
-      _12: Tag[T12],
-      _13: Tag[T13],
-      _14: Tag[T14],
-      _15: Tag[T15],
-      _16: Tag[T16],
-      _17: Tag[T17],
-      _18: Tag[T18]
-  ) extends Tag[unsafe.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ]]
-      with StructTag {
+
+  final case class CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11], _12: Tag[T12], _13: Tag[T13], _14: Tag[T14], _15: Tag[T15], _16: Tag[T16], _17: Tag[T17], _18: Tag[T18])
+    extends Tag[unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -3685,178 +2697,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct18[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18
-        ]]
-    ): unsafe.CStruct18[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18
-    ] = {
-      new unsafe.CStruct18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18
-      ](ptr.rawptr)
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]]): unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18] = {
+      new unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct18[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18
-        ]],
-        value: unsafe.CStruct18[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18
-        ]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]], value: unsafe.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct19[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19
-  ](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11],
-      _12: Tag[T12],
-      _13: Tag[T13],
-      _14: Tag[T14],
-      _15: Tag[T15],
-      _16: Tag[T16],
-      _17: Tag[T17],
-      _18: Tag[T18],
-      _19: Tag[T19]
-  ) extends Tag[unsafe.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ]]
-      with StructTag {
+
+  final case class CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11], _12: Tag[T12], _13: Tag[T13], _14: Tag[T14], _15: Tag[T15], _16: Tag[T16], _17: Tag[T17], _18: Tag[T18], _19: Tag[T19])
+    extends Tag[unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -4135,186 +2989,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct19[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19
-        ]]
-    ): unsafe.CStruct19[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19
-    ] = {
-      new unsafe.CStruct19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19
-      ](ptr.rawptr)
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]]): unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19] = {
+      new unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct19[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19
-        ]],
-        value: unsafe.CStruct19[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19
-        ]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]], value: unsafe.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct20[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20
-  ](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11],
-      _12: Tag[T12],
-      _13: Tag[T13],
-      _14: Tag[T14],
-      _15: Tag[T15],
-      _16: Tag[T16],
-      _17: Tag[T17],
-      _18: Tag[T18],
-      _19: Tag[T19],
-      _20: Tag[T20]
-  ) extends Tag[unsafe.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ]]
-      with StructTag {
+
+  final case class CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11], _12: Tag[T12], _13: Tag[T13], _14: Tag[T14], _15: Tag[T15], _16: Tag[T16], _17: Tag[T17], _18: Tag[T18], _19: Tag[T19], _20: Tag[T20])
+    extends Tag[unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -4617,194 +3305,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct20[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20
-        ]]
-    ): unsafe.CStruct20[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20
-    ] = {
-      new unsafe.CStruct20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20
-      ](ptr.rawptr)
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]]): unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20] = {
+      new unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct20[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20
-        ]],
-        value: unsafe.CStruct20[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20
-        ]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]], value: unsafe.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct21[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21
-  ](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11],
-      _12: Tag[T12],
-      _13: Tag[T13],
-      _14: Tag[T14],
-      _15: Tag[T15],
-      _16: Tag[T16],
-      _17: Tag[T17],
-      _18: Tag[T18],
-      _19: Tag[T19],
-      _20: Tag[T20],
-      _21: Tag[T21]
-  ) extends Tag[unsafe.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ]]
-      with StructTag {
+
+  final case class CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11], _12: Tag[T12], _13: Tag[T13], _14: Tag[T14], _15: Tag[T15], _16: Tag[T16], _17: Tag[T17], _18: Tag[T18], _19: Tag[T19], _20: Tag[T20], _21: Tag[T21])
+    extends Tag[unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -5132,202 +3646,20 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct21[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20,
-          T21
-        ]]
-    ): unsafe.CStruct21[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21
-    ] = {
-      new unsafe.CStruct21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21
-      ](ptr.rawptr)
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]]): unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21] = {
+      new unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct21[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20,
-          T21
-        ]],
-        value: unsafe.CStruct21[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20,
-          T21
-        ]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]], value: unsafe.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
-  final case class CStruct22[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      T22
-  ](
-      _1: Tag[T1],
-      _2: Tag[T2],
-      _3: Tag[T3],
-      _4: Tag[T4],
-      _5: Tag[T5],
-      _6: Tag[T6],
-      _7: Tag[T7],
-      _8: Tag[T8],
-      _9: Tag[T9],
-      _10: Tag[T10],
-      _11: Tag[T11],
-      _12: Tag[T12],
-      _13: Tag[T13],
-      _14: Tag[T14],
-      _15: Tag[T15],
-      _16: Tag[T16],
-      _17: Tag[T17],
-      _18: Tag[T18],
-      _19: Tag[T19],
-      _20: Tag[T20],
-      _21: Tag[T21],
-      _22: Tag[T22]
-  ) extends Tag[unsafe.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ]]
-      with StructTag {
+
+  final case class CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3], _4: Tag[T4], _5: Tag[T5], _6: Tag[T6], _7: Tag[T7], _8: Tag[T8], _9: Tag[T9], _10: Tag[T10], _11: Tag[T11], _12: Tag[T12], _13: Tag[T13], _14: Tag[T14], _15: Tag[T15], _16: Tag[T16], _17: Tag[T17], _18: Tag[T18], _19: Tag[T19], _20: Tag[T20], _21: Tag[T21], _22: Tag[T22])
+    extends Tag[unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]]
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       res = align(res, _1.alignment) + _1.size
@@ -5681,141 +4013,21 @@ object Tag {
       case _ =>
         throwUndefined()
     }
-    @alwaysinline override def load(
-        ptr: unsafe.Ptr[unsafe.CStruct22[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20,
-          T21,
-          T22
-        ]]
-    ): unsafe.CStruct22[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      T22
-    ] = {
-      new unsafe.CStruct22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22
-      ](ptr.rawptr)
+    @alwaysinline override def load(ptr: unsafe.Ptr[unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]]): unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22] = {
+      new unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](ptr.rawptr)
     }
-    @alwaysinline override def store(
-        ptr: unsafe.Ptr[unsafe.CStruct22[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20,
-          T21,
-          T22
-        ]],
-        value: unsafe.CStruct22[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20,
-          T21,
-          T22
-        ]
-    ): Unit = {
+    @alwaysinline override def store(ptr: unsafe.Ptr[unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]], value: unsafe.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]): Unit = {
       val dst = ptr.rawptr
       val src = value.rawptr
       libc.memcpy(dst, src, size.toULong)
     }
   }
 
+
   abstract class CFuncPtrTag[F <: unsafe.CFuncPtr] private[unsafe] ()
       extends Tag[F] {
-
-    /** Internal method used to cast Ptr[_] to CFuncPtr using its underlying
-     *  RawPtr Takes RawPtr instead Ptr[_] to skip extra boxing
+    /** Internal method used to cast Ptr[_] to CFuncPtr using its underlying RawPtr
+     *  Takes RawPtr instead Ptr[_] to skip extra boxing
      */
     private[unsafe] def fromRawPtr(rawptr: RawPtr): F
 
@@ -5825,10 +4037,12 @@ object Tag {
       fromRawPtr(loadRawPtr(ptr.rawptr))
     @alwaysinline override def store(ptr: unsafe.Ptr[F], value: F): Unit =
       storeRawPtr(toRawPtr(ptr), value.rawptr)
-  }
+    }
 
-  abstract class CFuncPtr0[R] extends CFuncPtrTag[unsafe.CFuncPtr0[R]]
-  abstract class CFuncPtr1[T1, R] extends CFuncPtrTag[unsafe.CFuncPtr1[T1, R]]
+  abstract class CFuncPtr0[R]
+      extends CFuncPtrTag[unsafe.CFuncPtr0[R]]
+  abstract class CFuncPtr1[T1, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr1[T1, R]]
   abstract class CFuncPtr2[T1, T2, R]
       extends CFuncPtrTag[unsafe.CFuncPtr2[T1, T2, R]]
   abstract class CFuncPtr3[T1, T2, T3, R]
@@ -5844,444 +4058,38 @@ object Tag {
   abstract class CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R]
       extends CFuncPtrTag[unsafe.CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R]]
   abstract class CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
-      extends CFuncPtrTag[
-        unsafe.CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
-      ]
+      extends CFuncPtrTag[unsafe.CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]]
   abstract class CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
-      extends CFuncPtrTag[
-        unsafe.CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
-      ]
+      extends CFuncPtrTag[unsafe.CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]]
   abstract class CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
-      extends CFuncPtrTag[
-        unsafe.CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
-      ]
-  abstract class CFuncPtr12[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      R
-  ] extends CFuncPtrTag[
-        unsafe.CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
-      ]
-  abstract class CFuncPtr13[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      R
-  ] extends CFuncPtrTag[unsafe.CFuncPtr13[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        R
-      ]]
-  abstract class CFuncPtr14[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      R
-  ] extends CFuncPtrTag[unsafe.CFuncPtr14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        R
-      ]]
-  abstract class CFuncPtr15[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      R
-  ] extends CFuncPtrTag[unsafe.CFuncPtr15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        R
-      ]]
-  abstract class CFuncPtr16[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      R
-  ] extends CFuncPtrTag[unsafe.CFuncPtr16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        R
-      ]]
-  abstract class CFuncPtr17[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      R
-  ] extends CFuncPtrTag[unsafe.CFuncPtr17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        R
-      ]]
-  abstract class CFuncPtr18[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      R
-  ] extends CFuncPtrTag[unsafe.CFuncPtr18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        R
-      ]]
-  abstract class CFuncPtr19[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      R
-  ] extends CFuncPtrTag[unsafe.CFuncPtr19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        R
-      ]]
-  abstract class CFuncPtr20[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      R
-  ] extends CFuncPtrTag[unsafe.CFuncPtr20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        R
-      ]]
-  abstract class CFuncPtr21[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      R
-  ] extends CFuncPtrTag[unsafe.CFuncPtr21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        R
-      ]]
-  abstract class CFuncPtr22[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      T22,
-      R
-  ] extends CFuncPtrTag[unsafe.CFuncPtr22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        R
-      ]]
+      extends CFuncPtrTag[unsafe.CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]]
+  abstract class CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]]
+  abstract class CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]]
+  abstract class CFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]]
+  abstract class CFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]]
+  abstract class CFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]]
+  abstract class CFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]]
+  abstract class CFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]]
+  abstract class CFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]]
+  abstract class CFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]]
+  abstract class CFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]]
+  abstract class CFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]
+      extends CFuncPtrTag[unsafe.CFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]]
 
-  @alwaysinline implicit def materializePtrTag[T](implicit
-      tag: Tag[T]
-  ): Tag[unsafe.Ptr[T]] =
+  @alwaysinline implicit def materializePtrTag[T](implicit tag: Tag[T]): Tag[unsafe.Ptr[T]] =
     Tag.Ptr(tag)
-  @alwaysinline implicit def materializeClassTag[T <: AnyRef: ClassTag]
-      : Tag[T] =
-    Tag.Class(
-      implicitly[ClassTag[T]].runtimeClass.asInstanceOf[java.lang.Class[T]]
-    )
+  @alwaysinline implicit def materializeClassTag[T <: AnyRef: ClassTag]: Tag[T] =
+    Tag.Class(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[java.lang.Class[T]])
   @alwaysinline implicit def materializeUnitTag: Tag[scala.Unit] =
     Unit
   @alwaysinline implicit def materializeBooleanTag: Tag[scala.Boolean] =
@@ -6328,2193 +4136,251 @@ object Tag {
     Nat8
   @alwaysinline implicit def materializeNat9Tag: Tag[unsafe.Nat._9] =
     Nat9
-  @alwaysinline implicit def materializeNatDigit2Tag[
-      N1 <: Nat.Base: Tag,
-      N2 <: Nat.Base: Tag
-  ]: Tag.Digit2[N1, N2] =
+  @alwaysinline implicit def materializeNatDigit2Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag]: Tag.Digit2[N1, N2] =
     Tag.Digit2(implicitly[Tag[N1]], implicitly[Tag[N2]])
-  @alwaysinline implicit def materializeNatDigit3Tag[
-      N1 <: Nat.Base: Tag,
-      N2 <: Nat.Base: Tag,
-      N3 <: Nat.Base: Tag
-  ]: Tag.Digit3[N1, N2, N3] =
+  @alwaysinline implicit def materializeNatDigit3Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag]: Tag.Digit3[N1, N2, N3] =
     Tag.Digit3(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]])
-  @alwaysinline implicit def materializeNatDigit4Tag[
-      N1 <: Nat.Base: Tag,
-      N2 <: Nat.Base: Tag,
-      N3 <: Nat.Base: Tag,
-      N4 <: Nat.Base: Tag
-  ]: Tag.Digit4[N1, N2, N3, N4] =
-    Tag.Digit4(
-      implicitly[Tag[N1]],
-      implicitly[Tag[N2]],
-      implicitly[Tag[N3]],
-      implicitly[Tag[N4]]
-    )
-  @alwaysinline implicit def materializeNatDigit5Tag[
-      N1 <: Nat.Base: Tag,
-      N2 <: Nat.Base: Tag,
-      N3 <: Nat.Base: Tag,
-      N4 <: Nat.Base: Tag,
-      N5 <: Nat.Base: Tag
-  ]: Tag.Digit5[N1, N2, N3, N4, N5] =
-    Tag.Digit5(
-      implicitly[Tag[N1]],
-      implicitly[Tag[N2]],
-      implicitly[Tag[N3]],
-      implicitly[Tag[N4]],
-      implicitly[Tag[N5]]
-    )
-  @alwaysinline implicit def materializeNatDigit6Tag[
-      N1 <: Nat.Base: Tag,
-      N2 <: Nat.Base: Tag,
-      N3 <: Nat.Base: Tag,
-      N4 <: Nat.Base: Tag,
-      N5 <: Nat.Base: Tag,
-      N6 <: Nat.Base: Tag
-  ]: Tag.Digit6[N1, N2, N3, N4, N5, N6] =
-    Tag.Digit6(
-      implicitly[Tag[N1]],
-      implicitly[Tag[N2]],
-      implicitly[Tag[N3]],
-      implicitly[Tag[N4]],
-      implicitly[Tag[N5]],
-      implicitly[Tag[N6]]
-    )
-  @alwaysinline implicit def materializeNatDigit7Tag[
-      N1 <: Nat.Base: Tag,
-      N2 <: Nat.Base: Tag,
-      N3 <: Nat.Base: Tag,
-      N4 <: Nat.Base: Tag,
-      N5 <: Nat.Base: Tag,
-      N6 <: Nat.Base: Tag,
-      N7 <: Nat.Base: Tag
-  ]: Tag.Digit7[N1, N2, N3, N4, N5, N6, N7] =
-    Tag.Digit7(
-      implicitly[Tag[N1]],
-      implicitly[Tag[N2]],
-      implicitly[Tag[N3]],
-      implicitly[Tag[N4]],
-      implicitly[Tag[N5]],
-      implicitly[Tag[N6]],
-      implicitly[Tag[N7]]
-    )
-  @alwaysinline implicit def materializeNatDigit8Tag[
-      N1 <: Nat.Base: Tag,
-      N2 <: Nat.Base: Tag,
-      N3 <: Nat.Base: Tag,
-      N4 <: Nat.Base: Tag,
-      N5 <: Nat.Base: Tag,
-      N6 <: Nat.Base: Tag,
-      N7 <: Nat.Base: Tag,
-      N8 <: Nat.Base: Tag
-  ]: Tag.Digit8[N1, N2, N3, N4, N5, N6, N7, N8] =
-    Tag.Digit8(
-      implicitly[Tag[N1]],
-      implicitly[Tag[N2]],
-      implicitly[Tag[N3]],
-      implicitly[Tag[N4]],
-      implicitly[Tag[N5]],
-      implicitly[Tag[N6]],
-      implicitly[Tag[N7]],
-      implicitly[Tag[N8]]
-    )
-  @alwaysinline implicit def materializeNatDigit9Tag[
-      N1 <: Nat.Base: Tag,
-      N2 <: Nat.Base: Tag,
-      N3 <: Nat.Base: Tag,
-      N4 <: Nat.Base: Tag,
-      N5 <: Nat.Base: Tag,
-      N6 <: Nat.Base: Tag,
-      N7 <: Nat.Base: Tag,
-      N8 <: Nat.Base: Tag,
-      N9 <: Nat.Base: Tag
-  ]: Tag.Digit9[N1, N2, N3, N4, N5, N6, N7, N8, N9] =
-    Tag.Digit9(
-      implicitly[Tag[N1]],
-      implicitly[Tag[N2]],
-      implicitly[Tag[N3]],
-      implicitly[Tag[N4]],
-      implicitly[Tag[N5]],
-      implicitly[Tag[N6]],
-      implicitly[Tag[N7]],
-      implicitly[Tag[N8]],
-      implicitly[Tag[N9]]
-    )
+  @alwaysinline implicit def materializeNatDigit4Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag]: Tag.Digit4[N1, N2, N3, N4] =
+    Tag.Digit4(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]])
+  @alwaysinline implicit def materializeNatDigit5Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag]: Tag.Digit5[N1, N2, N3, N4, N5] =
+    Tag.Digit5(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]], implicitly[Tag[N5]])
+  @alwaysinline implicit def materializeNatDigit6Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag]: Tag.Digit6[N1, N2, N3, N4, N5, N6] =
+    Tag.Digit6(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]], implicitly[Tag[N5]], implicitly[Tag[N6]])
+  @alwaysinline implicit def materializeNatDigit7Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag, N7 <: Nat.Base : Tag]: Tag.Digit7[N1, N2, N3, N4, N5, N6, N7] =
+    Tag.Digit7(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]], implicitly[Tag[N5]], implicitly[Tag[N6]], implicitly[Tag[N7]])
+  @alwaysinline implicit def materializeNatDigit8Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag, N7 <: Nat.Base : Tag, N8 <: Nat.Base : Tag]: Tag.Digit8[N1, N2, N3, N4, N5, N6, N7, N8] =
+    Tag.Digit8(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]], implicitly[Tag[N5]], implicitly[Tag[N6]], implicitly[Tag[N7]], implicitly[Tag[N8]])
+  @alwaysinline implicit def materializeNatDigit9Tag[N1 <: Nat.Base : Tag, N2 <: Nat.Base : Tag, N3 <: Nat.Base : Tag, N4 <: Nat.Base : Tag, N5 <: Nat.Base : Tag, N6 <: Nat.Base : Tag, N7 <: Nat.Base : Tag, N8 <: Nat.Base : Tag, N9 <: Nat.Base : Tag]: Tag.Digit9[N1, N2, N3, N4, N5, N6, N7, N8, N9] =
+    Tag.Digit9(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]], implicitly[Tag[N4]], implicitly[Tag[N5]], implicitly[Tag[N6]], implicitly[Tag[N7]], implicitly[Tag[N8]], implicitly[Tag[N9]])
   @alwaysinline implicit def materializeCStruct0Tag: Tag.CStruct0 =
     Tag.CStruct0()
   @alwaysinline implicit def materializeCStruct1Tag[T1: Tag]: Tag.CStruct1[T1] =
     Tag.CStruct1(implicitly[Tag[T1]])
-  @alwaysinline implicit def materializeCStruct2Tag[T1: Tag, T2: Tag]
-      : Tag.CStruct2[T1, T2] =
+  @alwaysinline implicit def materializeCStruct2Tag[T1: Tag, T2: Tag]: Tag.CStruct2[T1, T2] =
     Tag.CStruct2(implicitly[Tag[T1]], implicitly[Tag[T2]])
-  @alwaysinline implicit def materializeCStruct3Tag[T1: Tag, T2: Tag, T3: Tag]
-      : Tag.CStruct3[T1, T2, T3] =
+  @alwaysinline implicit def materializeCStruct3Tag[T1: Tag, T2: Tag, T3: Tag]: Tag.CStruct3[T1, T2, T3] =
     Tag.CStruct3(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]])
-  @alwaysinline implicit def materializeCStruct4Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag
-  ]: Tag.CStruct4[T1, T2, T3, T4] =
-    Tag.CStruct4(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]]
-    )
-  @alwaysinline implicit def materializeCStruct5Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag
-  ]: Tag.CStruct5[T1, T2, T3, T4, T5] =
-    Tag.CStruct5(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]]
-    )
-  @alwaysinline implicit def materializeCStruct6Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag
-  ]: Tag.CStruct6[T1, T2, T3, T4, T5, T6] =
-    Tag.CStruct6(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]]
-    )
-  @alwaysinline implicit def materializeCStruct7Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag
-  ]: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7] =
-    Tag.CStruct7(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]]
-    )
-  @alwaysinline implicit def materializeCStruct8Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag
-  ]: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] =
-    Tag.CStruct8(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]]
-    )
-  @alwaysinline implicit def materializeCStruct9Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag
-  ]: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] =
-    Tag.CStruct9(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]]
-    )
-  @alwaysinline implicit def materializeCStruct10Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag
-  ]: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] =
-    Tag.CStruct10(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]]
-    )
-  @alwaysinline implicit def materializeCStruct11Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag
-  ]: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11] =
-    Tag.CStruct11(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]]
-    )
-  @alwaysinline implicit def materializeCStruct12Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag
-  ]: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12] =
-    Tag.CStruct12(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]],
-      implicitly[Tag[T12]]
-    )
-  @alwaysinline implicit def materializeCStruct13Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag
-  ]: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13] =
-    Tag.CStruct13(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]],
-      implicitly[Tag[T12]],
-      implicitly[Tag[T13]]
-    )
-  @alwaysinline implicit def materializeCStruct14Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag
-  ]: Tag.CStruct14[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14
-  ] =
-    Tag.CStruct14(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]],
-      implicitly[Tag[T12]],
-      implicitly[Tag[T13]],
-      implicitly[Tag[T14]]
-    )
-  @alwaysinline implicit def materializeCStruct15Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag
-  ]: Tag.CStruct15[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15
-  ] =
-    Tag.CStruct15(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]],
-      implicitly[Tag[T12]],
-      implicitly[Tag[T13]],
-      implicitly[Tag[T14]],
-      implicitly[Tag[T15]]
-    )
-  @alwaysinline implicit def materializeCStruct16Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag
-  ]: Tag.CStruct16[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16
-  ] =
-    Tag.CStruct16(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]],
-      implicitly[Tag[T12]],
-      implicitly[Tag[T13]],
-      implicitly[Tag[T14]],
-      implicitly[Tag[T15]],
-      implicitly[Tag[T16]]
-    )
-  @alwaysinline implicit def materializeCStruct17Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag
-  ]: Tag.CStruct17[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17
-  ] =
-    Tag.CStruct17(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]],
-      implicitly[Tag[T12]],
-      implicitly[Tag[T13]],
-      implicitly[Tag[T14]],
-      implicitly[Tag[T15]],
-      implicitly[Tag[T16]],
-      implicitly[Tag[T17]]
-    )
-  @alwaysinline implicit def materializeCStruct18Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag,
-      T18: Tag
-  ]: Tag.CStruct18[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18
-  ] =
-    Tag.CStruct18(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]],
-      implicitly[Tag[T12]],
-      implicitly[Tag[T13]],
-      implicitly[Tag[T14]],
-      implicitly[Tag[T15]],
-      implicitly[Tag[T16]],
-      implicitly[Tag[T17]],
-      implicitly[Tag[T18]]
-    )
-  @alwaysinline implicit def materializeCStruct19Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag,
-      T18: Tag,
-      T19: Tag
-  ]: Tag.CStruct19[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19
-  ] =
-    Tag.CStruct19(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]],
-      implicitly[Tag[T12]],
-      implicitly[Tag[T13]],
-      implicitly[Tag[T14]],
-      implicitly[Tag[T15]],
-      implicitly[Tag[T16]],
-      implicitly[Tag[T17]],
-      implicitly[Tag[T18]],
-      implicitly[Tag[T19]]
-    )
-  @alwaysinline implicit def materializeCStruct20Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag,
-      T18: Tag,
-      T19: Tag,
-      T20: Tag
-  ]: Tag.CStruct20[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20
-  ] =
-    Tag.CStruct20(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]],
-      implicitly[Tag[T12]],
-      implicitly[Tag[T13]],
-      implicitly[Tag[T14]],
-      implicitly[Tag[T15]],
-      implicitly[Tag[T16]],
-      implicitly[Tag[T17]],
-      implicitly[Tag[T18]],
-      implicitly[Tag[T19]],
-      implicitly[Tag[T20]]
-    )
-  @alwaysinline implicit def materializeCStruct21Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag,
-      T18: Tag,
-      T19: Tag,
-      T20: Tag,
-      T21: Tag
-  ]: Tag.CStruct21[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21
-  ] =
-    Tag.CStruct21(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]],
-      implicitly[Tag[T12]],
-      implicitly[Tag[T13]],
-      implicitly[Tag[T14]],
-      implicitly[Tag[T15]],
-      implicitly[Tag[T16]],
-      implicitly[Tag[T17]],
-      implicitly[Tag[T18]],
-      implicitly[Tag[T19]],
-      implicitly[Tag[T20]],
-      implicitly[Tag[T21]]
-    )
-  @alwaysinline implicit def materializeCStruct22Tag[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag,
-      T18: Tag,
-      T19: Tag,
-      T20: Tag,
-      T21: Tag,
-      T22: Tag
-  ]: Tag.CStruct22[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22
-  ] =
-    Tag.CStruct22(
-      implicitly[Tag[T1]],
-      implicitly[Tag[T2]],
-      implicitly[Tag[T3]],
-      implicitly[Tag[T4]],
-      implicitly[Tag[T5]],
-      implicitly[Tag[T6]],
-      implicitly[Tag[T7]],
-      implicitly[Tag[T8]],
-      implicitly[Tag[T9]],
-      implicitly[Tag[T10]],
-      implicitly[Tag[T11]],
-      implicitly[Tag[T12]],
-      implicitly[Tag[T13]],
-      implicitly[Tag[T14]],
-      implicitly[Tag[T15]],
-      implicitly[Tag[T16]],
-      implicitly[Tag[T17]],
-      implicitly[Tag[T18]],
-      implicitly[Tag[T19]],
-      implicitly[Tag[T20]],
-      implicitly[Tag[T21]],
-      implicitly[Tag[T22]]
-    )
-  @alwaysinline implicit def materializeCArrayTag[T: Tag, N <: unsafe.Nat: Tag]
-      : Tag.CArray[T, N] =
+  @alwaysinline implicit def materializeCStruct4Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag]: Tag.CStruct4[T1, T2, T3, T4] =
+    Tag.CStruct4(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]])
+  @alwaysinline implicit def materializeCStruct5Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag]: Tag.CStruct5[T1, T2, T3, T4, T5] =
+    Tag.CStruct5(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]])
+  @alwaysinline implicit def materializeCStruct6Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag]: Tag.CStruct6[T1, T2, T3, T4, T5, T6] =
+    Tag.CStruct6(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]])
+  @alwaysinline implicit def materializeCStruct7Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag]: Tag.CStruct7[T1, T2, T3, T4, T5, T6, T7] =
+    Tag.CStruct7(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]])
+  @alwaysinline implicit def materializeCStruct8Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag]: Tag.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] =
+    Tag.CStruct8(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]])
+  @alwaysinline implicit def materializeCStruct9Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag]: Tag.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] =
+    Tag.CStruct9(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]])
+  @alwaysinline implicit def materializeCStruct10Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag]: Tag.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] =
+    Tag.CStruct10(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]])
+  @alwaysinline implicit def materializeCStruct11Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag]: Tag.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11] =
+    Tag.CStruct11(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]])
+  @alwaysinline implicit def materializeCStruct12Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag]: Tag.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12] =
+    Tag.CStruct12(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]])
+  @alwaysinline implicit def materializeCStruct13Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag]: Tag.CStruct13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13] =
+    Tag.CStruct13(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]])
+  @alwaysinline implicit def materializeCStruct14Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag]: Tag.CStruct14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14] =
+    Tag.CStruct14(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]], implicitly[Tag[T14]])
+  @alwaysinline implicit def materializeCStruct15Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag]: Tag.CStruct15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15] =
+    Tag.CStruct15(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]], implicitly[Tag[T14]], implicitly[Tag[T15]])
+  @alwaysinline implicit def materializeCStruct16Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag]: Tag.CStruct16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16] =
+    Tag.CStruct16(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]], implicitly[Tag[T14]], implicitly[Tag[T15]], implicitly[Tag[T16]])
+  @alwaysinline implicit def materializeCStruct17Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag]: Tag.CStruct17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17] =
+    Tag.CStruct17(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]], implicitly[Tag[T14]], implicitly[Tag[T15]], implicitly[Tag[T16]], implicitly[Tag[T17]])
+  @alwaysinline implicit def materializeCStruct18Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, T18: Tag]: Tag.CStruct18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18] =
+    Tag.CStruct18(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]], implicitly[Tag[T14]], implicitly[Tag[T15]], implicitly[Tag[T16]], implicitly[Tag[T17]], implicitly[Tag[T18]])
+  @alwaysinline implicit def materializeCStruct19Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, T18: Tag, T19: Tag]: Tag.CStruct19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19] =
+    Tag.CStruct19(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]], implicitly[Tag[T14]], implicitly[Tag[T15]], implicitly[Tag[T16]], implicitly[Tag[T17]], implicitly[Tag[T18]], implicitly[Tag[T19]])
+  @alwaysinline implicit def materializeCStruct20Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, T18: Tag, T19: Tag, T20: Tag]: Tag.CStruct20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20] =
+    Tag.CStruct20(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]], implicitly[Tag[T14]], implicitly[Tag[T15]], implicitly[Tag[T16]], implicitly[Tag[T17]], implicitly[Tag[T18]], implicitly[Tag[T19]], implicitly[Tag[T20]])
+  @alwaysinline implicit def materializeCStruct21Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, T18: Tag, T19: Tag, T20: Tag, T21: Tag]: Tag.CStruct21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21] =
+    Tag.CStruct21(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]], implicitly[Tag[T14]], implicitly[Tag[T15]], implicitly[Tag[T16]], implicitly[Tag[T17]], implicitly[Tag[T18]], implicitly[Tag[T19]], implicitly[Tag[T20]], implicitly[Tag[T21]])
+  @alwaysinline implicit def materializeCStruct22Tag[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, T18: Tag, T19: Tag, T20: Tag, T21: Tag, T22: Tag]: Tag.CStruct22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22] =
+    Tag.CStruct22(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]], implicitly[Tag[T4]], implicitly[Tag[T5]], implicitly[Tag[T6]], implicitly[Tag[T7]], implicitly[Tag[T8]], implicitly[Tag[T9]], implicitly[Tag[T10]], implicitly[Tag[T11]], implicitly[Tag[T12]], implicitly[Tag[T13]], implicitly[Tag[T14]], implicitly[Tag[T15]], implicitly[Tag[T16]], implicitly[Tag[T17]], implicitly[Tag[T18]], implicitly[Tag[T19]], implicitly[Tag[T20]], implicitly[Tag[T21]], implicitly[Tag[T22]])
+  @alwaysinline implicit def materializeCArrayTag[T: Tag, N <: unsafe.Nat: Tag]: Tag.CArray[T, N] =
     Tag.CArray(implicitly[Tag[T]], implicitly[Tag[N]])
 
-  @alwaysinline implicit def materializeCFuncPtr0[R: Tag]
-      : CFuncPtrTag[unsafe.CFuncPtr0[R]] = {
+  @alwaysinline implicit def materializeCFuncPtr0[R: Tag]: CFuncPtrTag[unsafe.CFuncPtr0[R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr0[R]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr0[R] = {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr0[R] = {
         unsafe.CFuncPtr0.fromRawPtr[R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr1[T1: Tag, R: Tag]
-      : CFuncPtrTag[unsafe.CFuncPtr1[T1, R]] = {
+  @alwaysinline implicit def materializeCFuncPtr1[T1: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr1[T1, R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr1[T1, R]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr1[T1, R] = {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr1[T1, R] = {
         unsafe.CFuncPtr1.fromRawPtr[T1, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr2[T1: Tag, T2: Tag, R: Tag]
-      : CFuncPtrTag[unsafe.CFuncPtr2[T1, T2, R]] = {
+  @alwaysinline implicit def materializeCFuncPtr2[T1: Tag, T2: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr2[T1, T2, R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr2[T1, T2, R]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr2[T1, T2, R] = {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr2[T1, T2, R] = {
         unsafe.CFuncPtr2.fromRawPtr[T1, T2, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr3[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr3[T1, T2, T3, R]] = {
+  @alwaysinline implicit def materializeCFuncPtr3[T1: Tag, T2: Tag, T3: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr3[T1, T2, T3, R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr3[T1, T2, T3, R]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr3[T1, T2, T3, R] = {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr3[T1, T2, T3, R] = {
         unsafe.CFuncPtr3.fromRawPtr[T1, T2, T3, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr4[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr4[T1, T2, T3, T4, R]] = {
+  @alwaysinline implicit def materializeCFuncPtr4[T1: Tag, T2: Tag, T3: Tag, T4: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr4[T1, T2, T3, T4, R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr4[T1, T2, T3, T4, R]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr4[T1, T2, T3, T4, R] = {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr4[T1, T2, T3, T4, R] = {
         unsafe.CFuncPtr4.fromRawPtr[T1, T2, T3, T4, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr5[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr5[T1, T2, T3, T4, T5, R]] = {
+  @alwaysinline implicit def materializeCFuncPtr5[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr5[T1, T2, T3, T4, T5, R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr5[T1, T2, T3, T4, T5, R]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr5[T1, T2, T3, T4, T5, R] = {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr5[T1, T2, T3, T4, T5, R] = {
         unsafe.CFuncPtr5.fromRawPtr[T1, T2, T3, T4, T5, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr6[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr6[T1, T2, T3, T4, T5, T6, R]] = {
+  @alwaysinline implicit def materializeCFuncPtr6[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr6[T1, T2, T3, T4, T5, T6, R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr6[T1, T2, T3, T4, T5, T6, R]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr6[T1, T2, T3, T4, T5, T6, R] = {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr6[T1, T2, T3, T4, T5, T6, R] = {
         unsafe.CFuncPtr6.fromRawPtr[T1, T2, T3, T4, T5, T6, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr7[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R]] = {
+  @alwaysinline implicit def materializeCFuncPtr7[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] = {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R] = {
         unsafe.CFuncPtr7.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr8[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R]] = {
+  @alwaysinline implicit def materializeCFuncPtr8[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] = {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R] = {
         unsafe.CFuncPtr8.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr9[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]] = {
+  @alwaysinline implicit def materializeCFuncPtr9[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = {
-        unsafe.CFuncPtr9.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](
-          rawptr
-        )
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = {
+        unsafe.CFuncPtr9.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr10[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      R: Tag
-  ]: CFuncPtrTag[
-    unsafe.CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
-  ] = {
-    new CFuncPtrTag[
-      unsafe.CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
-    ] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = {
-        unsafe.CFuncPtr10
-          .fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr10[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = {
+        unsafe.CFuncPtr10.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr11[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      R: Tag
-  ]: CFuncPtrTag[
-    unsafe.CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
-  ] = {
-    new CFuncPtrTag[
-      unsafe.CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
-    ] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] = {
-        unsafe.CFuncPtr11
-          .fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr11[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] = {
+        unsafe.CFuncPtr11.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr12[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      R: Tag
-  ]: CFuncPtrTag[
-    unsafe.CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
-  ] = {
-    new CFuncPtrTag[
-      unsafe.CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
-    ] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr12[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        R
-      ] = {
-        unsafe.CFuncPtr12
-          .fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](
-            rawptr
-          )
+  @alwaysinline implicit def materializeCFuncPtr12[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] = {
+        unsafe.CFuncPtr12.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr13[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      R: Tag
-  ]: CFuncPtrTag[
-    unsafe.CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
-  ] = {
-    new CFuncPtrTag[unsafe.CFuncPtr13[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      R
-    ]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr13[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        R
-      ] = {
-        unsafe.CFuncPtr13.fromRawPtr[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          R
-        ](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr13[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] = {
+        unsafe.CFuncPtr13.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr14[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr14[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    R
-  ]] = {
-    new CFuncPtrTag[unsafe.CFuncPtr14[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      R
-    ]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr14[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        R
-      ] = {
-        unsafe.CFuncPtr14.fromRawPtr[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          R
-        ](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr14[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R] = {
+        unsafe.CFuncPtr14.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr15[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr15[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    R
-  ]] = {
-    new CFuncPtrTag[unsafe.CFuncPtr15[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      R
-    ]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr15[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        R
-      ] = {
-        unsafe.CFuncPtr15.fromRawPtr[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          R
-        ](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr15[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R] = {
+        unsafe.CFuncPtr15.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr16[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr16[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    R
-  ]] = {
-    new CFuncPtrTag[unsafe.CFuncPtr16[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      R
-    ]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr16[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        R
-      ] = {
-        unsafe.CFuncPtr16.fromRawPtr[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          R
-        ](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr16[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R] = {
+        unsafe.CFuncPtr16.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr17[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr17[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    R
-  ]] = {
-    new CFuncPtrTag[unsafe.CFuncPtr17[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      R
-    ]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr17[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        R
-      ] = {
-        unsafe.CFuncPtr17.fromRawPtr[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          R
-        ](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr17[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] = {
+        unsafe.CFuncPtr17.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr18[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag,
-      T18: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr18[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    R
-  ]] = {
-    new CFuncPtrTag[unsafe.CFuncPtr18[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      R
-    ]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr18[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        R
-      ] = {
-        unsafe.CFuncPtr18.fromRawPtr[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          R
-        ](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr18[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, T18: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R] = {
+        unsafe.CFuncPtr18.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr19[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag,
-      T18: Tag,
-      T19: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr19[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    R
-  ]] = {
-    new CFuncPtrTag[unsafe.CFuncPtr19[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      R
-    ]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr19[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        R
-      ] = {
-        unsafe.CFuncPtr19.fromRawPtr[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          R
-        ](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr19[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, T18: Tag, T19: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R] = {
+        unsafe.CFuncPtr19.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr20[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag,
-      T18: Tag,
-      T19: Tag,
-      T20: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr20[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    R
-  ]] = {
-    new CFuncPtrTag[unsafe.CFuncPtr20[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      R
-    ]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr20[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        R
-      ] = {
-        unsafe.CFuncPtr20.fromRawPtr[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20,
-          R
-        ](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr20[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, T18: Tag, T19: Tag, T20: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R] = {
+        unsafe.CFuncPtr20.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr21[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag,
-      T18: Tag,
-      T19: Tag,
-      T20: Tag,
-      T21: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr21[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    R
-  ]] = {
-    new CFuncPtrTag[unsafe.CFuncPtr21[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      R
-    ]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr21[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        R
-      ] = {
-        unsafe.CFuncPtr21.fromRawPtr[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20,
-          T21,
-          R
-        ](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr21[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, T18: Tag, T19: Tag, T20: Tag, T21: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] = {
+        unsafe.CFuncPtr21.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R](rawptr)
       }
     }
   }
 
-  @alwaysinline implicit def materializeCFuncPtr22[
-      T1: Tag,
-      T2: Tag,
-      T3: Tag,
-      T4: Tag,
-      T5: Tag,
-      T6: Tag,
-      T7: Tag,
-      T8: Tag,
-      T9: Tag,
-      T10: Tag,
-      T11: Tag,
-      T12: Tag,
-      T13: Tag,
-      T14: Tag,
-      T15: Tag,
-      T16: Tag,
-      T17: Tag,
-      T18: Tag,
-      T19: Tag,
-      T20: Tag,
-      T21: Tag,
-      T22: Tag,
-      R: Tag
-  ]: CFuncPtrTag[unsafe.CFuncPtr22[
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    R
-  ]] = {
-    new CFuncPtrTag[unsafe.CFuncPtr22[
-      T1,
-      T2,
-      T3,
-      T4,
-      T5,
-      T6,
-      T7,
-      T8,
-      T9,
-      T10,
-      T11,
-      T12,
-      T13,
-      T14,
-      T15,
-      T16,
-      T17,
-      T18,
-      T19,
-      T20,
-      T21,
-      T22,
-      R
-    ]] {
-      @alwaysinline override private[unsafe] def fromRawPtr(
-          rawptr: RawPtr
-      ): unsafe.CFuncPtr22[
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        R
-      ] = {
-        unsafe.CFuncPtr22.fromRawPtr[
-          T1,
-          T2,
-          T3,
-          T4,
-          T5,
-          T6,
-          T7,
-          T8,
-          T9,
-          T10,
-          T11,
-          T12,
-          T13,
-          T14,
-          T15,
-          T16,
-          T17,
-          T18,
-          T19,
-          T20,
-          T21,
-          T22,
-          R
-        ](rawptr)
+  @alwaysinline implicit def materializeCFuncPtr22[T1: Tag, T2: Tag, T3: Tag, T4: Tag, T5: Tag, T6: Tag, T7: Tag, T8: Tag, T9: Tag, T10: Tag, T11: Tag, T12: Tag, T13: Tag, T14: Tag, T15: Tag, T16: Tag, T17: Tag, T18: Tag, T19: Tag, T20: Tag, T21: Tag, T22: Tag, R: Tag]: CFuncPtrTag[unsafe.CFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]] = {
+    new CFuncPtrTag[unsafe.CFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]] {
+      @alwaysinline override private[unsafe] def fromRawPtr(rawptr: RawPtr): unsafe.CFuncPtr22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] = {
+        unsafe.CFuncPtr22.fromRawPtr[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](rawptr)
       }
     }
   }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala
@@ -1,5 +1,3 @@
-// ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 1)
-
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
 // personally identifiable information in sourceLocation lines.
@@ -26,17 +24,13 @@ sealed abstract class Tag[T] {
 }
 
 object Tag {
-
   final case class Ptr[T](of: Tag[T]) extends Tag[unsafe.Ptr[T]] {
     @alwaysinline def size: CSize = 8.toULong
-
     @alwaysinline def alignment: CSize = 8.toULong
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.Ptr[T]]
     ): unsafe.Ptr[T] =
       fromRawPtr[T](loadRawPtr(toRawPtr(ptr)))
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.Ptr[T]],
         value: unsafe.Ptr[T]
@@ -46,425 +40,245 @@ object Tag {
 
   final case class Class[T <: AnyRef](of: java.lang.Class[T]) extends Tag[T] {
     @alwaysinline def size: CSize = 8.toULong
-
     @alwaysinline def alignment: CSize = 8.toULong
-
     @alwaysinline override def load(ptr: unsafe.Ptr[T]): T =
       loadObject(toRawPtr(ptr)).asInstanceOf[T]
-
     @alwaysinline override def store(ptr: unsafe.Ptr[T], value: T): Unit =
       storeObject(toRawPtr(ptr), value.asInstanceOf[Object])
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
-
   object Unit extends Tag[scala.Unit] {
     @alwaysinline def size: CSize = 8.toULong
-
     @alwaysinline def alignment: CSize = 8.toULong
-
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Unit]): scala.Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 68)
       loadObject(toRawPtr(ptr)).asInstanceOf[Unit]
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[scala.Unit],
         value: scala.Unit
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 77)
       storeObject(toRawPtr(ptr), value.asInstanceOf[Object])
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object Boolean extends Tag[scala.Boolean] {
     @alwaysinline def size: CSize = 1.toULong
-
     @alwaysinline def alignment: CSize = 1.toULong
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[scala.Boolean]
     ): scala.Boolean =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 73)
       loadBoolean(toRawPtr(ptr))
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[scala.Boolean],
         value: scala.Boolean
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 82)
       storeBoolean(toRawPtr(ptr), value)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object Char extends Tag[scala.Char] {
     @alwaysinline def size: CSize = 2.toULong
-
     @alwaysinline def alignment: CSize = 2.toULong
-
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Char]): scala.Char =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 73)
       loadChar(toRawPtr(ptr))
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[scala.Char],
         value: scala.Char
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 82)
       storeChar(toRawPtr(ptr), value)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object Byte extends Tag[scala.Byte] {
     @alwaysinline def size: CSize = 1.toULong
-
     @alwaysinline def alignment: CSize = 1.toULong
-
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Byte]): scala.Byte =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 73)
       loadByte(toRawPtr(ptr))
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[scala.Byte],
         value: scala.Byte
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 82)
       storeByte(toRawPtr(ptr), value)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object UByte extends Tag[unsigned.UByte] {
     @alwaysinline def size: CSize = 1.toULong
-
     @alwaysinline def alignment: CSize = 1.toULong
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsigned.UByte]
     ): unsigned.UByte =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 71)
       loadByte(toRawPtr(ptr)).toUByte
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsigned.UByte],
         value: unsigned.UByte
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 80)
       storeByte(toRawPtr(ptr), value.toByte)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object Short extends Tag[scala.Short] {
     @alwaysinline def size: CSize = 2.toULong
-
     @alwaysinline def alignment: CSize = 2.toULong
-
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Short]): scala.Short =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 73)
       loadShort(toRawPtr(ptr))
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[scala.Short],
         value: scala.Short
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 82)
       storeShort(toRawPtr(ptr), value)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object UShort extends Tag[unsigned.UShort] {
     @alwaysinline def size: CSize = 2.toULong
-
     @alwaysinline def alignment: CSize = 2.toULong
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsigned.UShort]
     ): unsigned.UShort =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 71)
       loadShort(toRawPtr(ptr)).toUShort
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsigned.UShort],
         value: unsigned.UShort
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 80)
       storeShort(toRawPtr(ptr), value.toShort)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object Int extends Tag[scala.Int] {
     @alwaysinline def size: CSize = 4.toULong
-
     @alwaysinline def alignment: CSize = 4.toULong
-
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Int]): scala.Int =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 73)
       loadInt(toRawPtr(ptr))
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[scala.Int],
         value: scala.Int
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 82)
       storeInt(toRawPtr(ptr), value)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object UInt extends Tag[unsigned.UInt] {
     @alwaysinline def size: CSize = 4.toULong
-
     @alwaysinline def alignment: CSize = 4.toULong
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsigned.UInt]
     ): unsigned.UInt =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 71)
       loadInt(toRawPtr(ptr)).toUInt
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsigned.UInt],
         value: unsigned.UInt
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 80)
       storeInt(toRawPtr(ptr), value.toInt)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object Long extends Tag[scala.Long] {
     @alwaysinline def size: CSize = 8.toULong
-
     @alwaysinline def alignment: CSize = 8.toULong
-
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Long]): scala.Long =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 73)
       loadLong(toRawPtr(ptr))
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[scala.Long],
         value: scala.Long
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 82)
       storeLong(toRawPtr(ptr), value)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object ULong extends Tag[unsigned.ULong] {
     @alwaysinline def size: CSize = 8.toULong
-
     @alwaysinline def alignment: CSize = 8.toULong
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsigned.ULong]
     ): unsigned.ULong =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 71)
       loadLong(toRawPtr(ptr)).toULong
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsigned.ULong],
         value: unsigned.ULong
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 80)
       storeLong(toRawPtr(ptr), value.toLong)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object Float extends Tag[scala.Float] {
     @alwaysinline def size: CSize = 4.toULong
-
     @alwaysinline def alignment: CSize = 4.toULong
-
     @alwaysinline override def load(ptr: unsafe.Ptr[scala.Float]): scala.Float =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 73)
       loadFloat(toRawPtr(ptr))
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[scala.Float],
         value: scala.Float
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 82)
       storeFloat(toRawPtr(ptr), value)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 62)
 
   object Double extends Tag[scala.Double] {
     @alwaysinline def size: CSize = 8.toULong
-
     @alwaysinline def alignment: CSize = 8.toULong
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[scala.Double]
     ): scala.Double =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 73)
       loadDouble(toRawPtr(ptr))
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 75)
     @alwaysinline override def store(
         ptr: unsafe.Ptr[scala.Double],
         value: scala.Double
     ): Unit =
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 82)
       storeDouble(toRawPtr(ptr), value)
-
-    // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 84)
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 87)
 
   private[scalanative] sealed trait NatTag {
     def toInt: Int
-
     def toUInt: UInt = toInt.toUInt
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 94)
-
   object Nat0 extends Tag[unsafe.Nat._0] with NatTag {
     @noinline def size: CSize = throwUndefined()
-
     @noinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = 0
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 94)
-
   object Nat1 extends Tag[unsafe.Nat._1] with NatTag {
     @noinline def size: CSize = throwUndefined()
-
     @noinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = 1
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 94)
-
   object Nat2 extends Tag[unsafe.Nat._2] with NatTag {
     @noinline def size: CSize = throwUndefined()
-
     @noinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = 2
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 94)
-
   object Nat3 extends Tag[unsafe.Nat._3] with NatTag {
     @noinline def size: CSize = throwUndefined()
-
     @noinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = 3
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 94)
-
   object Nat4 extends Tag[unsafe.Nat._4] with NatTag {
     @noinline def size: CSize = throwUndefined()
-
     @noinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = 4
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 94)
-
   object Nat5 extends Tag[unsafe.Nat._5] with NatTag {
     @noinline def size: CSize = throwUndefined()
-
     @noinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = 5
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 94)
-
   object Nat6 extends Tag[unsafe.Nat._6] with NatTag {
     @noinline def size: CSize = throwUndefined()
-
     @noinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = 6
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 94)
-
   object Nat7 extends Tag[unsafe.Nat._7] with NatTag {
     @noinline def size: CSize = throwUndefined()
-
     @noinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = 7
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 94)
-
   object Nat8 extends Tag[unsafe.Nat._8] with NatTag {
     @noinline def size: CSize = throwUndefined()
-
     @noinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = 8
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 94)
-
   object Nat9 extends Tag[unsafe.Nat._9] with NatTag {
     @noinline def size: CSize = throwUndefined()
-
     @noinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = 9
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 102)
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 109)
 
   final case class Digit2[N1 <: Nat.Base, N2 <: Nat.Base](
       _1: Tag[N1],
@@ -472,21 +286,14 @@ object Tag {
   ) extends Tag[unsafe.Nat.Digit2[N1, N2]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
-
     @alwaysinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = {
       var res = 0
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _1.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _2.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 121)
       res
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 109)
 
   final case class Digit3[N1 <: Nat.Base, N2 <: Nat.Base, N3 <: Nat.Base](
       _1: Tag[N1],
@@ -495,23 +302,15 @@ object Tag {
   ) extends Tag[unsafe.Nat.Digit3[N1, N2, N3]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
-
     @alwaysinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = {
       var res = 0
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _1.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _2.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _3.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 121)
       res
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 109)
 
   final case class Digit4[
       N1 <: Nat.Base,
@@ -522,25 +321,16 @@ object Tag {
       extends Tag[unsafe.Nat.Digit4[N1, N2, N3, N4]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
-
     @alwaysinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = {
       var res = 0
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _1.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _2.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _3.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _4.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 121)
       res
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 109)
 
   final case class Digit5[
       N1 <: Nat.Base,
@@ -552,27 +342,17 @@ object Tag {
       extends Tag[unsafe.Nat.Digit5[N1, N2, N3, N4, N5]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
-
     @alwaysinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = {
       var res = 0
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _1.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _2.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _3.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _4.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _5.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 121)
       res
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 109)
 
   final case class Digit6[
       N1 <: Nat.Base,
@@ -591,29 +371,18 @@ object Tag {
   ) extends Tag[unsafe.Nat.Digit6[N1, N2, N3, N4, N5, N6]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
-
     @alwaysinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = {
       var res = 0
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _1.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _2.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _3.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _4.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _5.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _6.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 121)
       res
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 109)
 
   final case class Digit7[
       N1 <: Nat.Base,
@@ -634,31 +403,19 @@ object Tag {
   ) extends Tag[unsafe.Nat.Digit7[N1, N2, N3, N4, N5, N6, N7]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
-
     @alwaysinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = {
       var res = 0
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _1.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _2.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _3.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _4.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _5.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _6.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _7.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 121)
       res
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 109)
 
   final case class Digit8[
       N1 <: Nat.Base,
@@ -681,33 +438,20 @@ object Tag {
   ) extends Tag[unsafe.Nat.Digit8[N1, N2, N3, N4, N5, N6, N7, N8]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
-
     @alwaysinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = {
       var res = 0
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _1.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _2.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _3.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _4.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _5.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _6.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _7.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _8.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 121)
       res
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 109)
 
   final case class Digit9[
       N1 <: Nat.Base,
@@ -732,50 +476,32 @@ object Tag {
   ) extends Tag[unsafe.Nat.Digit9[N1, N2, N3, N4, N5, N6, N7, N8, N9]]
       with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
-
     @alwaysinline def alignment: CSize = throwUndefined()
-
     @alwaysinline def toInt: Int = {
       var res = 0
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _1.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _2.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _3.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _4.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _5.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _6.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _7.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _8.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 119)
       res = res * 10 + _9.asInstanceOf[NatTag].toInt
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 121)
       res
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 126)
-
   final case class CArray[T, N <: unsafe.Nat](of: Tag[T], n: Tag[N])
       extends Tag[unsafe.CArray[T, N]] {
     @alwaysinline def size: CSize = of.size * n.asInstanceOf[NatTag].toUInt
-
     @alwaysinline def alignment: CSize = of.alignment
-
     @alwaysinline override def offset(idx: CSize): CSize = of.size * idx.toUInt
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CArray[T, N]]
     ): unsafe.CArray[T, N] = {
       new unsafe.CArray[T, N](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CArray[T, N]],
         value: unsafe.CArray[T, N]
@@ -800,33 +526,24 @@ object Tag {
     offset + padding
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
-
   final case class CStruct0() extends Tag[unsafe.CStruct0] with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct0]
     ): unsafe.CStruct0 = {
       new unsafe.CStruct0(ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct0],
         value: unsafe.CStruct0
@@ -837,44 +554,31 @@ object Tag {
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
-
   final case class CStruct1[T1](_1: Tag[T1])
       extends Tag[unsafe.CStruct1[T1]]
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct1[T1]]
     ): unsafe.CStruct1[T1] = {
       new unsafe.CStruct1[T1](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct1[T1]],
         value: unsafe.CStruct1[T1]
@@ -885,55 +589,37 @@ object Tag {
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
-
   final case class CStruct2[T1, T2](_1: Tag[T1], _2: Tag[T2])
       extends Tag[unsafe.CStruct2[T1, T2]]
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct2[T1, T2]]
     ): unsafe.CStruct2[T1, T2] = {
       new unsafe.CStruct2[T1, T2](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct2[T1, T2]],
         value: unsafe.CStruct2[T1, T2]
@@ -944,68 +630,44 @@ object Tag {
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
-
   final case class CStruct3[T1, T2, T3](_1: Tag[T1], _2: Tag[T2], _3: Tag[T3])
       extends Tag[unsafe.CStruct3[T1, T2, T3]]
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct3[T1, T2, T3]]
     ): unsafe.CStruct3[T1, T2, T3] = {
       new unsafe.CStruct3[T1, T2, T3](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct3[T1, T2, T3]],
         value: unsafe.CStruct3[T1, T2, T3]
@@ -1016,8 +678,6 @@ object Tag {
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
-
   final case class CStruct4[T1, T2, T3, T4](
       _1: Tag[T1],
       _2: Tag[T2],
@@ -1027,76 +687,47 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct4[T1, T2, T3, T4]]
     ): unsafe.CStruct4[T1, T2, T3, T4] = {
       new unsafe.CStruct4[T1, T2, T3, T4](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct4[T1, T2, T3, T4]],
         value: unsafe.CStruct4[T1, T2, T3, T4]
@@ -1106,8 +737,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct5[T1, T2, T3, T4, T5](
       _1: Tag[T1],
@@ -1119,93 +748,56 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct5[T1, T2, T3, T4, T5]]
     ): unsafe.CStruct5[T1, T2, T3, T4, T5] = {
       new unsafe.CStruct5[T1, T2, T3, T4, T5](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct5[T1, T2, T3, T4, T5]],
         value: unsafe.CStruct5[T1, T2, T3, T4, T5]
@@ -1215,8 +807,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct6[T1, T2, T3, T4, T5, T6](
       _1: Tag[T1],
@@ -1229,112 +819,66 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct6[T1, T2, T3, T4, T5, T6]]
     ): unsafe.CStruct6[T1, T2, T3, T4, T5, T6] = {
       new unsafe.CStruct6[T1, T2, T3, T4, T5, T6](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct6[T1, T2, T3, T4, T5, T6]],
         value: unsafe.CStruct6[T1, T2, T3, T4, T5, T6]
@@ -1344,8 +888,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct7[T1, T2, T3, T4, T5, T6, T7](
       _1: Tag[T1],
@@ -1359,133 +901,77 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]]
     ): unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7] = {
       new unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]],
         value: unsafe.CStruct7[T1, T2, T3, T4, T5, T6, T7]
@@ -1495,8 +981,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct8[T1, T2, T3, T4, T5, T6, T7, T8](
       _1: Tag[T1],
@@ -1511,156 +995,89 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]]
     ): unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8] = {
       new unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]],
         value: unsafe.CStruct8[T1, T2, T3, T4, T5, T6, T7, T8]
@@ -1670,8 +1087,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9](
       _1: Tag[T1],
@@ -1687,181 +1102,102 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]]
     ): unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9] = {
       new unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]],
         value: unsafe.CStruct9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
@@ -1871,8 +1207,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](
       _1: Tag[T1],
@@ -1889,202 +1223,111 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[
           unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
@@ -2092,7 +1335,6 @@ object Tag {
     ): unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] = {
       new unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[
           unsafe.CStruct10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
@@ -2104,8 +1346,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](
       _1: Tag[T1],
@@ -2123,231 +1363,126 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[
           unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
@@ -2357,7 +1492,6 @@ object Tag {
         ptr.rawptr
       )
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[
           unsafe.CStruct11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
@@ -2369,8 +1503,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](
       _1: Tag[T1],
@@ -2391,262 +1523,142 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _12.alignment) + _12.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 11 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[
           unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
@@ -2656,7 +1668,6 @@ object Tag {
         ptr.rawptr
       )
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[
           unsafe.CStruct12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
@@ -2681,8 +1692,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct13[
       T1,
@@ -2718,295 +1727,159 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _12.alignment) + _12.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _13.alignment) + _13.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 11 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 12 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct13[
           T1,
@@ -3054,7 +1927,6 @@ object Tag {
         T13
       ](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct13[
           T1,
@@ -3092,8 +1964,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct14[
       T1,
@@ -3144,330 +2014,177 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _12.alignment) + _12.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _13.alignment) + _13.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _14.alignment) + _14.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 11 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 12 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 13 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct14[
           T1,
@@ -3518,7 +2235,6 @@ object Tag {
         T14
       ](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct14[
           T1,
@@ -3558,8 +2274,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct15[
       T1,
@@ -3613,367 +2327,196 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _12.alignment) + _12.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _13.alignment) + _13.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _14.alignment) + _14.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _15.alignment) + _15.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 11 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 12 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 13 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 14 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct15[
           T1,
@@ -4027,7 +2570,6 @@ object Tag {
         T15
       ](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct15[
           T1,
@@ -4069,8 +2611,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct16[
       T1,
@@ -4127,406 +2667,216 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _12.alignment) + _12.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _13.alignment) + _13.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _14.alignment) + _14.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _15.alignment) + _15.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _16.alignment) + _16.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 11 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 12 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 13 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 14 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 15 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct16[
           T1,
@@ -4583,7 +2933,6 @@ object Tag {
         T16
       ](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct16[
           T1,
@@ -4627,8 +2976,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct17[
       T1,
@@ -4688,447 +3035,237 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _12.alignment) + _12.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _13.alignment) + _13.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _14.alignment) + _14.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _15.alignment) + _15.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _16.alignment) + _16.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _17.alignment) + _17.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 11 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 12 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 13 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 14 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 15 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 16 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct17[
           T1,
@@ -5188,7 +3325,6 @@ object Tag {
         T17
       ](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct17[
           T1,
@@ -5234,8 +3370,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct18[
       T1,
@@ -5298,490 +3432,259 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _12.alignment) + _12.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _13.alignment) + _13.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _14.alignment) + _14.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _15.alignment) + _15.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _16.alignment) + _16.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _17.alignment) + _17.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _18.alignment) + _18.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_18.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 11 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 12 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 13 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 14 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 15 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 16 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 17 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _18.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct18[
           T1,
@@ -5844,7 +3747,6 @@ object Tag {
         T18
       ](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct18[
           T1,
@@ -5892,8 +3794,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct19[
       T1,
@@ -5959,535 +3859,282 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _12.alignment) + _12.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _13.alignment) + _13.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _14.alignment) + _14.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _15.alignment) + _15.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _16.alignment) + _16.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _17.alignment) + _17.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _18.alignment) + _18.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _19.alignment) + _19.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_18.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_19.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 11 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 12 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 13 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 14 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 15 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 16 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 17 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _18.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 18 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _18.alignment) + _18.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _19.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct19[
           T1,
@@ -6553,7 +4200,6 @@ object Tag {
         T19
       ](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct19[
           T1,
@@ -6603,8 +4249,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct20[
       T1,
@@ -6673,582 +4317,306 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _12.alignment) + _12.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _13.alignment) + _13.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _14.alignment) + _14.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _15.alignment) + _15.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _16.alignment) + _16.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _17.alignment) + _17.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _18.alignment) + _18.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _19.alignment) + _19.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _20.alignment) + _20.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_18.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_19.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_20.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 11 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 12 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 13 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 14 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 15 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 16 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 17 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _18.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 18 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _18.alignment) + _18.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _19.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 19 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _18.alignment) + _18.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _19.alignment) + _19.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _20.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct20[
           T1,
@@ -7317,7 +4685,6 @@ object Tag {
         T20
       ](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct20[
           T1,
@@ -7369,8 +4736,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct21[
       T1,
@@ -7442,631 +4807,331 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _12.alignment) + _12.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _13.alignment) + _13.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _14.alignment) + _14.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _15.alignment) + _15.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _16.alignment) + _16.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _17.alignment) + _17.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _18.alignment) + _18.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _19.alignment) + _19.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _20.alignment) + _20.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _21.alignment) + _21.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_18.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_19.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_20.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_21.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 11 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 12 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 13 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 14 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 15 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 16 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 17 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _18.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 18 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _18.alignment) + _18.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _19.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 19 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _18.alignment) + _18.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _19.alignment) + _19.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _20.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 20 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _18.alignment) + _18.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _19.alignment) + _19.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _20.alignment) + _20.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _21.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct21[
           T1,
@@ -8138,7 +5203,6 @@ object Tag {
         T21
       ](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct21[
           T1,
@@ -8192,8 +5256,6 @@ object Tag {
       libc.memcpy(dst, src, size.toULong)
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 159)
 
   final case class CStruct22[
       T1,
@@ -8268,682 +5330,357 @@ object Tag {
       with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _1.alignment) + _1.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _2.alignment) + _2.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _3.alignment) + _3.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _4.alignment) + _4.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _5.alignment) + _5.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _6.alignment) + _6.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _7.alignment) + _7.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _8.alignment) + _8.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _9.alignment) + _9.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _10.alignment) + _10.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _11.alignment) + _11.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _12.alignment) + _12.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _13.alignment) + _13.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _14.alignment) + _14.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _15.alignment) + _15.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _16.alignment) + _16.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _17.alignment) + _17.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _18.alignment) + _18.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _19.alignment) + _19.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _20.alignment) + _20.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _21.alignment) + _21.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 167)
       res = align(res, _22.alignment) + _22.size
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 169)
       align(res, alignment)
     }
-
     @alwaysinline def alignment: CSize = {
       var res = 1.toULong
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_18.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_19.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_20.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_21.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 174)
       res = res.max(_22.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 176)
       res
     }
-
     @alwaysinline override def offset(idx: CSize): CSize = idx.toInt match {
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 0 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _1.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 1 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _2.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 2 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _3.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 3 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _4.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 4 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _5.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 5 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _6.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 6 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _7.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 7 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _8.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 8 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _9.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 9 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _10.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 10 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _11.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 11 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _12.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 12 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _13.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 13 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _14.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 14 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _15.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 15 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _16.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 16 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _17.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 17 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _18.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 18 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _18.alignment) + _18.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _19.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 19 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _18.alignment) + _18.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _19.alignment) + _19.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _20.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 20 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _18.alignment) + _18.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _19.alignment) + _19.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _20.alignment) + _20.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _21.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 180)
       case 21 =>
         var res = 0.toULong
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _1.alignment) + _1.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _2.alignment) + _2.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _3.alignment) + _3.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _4.alignment) + _4.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _5.alignment) + _5.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _6.alignment) + _6.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _7.alignment) + _7.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _8.alignment) + _8.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _9.alignment) + _9.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _10.alignment) + _10.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _11.alignment) + _11.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _12.alignment) + _12.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _13.alignment) + _13.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _14.alignment) + _14.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _15.alignment) + _15.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _16.alignment) + _16.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _17.alignment) + _17.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _18.alignment) + _18.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _19.alignment) + _19.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _20.alignment) + _20.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 183)
         res = align(res, _21.alignment) + _21.size
-        // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 185)
         align(res, _22.alignment)
-      // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 187)
       case _ =>
         throwUndefined()
     }
-
     @alwaysinline override def load(
         ptr: unsafe.Ptr[unsafe.CStruct22[
           T1,
@@ -9018,7 +5755,6 @@ object Tag {
         T22
       ](ptr.rawptr)
     }
-
     @alwaysinline override def store(
         ptr: unsafe.Ptr[unsafe.CStruct22[
           T1,
@@ -9075,8 +5811,6 @@ object Tag {
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 201)
-
   abstract class CFuncPtrTag[F <: unsafe.CFuncPtr] private[unsafe] ()
       extends Tag[F] {
 
@@ -9086,69 +5820,41 @@ object Tag {
     private[unsafe] def fromRawPtr(rawptr: RawPtr): F
 
     @alwaysinline def size: CSize = 8.toULong
-
     @alwaysinline def alignment: CSize = 8.toULong
-
     @alwaysinline override def load(ptr: unsafe.Ptr[F]): F =
       fromRawPtr(loadRawPtr(ptr.rawptr))
-
     @alwaysinline override def store(ptr: unsafe.Ptr[F], value: F): Unit =
       storeRawPtr(toRawPtr(ptr), value.rawptr)
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr0[R] extends CFuncPtrTag[unsafe.CFuncPtr0[R]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr1[T1, R] extends CFuncPtrTag[unsafe.CFuncPtr1[T1, R]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr2[T1, T2, R]
       extends CFuncPtrTag[unsafe.CFuncPtr2[T1, T2, R]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr3[T1, T2, T3, R]
       extends CFuncPtrTag[unsafe.CFuncPtr3[T1, T2, T3, R]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr4[T1, T2, T3, T4, R]
       extends CFuncPtrTag[unsafe.CFuncPtr4[T1, T2, T3, T4, R]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr5[T1, T2, T3, T4, T5, R]
       extends CFuncPtrTag[unsafe.CFuncPtr5[T1, T2, T3, T4, T5, R]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr6[T1, T2, T3, T4, T5, T6, R]
       extends CFuncPtrTag[unsafe.CFuncPtr6[T1, T2, T3, T4, T5, T6, R]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R]
       extends CFuncPtrTag[unsafe.CFuncPtr7[T1, T2, T3, T4, T5, T6, T7, R]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R]
       extends CFuncPtrTag[unsafe.CFuncPtr8[T1, T2, T3, T4, T5, T6, T7, T8, R]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
       extends CFuncPtrTag[
         unsafe.CFuncPtr9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
       ]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
       extends CFuncPtrTag[
         unsafe.CFuncPtr10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
       ]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
       extends CFuncPtrTag[
         unsafe.CFuncPtr11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
       ]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr12[
       T1,
       T2,
@@ -9166,8 +5872,6 @@ object Tag {
   ] extends CFuncPtrTag[
         unsafe.CFuncPtr12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
       ]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr13[
       T1,
       T2,
@@ -9199,8 +5903,6 @@ object Tag {
         T13,
         R
       ]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr14[
       T1,
       T2,
@@ -9234,8 +5936,6 @@ object Tag {
         T14,
         R
       ]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr15[
       T1,
       T2,
@@ -9271,8 +5971,6 @@ object Tag {
         T15,
         R
       ]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr16[
       T1,
       T2,
@@ -9310,8 +6008,6 @@ object Tag {
         T16,
         R
       ]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr17[
       T1,
       T2,
@@ -9351,8 +6047,6 @@ object Tag {
         T17,
         R
       ]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr18[
       T1,
       T2,
@@ -9394,8 +6088,6 @@ object Tag {
         T18,
         R
       ]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr19[
       T1,
       T2,
@@ -9439,8 +6131,6 @@ object Tag {
         T19,
         R
       ]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr20[
       T1,
       T2,
@@ -9486,8 +6176,6 @@ object Tag {
         T20,
         R
       ]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr21[
       T1,
       T2,
@@ -9535,8 +6223,6 @@ object Tag {
         T21,
         R
       ]]
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 221)
   abstract class CFuncPtr22[
       T1,
       T2,
@@ -9587,127 +6273,72 @@ object Tag {
         R
       ]]
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 224)
-
   @alwaysinline implicit def materializePtrTag[T](implicit
       tag: Tag[T]
   ): Tag[unsafe.Ptr[T]] =
     Tag.Ptr(tag)
-
   @alwaysinline implicit def materializeClassTag[T <: AnyRef: ClassTag]
       : Tag[T] =
     Tag.Class(
       implicitly[ClassTag[T]].runtimeClass.asInstanceOf[java.lang.Class[T]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeUnitTag: Tag[scala.Unit] =
     Unit
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeBooleanTag: Tag[scala.Boolean] =
     Boolean
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeCharTag: Tag[scala.Char] =
     Char
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeByteTag: Tag[scala.Byte] =
     Byte
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeUByteTag: Tag[unsigned.UByte] =
     UByte
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeShortTag: Tag[scala.Short] =
     Short
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeUShortTag: Tag[unsigned.UShort] =
     UShort
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeIntTag: Tag[scala.Int] =
     Int
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeUIntTag: Tag[unsigned.UInt] =
     UInt
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeLongTag: Tag[scala.Long] =
     Long
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeULongTag: Tag[unsigned.ULong] =
     ULong
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeFloatTag: Tag[scala.Float] =
     Float
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 230)
   @alwaysinline implicit def materializeDoubleTag: Tag[scala.Double] =
     Double
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 234)
   @alwaysinline implicit def materializeNat0Tag: Tag[unsafe.Nat._0] =
     Nat0
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 234)
   @alwaysinline implicit def materializeNat1Tag: Tag[unsafe.Nat._1] =
     Nat1
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 234)
   @alwaysinline implicit def materializeNat2Tag: Tag[unsafe.Nat._2] =
     Nat2
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 234)
   @alwaysinline implicit def materializeNat3Tag: Tag[unsafe.Nat._3] =
     Nat3
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 234)
   @alwaysinline implicit def materializeNat4Tag: Tag[unsafe.Nat._4] =
     Nat4
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 234)
   @alwaysinline implicit def materializeNat5Tag: Tag[unsafe.Nat._5] =
     Nat5
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 234)
   @alwaysinline implicit def materializeNat6Tag: Tag[unsafe.Nat._6] =
     Nat6
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 234)
   @alwaysinline implicit def materializeNat7Tag: Tag[unsafe.Nat._7] =
     Nat7
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 234)
   @alwaysinline implicit def materializeNat8Tag: Tag[unsafe.Nat._8] =
     Nat8
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 234)
   @alwaysinline implicit def materializeNat9Tag: Tag[unsafe.Nat._9] =
     Nat9
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 242)
   @alwaysinline implicit def materializeNatDigit2Tag[
       N1 <: Nat.Base: Tag,
       N2 <: Nat.Base: Tag
   ]: Tag.Digit2[N1, N2] =
     Tag.Digit2(implicitly[Tag[N1]], implicitly[Tag[N2]])
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 242)
   @alwaysinline implicit def materializeNatDigit3Tag[
       N1 <: Nat.Base: Tag,
       N2 <: Nat.Base: Tag,
       N3 <: Nat.Base: Tag
   ]: Tag.Digit3[N1, N2, N3] =
     Tag.Digit3(implicitly[Tag[N1]], implicitly[Tag[N2]], implicitly[Tag[N3]])
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 242)
   @alwaysinline implicit def materializeNatDigit4Tag[
       N1 <: Nat.Base: Tag,
       N2 <: Nat.Base: Tag,
@@ -9720,8 +6351,6 @@ object Tag {
       implicitly[Tag[N3]],
       implicitly[Tag[N4]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 242)
   @alwaysinline implicit def materializeNatDigit5Tag[
       N1 <: Nat.Base: Tag,
       N2 <: Nat.Base: Tag,
@@ -9736,8 +6365,6 @@ object Tag {
       implicitly[Tag[N4]],
       implicitly[Tag[N5]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 242)
   @alwaysinline implicit def materializeNatDigit6Tag[
       N1 <: Nat.Base: Tag,
       N2 <: Nat.Base: Tag,
@@ -9754,8 +6381,6 @@ object Tag {
       implicitly[Tag[N5]],
       implicitly[Tag[N6]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 242)
   @alwaysinline implicit def materializeNatDigit7Tag[
       N1 <: Nat.Base: Tag,
       N2 <: Nat.Base: Tag,
@@ -9774,8 +6399,6 @@ object Tag {
       implicitly[Tag[N6]],
       implicitly[Tag[N7]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 242)
   @alwaysinline implicit def materializeNatDigit8Tag[
       N1 <: Nat.Base: Tag,
       N2 <: Nat.Base: Tag,
@@ -9796,8 +6419,6 @@ object Tag {
       implicitly[Tag[N7]],
       implicitly[Tag[N8]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 242)
   @alwaysinline implicit def materializeNatDigit9Tag[
       N1 <: Nat.Base: Tag,
       N2 <: Nat.Base: Tag,
@@ -9820,26 +6441,16 @@ object Tag {
       implicitly[Tag[N8]],
       implicitly[Tag[N9]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct0Tag: Tag.CStruct0 =
     Tag.CStruct0()
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct1Tag[T1: Tag]: Tag.CStruct1[T1] =
     Tag.CStruct1(implicitly[Tag[T1]])
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct2Tag[T1: Tag, T2: Tag]
       : Tag.CStruct2[T1, T2] =
     Tag.CStruct2(implicitly[Tag[T1]], implicitly[Tag[T2]])
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct3Tag[T1: Tag, T2: Tag, T3: Tag]
       : Tag.CStruct3[T1, T2, T3] =
     Tag.CStruct3(implicitly[Tag[T1]], implicitly[Tag[T2]], implicitly[Tag[T3]])
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct4Tag[
       T1: Tag,
       T2: Tag,
@@ -9852,8 +6463,6 @@ object Tag {
       implicitly[Tag[T3]],
       implicitly[Tag[T4]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct5Tag[
       T1: Tag,
       T2: Tag,
@@ -9868,8 +6477,6 @@ object Tag {
       implicitly[Tag[T4]],
       implicitly[Tag[T5]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct6Tag[
       T1: Tag,
       T2: Tag,
@@ -9886,8 +6493,6 @@ object Tag {
       implicitly[Tag[T5]],
       implicitly[Tag[T6]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct7Tag[
       T1: Tag,
       T2: Tag,
@@ -9906,8 +6511,6 @@ object Tag {
       implicitly[Tag[T6]],
       implicitly[Tag[T7]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct8Tag[
       T1: Tag,
       T2: Tag,
@@ -9928,8 +6531,6 @@ object Tag {
       implicitly[Tag[T7]],
       implicitly[Tag[T8]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct9Tag[
       T1: Tag,
       T2: Tag,
@@ -9952,8 +6553,6 @@ object Tag {
       implicitly[Tag[T8]],
       implicitly[Tag[T9]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct10Tag[
       T1: Tag,
       T2: Tag,
@@ -9978,8 +6577,6 @@ object Tag {
       implicitly[Tag[T9]],
       implicitly[Tag[T10]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct11Tag[
       T1: Tag,
       T2: Tag,
@@ -10006,8 +6603,6 @@ object Tag {
       implicitly[Tag[T10]],
       implicitly[Tag[T11]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct12Tag[
       T1: Tag,
       T2: Tag,
@@ -10036,8 +6631,6 @@ object Tag {
       implicitly[Tag[T11]],
       implicitly[Tag[T12]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct13Tag[
       T1: Tag,
       T2: Tag,
@@ -10068,8 +6661,6 @@ object Tag {
       implicitly[Tag[T12]],
       implicitly[Tag[T13]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct14Tag[
       T1: Tag,
       T2: Tag,
@@ -10117,8 +6708,6 @@ object Tag {
       implicitly[Tag[T13]],
       implicitly[Tag[T14]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct15Tag[
       T1: Tag,
       T2: Tag,
@@ -10169,8 +6758,6 @@ object Tag {
       implicitly[Tag[T14]],
       implicitly[Tag[T15]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct16Tag[
       T1: Tag,
       T2: Tag,
@@ -10224,8 +6811,6 @@ object Tag {
       implicitly[Tag[T15]],
       implicitly[Tag[T16]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct17Tag[
       T1: Tag,
       T2: Tag,
@@ -10282,8 +6867,6 @@ object Tag {
       implicitly[Tag[T16]],
       implicitly[Tag[T17]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct18Tag[
       T1: Tag,
       T2: Tag,
@@ -10343,8 +6926,6 @@ object Tag {
       implicitly[Tag[T17]],
       implicitly[Tag[T18]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct19Tag[
       T1: Tag,
       T2: Tag,
@@ -10407,8 +6988,6 @@ object Tag {
       implicitly[Tag[T18]],
       implicitly[Tag[T19]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct20Tag[
       T1: Tag,
       T2: Tag,
@@ -10474,8 +7053,6 @@ object Tag {
       implicitly[Tag[T19]],
       implicitly[Tag[T20]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct21Tag[
       T1: Tag,
       T2: Tag,
@@ -10544,8 +7121,6 @@ object Tag {
       implicitly[Tag[T20]],
       implicitly[Tag[T21]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 250)
   @alwaysinline implicit def materializeCStruct22Tag[
       T1: Tag,
       T2: Tag,
@@ -10617,13 +7192,9 @@ object Tag {
       implicitly[Tag[T21]],
       implicitly[Tag[T22]]
     )
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 253)
   @alwaysinline implicit def materializeCArrayTag[T: Tag, N <: unsafe.Nat: Tag]
       : Tag.CArray[T, N] =
     Tag.CArray(implicitly[Tag[T]], implicitly[Tag[N]])
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr0[R: Tag]
       : CFuncPtrTag[unsafe.CFuncPtr0[R]] = {
@@ -10636,8 +7207,6 @@ object Tag {
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
-
   @alwaysinline implicit def materializeCFuncPtr1[T1: Tag, R: Tag]
       : CFuncPtrTag[unsafe.CFuncPtr1[T1, R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr1[T1, R]] {
@@ -10649,8 +7218,6 @@ object Tag {
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
-
   @alwaysinline implicit def materializeCFuncPtr2[T1: Tag, T2: Tag, R: Tag]
       : CFuncPtrTag[unsafe.CFuncPtr2[T1, T2, R]] = {
     new CFuncPtrTag[unsafe.CFuncPtr2[T1, T2, R]] {
@@ -10661,8 +7228,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr3[
       T1: Tag,
@@ -10679,8 +7244,6 @@ object Tag {
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
-
   @alwaysinline implicit def materializeCFuncPtr4[
       T1: Tag,
       T2: Tag,
@@ -10696,8 +7259,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr5[
       T1: Tag,
@@ -10716,8 +7277,6 @@ object Tag {
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
-
   @alwaysinline implicit def materializeCFuncPtr6[
       T1: Tag,
       T2: Tag,
@@ -10735,8 +7294,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr7[
       T1: Tag,
@@ -10757,8 +7314,6 @@ object Tag {
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
-
   @alwaysinline implicit def materializeCFuncPtr8[
       T1: Tag,
       T2: Tag,
@@ -10778,8 +7333,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr9[
       T1: Tag,
@@ -10803,8 +7356,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr10[
       T1: Tag,
@@ -10833,8 +7384,6 @@ object Tag {
     }
   }
 
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
-
   @alwaysinline implicit def materializeCFuncPtr11[
       T1: Tag,
       T2: Tag,
@@ -10862,8 +7411,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr12[
       T1: Tag,
@@ -10909,8 +7456,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr13[
       T1: Tag,
@@ -10983,8 +7528,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr14[
       T1: Tag,
@@ -11075,8 +7618,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr15[
       T1: Tag,
@@ -11172,8 +7713,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr16[
       T1: Tag,
@@ -11274,8 +7813,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr17[
       T1: Tag,
@@ -11381,8 +7918,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr18[
       T1: Tag,
@@ -11493,8 +8028,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr19[
       T1: Tag,
@@ -11610,8 +8143,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr20[
       T1: Tag,
@@ -11732,8 +8263,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr21[
       T1: Tag,
@@ -11859,8 +8388,6 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 262)
 
   @alwaysinline implicit def materializeCFuncPtr22[
       T1: Tag,
@@ -11991,6 +8518,4 @@ object Tag {
       }
     }
   }
-
-  // ###sourceLocation(file: "/home/wmazur/projects/scalacenter/scala-native/scala-native/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb", line: 271)
 }

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/Tag.scala.gyb
@@ -1,3 +1,4 @@
+// format: off 
 
 // BEWARE: This file is generated - direct edits will be lost.
 // Do not edit this it directly other than to remove
@@ -59,7 +60,6 @@ object Tag {
   %          ('Float', 'scala.Float', 4),
   %          ('Double', 'scala.Double', 8)]
   % for (name, T, size) in prims:
-
   object ${name} extends Tag[${T}] {
     @alwaysinline def size: CSize = ${size}.toULong
     @alwaysinline def alignment: CSize = ${size}.toULong
@@ -91,7 +91,6 @@ object Tag {
   }
 
   % for N in range(0, 10):
-
   object Nat${N} extends Tag[unsafe.Nat._${N}] with NatTag {
     @noinline def size: CSize = throwUndefined()
     @noinline def alignment: CSize = throwUndefined()
@@ -99,18 +98,15 @@ object Tag {
   }
 
   % end
-
   % for N in range(2, 10):
   %   Ns      = ["N" + str(i) for i in range(1, N + 1)]
   %   BoundNs = "[" + ", ".join(N + " <: Nat.Base" for N in Ns) + "]"
   %   JustNs  = "[" + ", ".join(Ns) + "]"
   %   TagNs   = ["Tag[{}]".format(n) for n in Ns]
   %   args    = ", ".join("_{}: {}".format(i + 1, T) for (i, T) in enumerate(TagNs))
-
   final case class Digit${N}${BoundNs}(${args})
       extends Tag[unsafe.Nat.Digit${N}${JustNs}]
-      with NatTag
-  {
+      with NatTag {
     @alwaysinline def size: CSize = throwUndefined()
     @alwaysinline def alignment: CSize = throwUndefined()
     @alwaysinline def toInt: Int = {
@@ -159,8 +155,7 @@ object Tag {
 
   final case class CStruct${N}${JustTs}(${args})
     extends Tag[unsafe.CStruct${N}${JustTs}]
-    with StructTag
-  {
+    with StructTag {
     @alwaysinline def size: CSize = {
       var res = 0.toULong
       % for i in range(1, N + 1):

--- a/scripts/gyb_all.sh
+++ b/scripts/gyb_all.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+scalanativeUnsafe=nativelib/src/main/scala/scala/scalanative/unsafe
+scalanativeRuntime=nativelib/src/main/scala/scala/scalanative/runtime
+
+function gyb {
+  file=$1
+  if [ ${file: -4} == ".gyb" ]; then
+    scripts/gyb.py --line-directive '' -o "${file%.gyb}" "$file"
+  else 
+    echo "$file is not a .gyb file"
+    exit 1
+  fi
+}
+
+gyb $scalanativeUnsafe/Tag.scala.gyb
+gyb $scalanativeUnsafe/Nat.scala.gyb
+gyb $scalanativeUnsafe/CStruct.scala.gyb
+gyb $scalanativeUnsafe/CFuncPtr.scala.gyb
+
+gyb $scalanativeRuntime/Arrays.scala.gyb
+gyb $scalanativeRuntime/Boxes.scala.gyb
+gyb $scalanativeRuntime/Primitives.scala.gyb
+
+scripts/scalafmt \
+  $scalanativeUnsafe/Tag.scala \
+  $scalanativeUnsafe/Nat.scala \
+  $scalanativeUnsafe/CStruct.scala \
+  $scalanativeUnsafe/CFuncPtr.scala \
+  $scalanativeRuntime/Arrays.scala \
+  $scalanativeRuntime/Boxes.scala \
+  $scalanativeRuntime/Primitives.scala

--- a/scripts/gyb_all.sh
+++ b/scripts/gyb_all.sh
@@ -23,12 +23,3 @@ gyb $scalanativeUnsafe/CFuncPtr.scala.gyb
 gyb $scalanativeRuntime/Arrays.scala.gyb
 gyb $scalanativeRuntime/Boxes.scala.gyb
 gyb $scalanativeRuntime/Primitives.scala.gyb
-
-scripts/scalafmt \
-  $scalanativeUnsafe/Tag.scala \
-  $scalanativeUnsafe/Nat.scala \
-  $scalanativeUnsafe/CStruct.scala \
-  $scalanativeUnsafe/CFuncPtr.scala \
-  $scalanativeRuntime/Arrays.scala \
-  $scalanativeRuntime/Boxes.scala \
-  $scalanativeRuntime/Primitives.scala


### PR DESCRIPTION
This PR does cherry-pick changes made to the generation of gyb templates to lower the amount of diffs when introducing small changes. This change was originally a part of #1571. Original script was update to make it more user friendly.