### PR TITLE
Fix #2624: Move posix UdpSocketTest to corresponding directory & package

### DIFF
--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
@@ -1,4 +1,5 @@
-package java.net
+package scala.scalanative.posix
+package sys
 
 import scalanative.posix.arpa.inet._
 import scalanative.posix.fcntl

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
@@ -60,7 +60,7 @@ class UdpSocketTest {
       assertNotEquals("socket create", InvalidSocket, socket)
       socket.toInt
     } else {
-      val sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+      val sock = sys.socket.socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
       assertNotEquals("socket create", -1, sock)
       sock
     }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
@@ -147,7 +147,7 @@ class UdpSocketTest {
         val maxInData = 2 * outData.length
         val inData: Ptr[Byte] = alloc[Byte](maxInData)
 
-        // Try to prevent spourious race conditions
+        // Try to prevent spourious race conditions.
         Thread.sleep(100)
 
         def checkRecvfromResult(v: CSSize, label: String): Unit = {

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
@@ -147,7 +147,7 @@ class UdpSocketTest {
         val maxInData = 2 * outData.length
         val inData: Ptr[Byte] = alloc[Byte](maxInData)
 
-        // Try to prevent spourious race conditions.
+        // Try to prevent spurious race conditions.
         Thread.sleep(100)
 
         def checkRecvfromResult(v: CSSize, label: String): Unit = {


### PR DESCRIPTION
UdpSocketTest.scala tests posix socket routines.  This PR 
moves the file to a posix directory & package. This should
give a better clue or hint of the file's intended purpose.