### PR TITLE
Improve PR #2679: Provide better clues in Contributor's Guide for finding main methods.

### DIFF
--- a/docs/contrib/appendices.rst
+++ b/docs/contrib/appendices.rst
@@ -38,7 +38,7 @@ yielding::
 
 `LAL16java.lang.String_uEo` is the return type.
 
-scala 2 style main methods
+Scala 2 style main methods
 --------------------------
 
 The following code

--- a/docs/contrib/appendices.rst
+++ b/docs/contrib/appendices.rst
@@ -1,0 +1,80 @@
+.. _appendices:
+.. _appendix_a:
+
+Appendix A: Finding main methods in .ll files
+=============================================
+
+:ref:`name_mangling` describes the precise, low level details
+Scala Native uses to transform names when generating code into `.ll` files.
+
+This section shows how that information might be used to find a given
+method in those files. The `main` method is used as an example.
+
+Scala 3 style main methods
+--------------------------
+
+The following code
+
+.. code-block:: scala
+
+    package example
+    @main def run(): Unit = ???
+    
+creates a fully qualified class name `example.run`, with
+length 11.
+
+.. code-block:: text
+
+    C := example.run - fully qualified of the main class
+    N := 11          - length of fully qualified class name C
+
+The entry point for this name has the form::
+  
+  _SM<N><C>$D4mainLAL16java.lang.String_uEo
+
+yielding::
+
+  _SM11example.run$D4mainLAL16java.lang.String_uEo
+
+`LAL16java.lang.String_uEo` is the return type.
+
+scala 2 style main methods
+--------------------------
+
+The following code
+
+.. code-block:: scala
+
+    package example
+
+    object Test {
+        def main(args: Array[String]): Unit = ()
+    }
+    
+creates a fully qualified class name `example.Test`, with
+length 12.
+
+.. code-block:: text
+
+    C := example.Test - fully qualified of the main class
+    N := 12           - length of fully qualified class name C
+
+A static main method forwarder is defined in a companion class
+to implement the companion and has the form::
+
+  _SM<N><C>D4mainLAL16java.lang.String_uEo
+
+yielding::
+
+  _SM12example.TestD4mainLAL16java.lang.String_uEo.
+
+The actual main method defined in the companion object has the form::
+  
+  _SM<N+1><C>$D4mainLAL16java.lang.String_uEo
+
+yielding::
+
+  _SM13example.Test$D4mainLAL16java.lang.String_uEo
+
+`LAL16java.lang.String_uEo` is the return type.
+

--- a/docs/contrib/compiler.rst
+++ b/docs/contrib/compiler.rst
@@ -55,10 +55,12 @@ A Linux example on system with 4 CPUs::
     sandbox/.3/target/scala-3.1.3/native/0.ll
 
 Any method, including the ``main`` method, might be defined in any of
-these files.    
+these files. :ref:`appendix_a`  will help locating the code you are
+interested in.
 
-Locating the code you are interested in will require that
-you are familiar with the `LLVM assembly language <http://llvm.org/docs/LangRef.html>`_. As NIR is a subset of the LLVM assembly language, :ref:`nir` may
+Once you have located the code, you must be familiar with the
+`LLVM assembly language <http://llvm.org/docs/LangRef.html>`_.
+NIR is a subset of the LLVM assembly language, so :ref:`nir` may
 be a gentler starting point.
 
 When working on the compiler plugin you'll need to clean the sandbox (or other

--- a/docs/contrib/index.rst
+++ b/docs/contrib/index.rst
@@ -12,3 +12,4 @@ Contributor's Guide
   nir
   mangling
   ides
+  appendices

--- a/docs/contrib/mangling.rst
+++ b/docs/contrib/mangling.rst
@@ -1,3 +1,5 @@
+.. _name_mangling:
+
 Name mangling
 -------------
 


### PR DESCRIPTION
Add more detail to the section in the Contributor's Guide which describes how to
find main methods in `.ll` files.  This is a second generation of PR #2679.
I think it better addresses the concerns expressed in Issue #2435.

Wojciech,
In Issue #2679 you kindly provide some text and examples.
I have tried to accurately paraphrase you words.

In that text you used the idiom "_SM" for Scala 3, but
"SM" (no underscore) in the Scala 2 discussion.

When I ran the examples given in this PR, both
Scala 2 & Scala 3 used the "_SM" prefix. I purposely
used different names & lengths in the examples
so that I could distinguish Scala 3 symbols from 
Scala 2.  I documented the "_SM" prefix in
both cases.  Did I miss something?

I understand that the original text was "on-the-fly".
Sometimes differences are typos and sometimes they
are correct and subtle.

If I got it wrong, please advise and I will correct.
Thank you.

End users trying to work through the examples are
sure to pick up on errors I have introduced by 
the limits of my knowledge.
