### PR TITLE
Fix #2314: Posix netdb getaddrinfo now handles null hints arguments correctly

### DIFF
--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -37,20 +37,25 @@ void scalanative_convert_scalanative_addrinfo(struct scalanative_addrinfo *in,
                                               struct addrinfo *out) {
     // ai_addr and ai_next fields are set to NULL because this function is only
     // used for converting hints parameter for the getaddrinfo function, which
-    // doesn't
-    // care about them
-    out->ai_flags = in->ai_flags;
-    out->ai_family = in->ai_family;
-    out->ai_socktype = in->ai_socktype;
-    out->ai_protocol = in->ai_protocol;
-    out->ai_addrlen = in->ai_addrlen;
-    if (in->ai_canonname == NULL) {
-        out->ai_canonname = NULL;
+    // doesn't care about them
+    if (in == NULL) {
+        // Use of Posix spec of ai_flags being 0, not GNU extension value.
+        memset(out, 0, sizeof(struct addrinfo));
+        out->ai_family = AF_UNSPEC;
     } else {
-        out->ai_canonname = strdup(in->ai_canonname);
+        out->ai_flags = in->ai_flags;
+        out->ai_family = in->ai_family;
+        out->ai_socktype = in->ai_socktype;
+        out->ai_protocol = in->ai_protocol;
+        out->ai_addrlen = in->ai_addrlen;
+        if (in->ai_canonname == NULL) {
+            out->ai_canonname = NULL;
+        } else {
+            out->ai_canonname = strdup(in->ai_canonname);
+        }
+        out->ai_addr = NULL;
+        out->ai_next = NULL;
     }
-    out->ai_addr = NULL;
-    out->ai_next = NULL;
 }
 
 void scalanative_convert_addrinfo(struct addrinfo *in,

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/NetdbTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/NetdbTest.scala
@@ -1,21 +1,107 @@
 package scala.scalanative.posix
 
 import org.scalanative.testsuite.utils.Platform
-
-import scalanative.unsafe._
-
 import scalanative.meta.LinktimeInfo.isWindows
 
-import scalanative.libc.string.strlen
+import scala.annotation.tailrec
+
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+import scalanative.libc.string.{strlen, strncmp}
 
 import scalanative.posix.netdb._
 import scalanative.posix.netdbOps._
-import scalanative.posix.sys.socket.{AF_INET, SOCK_DGRAM}
+import scalanative.posix.sys.socket.{AF_INET, AF_UNSPEC, SOCK_DGRAM}
 
 import org.junit.Test
 import org.junit.Assert._
 
 class NetdbTest {
+
+  @tailrec
+  private def compareAddrinfoLists(
+      ai1Ptr: Ptr[addrinfo],
+      ai2Ptr: Ptr[addrinfo]
+  ): Unit = {
+
+    if (((ai1Ptr == null) || (ai2Ptr == null))) {
+      assertEquals("unmatched addrinfo null pointers,", ai1Ptr, ai2Ptr)
+    } else {
+      assertEquals(
+        s"unmatched field: ai_flags, ",
+        ai1Ptr.ai_flags,
+        ai2Ptr.ai_flags
+      )
+
+      assertEquals(
+        s"unmatched field: ai_family, ",
+        ai1Ptr.ai_family,
+        ai2Ptr.ai_family
+      )
+
+      assertEquals(
+        s"unmatched field: ai_socktype, ",
+        ai1Ptr.ai_socktype,
+        ai2Ptr.ai_socktype
+      )
+
+      assertEquals(
+        s"unmatched field: ai_protocol, ",
+        ai1Ptr.ai_protocol,
+        ai2Ptr.ai_protocol
+      )
+
+      assertEquals(
+        s"unmatched field: ai_addrlen, ",
+        ai1Ptr.ai_addrlen,
+        ai2Ptr.ai_addrlen
+      )
+
+      if (((ai1Ptr.ai_canonname == null) || (ai2Ptr.ai_canonname == null))) {
+        assertEquals("ai_canonname,", ai1Ptr.ai_canonname, ai2Ptr.ai_canonname)
+      } else {
+
+        val cmp = strncmp(
+          ai1Ptr.ai_canonname,
+          ai2Ptr.ai_canonname,
+          // 255 is largest FQDN (fully qualified domain name) allowed.
+          255.toUInt
+        )
+
+        if (cmp != 0) {
+          val ai1Name = fromCString(ai1Ptr.ai_canonname)
+          val ai2Name = fromCString(ai2Ptr.ai_canonname)
+
+          assertEquals(s"ai_canonname: '${ai1Name}' != '${ai2Name}'", 0, cmp)
+        }
+      }
+
+      compareAddrinfoLists(
+        ai1Ptr.ai_next.asInstanceOf[Ptr[addrinfo]],
+        ai2Ptr.ai_next.asInstanceOf[Ptr[addrinfo]]
+      )
+    }
+  }
+
+  private def callGetaddrinfo(host: CString, hints: Ptr[addrinfo])(implicit
+      z: Zone
+  ): Ptr[addrinfo] = {
+
+    val resultPtr = stackalloc[Ptr[addrinfo]]()
+
+    val status = getaddrinfo(host, null, hints, resultPtr);
+
+    assertEquals(
+      s"getaddrinfo failed: ${fromCString(gai_strerror(status))}",
+      0,
+      status
+    )
+
+    assertNotNull("getaddrinfo returned empty list", !resultPtr)
+
+    !resultPtr
+  }
 
   @Test def gai_strerrorMustTranslateErrorCodes(): Unit = Zone { implicit z =>
     if (!isWindows) {
@@ -52,6 +138,51 @@ class NetdbTest {
         strlen(gaiFailureMsg)
       )
     }
+  }
+
+  @Test def getaddrinfoWithNullHintsShouldFollowPosixSpec(): Unit = Zone {
+    implicit z =>
+      if (!isWindows) {
+
+        val host = c"127.0.0.1"
+
+        val nullHintsAiPtr = callGetaddrinfo(host, null)
+
+        try {
+
+          /* Calling getaddrinfo with these hints and with null hints
+           * should return identical results.
+           *
+           * In particular, ai_flags are left with the 0 as created
+           * by stackalloc(). This is the value defined by Posix.
+           * GNU defines a different and possibly more useful value.
+           *
+           * The provided hints are from the Posix specification of the
+           * equivalent of calling getaddrinfo null hints. The two
+           * results should match.
+           */
+
+          val hints = stackalloc[addrinfo]()
+          hints.ai_family = AF_UNSPEC
+
+          val defaultHintsAiPtr = callGetaddrinfo(host, hints)
+
+          try {
+            assertEquals(
+              s"unexpected ai_family,",
+              AF_INET,
+              nullHintsAiPtr.ai_family
+            )
+
+            compareAddrinfoLists(nullHintsAiPtr, defaultHintsAiPtr)
+
+          } finally {
+            freeaddrinfo(defaultHintsAiPtr)
+          }
+        } finally {
+          freeaddrinfo(nullHintsAiPtr)
+        }
+      }
   }
 
 }


### PR DESCRIPTION
Posix `netdb.scala#getaddrinfo` method now handle null hints arguments as specified.