### PR TITLE
Fix negation of floating point numbers

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1379,7 +1379,7 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
     def negateInt(value: nir.Val)(implicit pos: nir.Position): Val =
       buf.bin(Bin.Isub, value.ty, numOfType(0, value.ty), value, unwind)
     def negateFloat(value: nir.Val)(implicit pos: nir.Position): Val =
-      buf.bin(Bin.Fsub, value.ty, numOfType(0, value.ty), value, unwind)
+      buf.bin(Bin.Fmul, value.ty, numOfType(-1, value.ty), value, unwind)
     def negateBits(value: nir.Val)(implicit pos: nir.Position): Val =
       buf.bin(Bin.Xor, value.ty, numOfType(-1, value.ty), value, unwind)
     def negateBool(value: nir.Val)(implicit pos: nir.Position): Val =

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1257,7 +1257,7 @@ trait NirGenExpr(using Context) {
         case (_: Type.I, NOT) =>
           buf.bin(Bin.Xor, tpe, numOfType(-1, tpe), coerced, unwind)
         case (_: Type.F, NEG) =>
-          buf.bin(Bin.Fsub, tpe, numOfType(0, tpe), coerced, unwind)
+          buf.bin(Bin.Fmul, tpe, numOfType(-1, tpe), coerced, unwind)
         case (_: Type.I, NEG) =>
           buf.bin(Bin.Isub, tpe, numOfType(0, tpe), coerced, unwind)
         case (Type.Bool, ZNOT) => negateBool(coerced)

--- a/unit-tests/shared/src/test/scala/javalib/lang/DoubleTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/DoubleTest.scala
@@ -393,4 +393,43 @@ class DoubleTest {
     assertFalse(f(3.0))
     assertFalse(f(-1.5))
   }
+
+  @Test def negateTest(): Unit = {
+    val delta = 0.000000001
+    val one = 1.0
+    assertEquals("negate one", -1.0, -one, delta)
+    assertEquals("negate minus one", 1.0, -(-one), delta)
+
+    val x = 0.0
+    assertTrue("Negated value is equal to zero", 0.0 == -0.0)
+    assertFalse("Can distinguish negated zero", 0.0.equals(-0.0))
+    assertTrue("negate zero", -0.0.equals(-x))
+    assertTrue("negate minus zero", 0.0.equals(-(-x)))
+
+    assertEquals(
+      "negate minValue",
+      scala.Double.MaxValue,
+      -scala.Double.MinValue,
+      delta
+    )
+    assertEquals(
+      "negate maxValue",
+      scala.Double.MinValue,
+      -scala.Double.MaxValue,
+      delta
+    )
+
+    assertEquals(
+      "negate infinity",
+      scala.Double.NegativeInfinity,
+      -scala.Double.PositiveInfinity,
+      delta
+    )
+    assertEquals(
+      "negate neg inf",
+      scala.Double.PositiveInfinity,
+      -scala.Double.NegativeInfinity,
+      delta
+    )
+  }
 }

--- a/unit-tests/shared/src/test/scala/javalib/lang/FloatTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/FloatTest.scala
@@ -363,4 +363,43 @@ class FloatTest {
     assertFalse(f(3f))
     assertFalse(f(-1.5f))
   }
+
+  @Test def negateTest(): Unit = {
+    val delta = 0.000000001f
+    val one = 1.0f
+    assertEquals("negate one", -1.0f, -one, delta)
+    assertEquals("negate minus one", 1.0f, -(-one), delta)
+
+    val x = 0.0f
+    assertTrue("Negated value is equal to zero", 0.0f == -0.0f)
+    assertFalse("Can distinguish negated zero", 0.0f.equals(-0.0f))
+    assertTrue("negate zero", -0.0f.equals(-x))
+    assertTrue("negate minus zero", 0.0f.equals(-(-x)))
+    
+    assertEquals(
+      "negate minValue",
+      scala.Float.MaxValue,
+      -scala.Float.MinValue,
+      delta
+    )
+    assertEquals(
+      "negate maxValue",
+      scala.Float.MinValue,
+      -scala.Float.MaxValue,
+      delta
+    )
+
+    assertEquals(
+      "negate infinity",
+      scala.Float.NegativeInfinity,
+      -scala.Float.PositiveInfinity,
+      delta
+    )
+    assertEquals(
+      "negate neg inf",
+      scala.Float.PositiveInfinity,
+      -scala.Float.NegativeInfinity,
+      delta
+    )
+  }
 }

--- a/unit-tests/shared/src/test/scala/javalib/lang/FloatTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/FloatTest.scala
@@ -375,7 +375,7 @@ class FloatTest {
     assertFalse("Can distinguish negated zero", 0.0f.equals(-0.0f))
     assertTrue("negate zero", -0.0f.equals(-x))
     assertTrue("negate minus zero", 0.0f.equals(-(-x)))
-    
+
     assertEquals(
       "negate minValue",
       scala.Float.MaxValue,


### PR DESCRIPTION
This PR fixes #2563 and incorrect negation of floats and doubles equal to zero. It is being fixed by replacing existing negation logic based on substitution from 0, with multiplication by -1. The same logic is also used in Scala.js 

Because the fix was introduced in the NIR generation code libraries compiled with 0.4.3 would still produce incorrect negations.

* Added tests for negation of Double and Float
* Fixed logic of negation for float numbers