### PR TITLE
Partial fix #2623: posixlib sys/socket sendto() & recvfrom() now succeed on Linux & Windows using IPv6

### DIFF
--- a/posixlib/src/main/resources/scala-native/netinet/in.h
+++ b/posixlib/src/main/resources/scala-native/netinet/in.h
@@ -33,10 +33,10 @@ struct scalanative_sockaddr_in {
 };
 
 struct scalanative_sockaddr_in6 {
-    struct scalanative_in6_addr sin6_addr;
     scalanative_sa_family_t sin6_family;
     in_port_t sin6_port;
     uint32_t sin6_flowinfo;
+    struct scalanative_in6_addr sin6_addr;
     uint32_t sin6_scope_id;
 };
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
@@ -23,10 +23,10 @@ object in {
 
   type in6_addr = CStruct1[CArray[uint8_t, _16]] // s6_addr
   type sockaddr_in6 = CStruct5[
-    in6_addr, // sin6_addr
     socket.sa_family_t, // sin6_family
     in_port_t, // sin6_port
     uint32_t, // sin6_flowinfo
+    in6_addr, // sin6_addr
     uint32_t // sin6_scope_id
   ]
 
@@ -130,7 +130,6 @@ object in {
 
   @name("scalanative_in6_is_addr_mc_global")
   def IN6_IS_ADDR_MC_GLOBAL(arg: Ptr[in6_addr]): CInt = extern
-
 }
 
 object inOps {
@@ -151,15 +150,15 @@ object inOps {
   }
 
   implicit class sockaddr_in6Ops(val ptr: Ptr[sockaddr_in6]) extends AnyVal {
-    def sin6_addr: in6_addr = ptr._1
-    def sin6_family: socket.sa_family_t = ptr._2
-    def sin6_port: in_port_t = ptr._3
-    def sin6_flowinfo: uint32_t = ptr._4
+    def sin6_family: socket.sa_family_t = ptr._1
+    def sin6_port: in_port_t = ptr._2
+    def sin6_flowinfo: uint32_t = ptr._3
+    def sin6_addr: in6_addr = ptr._4
     def sin6_scope_id: uint32_t = ptr._5
-    def sin6_addr_=(v: in6_addr): Unit = ptr._1 = v
-    def sin6_family_=(v: socket.sa_family_t): Unit = ptr._2 = v
-    def sin6_port_=(v: in_port_t): Unit = ptr._3 = v
-    def sin6_flowinfo_=(v: uint32_t): Unit = ptr._4 = v
+    def sin6_family_=(v: socket.sa_family_t): Unit = ptr._1 = v
+    def sin6_port_=(v: in_port_t): Unit = ptr._2 = v
+    def sin6_flowinfo_=(v: uint32_t): Unit = ptr._3 = v
+    def sin6_addr_=(v: in6_addr): Unit = ptr._4 = v
     def sin6_scope_id_=(v: uint32_t): Unit = ptr._5 = v
   }
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/SocketTestHelpers.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/SocketTestHelpers.scala
@@ -1,0 +1,143 @@
+package scala.scalanative.posix
+package sys
+
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+import scalanative.libc.errno
+import scalanative.libc.string.strerror
+
+import scalanative.posix.netdb._
+import scalanative.posix.netdbOps._
+import scalanative.posix.netinet.in._
+import scalanative.posix.netinet.inOps._
+import scalanative.posix.poll._
+import scalanative.posix.pollOps._
+import scalanative.posix.sys.socket._
+
+import scalanative.meta.LinktimeInfo.isWindows
+
+import scala.scalanative.windows._
+import scala.scalanative.windows.WinSocketApi._
+import scala.scalanative.windows.WinSocketApiExt._
+import scala.scalanative.windows.WinSocketApiOps._
+import scala.scalanative.windows.ErrorHandlingApi._
+
+import org.junit.Assert._
+import org.junit.Assume._
+
+object SocketTestHelpers {
+
+  def hasLoopbackAddress(
+      family: CInt,
+      socktype: CInt,
+      protocol: CInt
+  ): Boolean = {
+    if (isWindows) {
+      /* Discovery is not implemented on Windows; an exercise for the reader.
+       *
+       * IPv6 is known to be available on Scala Native Continuous Integration
+       * (CI) systems.  It is also usually present, at least for loopback,
+       * on Windows systems.
+       *
+       * Until IPv6 discovery is implemented, enable the test unconditionally,
+       * knowing that it will give impolite errors on some Windows systems
+       * in the wild. Such people can change the 'true' below to 'false'.
+       */
+
+      true
+    } else
+      Zone { implicit z =>
+        /* Test where a working IPv6 or IPv4 network is available.
+         * The Scala Native GitHub CI environment is known to have a
+         * working IPv6 network. Arbitrary local systems may not.
+         *
+         * The JVM sets a system property "java.net.preferIPv4Stack=false"
+         * when an IPv6 interface is active. Scala Native does not
+         * set this property. One has to see if an IPv6 loopback address
+         * can be found.
+         */
+
+        assumeTrue(
+          s"Address family ${family} is not supported",
+          (family == AF_INET6) || (family == AF_INET)
+        )
+        assumeTrue(
+          s"Socket type ${socktype} is not supported",
+          (socktype == SOCK_DGRAM) || (socktype == SOCK_STREAM)
+        )
+        assumeTrue(
+          s"IP protocol ${protocol} is not supported",
+          (protocol == IPPROTO_UDP) || (protocol == IPPROTO_TCP)
+        )
+
+        val localhost =
+          if (family == AF_INET) c"127.0.0.1"
+          else c"::1"
+
+        val hints = stackalloc[addrinfo]()
+        hints.ai_family = family
+        hints.ai_socktype = socktype
+        hints.ai_protocol = protocol
+        hints.ai_flags = AI_NUMERICHOST
+
+        val resultPtr = stackalloc[Ptr[addrinfo]]()
+
+        val status = getaddrinfo(localhost, null, hints, resultPtr);
+
+        if (status == 0) {
+          freeaddrinfo(!resultPtr) // leak not, want not!
+        } else if ((status != EAI_FAMILY) && (status != EAI_SOCKTYPE)) {
+          val msg = s"getaddrinfo failed: ${fromCString(gai_strerror(status))}"
+          assertEquals(msg, 0, status)
+        }
+
+        /* status 0 means 'found'
+         * status EAI_FAMILY means 'not found'.
+         * status EAI_SOCKTYPE means not only 'not found' but not even
+         *          supported. i.e. Looking for IPv6 with IPv4 single stack.
+         */
+
+        status == 0
+      }
+  }
+
+  def pollReadyToRecv(fd: CInt, timeout: CInt): Unit = {
+    // timeout is in milliseconds.
+
+    if (isWindows) {
+      val fds = stackalloc[WSAPollFd](1.toUInt)
+      fds.socket = fd.toPtr[Byte]
+      fds.events = WinSocketApiExt.POLLIN
+
+      val ret = WSAPoll(fds, 1.toUInt, timeout)
+
+      if (ret == 0) {
+        fail(s"poll timed out after ${timeout} milliseconds")
+      } else if (ret < 0) {
+        val reason = ErrorHandlingApiOps.errorMessage(GetLastError())
+        fail(s"poll for input failed - $reason")
+      }
+    } else {
+      val fds = stackalloc[struct_pollfd](1.toUInt)
+      (fds + 0).fd = fd
+      (fds + 0).events = pollEvents.POLLIN | pollEvents.POLLRDNORM
+
+      errno.errno = 0
+
+      /* poll() sounds like a nasty busy wait loop, but is event driven
+       * in the kernel.
+       */
+
+      val ret = poll(fds, 1.toUInt, timeout)
+
+      if (ret == 0) {
+        fail(s"poll timed out after ${timeout} milliseconds")
+      } else if (ret < 0) {
+        val reason = fromCString(strerror(errno.errno))
+        fail(s"poll for input failed - $reason")
+      }
+      // else good to go
+    }
+  }
+}

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
@@ -120,7 +120,7 @@ class Udp6SocketTest {
 
   private def formatIn6addr(addr: in6_addr): String = Zone { implicit z =>
     val dstSize = INET6_ADDRSTRLEN + 1
-    val dst = alloc[Byte](dstSize)
+    val dst = alloc[Byte](dstSize.toUSize)
 
     val result = inet_ntop(
       AF_INET6,
@@ -232,7 +232,7 @@ class Udp6SocketTest {
 
         // Provide extra room to allow detecting extra junk being sent.
         val maxInData = 2 * outData.length
-        val inData: Ptr[Byte] = alloc[Byte](maxInData)
+        val inData: Ptr[Byte] = alloc[Byte](maxInData.toUSize)
 
         // Test not fetching remote address. Exercise last two arguments.
         val nBytesPeekedAt =

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
@@ -59,10 +59,17 @@ class Udp6SocketTest {
      * we run test matrices.
      */
 
-    assumeFalse(
-      "IPv6 UDP loopback is not available on linux-arm64 CI",
-      Platform.isLinux && Platform.isArm64
-    )
+    if (Platform.isLinux) {
+      // IPv6 appears to not be configured on CI Docker/qemu
+      assumeFalse(
+        "IPv6 UDP loopback is not available on linux-arm64 CI",
+        Platform.isArm64
+      )
+      assumeFalse(
+        "IPv6 UDP loopback is not available on linux-x86 CI",
+        Platform.is32BitPlatform
+      )
+    }
   }
 
   // For some unknown reason inlining content of this method leads to failures

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
@@ -216,14 +216,14 @@ class Udp6SocketTest {
         val nBytesSent = sendto(
           outSocket,
           toCString(outData),
-          outData.length.toULong,
+          outData.length.toUSize,
           0,
           out6Addr.asInstanceOf[Ptr[sockaddr]],
           sizeof[sockaddr_in6].toUInt
         )
 
         assertTrue(s"sendto failed errno: ${errno.errno}\n", (nBytesSent >= 0))
-        assertEquals("sendto length", outData.size, nBytesSent)
+        assertEquals("sendto length", outData.size, nBytesSent.toInt)
 
         // If inSocket did not get data by timeout, it probably never will.
         pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
@@ -1,0 +1,306 @@
+package scala.scalanative.posix
+package sys
+
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+import scalanative.libc.errno
+import scalanative.libc.string.{memcmp, strerror}
+
+import scalanative.posix.arpa.inet._
+import scalanative.posix.fcntl
+import scalanative.posix.fcntl.{F_SETFL, O_NONBLOCK}
+import scalanative.posix.netinet.in._
+import scalanative.posix.netinet.inOps._
+import scalanative.posix.sys.socket._
+import scalanative.posix.sys.SocketTestHelpers._
+
+import scalanative.meta.LinktimeInfo.isWindows
+
+import scala.scalanative.windows._
+import scala.scalanative.windows.WinSocketApi._
+import scala.scalanative.windows.WinSocketApiExt._
+import scala.scalanative.windows.WinSocketApiOps
+import scala.scalanative.windows.ErrorHandlingApi._
+
+import org.scalanative.testsuite.utils.Platform
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Before
+
+class Udp6SocketTest {
+
+  /* Tests are failing on GitHub CI BSD based systems.
+   * (errno 47: Address family not supported by protocol).
+   * This is caused by SN not properly handling sin6_len on BSD.
+   * See SN Issue #2626. Disable testing on IPv6 until that Issue is fixed.
+   */
+
+  val isIPv6Available = !(Platform.isMacOs || Platform.isFreeBSD) &&
+    hasLoopbackAddress(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)
+
+  @Before
+  def before(): Unit = {
+    assumeTrue("IPv6 UDP loopback is not available", isIPv6Available)
+
+    /* Scala Native Continuous Integration linux-arm64 multiarch runs
+     * fail, where they succeed on other test configurations.
+     *
+     * The failing tests use qemu emulator. Test should succeed on real
+     * hardware. Disable everywhere because GITHUB_* environment variables
+     * are not passed to qemu.
+     *
+     * The failing tests report that an IPv6 loopback address is available
+     * but fail when these tests attempt to bind() to it. Private debugging
+     * indicates that the address passed to bind() should be good.
+     * Probably a problem with qemu configuration & IPv6. Which is why
+     * we run test matrices.
+     */
+
+    assumeFalse(
+      "IPv6 UDP loopback is not available on linux-arm64 CI",
+      Platform.isLinux && Platform.isArm64
+    )
+  }
+
+  // For some unknown reason inlining content of this method leads to failures
+  // on Unix, probably due to bug in linktime conditions.
+  private def setSocketBlocking(socket: CInt): Unit = {
+    if (isWindows) {
+      val mode = stackalloc[CInt]()
+      !mode = 1
+      assertNotEquals(
+        "iotctl setBLocking",
+        -1,
+        ioctlSocket(socket.toPtr[Byte], FIONBIO, mode)
+      )
+    } else {
+      assertNotEquals(
+        s"fcntl set blocking",
+        -1,
+        fcntl.fcntl(socket, F_SETFL, O_NONBLOCK)
+      )
+    }
+  }
+
+  private def createAndCheckUdpSocket(): CInt = {
+    if (isWindows) {
+      val socket = WSASocketW(
+        addressFamily = AF_INET6,
+        socketType = SOCK_DGRAM,
+        protocol = IPPROTO_UDP,
+        protocolInfo = null,
+        group = 0.toUInt,
+        flags = WSA_FLAG_OVERLAPPED
+      )
+      assertNotEquals("socket create", InvalidSocket, socket)
+      socket.toInt
+    } else {
+      val sock = sys.socket.socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)
+      assertNotEquals("socket create", -1, sock)
+      sock
+    }
+  }
+
+  private def closeSocket(socket: CInt): Unit = {
+    if (isWindows) WinSocketApi.closeSocket(socket.toPtr[Byte])
+    else unistd.close(socket)
+  }
+
+  private def checkRecvfromResult(v: CSSize, label: String): Unit = {
+    if (v.toInt < 0) {
+      val reason =
+        if (isWindows) ErrorHandlingApiOps.errorMessage(GetLastError())
+        else fromCString(strerror(errno.errno))
+      fail(s"$label failed - $reason")
+    }
+  }
+
+  private def formatIn6addr(addr: in6_addr): String = Zone { implicit z =>
+    val dstSize = INET6_ADDRSTRLEN + 1
+    val dst = alloc[Byte](dstSize)
+
+    val result = inet_ntop(
+      AF_INET6,
+      addr.at1.at(0).asInstanceOf[Ptr[Byte]],
+      dst,
+      dstSize.toUInt
+    )
+
+    assertNotEquals(s"inet_ntop failed errno: ${errno.errno}", result, null)
+
+    fromCString(dst)
+  }
+
+  @Test def sendtoRecvfrom(): Unit = Zone { implicit z =>
+    if (isWindows) {
+      WinSocketApiOps.init()
+    }
+
+    val in6SockAddr = alloc[sockaddr_in6]()
+    in6SockAddr.sin6_family = AF_INET6.toUShort
+
+    /* Scala Native currently implements neither inaddr_loopback
+     * nor IN6ADDR_LOOPBACK_INIT. When they become available,
+     * this code can be simplified by using the former instead
+     * of the inet_pton(code below). All things in due time.
+     *
+     * in6SockAddr.sin6_addr = in6addr_loopback
+     */
+
+    // sin6_port is already the desired 0; "find a free port".
+    // all other fields already 0.
+
+    val localhost = c"::1"
+    val ptonStatus = inet_pton(
+      AF_INET6,
+      localhost,
+      in6SockAddr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]]
+    )
+
+    assertEquals(s"inet_pton failed errno: ${errno.errno}", ptonStatus, 1)
+
+    val inSocket: CInt = createAndCheckUdpSocket()
+
+    try {
+      setSocketBlocking(inSocket)
+
+      // Get port for sendto() to use.
+      val bindStatus = bind(
+        inSocket,
+        in6SockAddr
+          .asInstanceOf[Ptr[sockaddr]],
+        sizeof[sockaddr_in6].toUInt
+      )
+
+      assertNotEquals(s"bind failed,  errno: ${errno.errno}", -1, bindStatus)
+
+      val inAddrInfo = alloc[sockaddr_in6]()
+      val gsnAddrLen = alloc[socklen_t]()
+      !gsnAddrLen = sizeof[sockaddr_in6].toUInt
+
+      val gsnStatus = getsockname(
+        inSocket,
+        inAddrInfo.asInstanceOf[Ptr[sockaddr]],
+        gsnAddrLen
+      )
+
+      assertNotEquals("getsockname failed errno: ${errno.errno}", -1, gsnStatus)
+
+      // Now use port.
+      val outSocket = createAndCheckUdpSocket()
+
+      try {
+        val out6Addr = alloc[sockaddr_in6]()
+        out6Addr.sin6_family = AF_INET6.toUShort
+        out6Addr.sin6_port = inAddrInfo.sin6_port
+        out6Addr.sin6_addr = in6SockAddr.sin6_addr
+
+        // all other fields in out6Addr have been cleared by alloc[].
+
+        val outData =
+          """
+          |"She moved through the fair" lyrics, Traditional, no copyright
+          |   I dreamed it last night
+          |   That my true love came in
+          |   So softly she entered
+          |   Her feet made no din
+          |   She came close beside me
+          |   And this she did say,
+          |   "It will not be long, love
+          |   Till our wedding day."
+          """.stripMargin
+
+        val nBytesSent = sendto(
+          outSocket,
+          toCString(outData),
+          outData.length.toULong,
+          0,
+          out6Addr.asInstanceOf[Ptr[sockaddr]],
+          sizeof[sockaddr_in6].toUInt
+        )
+
+        assertTrue(s"sendto failed errno: ${errno.errno}\n", (nBytesSent >= 0))
+        assertEquals("sendto length", outData.size, nBytesSent)
+
+        // If inSocket did not get data by timeout, it probably never will.
+        pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout
+
+        /// Two tests using one inbound packet, save test duplication.
+
+        // Provide extra room to allow detecting extra junk being sent.
+        val maxInData = 2 * outData.length
+        val inData: Ptr[Byte] = alloc[Byte](maxInData)
+
+        // Test not fetching remote address. Exercise last two arguments.
+        val nBytesPeekedAt =
+          recvfrom(
+            inSocket,
+            inData,
+            maxInData.toUInt,
+            MSG_PEEK,
+            null.asInstanceOf[Ptr[sockaddr]],
+            null.asInstanceOf[Ptr[socklen_t]]
+          )
+
+        checkRecvfromResult(nBytesPeekedAt, "recvfrom_1")
+
+        /* Friendlier code here and after the next recvfrom() would loop
+         *  on partial reads rather than fail.
+         *  Punt to a future generation. Since this is loopback and
+         *  writes are small, if any bytes are ready, all should be.
+         */
+        assertEquals("recvfrom_1 length", nBytesSent, nBytesPeekedAt)
+
+        // Test retrieving remote address.
+        val srcAddr = alloc[sockaddr_in6]()
+        val srcAddrLen = alloc[socklen_t]()
+        !srcAddrLen = sizeof[sockaddr_in6].toUInt
+
+        val nBytesRecvd =
+          recvfrom(
+            inSocket,
+            inData,
+            maxInData.toUInt,
+            0,
+            srcAddr.asInstanceOf[Ptr[sockaddr]],
+            srcAddrLen
+          )
+
+        checkRecvfromResult(nBytesRecvd, "recvfrom_2")
+        assertEquals("recvfrom_2 length", nBytesSent, nBytesRecvd)
+
+        // Did packet came from where we expected, and not from Mars?
+
+        val addrsMatch = {
+          0 == memcmp(
+            in6SockAddr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]],
+            srcAddr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]],
+            sizeof[in6_addr]
+          )
+        }
+
+        if (!addrsMatch) {
+          val expectedNtop = formatIn6addr(in6SockAddr.sin6_addr)
+          val gotNtop = formatIn6addr(srcAddr.sin6_addr)
+
+          val msg =
+            s"expected remote address: '${expectedNtop}' got: '${gotNtop}'"
+          fail(msg)
+        }
+
+        assertEquals("inData is not NUL terminated", 0, inData(nBytesRecvd))
+
+        // Are received contents good?
+        assertEquals("recvfrom content", outData, fromCString(inData))
+
+      } finally {
+        closeSocket(outSocket)
+      }
+    } finally {
+      closeSocket(inSocket)
+    }
+  }
+}

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
@@ -11,6 +11,8 @@ import scalanative.posix.arpa.inet.inet_addr
 import scalanative.posix.fcntl.{F_SETFL, O_NONBLOCK}
 import scalanative.posix.netinet.in._
 import scalanative.posix.netinet.inOps._
