### PR TITLE
Fix #2395: posixlib usleep method is now deprecated

### DIFF
--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -33,7 +33,14 @@ object unistd {
   def sleep(seconds: CUnsignedInt): CUnsignedInt = extern
   def truncate(path: CString, length: off_t): CInt = extern
   def unlink(path: CString): CInt = extern
+
+  // Maintainer: See 'Developer Note' in Issue #2395 about complete removal.
+  @deprecated(
+    "Removed in POSIX.1-2008. Use POSIX time.h nanosleep().",
+    "posixlib 0.4.5"
+  )
   def usleep(usecs: CUnsignedInt): CInt = extern
+
   def vfork(): CInt = extern
   def write(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
 


### PR DESCRIPTION
The POSIX  `unistd.scala` `usleep()` method is deprecated. 

See the referenced issue for background and discussion of
how to handle `usleep()` after the deprecation period.

  `usleep()` was declared obsolete in POSIX.1-2001 and removed in POSIX.1-2008.

There are no uses of `usleep()` within the Scala Native repository.

Tested privately with the results below. Short story is that 
all is as intended & expected. For those who like to see
the raw data:
```
Scalac default is --deprecation: false	
[warn] there was 1 deprecation warning; re-run with -deprecation for details
[warn] one warning found

program runs

Scalac with explicitly enabled --deprecation, no "-Xfatal-warnings"

[warn] 23 |    val status = unistd.usleep(10.toUInt)
[warn]    |                 ^^^^^^^^^^^^^
[warn]    |method usleep in object unistd is deprecated since posixlib 0.4.5: R\
emoved in POSIX.1-2008. Use POSIX time.h nanosleep().

program runs

Scalac with explicitly enabled --deprecation, with enabled "-Xfatal-warnings"

[error] 23 |    val status = unistd.usleep(10.toUInt)
[error]    |                 ^^^^^^^^^^^^^
[error]    |method usleep in object unistd is deprecated since posixlib 0.4.5: \
Removed in POSIX.1-2008. Use POSIX time.h nanosleep().
[error] one error found
[error] (sandbox3 / Compile / compileIncremental) Compilation failed

compilations stops, program never runs.
```
             