### PR TITLE
Fix #2586: Port three Scala.js fixes

### DIFF
--- a/javalib/src/main/scala/java/io/Writer.scala
+++ b/javalib/src/main/scala/java/io/Writer.scala
@@ -1,14 +1,16 @@
 package java.io
 
-abstract class Writer private[this] (_lock: Option[Object])
-    extends Appendable
-    with Closeable
-    with Flushable {
+// Ported from Scala.js, commit: 7d7a621, dated 2022-03-07
 
-  protected val lock = _lock.getOrElse(this)
+abstract class Writer() extends Appendable with Closeable with Flushable {
+  protected var lock: Object = this
 
-  protected def this(lock: Object) = this(Some(lock))
-  protected def this() = this(None)
+  protected def this(lock: Object) = {
+    this()
+    if (lock eq null)
+      throw new NullPointerException()
+    this.lock = lock
+  }
 
   def write(c: Int): Unit =
     write(Array(c.toChar))
@@ -43,4 +45,5 @@ abstract class Writer private[this] (_lock: Option[Object])
   def flush(): Unit
 
   def close(): Unit
+
 }


### PR DESCRIPTION
 We port the changes from Scala.js, commit: 7d7a621, dated 2022-03-07, which affect
Scala Native.

To minimize transcription errors, we re-ported the entirety of `Reader.scala`, `Writer.scala`, 
& `URLDecoder.scala`. Those files were originally ported from Scala.js.

`URI.scala` from that commit was not ported because it uses a Scala.js implementation
of regular expressions and the port would not be trivial.  The current `URI.scala`  was
ported from Apache Harmony and will probably need to be replaced someday by
the Scala.js version. However, today is not that day.

`Timer.scala` and its associated `TimerTest.scala` appear to never have been 
ported/implemented in Scala Native so no changes were applicable. 