### PR TITLE
Port new implementation of TreeSet and PriorityQueue from Scala.js

### DIFF
--- a/javalib/src/main/scala-2.11/scala/scalanative/compat/annotation.scala
+++ b/javalib/src/main/scala-2.11/scala/scalanative/compat/annotation.scala
@@ -1,0 +1,8 @@
+package scala.scalanative.compat
+
+import scala.annotation.StaticAnnotation
+
+object annotation {
+  // Stub for nowarn annotations to allow compilation with legacy versions of Scala
+  class nowarn(value: String = "") extends StaticAnnotation
+}

--- a/javalib/src/main/scala-2.12/scala/scalanative/compat/annotation.scala
+++ b/javalib/src/main/scala-2.12/scala/scalanative/compat/annotation.scala
@@ -1,0 +1,8 @@
+package scala.scalanative.compat
+
+import scala.annotation.StaticAnnotation
+
+object annotation {
+  // Stub for nowarn annotations to allow compilation with legacy versions of Scala
+  class nowarn(value: String = "") extends StaticAnnotation
+}

--- a/javalib/src/main/scala-2.13/scala/scalanative/compat/annotation.scala
+++ b/javalib/src/main/scala-2.13/scala/scalanative/compat/annotation.scala
@@ -1,0 +1,5 @@
+package scala.scalanative.compat
+
+object annotation {
+  type nowarn = scala.annotation.nowarn
+}

--- a/javalib/src/main/scala-3/scala/scalanative/compat/annotation.scala
+++ b/javalib/src/main/scala-3/scala/scalanative/compat/annotation.scala
@@ -1,0 +1,5 @@
+package scala.scalanative.compat
+
+object annotation {
+  type nowarn = scala.annotation.nowarn
+}

--- a/javalib/src/main/scala/java/util/NaturalComparator.scala
+++ b/javalib/src/main/scala/java/util/NaturalComparator.scala
@@ -1,0 +1,48 @@
+// Ported from Scala.js, revision 67d32b0, dated 1 Aug 2019
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util
+
+/** A universal `Comparator` using the *natural ordering* of the elements.
+ *
+ *  A number of JDK APIs accept a possibly-null `Comparator`, and use the
+ *  *natural ordering* of elements when it is `null`. This universal comparator
+ *  can be used internally instead of systematically testing for `null`,
+ *  simplifying code paths.
+ *
+ *  The `compare()` method of this comparator throws `ClassCastException`s when
+ *  used with values that cannot be compared using natural ordering, assuming
+ *  Scala.js is configured with compliant `asInstanceOf`s. The behavior is
+ *  otherwise undefined.
+ */
+private[util] object NaturalComparator extends Comparator[Any] {
+  def compare(o1: Any, o2: Any): Int =
+    o1.asInstanceOf[Comparable[Any]].compareTo(o2)
+
+  /** Selects the given comparator if it is non-null, otherwise the natural
+   *  comparator.
+   */
+  def select[A](comparator: Comparator[A]): Comparator[_ >: A] =
+    if (comparator eq null) this
+    else comparator
+
+  /** Unselects the given comparator, returning `null` if it was the natural
+   *  comparator.
+   *
+   *  This method is useful to re-expose to a public API an internal comparator
+   *  that was obtained with `select()`.
+   */
+  def unselect[A](comparator: Comparator[A]): Comparator[A] =
+    if (comparator eq this) null
+    else comparator
+}

--- a/javalib/src/main/scala/java/util/PriorityQueue.scala
+++ b/javalib/src/main/scala/java/util/PriorityQueue.scala
@@ -1,147 +1,313 @@
+// Ported from Scala.js, revision: 6819668, dated 7 Oct 2020
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
-import java.lang.Comparable
-import scala.math.Ordering
-import scala.collection.mutable
 import scala.annotation.tailrec
-import scala.language.existentials
+import scala.annotation.nowarn
 
