### PR TITLE
Fix formatting in the resources chapter in the docs

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -623,37 +623,35 @@ Embedding Resources
 -------------------
 
 In Scala Native, resources are implemented via embedding a resource in a resulting
-binary file. Only `getClass().getResourceAsInputStream()` is implemented.
+binary file. Only ``getClass().getResourceAsInputStream()`` is implemented.
 For that to work, you have to specify an additional NativeConfig option:
 
-```scala
-nativeConfig ~= {
-  _.withEmbedResources(true)
-}
-```
+.. code-block:: scala
+
+  nativeConfig ~= {
+    _.withEmbedResources(true)
+  }
 
 This will include the resource files found on the classpath in the resulting
 binary file. Please note that files with following extensions cannot be embedded
 and used as a resource:
 
-```
-".class", ".tasty", ".nir", ".scala", ".java", ".jar",
-```
+``".class", ".tasty", ".nir", ".scala", ".java", ".jar"``
 
 This is to avoid unnecesarily embedding source files. If necessary, please
 consider using a different file extension for embedding. Files found in the
-resources/scala-native directory will not be embedded as well. It is recommended
+``resources/scala-native`` directory will not be embedded as well. It is recommended
 to add the ".c" nad ".h" files there.
 
-Reasoning for the lack of getResource() and getResources():
+Reasoning for the lack of ``getResource()`` and ``getResources()``:
 
 In Scala Native, the outputted file that can be run is a binary, unlike JVM's
-classfiles and jars. For that reason, if getResources() URI methods would be implemented,
+classfiles and jars. For that reason, if ``getResources()`` URI methods would be implemented,
 a new URI format using a seperate FileSystem would have to be added (e.g. instead
-of obtaining `jar:file:path.ext` you would obtain `embedded:path.ext`). As this still
+of obtaining ``jar:file:path.ext`` you would obtain ``embedded:path.ext``). As this still
 would provide a meaningful inconsistency between JVM's javalib API and Scala
 Native's reimplementation, this remains not implemented for now. The added
-getClass().getResourceAsInputStream() however is able to be consistent between
+``getClass().getResourceAsInputStream()`` however is able to be consistent between
 the platforms.
 
 Continue to :ref:`libc`.


### PR DESCRIPTION
Previously the formatting was slightly broken, as the `.md` instead of `.rst` syntax was used by mistake. This PR corrects that, improving readability.