### PR TITLE
Add ScalaNativeJUnitPlugin instructions for cross projects

### DIFF
--- a/docs/changelog/0.4.4.md
+++ b/docs/changelog/0.4.4.md
@@ -34,7 +34,7 @@ More information about this new feature can be found [here](https://scala-native
 ### New sbt plugin - ScalaNativeJUnitPlugin 
 In this release we have added a new sbt plugin dedicated for easier setup of JUnit tests framework. `ScalaNativeJUnitPlugin` is a port of similar feature from Scala.js - it allows you to forget about specifying dedicated library dependencies for tests runtime. It does also ensure that JUnit plugin would no longer be included in dependencies of downstream libraries.
 
-When migrating to newer version of Scala Native you enable both Scala Native support and setup JUnit runtime with the current version using only one setting in your project `enablePlugins(ScalaNativeJUnitPlugin)`. Remember to remove the old settings needed for JUnit support:
+When migrating to newer version of Scala Native you enable both Scala Native support and setup JUnit runtime with the current version using only one setting in your project `enablePlugins(ScalaNativeJUnitPlugin)`. If building with a cross project you can use the following syntax to add it to the cross project: `.nativeConfigure(_.enablePlugins(ScalaNativeJUnitPlugin))`. Remember to remove the old settings needed for JUnit support:
 ```
 addCompilerPlugin("org.scala-native" % "junit-plugin" % nativeVersion cross CrossVersion.full)
 libraryDependencies += "org.scala-native" %%% "junit-runtime" % nativeVersion % Test


### PR DESCRIPTION
We probably need to move these into the main documentation or perhaps put them in the main docs with a link from the release notes into the main docs.