### PR TITLE
Update sbt to the 1.6.2 which CI has been using for a while.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.1
+sbt.version = 1.6.2


### PR DESCRIPTION
We update the version of `sbt` to `1.6.2`. 

From `ci-docker/Dockerfile` it appears that CI has been exercising this version for a while.
```
RUN curl -s "https://get.sdkman.io" | bash  \
  && . "$HOME/.sdkman/bin/sdkman-init.sh" \
  && sdk install sbt 1.6.2 \ 
  && sdk install java 8.0.275.hs-adpt
```
