### PR TITLE
Fix #2666: posix dirent constants are now parameterless methods

### DIFF
--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -31,8 +31,8 @@ object FileHelpers {
     case object Link extends FileType
 
     private[scalanative] def unixFileType(tpe: CInt) =
-      if (tpe == DT_LNK()) Link
-      else if (tpe == DT_DIR()) Directory
+      if (tpe == DT_LNK) Link
+      else if (tpe == DT_DIR) Directory
       else Normal
 
     private[scalanative] def windowsFileType(attributes: DWord) = {

--- a/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/dirent.scala
@@ -21,21 +21,21 @@ object dirent {
   def closedir(dirp: Ptr[DIR]): CInt = extern
 
   @name("scalanative_dt_unknown")
-  def DT_UNKNOWN(): CInt = extern
+  def DT_UNKNOWN: CInt = extern
   @name("scalanative_dt_fifo")
-  def DT_FIFO(): CInt = extern
+  def DT_FIFO: CInt = extern
   @name("scalanative_dt_chr")
-  def DT_CHR(): CInt = extern
+  def DT_CHR: CInt = extern
   @name("scalanative_dt_dir")
-  def DT_DIR(): CInt = extern
+  def DT_DIR: CInt = extern
   @name("scalanative_dt_blk")
-  def DT_BLK(): CInt = extern
+  def DT_BLK: CInt = extern
   @name("scalanative_dt_reg")
-  def DT_REG(): CInt = extern
+  def DT_REG: CInt = extern
   @name("scalanative_dt_lnk")
-  def DT_LNK(): CInt = extern
+  def DT_LNK: CInt = extern
   @name("scalanative_dt_sock")
-  def DT_SOCK(): CInt = extern
+  def DT_SOCK: CInt = extern
   @name("scalanative_dt_wht")
-  def DT_WHT(): CInt = extern
+  def DT_WHT: CInt = extern
 }


### PR DESCRIPTION
##### This PR introduces a small source incompatibility so it needs to be on the 0.5.0 train.

Posixlib `dirent.scala` now follows the convention across Scala Native posixlib
that Posix C constants are Scala parameterless (zero-arity)  methods.
