### PR TITLE
Fix #2707: Implement most of POSIX stddef.h

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -55,7 +55,7 @@ C Header          Scala Native Module
 `spawn.h`_        N/A
 `stdarg.h`_       N/A
 `stdbool.h`_      N/A
-`stddef.h`_       N/A
+`stddef.h`_       scala.scalanative.posix.stddef_
 `stdint.h`_       N/A
 `stdio.h`_        N/A
 `stdlib.h`_       scala.scalanative.posix.stdlib_
@@ -200,6 +200,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.regex: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/regex.scala
 .. _scala.scalanative.posix.sched: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sched.scala
 .. _scala.scalanative.posix.signal: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
+.. _scala.scalanative.posix.stddef: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/stddef.scala
 .. _scala.scalanative.posix.stdlib: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
 .. _scala.scalanative.posix.sys.resource: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
 .. _scala.scalanative.posix.sys.select: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala

--- a/posixlib/src/main/resources/scala-native/stddef.c
+++ b/posixlib/src/main/resources/scala-native/stddef.c
@@ -1,6 +1,3 @@
-#ifdef _WIN32
-#error "posixlib is not implemented on Windows."
-#else // not _WIN32
 #include <stddef.h>
 
 // Macros

--- a/posixlib/src/main/resources/scala-native/stddef.c
+++ b/posixlib/src/main/resources/scala-native/stddef.c
@@ -1,0 +1,9 @@
+#ifdef _WIN32
+#error "posixlib is not implemented on Windows."
+#else // not _WIN32
+#include <stddef.h>
+
+// Macros
+void *scalanative_posix_null() { return NULL; }
+
+#endif // _Win32

--- a/posixlib/src/main/resources/scala-native/stddef.c
+++ b/posixlib/src/main/resources/scala-native/stddef.c
@@ -2,5 +2,3 @@
 
 // Macros
 void *scalanative_posix_null() { return NULL; }
-
-#endif // _Win32

--- a/posixlib/src/main/scala/scala/scalanative/posix/stddef.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/stddef.scala
@@ -1,0 +1,20 @@
+package scala.scalanative
+package posix
+
+import scala.scalanative.unsafe._
+import scala.scalanative.posix.sys.types
+
+@extern
+object stddef {
+  type ptrdiff_t = CLong
+  type wchar_t = CInt
+  type size_t = types.size_t
+
+// Macros
+
+  // Ptr[Byte] is Scala Native convention for C (void *).
+  @name("scalanative_posix_null")
+  def NULL: Ptr[Byte] = extern
+
+  // offsetof() is not implemented in Scala Native.
+}


### PR DESCRIPTION
We implement most of POSIX stddef.h. In particular, NULL.

The motivation is to have a single, common NULL for all posixlib files to use.
A number of POSIX `.h` specifications require that the file define NULL.
Here, the file can refer in a comment to the common `stddef.scala`.
A slight variance from the standard, but the best than can be done
in economic time.

The `offsetof()` requirement is not implemented because the 
concept does not translate well/easily to Scala Native.
