### PR TITLE
Fix I2633: posix netdb.c now has FreeBSD required include file

### DIFF
--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -1,4 +1,5 @@
 #include "netdb.h"
+#include <sys/socket.h> // yes <>, not ""
 #include "sys/socket_conversions.h"
 #include <stddef.h>
 #include <stdlib.h>


### PR DESCRIPTION
This PR is the result of teamwork.

Alain De Vos (at_devosalain) discovered and reported a defect which prevented Scala Native from
building on FreeBSD. See Issue #2633.  Alain isolated a fix and showed that Scala Native built 
successfully on FreeBSD with that fix.  Alain should be considered the primary author.  I am
just doing the administrative work of submitting a PR.  

Ekrich posted that Alain needed to sign the Scala CLA before his work could become this PR. 
Alain reported that this has been done.

I think all is in order. Thank you Alain.