### PR TITLE
Fix #2649: RuntimeTest on unix systems now uses best guess of system 'ls' command

### DIFF
--- a/unit-tests/shared/src/test/scala/javalib/lang/RuntimeTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/RuntimeTest.scala
@@ -14,11 +14,35 @@ import scala.scalanative.junit.utils.AssumesHelper._
 class RuntimeTest {
   import ProcessUtils._
   private val EOL = System.lineSeparator()
+
+  private val isLinux =
+    System.getProperty("os.name").toLowerCase.contains("linux")
+
+  /* See Issues #2649 & #2652 re use of 'ls'.
+   * Avoid a problem with ":.:", or variants in the user's PATH definition.
+   * Historically the 'resourceDir' has contained an executable file
+   * named 'ls'. When $PATH contains "." that file gets executed
+   * rather that the system standard "ls", causing the execDir test to
+   * fail.
+   *
+   * A private "ls" being found on the user's path before the
+   * system standard "ls" causes similar issues.
+   *
+   * Guessing and using a hard coded "/usr/bin/ls" is the least bad
+   * of several design alternatives ("dir", "find").
+   *
+   * The chosen location should work on unmodified Linux, macOS, and
+   * FreeBSD systems. Given the variety of system
+   * configurations in the wild, some OS or system is bound to have 'ls'
+   * in a different location.
+   */
+
   private def lsCommand =
-    if (isWindows)
+    if (isWindows) {
       Array("cmd", "/c", "dir", "/b")
-    else
-      Array("ls")
+    } else {
+      Array("/usr/bin/ls") // See /* */ block comment immediately above.
+    }
 
   @Test def execCommand(): Unit = {
     val proc = Runtime.getRuntime.exec(lsCommand :+ resourceDir)

--- a/unit-tests/shared/src/test/scala/javalib/lang/RuntimeTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/RuntimeTest.scala
@@ -40,10 +40,8 @@ class RuntimeTest {
   private def lsCommand =
     if (isWindows) {
       Array("cmd", "/c", "dir", "/b")
-    } else if (isMacOs || isFreeBSD) {
+    } else {
       Array("/bin/ls")
-    } else { // Linux
-      Array("/usr/bin/ls")
     }
 
   @Test def execCommand(): Unit = {

--- a/unit-tests/shared/src/test/scala/javalib/lang/RuntimeTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/RuntimeTest.scala
@@ -28,10 +28,10 @@ class RuntimeTest {
    * A private "ls" being found on the user's path before the
    * system standard "ls" causes similar issues.
    *
-   * Guessing and using a hard coded "/usr/bin/ls" is the least bad
+   * Guessing and using a hard coded "ls" is the least bad
    * of several design alternatives ("dir", "find").
    *
-   * The chosen location should work on unmodified Linux, macOS, and
+   * The chosen locations should work on unmodified Linux, macOS, and
    * FreeBSD systems. Given the variety of system
    * configurations in the wild, some OS or system is bound to have 'ls'
    * in a different location.
@@ -40,8 +40,10 @@ class RuntimeTest {
   private def lsCommand =
     if (isWindows) {
       Array("cmd", "/c", "dir", "/b")
-    } else {
-      Array("/usr/bin/ls") // See /* */ block comment immediately above.
+    } else if (isMacOs || isFreeBSD) {
+      Array("/bin/ls")
+    } else { // Linux
+      Array("/usr/bin/ls")
     }
 
   @Test def execCommand(): Unit = {

--- a/unit-tests/shared/src/test/scala/javalib/lang/RuntimeTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/RuntimeTest.scala
@@ -15,9 +15,6 @@ class RuntimeTest {
   import ProcessUtils._
   private val EOL = System.lineSeparator()
 
-  private val isLinux =
-    System.getProperty("os.name").toLowerCase.contains("linux")
-
   /* See Issues #2649 & #2652 re use of 'ls'.
    * Avoid a problem with ":.:", or variants in the user's PATH definition.
    * Historically the 'resourceDir' has contained an executable file


### PR DESCRIPTION
`RuntimeTest` now succeeds for users who have ":.:" (search current directory) or variants,
'ls' alias definitions in their shell, and/or local "`s` implementations in their $PATH.

This is a "reduction in strength" fix, not a total cure. That is, the test should work
outside the Scala Native Continuous Integration environment for more developers,
but there are still ways to break it.

The chosen best guess for the location of the system `ls` program (`/bin/ls`) is the best
of several bad design alternatives.  It should work on unmodified Linux, macOS, & FreeBSD
systems.