### PR TITLE
Fix Immix GC compilation errors

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/Heap.c
@@ -266,7 +266,7 @@ void Heap_Collect(Heap *heap, Stack *stack) {
     if (stats != NULL) {
         nullify_start_ns = scalanative_nano_time();
     }
-    WeakRefStack_Nullify(heap);
+    WeakRefStack_Nullify();
     if (stats != NULL) {
         sweep_start_ns = scalanative_nano_time();
     }
@@ -276,7 +276,7 @@ void Heap_Collect(Heap *heap, Stack *stack) {
         Stats_RecordCollection(stats, start_ns, nullify_start_ns,
                                sweep_start_ns, end_ns);
     }
-    WeakRefStack_CallHandlers(heap);
+    WeakRefStack_CallHandlers();
 #ifdef DEBUG_PRINT
     printf("End collect\n");
     fflush(stdout);

--- a/nativelib/src/main/resources/scala-native/gc/immix/WeakRefStack.c
+++ b/nativelib/src/main/resources/scala-native/gc/immix/WeakRefStack.c
@@ -13,7 +13,7 @@ void (*handlerFn)() = NULL;
 // Used to correctly set "NULL" values in place of cleaned objects
 // and to call other handler functions with WeakRefStack_CallHandlers.
 
-void WeakRefStack_Nullify() {
+void WeakRefStack_Nullify(void) {
     visited = false;
     Bytemap *bytemap = heap.bytemap;
     while (!Stack_IsEmpty(&weakRefStack)) {
@@ -34,7 +34,7 @@ void WeakRefStack_Nullify() {
 
 void WeakRefStack_SetHandler(void *handler) { handlerFn = handler; }
 
-void WeakRefStack_CallHandlers(Heap *heap) {
+void WeakRefStack_CallHandlers(void) {
     if (visited && handlerFn != NULL) {
         visited = false;
 

--- a/nativelib/src/main/resources/scala-native/gc/immix/WeakRefStack.h
+++ b/nativelib/src/main/resources/scala-native/gc/immix/WeakRefStack.h
@@ -3,8 +3,8 @@
 #include "Object.h"
 #include "Heap.h"
 
-void WeakRefStack_Nullify();
+void WeakRefStack_Nullify(void);
 void WeakRefStack_SetHandler(void *handler);
-void WeakRefStack_CallHandlers();
+void WeakRefStack_CallHandlers(void);
 
 #endif // WEAK_REF_STACK_H


### PR DESCRIPTION
Fixes Immix GC compilation errors when the prototype of function does not match its definition (found when compiling using clang 15)