### PR TITLE
Fix warning in doc generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,7 +78,7 @@ release = u'0.4.5-SNAPSHOT'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
While setting up doc development on macOS I found the the following warning:

```
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).
```

This is reported online for Sphinx > v5.0

**Sphinx v5.0.2** on my system.

@LeeTibbert Can you try this one line change - run `make clean` and then `make html` to check that it won't cause any harm?