### PR TITLE
Fix #2660, #2661: Provide Posix netdb gai_strerror method and associated EAI definitions

### DIFF
--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -1,6 +1,8 @@
 #include "netdb.h"
 
-#ifndef _WIN32
+#ifdef _WIN32
+#include <Winerror.h>
+#else // not _WIN32
 // FreeBSD wants AF_INET, which is in <sys/socket.h> but not in the local
 // "sys/socket.h".
 //
@@ -134,6 +136,7 @@ int scalanative_ai_canonname() { return AI_CANONNAME; }
 
 // EAI_* items are declared in the order of Posix specification
 
+#ifndef _WIN32
 int scalanative_eai_again() { return EAI_AGAIN; }
 
 int scalanative_eai_badflags() { return EAI_BADFLAGS; }
@@ -153,3 +156,32 @@ int scalanative_eai_socktype() { return EAI_SOCKTYPE; }
 int scalanative_eai_system() { return EAI_SYSTEM; }
 
 int scalanative_eai_overflow() { return EAI_OVERFLOW; }
+
+#else // _Win32
+/* Reference:  https://docs.microsoft.com/en-us/windows/win32/api
+ *                 /ws2tcpip/nf-ws2tcpip-getaddrinfo
+ */
+
+int scalanative_eai_again() { return WSATRY_AGAIN; }
+
+int scalanative_eai_badflags() { return WSAEINVAL; }
+
+int scalanative_eai_fail() { return WSANO_RECOVERY; }
+
+int scalanative_eai_family() { return WSAEAFNOSUPPORT; }
+
+int scalanative_eai_memory() { return WSA_NOT_ENOUGH_MEMORY; }
+
+int scalanative_eai_noname() { return WSAHOST_NOT_FOUND; }
+
+int scalanative_eai_service() { return WSATYPE_NOT_FOUND; }
+
+int scalanative_eai_socktype() { return WSAESOCKTNOSUPPORT; }
+
+// Windows seems not to have an equivalent, use ubiquitous -1
+int scalanative_eai_system() { return -1; }
+
+// Windows seems not to have an equivalent, use ubiquitous -1
+int scalanative_eai_overflow() { return -1; }
+
+#endif // _Win32

--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -131,3 +131,25 @@ int scalanative_ai_addrconfig() { return AI_ADDRCONFIG; }
 int scalanative_ai_v4mapped() { return AI_V4MAPPED; }
 
 int scalanative_ai_canonname() { return AI_CANONNAME; }
+
+// EAI_* items are declared in the order of Posix specification
+
+int scalanative_eai_again() { return EAI_AGAIN; }
+
+int scalanative_eai_badflags() { return EAI_BADFLAGS; }
+
+int scalanative_eai_fail() { return EAI_FAIL; }
+
+int scalanative_eai_family() { return EAI_FAMILY; }
+
+int scalanative_eai_memory() { return EAI_MEMORY; }
+
+int scalanative_eai_noname() { return EAI_NONAME; }
+
+int scalanative_eai_service() { return EAI_SERVICE; }
+
+int scalanative_eai_socktype() { return EAI_SOCKTYPE; }
+
+int scalanative_eai_system() { return EAI_SYSTEM; }
+
+int scalanative_eai_overflow() { return EAI_OVERFLOW; }

--- a/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
@@ -13,6 +13,9 @@ object netdb {
   @name("scalanative_freeaddrinfo")
   def freeaddrinfo(addr: Ptr[addrinfo]): Unit = extern
 
+  // direct call to C
+  def gai_strerror(errcode: CInt): CString = extern
+
   @name("scalanative_getaddrinfo")
   def getaddrinfo(
       name: CString,
@@ -49,6 +52,38 @@ object netdb {
 
   @name("scalanative_ai_canonname")
   def AI_CANONNAME: CInt = extern
+
+  // EAI_* items are declared in the order of Posix specification
+
+  @name("scalanative_eai_again")
+  def EAI_AGAIN: CInt = extern
+
+  @name("scalanative_eai_badflags")
+  def EAI_BADFLAGS: CInt = extern
+
+  @name("scalanative_eai_fail")
+  def EAI_FAIL: CInt = extern
+
+  @name("scalanative_eai_family")
+  def EAI_FAMILY: CInt = extern
+
+  @name("scalanative_eai_memory")
+  def EAI_MEMORY: CInt = extern
+
+  @name("scalanative_eai_noname")
+  def EAI_NONAME: CInt = extern
+
+  @name("scalanative_eai_service")
+  def EAI_SERVICE: CInt = extern
+
+  @name("scalanative_eai_socktype")
+  def EAI_SOCKTYPE: CInt = extern
+
+  @name("scalanative_eai_system")
+  def EAI_SYSTEM: CInt = extern
+
+  @name("scalanative_eai_overflow")
+  def EAI_OVERFLOW: CInt = extern
 }
 
 object netdbOps {

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/NetdbTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/NetdbTest.scala
@@ -1,0 +1,57 @@
+package scala.scalanative.posix
+
+import org.scalanative.testsuite.utils.Platform
+
+import scalanative.unsafe._
+
+import scalanative.meta.LinktimeInfo.isWindows
+
+import scalanative.libc.string.strlen
+
+import scalanative.posix.netdb._
+import scalanative.posix.netdbOps._
+import scalanative.posix.sys.socket.{AF_INET, SOCK_DGRAM}
+
+import org.junit.Test
+import org.junit.Assert._
+
+class NetdbTest {
+
+  @Test def gai_strerrorMustTranslateErrorCodes(): Unit = Zone { implicit z =>
+    if (!isWindows) {
+      val resultPtr = stackalloc[Ptr[addrinfo]]()
+
+      // Workaround Issue #2314 - getaddrinfo fails with null hints.
+      val hints = stackalloc[addrinfo]()
+      hints.ai_family = AF_INET
+      hints.ai_socktype = SOCK_DGRAM
+
+      // Calling with no host & no service should cause gai error EAI_NONAME.
+      val status = getaddrinfo(null, null, hints, resultPtr);
+
+      assertNotEquals(s"Expected getaddrinfo call to fail,", 0, status)
+
+      assertEquals(s"Unexpected getaddrinfo failure,", EAI_NONAME, status)
+
+      val gaiFailureMsg = gai_strerror(status)
+
+      assertNotNull(s"gai_strerror returned NULL/null,", status)
+
+      /* Check that translated text exists but not for the exact text.
+       * The text may vary by operating system and C locale.
+       * Such translations from integers to varying text is gai_strerror()'s
+       * very reason for being.
+       *
+       * One common linux translation of EAI_NONAME is:
+       * "Name or service not known".
+       */
+
+      assertNotEquals(
+        s"gai_strerror returned zero length string,",
+        0,
+        strlen(gaiFailureMsg)
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
 We implement the `gai_strerror` method and `EAI_*` definitions as described in the Posix specification
for `netdb.h`. Posix `netdb.scala` becomes incrementally more complete.

Full disclosure for reviewers about the Windows implementation:
Windows seems not to have the `EAI_*` values defined for C.
I followed:
```
/* Reference:  https://docs.microsoft.com/en-us/windows/win32/api               
 *                 /ws2tcpip/nf-ws2tcpip-getaddrinfo                            
 */
```
Two Posix `EAI_` were not documented as having an
equivalent in Windows.  I used the general unix 
error code of -1.   This could probably be improved
upon by a Windows expert.

 ```
// Windows seems not to have an equivalent, use ubiquitous -1                   
int scalanative_eai_system() { return -1; }

// Windows seems not to have an equivalent, use ubiquitous -1                   
int scalanative_eai_overflow() { return -1; }
```