### PR TITLE
Fix #2641: TGMathTest.trigonometrics reliably succeeds on Apple arm64 hardware

### DIFF
--- a/unit-tests/native/src/test/scala/scala/scalanative/TestUtils.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/TestUtils.scala
@@ -9,8 +9,19 @@ private[scalanative] object TestUtils {
     val diff = Math.abs(act - exp)
     diff <= eps(act, exp)
   }
+
+  /* The mathematically inclined and informed will notice that 'eps' here
+   * is a misnomer & misdirection (a.k.a lie).
+   *
+   * These methods have the proper math meaning only when nUlp == 1.
+   */
+
+  def eps(actual: Double, expected: Double, nUlp: Int): Double =
+    nUlp * Math.max(Math.ulp(actual), Math.ulp(expected))
+
   def eps(actual: Double, expected: Double): Double =
     2 * Math.max(Math.ulp(actual), Math.ulp(expected))
+
   def eps(actual: Float, expected: Float): Float =
     2 * Math.max(Math.ulp(actual), Math.ulp(expected))
 }


### PR DESCRIPTION
The tangent function `tan()` in the math library on Apple M1 (arm64) hardware is well known, to [some](https://members.loria.fr/PZimmermann/papers/accuracy.pdf), to sometimes return values outside of the 2 ulp (unit-in-last-place) test use in the Scala Native test environment. 

Loosen this test on macOS just enough that known differences are not triggered but unexpectedly large differences are still detected and cause the  assertion to fail. See referenced issue for detailed discussion.