+import scalanative.posix.poll._
+import scalanative.posix.pollOps._
 import scalanative.posix.sys.socket._
 import scalanative.posix.sys.SocketTestHelpers._
 import scalanative.posix.unistd
@@ -187,7 +189,7 @@ class UdpSocketTest {
         )
 
         assertTrue(s"sendto failed errno: ${errno.errno}\n", (nBytesSent >= 0))
-        assertEquals("sendto", outData.size, nBytesSent)
+        assertEquals("sendto", outData.size, nBytesSent.toInt)
 
         // If inSocket did not get data by timeout, it probably never will.
         pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
@@ -1,19 +1,22 @@
 package scala.scalanative.posix
 package sys
 
-import scalanative.posix.arpa.inet._
-import scalanative.posix.fcntl
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+import scalanative.libc.errno
+import scalanative.libc.string.strerror
+
+import scalanative.posix.arpa.inet.inet_addr
 import scalanative.posix.fcntl.{F_SETFL, O_NONBLOCK}
 import scalanative.posix.netinet.in._
 import scalanative.posix.netinet.inOps._
-import scalanative.posix.poll._
-import scalanative.posix.pollOps._
 import scalanative.posix.sys.socket._
-import scalanative.posix.sys.socketOps._
+import scalanative.posix.sys.SocketTestHelpers._
 import scalanative.posix.unistd
