### PR TITLE
WIP: Update JVM version to Adoptium JDK 332 Hotspot

### DIFF
--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /home/scala-native/scala-native
 RUN curl -s "https://get.sdkman.io" | bash  \
   && . "$HOME/.sdkman/bin/sdkman-init.sh" \
   && sdk install sbt 1.6.2 \ 
-  && sdk install java 8.0.275.hs-adpt
+  && sdk install java 8.0.332.hs-adpt
 
 ENV LC_ALL "C.UTF-8"
 ENV LANG "C.UTF-8"


### PR DESCRIPTION
Change version of JDK used in Dockerfile to latest Adoptium (Adopt OpenJDK)  332.
