### PR TITLE
Avoid ProcessTest failures with macOS arm64 Rosetta

### DIFF
--- a/nativelib/src/main/resources/scala-native/platform/platform.c
+++ b/nativelib/src/main/resources/scala-native/platform/platform.c
@@ -4,8 +4,13 @@
 #else
 #include <sys/utsname.h>
 #endif
+
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
 
 int scalanative_platform_is_freebsd() {
 #if defined(__FreeBSD__)
@@ -29,6 +34,47 @@ int scalanative_platform_is_mac() {
 #else
     return 0;
 #endif
+}
+
+/* 'scalanative_platform_probe_mac_x8664_is_arm64' is original work
+ * for Scala Native.  It has been informed by information at these URLs:
+ *   https://developer.apple.com/documentation/kernel/1387446-sysctlbyname
+ *   https://developer.apple.com/documentation/apple-silicon/
+ *     about-the-rosetta-translation-environment#
+ *     Determine-Whether-Your-App-Is-Running-as-a-Translated-Binary
+ */
+
+// Three expected conditions, error: -1, not emulated: 0, emulated: > 0.
+
+int scalanative_platform_probe_mac_x8664_is_arm64() {
+    int translated = 0;
+
+#ifdef __APPLE__
+    size_t translatedLen = sizeof(translated);
+
+    int ret = sysctlbyname("sysctl.proc_translated", &translated,
+                           &translatedLen, NULL, 0);
+
+    if (ret < 0) {
+        /* 'errno' has been set.
+         * Do not raise C signal here because such are not Scala Native
+         * exceptions and do not play nicely.
+         * Return failure to caller and let it ignore error or
+         * raise proper Scala Native exception.
+         */
+        translated = -1;
+    }
+    // else 'translated' has been set by sysctlbyname
+
+    /* Getting the real hardware architecture is __hard__.
+     * This test assumes 'translated == 1' means "Rosetta 2 on arm64".
+     * This should be a safe assumption on any macOS more recent than
+     * 2011 or so. PowerPC translation was removed about then.
+     */
+
+#endif
+
+    return translated;
 }
 
 int scalanative_platform_is_windows() {

--- a/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala
@@ -2,6 +2,7 @@ package scala.scalanative
 package runtime
 
 import scala.scalanative.unsafe.{CSize, CString, CFuncPtr2, extern, name}
+import scala.scalanative.unsafe.CInt
 
 @extern
 object Platform {
@@ -13,6 +14,9 @@ object Platform {
 
   @name("scalanative_platform_is_mac")
   def isMac(): Boolean = extern
+
+  @name("scalanative_platform_probe_mac_x8664_is_arm64")
+  def probeMacX8664IsArm64(): CInt = extern
 
   @name("scalanative_platform_is_windows")
   def isWindows(): Boolean = extern

--- a/nativelib/src/main/scala/scala/scalanative/runtime/PlatformExt.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/PlatformExt.scala
@@ -4,7 +4,24 @@ object PlatformExt {
   private lazy val osArch =
     System.getProperty("os.arch").toLowerCase()
 
+  /* BE __EXTREMELY__ CAREFUL changing the next declaration.
+   *
+   * The declaration of 'isArm64', as implemented, is a misnomer.
+   * It does not accurately report the lowest level 'bare metal' hardware.
+   * That is, it reports "false" when the hardware is arm64 but the
+   * program is running under (Rosetta 2) translation.
+   *
+   * Normally one would correct the definition. However, there are
+   * significant parts of Scala Native which require the current definition
+   * (and fail with an inclusive & accurate one). CVarArgsList is one of
+   * these.
+   *
+   * Translated programs have os.arch == "X86_64" but may still be
+   * sensitive to hardware arm64 issues.
+   */
+
   // On M1 macs it's arm64, on windows we set it to aarch64
   // see ./nativelib/src/main/resources/scala-native/platform.c for details
+
   lazy val isArm64 = osArch == "arm64" || osArch == "aarch64"
 }

--- a/unit-tests/jvm/src/test/scala/utils/Platform.scala
+++ b/unit-tests/jvm/src/test/scala/utils/Platform.scala
@@ -32,4 +32,6 @@ object Platform {
   final val isArm64 = {
     osArch == "arm64" || osArch == "aarch64"
   }
+
+  final val hasArm64SignalQuirk = false
 }

--- a/unit-tests/native/src/test/scala/utils/Platform.scala
+++ b/unit-tests/native/src/test/scala/utils/Platform.scala
@@ -4,6 +4,8 @@ package org.scalanative.testsuite.utils
 
 import scala.scalanative.buildinfo.ScalaNativeBuildInfo
 
+import scala.scalanative.runtime
+
 object Platform {
 
   def scalaVersion: String = ScalaNativeBuildInfo.scalaVersion
@@ -25,5 +27,17 @@ object Platform {
   final val isWindows = osNameProp.toLowerCase.startsWith("windows")
   final val isMacOs = osNameProp.toLowerCase.contains("mac")
 
-  final val isArm64 = scalanative.runtime.PlatformExt.isArm64
+  final val isArm64 = runtime.PlatformExt.isArm64
+
+  /* Scala Native has problem sending C signals on Apple arm64 hardware.
+   * Hardware reporting in Scala Native is tricky. 'isArm64' reports true
+   * when the process is running directly on 'bare metal' but _not_ when
+   * the process is (Rosetta 2) translated running on arm64.
+   *
+   * The bug in question occurs in either case, so report lowest level
+   * hardware.
+   */
+
+  final val hasArm64SignalQuirk =
+    isArm64 || (runtime.Platform.probeMacX8664IsArm64() > 0)
 }

--- a/unit-tests/shared/src/test/scala/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/ProcessTest.scala
@@ -9,7 +9,7 @@ import scala.io.Source
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import org.scalanative.testsuite.utils.Platform._
+import org.scalanative.testsuite.utils.Platform, Platform._
 import scala.scalanative.junit.utils.AssumesHelper._
 
 class ProcessTest {
@@ -183,8 +183,10 @@ class ProcessTest {
 
   @Test def destroy(): Unit = {
     assumeFalse(
-      "Breaks test runner when executed in emulator",
-      !executingInJVM && isArm64
+      // Fails with traceback on mac arm64 and maybe others.
+      // See Issue #2648
+      "Test is available on arm64 hardware only when using JVM",
+      Platform.hasArm64SignalQuirk
     )
     val proc = processSleep(2.0).start()
 
@@ -195,7 +197,7 @@ class ProcessTest {
       proc.waitFor(500, TimeUnit.MILLISECONDS)
     )
     assertEquals(
-      // SIGTERM, excess 143
+      // SIGTERM, use unix signal 'excess 128' convention on non-Windows.
       if (isWindows) 1 else 0x80 + 15,
       proc.exitValue
     )
@@ -203,8 +205,10 @@ class ProcessTest {
 
   @Test def destroyForcibly(): Unit = {
     assumeFalse(
-      "Breaks test runner when executed in emulator",
-      !executingInJVM && isArm64
+      // Fails with traceback on mac arm64 and maybe others.
+      // See Issue #2648
+      "Test is available on arm64 hardware only when using JVM",
+      Platform.hasArm64SignalQuirk
     )
     val proc = processSleep(2.0).start()
 
@@ -215,7 +219,7 @@ class ProcessTest {
       p.waitFor(500, TimeUnit.MILLISECONDS)
     )
     assertEquals(
-      // SIGKILL, excess 128
+      // SIGKILL, use unix signal 'excess 128' convention on non-Windows.
       if (isWindows) 1 else 0x80 + 9,
       proc.exitValue
     )


### PR DESCRIPTION
ProcessTest now bypasses two tests which were causing it to fail in
Rosetta translated  processes.

This PR is related to Issue #2644 and bypasses an issue reported in #2650.
It can not be said to `fix` either, it just avoids provoking them.

The presenting problem is that `ProcessTest` would fail on macOS arm64 silicon
when the test process was translated by Rosetta 2.  Existing code caused the 
test to be skipped when the process was running on `bare metal`.

The significance of the problem is that Scala Native gives no guidance of
which JVM to use on Apple silicon.
 
Azul Zulu provides 'universal' images so `os.arch` gets set to the expected `arm64` .

Adoptium Temurin is available for macOS. This has evolved from OpenJDK, so 
people who have used OpenJDK are quite likely to find it before Azul.  Temurin JDK
provides a JDK for Java 8, but it has X86_64 support only, not universal.  When
someone builds Scala Native using Temurin, the test executable runs using
Rosetta.  This, and the bug(s) of Issue #2644, cause ProcessTest to fail in
a most scary and un-informative way.