-import scalanative.unsafe._
-import scalanative.unsigned._
+
 import scalanative.meta.LinktimeInfo.isWindows
+
 import scala.scalanative.windows._
 import scala.scalanative.windows.WinSocketApi._
 import scala.scalanative.windows.WinSocketApiExt._
@@ -23,11 +26,16 @@ import scala.scalanative.windows.ErrorHandlingApi._
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
-import scala.scalanative.libc.errno
-import scala.scalanative.libc.string.strerror
+import org.junit.Before
 
 class UdpSocketTest {
-  // All tests in this class assume that an IPv4 network is up & running.
+
+  val isIPv4Available = hasLoopbackAddress(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+
+  @Before
+  def before(): Unit = {
+    assumeTrue("IPv4 UDP loopback is not available", isIPv4Available)
+  }
 
   // For some unknown reason inlining content of this method leads to failures
   // on Unix, probably due to bug in linktime conditions.
@@ -140,7 +148,7 @@ class UdpSocketTest {
 
       // Get port for sendto() to use.
       val bindStatus = bind(inSocket, inAddr, sizeof[sockaddr].toUInt)
-      assertNotEquals("bind", -1, bindStatus)
+      assertNotEquals(s"bind failed,  errno: ${errno.errno}", -1, bindStatus)
 
       val inAddrInfo = alloc[sockaddr]()
       val gsnAddrLen = alloc[socklen_t]()
@@ -177,7 +185,9 @@ class UdpSocketTest {
           outAddr,
           sizeof[sockaddr].toUInt
         )
-        assertEquals("sendto", outData.size.toSize, nBytesSent)
+
+        assertTrue(s"sendto failed errno: ${errno.errno}\n", (nBytesSent >= 0))
+        assertEquals("sendto", outData.size, nBytesSent)
 
         // If inSocket did not get data by timeout, it probably never will.
         pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout


### PR DESCRIPTION
##### This PR introduces a binary change and is intended for the next Scala Native version which changes the major version number.  
 
As per the title, the the two posixlib sys/socket sendto() & recvfrom() methods now succeed when using IPv6.
The new test suite `Udp6SocketTest.scala`  exercises those methods using IPv6. Lessons learned from
`Udp6SocketTest.scala` were applied to the existing IPv4 `UdpSocketTest.scala`.

Issue #2626 remains. I hope to address it a PR after this one has merged. 
Proof-of-concept code is working on macOS.

Running the tests on BSD based systems, macOS & FreeBSD, is disabled
until Issue #2226 is fixed.

This PR supersedes WIP PR #2632.  
 
###### Rationale:

Posix specifies the name and type of elements of a structure. The order is not
specified so Scala Native can use any order it chooses.  Common & civilized
practice is to follow the order in the posix spec. Linux, macOs, FreeBSD, and
Windows all follow this practice.     

Scala Native now follows suite.  This reduces cognitive load and WT? factor on
the severely limited number of developers using Scala Native with IPv6.