### PR TITLE
Remove non-exist build-essential from Arch Linux instructions

### DIFF
--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -79,7 +79,7 @@ installation of macOS.
 
 .. code-block:: shell
 
-    $ sudo pacman -S llvm clang build-essential
+    $ sudo pacman -S llvm clang
     $ sudo pacman -S gc # optional
 
 *Note:* A version of zlib that is sufficiently recent comes with the


### PR DESCRIPTION
```
$ sudo pacman -S llvm clang build-essential
warning: llvm-13.0.1-2 is up to date -- reinstalling
warning: clang-13.0.1-2 is up to date -- reinstalling
error: target not found: build-essential
```