### PR TITLE
Fix #2657: Three posix time.h variables no longer require empty parentheses

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -138,15 +138,15 @@ object time {
 // POSIX variables (vals, not vars)
 
   @name("scalanative_daylight")
-  def daylight(): CInt = extern
+  def daylight: CInt = extern
 
   // XSI
   @name("scalanative_timezone")
-  def timezone(): CLong = extern
+  def timezone: CLong = extern
 
   // XSI
   @name("scalanative_tzname")
-  def tzname(): Ptr[CStruct2[CString, CString]] = extern
+  def tzname: Ptr[CStruct2[CString, CString]] = extern
 
 // Macros
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -91,7 +91,7 @@ class TimeTest {
        */
 
       val time_ptr = stackalloc[time_t]()
-      !time_ptr = epoch + timezone()
+      !time_ptr = epoch + timezone
       val time: Ptr[tm] = localtime(time_ptr)
       val cstr: CString = asctime(time)
       val str: String = fromCString(cstr)
@@ -110,7 +110,7 @@ class TimeTest {
         // See _essential_ comment in corresponding localtime test about logic.
 
         val time_ptr = stackalloc[time_t]()
-        !time_ptr = epoch + timezone()
+        !time_ptr = epoch + timezone
         val time: Ptr[tm] = localtime_r(time_ptr, alloc[tm]())
         val cstr: CString = asctime_r(time, alloc[Byte](26.toUSize))
         val str: String = fromCString(cstr)

--- a/windowslib/src/main/scala/scala/scalanative/windows/crt/time.scala
+++ b/windowslib/src/main/scala/scala/scalanative/windows/crt/time.scala
@@ -40,11 +40,11 @@ object time {
   def tzset(): Unit = extern
 
   @name("_daylight")
-  def daylight(): CInt = extern
+  def daylight: CInt = extern
 
   @name("_timezone")
-  def timezone(): CLong = extern
+  def timezone: CLong = extern
 
   @name("_tzname")
-  def tzname(): Ptr[CStruct2[CString, CString]] = extern
+  def tzname: Ptr[CStruct2[CString, CString]] = extern
 }


### PR DESCRIPTION
##### This probably needs to be on the 0.5.0 train: Source incompatibility.

Posix `time.h` defines three variable: `daylight`, `timezone`, and  `tzname`. In Scala parlance, these 
need be parameterless, not zero argument (arity-0), methods. as they do not have side effects.
`timezone()` is changed to `timezone` are as the other two, *mutatis mutandis`.

Deprecating the existing zero argument methods and supplying new parameterless
methods was considered but proved not to be feasible, due to duplicate definitions.

##### Reviewer(s): 
Windows is not posix, but it seemed to make sense to make the corresponding
changes in `windows/time.c`.
