### PR TITLE
Update clangfmt script

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -6,13 +6,13 @@ on:
       - main
 jobs:
   check-lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install clang-format
         run: |
           sudo apt update
-          sudo apt install clang-format-6.0
+          sudo apt install clang-format-10
       - uses: actions/checkout@v2
       - run: ./scripts/check-lint.sh
         env:
-          CLANG_FORMAT_PATH: "/usr/bin/clang-format-6.0"
+          CLANG_FORMAT_PATH: "/usr/bin/clang-format-10"

--- a/docs/contrib/contributing.rst
+++ b/docs/contrib/contributing.rst
@@ -37,30 +37,36 @@ uses the `.scalafmt.conf` file at the root of the project. No configuration
 is needed.
 
 Formatting C and C++ code uses `clang-format` which requires LLVM library
-dependencies. For `clang-format` we use the same version as the minimum
-version of LLVM and `clang`. This may not be the version of `clang` used
-for development as most developers will use a newer version. In order
+dependencies. For `clang-format` we use any version greater than `10`
+as most developers use a newer version of LLVM and `clang`. In order
 to make this easier we have a environment variable, `CLANG_FORMAT_PATH`
-which can be set to the older version. Another option is to make sure the
+which can be set to a compatible version. Another option is to make sure the
 correct version of `clang-format` is available in your path. Refer to
-:ref:`setup` for the minimum version to install and use.
+:ref:`setup` for the minimum version of `clang` supported.
 
 The following shows examples for two common operating systems. You may add
 the environment variable to your shell startup file for convenience:
 
 **macOS**
 
-.. code-block:: shell
-
-    $ export CLANG_FORMAT_PATH=/usr/local/opt/llvm@6/bin/clang-format
-
-*Note:* Example for `brew`. Other package managers may use different locations.
-
-**Ubuntu**
+Normal macOS tools does not include clang-format so installing via `brew`
+is a good option.
 
 .. code-block:: shell
 
-    $ export CLANG_FORMAT_PATH=/usr/lib/llvm-6.0/bin/clang-format
+    % brew install clang-format
+    % export CLANG_FORMAT_PATH=/opt/homebrew/bin/clang-format
+
+*Note:* `brew` for M1 installs at the above location which is in the PATH so
+the export is not needed and is for reference only. Other package managers may
+use different locations.
+
+**Ubuntu 20.04**
+
+.. code-block:: shell
+
+    $ sudo apt install clang-format-10
+    $ export CLANG_FORMAT_PATH=/usr/lib/llvm-10/bin/clang-format
 
 The script `./scripts/clangfmt` will use the `.clang-format` file
 at the root of the project for settings used in formatting.

--- a/scripts/clangfmt
+++ b/scripts/clangfmt
@@ -32,7 +32,7 @@ check_clang_format_version() {
     | grep -E -i -o "[0-9]+.[0-9]+")
 
   major=${version%%.*}
-  [ $major -gt $CLANG_FORMAT_VERSION ]
+  [ $major -ge $CLANG_FORMAT_VERSION ]
 }
 
 clang_format=

--- a/scripts/clangfmt
+++ b/scripts/clangfmt
@@ -11,8 +11,8 @@
 
 set -euo pipefail
 
-# The required version of clang-format (matches minimum clang version) for CI
-CLANG_FORMAT_VERSION=6
+# The minimum version of clang-format with the new options
+CLANG_FORMAT_VERSION=10
 
 die() {
   while [ "$#" -gt 0 ]; do
@@ -32,7 +32,7 @@ check_clang_format_version() {
     | grep -E -i -o "[0-9]+.[0-9]+")
 
   major=${version%%.*}
-  [ $major -eq $CLANG_FORMAT_VERSION ]
+  [ $major -gt $CLANG_FORMAT_VERSION ]
 }
 
 clang_format=
@@ -74,17 +74,13 @@ while [ "$#" -gt 0 ]; do
 done
 
 # Use this block for version 10 and above
-# if [ "$test_mode" = true ]; then
-#   opts="--dry-run"
-#   err="--Werror"
-# else
-#   opts="-i"
-#   err=
-# fi
-
-# Remove for version 10 and above
-opts="-i"
-err=
+if [ "$test_mode" = true ]; then
+  opts="--dry-run"
+  err="--Werror"
+else
+  opts="-i"
+  err=
+fi
 
 if [ "$#" -gt 0 ]; then
   "$clang_format" --style=file "$opts" "$@"
@@ -93,11 +89,4 @@ else
     xargs "$clang_format" --style=file "$opts" $err || \
       die "C/C++ code formatting changes detected" \
           "Run '$0' to reformat."
-fi
-
-# Remove for version 10 and above
-if [ "$test_mode" = true ]; then
-  git diff --quiet --exit-code || \
-    die "C/C++ code formatting changes detected" \
-        "Run '$0' to reformat."
 fi


### PR DESCRIPTION
This change allows developers to use `clang-format` 10 or greater. Version 10 was chosen because the `--dry-run` and `--Werror` options were added. This allows us to skip the extra `git diff` step now as the formatter outputs where the error has occurred when formatting was needed.