-class PriorityQueue[E] protected (
-    ordering: Ordering[_ >: E],
-    _comparator: Comparator[_ >: E]
+class PriorityQueue[E] private (
+    private val comp: Comparator[_ >: E],
+    internal: Boolean
 ) extends AbstractQueue[E]
-    with Serializable { self =>
+    with Serializable {
+
+  def this() =
+    this(NaturalComparator, internal = true)
 
   def this(initialCapacity: Int) = {
-    this(defaultOrdering[E], null.asInstanceOf[Comparator[_ >: E]])
+    this()
     if (initialCapacity < 1)
       throw new IllegalArgumentException()
   }
 
-  def this() =
-    this(11)
+  def this(comparator: Comparator[_ >: E]) = {
+    this(NaturalComparator.select(comparator), internal = true)
+  }
 
   def this(initialCapacity: Int, comparator: Comparator[_ >: E]) = {
-    this(
-      PriorityQueue.safeGetOrdering[E](comparator),
-      null.asInstanceOf[Comparator[E]]
-    )
+    this(comparator)
     if (initialCapacity < 1)
       throw new IllegalArgumentException()
   }
 
   def this(c: Collection[_ <: E]) = {
-    this(defaultOrdering[E], null.asInstanceOf[Comparator[E]])
+    this(
+      c match {
+        case c: PriorityQueue[_] =>
+          c.comp.asInstanceOf[Comparator[_ >: E]]
+        case c: SortedSet[_] =>
+          NaturalComparator.select(
+            c.comparator().asInstanceOf[Comparator[_ >: E]]
+          )
+        case _ =>
+          NaturalComparator
+      },
+      internal = true
+    )
     addAll(c)
   }
 
   def this(c: PriorityQueue[_ <: E]) = {
-    this(
-      PriorityQueue.safeGetOrdering[E](c.comparator()),
-      c.comparator().asInstanceOf[Comparator[E]]
-    )
+    this(c.comp.asInstanceOf[Comparator[_ >: E]], internal = true)
     addAll(c)
   }
 
   def this(sortedSet: SortedSet[_ <: E]) = {
     this(
-      PriorityQueue.safeGetOrdering[E](sortedSet.comparator()),
-      sortedSet.comparator().asInstanceOf[Comparator[E]]
+      NaturalComparator.select(
+        sortedSet.comparator().asInstanceOf[Comparator[_ >: E]]
+      ),
+      internal = true
     )
     addAll(sortedSet)
   }
 
-  private implicit object BoxOrdering extends Ordering[Box[E]] {
-    def compare(a: Box[E], b: Box[E]): Int = ordering.compare(b.inner, a.inner)
-  }
-
-  private val inner: mutable.PriorityQueue[Box[E]] =
-    new mutable.PriorityQueue[Box[E]]()
+  // The index 0 is not used; the root is at index 1.
+  // This is standard practice in binary heaps, to simplify arithmetics.
+  private[this] var inner = new Array[Any](16).asInstanceOf[Array[E]]
+  // Size of the objects stored in the inner array
+  private[this] var innerNextIdx = 1
 
   override def add(e: E): Boolean = {
-    if (e == null) throw new NullPointerException()
-    else {
-      inner += Box(e)
-      true
+    if (e == null)
+      throw new NullPointerException()
+    if (innerNextIdx >= innerNextIdx) {
+      inner = Array.copyOf(inner, innerNextIdx * 2)
     }
+    inner(innerNextIdx) = e
+    fixUp(innerNextIdx)
+    innerNextIdx += 1
+    true
   }
 
   def offer(e: E): Boolean = add(e)
 
   def peek(): E =
-    inner.headOption.fold(null.asInstanceOf[E])(_.inner)
+    if (innerNextIdx > 1) inner(1)
+    else null.asInstanceOf[E]
 
   override def remove(o: Any): Boolean = {
-    val boxed = Box(o.asInstanceOf[E])
-    val initialSize = inner.size
+    if (o == null) {
+      false
+    } else {
+      val len = innerNextIdx
+      var i = 1
+      while (i != len && !o.equals(inner(i): @nowarn)) {
+        i += 1
+      }
 
-    @tailrec
-    def takeLeft(
-        part: mutable.PriorityQueue[Box[E]]
-    ): mutable.PriorityQueue[Box[E]] = {
-      if (inner.isEmpty) part
-      else {
-        val next = inner.dequeue()
-        if (boxed == next) part
-        else if (BoxOrdering.compare(boxed, next) > 0)
-          part += next
-        else takeLeft(part += next)
+      if (i != len) {
+        removeAt(i)
+        true
+      } else {
+        false
       }
     }
-
-    val left = takeLeft(new mutable.PriorityQueue[Box[E]]())
-    inner ++= left
-
-    (inner.size != initialSize)
   }
 
-  override def contains(o: Any): Boolean =
-    inner.exists(_ === Box(o))
+  private def removeExact(o: Any): Unit = {
+    val len = innerNextIdx
+    var i = 1
+    while (i != len && (o.asInstanceOf[AnyRef] ne inner(i)
+          .asInstanceOf[AnyRef])) {
+      i += 1
+    }
+    if (i == len)
+      throw new ConcurrentModificationException()
+    removeAt(i)
+  }
+
+  private def removeAt(i: Int): Unit = {
+    val newLength = innerNextIdx - 1
+    innerNextIdx = newLength
+    if (i == newLength) {
+      inner(i) = null.asInstanceOf[E]
+    } else {
+      inner(i) = inner(newLength)
+      fixUpOrDown(i)
+    }
+  }
+
+  override def contains(o: Any): Boolean = {
+    if (o == null) {
+      false
+    } else {
+      val len = innerNextIdx
+      var i = 1
+      while (i != len && !o.equals(inner(i)): @nowarn) {
+        i += 1
+      }
+      i != len
+    }
+  }
 
   def iterator(): Iterator[E] = {
     new Iterator[E] {
-      private val iter = inner.clone.iterator
+      private[this] var inner: Array[E] = PriorityQueue.this.inner
+      private[this] var innerSize = innerNextIdx
+      private[this] var nextIdx: Int = 1
+      private[this] var last: E = _ // null
 
-      private var last: Option[E] = None
-
-      def hasNext(): Boolean = iter.hasNext
+      def hasNext(): Boolean = nextIdx < innerSize
 
       def next(): E = {
-        last = Some(iter.next().inner)
-        last.get
+        if (!hasNext())
+          throw new NoSuchElementException("empty iterator")
+        last = inner(nextIdx)
+        nextIdx += 1
+        last
       }
 
       override def remove(): Unit = {
-        if (last.isEmpty) {
+        /* Once we start removing elements, the inner array of the enclosing
+         * PriorityQueue will be modified in arbitrary ways. In particular,
+         * entries yet to be iterated can be moved before `nextIdx` if the
+         * removal requires a `fixUp()`.
+         *
+         * Therefore, at the first removal, we take a snapshot of the remainder
+         * of the inner array yet to be iterated, and continue iterating over
+         * the snapshot.
+         *
+         * We use a linear lookup based on reference equality to precisely
+         * remove the entries that we are still iterating over (in
+         * `removeExact()`).
+         *
+         * This means that this method is O(n), contrary to typical
+         * expectations for `Iterator.remove()`. I could not come up with a
+         * better algorithm.
+         */
+
+        if (last == null)
           throw new IllegalStateException()
-        } else {
-          last.foreach(self.remove(_))
-          last = None
+        if (inner eq PriorityQueue.this.inner) {
+          innerSize = innerNextIdx - nextIdx
+          val arr = new Array[Any](innerSize)
+          Array.copy(inner, nextIdx, arr, 0, innerSize)
+          inner = arr.asInstanceOf[Array[E]]
+          nextIdx = 0
         }
+        removeExact(last)
+        last = null.asInstanceOf[E]
       }
     }
   }
 
-  def size(): Int = inner.size
+  def size(): Int = innerNextIdx - 1
 
-  override def clear(): Unit =
-    inner.dequeueAll
+  override def clear(): Unit = {
+    var i = 1
+    while (i != innerNextIdx) {
+      inner(i) = null.asInstanceOf[E]
+      i += 1
+    }
+    innerNextIdx = 1
+  }
 
-  def poll(): E =
-    if (inner.isEmpty) null.asInstanceOf[E]
-    else inner.dequeue().inner
+  def poll(): E = {
+    val inner = this.inner // local copy
+    if (innerNextIdx > 1) {
+      val newSize = innerNextIdx - 1
+      val result = inner(1)
+      inner(1) = inner(newSize)
+      innerNextIdx = newSize
+      fixDown(1)
+      result
+    } else {
+      null.asInstanceOf[E]
+    }
+  }
 
-  def comparator(): Comparator[_ >: E] = _comparator
-}
+  def comparator(): Comparator[_ >: E] =
+    NaturalComparator.unselect(comp)
 
-object PriorityQueue {
+  // Heavy lifting: heap fixup
 
-  def safeGetOrdering[E](_comp: => Comparator[_]): Ordering[E] = {
-    val comp: Comparator[_] = _comp
-    val ord =
-      if (comp == null) defaultOrdering[E]
-      else Ordering.comparatorToOrdering(comp)
+  /** Fixes the heap property around the child at index `m`, either up the tree
+   *  or down the tree, depending on which side is found to violate the heap
+   *  property.
+   */
+  private[this] def fixUpOrDown(m: Int): Unit = {
+    val inner = this.inner // local copy
+    if (m > 1 && comp.compare(inner(m >> 1), inner(m)) > 0)
+      fixUp(m)
+    else
+      fixDown(m)
+  }
 
-    ord.asInstanceOf[Ordering[E]]
+  /** Fixes the heap property from the child at index `m` up the tree, towards
+   *  the root.
+   */
+  private[this] def fixUp(m: Int): Unit = {
+    val inner = this.inner // local copy
+
+    /* At each step, even though `m` changes, the element moves with it, and
+     * hence inner(m) is always the same initial `innerAtM`.
+     */
+    val innerAtM = inner(m)
+
+    @inline @tailrec
+    def loop(m: Int): Unit = {
+      if (m > 1) {
+        val parent = m >> 1
+        val innerAtParent = inner(parent)
+        if (comp.compare(innerAtParent, innerAtM) > 0) {
+          inner(parent) = innerAtM
+          inner(m) = innerAtParent
+          loop(parent)
+        }
+      }
+    }
+
+    loop(m)
+  }
+
+  /** Fixes the heap property from the child at index `m` down the tree, towards
+   *  the leaves.
+   */
+  private[this] def fixDown(m: Int): Unit = {
+    val inner = this.inner // local copy
+    val size = innerNextIdx - 1
+
+    /* At each step, even though `m` changes, the element moves with it, and
+     * hence inner(m) is always the same initial `innerAtM`.
+     */
+    val innerAtM = inner(m)
+
+    @inline @tailrec
+    def loop(m: Int): Unit = {
+      var j = 2 * m // left child of `m`
+      if (j <= size) {
+        var innerAtJ = inner(j)
+
+        // if the left child is greater than the right child, switch to the right child
+        if (j < size) {
+          val innerAtJPlus1 = inner(j + 1)
+          if (comp.compare(innerAtJ, innerAtJPlus1) > 0) {
+            j += 1
+            innerAtJ = innerAtJPlus1
+          }
+        }
+
+        // if the node `m` is greater than the selected child, swap and recurse
+        if (comp.compare(innerAtM, innerAtJ) > 0) {
+          inner(m) = innerAtJ
+          inner(j) = innerAtM
+          loop(j)
+        }
+      }
+    }
+
+    loop(m)
   }
 }

--- a/javalib/src/main/scala/java/util/PriorityQueue.scala
+++ b/javalib/src/main/scala/java/util/PriorityQueue.scala
@@ -14,7 +14,7 @@
 package java.util
 
 import scala.annotation.tailrec
-import scala.annotation.nowarn
+import scala.scalanative.compat.annotation.nowarn
 
 class PriorityQueue[E] private (
     private val comp: Comparator[_ >: E],
@@ -82,8 +82,10 @@ class PriorityQueue[E] private (
   override def add(e: E): Boolean = {
     if (e == null)
       throw new NullPointerException()
-    if (innerNextIdx >= innerNextIdx) {
-      inner = Array.copyOf(inner, innerNextIdx * 2)
+    if (innerNextIdx >= inner.length) {
+      val cpy = new Array[Any](inner.length * 2).asInstanceOf[Array[E]]
+      Array.copy(inner, 0, cpy, 0, innerNextIdx)
+      inner = cpy
     }
     inner(innerNextIdx) = e
     fixUp(innerNextIdx)
@@ -103,7 +105,7 @@ class PriorityQueue[E] private (
     } else {
       val len = innerNextIdx
       var i = 1
-      while (i != len && !o.equals(inner(i): @nowarn)) {
+      while (i != len && !o.equals(inner(i)): @nowarn) {
         i += 1
       }
 

--- a/javalib/src/main/scala/java/util/RedBlackTree.scala
+++ b/javalib/src/main/scala/java/util/RedBlackTree.scala
@@ -44,18 +44,21 @@ private[util] object RedBlackTree {
   @inline
   final class Bound[A](val bound: A, val kind: BoundKind)
 
-  def isWithinLowerBound[A](key: Any, bound: A, boundKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Boolean = {
+  def isWithinLowerBound[A](key: Any, bound: A, boundKind: BoundKind)(implicit
+      comp: Comparator[_ >: A]
+  ): Boolean = {
     boundKind == NoBound || compare(key, bound) >= boundKind
   }
 
-  def isWithinUpperBound[A](key: Any, bound: A, boundKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Boolean = {
+  def isWithinUpperBound[A](key: Any, bound: A, boundKind: BoundKind)(implicit
+      comp: Comparator[_ >: A]
+  ): Boolean = {
     boundKind == NoBound || compare(key, bound) <= -boundKind
   }
 
-  def intersectLowerBounds[A](bound1: Bound[A], bound2: Bound[A])(
-      implicit comp: Comparator[_ >: A]): Bound[A] = {
+  def intersectLowerBounds[A](bound1: Bound[A], bound2: Bound[A])(implicit
+      comp: Comparator[_ >: A]
+  ): Bound[A] = {
     if (bound1.kind == NoBound) {
       bound2
     } else if (bound2.kind == NoBound) {
@@ -69,8 +72,9 @@ private[util] object RedBlackTree {
     }
   }
 
-  def intersectUpperBounds[A](bound1: Bound[A], bound2: Bound[A])(
-      implicit comp: Comparator[_ >: A]): Bound[A] = {
+  def intersectUpperBounds[A](bound1: Bound[A], bound2: Bound[A])(implicit
+      comp: Comparator[_ >: A]
+  ): Bound[A] = {
     if (bound1.kind == NoBound) {
       bound2
     } else if (bound2.kind == NoBound) {
@@ -124,7 +128,7 @@ private[util] object RedBlackTree {
     override def equals(that: Any): Boolean = that match {
       case that: Map.Entry[_, _] =>
         Objects.equals(getKey(), that.getKey()) &&
-        Objects.equals(getValue(), that.getValue())
+          Objects.equals(getValue(), that.getValue())
       case _ =>
         false
     }
@@ -147,21 +151,33 @@ private[util] object RedBlackTree {
 
   object Node {
     @inline
-    def apply[A, B](key: A, value: B, red: Boolean, left: Node[A, B],
-        right: Node[A, B], parent: Node[A, B]): Node[A, B] = {
+    def apply[A, B](
+        key: A,
+        value: B,
+        red: Boolean,
+        left: Node[A, B],
+        right: Node[A, B],
+        parent: Node[A, B]
+    ): Node[A, B] = {
       new Node(key, value, red, left, right, parent)
     }
 
     @inline
-    def leaf[A, B](key: A, value: B, red: Boolean, parent: Node[A, B]): Node[A, B] =
+    def leaf[A, B](
+        key: A,
+        value: B,
+        red: Boolean,
+        parent: Node[A, B]
+    ): Node[A, B] =
       new Node(key, value, red, null, null, parent)
   }
 
   // ---- comparator helper ----
 
   @inline
-  private[this] def compare[A](key1: Any, key2: A)(
-      implicit comp: Comparator[_ >: A]): Int = {
+  private[this] def compare[A](key1: Any, key2: A)(implicit
+      comp: Comparator[_ >: A]
+  ): Int = {
     /* The implementation of `compare` and/or its generic bridge may perform
      * monomorphic casts that can fail. This is according to spec for TreeSet
      * and TreeMap.
@@ -183,9 +199,13 @@ private[util] object RedBlackTree {
 
   def size(tree: Tree[_, _]): Int = tree.size
 
-  def projectionSize[A, B](tree: Tree[A, B], lowerBound: A,
-      lowerKind: BoundKind, upperBound: A, upperKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Int = {
+  def projectionSize[A, B](
+      tree: Tree[A, B],
+      lowerBound: A,
+      lowerKind: BoundKind,
+      upperBound: A,
+      upperKind: BoundKind
+  )(implicit comp: Comparator[_ >: A]): Int = {
     if (lowerKind == NoBound && upperKind == NoBound) {
       size(tree)
     } else {
@@ -202,9 +222,13 @@ private[util] object RedBlackTree {
 
   def isEmpty(tree: Tree[_, _]): Boolean = tree.root eq null
 
-  def projectionIsEmpty[A](tree: Tree[A, _], lowerBound: A,
-      lowerKind: BoundKind, upperBound: A, upperKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Boolean = {
+  def projectionIsEmpty[A](
+      tree: Tree[A, _],
+      lowerBound: A,
+      lowerKind: BoundKind,
+      upperBound: A,
+      upperKind: BoundKind
+  )(implicit comp: Comparator[_ >: A]): Boolean = {
     if (lowerKind == NoBound && upperKind == NoBound) {
       isEmpty(tree)
     } else {
@@ -220,14 +244,16 @@ private[util] object RedBlackTree {
 
   // ---- search ----
 
-  def get[A, B](tree: Tree[A, B], key: Any)(
-      implicit comp: Comparator[_ >: A]): B = {
+  def get[A, B](tree: Tree[A, B], key: Any)(implicit
+      comp: Comparator[_ >: A]
+  ): B = {
     nullableNodeFlatMap(getNode(tree.root, key))(_.value)
   }
 
   @tailrec
-  private[this] def getNode[A, B](node: Node[A, B], key: Any)(
-      implicit comp: Comparator[_ >: A]): Node[A, B] = {
+  private[this] def getNode[A, B](node: Node[A, B], key: Any)(implicit
+      comp: Comparator[_ >: A]
+  ): Node[A, B] = {
     if (node eq null) {
       null
     } else {
@@ -238,8 +264,9 @@ private[util] object RedBlackTree {
     }
   }
 
-  def contains[A](tree: Tree[A, _], key: Any)(
-      implicit comp: Comparator[_ >: A]): Boolean = {
+  def contains[A](tree: Tree[A, _], key: Any)(implicit
+      comp: Comparator[_ >: A]
+  ): Boolean = {
     getNode(tree.root, key) ne null
   }
 
@@ -277,17 +304,22 @@ private[util] object RedBlackTree {
    *  Returns `null` if there is no such node.
    */
   def minNodeAfter[A, B](tree: Tree[A, B], key: A, boundKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Node[A, B] = {
+      implicit comp: Comparator[_ >: A]
+  ): Node[A, B] = {
     minNodeAfter(tree.root, key, boundKind)
   }
 
-  def minKeyAfter[A](tree: Tree[A, _], key: A, boundKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): A = {
+  def minKeyAfter[A](tree: Tree[A, _], key: A, boundKind: BoundKind)(implicit
+      comp: Comparator[_ >: A]
+  ): A = {
     nullableNodeKey(minNodeAfter(tree.root, key, boundKind))
   }
 
-  private def minNodeAfter[A, B](node: Node[A, B], key: A, boundKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Node[A, B] = {
+  private def minNodeAfter[A, B](
+      node: Node[A, B],
+      key: A,
+      boundKind: BoundKind
+  )(implicit comp: Comparator[_ >: A]): Node[A, B] = {
     if (node eq null) {
       null
     } else if (boundKind == NoBound) {
@@ -326,17 +358,22 @@ private[util] object RedBlackTree {
    *  Returns `null` if there is no such node.
    */
   def maxNodeBefore[A, B](tree: Tree[A, B], key: A, boundKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Node[A, B] = {
+      implicit comp: Comparator[_ >: A]
+  ): Node[A, B] = {
     maxNodeBefore(tree.root, key, boundKind)
   }
 
-  def maxKeyBefore[A](tree: Tree[A, _], key: A, boundKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): A = {
+  def maxKeyBefore[A](tree: Tree[A, _], key: A, boundKind: BoundKind)(implicit
+      comp: Comparator[_ >: A]
+  ): A = {
     nullableNodeKey(maxNodeBefore(tree.root, key, boundKind))
   }
 
-  private def maxNodeBefore[A, B](node: Node[A, B], key: A, boundKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Node[A, B] = {
+  private def maxNodeBefore[A, B](
+      node: Node[A, B],
+      key: A,
+      boundKind: BoundKind
+  )(implicit comp: Comparator[_ >: A]): Node[A, B] = {
     if (node eq null) {
       null
     } else if (boundKind == NoBound) {
@@ -371,8 +408,9 @@ private[util] object RedBlackTree {
 
   // ---- insertion ----
 
-  def insert[A, B](tree: Tree[A, B], key: A, value: B)(
-      implicit comp: Comparator[_ >: A]): B = {
+  def insert[A, B](tree: Tree[A, B], key: A, value: B)(implicit
+      comp: Comparator[_ >: A]
+  ): B = {
     /* The target node is the node with `key` if it exists, or the node under
      * which we need to insert the new `key`.
      * We use a loop here instead of a tailrec def because we need 2 results
@@ -415,8 +453,10 @@ private[util] object RedBlackTree {
   }
 
   @tailrec
-  private[this] def fixAfterInsert[A, B](tree: Tree[A, B],
-      node: Node[A, B]): Unit = {
+  private[this] def fixAfterInsert[A, B](
+      tree: Tree[A, B],
+      node: Node[A, B]
+  ): Unit = {
     val parent = node.parent
     if (parent eq null) {
       // The inserted node is the root; mark it black and we're done
@@ -469,8 +509,9 @@ private[util] object RedBlackTree {
 
   // ---- deletion ----
 
-  def delete[A, B](tree: Tree[A, B], key: Any)(
-      implicit comp: Comparator[_ >: A]): B = {
+  def delete[A, B](tree: Tree[A, B], key: Any)(implicit
+      comp: Comparator[_ >: A]
+  ): B = {
     nullableNodeFlatMap(getNode(tree.root, key)) { node =>
       deleteNode(tree, node)
       node.value
@@ -506,7 +547,8 @@ private[util] object RedBlackTree {
        */
       val succ = minNodeNonNull(node.right)
       // Assert: succ.left eq null
-      val succWasRed = succ.red // conceptually, the color of `node` after the swap
+      val succWasRed =
+        succ.red // conceptually, the color of `node` after the swap
       val onlyChildOfSucc = succ.right
       val newParentOfTheChild = if (succ.parent eq node) {
         succ
@@ -533,8 +575,11 @@ private[util] object RedBlackTree {
    * `parent` explicitly from above.
    */
   @tailrec
-  private[this] def fixAfterDelete[A, B](tree: Tree[A, B], node: Node[A, B],
-      parent: Node[A, B]): Unit = {
+  private[this] def fixAfterDelete[A, B](
+      tree: Tree[A, B],
+      node: Node[A, B],
+      parent: Node[A, B]
+  ): Unit = {
     if ((node ne tree.root) && isBlack(node)) {
       // `node` can *still* be null here; we cannot use `node.isLeftChild`
       if (node eq parent.left) {
@@ -605,7 +650,9 @@ private[util] object RedBlackTree {
 
   /** Returns `null.asInstanceOf[C]` if `node eq null`, otherwise `f(node)`. */
   @inline
-  private def nullableNodeFlatMap[A, B, C](node: Node[A, B])(f: Node[A, B] => C): C =
+  private def nullableNodeFlatMap[A, B, C](
+      node: Node[A, B]
+  )(f: Node[A, B] => C): C =
     if (node eq null) null.asInstanceOf[C]
     else f(node)
 
@@ -703,8 +750,11 @@ private[util] object RedBlackTree {
    *  setting `from`'s parent to the `to`'s previous parent. The children of
    *  `from` are left unchanged.
    */
-  private[this] def transplant[A, B](tree: Tree[A, B], to: Node[A, B],
-      from: Node[A, B]): Unit = {
+  private[this] def transplant[A, B](
+      tree: Tree[A, B],
+      to: Node[A, B],
+      from: Node[A, B]
+  ): Unit = {
     if (to.isRoot)
       tree.root = from
     else if (to.isLeftChild)
@@ -727,9 +777,10 @@ private[util] object RedBlackTree {
   def valuesIterator[A, B](tree: Tree[A, B]): Iterator[B] =
     new ValuesIterator(tree)
 
-  private[this] abstract class AbstractTreeIterator[A, B, R](tree: Tree[A, B],
-      private[this] var nextNode: Node[A, B])
-      extends Iterator[R] {
+  private[this] abstract class AbstractTreeIterator[A, B, R](
+      tree: Tree[A, B],
+      private[this] var nextNode: Node[A, B]
+  ) extends Iterator[R] {
 
     private[this] var lastNode: Node[A, B] = _ // null
 
@@ -783,31 +834,51 @@ private[util] object RedBlackTree {
 
   // ---- projection iterators ----
 
-  def projectionIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Iterator[Map.Entry[A, B]] = {
+  def projectionIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A]): Iterator[Map.Entry[A, B]] = {
     new ProjectionEntriesIterator(tree, start, startKind, end, endKind)
   }
 
-  def projectionKeysIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Iterator[A] = {
+  def projectionKeysIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A]): Iterator[A] = {
     new ProjectionKeysIterator(tree, start, startKind, end, endKind)
   }
 
-  def projectionValuesIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Iterator[B] = {
+  def projectionValuesIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A]): Iterator[B] = {
     new ProjectionValuesIterator(tree, start, startKind, end, endKind)
   }
 
-  private[this] abstract class ProjectionIterator[A, B, R](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A])
+  private[this] abstract class ProjectionIterator[A, B, R](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A])
       extends AbstractTreeIterator[A, B, R](
-          tree,
-          ProjectionIterator.nullIfAfterEnd(
-              minNodeAfter(tree.root, start, startKind), end, endKind)) {
+        tree,
+        ProjectionIterator.nullIfAfterEnd(
+          minNodeAfter(tree.root, start, startKind),
+          end,
+          endKind
+        )
+      ) {
 
     protected final def advance(node: Node[A, B]): Node[A, B] =
       ProjectionIterator.nullIfAfterEnd(successor(node), end, endKind)
@@ -815,8 +886,11 @@ private[util] object RedBlackTree {
 
   private[this] object ProjectionIterator {
     @inline
-    private def nullIfAfterEnd[A, B](node: Node[A, B], end: A,
-        endKind: BoundKind)(implicit comp: Comparator[_ >: A]): Node[A, B] = {
+    private def nullIfAfterEnd[A, B](
+        node: Node[A, B],
+        end: A,
+        endKind: BoundKind
+    )(implicit comp: Comparator[_ >: A]): Node[A, B] = {
       if (endKind != NoBound && (node ne null) &&
           !isWithinUpperBound(node.key, end, endKind)) {
         null
@@ -826,26 +900,56 @@ private[util] object RedBlackTree {
     }
   }
 
-  private[this] final class ProjectionEntriesIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A])
-      extends ProjectionIterator[A, B, Map.Entry[A, B]](tree, start, startKind, end, endKind) {
+  private[this] final class ProjectionEntriesIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A])
+      extends ProjectionIterator[A, B, Map.Entry[A, B]](
+        tree,
+        start,
+        startKind,
+        end,
+        endKind
+      ) {
 
     def nextResult(node: Node[A, B]): Map.Entry[A, B] = node
   }
 
-  private[this] final class ProjectionKeysIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A])
-      extends ProjectionIterator[A, B, A](tree, start, startKind, end, endKind) {
+  private[this] final class ProjectionKeysIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A])
+      extends ProjectionIterator[A, B, A](
+        tree,
+        start,
+        startKind,
+        end,
+        endKind
+      ) {
 
     def nextResult(node: Node[A, B]): A = node.key
   }
 
-  private[this] final class ProjectionValuesIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A])
-      extends ProjectionIterator[A, B, B](tree, start, startKind, end, endKind) {
+  private[this] final class ProjectionValuesIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A])
+      extends ProjectionIterator[A, B, B](
+        tree,
+        start,
+        startKind,
+        end,
+        endKind
+      ) {
 
     def nextResult(node: Node[A, B]): B = node.value
   }
@@ -862,47 +966,82 @@ private[util] object RedBlackTree {
    */
 
   def descendingIterator[A, B](tree: Tree[A, B]): Iterator[Map.Entry[A, B]] = {
-    descendingIterator(tree, null.asInstanceOf[A], NoBound,
-        null.asInstanceOf[A], NoBound)(null)
+    descendingIterator(
+      tree,
+      null.asInstanceOf[A],
+      NoBound,
+      null.asInstanceOf[A],
+      NoBound
+    )(null)
   }
 
   def descendingKeysIterator[A, B](tree: Tree[A, B]): Iterator[A] = {
-    descendingKeysIterator(tree, null.asInstanceOf[A], NoBound,
-        null.asInstanceOf[A], NoBound)(null)
+    descendingKeysIterator(
+      tree,
+      null.asInstanceOf[A],
+      NoBound,
+      null.asInstanceOf[A],
+      NoBound
+    )(null)
   }
 
   def descendingValuesIterator[A, B](tree: Tree[A, B]): Iterator[B] = {
-    descendingValuesIterator(tree, null.asInstanceOf[A], NoBound,
-        null.asInstanceOf[A], NoBound)(null)
+    descendingValuesIterator(
+      tree,
+      null.asInstanceOf[A],
+      NoBound,
+      null.asInstanceOf[A],
+      NoBound
+    )(null)
   }
 
   // ---- descending projection iterators ----
 
-  def descendingIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Iterator[Map.Entry[A, B]] = {
+  def descendingIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A]): Iterator[Map.Entry[A, B]] = {
     new DescendingEntriesIterator(tree, start, startKind, end, endKind)
   }
 
-  def descendingKeysIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Iterator[A] = {
+  def descendingKeysIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A]): Iterator[A] = {
     new DescendingKeysIterator(tree, start, startKind, end, endKind)
   }
 
-  def descendingValuesIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A]): Iterator[B] = {
+  def descendingValuesIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A]): Iterator[B] = {
     new DescendingValuesIterator(tree, start, startKind, end, endKind)
   }
 
-  private[this] abstract class DescendingTreeIterator[A, B, R](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A])
+  private[this] abstract class DescendingTreeIterator[A, B, R](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A])
       extends AbstractTreeIterator[A, B, R](
-          tree,
-          DescendingTreeIterator.nullIfBeforeEnd(
-              maxNodeBefore(tree.root, start, startKind), end, endKind)) {
+        tree,
+        DescendingTreeIterator.nullIfBeforeEnd(
+          maxNodeBefore(tree.root, start, startKind),
+          end,
+          endKind
+        )
+      ) {
 
     protected final def advance(node: Node[A, B]): Node[A, B] =
       DescendingTreeIterator.nullIfBeforeEnd(predecessor(node), end, endKind)
@@ -910,8 +1049,11 @@ private[util] object RedBlackTree {
 
   private[this] object DescendingTreeIterator {
     @inline
-    private def nullIfBeforeEnd[A, B](node: Node[A, B], end: A,
-        endKind: BoundKind)(implicit comp: Comparator[_ >: A]): Node[A, B] = {
+    private def nullIfBeforeEnd[A, B](
+        node: Node[A, B],
+        end: A,
+        endKind: BoundKind
+    )(implicit comp: Comparator[_ >: A]): Node[A, B] = {
       if (endKind != NoBound && (node ne null) &&
           !isWithinLowerBound(node.key, end, endKind)) {
         null
@@ -921,26 +1063,56 @@ private[util] object RedBlackTree {
     }
   }
 
-  private[this] final class DescendingEntriesIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A])
-      extends DescendingTreeIterator[A, B, Map.Entry[A, B]](tree, start, startKind, end, endKind) {
+  private[this] final class DescendingEntriesIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A])
+      extends DescendingTreeIterator[A, B, Map.Entry[A, B]](
+        tree,
+        start,
+        startKind,
+        end,
+        endKind
+      ) {
 
     def nextResult(node: Node[A, B]): Map.Entry[A, B] = node
   }
 
-  private[this] final class DescendingKeysIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A])
-      extends DescendingTreeIterator[A, B, A](tree, start, startKind, end, endKind) {
+  private[this] final class DescendingKeysIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A])
+      extends DescendingTreeIterator[A, B, A](
+        tree,
+        start,
+        startKind,
+        end,
+        endKind
+      ) {
 
     def nextResult(node: Node[A, B]): A = node.key
   }
 
-  private[this] final class DescendingValuesIterator[A, B](tree: Tree[A, B],
-      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
-      implicit comp: Comparator[_ >: A])
-      extends DescendingTreeIterator[A, B, B](tree, start, startKind, end, endKind) {
+  private[this] final class DescendingValuesIterator[A, B](
+      tree: Tree[A, B],
+      start: A,
+      startKind: BoundKind,
+      end: A,
+      endKind: BoundKind
+  )(implicit comp: Comparator[_ >: A])
+      extends DescendingTreeIterator[A, B, B](
+        tree,
+        start,
+        startKind,
+        end,
+        endKind
+      ) {
 
     def nextResult(node: Node[A, B]): B = node.value
   }
@@ -949,8 +1121,12 @@ private[util] object RedBlackTree {
 
   /** Common implementation of `fromOrderedKeys` and `fromOrderedEntries`. */
   @noinline
-  def fromOrdered[A, B, C](xs: Iterator[A], size: Int,
-      keyOf: Function1[A, B], valueOf: Function1[A, C]): Tree[B, C] = {
+  def fromOrdered[A, B, C](
+      xs: Iterator[A],
+      size: Int,
+      keyOf: Function1[A, B],
+      valueOf: Function1[A, C]
+  ): Tree[B, C] = {
     // maximum depth of non-leaf nodes == floor(log2(size))
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size)
 
@@ -994,14 +1170,23 @@ private[util] object RedBlackTree {
   /** Build a Tree suitable for a TreeMap from an ordered sequence of key/value
    *  pairs.
    */
-  def fromOrderedEntries[A, B](xs: Iterator[Map.Entry[A, B]], size: Int): Tree[A, B] =
-    fromOrdered(xs, size, (x: Map.Entry[A, B]) => x.getKey(), (x: Map.Entry[A, B]) => x.getValue())
+  def fromOrderedEntries[A, B](
+      xs: Iterator[Map.Entry[A, B]],
+      size: Int
+  ): Tree[A, B] =
+    fromOrdered(
+      xs,
+      size,
+      (x: Map.Entry[A, B]) => x.getKey(),
+      (x: Map.Entry[A, B]) => x.getValue()
+    )
 
   private def copyTree[A, B](n: Node[A, B]): Node[A, B] = {
     if (n eq null) {
       null
     } else {
-      val c = Node(n.key, n.value, n.red, copyTree(n.left), copyTree(n.right), null)
+      val c =
+        Node(n.key, n.value, n.red, copyTree(n.left), copyTree(n.right), null)
       if (c.left != null)
         c.left.parent = c
       if (c.right != null)

--- a/javalib/src/main/scala/java/util/RedBlackTree.scala
+++ b/javalib/src/main/scala/java/util/RedBlackTree.scala
@@ -1,0 +1,1012 @@
+// Ported form Scala.js, revision 6819668, dated 7 Oct 2020
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util
+
+import scala.annotation.tailrec
+
+/** The red-black tree implementation used by `TreeSet`s.
+ *
+ *  It could also be used by `TreeMap`s in the future.
+ *
+ *  This implementation was copied and adapted from
+ *  `scala.collection.mutable.RedBlackTree` as found in Scala 2.13.0.
+ */
+private[util] object RedBlackTree {
+
+  // ---- bounds helpers ----
+
+  type BoundKind = Int
+
+  /* The values of `InclusiveBound` and `ExclusiveBound` must be 0 and 1,
+   * respectively. Some of the algorithms in this implementation rely on them
+   * having those specific values, as they do arithmetics with them.
+   */
+  final val InclusiveBound = 0
+  final val ExclusiveBound = 1
+  final val NoBound = 2
+
+  @inline
+  def boundKindFromIsInclusive(isInclusive: Boolean): BoundKind =
+    if (isInclusive) InclusiveBound
+    else ExclusiveBound
+
+  @inline
+  final class Bound[A](val bound: A, val kind: BoundKind)
+
+  def isWithinLowerBound[A](key: Any, bound: A, boundKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Boolean = {
+    boundKind == NoBound || compare(key, bound) >= boundKind
+  }
+
+  def isWithinUpperBound[A](key: Any, bound: A, boundKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Boolean = {
+    boundKind == NoBound || compare(key, bound) <= -boundKind
+  }
+
+  def intersectLowerBounds[A](bound1: Bound[A], bound2: Bound[A])(
+      implicit comp: Comparator[_ >: A]): Bound[A] = {
+    if (bound1.kind == NoBound) {
+      bound2
+    } else if (bound2.kind == NoBound) {
+      bound1
+    } else {
+      val cmp = compare(bound1.bound, bound2.bound)
+      if (cmp > 0 || (cmp == 0 && bound1.kind == ExclusiveBound))
+        bound1
+      else
+        bound2
+    }
+  }
+
+  def intersectUpperBounds[A](bound1: Bound[A], bound2: Bound[A])(
+      implicit comp: Comparator[_ >: A]): Bound[A] = {
+    if (bound1.kind == NoBound) {
+      bound2
+    } else if (bound2.kind == NoBound) {
+      bound1
+    } else {
+      val cmp = compare(bound1.bound, bound2.bound)
+      if (cmp < 0 || (cmp == 0 && bound1.kind == ExclusiveBound))
+        bound1
+      else
+        bound2
+    }
+  }
+
+  // ---- class structure ----
+
+  /* For performance reasons, this implementation uses `null` references to
+   * represent leaves instead of a sentinel node.
+   *
+   * Currently, the internal nodes do not store their subtree size - only the
+   * tree object keeps track of its size. Therefore, while obtaining the size
+   * of the whole tree is O(1), knowing the number of entries inside a range is
+   * O(n) on the size of the range.
+   */
+
+  final class Tree[A, B](var root: Node[A, B], var size: Int) {
+    def treeCopy(): Tree[A, B] = new Tree(copyTree(root), size)
+  }
+
+  object Tree {
+    def empty[A, B]: Tree[A, B] = new Tree(null, 0)
+  }
+
+  final class Node[A, B](
+      val key: A,
+      private[RedBlackTree] var value: B,
+      private[RedBlackTree] var red: Boolean,
+      private[RedBlackTree] var left: Node[A, B],
+      private[RedBlackTree] var right: Node[A, B],
+      private[RedBlackTree] var parent: Node[A, B]
+  ) extends Map.Entry[A, B] {
+    def getKey(): A = key
+
+    def getValue(): B = value
+
+    def setValue(v: B): B = {
+      val oldValue = value
+      value = v
+      oldValue
+    }
+
+    override def equals(that: Any): Boolean = that match {
+      case that: Map.Entry[_, _] =>
+        Objects.equals(getKey(), that.getKey()) &&
+        Objects.equals(getValue(), that.getValue())
+      case _ =>
+        false
+    }
+
+    override def hashCode(): Int =
+      Objects.hashCode(key) ^ Objects.hashCode(value)
+
+    override def toString(): String =
+      "" + getKey() + "=" + getValue()
+
+    @inline private[RedBlackTree] def isRoot: Boolean =
+      parent eq null
+
+    @inline private[RedBlackTree] def isLeftChild: Boolean =
+      (parent ne null) && (parent.left eq this)
+
+    @inline private[RedBlackTree] def isRightChild: Boolean =
+      (parent ne null) && (parent.right eq this)
+  }
+
+  object Node {
+    @inline
+    def apply[A, B](key: A, value: B, red: Boolean, left: Node[A, B],
+        right: Node[A, B], parent: Node[A, B]): Node[A, B] = {
+      new Node(key, value, red, left, right, parent)
+    }
+
+    @inline
+    def leaf[A, B](key: A, value: B, red: Boolean, parent: Node[A, B]): Node[A, B] =
+      new Node(key, value, red, null, null, parent)
+  }
+
+  // ---- comparator helper ----
+
+  @inline
+  private[this] def compare[A](key1: Any, key2: A)(
+      implicit comp: Comparator[_ >: A]): Int = {
+    /* The implementation of `compare` and/or its generic bridge may perform
+     * monomorphic casts that can fail. This is according to spec for TreeSet
+     * and TreeMap.
+     */
+    comp.asInstanceOf[Comparator[Any]].compare(key1, key2)
+  }
+
+  // ---- getters ----
+
+  private def isRed(node: Node[_, _]): Boolean = (node ne null) && node.red
+
+  private def isBlack(node: Node[_, _]): Boolean = (node eq null) || !node.red
+
+  // ---- size ----
+
+  private def size(node: Node[_, _]): Int =
+    if (node eq null) 0
+    else 1 + size(node.left) + size(node.right)
+
+  def size(tree: Tree[_, _]): Int = tree.size
+
+  def projectionSize[A, B](tree: Tree[A, B], lowerBound: A,
+      lowerKind: BoundKind, upperBound: A, upperKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Int = {
+    if (lowerKind == NoBound && upperKind == NoBound) {
+      size(tree)
+    } else {
+      var result = 0
+      val iter =
+        projectionIterator(tree, lowerBound, lowerKind, upperBound, upperKind)
+      while (iter.hasNext()) {
+        iter.next()
+        result += 1
+      }
+      result
+    }
+  }
+
+  def isEmpty(tree: Tree[_, _]): Boolean = tree.root eq null
+
+  def projectionIsEmpty[A](tree: Tree[A, _], lowerBound: A,
+      lowerKind: BoundKind, upperBound: A, upperKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Boolean = {
+    if (lowerKind == NoBound && upperKind == NoBound) {
+      isEmpty(tree)
+    } else {
+      val node = minNodeAfter(tree, lowerBound, lowerKind)
+      (node eq null) || !isWithinUpperBound(node.key, upperBound, upperKind)
+    }
+  }
+
+  def clear(tree: Tree[_, _]): Unit = {
+    tree.root = null
+    tree.size = 0
+  }
+
+  // ---- search ----
+
+  def get[A, B](tree: Tree[A, B], key: Any)(
+      implicit comp: Comparator[_ >: A]): B = {
+    nullableNodeFlatMap(getNode(tree.root, key))(_.value)
+  }
+
+  @tailrec
+  private[this] def getNode[A, B](node: Node[A, B], key: Any)(
+      implicit comp: Comparator[_ >: A]): Node[A, B] = {
+    if (node eq null) {
+      null
+    } else {
+      val cmp = compare(key, node.key)
+      if (cmp < 0) getNode(node.left, key)
+      else if (cmp > 0) getNode(node.right, key)
+      else node
+    }
+  }
+
+  def contains[A](tree: Tree[A, _], key: Any)(
+      implicit comp: Comparator[_ >: A]): Boolean = {
+    getNode(tree.root, key) ne null
+  }
+
+  def minNode[A, B](tree: Tree[A, B]): Node[A, B] =
+    minNode(tree.root)
+
+  def minKey[A](tree: Tree[A, _]): A =
+    nullableNodeKey(minNode(tree.root))
+
+  private def minNode[A, B](node: Node[A, B]): Node[A, B] =
+    nullableNodeFlatMap(node)(minNodeNonNull(_))
+
+  @tailrec
+  private def minNodeNonNull[A, B](node: Node[A, B]): Node[A, B] =
+    if (node.left eq null) node
+    else minNodeNonNull(node.left)
+
+  def maxNode[A, B](tree: Tree[A, B]): Node[A, B] =
+    maxNode(tree.root)
+
+  def maxKey[A](tree: Tree[A, _]): A =
+    nullableNodeKey(maxNode(tree.root))
+
+  private def maxNode[A, B](node: Node[A, B]): Node[A, B] =
+    nullableNodeFlatMap(node)(maxNodeNonNull(_))
+
+  @tailrec
+  private def maxNodeNonNull[A, B](node: Node[A, B]): Node[A, B] =
+    if (node.right eq null) node
+    else maxNodeNonNull(node.right)
+
+  /** Returns the first (lowest) map entry with a key (equal or) greater than
+   *  `key`.
+   *
+   *  Returns `null` if there is no such node.
+   */
+  def minNodeAfter[A, B](tree: Tree[A, B], key: A, boundKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Node[A, B] = {
+    minNodeAfter(tree.root, key, boundKind)
+  }
+
+  def minKeyAfter[A](tree: Tree[A, _], key: A, boundKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): A = {
+    nullableNodeKey(minNodeAfter(tree.root, key, boundKind))
+  }
+
+  private def minNodeAfter[A, B](node: Node[A, B], key: A, boundKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Node[A, B] = {
+    if (node eq null) {
+      null
+    } else if (boundKind == NoBound) {
+      minNodeNonNull(node)
+    } else {
+      @tailrec
+      def minNodeAfterNonNull(node: Node[A, B]): Node[A, B] = {
+        val cmp = compare(key, node.key)
+        if (cmp == 0) {
+          if (boundKind == InclusiveBound)
+            node
+          else
+            successor(node)
+        } else if (cmp < 0) {
+          val child = node.left
+          if (child eq null)
+            node
+          else
+            minNodeAfterNonNull(child)
+        } else {
+          val child = node.right
+          if (child eq null)
+            successor(node)
+          else
+            minNodeAfterNonNull(child)
+        }
+      }
+
+      minNodeAfterNonNull(node)
+    }
+  }
+
+  /** Returns the last (highest) map entry with a key (equal or) smaller than
+   *  `key`.
+   *
+   *  Returns `null` if there is no such node.
+   */
+  def maxNodeBefore[A, B](tree: Tree[A, B], key: A, boundKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Node[A, B] = {
+    maxNodeBefore(tree.root, key, boundKind)
+  }
+
+  def maxKeyBefore[A](tree: Tree[A, _], key: A, boundKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): A = {
+    nullableNodeKey(maxNodeBefore(tree.root, key, boundKind))
+  }
+
+  private def maxNodeBefore[A, B](node: Node[A, B], key: A, boundKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Node[A, B] = {
+    if (node eq null) {
+      null
+    } else if (boundKind == NoBound) {
+      maxNodeNonNull(node)
+    } else {
+      @tailrec
+      def maxNodeBeforeNonNull(node: Node[A, B]): Node[A, B] = {
+        val cmp = compare(key, node.key)
+        if (cmp == 0) {
+          if (boundKind == InclusiveBound)
+            node
+          else
+            predecessor(node)
+        } else if (cmp < 0) {
+          val child = node.left
+          if (child eq null)
+            predecessor(node)
+          else
+            maxNodeBeforeNonNull(child)
+        } else {
+          val child = node.right
+          if (child eq null)
+            node
+          else
+            maxNodeBeforeNonNull(child)
+        }
+      }
+
+      maxNodeBeforeNonNull(node)
+    }
+  }
+
+  // ---- insertion ----
+
+  def insert[A, B](tree: Tree[A, B], key: A, value: B)(
+      implicit comp: Comparator[_ >: A]): B = {
+    /* The target node is the node with `key` if it exists, or the node under
+     * which we need to insert the new `key`.
+     * We use a loop here instead of a tailrec def because we need 2 results
+     * from this lookup: `targetNode` and `cmp`.
+     */
+    var targetNode: Node[A, B] = null
+    var nextNode: Node[A, B] = tree.root
+    var cmp: Int = 1
+    while ((nextNode ne null) && cmp != 0) {
+      targetNode = nextNode
+      cmp = compare(key, nextNode.key)
+      nextNode = if (cmp < 0) nextNode.left else nextNode.right
+    }
+
+    if (cmp == 0) {
+      // Found existing node: just update its value
+      targetNode.setValue(value)
+    } else {
+      // Insert a new node under targetNode, then fix the RB tree
+      val newNode = Node.leaf(key, value, red = true, targetNode)
+
+      if (targetNode eq null) {
+        /* Here, the key was never compared to anything. Compare it with itself
+         * so that we eagerly cause the comparator to throw if it cannot handle
+         * the key at all, before we put the key in the map.
+         */
+        compare(key, key)
+        tree.root = newNode
+      } else if (cmp < 0) {
+        targetNode.left = newNode
+      } else {
+        targetNode.right = newNode
+      }
+
+      fixAfterInsert(tree, newNode)
+      tree.size += 1
+
+      null.asInstanceOf[B]
+    }
+  }
+
+  @tailrec
+  private[this] def fixAfterInsert[A, B](tree: Tree[A, B],
+      node: Node[A, B]): Unit = {
+    val parent = node.parent
+    if (parent eq null) {
+      // The inserted node is the root; mark it black and we're done
+      node.red = false
+    } else if (isBlack(parent)) {
+      // The parent is black and the node is red; we're done
+    } else if (parent.isLeftChild) {
+      val grandParent = parent.parent
+      val uncle = grandParent.right
+      if (isRed(uncle)) {
+        parent.red = false
+        uncle.red = false
+        grandParent.red = true
+        fixAfterInsert(tree, grandParent)
+      } else {
+        if (node.isRightChild) {
+          rotateLeft(tree, parent)
+          // Now `parent` is the child of `node`, which is the child of `grandParent`
+          node.red = false
+        } else {
+          parent.red = false
+        }
+        grandParent.red = true
+        rotateRight(tree, grandParent)
+        // Now the node which took the place of `grandParent` is black, so we're done
+      }
+    } else {
+      // Symmetric cases
+      val grandParent = parent.parent
+      val uncle = grandParent.left
+      if (isRed(uncle)) {
+        parent.red = false
+        uncle.red = false
+        grandParent.red = true
+        fixAfterInsert(tree, grandParent)
+      } else {
+        if (node.isLeftChild) {
+          rotateRight(tree, parent)
+          // Now `parent` is the child of `node`, which is the child of `grandParent`
+          node.red = false
+        } else {
+          parent.red = false
+        }
+        grandParent.red = true
+        rotateLeft(tree, grandParent)
+        // Now the node which took the place of `grandParent` is black, so we're done
+      }
+    }
+  }
+
+  // ---- deletion ----
+
+  def delete[A, B](tree: Tree[A, B], key: Any)(
+      implicit comp: Comparator[_ >: A]): B = {
+    nullableNodeFlatMap(getNode(tree.root, key)) { node =>
+      deleteNode(tree, node)
+      node.value
+    }
+  }
+
+  def deleteNode[A, B](tree: Tree[A, B], node: Node[A, B]): Unit = {
+    if (node.left eq null) {
+      val onlyChild = node.right // can be null
+      transplant(tree, node, onlyChild)
+      if (!node.red)
+        fixAfterDelete(tree, onlyChild, node.parent)
+    } else if (node.right eq null) {
+      val onlyChild = node.left
+      transplant(tree, node, onlyChild)
+      if (!node.red)
+        fixAfterDelete(tree, onlyChild, node.parent)
+    } else {
+      /* We don't know how to delete a node with 2 children, so we're going to
+       * find the successor `succ` of `node`, then (conceptually) swap it with
+       * `node` before deleting `node`. We can do this because we know that
+       * `succ` has a null `left` child.
+       *
+       * In fact we transplant the `onlyChildOfSucc` (originally at
+       * `succ.right`) in place of `succ`, then transplant `succ` in place of
+       * `node` (also acquiring its color), and finally fixing up the tree
+       * around `onlyChildOfSucc`.
+       *
+       * Textbook red-black trees simply set the `key` and `value` of `node` to
+       * be those of `succ`, then delete `succ`. We cannot do this because our
+       * `key` is immutable (it *has* to be for `Node` to comply with the
+       * contract of `Map.Entry`).
+       */
+      val succ = minNodeNonNull(node.right)
+      // Assert: succ.left eq null
+      val succWasRed = succ.red // conceptually, the color of `node` after the swap
+      val onlyChildOfSucc = succ.right
+      val newParentOfTheChild = if (succ.parent eq node) {
+        succ
+      } else {
+        val theParent = succ.parent
+        transplant(tree, succ, onlyChildOfSucc)
+        succ.right = node.right
+        succ.right.parent = succ
+        theParent
+      }
+      transplant(tree, node, succ)
+      succ.left = node.left
+      succ.left.parent = succ
+      succ.red = node.red
+      // Assert: if (onlyChildOfSucc ne null) then (newParentOfTheChild eq onlyChildOfSucc.parent)
+      if (!succWasRed)
+        fixAfterDelete(tree, onlyChildOfSucc, newParentOfTheChild)
+    }
+
+    tree.size -= 1
+  }
+
+  /* `node` can be `null` (in which case it is black), so we have to pass
+   * `parent` explicitly from above.
+   */
+  @tailrec
+  private[this] def fixAfterDelete[A, B](tree: Tree[A, B], node: Node[A, B],
+      parent: Node[A, B]): Unit = {
+    if ((node ne tree.root) && isBlack(node)) {
+      // `node` can *still* be null here; we cannot use `node.isLeftChild`
+      if (node eq parent.left) {
+        // From now on, we don't use `node` anymore; we just fix up at `parent`
+
+        var rightChild = parent.right
+        // assert(rightChild ne null)
+
+        if (rightChild.red) {
+          rightChild.red = false
+          parent.red = true
+          rotateLeft(tree, parent)
+          rightChild = parent.right // shape changed; update `rightChild`
+        }
+        if (isBlack(rightChild.left) && isBlack(rightChild.right)) {
+          rightChild.red = true
+          fixAfterDelete(tree, parent, parent.parent)
+        } else {
+          if (isBlack(rightChild.right)) {
+            rightChild.left.red = false
+            rightChild.red = true
+            rotateRight(tree, rightChild)
+            rightChild = parent.right // shape changed; update `rightChild`
+          }
+          rightChild.red = parent.red
+          parent.red = false
+          rightChild.right.red = false
+          rotateLeft(tree, parent)
+          // we're done here
+        }
+      } else { // symmetric cases
+        // From now on, we don't use `node` anymore; we just fix up at `parent`
+
+        var leftChild = parent.left
+        // assert(leftChild ne null)
+
+        if (leftChild.red) {
+          leftChild.red = false
+          parent.red = true
+          rotateRight(tree, parent)
+          leftChild = parent.left // shape changed; update `leftChild`
+        }
+        if (isBlack(leftChild.right) && isBlack(leftChild.left)) {
+          leftChild.red = true
+          fixAfterDelete(tree, parent, parent.parent)
+        } else {
+          if (isBlack(leftChild.left)) {
+            leftChild.right.red = false
+            leftChild.red = true
+            rotateLeft(tree, leftChild)
+            leftChild = parent.left // shape changed; update `leftChild`
+          }
+          leftChild.red = parent.red
+          parent.red = false
+          leftChild.left.red = false
+          rotateRight(tree, parent)
+          // we're done here
+        }
+      }
+    } else {
+      // We found a red node or the root; mark it black and we're done
+      if (node ne null)
+        node.red = false
+    }
+  }
+
+  // ---- helpers ----
+
+  /** Returns `null.asInstanceOf[C]` if `node eq null`, otherwise `f(node)`. */
+  @inline
+  private def nullableNodeFlatMap[A, B, C](node: Node[A, B])(f: Node[A, B] => C): C =
+    if (node eq null) null.asInstanceOf[C]
+    else f(node)
+
+  /** Returns `null.asInstanceOf[A]` if `node eq null`, otherwise `node.key`. */
+  @inline
+  private def nullableNodeKey[A, B](node: Node[A, B]): A =
+    if (node eq null) null.asInstanceOf[A]
+    else node.key
+
+  /** Returns the node that follows `node` in an in-order tree traversal.
+   *
+   *  If `node` has the maximum key (and is, therefore, the last node), this
+   *  method returns `null`.
+   */
+  private[this] def successor[A, B](node: Node[A, B]): Node[A, B] = {
+    if (node.right ne null) {
+      minNodeNonNull(node.right)
+    } else {
+      @inline @tailrec
+      def closestAncestorOnTheRight(node: Node[A, B]): Node[A, B] = {
+        val parent = node.parent
+        if ((parent eq null) || (node eq parent.left)) parent
+        else closestAncestorOnTheRight(parent)
+      }
+      closestAncestorOnTheRight(node)
+    }
+  }
+
+  /** Returns the node that precedes `node` in an in-order tree traversal.
+   *
+   *  If `node` has the minimum key (and is, therefore, the first node), this
+   *  method returns `null`.
+   */
+  private[this] def predecessor[A, B](node: Node[A, B]): Node[A, B] = {
+    if (node.left ne null) {
+      maxNodeNonNull(node.left)
+    } else {
+      @inline @tailrec
+      def closestAncestorOnTheLeft(node: Node[A, B]): Node[A, B] = {
+        val parent = node.parent
+        if ((parent eq null) || (node eq parent.right)) parent
+        else closestAncestorOnTheLeft(parent)
+      }
+      closestAncestorOnTheLeft(node)
+    }
+  }
+
+  private[this] def rotateLeft[A, B](tree: Tree[A, B], x: Node[A, B]): Unit = {
+    if (x ne null) {
+      // assert(x.right ne null)
+      val y = x.right
+      x.right = y.left
+
+      if (y.left ne null)
+        y.left.parent = x
+      y.parent = x.parent
+
+      if (x.isRoot)
+        tree.root = y
+      else if (x.isLeftChild)
+        x.parent.left = y
+      else
+        x.parent.right = y
+
+      y.left = x
+      x.parent = y
+    }
+  }
+
+  private[this] def rotateRight[A, B](tree: Tree[A, B], x: Node[A, B]): Unit = {
+    if (x ne null) {
+      // assert(x.left ne null)
+      val y = x.left
+      x.left = y.right
+
+      if (y.right ne null)
+        y.right.parent = x
+      y.parent = x.parent
+
+      if (x.isRoot)
+        tree.root = y
+      else if (x.isRightChild)
+        x.parent.right = y
+      else
+        x.parent.left = y
+
+      y.right = x
+      x.parent = y
+    }
+  }
+
+  /** Transplant the node `from` to the place of node `to`.
+   *
+   *  This is done by setting `from` as a child of `to`'s previous parent and
+   *  setting `from`'s parent to the `to`'s previous parent. The children of
+   *  `from` are left unchanged.
+   */
+  private[this] def transplant[A, B](tree: Tree[A, B], to: Node[A, B],
+      from: Node[A, B]): Unit = {
+    if (to.isRoot)
+      tree.root = from
+    else if (to.isLeftChild)
+      to.parent.left = from
+    else
+      to.parent.right = from
+
+    if (from ne null)
+      from.parent = to.parent
+  }
+
+  // ---- iterators ----
+
+  def iterator[A, B](tree: Tree[A, B]): Iterator[Map.Entry[A, B]] =
+    new EntriesIterator(tree)
+
+  def keysIterator[A, B](tree: Tree[A, B]): Iterator[A] =
+    new KeysIterator(tree)
+
+  def valuesIterator[A, B](tree: Tree[A, B]): Iterator[B] =
+    new ValuesIterator(tree)
+
+  private[this] abstract class AbstractTreeIterator[A, B, R](tree: Tree[A, B],
+      private[this] var nextNode: Node[A, B])
+      extends Iterator[R] {
+
+    private[this] var lastNode: Node[A, B] = _ // null
+
+    protected def advance(node: Node[A, B]): Node[A, B]
+    protected def nextResult(node: Node[A, B]): R
+
+    def hasNext(): Boolean = nextNode ne null
+
+    def next(): R = {
+      val node = nextNode
+      if (node eq null)
+        throw new NoSuchElementException("next on empty iterator")
+      lastNode = node
+      nextNode = advance(node)
+      nextResult(node)
+    }
+
+    override def remove(): Unit = {
+      val node = lastNode
+      if (node eq null)
+        throw new IllegalStateException()
+      deleteNode(tree, node)
+      lastNode = null
+    }
+  }
+
+  private[this] abstract class TreeIterator[A, B, R](tree: Tree[A, B])
+      extends AbstractTreeIterator[A, B, R](tree, minNode(tree)) {
+
+    protected final def advance(node: Node[A, B]): Node[A, B] =
+      successor(node)
+  }
+
+  private[this] final class EntriesIterator[A, B](tree: Tree[A, B])
+      extends TreeIterator[A, B, Map.Entry[A, B]](tree) {
+
+    protected def nextResult(node: Node[A, B]): Map.Entry[A, B] = node
+  }
+
+  private[this] final class KeysIterator[A, B](tree: Tree[A, B])
+      extends TreeIterator[A, B, A](tree) {
+
+    protected def nextResult(node: Node[A, B]): A = node.key
+  }
+
+  private[this] final class ValuesIterator[A, B](tree: Tree[A, B])
+      extends TreeIterator[A, B, B](tree) {
+
+    protected def nextResult(node: Node[A, B]): B = node.value
+  }
+
+  // ---- projection iterators ----
+
+  def projectionIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Iterator[Map.Entry[A, B]] = {
+    new ProjectionEntriesIterator(tree, start, startKind, end, endKind)
+  }
+
+  def projectionKeysIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Iterator[A] = {
+    new ProjectionKeysIterator(tree, start, startKind, end, endKind)
+  }
+
+  def projectionValuesIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Iterator[B] = {
+    new ProjectionValuesIterator(tree, start, startKind, end, endKind)
+  }
+
+  private[this] abstract class ProjectionIterator[A, B, R](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A])
+      extends AbstractTreeIterator[A, B, R](
+          tree,
+          ProjectionIterator.nullIfAfterEnd(
+              minNodeAfter(tree.root, start, startKind), end, endKind)) {
+
+    protected final def advance(node: Node[A, B]): Node[A, B] =
+      ProjectionIterator.nullIfAfterEnd(successor(node), end, endKind)
+  }
+
+  private[this] object ProjectionIterator {
+    @inline
+    private def nullIfAfterEnd[A, B](node: Node[A, B], end: A,
+        endKind: BoundKind)(implicit comp: Comparator[_ >: A]): Node[A, B] = {
+      if (endKind != NoBound && (node ne null) &&
+          !isWithinUpperBound(node.key, end, endKind)) {
+        null
+      } else {
+        node
+      }
+    }
+  }
+
+  private[this] final class ProjectionEntriesIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A])
+      extends ProjectionIterator[A, B, Map.Entry[A, B]](tree, start, startKind, end, endKind) {
+
+    def nextResult(node: Node[A, B]): Map.Entry[A, B] = node
+  }
+
+  private[this] final class ProjectionKeysIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A])
+      extends ProjectionIterator[A, B, A](tree, start, startKind, end, endKind) {
+
+    def nextResult(node: Node[A, B]): A = node.key
+  }
+
+  private[this] final class ProjectionValuesIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A])
+      extends ProjectionIterator[A, B, B](tree, start, startKind, end, endKind) {
+
+    def nextResult(node: Node[A, B]): B = node.value
+  }
+
+  // ---- descending iterators ----
+
+  /* We do not have optimized iterators for descending order on
+   * non-projections, as they would be of questionable value. Instead, we use
+   * descending project iterators instead.
+   *
+   * Since we know that both bounds do not exist, we know that the comparator
+   * will never be used by the algorithms in DescendingTreeIterator, so we do
+   * not require one and instead push a `null` internally.
+   */
+
+  def descendingIterator[A, B](tree: Tree[A, B]): Iterator[Map.Entry[A, B]] = {
+    descendingIterator(tree, null.asInstanceOf[A], NoBound,
+        null.asInstanceOf[A], NoBound)(null)
+  }
+
+  def descendingKeysIterator[A, B](tree: Tree[A, B]): Iterator[A] = {
+    descendingKeysIterator(tree, null.asInstanceOf[A], NoBound,
+        null.asInstanceOf[A], NoBound)(null)
+  }
+
+  def descendingValuesIterator[A, B](tree: Tree[A, B]): Iterator[B] = {
+    descendingValuesIterator(tree, null.asInstanceOf[A], NoBound,
+        null.asInstanceOf[A], NoBound)(null)
+  }
+
+  // ---- descending projection iterators ----
+
+  def descendingIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Iterator[Map.Entry[A, B]] = {
+    new DescendingEntriesIterator(tree, start, startKind, end, endKind)
+  }
+
+  def descendingKeysIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Iterator[A] = {
+    new DescendingKeysIterator(tree, start, startKind, end, endKind)
+  }
+
+  def descendingValuesIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A]): Iterator[B] = {
+    new DescendingValuesIterator(tree, start, startKind, end, endKind)
+  }
+
+  private[this] abstract class DescendingTreeIterator[A, B, R](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A])
+      extends AbstractTreeIterator[A, B, R](
+          tree,
+          DescendingTreeIterator.nullIfBeforeEnd(
+              maxNodeBefore(tree.root, start, startKind), end, endKind)) {
+
+    protected final def advance(node: Node[A, B]): Node[A, B] =
+      DescendingTreeIterator.nullIfBeforeEnd(predecessor(node), end, endKind)
+  }
+
+  private[this] object DescendingTreeIterator {
+    @inline
+    private def nullIfBeforeEnd[A, B](node: Node[A, B], end: A,
+        endKind: BoundKind)(implicit comp: Comparator[_ >: A]): Node[A, B] = {
+      if (endKind != NoBound && (node ne null) &&
+          !isWithinLowerBound(node.key, end, endKind)) {
+        null
+      } else {
+        node
+      }
+    }
+  }
+
+  private[this] final class DescendingEntriesIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A])
+      extends DescendingTreeIterator[A, B, Map.Entry[A, B]](tree, start, startKind, end, endKind) {
+
+    def nextResult(node: Node[A, B]): Map.Entry[A, B] = node
+  }
+
+  private[this] final class DescendingKeysIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A])
+      extends DescendingTreeIterator[A, B, A](tree, start, startKind, end, endKind) {
+
+    def nextResult(node: Node[A, B]): A = node.key
+  }
+
+  private[this] final class DescendingValuesIterator[A, B](tree: Tree[A, B],
+      start: A, startKind: BoundKind, end: A, endKind: BoundKind)(
+      implicit comp: Comparator[_ >: A])
+      extends DescendingTreeIterator[A, B, B](tree, start, startKind, end, endKind) {
+
+    def nextResult(node: Node[A, B]): B = node.value
+  }
+
+  // building
+
+  /** Common implementation of `fromOrderedKeys` and `fromOrderedEntries`. */
+  @noinline
+  def fromOrdered[A, B, C](xs: Iterator[A], size: Int,
+      keyOf: Function1[A, B], valueOf: Function1[A, C]): Tree[B, C] = {
+    // maximum depth of non-leaf nodes == floor(log2(size))
+    val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size)
+
+    @noinline
+    def createSubTree(level: Int, size: Int): Node[B, C] = size match {
+      case 0 =>
+        null
+      case 1 =>
+        /* Nodes on the last level must be red, because the last level might
+         * not be full. If they were black, then the paths from the root to the
+         * last level would have 1 more black node than those ending at the
+         * second-to-last level.
+         * Exception: when the only node is the root, because the root must be
+         * black.
+         */
+        val item = xs.next()
+        val red = level == maxUsedDepth && level != 1
+        Node.leaf(keyOf(item), valueOf(item), red, null)
+      case _ =>
+        val leftSize = (size - 1) >> 1 // opt: (size - 1) / 2 with size > 0
+        val left = createSubTree(level + 1, leftSize)
+        val item = xs.next()
+        val right = createSubTree(level + 1, size - 1 - leftSize)
+        val node = Node(keyOf(item), valueOf(item), false, left, right, null)
+        if (left ne null)
+          left.parent = node
+        right.parent = node
+        node
+    }
+
+    new Tree(createSubTree(1, size), size)
+  }
+
+  /** Build a Tree suitable for a TreeSet from an ordered sequence of keys.
+   *
+   *  All values will be `()`.
+   */
+  def fromOrderedKeys[A](xs: Iterator[A], size: Int): Tree[A, Any] =
+    fromOrdered(xs, size, (x: A) => x, (_: A) => ())
+
+  /** Build a Tree suitable for a TreeMap from an ordered sequence of key/value
+   *  pairs.
+   */
+  def fromOrderedEntries[A, B](xs: Iterator[Map.Entry[A, B]], size: Int): Tree[A, B] =
+    fromOrdered(xs, size, (x: Map.Entry[A, B]) => x.getKey(), (x: Map.Entry[A, B]) => x.getValue())
+
+  private def copyTree[A, B](n: Node[A, B]): Node[A, B] = {
+    if (n eq null) {
+      null
+    } else {
+      val c = Node(n.key, n.value, n.red, copyTree(n.left), copyTree(n.right), null)
+      if (c.left != null)
+        c.left.parent = c
+      if (c.right != null)
+        c.right.parent = c
+      c
+    }
+  }
+}

--- a/javalib/src/main/scala/java/util/TreeSet.scala
+++ b/javalib/src/main/scala/java/util/TreeSet.scala
@@ -1,137 +1,85 @@
+// Ported from Scala.js, revision: 730ee11, dated 9 Aug 2019
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
-import scala.collection.mutable
-import scala.math.Ordering
-import ScalaOps._
-import ScalaCompatOps._
+import java.lang.Cloneable
+import java.util.{RedBlackTree => RB}
 
-class TreeSet[E](_comparator: Comparator[_ >: E])
-    extends AbstractSet[E]
+class TreeSet[E] private (tree: RB.Tree[E, Any])(implicit
+    comp: Comparator[_ >: E]
+) extends AbstractSet[E]
     with NavigableSet[E]
     with Cloneable
-    with Serializable { self =>
+    with Serializable {
+
+  import TreeSet._
+
+  /* Note: in practice, the values of `tree` are always `()` (aka `undefined`).
+   * We use `Any` because we need to deal with `null`s, and referencing
+   * `scala.runtime.BoxedUnit` in this code would be really ugly.
+   */
 
   def this() =
-    this(null.asInstanceOf[Comparator[_ >: E]])
+    this(RB.Tree.empty[E, Any])(NaturalComparator)
+
+  def this(comparator: Comparator[_ >: E]) =
+    this(RB.Tree.empty[E, Any])(NaturalComparator.select(comparator))
 
   def this(collection: Collection[_ <: E]) = {
-    this(null.asInstanceOf[Comparator[E]])
+    this()
     addAll(collection)
   }
 
   def this(sortedSet: SortedSet[E]) = {
-    this(sortedSet.comparator())
-    addAll(sortedSet)
+    this(RB.fromOrderedKeys(sortedSet.iterator(), sortedSet.size()))(
+      NaturalComparator.select(sortedSet.comparator())
+    )
   }
 
-  private implicit object BoxOrdering extends Ordering[Box[E]] {
+  def iterator(): Iterator[E] =
+    RB.keysIterator(tree)
 
-    val cmp = {
-      if (_comparator ne null) _comparator
-      else defaultOrdering[E]
-    }
-
-    def compare(a: Box[E], b: Box[E]): Int = cmp.compare(a.inner, b.inner)
-  }
-
-  protected val inner: mutable.TreeSet[Box[E]] = new mutable.TreeSet[Box[E]]()
-
-  def iterator(): Iterator[E] = {
-    new Iterator[E] {
-      private val iter = inner.clone.iterator
-
-      private var last: Option[E] = None
-
-      def hasNext(): Boolean = iter.hasNext
-
-      def next(): E = {
-        last = Some(iter.next().inner)
-        last.get
-      }
-
-      override def remove(): Unit = {
-        if (last.isEmpty) {
-          throw new IllegalStateException()
-        } else {
-          last.foreach(self.remove(_))
-          last = None
-        }
-      }
-    }
-  }
-
-  def descendingIterator(): Iterator[E] = {
-    new Iterator[E] {
-      private val iter = inner.iterator.toList.reverse.iterator
-
-      private var last: Option[E] = None
-
-      def hasNext(): Boolean = iter.hasNext
-
-      def next(): E = {
-        val nxt = iter.next().inner
-        last = Some(nxt)
-        nxt
-      }
-
-      override def remove(): Unit = {
-        if (last.isEmpty) {
-          throw new IllegalStateException()
-        } else {
-          last.foreach(self.remove(_))
-          last = None
-        }
-      }
-    }
-  }
+  def descendingIterator(): Iterator[E] =
+    RB.descendingKeysIterator(tree)
 
   def descendingSet(): NavigableSet[E] = {
-    val descSetFun = { () =>
-      val retSet = new mutable.TreeSet[Box[E]]()(BoxOrdering.reverse)
-      retSet ++= inner
-      retSet
-    }
-    new NavigableView(this, descSetFun, None, true, None, true)
+    new DescendingProjection(
+      tree,
+      null.asInstanceOf[E],
+      RB.NoBound,
+      null.asInstanceOf[E],
+      RB.NoBound
+    )
   }
 
   def size(): Int =
-    inner.size
+    RB.size(tree)
 
   override def isEmpty(): Boolean =
-    inner.headOption.isEmpty
+    RB.isEmpty(tree)
 
   override def contains(o: Any): Boolean =
-    inner.contains(Box(o.asInstanceOf[E]))
+    RB.contains(tree, o)
 
-  override def add(e: E): Boolean = {
-    val boxed = Box(e)
-
-    if (isEmpty())
-      BoxOrdering.compare(boxed, boxed)
-
-    inner.add(boxed)
-  }
+  override def add(e: E): Boolean =
+    RB.insert(tree, e, ()) == null
 
   override def remove(o: Any): Boolean =
-    inner.remove(Box(o.asInstanceOf[E]))
+    RB.delete(tree, o) != null
 
   override def clear(): Unit =
-    inner.clear()
-
-  override def addAll(c: Collection[_ <: E]): Boolean = {
-    val iter = c.iterator()
-    var changed = false
-    while (iter.hasNext()) changed = add(iter.next()) || changed
-    changed
-  }
-
-  override def removeAll(c: Collection[_]): Boolean = {
-    val iter = c.iterator()
-    var changed = false
-    while (iter.hasNext())
-      changed = inner.remove(Box(iter.next()).asInstanceOf[Box[E]]) || changed
-    changed
-  }
+    RB.clear(tree)
 
   def subSet(
       fromElement: E,
@@ -139,66 +87,32 @@ class TreeSet[E](_comparator: Comparator[_ >: E])
       toElement: E,
       toInclusive: Boolean
   ): NavigableSet[E] = {
-    val boxedFrom = Box(fromElement)
-    val boxedTo = Box(toElement)
-    val subSetFun = { () =>
-      // the creation of a new TreeSet is to avoid a mysterious bug with scala 2.10
-      var base = new mutable.TreeSet[Box[E]]
-      base ++= inner.range(boxedFrom, boxedTo)
-      if (!fromInclusive)
-        base = base.diff(Set(boxedFrom))
-
-      if (toInclusive && inner.contains(boxedTo))
-        base = base.diff(Set(boxedTo))
-
-      base
-    }
-
-    new NavigableView(
-      this,
-      subSetFun,
-      Some(fromElement),
-      fromInclusive,
-      Some(toElement),
-      toInclusive
+    new Projection(
+      tree,
+      fromElement,
+      RB.boundKindFromIsInclusive(fromInclusive),
+      toElement,
+      RB.boundKindFromIsInclusive(toInclusive)
     )
   }
 
   def headSet(toElement: E, inclusive: Boolean): NavigableSet[E] = {
-    val boxed = Box(toElement)
-    val headSetFun = { () =>
-      // the creation of a new TreeSet is to avoid a mysterious bug with scala 2.10
-      var base = new mutable.TreeSet[Box[E]]
-      if (inclusive)
-        base ++= inner.compatOps.rangeTo(boxed)
-      else
-        base ++= inner.compatOps.rangeUntil(boxed)
-
-      base
-    }
-
-    new NavigableView(this, headSetFun, None, true, Some(toElement), inclusive)
+    new Projection(
+      tree,
+      null.asInstanceOf[E],
+      RB.NoBound,
+      toElement,
+      RB.boundKindFromIsInclusive(inclusive)
+    )
   }
 
   def tailSet(fromElement: E, inclusive: Boolean): NavigableSet[E] = {
-    val boxed = Box(fromElement)
-    val tailSetFun = { () =>
-      // the creation of a new TreeSet is to avoid a mysterious bug with scala 2.10
-      var base = new mutable.TreeSet[Box[E]]
-      base ++= inner.compatOps.rangeFrom(boxed)
-      if (!inclusive)
-        base -= boxed
-
-      base
-    }
-
-    new NavigableView(
-      this,
-      tailSetFun,
-      Some(fromElement),
-      inclusive,
-      None,
-      true
+    new Projection(
+      tree,
+      fromElement,
+      RB.boundKindFromIsInclusive(inclusive),
+      null.asInstanceOf[E],
+      RB.NoBound
     )
   }
 
@@ -211,44 +125,416 @@ class TreeSet[E](_comparator: Comparator[_ >: E])
   def tailSet(fromElement: E): SortedSet[E] =
     tailSet(fromElement, true)
 
-  def comparator(): Comparator[_ >: E] = _comparator
+  def comparator(): Comparator[_ >: E] =
+    NaturalComparator.unselect(comp)
 
-  def first(): E =
-    inner.head.inner
+  def first(): E = {
+    if (isEmpty())
+      throw new NoSuchElementException()
+    RB.minKey(tree)
+  }
 
-  def last(): E =
-    inner.last.inner
+  def last(): E = {
+    if (isEmpty())
+      throw new NoSuchElementException()
+    RB.maxKey(tree)
+  }
 
   def lower(e: E): E =
-    headSet(e, false).scalaOps.lastOption.getOrElse(null.asInstanceOf[E])
+    RB.maxKeyBefore(tree, e, RB.ExclusiveBound)
 
   def floor(e: E): E =
-    headSet(e, true).scalaOps.lastOption.getOrElse(null.asInstanceOf[E])
+    RB.maxKeyBefore(tree, e, RB.InclusiveBound)
 
   def ceiling(e: E): E =
-    tailSet(e, true).scalaOps.headOption.getOrElse(null.asInstanceOf[E])
+    RB.minKeyAfter(tree, e, RB.InclusiveBound)
 
   def higher(e: E): E =
-    tailSet(e, false).scalaOps.headOption.getOrElse(null.asInstanceOf[E])
+    RB.minKeyAfter(tree, e, RB.ExclusiveBound)
 
   def pollFirst(): E = {
-    val polled = inner.headOption
-    if (polled.isDefined) {
-      val elem = polled.get.inner
-      remove(elem)
-      elem
-    } else null.asInstanceOf[E]
+    val node = RB.minNode(tree)
+    if (node ne null) {
+      RB.deleteNode(tree, node)
+      node.key
+    } else {
+      null.asInstanceOf[E]
+    }
   }
 
   def pollLast(): E = {
-    val polled = inner.lastOption
-    if (polled.isDefined) {
-      val elem = polled.get.inner
-      remove(elem)
-      elem
-    } else null.asInstanceOf[E]
+    val node = RB.maxNode(tree)
+    if (node ne null) {
+      RB.deleteNode(tree, node)
+      node.key
+    } else {
+      null.asInstanceOf[E]
+    }
   }
 
   override def clone(): TreeSet[E] =
-    new TreeSet(this)
+    new TreeSet(tree.treeCopy())(comp)
+}
+
+private object TreeSet {
+  private abstract class AbstractProjection[E](
+      protected val tree: RB.Tree[E, Any],
+      protected val lowerBound: E,
+      protected val lowerKind: RB.BoundKind,
+      protected val upperBound: E,
+      protected val upperKind: RB.BoundKind
+  )(implicit protected val comp: Comparator[_ >: E])
+      extends AbstractSet[E]
+      with NavigableSet[E] {
+
+    // To be implemented by the two concrete subclasses, depending on the order
+
+    protected def nextKey(key: E, boundKind: RB.BoundKind): E
+    protected def previousKey(key: E, boundKind: RB.BoundKind): E
+
+    protected def subSetGeneric(
+        newFromElement: E = null.asInstanceOf[E],
+        newFromBoundKind: RB.BoundKind = RB.NoBound,
+        newToElement: E = null.asInstanceOf[E],
+        newToBoundKind: RB.BoundKind = RB.NoBound
+    ): NavigableSet[E]
+
+    // Implementation of most of the NavigableSet API
+
+    def size(): Int =
+      RB.projectionSize(tree, lowerBound, lowerKind, upperBound, upperKind)
+
+    override def isEmpty(): Boolean =
+      RB.projectionIsEmpty(tree, lowerBound, lowerKind, upperBound, upperKind)
+
+    override def contains(o: Any): Boolean =
+      isWithinBounds(o) && RB.contains(tree, o)
+
+    override def add(e: E): Boolean = {
+      if (!isWithinBounds(e))
+        throw new IllegalArgumentException
+      RB.insert(tree, e, ()) == null
+    }
+
+    override def remove(o: Any): Boolean =
+      isWithinBounds(o) && RB.delete(tree, o) != null
+
+    def lower(e: E): E =
+      previousKey(e, RB.ExclusiveBound)
+
+    def floor(e: E): E =
+      previousKey(e, RB.InclusiveBound)
+
+    def ceiling(e: E): E =
+      nextKey(e, RB.InclusiveBound)
+
+    def higher(e: E): E =
+      nextKey(e, RB.ExclusiveBound)
+
+    def subSet(
+        fromElement: E,
+        fromInclusive: Boolean,
+        toElement: E,
+        toInclusive: Boolean
+    ): NavigableSet[E] = {
+      subSetGeneric(
+        fromElement,
+        RB.boundKindFromIsInclusive(fromInclusive),
+        toElement,
+        RB.boundKindFromIsInclusive(toInclusive)
+      )
+    }
+
+    def headSet(toElement: E, inclusive: Boolean): NavigableSet[E] = {
+      subSetGeneric(
+        newToElement = toElement,
+        newToBoundKind = RB.boundKindFromIsInclusive(inclusive)
+      )
+    }
+
+    def tailSet(fromElement: E, inclusive: Boolean): NavigableSet[E] = {
+      subSetGeneric(
+        newFromElement = fromElement,
+        newFromBoundKind = RB.boundKindFromIsInclusive(inclusive)
+      )
+    }
+
+    def subSet(fromElement: E, toElement: E): SortedSet[E] =
+      subSet(fromElement, true, toElement, false)
+
+    def headSet(toElement: E): SortedSet[E] =
+      headSet(toElement, false)
+
+    def tailSet(fromElement: E): SortedSet[E] =
+      tailSet(fromElement, true)
+
+    // Common implementation of pollFirst() and pollLast()
+
+    @inline
+    protected final def pollLower(): E = {
+      val node = RB.minNodeAfter(tree, lowerBound, lowerKind)
+      if (node ne null) {
+        val key = node.key
+        if (isWithinUpperBound(key)) {
+          RB.deleteNode(tree, node)
+          key
+        } else {
+          null.asInstanceOf[E]
+        }
+      } else {
+        null.asInstanceOf[E]
+      }
+    }
+
+    @inline
+    protected final def pollUpper(): E = {
+      val node = RB.maxNodeBefore(tree, upperBound, upperKind)
+      if (node ne null) {
+        val key = node.key
+        if (isWithinLowerBound(key)) {
+          RB.deleteNode(tree, node)
+          key
+        } else {
+          null.asInstanceOf[E]
+        }
+      } else {
+        null.asInstanceOf[E]
+      }
+    }
+
+    // Helpers
+
+    protected final def isWithinBounds(key: Any): Boolean =
+      isWithinLowerBound(key) && isWithinUpperBound(key)
+
+    protected final def isWithinLowerBound(key: Any): Boolean =
+      RB.isWithinLowerBound(key, lowerBound, lowerKind)
+
+    protected final def isWithinUpperBound(key: Any): Boolean =
+      RB.isWithinUpperBound(key, upperBound, upperKind)
+
+    protected final def ifWithinLowerBound(e: E): E =
+      if (e != null && isWithinLowerBound(e)) e
+      else null.asInstanceOf[E]
+
+    protected final def ifWithinUpperBound(e: E): E =
+      if (e != null && isWithinUpperBound(e)) e
+      else null.asInstanceOf[E]
+  }
+
+  private final class Projection[E](
+      tree0: RB.Tree[E, Any],
+      fromElement0: E,
+      fromBoundKind0: RB.BoundKind,
+      toElement0: E,
+      toBoundKind0: RB.BoundKind
+  )(implicit comp: Comparator[_ >: E])
+      extends AbstractProjection[E](
+        tree0,
+        fromElement0,
+        fromBoundKind0,
+        toElement0,
+        toBoundKind0
+      ) {
+
+    // Access fields under a different name, more appropriate for some uses
+
+    @inline private def fromElement: E = lowerBound
+    @inline private def fromBoundKind: RB.BoundKind = lowerKind
+    @inline private def toElement: E = upperBound
+    @inline private def toBoundKind: RB.BoundKind = upperKind
+
+    /* Implementation of the abstract methods from AbstractProjection
+     * Some are marked `@inline` for the likely case where
+     * `DescendingProjection` is not reachable at all and hence
+     * dead-code-eliminated.
+     */
+
+    @inline
+    protected def nextKey(key: E, boundKind: RB.BoundKind): E =
+      ifWithinUpperBound(RB.minKeyAfter(tree, key, boundKind))
+
+    @inline
+    protected def previousKey(key: E, boundKind: RB.BoundKind): E =
+      ifWithinLowerBound(RB.maxKeyBefore(tree, key, boundKind))
+
+    protected def subSetGeneric(
+        newFromElement: E,
+        newFromBoundKind: RB.BoundKind,
+        newToElement: E,
+        newToBoundKind: RB.BoundKind
+    ): NavigableSet[E] = {
+      val intersectedFromBound = RB.intersectLowerBounds(
+        new RB.Bound(fromElement, fromBoundKind),
+        new RB.Bound(newFromElement, newFromBoundKind)
+      )
+      val intersectedToBound = RB.intersectUpperBounds(
+        new RB.Bound(toElement, toBoundKind),
+        new RB.Bound(newToElement, newToBoundKind)
+      )
+      new Projection(
+        tree,
+        intersectedFromBound.bound,
+        intersectedFromBound.kind,
+        intersectedToBound.bound,
+        intersectedToBound.kind
+      )
+    }
+
+    // Methods of the NavigableSet API that are not implemented in AbstractProjection
+
+    def iterator(): Iterator[E] =
+      RB.projectionKeysIterator(
+        tree,
+        fromElement,
+        fromBoundKind,
+        toElement,
+        toBoundKind
+      )
+
+    def comparator(): Comparator[_ >: E] =
+      NaturalComparator.unselect(comp)
+
+    def first(): E = {
+      val key = nextKey(fromElement, fromBoundKind)
+      if (key == null)
+        throw new NoSuchElementException()
+      key
+    }
+
+    def last(): E = {
+      val key = previousKey(toElement, toBoundKind)
+      if (key == null)
+        throw new NoSuchElementException()
+      key
+    }
+
+    @noinline
+    def pollFirst(): E =
+      pollLower()
+
+    @noinline
+    def pollLast(): E =
+      pollUpper()
+
+    def descendingSet(): NavigableSet[E] =
+      new DescendingProjection(
+        tree,
+        toElement,
+        toBoundKind,
+        fromElement,
+        fromBoundKind
+      )
+
+    def descendingIterator(): Iterator[E] =
+      RB.descendingKeysIterator(
+        tree,
+        toElement,
+        toBoundKind,
+        fromElement,
+        fromBoundKind
+      )
+  }
+
+  private final class DescendingProjection[E](
+      tree0: RB.Tree[E, Any],
+      fromElement0: E,
+      fromBoundKind0: RB.BoundKind,
+      toElement0: E,
+      toBoundKind0: RB.BoundKind
+  )(implicit comp: Comparator[_ >: E])
+      extends AbstractProjection[E](
+        tree0,
+        toElement0,
+        toBoundKind0,
+        fromElement0,
+        fromBoundKind0
+      ) {
+
+    // Access fields under a different name, more appropriate for some uses
+
+    @inline private def fromElement: E = upperBound
+    @inline private def fromBoundKind: RB.BoundKind = upperKind
+    @inline private def toElement: E = lowerBound
+    @inline private def toBoundKind: RB.BoundKind = lowerKind
+
+    // Implementation of the abstract methods from AbstractProjection
+
+    protected def nextKey(key: E, boundKind: RB.BoundKind): E =
+      ifWithinLowerBound(RB.maxKeyBefore(tree, key, boundKind))
+
+    protected def previousKey(key: E, boundKind: RB.BoundKind): E =
+      ifWithinUpperBound(RB.minKeyAfter(tree, key, boundKind))
+
+    protected def subSetGeneric(
+        newFromElement: E,
+        newFromBoundKind: RB.BoundKind,
+        newToElement: E,
+        newToBoundKind: RB.BoundKind
+    ): NavigableSet[E] = {
+      val intersectedFromBound = RB.intersectUpperBounds(
+        new RB.Bound(fromElement, fromBoundKind),
+        new RB.Bound(newFromElement, newFromBoundKind)
+      )
+      val intersectedToBound = RB.intersectLowerBounds(
+        new RB.Bound(toElement, toBoundKind),
+        new RB.Bound(newToElement, newToBoundKind)
+      )
+      new Projection(
+        tree,
+        intersectedFromBound.bound,
+        intersectedFromBound.kind,
+        intersectedToBound.bound,
+        intersectedToBound.kind
+      )
+    }
+
+    // Methods of the NavigableSet API that are not implemented in AbstractProjection
+
+    def iterator(): Iterator[E] =
+      RB.descendingKeysIterator(
+        tree,
+        fromElement,
+        fromBoundKind,
+        toElement,
+        toBoundKind
+      )
+
+    def comparator(): Comparator[_ >: E] =
+      Collections.reverseOrder(NaturalComparator.unselect(comp))
+
+    def first(): E = {
+      val key = nextKey(fromElement, fromBoundKind)
+      if (key == null)
+        throw new NoSuchElementException()
+      key
+    }
+
+    def last(): E = {
+      val key = previousKey(toElement, toBoundKind)
+      if (key == null)
+        throw new NoSuchElementException()
+      key
+    }
+
+    @noinline
+    def pollFirst(): E =
+      pollUpper()
+
+    @noinline
+    def pollLast(): E =
+      pollLower()
+
+    def descendingSet(): NavigableSet[E] =
+      new Projection(tree, toElement, toBoundKind, fromElement, fromBoundKind)
+
+    def descendingIterator(): Iterator[E] =
+      RB.projectionKeysIterator(
+        tree,
+        toElement,
+        toBoundKind,
+        fromElement,
+        fromBoundKind
+      )
+  }
 }

--- a/unit-tests/shared/src/test/scala/javalib/util/LinkedHashSetTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/LinkedHashSetTest.scala
@@ -1,0 +1,60 @@
+// Ported from Scala.js, revision cbf86bb, dated 24 Oct 2020
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalanative.testsuite.javalib.util
+
+import java.{util => ju}
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.reflect.ClassTag
+
+class LinkedHashSetTest extends HashSetTest {
+
+  override def factory: LinkedHashSetFactory = new LinkedHashSetFactory
+
+  @Test def iterateInOrder(): Unit = {
+    val hs = factory.empty[String]
+
+    val l1 = TrivialImmutableCollection("ONE", "TWO", null)
+    assertTrue(hs.addAll(l1))
+    assertEquals(3, hs.size)
+
+    val iter1 = hs.iterator()
+    for (i <- 0 until 3) {
+      assertTrue(iter1.hasNext())
+      assertEquals(l1(i), iter1.next())
+    }
+    assertFalse(iter1.hasNext())
+
+    val l2 = TrivialImmutableCollection("ONE", "TWO", null, "THREE")
+    assertTrue(hs.add(l2(3)))
+
+    val iter2 = hs.iterator()
+    for (i <- 0 until 4) {
+      assertTrue(iter2.hasNext())
+      assertEquals(l2(i), iter2.next())
+    }
+    assertFalse(iter2.hasNext())
+  }
+
+}
+
+class LinkedHashSetFactory extends HashSetFactory {
+  override def implementationName: String =
+    "java.util.LinkedHashSet"
+
+  override def empty[E: ClassTag]: ju.LinkedHashSet[E] =
+    new ju.LinkedHashSet[E]()
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/NavigableSetTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/NavigableSetTest.scala
@@ -1,0 +1,138 @@
+// Ported from Scala.js, revision cbf86bb, dated 24 Oct 2020
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalanative.testsuite.javalib.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.{util => ju}
+
+import scala.reflect.ClassTag
+
+trait NavigableSetTest extends SetTest {
+
+  def factory: NavigableSetFactory
+
+  @Test def ceiling(): Unit = {
+    val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val nsInt = factory.empty[Int]
+
+    nsInt.addAll(lInt)
+
+    assertEquals(1, nsInt.ceiling(-10))
+    assertEquals(1, nsInt.ceiling(0))
+    assertEquals(1, nsInt.ceiling(1))
+    assertEquals(5, nsInt.ceiling(5))
+
+    val lString = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val nsString = factory.empty[String]
+
+    nsString.addAll(lString)
+
+    assertEquals("a", nsString.ceiling("00000"))
+    assertEquals("a", nsString.ceiling("0"))
+    assertEquals("a", nsString.ceiling("a"))
+    assertEquals("d", nsString.ceiling("d"))
+    assertNull(nsString.ceiling("z"))
+  }
+
+  @Test def floor(): Unit = {
+    val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val nsInt = factory.empty[Int]
+
+    nsInt.addAll(lInt)
+
+    assertEquals(5, nsInt.floor(10))
+    assertEquals(5, nsInt.floor(5))
+    assertEquals(3, nsInt.floor(3))
+    assertEquals(1, nsInt.floor(1))
+
+    val lString = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val nsString = factory.empty[String]
+
+    nsString.addAll(lString)
+
+    assertEquals("e", nsString.floor("zzzzz"))
+    assertEquals("d", nsString.floor("d"))
+    assertEquals("b", nsString.floor("b"))
+    assertEquals("a", nsString.floor("a"))
+    assertNull(nsString.floor("0"))
+  }
+
+  @Test def higher(): Unit = {
+    val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val nsInt = factory.empty[Int]
+
+    nsInt.addAll(lInt)
+
+    assertEquals(5, nsInt.higher(4))
+    assertEquals(4, nsInt.higher(3))
+    assertEquals(2, nsInt.higher(1))
+    assertEquals(1, nsInt.higher(-10))
+
+    val lString = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val nsString = factory.empty[String]
+
+    nsString.addAll(lString)
+
+    assertNull(nsString.higher("zzzzz"))
+    assertEquals("e", nsString.higher("d"))
+    assertEquals("c", nsString.higher("b"))
+    assertEquals("b", nsString.higher("a"))
+    assertEquals("a", nsString.higher("0"))
+  }
+
+  @Test def lower(): Unit = {
+    val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val nsInt = factory.empty[Int]
+
+    nsInt.addAll(lInt)
+
+    assertEquals(4, nsInt.lower(5))
+    assertEquals(3, nsInt.lower(4))
+    assertEquals(2, nsInt.lower(3))
+    assertEquals(5, nsInt.lower(10))
+
+    val lString = TrivialImmutableCollection("a", "e", "b", "c", "d")
+    val nsString = factory.empty[String]
+
+    nsString.addAll(lString)
+
+    assertEquals("e", nsString.lower("zzzzz"))
+    assertEquals("c", nsString.lower("d"))
+    assertEquals("a", nsString.lower("b"))
+    assertNull(nsString.lower("a"))
+    assertNull(nsString.lower("0"))
+  }
+
+  @Test def pollFirstAndLast(): Unit = {
+    val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val ns = factory.empty[Int]
+
+    ns.addAll(lInt)
+
+    assertTrue(ns.contains(1))
+    assertEquals(1, ns.pollFirst())
+    assertFalse(ns.contains(1))
+    assertEquals(5, ns.pollLast())
+    assertEquals(2, ns.pollFirst())
+    assertEquals(4, ns.pollLast())
+    assertEquals(3, ns.pollFirst())
+    assertTrue(ns.isEmpty())
+  }
+}
+
+trait NavigableSetFactory extends SetFactory {
+  def empty[E: ClassTag]: ju.NavigableSet[E]
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/OptionalTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/OptionalTest.scala
@@ -1,0 +1,191 @@
+// Ported from Scala.js, revision c473689, dated 3 May 2021
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalanative.testsuite.javalib.util
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.Optional
+import java.util.function._
+
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
+
+class OptionalTest {
+
+  @Test def testCreation(): Unit = {
+    Optional.empty[String]()
+    Optional.of[String]("")
+    assertThrows(classOf[NullPointerException], Optional.of[String](null))
+    Optional.ofNullable[String]("")
+    Optional.ofNullable[String](null)
+  }
+
+  @Test def testEquals(): Unit = {
+    assertEquals(Optional.empty[String](), Optional.ofNullable[String](null))
+    assertEquals(Optional.of[String](""), Optional.ofNullable[String](""))
+    assertNotEquals(Optional.of[String]("1"), Optional.ofNullable[String]("2"))
+    assertEquals(Optional.of[Int](1), Optional.ofNullable[Int](1))
+    assertNotEquals(Optional.of[Int](1), Optional.ofNullable[Int](2))
+    case class Test(value: Long)
+    assertEquals(Optional.of(Test(1L)), Optional.ofNullable(Test(1L)))
+    assertNotEquals(Optional.of(Test(1L)), Optional.ofNullable(Test(2L)))
+  }
+
+  @Test def testIsPresent(): Unit = {
+    val emp = Optional.empty[String]()
+    assertFalse(emp.isPresent())
+    val fullInt = Optional.of[Int](1)
+    assertTrue(fullInt.isPresent())
+    val fullString = Optional.of[String]("")
+    assertTrue(fullString.isPresent())
+  }
+
+  @Test def testGet(): Unit = {
+    val emp = Optional.empty[String]()
+    assertThrows(classOf[NoSuchElementException], emp.get())
+    val fullInt = Optional.of[Int](1)
+    assertEquals(1, fullInt.get())
+    val fullString = Optional.of[String]("")
+    assertEquals("", fullString.get())
+    class Test()
+    val t = new Test()
+    assertEquals(t, Optional.of(t).get())
+  }
+
+  @Test def testIfPresent(): Unit = {
+    val emp = Optional.empty[String]()
+    emp.ifPresent(new Consumer[String] {
+      def accept(t: String): Unit =
+        fail("empty().ifPresent() should not call the callback")
+    })
+
+    var result: Option[String] = None
+    val fullString = Optional.of("hello")
+    fullString.ifPresent(new Consumer[String] {
+      def accept(t: String): Unit = {
+        assertTrue("of().ifPresent() should call its callback only once", result.isEmpty)
+        result = Some(t)
+      }
+    })
+    assertEquals(Some("hello"), result)
+  }
+
+  @Test def testFilter(): Unit = {
+    assertEquals(Optional.empty[String](),
+        Optional.empty[String]().filter(new Predicate[String] {
+          def test(t: String): Boolean =
+            throw new AssertionError("Optional.empty().filter() should not call its argument")
+        }))
+
+    val predicate = new Predicate[String] {
+      def test(t: String): Boolean = t.length() < 10
+    }
+
+    assertEquals(Optional.empty[String](),
+        Optional.of[String]("this string is too long").filter(predicate))
+    assertEquals(Optional.of("short"),
+        Optional.of("short").filter(predicate))
+  }
+
+  @Test def testMap(): Unit = {
+    assertEquals(Optional.empty[String](),
+        Optional.empty[String]().map[Int](new Function[String, Int] {
+          def apply(t: String): Int =
+            throw new AssertionError("Optional.empty().map() should not call its argument")
+        }))
+
+    val mapper = new Function[String, Int] {
+      def apply(t: String): Int = t.length()
+    }
+
+    assertEquals(Optional.of(8),
+        Optional.of("a string").map[Int](mapper))
+    assertEquals(Optional.of(14),
+        Optional.of("another string").map[Int](mapper))
+
+    assertEquals(Optional.empty[String](),
+        Optional.of("a string").map[String](new Function[String, String] {
+          def apply(t: String): String = null
+        }))
+  }
+
+  @Test def testFlatMap(): Unit = {
+    assertEquals(Optional.empty[String](),
+        Optional.empty[String]().flatMap[Int](new Function[String, Optional[Int]] {
+          def apply(t: String): Optional[Int] =
+            throw new AssertionError("Optional.empty().flatMap() should not call its argument")
+        }))
+
+    val mapper = new Function[String, Optional[Int]] {
+      def apply(t: String): Optional[Int] =
+        if (t.isEmpty()) Optional.empty()
+        else Optional.of(t.length())
+    }
+
+    assertEquals(Optional.of(8),
+        Optional.of("a string").flatMap[Int](mapper))
+    assertEquals(Optional.of(14),
+        Optional.of("another string").flatMap[Int](mapper))
+    assertEquals(Optional.empty(),
+        Optional.of("").flatMap[Int](mapper))
+  }
+
+  @Test def testOrElse(): Unit = {
+    val emp = Optional.empty[String]()
+    assertEquals("123", emp.orElse("123"))
+    val emptyInt = Optional.empty[Int]()
+    assertEquals(2, emptyInt.orElse(2))
+  }
+
+  @Test def testOrElseGet(): Unit = {
+    assertEquals("a string",
+        Optional.of("a string").orElseGet(new Supplier[String] {
+          def get(): String =
+            throw new AssertionError("Optional.of().orElseGet() should not call its argument")
+        }))
+
+    assertEquals("fallback",
+        Optional.empty[String]().orElseGet(new Supplier[String] {
+          def get(): String = "fallback"
+        }))
+
+    assertNull(
+        Optional.empty[String]().orElseGet(new Supplier[String] {
+          def get(): String = null
+        }))
+  }
+
+  @Test def testOrThrowCustomException(): Unit = {
+    assertEquals("a string",
+        Optional.of("a string").orElseThrow(new Supplier[IllegalArgumentException] {
+          def get(): IllegalArgumentException =
+            throw new AssertionError("Optional.of().orElseThrow() should not call its argument")
+        }))
+
+    val ex = assertThrows(classOf[IllegalArgumentException],
+        Optional.empty[String]().orElseThrow(new Supplier[IllegalArgumentException] {
+          def get(): IllegalArgumentException =
+            new IllegalArgumentException("fallback")
+        }))
+    assertEquals("fallback", ex.getMessage())
+  }
+
+  @Test def testHashCode(): Unit = {
+    val emp = Optional.empty[String]()
+    assertEquals(emp.hashCode(), 0)
+    val fullString = Optional.of[String]("123")
+    assertEquals(fullString.hashCode(), "123".hashCode())
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/OptionalTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/OptionalTest.scala
@@ -74,7 +74,10 @@ class OptionalTest {
     val fullString = Optional.of("hello")
     fullString.ifPresent(new Consumer[String] {
       def accept(t: String): Unit = {
-        assertTrue("of().ifPresent() should call its callback only once", result.isEmpty)
+        assertTrue(
+          "of().ifPresent() should call its callback only once",
+          result.isEmpty
+        )
         result = Some(t)
       }
     })
@@ -82,50 +85,74 @@ class OptionalTest {
   }
 
   @Test def testFilter(): Unit = {
-    assertEquals(Optional.empty[String](),
-        Optional.empty[String]().filter(new Predicate[String] {
+    assertEquals(
+      Optional.empty[String](),
+      Optional
+        .empty[String]()
+        .filter(new Predicate[String] {
           def test(t: String): Boolean =
-            throw new AssertionError("Optional.empty().filter() should not call its argument")
-        }))
+            throw new AssertionError(
+              "Optional.empty().filter() should not call its argument"
+            )
+        })
+    )
 
     val predicate = new Predicate[String] {
       def test(t: String): Boolean = t.length() < 10
     }
 
-    assertEquals(Optional.empty[String](),
-        Optional.of[String]("this string is too long").filter(predicate))
-    assertEquals(Optional.of("short"),
-        Optional.of("short").filter(predicate))
+    assertEquals(
+      Optional.empty[String](),
+      Optional.of[String]("this string is too long").filter(predicate)
+    )
+    assertEquals(Optional.of("short"), Optional.of("short").filter(predicate))
   }
 
   @Test def testMap(): Unit = {
-    assertEquals(Optional.empty[String](),
-        Optional.empty[String]().map[Int](new Function[String, Int] {
+    assertEquals(
+      Optional.empty[String](),
+      Optional
+        .empty[String]()
+        .map[Int](new Function[String, Int] {
           def apply(t: String): Int =
-            throw new AssertionError("Optional.empty().map() should not call its argument")
-        }))
+            throw new AssertionError(
+              "Optional.empty().map() should not call its argument"
+            )
+        })
+    )
 
     val mapper = new Function[String, Int] {
       def apply(t: String): Int = t.length()
     }
 
-    assertEquals(Optional.of(8),
-        Optional.of("a string").map[Int](mapper))
-    assertEquals(Optional.of(14),
-        Optional.of("another string").map[Int](mapper))
+    assertEquals(Optional.of(8), Optional.of("a string").map[Int](mapper))
+    assertEquals(
+      Optional.of(14),
+      Optional.of("another string").map[Int](mapper)
+    )
 
-    assertEquals(Optional.empty[String](),
-        Optional.of("a string").map[String](new Function[String, String] {
+    assertEquals(
+      Optional.empty[String](),
+      Optional
+        .of("a string")
+        .map[String](new Function[String, String] {
           def apply(t: String): String = null
-        }))
+        })
+    )
   }
 
   @Test def testFlatMap(): Unit = {
-    assertEquals(Optional.empty[String](),
-        Optional.empty[String]().flatMap[Int](new Function[String, Optional[Int]] {
+    assertEquals(
+      Optional.empty[String](),
+      Optional
+        .empty[String]()
+        .flatMap[Int](new Function[String, Optional[Int]] {
           def apply(t: String): Optional[Int] =
-            throw new AssertionError("Optional.empty().flatMap() should not call its argument")
-        }))
+            throw new AssertionError(
+              "Optional.empty().flatMap() should not call its argument"
+            )
+        })
+    )
 
     val mapper = new Function[String, Optional[Int]] {
       def apply(t: String): Optional[Int] =
@@ -133,12 +160,12 @@ class OptionalTest {
         else Optional.of(t.length())
     }
 
-    assertEquals(Optional.of(8),
-        Optional.of("a string").flatMap[Int](mapper))
-    assertEquals(Optional.of(14),
-        Optional.of("another string").flatMap[Int](mapper))
-    assertEquals(Optional.empty(),
-        Optional.of("").flatMap[Int](mapper))
+    assertEquals(Optional.of(8), Optional.of("a string").flatMap[Int](mapper))
+    assertEquals(
+      Optional.of(14),
+      Optional.of("another string").flatMap[Int](mapper)
+    )
+    assertEquals(Optional.empty(), Optional.of("").flatMap[Int](mapper))
   }
 
   @Test def testOrElse(): Unit = {
@@ -149,35 +176,58 @@ class OptionalTest {
   }
 
   @Test def testOrElseGet(): Unit = {
-    assertEquals("a string",
-        Optional.of("a string").orElseGet(new Supplier[String] {
+    assertEquals(
+      "a string",
+      Optional
+        .of("a string")
+        .orElseGet(new Supplier[String] {
           def get(): String =
-            throw new AssertionError("Optional.of().orElseGet() should not call its argument")
-        }))
+            throw new AssertionError(
+              "Optional.of().orElseGet() should not call its argument"
+            )
+        })
+    )
 
-    assertEquals("fallback",
-        Optional.empty[String]().orElseGet(new Supplier[String] {
+    assertEquals(
+      "fallback",
+      Optional
+        .empty[String]()
+        .orElseGet(new Supplier[String] {
           def get(): String = "fallback"
-        }))
+        })
+    )
 
     assertNull(
-        Optional.empty[String]().orElseGet(new Supplier[String] {
+      Optional
+        .empty[String]()
+        .orElseGet(new Supplier[String] {
           def get(): String = null
-        }))
+        })
+    )
   }
 
   @Test def testOrThrowCustomException(): Unit = {
-    assertEquals("a string",
-        Optional.of("a string").orElseThrow(new Supplier[IllegalArgumentException] {
+    assertEquals(
+      "a string",
+      Optional
+        .of("a string")
+        .orElseThrow(new Supplier[IllegalArgumentException] {
           def get(): IllegalArgumentException =
-            throw new AssertionError("Optional.of().orElseThrow() should not call its argument")
-        }))
+            throw new AssertionError(
+              "Optional.of().orElseThrow() should not call its argument"
+            )
+        })
+    )
 
-    val ex = assertThrows(classOf[IllegalArgumentException],
-        Optional.empty[String]().orElseThrow(new Supplier[IllegalArgumentException] {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      Optional
+        .empty[String]()
+        .orElseThrow(new Supplier[IllegalArgumentException] {
           def get(): IllegalArgumentException =
             new IllegalArgumentException("fallback")
-        }))
+        })
+    )
     assertEquals("fallback", ex.getMessage())
   }
 

--- a/unit-tests/shared/src/test/scala/javalib/util/PriorityQueueTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/PriorityQueueTest.scala
@@ -1,0 +1,479 @@
+// Ported from Scala.js, revision d0808af, dated 6 Jan 2021
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalanative.testsuite.javalib.util
+
+import scala.reflect.ClassTag
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import java.util.PriorityQueue
+import java.util.Comparator
+
+import org.scalanative.testsuite.utils.Platform.executingInJVM
+
+class PriorityQueueTest extends CollectionTest {
+  def factory: PriorityQueueFactory = new PriorityQueueFactory
+
+  @Test def addAndRemoveInt(): Unit = {
+    val pq = new PriorityQueue[Int]()
+
+    assertEquals(0, pq.size())
+    assertTrue(pq.add(111))
+    assertEquals(1, pq.size())
+    assertTrue(pq.add(222))
+    assertEquals(2, pq.size())
+    assertEquals(111, pq.poll())
+    assertEquals(1, pq.size())
+    assertEquals(222, pq.poll())
+    assertTrue(pq.add(222))
+    assertTrue(pq.add(222))
+    assertTrue(pq.remove(222))
+    assertTrue(pq.remove(222))
+    assertFalse(pq.remove(222))
+  }
+
+  @Test def addAndRemoveString(): Unit = {
+    val pq = new PriorityQueue[String]()
+
+    assertEquals(0, pq.size())
+    assertTrue(pq.add("aaa"))
+    assertEquals(1, pq.size())
+    assertTrue(pq.add("bbb"))
+    assertEquals(2, pq.size())
+    assertEquals("aaa", pq.poll())
+    assertEquals(1, pq.size())
+    assertEquals("bbb", pq.poll())
+    assertTrue(pq.add("bbb"))
+    assertTrue(pq.add("bbb"))
+    assertTrue(pq.remove("bbb"))
+    assertTrue(pq.remove("bbb"))
+    assertFalse(pq.remove("bbb"))
+    assertNull(pq.poll())
+  }
+
+  @Test def addAndRemoveObjectWithCustomComparator(): Unit = {
+    case class Rect(x: Int, y: Int)
+
+    val areaComp = new Comparator[Rect] {
+      def compare(a: Rect, b: Rect): Int = (a.x*a.y) - (b.x*b.y)
+    }
+
+    val pq = new PriorityQueue[Rect](11, areaComp)
+
+    assertTrue(pq.add(Rect(1,2)))
+    assertTrue(pq.add(Rect(2,3)))
+    assertTrue(pq.add(Rect(1,3)))
+
+    val first = pq.poll()
+    assertEquals(1, first.x)
+    assertEquals(2, first.y)
+
+    assertFalse(pq.remove(first))
+
+    val second = pq.peek()
+    assertEquals(1, second.x)
+    assertEquals(3, second.y)
+
+    assertTrue(pq.remove(second))
+    assertFalse(pq.remove(second))
+
+    val third = pq.peek()
+    assertEquals(2, third.x)
+    assertEquals(3, third.y)
+
+    assertTrue(pq.remove(third))
+    assertFalse(pq.remove(third))
+
+    assertTrue(pq.isEmpty)
+
+    assertTrue(pq.peek() eq null)
+    assertTrue(pq.poll() eq null)
+  }
+
+  @Test def addAndRemoveDoubleCornerCases(): Unit = {
+    val pq = new PriorityQueue[Double]()
+
+    assertTrue(pq.add(1.0))
+    assertTrue(pq.add(+0.0))
+    assertTrue(pq.add(-0.0))
+    assertTrue(pq.add(Double.NaN))
+
+    assertTrue(pq.poll.equals(-0.0))
+
+    assertTrue(pq.poll.equals(+0.0))
+
+    assertTrue(pq.poll.equals(1.0))
+
+    assertTrue(pq.peek.isNaN)
+
+    assertTrue(pq.remove(Double.NaN))
+
+    assertTrue(pq.isEmpty)
+  }
+
+  @Test def ctorCollectionInt(): Unit = {
+    val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val pq = new PriorityQueue[Int](l)
+
+    assertEquals(5, pq.size())
+    for (i <- 1 to 5) {
+      assertEquals(i, pq.poll())
+    }
+    assertTrue(pq.isEmpty)
+  }
+
+  @Test def ctorPriorityQueueInt(): Unit = {
+    val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val pq1 = new PriorityQueue[Int](l)
+    val pq2 = new PriorityQueue[Int](pq1)
+
+    assertEquals(5, pq1.size())
+    assertEquals(5, pq2.size())
+    for (i <- 1 to 5) {
+      assertEquals(pq2.poll(), pq1.poll())
+    }
+    assertTrue(pq1.isEmpty)
+    assertTrue(pq2.isEmpty)
+  }
+
+  @Test def ctorSortedSetInt(): Unit = {
+    val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val ss = new java.util.concurrent.ConcurrentSkipListSet[Int](l)
+    val pq1 = new PriorityQueue[Int](l)
+    val pq2 = new PriorityQueue[Int](ss)
+
+    assertEquals(5, pq1.size())
+    assertEquals(5, pq2.size())
+    for (i <- 1 to 5) {
+      assertEquals(pq2.poll(), pq1.poll())
+    }
+    assertTrue(pq1.isEmpty)
+    assertTrue(pq2.isEmpty)
+  }
+
+  @Test def testClear(): Unit = {
+    val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val pq = new PriorityQueue[Int](l)
+
+    assertEquals(5, pq.size())
+    pq.clear()
+    assertEquals(0, pq.size())
+  }
+
+  @Test def addAllCollectionIntAndAddInt(): Unit = {
+    val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val pq = new PriorityQueue[Int]()
+
+    assertEquals(0, pq.size())
+    pq.addAll(l)
+    assertEquals(5, pq.size())
+    pq.add(6)
+    assertEquals(6, pq.size())
+  }
+
+  @Test def containsDoubleCornerCasesPriorityQueue(): Unit = {
+    val pq = new PriorityQueue[Double]()
+
+    assertTrue(pq.add(11111.0))
+    assertEquals(1, pq.size())
+    assertTrue(pq.contains(11111.0))
+    assertEquals(11111.0, pq.iterator.next(), 0.0)
+
+    assertTrue(pq.add(Double.NaN))
+    assertEquals(2, pq.size())
+    assertTrue(pq.contains(Double.NaN))
+    assertFalse(pq.contains(+0.0))
+    assertFalse(pq.contains(-0.0))
+
+    assertTrue(pq.remove(Double.NaN))
+    assertTrue(pq.add(+0.0))
+    assertEquals(2, pq.size())
+    assertFalse(pq.contains(Double.NaN))
+    assertTrue(pq.contains(+0.0))
+    assertFalse(pq.contains(-0.0))
+
+    assertTrue(pq.remove(+0.0))
+    assertTrue(pq.add(-0.0))
+    assertEquals(2, pq.size())
+    assertFalse(pq.contains(Double.NaN))
+    assertFalse(pq.contains(+0.0))
+    assertTrue(pq.contains(-0.0))
+
+    assertTrue(pq.add(+0.0))
+    assertTrue(pq.add(Double.NaN))
+    assertTrue(pq.contains(Double.NaN))
+    assertTrue(pq.contains(+0.0))
+    assertTrue(pq.contains(-0.0))
+  }
+
+  @Test def pollIntStringDouble(): Unit = {
+    val pqInt = new PriorityQueue[Int]()
+
+    assertTrue(pqInt.add(1000))
+    assertTrue(pqInt.add(10))
+    assertEquals(10, pqInt.poll())
+
+    val pqString = new PriorityQueue[String]()
+
+    assertTrue(pqString.add("pluto"))
+    assertTrue(pqString.add("pippo"))
+    assertEquals("pippo", pqString.poll())
+
+    val pqDouble = new PriorityQueue[Double]()
+
+    assertTrue(pqDouble.add(+10000.987))
+    assertTrue(pqDouble.add(-0.987))
+    assertEquals(-0.987, pqDouble.poll(), 0.0)
+  }
+
+  @Test def pollIntEntireQueue(): Unit = {
+    val pq = newPriorityQueueWith0Until100()
+
+    var nextExpected = 0
+    while (!pq.isEmpty()) {
+      assertEquals(nextExpected, pq.poll())
+      nextExpected += 1
+    }
+    assertEquals(100, nextExpected)
+  }
+
+  @Test def removePreservesPriorities(): Unit = {
+    for (itemToRemove <- 0 until 100) {
+      val pq = newPriorityQueueWith0Until100()
+
+      assertTrue(pq.remove(itemToRemove))
+
+      var nextExpected = 0
+      while (!pq.isEmpty()) {
+        if (nextExpected == itemToRemove)
+          nextExpected += 1
+        assertEquals(s"after removing $itemToRemove", nextExpected, pq.poll())
+        nextExpected += 1
+      }
+
+      if (itemToRemove == 99)
+        assertEquals(99, nextExpected)
+      else
+        assertEquals(100, nextExpected)
+    }
+  }
+
+  @Test def iteratorRemovePreservesPriorities(): Unit = {
+    for (itemToRemove <- 0 until 100) {
+      val pq = newPriorityQueueWith0Until100()
+
+      val iter = pq.iterator()
+      while (iter.next() != itemToRemove) {}
+      iter.remove()
+
+      var nextExpected = 0
+      while (!pq.isEmpty()) {
+        if (nextExpected == itemToRemove)
+          nextExpected += 1
+        assertEquals(s"after removing $itemToRemove", nextExpected, pq.poll())
+        nextExpected += 1
+      }
+
+      if (itemToRemove == 99)
+        assertEquals(99, nextExpected)
+      else
+        assertEquals(100, nextExpected)
+    }
+  }
+
+  // --- Begin Whitebox Tests ---
+
+  /* The following tests are meant to test the behavior of `Iterator.remove()`
+   * and subsequent iteration in very specific scenarios that are corner cases
+   * of the current implementation.
+   *
+   * We could write the same tests as blackbox, but then we would not be able
+   * to verify that they are indeed testing the scenarios they are supposed to
+   * test.
+   *
+   * Therefore, these tests are whitebox, and rely on details of our own
+   * implementation. They verify that elements are iterated in a very specific
+   * order, and that the internal representation of the heap evolves in the way
+   * we expect.
+   *
+   * Since the following tests are whitebox, they may have to be changed if the
+   * internal data structure and/or algorithms of PriorityQueue are modified in
+   * the future.
+   */
+
+  @Test def iteratorRemovePreservesPrioritiesIntCornerCase(): Unit = {
+    /* This tests the specific scenario where `Iterator.remove()` causes the
+     * array to be reordered in such a way that a) elements yet to be iterated
+     * are moved before the iteration cursor, and b) elements already iteratoed
+     * are moved after the cursor.
+     *
+     * Due to the nature of a binary heap, triggering this scenario is quite
+     * difficult, and does not easily happen by chance. The arrangement of
+     * nodes has to be engineered in a specific way for the test to be
+     * meaningful.
+     */
+
+    assumeFalse("whitebox test of our own implementation", executingInJVM)
+
+    val pq = new java.util.PriorityQueue[Int]()
+    for (x <- List(1, 2, 30, 4, 3, 40, 35, 10))
+      pq.add(x)
+
+    assertEquals("[1, 2, 30, 4, 3, 40, 35, 10]", pq.toString())
+
+    val iter = pq.iterator()
+    assertEquals(1, iter.next())
+    assertEquals(2, iter.next())
+    assertEquals(30, iter.next())
+    assertEquals(4, iter.next())
+    assertEquals(3, iter.next())
+    assertEquals(40, iter.next())
+
+    iter.remove()
+    assertEquals("[1, 2, 10, 4, 3, 30, 35]", pq.toString())
+
+    assertEquals(35, iter.next())
+    assertEquals(10, iter.next())
+
+    iter.remove()
+    assertEquals("[1, 2, 30, 4, 3, 35]", pq.toString())
+
+    assertFalse(iter.hasNext())
+  }
+
+  @Test def iteratorRemoveDoubleCornerCase(): Unit = {
+    /* This tests that when `Iterator.remove()` is supposed to remove a zero,
+     * it does not accidentally remove a zero of the opposite sign.
+     *
+     * To be meaningful, this tests requires that the zero we are trying to
+     * remove be positioned further in the internal array than the other one.
+     */
+
+    assumeFalse("whitebox test of our own implementation", executingInJVM)
+
+    val pq = new java.util.PriorityQueue[Double]()
+    for (x <- List(-1.0, -0.0, 0.0, 3.5, Double.NaN))
+      pq.add(x)
+
+    assertEquals("[-1.0, -0.0, 0.0, 3.5, NaN]", pq.toString())
+
+    val iter = pq.iterator()
+    assertEquals(-1.0: Any, iter.next())
+    assertEquals(-0.0: Any, iter.next())
+    assertEquals(0.0: Any, iter.next())
+
+    iter.remove()
+    assertEquals("+0.0 must have been removed, not -0.0",
+        "[-1.0, -0.0, NaN, 3.5]", pq.toString())
+    assertTrue("+0.0 must have been removed, not -0.0",
+        pq.contains(-0.0) && !pq.contains(0.0))
+
+    assertEquals(3.5: Any, iter.next())
+    assertEquals(Double.NaN: Any, iter.next())
+
+    iter.remove()
+    assertEquals("NaN must have been removed", "[-1.0, -0.0, 3.5]", pq.toString())
+
+    assertFalse(iter.hasNext())
+  }
+
+  @Test def iteratorRemoveCustomObjectCornerCase(): Unit = {
+    /* This tests that when `Iterator.remove()` is supposed to remove an
+     * object, it does not accidentally remove an other object that happens to
+     * be `equals` to it (but with a different identity).
+     *
+     * To be meaningful, this tests requires that the object we are trying to
+     * remove be positioned further in the internal array than the other one.
+     */
+
+    assumeFalse("whitebox test of our own implementation", executingInJVM)
+
+    final case class TestObj(i: Int)(val id: Int) extends Comparable[TestObj] {
+      def compareTo(o: TestObj): Int = Integer.compare(this.i, o.i)
+
+      override def toString(): String = s"TestObj@$id"
+    }
+
+    val first = TestObj(1)(10)
+    val second = TestObj(2)(20)
+    val third = TestObj(2)(21)
+    val fourth = TestObj(3)(30)
+    val fifth = TestObj(4)(40)
+
+    val pq = new java.util.PriorityQueue[TestObj]()
+    for (x <- List(first, second, third, fourth, fifth))
+      pq.add(x)
+
+    assertEquals(
+        "[TestObj@10, TestObj@20, TestObj@21, TestObj@30, TestObj@40]",
+        pq.toString())
+
+    val iter = pq.iterator()
+    assertSame(first, iter.next())
+    assertSame(second, iter.next())
+    assertSame(third, iter.next())
+
+    iter.remove()
+    assertEquals("third must have been removed, not second",
+        "[TestObj@10, TestObj@20, TestObj@40, TestObj@30]", pq.toString())
+
+    assertSame(fourth, iter.next())
+    assertSame(fifth, iter.next())
+
+    iter.remove()
+    assertEquals("[TestObj@10, TestObj@20, TestObj@30]", pq.toString())
+
+    assertFalse(iter.hasNext())
+  }
+
+  // --- End Whitebox Tests ---
+
+  /** Built with `scala.util.Random.shuffle((0 until 100).toList)`. */
+  private val listOfShuffled0Until100 = List(
+      89, 26, 23, 9, 96, 81, 34, 79, 37, 90, 45, 66, 16, 49, 70, 77, 5, 19, 39,
+      98, 44, 15, 1, 6, 43, 27, 40, 3, 68, 91, 76, 20, 54, 87, 85, 12, 86, 31,
+      67, 24, 95, 0, 38, 22, 97, 28, 59, 2, 94, 7, 51, 30, 72, 56, 18, 13, 14,
+      75, 53, 64, 47, 46, 58, 93, 74, 32, 57, 83, 60, 73, 11, 88, 69, 65, 33,
+      52, 29, 80, 50, 63, 10, 62, 48, 55, 41, 35, 21, 42, 61, 36, 99, 78, 82,
+      8, 4, 71, 25, 84, 92, 17
+  )
+
+  /** Creates a new priority queue in which the integers 0 until 100 have been
+   *  added in a random order.
+   *
+   *  The random order is important to avoid creating a degenerate heap where
+   *  the array is in strict increasing order. Such degenerate heaps tend to
+   *  pass tests too easily, even with broken implementations.
+   */
+  private def newPriorityQueueWith0Until100(): PriorityQueue[Int] = {
+    val pq = new PriorityQueue[Int]()
+    for (i <- listOfShuffled0Until100)
+      pq.add(i)
+    pq
+  }
+
+}
+
+class PriorityQueueFactory extends CollectionFactory {
+
+  override def implementationName: String =
+    "java.util.PriorityQueue"
+
+  override def empty[E: ClassTag]: PriorityQueue[E] =
+    new PriorityQueue()
+
+  override def allowsNullElement: Boolean = false
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/PriorityQueueTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/PriorityQueueTest.scala
@@ -68,14 +68,14 @@ class PriorityQueueTest extends CollectionTest {
     case class Rect(x: Int, y: Int)
 
     val areaComp = new Comparator[Rect] {
-      def compare(a: Rect, b: Rect): Int = (a.x*a.y) - (b.x*b.y)
+      def compare(a: Rect, b: Rect): Int = (a.x * a.y) - (b.x * b.y)
     }
 
     val pq = new PriorityQueue[Rect](11, areaComp)
 
-    assertTrue(pq.add(Rect(1,2)))
-    assertTrue(pq.add(Rect(2,3)))
-    assertTrue(pq.add(Rect(1,3)))
+    assertTrue(pq.add(Rect(1, 2)))
+    assertTrue(pq.add(Rect(2, 3)))
+    assertTrue(pq.add(Rect(1, 3)))
 
     val first = pq.poll()
     assertEquals(1, first.x)
@@ -376,16 +376,25 @@ class PriorityQueueTest extends CollectionTest {
     assertEquals(0.0: Any, iter.next())
 
     iter.remove()
-    assertEquals("+0.0 must have been removed, not -0.0",
-        "[-1.0, -0.0, NaN, 3.5]", pq.toString())
-    assertTrue("+0.0 must have been removed, not -0.0",
-        pq.contains(-0.0) && !pq.contains(0.0))
+    assertEquals(
+      "+0.0 must have been removed, not -0.0",
+      "[-1.0, -0.0, NaN, 3.5]",
+      pq.toString()
+    )
+    assertTrue(
+      "+0.0 must have been removed, not -0.0",
+      pq.contains(-0.0) && !pq.contains(0.0)
+    )
 
     assertEquals(3.5: Any, iter.next())
     assertEquals(Double.NaN: Any, iter.next())
 
     iter.remove()
-    assertEquals("NaN must have been removed", "[-1.0, -0.0, 3.5]", pq.toString())
+    assertEquals(
+      "NaN must have been removed",
+      "[-1.0, -0.0, 3.5]",
+      pq.toString()
+    )
 
     assertFalse(iter.hasNext())
   }
@@ -418,8 +427,9 @@ class PriorityQueueTest extends CollectionTest {
       pq.add(x)
 
     assertEquals(
-        "[TestObj@10, TestObj@20, TestObj@21, TestObj@30, TestObj@40]",
-        pq.toString())
+      "[TestObj@10, TestObj@20, TestObj@21, TestObj@30, TestObj@40]",
+      pq.toString()
+    )
 
     val iter = pq.iterator()
     assertSame(first, iter.next())
@@ -427,8 +437,11 @@ class PriorityQueueTest extends CollectionTest {
     assertSame(third, iter.next())
 
     iter.remove()
-    assertEquals("third must have been removed, not second",
-        "[TestObj@10, TestObj@20, TestObj@40, TestObj@30]", pq.toString())
+    assertEquals(
+      "third must have been removed, not second",
+      "[TestObj@10, TestObj@20, TestObj@40, TestObj@30]",
+      pq.toString()
+    )
 
     assertSame(fourth, iter.next())
     assertSame(fifth, iter.next())
@@ -443,12 +456,12 @@ class PriorityQueueTest extends CollectionTest {
 
   /** Built with `scala.util.Random.shuffle((0 until 100).toList)`. */
   private val listOfShuffled0Until100 = List(
-      89, 26, 23, 9, 96, 81, 34, 79, 37, 90, 45, 66, 16, 49, 70, 77, 5, 19, 39,
-      98, 44, 15, 1, 6, 43, 27, 40, 3, 68, 91, 76, 20, 54, 87, 85, 12, 86, 31,
-      67, 24, 95, 0, 38, 22, 97, 28, 59, 2, 94, 7, 51, 30, 72, 56, 18, 13, 14,
-      75, 53, 64, 47, 46, 58, 93, 74, 32, 57, 83, 60, 73, 11, 88, 69, 65, 33,
-      52, 29, 80, 50, 63, 10, 62, 48, 55, 41, 35, 21, 42, 61, 36, 99, 78, 82,
-      8, 4, 71, 25, 84, 92, 17
+    89, 26, 23, 9, 96, 81, 34, 79, 37, 90, 45, 66, 16, 49, 70, 77, 5, 19, 39,
+    98, 44, 15, 1, 6, 43, 27, 40, 3, 68, 91, 76, 20, 54, 87, 85, 12, 86, 31, 67,
+    24, 95, 0, 38, 22, 97, 28, 59, 2, 94, 7, 51, 30, 72, 56, 18, 13, 14, 75, 53,
+    64, 47, 46, 58, 93, 74, 32, 57, 83, 60, 73, 11, 88, 69, 65, 33, 52, 29, 80,
+    50, 63, 10, 62, 48, 55, 41, 35, 21, 42, 61, 36, 99, 78, 82, 8, 4, 71, 25,
+    84, 92, 17
   )
 
   /** Creates a new priority queue in which the integers 0 until 100 have been

--- a/unit-tests/shared/src/test/scala/javalib/util/PriorityQueueTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/PriorityQueueTest.scala
@@ -149,20 +149,21 @@ class PriorityQueueTest extends CollectionTest {
     assertTrue(pq2.isEmpty)
   }
 
-  @Test def ctorSortedSetInt(): Unit = {
-    val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
-    val ss = new java.util.concurrent.ConcurrentSkipListSet[Int](l)
-    val pq1 = new PriorityQueue[Int](l)
-    val pq2 = new PriorityQueue[Int](ss)
+  // Todo: Restare after implementing ConcurrentSkipListSet
+  // @Test def ctorSortedSetInt(): Unit = {
+  //   val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
+  //   val ss = new java.util.concurrent.ConcurrentSkipListSet[Int](l)
+  //   val pq1 = new PriorityQueue[Int](l)
+  //   val pq2 = new PriorityQueue[Int](ss)
 
-    assertEquals(5, pq1.size())
-    assertEquals(5, pq2.size())
-    for (i <- 1 to 5) {
-      assertEquals(pq2.poll(), pq1.poll())
-    }
-    assertTrue(pq1.isEmpty)
-    assertTrue(pq2.isEmpty)
-  }
+  //   assertEquals(5, pq1.size())
+  //   assertEquals(5, pq2.size())
+  //   for (i <- 1 to 5) {
+  //     assertEquals(pq2.poll(), pq1.poll())
+  //   }
+  //   assertTrue(pq1.isEmpty)
+  //   assertTrue(pq2.isEmpty)
+  // }
 
   @Test def testClear(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)

--- a/unit-tests/shared/src/test/scala/javalib/util/SortedSetTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/SortedSetTest.scala
@@ -1,0 +1,143 @@
+// Ported from Scala.js, revision c473689, dated 3 May 2021
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalanative.testsuite.javalib.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.{util => ju}
+
+import scala.reflect.ClassTag
+
+trait SortedSetTest extends SetTest {
+
+  def factory: SortedSetFactory
+
+  @Test def first(): Unit = {
+    val ssInt = factory.empty[Int]
+
+    assertTrue(ssInt.add(1000))
+    assertTrue(ssInt.add(10))
+    assertEquals(10, ssInt.first)
+
+    val ssString = factory.empty[String]
+
+    assertTrue(ssString.add("pluto"))
+    assertTrue(ssString.add("pippo"))
+    assertEquals("pippo", ssString.first)
+
+    val ssDouble = factory.empty[Double]
+
+    assertTrue(ssDouble.add(+10000.987))
+    assertTrue(ssDouble.add(-0.987))
+    assertEquals(-0.987, ssDouble.first, 0.0)
+  }
+
+  @Test def last(): Unit = {
+    val ssInt = factory.empty[Int]
+
+    assertTrue(ssInt.add(1000))
+    assertTrue(ssInt.add(10))
+    assertEquals(1000, ssInt.last)
+
+    val ssString = factory.empty[String]
+
+    assertTrue(ssString.add("pluto"))
+    assertTrue(ssString.add("pippo"))
+    assertEquals("pluto", ssString.last)
+
+    val ssDouble = factory.empty[Double]
+
+    assertTrue(ssDouble.add(+10000.987))
+    assertTrue(ssDouble.add(-0.987))
+    assertEquals(10000.987, ssDouble.last, 0.0)
+  }
+
+  val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
+
+  @Test def headSet(): Unit = {
+    val ss = factory.empty[Int]
+
+    ss.addAll(l)
+
+    val hs1 = ss.headSet(3)
+    val l1 = TrivialImmutableCollection(1, 2)
+    assertTrue(hs1.containsAll(l1))
+    assertTrue(hs1.removeAll(l1))
+    assertTrue(hs1.isEmpty)
+    assertEquals(3, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(3, 4, 5)))
+
+    ss.addAll(l)
+
+    val hs2 = ss.headSet(4)
+    val l2 = TrivialImmutableCollection(1, 2, 3)
+    assertTrue(hs2.containsAll(l2))
+    assertTrue(hs2.removeAll(l2))
+    assertTrue(hs2.isEmpty)
+    assertEquals(2, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(4, 5)))
+  }
+
+  @Test def tailSet(): Unit = {
+    val ss = factory.empty[Int]
+
+    ss.addAll(l)
+
+    val ts1 = ss.tailSet(3)
+    val l3 = TrivialImmutableCollection(3, 4, 5)
+    assertTrue(ts1.containsAll(l3))
+    assertTrue(ts1.removeAll(l3))
+    assertTrue(ts1.isEmpty)
+    assertEquals(2, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(1, 2)))
+
+    ss.addAll(l)
+
+    val ts2 = ss.tailSet(4)
+    val l4 = TrivialImmutableCollection(4, 5)
+    assertTrue(ts2.containsAll(l4))
+    assertTrue(ts2.removeAll(l4))
+    assertTrue(ts2.isEmpty)
+    assertEquals(3, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(1, 2, 3)))
+  }
+
+  @Test def subSet(): Unit = {
+    val ss = factory.empty[Int]
+
+    ss.addAll(l)
+
+    val ss1 = ss.subSet(2, 4)
+    val l5 = TrivialImmutableCollection(2, 3)
+    assertTrue(ss1.containsAll(l5))
+    assertTrue(ss1.removeAll(l5))
+    assertTrue(ss1.isEmpty)
+    assertEquals(3, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(1, 4, 5)))
+
+    ss.addAll(l)
+
+    val ss2 = ss.subSet(1, 5)
+    assertTrue(ss2.containsAll(l5))
+    assertTrue(ss2.removeAll(l5))
+    assertFalse(ss2.isEmpty)
+    assertEquals(3, ss.size)
+    assertTrue(ss.containsAll(TrivialImmutableCollection(1, 4, 5)))
+  }
+}
+
+trait SortedSetFactory extends SetFactory {
+  def empty[E: ClassTag]: ju.SortedSet[E]
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/TreeSetTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/TreeSetTest.scala
@@ -1,0 +1,380 @@
+// Ported from Scala.js, revision cbf86bb, dated 24 Oct 2020
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalanative.testsuite.javalib.util
+
+import org.junit.Assert._
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import scala.scalanative.junit.utils.AssertThrows.assertThrows
+import org.scalanative.testsuite.utils.Platform._
+
+import java.{util => ju}
+import ju.TreeSet
+import ju.Comparator
+
+import scala.reflect.ClassTag
+
+class TreeSetWithoutNullTest extends TreeSetTest(new TreeSetFactory) {
+
+  @Test def comparatorNull(): Unit = {
+    val ts1 = factory.empty[Int]
+
+    assertNull(ts1.comparator())
+
+    val ts2 = factory.empty[String]
+
+    assertNull(ts2.comparator())
+  }
+}
+
+class TreeSetWithNullTest extends TreeSetTest(new TreeSetWithNullFactory) {
+  @Test def comparatorNotNull(): Unit = {
+    val ts1 = factory.empty[Int]
+
+    assertFalse(ts1.comparator() == null)
+
+    val ts2 = factory.empty[String]
+
+    assertFalse(ts2.comparator() == null)
+  }
+}
+
+abstract class TreeSetTest(val factory: TreeSetFactory)
+    extends AbstractSetTest
+    with SortedSetTest
+    with NavigableSetTest {
+
+  @Test def addRemoveInt(): Unit = {
+    val ts = factory.empty[Int]
+
+    assertEquals(0, ts.size())
+    assertTrue(ts.add(222))
+    assertEquals(1, ts.size())
+    assertTrue(ts.add(111))
+    assertEquals(2, ts.size())
+    assertEquals(111, ts.first)
+    assertTrue(ts.remove(111))
+
+    assertEquals(1, ts.size())
+    assertEquals(222, ts.first)
+
+    assertTrue(ts.remove(222))
+    assertEquals(0, ts.size())
+    assertTrue(ts.isEmpty)
+    assertFalse(ts.remove(333))
+    assertThrows(classOf[NoSuchElementException], ts.first)
+
+    if (factory.allowsNullElement) {
+      assertTrue(ts.asInstanceOf[TreeSet[Any]].add(null))
+      assertTrue(ts.contains(null))
+      assertTrue(ts.remove(null))
+      assertFalse(ts.contains(null))
+    }
+  }
+
+  @Test def addRemoveString(): Unit = {
+    val ts = factory.empty[String]
+
+    assertEquals(0, ts.size())
+    assertTrue(ts.add("222"))
+    assertEquals(1, ts.size())
+    assertTrue(ts.add("111"))
+    assertEquals(2, ts.size())
+    assertEquals("111", ts.first)
+    assertTrue(ts.remove("111"))
+
+    assertEquals(1, ts.size())
+    assertEquals("222", ts.first)
+
+    assertTrue(ts.remove("222"))
+    assertEquals(0, ts.size())
+    assertFalse(ts.remove("333"))
+    assertTrue(ts.isEmpty)
+
+    if (factory.allowsNullElement) {
+      assertTrue(ts.add(null))
+      assertTrue(ts.contains(null))
+      assertTrue(ts.remove(null))
+      assertFalse(ts.contains(null))
+    }
+  }
+
+  @Test def addRemoveCustomComparator(): Unit = {
+    case class Rect(x: Int, y: Int)
+
+    val areaComp = new ju.Comparator[Rect] {
+      def compare(a: Rect, b: Rect): Int = (a.x * a.y) - (b.x * b.y)
+    }
+
+    val ts = factory.empty[Rect](areaComp)
+
+    assertTrue(ts.add(Rect(1, 2)))
+    assertTrue(ts.add(Rect(2, 3)))
+    assertTrue(ts.add(Rect(1, 3)))
+
+    val first = ts.first()
+    assertEquals(1, first.x)
+    assertEquals(2, first.y)
+
+    assertTrue(ts.remove(first))
+    assertFalse(ts.remove(first))
+
+    val second = ts.first()
+    assertEquals(1, second.x)
+    assertEquals(3, second.y)
+
+    assertTrue(ts.remove(second))
+
+    val third = ts.first()
+    assertEquals(2, third.x)
+    assertEquals(3, third.y)
+
+    assertTrue(ts.remove(third))
+
+    assertTrue(ts.isEmpty)
+  }
+
+  @Test def addRemoveDoubleCornerCases(): Unit = {
+    val ts = factory.empty[Double]
+
+    assertTrue(ts.add(1.0))
+    assertTrue(ts.add(+0.0))
+    assertTrue(ts.add(-0.0))
+    assertTrue(ts.add(Double.NaN))
+
+    assertTrue(ts.first.equals(-0.0))
+
+    assertTrue(ts.remove(-0.0))
+
+    assertTrue(ts.first.equals(+0.0))
+
+    assertTrue(ts.remove(+0.0))
+
+    assertTrue(ts.first.equals(1.0))
+
+    assertTrue(ts.remove(1.0))
+
+    assertTrue(ts.first.isNaN)
+
+    assertTrue(ts.remove(Double.NaN))
+
+    assertTrue(ts.isEmpty)
+  }
+
+  @Test def newFromCollectionInt(): Unit = {
+    val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val ts = factory.newFrom(l)
+
+    assertEquals(5, ts.size())
+    for (i <- 1 to 5) {
+      assertEquals(i, ts.first)
+      assertTrue(ts.remove(i))
+    }
+    assertTrue(ts.isEmpty)
+  }
+
+  @Test def clearTreeSet(): Unit = {
+    val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val ts = factory.empty[Int]
+
+    ts.addAll(l)
+
+    assertEquals(5, ts.size())
+    ts.clear()
+    assertEquals(0, ts.size())
+  }
+
+  @Test def addAllCollectionIntAndAddInt(): Unit = {
+    val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
+    val ts = factory.empty[Int]
+
+    assertEquals(0, ts.size())
+    ts.addAll(l)
+    assertEquals(5, ts.size())
+    ts.add(6)
+    assertEquals(6, ts.size())
+  }
+
+  @Test def containsDoubleCornerCasesTreeSet(): Unit = {
+    val ts = factory.empty[Double]
+
+    assertTrue(ts.add(11111.0))
+    assertEquals(1, ts.size())
+    assertTrue(ts.contains(11111.0))
+    assertEquals(11111.0, ts.iterator.next(), 0.0)
+
+    assertTrue(ts.add(Double.NaN))
+    assertEquals(2, ts.size())
+    assertTrue(ts.contains(Double.NaN))
+    assertFalse(ts.contains(+0.0))
+    assertFalse(ts.contains(-0.0))
+
+    assertTrue(ts.remove(Double.NaN))
+    assertTrue(ts.add(+0.0))
+    assertEquals(2, ts.size())
+    assertFalse(ts.contains(Double.NaN))
+    assertTrue(ts.contains(+0.0))
+    assertFalse(ts.contains(-0.0))
+
+    assertTrue(ts.remove(+0.0))
+    assertTrue(ts.add(-0.0))
+    assertEquals(2, ts.size())
+    assertFalse(ts.contains(Double.NaN))
+    assertFalse(ts.contains(+0.0))
+    assertTrue(ts.contains(-0.0))
+
+    assertTrue(ts.add(+0.0))
+    assertTrue(ts.add(Double.NaN))
+    assertTrue(ts.contains(Double.NaN))
+    assertTrue(ts.contains(+0.0))
+    assertTrue(ts.contains(-0.0))
+  }
+
+  @Test def addNullOrNullNotSupportedThrows(): Unit = {
+    val hs = factory.empty[String]
+
+    assertTrue(hs.add("ONE"))
+    assertTrue(hs.contains("ONE"))
+    assertFalse(hs.contains("TWO"))
+
+    if (factory.allowsNullElement) {
+      assertTrue(hs.add(null))
+      assertTrue(hs.contains(null))
+    } else {
+      assertThrows(classOf[Exception], hs.add(null))
+    }
+  }
+
+  @Test def addAllNullOrNullNotSupportedThrows(): Unit = {
+    val l = TrivialImmutableCollection("ONE", "TWO", (null: String))
+    val ts1 = factory.empty[String]
+
+    if (factory.allowsNullElement) {
+      assertTrue(ts1.addAll(l))
+      assertTrue(ts1.contains(null))
+      assertTrue(ts1.contains("ONE"))
+      assertFalse(ts1.contains("THREE"))
+    } else {
+      assertThrows(classOf[Exception], ts1.addAll(l))
+    }
+  }
+
+  @Test def addNonComparableObjectThrows(): Unit = {
+    assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
+
+    class TestObj(num: Int)
+
+    val ts1 = factory.empty[TestObj]
+    assertEquals(0, ts1.size())
+    assertThrows(classOf[ClassCastException], ts1.add(new TestObj(111)))
+  }
+
+  @Test def headSetTailSetSubSetThrowsOnAddElementOutOfBounds(): Unit = {
+    assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
+
+    val l = TrivialImmutableCollection(2, 3, 6)
+    val ts = factory.empty[Int]
+    ts.addAll(l)
+
+    val hs1 = ts.headSet(5, true)
+    assertTrue(hs1.add(4))
+    assertTrue(hs1.add(5))
+    assertThrows(classOf[IllegalArgumentException], hs1.add(6))
+
+    ts.clear()
+    ts.addAll(l)
+
+    val hs2 = ts.headSet(5, false)
+    assertTrue(hs2.add(4))
+    assertThrows(classOf[IllegalArgumentException], hs2.add(5))
+
+    ts.clear()
+    ts.addAll(l)
+
+    val ts1 = ts.tailSet(1, true)
+    assertTrue(ts1.add(7))
+    assertTrue(ts1.add(1))
+    assertThrows(classOf[IllegalArgumentException], ts1.add(0))
+
+    ts.clear()
+    ts.addAll(l)
+
+    val ts2 = ts.tailSet(1, false)
+    assertTrue(ts2.add(7))
+    assertThrows(classOf[IllegalArgumentException], ts2.add(1))
+
+    ts.clear()
+    ts.addAll(l)
+
+    val ss1 = ts.subSet(1, true, 5, true)
+    assertTrue(ss1.add(4))
+    assertTrue(ss1.add(1))
+    assertThrows(classOf[IllegalArgumentException], ss1.add(0))
+    assertTrue(ss1.add(5))
+    assertThrows(classOf[IllegalArgumentException], ss1.add(6))
+
+    ts.clear()
+    ts.addAll(l)
+
+    val ss2 = ts.subSet(1, false, 5, false)
+    assertTrue(ss2.add(4))
+    assertThrows(classOf[IllegalArgumentException], ss2.add(1))
+    assertThrows(classOf[IllegalArgumentException], ss2.add(5))
+  }
+}
+
+class TreeSetFactory extends AbstractSetFactory with NavigableSetFactory
+    with SortedSetFactory {
+  def implementationName: String =
+    "java.util.TreeSet"
+
+  def empty[E: ClassTag]: ju.TreeSet[E] =
+    new TreeSet[E]
+
+  def empty[E](cmp: ju.Comparator[E]): ju.TreeSet[E] =
+    new TreeSet[E](cmp)
+
+  def newFrom[E](coll: ju.Collection[E]): ju.TreeSet[E] =
+    new TreeSet[E](coll)
+
+  override def allowsNullElement: Boolean = false
+
+  override def allowsNullElementQuery: Boolean = false
+}
+
+class TreeSetWithNullFactory extends TreeSetFactory {
+
+  override def implementationName: String =
+    super.implementationName + " {allows null}"
+
+  case class EvenNullComp[E]() extends Comparator[E] {
+    def compare(a: E, b: E): Int =
+      (Option(a), Option(b)) match {
+        case (Some(e1), Some(e2)) => e1.asInstanceOf[Comparable[E]].compareTo(e2)
+        case (Some(e1), None) => -1
+        case (None, Some(e2)) => 1
+        case (None, None) => 0
+      }
+    }
+
+  override def empty[E: ClassTag]: ju.TreeSet[E] =
+    new TreeSet[E](EvenNullComp[E]())
+
+  override def allowsNullElement: Boolean = true
+
+  override def allowsNullElementQuery: Boolean = true
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/TreeSetTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/TreeSetTest.scala
@@ -337,7 +337,9 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
   }
 }
 
-class TreeSetFactory extends AbstractSetFactory with NavigableSetFactory
+class TreeSetFactory
+    extends AbstractSetFactory
+    with NavigableSetFactory
     with SortedSetFactory {
   def implementationName: String =
     "java.util.TreeSet"
@@ -364,12 +366,13 @@ class TreeSetWithNullFactory extends TreeSetFactory {
   case class EvenNullComp[E]() extends Comparator[E] {
     def compare(a: E, b: E): Int =
       (Option(a), Option(b)) match {
-        case (Some(e1), Some(e2)) => e1.asInstanceOf[Comparable[E]].compareTo(e2)
+        case (Some(e1), Some(e2)) =>
+          e1.asInstanceOf[Comparable[E]].compareTo(e2)
         case (Some(e1), None) => -1
         case (None, Some(e2)) => 1
-        case (None, None) => 0
+        case (None, None)     => 0
       }
-    }
+  }
 
   override def empty[E: ClassTag]: ju.TreeSet[E] =
     new TreeSet[E](EvenNullComp[E]())


### PR DESCRIPTION
This PR ports new Scala.js implementation of PriorityQueue and TreeSet - it removes usage of Scala collections in definition on this Java data stractures