### PR TITLE
Fix #2435: Bring .ll section up to date

### DIFF
--- a/docs/contrib/compiler.rst
+++ b/docs/contrib/compiler.rst
@@ -37,7 +37,10 @@ To compile the sandbox project run the following in the sbt shell::
 
     sbt> sandbox3/clean; sandbox3/nativeLink
 
-After compiling the sandbox project you can inspect the ``.ll`` files below
+Compiling will generate a number of files. The ``.ll`` LLVM assembly
+language files can be inspected to see what was passed to LLVM use.
+
+You can inspect the ``.ll`` files in the directories below
 ``sandbox/.3/target/``. Because Scala Native is under active development,
 the directory layout, names of files and their specific content may change.
 

--- a/docs/contrib/compiler.rst
+++ b/docs/contrib/compiler.rst
@@ -22,25 +22,42 @@ compile it to ``.ll`` using::
 
     clang -S -emit-llvm foo.c
 
-Now write the equivalent Scala code for the new intrinsic in the sandbox project.
+Now write the equivalent Scala code for the new intrinsic in the sandbox
+project.
 This project contains a minimal amount of code and has all the toolchain set up
 which makes it fast to iterate and inspect the output of the compilation.
 
+The following directions are using the Scala 3 project. To use other Scala
+versions first find the project name and then use that instead of "sandbox3",
+say "sandbox2_13"::
+
+    sbt> sandbox<TAB>
+    
 To compile the sandbox project run the following in the sbt shell::
 
-    sbt> sandbox/clean;sandbox/nativeLink
+    sbt> sandbox3/clean; sandbox3/nativeLink
 
-After compiling the sandbox project you can inspect the ``.ll`` files inside
-``sandbox/target/scala-<version>/ll``. The files are grouped by the package name.
-By default the ``Test.scala`` file doesn't define a package, so the resulting file
-will be ``__empty.ll``. Locating the code you are interested in might require that
-you get more familiar with the `LLVM assembly language <http://llvm.org/docs/LangRef.html>`_.
+After compiling the sandbox project you can inspect the ``.ll`` files below
+``sandbox/.3/target/``. Because Scala Native is under active development,
+the directory layout, names of files and their specific content may change.
+
+A Linux example, where the actual file names found may vary::
+
+    $ # on command line, with project root as current working directory.
+    $ find sandbox/.3/target -name "*.ll"
+    sandbox/.3/target/scala-3.1.3/native/3.ll
+    sandbox/.3/target/scala-3.1.3/native/2.ll
+    sandbox/.3/target/scala-3.1.3/native/1.ll
+    sandbox/.3/target/scala-3.1.3/native/0.ll
+
+Locating the code you are interested in will require that
+you are familiar with the `LLVM assembly language <http://llvm.org/docs/LangRef.html>`_.
 
 When working on the compiler plugin you'll need to clean the sandbox (or other
 Scala Native projects) if you want it to be recompiled with the newer version
 of the compiler plugin. This can be achieved with::
 
-    sbt> sandbox/clean;sandbox/run
+    sbt> sandbox3/clean; sandbox3/run
 
 Certain intrinsics might require adding new primitives to the compiler plugin.
 This can be done in ``NirPrimitives`` with an accompanying definition in

--- a/docs/contrib/compiler.rst
+++ b/docs/contrib/compiler.rst
@@ -38,13 +38,14 @@ To compile the sandbox project run the following in the sbt shell::
     sbt> sandbox3/clean; sandbox3/nativeLink
 
 Compiling will generate a number of files. The ``.ll`` LLVM assembly
-language files can be inspected to see what was passed to LLVM use.
+language files can be inspected to see what was passed to the LLVM step.
 
 You can inspect the ``.ll`` files in the directories below
 ``sandbox/.3/target/``. Because Scala Native is under active development,
 the directory layout, names of files and their specific content may change.
 
-A Linux example, where the actual file names found may vary::
+All definitions are generated into 1 or N=(number of CPUs) ``*.ll`` files. 
+A Linux example on system with 4 CPUs::
 
     $ # on command line, with project root as current working directory.
     $ find sandbox/.3/target -name "*.ll"
@@ -53,8 +54,12 @@ A Linux example, where the actual file names found may vary::
     sandbox/.3/target/scala-3.1.3/native/1.ll
     sandbox/.3/target/scala-3.1.3/native/0.ll
 
+Any method, including the ``main`` method, might be defined in any of
+these files.    
+
 Locating the code you are interested in will require that
-you are familiar with the `LLVM assembly language <http://llvm.org/docs/LangRef.html>`_.
+you are familiar with the `LLVM assembly language <http://llvm.org/docs/LangRef.html>`_. As NIR is a subset of the LLVM assembly language, :ref:`nir` may
+be a gentler starting point.
 
 When working on the compiler plugin you'll need to clean the sandbox (or other
 Scala Native projects) if you want it to be recompiled with the newer version


### PR DESCRIPTION
The description of running the sandbox project and how to find the ".ll" files
now reflects current practice. 

I tried to remove some "This flat out does not work" sections.
Those displease both current and entering developers.

My __profound__ thanks to the person or people who
created both the ReadTheDocs section on building
the Scala Native documents and the `makedocs` 
script itself.  Saved me time and spirit from having
to re-create stuff I used to know but do not use
often enough to retain.

I welcome review and suggestions for improvement, especially in
the area of how to find the `Test#main` information which used
to be in '__empty.ll`.  That is, helping the reader find the
'intrinsic' code they just created rather than punting to 
"learn LLVM and rat through the files".

 