### PR TITLE
Fix runtime problems on MacOS using M1 chips

### DIFF
--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -71,7 +71,14 @@ object System {
     } else {
       sysProps.setProperty("file.separator", "/")
       sysProps.setProperty("path.separator", ":")
-      sysProps.setProperty("java.io.tmpdir", "/tmp")
+      // MacOS uses TMPDIR to specify tmp directory, other formats are also used in the Unix system
+      def env(name: String): Option[String] = Option(envVars.get(name))
+      val tmpDirectory = env("TMPDIR")
+        .orElse(env("TEMPDIR"))
+        .orElse(env("TMP"))
+        .orElse(env("TEMP"))
+        .getOrElse("/tmp")
+      sysProps.setProperty("java.io.tmpdir", tmpDirectory)
     }
 
     sysProps

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -64,9 +64,10 @@ object Files {
       else throw new UnsupportedOperationException()
 
     val targetFile = target.toFile()
+    val targetExists = targetFile.exists()
 
     val out =
-      if (!targetFile.exists() || (targetFile.isFile() && replaceExisting)) {
+      if (!targetExists || (targetFile.isFile() && replaceExisting)) {
         new FileOutputStream(targetFile, append = false)
       } else if (targetFile.isDirectory() &&
           targetFile.list().isEmpty &&
@@ -81,8 +82,15 @@ object Files {
         throw new FileAlreadyExistsException(targetFile.getAbsolutePath())
       }
 
-    try copy(in, out)
-    finally out.close()
+    try {
+      val copyResult = copy(in, out)
+      // Make sure that created fi
+      if (!targetExists) {
+        targetFile.setReadable(true, ownerOnly = false)
+        targetFile.setWritable(true, ownerOnly = true)
+      }
+      copyResult
+    } finally out.close()
   }
 
   def copy(source: Path, out: OutputStream): Long = {

--- a/javalib/src/main/scala/java/nio/file/Files.scala
+++ b/javalib/src/main/scala/java/nio/file/Files.scala
@@ -84,7 +84,7 @@ object Files {
 
     try {
       val copyResult = copy(in, out)
-      // Make sure that created fi
+      // Make sure that created file has correct permissions
       if (!targetExists) {
         targetFile.setReadable(true, ownerOnly = false)
         targetFile.setWritable(true, ownerOnly = true)

--- a/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
+++ b/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
@@ -11,12 +11,16 @@
 #include <errno.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
 
 // The +1 accounts for the null char at the end of the name
 #ifdef __APPLE__
 #include <sys/posix_sem.h>
 #define SEM_MAX_LENGTH PSEMNAMLEN + 1
 #else
+#include <limits.h>
 #define SEM_MAX_LENGTH _POSIX_PATH_MAX + 1
 #endif
 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CVarArgList.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CVarArgList.scala
@@ -258,9 +258,8 @@ object CVarArgList {
       )
       currentIndex += tag.size
     }
-    
+
     new CVarArgList(toRawPtr(argListStorage))
   }
 
 }
- 

--- a/nativelib/src/main/scala/scala/scalanative/unsafe/CVarArgList.scala
+++ b/nativelib/src/main/scala/scala/scalanative/unsafe/CVarArgList.scala
@@ -71,6 +71,8 @@ object CVarArgList {
   )(implicit z: Zone): CVarArgList = {
     if (isWindows)
       toCVarArgList_X86_64_Windows(varargs)
+    else if (PlatformExt.isArm64 && Platform.isMac())
+      toCVarArgList_Arm64_MacOS(varargs)
     else
       toCVarArgList_Unix(varargs)
   }
@@ -216,4 +218,49 @@ object CVarArgList {
     new CVarArgList(resultStorage)
   }
 
+  private def toCVarArgList_Arm64_MacOS(
+      varargs: Seq[CVarArg]
+  )(implicit z: Zone) = {
+    val alignedArgs = varargs.map { arg =>
+      arg.value match {
+        case value: Byte =>
+          value.toLong: CVarArg
+        case value: Short =>
+          value.toLong: CVarArg
+        case value: Int =>
+          value.toLong: CVarArg
+        case value: UByte =>
+          value.toULong: CVarArg
+        case value: UShort =>
+          value.toULong: CVarArg
+        case value: UInt =>
+          value.toULong: CVarArg
+        case value: Float =>
+          value.toDouble: CVarArg
+        case o => arg
+      }
+    }
+
+    var totalSize = 0.toULong
+    alignedArgs.foreach { vararg =>
+      val tag = vararg.tag
+      totalSize = Tag.align(totalSize, tag.alignment) + tag.size
+    }
+
+    val argListStorage = z.alloc(totalSize).asInstanceOf[Ptr[Byte]]
+    var currentIndex = 0.toULong
+    alignedArgs.foreach { vararg =>
+      val tag = vararg.tag
+      currentIndex = Tag.align(currentIndex, tag.alignment)
+      tag.store(
+        (argListStorage + currentIndex).asInstanceOf[Ptr[Any]],
+        vararg.value
+      )
+      currentIndex += tag.size
+    }
+    
+    new CVarArgList(toRawPtr(argListStorage))
+  }
+
 }
+ 

--- a/posixlib/src/main/resources/scala-native/fcntl.c
+++ b/posixlib/src/main/resources/scala-native/fcntl.c
@@ -75,4 +75,12 @@ int scalanative_fcntl(int fd, int cmd, struct scalanative_flock *flock_struct) {
     return fcntl(fd, cmd, &flock_buf);
 }
 
+/* In Scala Native we don't support ... C syntax. On some plaforms e.g. MacOs
+ * Arm64 (M1) we need to replace the calls to fcntl with the proxy taking
+ * positional args.
+ */
+int scalanative_fcntl2(int fd, int cmd, int flags) {
+    return fcntl(fd, cmd, flags);
+}
+
 #endif // Unix or Mac OS

--- a/posixlib/src/main/resources/scala-native/fcntl.c
+++ b/posixlib/src/main/resources/scala-native/fcntl.c
@@ -75,12 +75,14 @@ int scalanative_fcntl(int fd, int cmd, struct scalanative_flock *flock_struct) {
     return fcntl(fd, cmd, &flock_buf);
 }
 
-/* In Scala Native we don't support ... C syntax. On some plaforms e.g. MacOs
- * Arm64 (M1) we need to replace the calls to fcntl with the proxy taking
- * positional args.
- */
-int scalanative_fcntl2(int fd, int cmd, int flags) {
+// On MacOS Arm64 it is defined as macro taking varargs delegating to _fcntl
+int scalanative_fcntl_i(int fd, int cmd, int flags) {
     return fcntl(fd, cmd, flags);
+}
+
+// On MacOS Arm64 is's defined as macro taking varargs delagating to _open
+int scalanative_open_m(const char *pathname, int flags, mode_t mode) {
+    return open(pathname, flags, mode);
 }
 
 #endif // Unix or Mac OS

--- a/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
@@ -11,9 +11,10 @@ object fcntl {
 
   def open(pathname: CString, flags: CInt): CInt = extern
 
+  @name("scalanative_open_m")
   def open(pathname: CString, flags: CInt, mode: mode_t): CInt = extern
 
-  @name("scalanative_fcntl2")
+  @name("scalanative_fcntl_i")
   def fcntl(fd: CInt, cmd: CInt, flags: CInt): CInt = extern
 
   @name("scalanative_fcntl")

--- a/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/fcntl.scala
@@ -13,6 +13,7 @@ object fcntl {
 
   def open(pathname: CString, flags: CInt, mode: mode_t): CInt = extern
 
+  @name("scalanative_fcntl2")
   def fcntl(fd: CInt, cmd: CInt, flags: CInt): CInt = extern
 
   @name("scalanative_fcntl")

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -8,6 +8,7 @@ import java.io.IOException
 
 import org.scalanative.testsuite.utils.Platform
 import scala.scalanative.meta.LinktimeInfo.isWindows
+import scala.scalanative.runtime.PlatformExt
 
 import scalanative.libc.{errno => libcErrno, string}
 import scala.scalanative.unsafe._
@@ -328,7 +329,7 @@ class TimeTest {
         // different time zone.
 
         val cp =
-          if (Platform.isFreeBSD)
+          if (Platform.isFreeBSD || (Platform.isMacOs && PlatformExt.isArm64))
             strptime(c"Fri Mar 31 14:47:44 2017", c"%a %b %d %T %Y", tmPtr)
           else
             strptime(

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
@@ -17,25 +17,34 @@ object ExternTest {
    */
   @extern
   object Ext1 {
-    def snprintf(buf: CString, size: CSize, format: CString, l: CString): Int =
+    def vsnprintf(
+        buf: CString,
+        size: CSize,
+        format: CString,
+        args: CVarArgList
+    ): Int =
       extern
   }
   @extern
   object Ext2 {
-    @name("snprintf")
-    def p(buf: CString, size: CSize, format: CString, i: Int): Int = extern
+    @name("vsnprintf")
+    def p(buf: CString, size: CSize, format: CString, args: CVarArgList): Int =
+      extern
   }
 
   // workaround for CI
-  def runTest(): Unit = {
+  def runTest(): Unit = Zone { implicit z: Zone =>
     import scalanative.libc.string
     val bufsize = 10.toUInt
     val buf1: Ptr[Byte] = stackalloc[Byte](bufsize)
     val buf2: Ptr[Byte] = stackalloc[Byte](bufsize)
-    Ext1.snprintf(buf1, bufsize, c"%s", c"hello")
-    assertTrue(string.strcmp(buf1, c"hello") == 0)
-    Ext2.p(buf2, bufsize, c"%d", 1)
-    assertTrue(string.strcmp(buf2, c"1") == 0)
+
+    val arg1 = c"hello"
+    Ext1.vsnprintf(buf1, bufsize, c"%s", toCVarArgList(arg1))
+    assertEquals("case 1", 0, string.strcmp(buf1, arg1))
+
+    Ext2.p(buf2, bufsize, c"%d", toCVarArgList(1))
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
   }
 }
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/unsafe/ExternTest.scala
@@ -17,6 +17,8 @@ object ExternTest {
    */
   @extern
   object Ext1 {
+    // Previously snprintf method was used here, however on MacOs Arm64
+    // it is defined as a macro and takes some additional implicit arguments
     def vsnprintf(
         buf: CString,
         size: CSize,


### PR DESCRIPTION
This PR is aimed to fix #2494  and other runtime issues when using macOS with M1 (arm64) chips. Because currently, we can't have any self-hosted Mac/M1 based machines that could be used in the CI all of the introduced changes are being tested only locally on the M1 host.  

- [x]  Fix CVarArgs - it should use the same logic as proposed by @shadaj in the 32bit branch, but with different padding 
- [x] Fix ProcessMonitor deadlocks - currently used `dispatch_semapthore` was leading to deadlocks, we replace it with named semaphores that would be used in both Mac and Linux. 
- [x] Use `TMPDIR` env to determinate `java.io.tmpdir` system property - on MacOs 12 wiht M1 files created in `/tmp` directory have wrong permissions. We should create them in the path described by `TMPDIR` 
- [x] Adapt TimeTest - TimeZone is not being abbreviated on Arm64 - same problems as in the FreeBSD
- [x] Fix failing java.io.FilesTest - 2 up to 4 tests are frequently failing due to bad descriptor or bad permissions
- [x] Fix failing java.io.SocketTest - Connecting to non-existing socket with timeout is blocking (for 1 min) and return incorrect exception
- [x] Fix failing scalanative.unsafe.ExternTest - incorrect results, probably due to incorrect Scala definition of snprintf method taking varargs (`...)`, where positional args are being passed.