### PR TITLE
Fix #2635: implement nativelib Platform.scala#isFreeBSD

### DIFF
--- a/nativelib/src/main/resources/scala-native/platform.c
+++ b/nativelib/src/main/resources/scala-native/platform.c
@@ -7,6 +7,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+int scalanative_platform_is_freebsd() {
+#if defined(__FreeBSD__)
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 int scalanative_platform_is_linux() {
 #ifdef __linux__
     return 1;

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
@@ -5,6 +5,9 @@ import scala.scalanative.unsafe.{CSize, CString, CFuncPtr2, extern, name}
 
 @extern
 object Platform {
+  @name("scalanative_platform_is_freebsd")
+  def isFreeBSD(): Boolean = extern
+
   @name("scalanative_platform_is_linux")
   def isLinux(): Boolean = extern
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/PlatformTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/PlatformTest.scala
@@ -1,0 +1,18 @@
+package scala.scalanative.runtime
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalanative.testsuite.utils
+
+import scala.scalanative.runtime
+
+class PlatformTest {
+  @Test def isFreeBSD(): Unit = {
+    val buildEnviron = utils.Platform.isFreeBSD // Test environment
+    val runtimeEnviron = runtime.Platform.isFreeBSD() // Unit under test
+
+    assertTrue(s"build: '${buildEnviron}' != runtime: '${runtimeEnviron}'",
+                 buildEnviron == runtimeEnviron)
+  }
+}

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/PlatformTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/PlatformTest.scala
@@ -12,7 +12,9 @@ class PlatformTest {
     val buildEnviron = utils.Platform.isFreeBSD // Test environment
     val runtimeEnviron = runtime.Platform.isFreeBSD() // Unit under test
 
-    assertTrue(s"build: '${buildEnviron}' != runtime: '${runtimeEnviron}'",
-                 buildEnviron == runtimeEnviron)
+    assertTrue(
+      s"build: '${buildEnviron}' != runtime: '${runtimeEnviron}'",
+      buildEnviron == runtimeEnviron
+    )
   }
 }


### PR DESCRIPTION
`nativelib runtime.Platform.scala` now provides the Boolean `isFreeBSD()` method.
