### PR TITLE
Fix deprecated  constructor `String(Array[Byte], Int, Int, Int)`

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -26,11 +26,13 @@ final class _String()
     this()
     if (length <= data.length - start && start >= 0 && 0 <= length) {
       offset = 0
+      count = length
       value = {
         val value = new Array[Char](length)
+        val highByte = (high & 0xff) << 8
         var i = 0
         while (i < length) {
-          value(i) = ((high & 0xff) << 8 | (data(start + i) & 0xff)).toChar
+          value(i) = (highByte | (data(start + i) & 0xff)).toChar
           i += 1
         }
         value

--- a/unit-tests/shared/src/test/scala/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/StringTest.scala
@@ -40,6 +40,12 @@ class StringTest {
     )
   }
 
+  @Test def stringArrayByteHighByte(): Unit = {
+    val str = "this constrcutor is deprecated"
+    assertEquals(str, new String(str.getBytes(), 0))
+    assertEquals(str, new String(str.getBytes(), 0, 0, str.length()))
+  }
+
   @Test def stringArrayByteStartLengthWithInvalidStartOrLength(): Unit = {
     val chars: Array[Char] = Array('a', 'b', 'c')
 


### PR DESCRIPTION
This PR fixed #2562 - was not setting a `count` field, leading to the creation of an empty string 

* Added test cases for failing constructor
* Added missing assignment to `count` field 
* Moved operation on high byte to a separate value