### PR TITLE
Fix #2643: Assumption in javalib SocketTest#soTimeout is now simpler

### DIFF
--- a/unit-tests/jvm/src/test/scala/utils/Platform.scala
+++ b/unit-tests/jvm/src/test/scala/utils/Platform.scala
@@ -25,8 +25,9 @@ object Platform {
 
   private val osNameProp = System.getProperty("os.name")
   final val isFreeBSD = osNameProp.equals("FreeBSD")
-  final val isWindows = osNameProp.toLowerCase.startsWith("windows")
+  final val isLinux = osNameProp.toLowerCase.contains("linux")
   final val isMacOs = osNameProp.toLowerCase.contains("mac")
+  final val isWindows = osNameProp.toLowerCase.startsWith("windows")
 
   private val osArch = System.getProperty("os.arch").toLowerCase(Locale.ROOT)
   final val isArm64 = {

--- a/unit-tests/native/src/test/scala/utils/Platform.scala
+++ b/unit-tests/native/src/test/scala/utils/Platform.scala
@@ -23,9 +23,10 @@ object Platform {
   final val hasCompliantAsInstanceOfs = true
 
   private val osNameProp = System.getProperty("os.name")
-  final val isFreeBSD = osNameProp.equals("FreeBSD")
-  final val isWindows = osNameProp.toLowerCase.startsWith("windows")
-  final val isMacOs = osNameProp.toLowerCase.contains("mac")
+  final val isFreeBSD = runtime.Platform.isFreeBSD()
+  final val isLinux = runtime.Platform.isLinux()
+  final val isMacOs = runtime.Platform.isMac()
+  final val isWindows = runtime.Platform.isWindows()
 
   final val isArm64 = runtime.PlatformExt.isArm64
 

--- a/unit-tests/shared/src/test/scala/javalib/net/SocketTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/SocketTest.scala
@@ -72,10 +72,10 @@ class SocketTest {
   @Test def soTimeout(): Unit = {
     assumeFalse(
       "getsockopt return not yet supported error on aarch64-linux-gnu",
-      Platform.isArm64 &&
-        !Platform.executingInJVM &&
-        !(Platform.isWindows || Platform.isMacOs)
+      Platform.isArm64 && Platform.isLinux &&
+        !Platform.executingInJVM
     )
+
     val s = new Socket()
     try {
       val prevValue = s.getSoTimeout


### PR DESCRIPTION
We modify an `assumeFalse()` statement in javalib `SocketTest#soTimeout` test so that the implementation
more closely matches the comment immediately above it. See one, do one.
```
   assumeFalse(
      "getsockopt return not yet supported error on aarch64-linux-gnu",
      Platform.isArm64 && Platform.isLinux &&
        !Platform.executingInJVM
    )
```
The increased parallelism makes it easier, for some, to suss the intended behavior.

1) An `isLinux` parameterless method was added to each of two `unit-tests` `Platform.scala` files:
```     
unit-tests/jvm/src/test/scala/utils/Platform.scala
unit-tests/native/src/test/scala/utils/Platform.scala
```
2) The `native` `Platform.scala` is now "single point of truth".
    It refers to the `runtime` `Platform.scala` file (which
    already had an `isLinux()` method.

    This way, the `runtime` methods get exercised by
     a native build, reducing the chance for unwanted
     variation.