### PR TITLE
Fix #2706: Implement clock methods and test cases, complete time.h

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -4,7 +4,7 @@ C POSIX Library
 ===============
 
 Scala Native provides bindings for a core subset of the
-`POSIX library <https://pubs.opengroup.org/onlinepubs/9699919799/idx/head.html>`_:
+`POSIX library <https://pubs.opengroup.org/onlinepubs/9699919799/idx/head.html>`_. See indicated source module for limitations, if any, and usage:
 
 ================= ==================================
 C Header          Scala Native Module

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -3,6 +3,7 @@ package posix
 
 import scala.scalanative.unsafe._
 import scala.scalanative.posix.sys.types, types._
+import scala.scalanative.posix.signal.sigevent
 
 // XSI comment before method indicates it is defined in
 // extended POSIX X/Open System Interfaces, not base POSIX.
@@ -10,23 +11,64 @@ import scala.scalanative.posix.sys.types, types._
 @extern
 object time {
 
-  type time_t = types.time_t
   type clock_t = types.clock_t
-  type timespec = CStruct2[time_t, CLong]
-  type tm = CStruct9[CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt, CInt]
+  type clockid_t = types.clockid_t
 
-  // Some methods here have a @name annotation and some do not.
-  // Methods where a @name extern "glue" layer would simply pass through
-  // the arguments or return value do not need that layer & its
-  // annotation.
-  //
-  // time_t is a simple type, not a structure, so it does not need to be
-  // transformed.
-  //
-  // Structures, such as timespec or tm, are subject to differing total
-  // sizes(tail padding), ordering of elements, and intervening padding.
-  // Expect an @name annotation and "glue" layer implementation to handle
-  // them.
+  /* locale_t is required by POSIX stanard but otherwise unused in this file.
+   * C (void *) which can be cast if/when posixlib locale.h is implemented.
+   */
+
+  type locale_t = Ptr[Byte]
+
+  /* NULL is required by the POSIX standard but is not directly implemented
+   * here. It is implemented in posix/stddef.scala.
+   *
+   * There is no good way to import stddef.scala NULL in an @extern
+   * object, such as this.
+   *
+   * The idiomatic scala 'null' is more likely to be used in scala files.
+   */
+
+  type pid_t = types.pid_t
+  type size_t = types.size_t
+
+  type time_t = types.time_t
+  type timer_t = types.timer_t
+
+  type timespec = CStruct2[
+    time_t, // tv_sec
+    CLong // tv_nsec
+  ]
+
+  type tm = CStruct9[
+    CInt, // tm_sec
+    CInt, // tm_min
+    CInt, // tm_hour
+    CInt, // tm_mday
+    CInt, // tm_mon
+    CInt, // tm_year
+    CInt, // tm_wday
+    CInt, // tm_yday
+    CInt // tm_isdst
+  ]
+
+  // See separate timer object below for itimerspec type and timer_*() methods.
+
+  /* Some methods here have a @name annotation and some do not.
+   * Methods where a @name extern "glue" layer would simply pass through
+   * the arguments or return value do not need that layer & its
+   * annotation.
+   *
+   * time_t is a simple type, not a structure, so it does not need to be
+   * transformed. Ptr also does not need to be transformed.
+   *
+   * _Static_assert code now in time.c checks the match of scalanative
+   * structures such as timespec and tm with the operating system definition.
+   * "clock_*" & "timer_*" use this assurance to avoid "glue".
+   *
+   * Some methods which now do not strictly need "@name" annotations
+   * retain them for historical reasons.
+   */
 
   @name("scalanative_asctime")
   def asctime(time_ptr: Ptr[tm]): CString = extern
@@ -35,8 +77,25 @@ object time {
   def asctime_r(time_ptr: Ptr[tm], buf: Ptr[CChar]): CString = extern
 
   def clock(): clock_t = extern
+
+  def clock_getres(clockid: clockid_t, res: Ptr[timespec]): CInt = extern
+
+  def clock_gettime(clockid: clockid_t, tp: Ptr[timespec]): CInt = extern
+
+  // No clock_nanosleep on macOS. time.c provides a stub always returning -1.
+  @name("scalanative_clock_nanosleep")
+  def clock_nanosleep(
+      clockid: clockid_t,
+      flags: CInt,
+      request: Ptr[timespec],
+      remain: Ptr[timespec]
+  ): CInt = extern
+
+  def clock_settime(clockid: clockid_t, tp: Ptr[timespec]): CInt = extern
+
   def ctime(time: Ptr[time_t]): CString = extern
   def ctime_r(time: Ptr[time_t], buf: Ptr[CChar]): CString = extern
+
   def difftime(time_end: CLong, time_beg: CLong): CDouble = extern
 
   @name("scalanative_gmtime")
@@ -71,7 +130,12 @@ object time {
     extern
 
   def time(arg: Ptr[time_t]): time_t = extern
+
+  // See separate timer object below for timer_*() methods.
+
   def tzset(): Unit = extern
+
+// POSIX variables (vals, not vars)
 
   @name("scalanative_daylight")
   def daylight(): CInt = extern
@@ -83,6 +147,28 @@ object time {
   // XSI
   @name("scalanative_tzname")
   def tzname(): Ptr[CStruct2[CString, CString]] = extern
+
+// Macros
+
+  @name("scalanative_clocks_per_sec")
+  def CLOCKS_PER_SEC: CInt = extern
+
+// Symbolic constants
+
+  @name("scalanative_clock_monotonic")
+  def CLOCK_MONOTONIC: clockid_t = extern
+
+  @name("scalanative_clock_process_cputime_id")
+  def CLOCK_PROCESS_CPUTIME_ID: clockid_t = extern
+
+  @name("scalanative_clock_realtime")
+  def CLOCK_REALTIME: clockid_t = extern
+
+  @name("scalanative_clock_thread_cputime_id")
+  def CLOCK_THREAD_CPUTIME_ID: clockid_t = extern
+
+  @name("scalanative_timer_abstime")
+  def TIMER_ABSTIME: CInt = extern
 }
 
 object timeOps {
@@ -114,5 +200,67 @@ object timeOps {
     def tm_wday_=(v: CInt): Unit = ptr._7 = v
     def tm_yday_=(v: CInt): Unit = ptr._8 = v
     def tm_isdst_=(v: CInt): Unit = ptr._9 = v
+  }
+}
+
+@extern
+object timer {
+  /* The five timer_*() methods are in this separate object to simplify
+   * the use of the more frequently used methods in time.h. Yes, at the
+   * cost of having to import this separate, not-described-by-POSIX object.
+   *
+   * 1) Some operating systems provide the timer_* symbols in a way that
+   *    no special linking is needed.  Include this object and link away.
+   *
+   * 2) Many/most operating systems require that the linker "-lrt" be specified
+   *    so that the real time library, librt, is can be used to resolve the
+   *    timer_* symbols.
+   *
+   * 3) macOS does not provide librt and has it own, entirely different, way of
+   *    handling timers.
+   */
+
+  import time.timespec
+
+  type itimerspec = CStruct2[
+    timespec, // it_interval
+    timespec // it_value
+  ]
+
+  def timer_create(
+      clockid: clockid_t,
+      sevp: sigevent,
+      timerid: Ptr[timer_t]
+  ): CInt = extern
+
+  def timer_delete(timerid: timer_t): CInt = extern
+
+  def timer_getoverrun(timerid: timer_t): CInt = extern
+
+  def timer_gettime(timerid: timer_t, curr_value: Ptr[itimerspec]): CInt =
+    extern
+
+  def timer_settime(
+      timerid: timer_t,
+      flags: CInt,
+      new_value: Ptr[itimerspec],
+      old_value: Ptr[itimerspec]
+  ): CInt = extern
+
+// Symbolic constants
+
+  @name("scalanative_timer_abstime")
+  def TIMER_ABSTIME: CInt = extern
+}
+
+object timerOps {
+  import time.timespec
+  import timer.itimerspec
+
+  implicit class itimerspecOps(val ptr: Ptr[itimerspec]) extends AnyVal {
+    def it_interval: timespec = ptr._1
+    def it_value: timespec = ptr._2
+    def it_interval_=(v: timespec): Unit = ptr._1 = v
+    def it_value_=(v: timespec): Unit = ptr._2 = v
   }
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -425,13 +425,13 @@ class TimeTest {
 
   @Test def clockGetresReturnsBelievableResults(): Unit = if (!isWindows) {
     val timespecP = stackalloc[timespec]()
-    timespecP.tv_sec = Long.MinValue // initialize with known bad values
-    timespecP.tv_nsec = Long.MinValue
+    timespecP.tv_sec = Int.MinValue // initialize with known bad values
+    timespecP.tv_nsec = Int.MinValue
 
     val result = clock_getres(CLOCK_REALTIME, timespecP)
 
     assertEquals(
-      s"clock_getres failed with errno: ${libcErrno.errno}",
+      s"clock_getres failed with errno: ${posixErrno.errno}",
       0,
       result
     )
@@ -439,7 +439,7 @@ class TimeTest {
     assertEquals(
       s"clock_getres tv_sec ${timespecP.tv_sec} != 0",
       0,
-      timespecP.tv_sec
+      timespecP.tv_sec.toInt
     )
 
     // Apparently silly test ensures CLOCKS_PER_SEC is exercised.
@@ -458,14 +458,14 @@ class TimeTest {
 
   @Test def clockGettimeReturnsBelievableResults(): Unit = if (!isWindows) {
     val timespecP = stackalloc[timespec]()
-    timespecP.tv_nsec = Long.MinValue // initialize with known bad value
+    timespecP.tv_nsec = Int.MinValue // initialize with known bad value
 
     val now = scala.scalanative.posix.time.time(null) // Seconds since Epoch
 
     val result = clock_gettime(CLOCK_REALTIME, timespecP)
 
     assertEquals(
-      s"clock_gettime failed with errno: ${libcErrno.errno}",
+      s"clock_gettime failed with errno: ${posixErrno.errno}",
       0,
       result
     )
@@ -489,8 +489,8 @@ class TimeTest {
      * test, not to stress either race conditions or developers.
      */
 
-    val acceptableDiff = 5L
-    val secondsDiff = Math.abs(timespecP.tv_sec - now)
+    val acceptableDiff = 5
+    val secondsDiff = Math.abs(timespecP.tv_sec.toInt - now.toInt)
 
     assertTrue(
       s"clock_gettime seconds ${secondsDiff} not within ${acceptableDiff}",
@@ -506,8 +506,8 @@ class TimeTest {
 
   @Test def clockNanosleepShouldExecute(): Unit = if (!isWindows) {
     val requestP = stackalloc[timespec]()
-    requestP.tv_sec = 0L
-    requestP.tv_nsec = 1L // will be rounded up to minimum clock resolution.
+    requestP.tv_sec = 0
+    requestP.tv_nsec = 1 // will be rounded up to minimum clock resolution.
 
     val result = clock_nanosleep(CLOCK_MONOTONIC, flags = 0, requestP, null)
 
@@ -551,8 +551,8 @@ class TimeTest {
      */
 
     assertTrue(
-      s"clock_settime failed with errno: ${libcErrno.errno}",
-      libcErrno.errno == (EINVAL) || libcErrno.errno == (EPERM)
+      s"clock_settime failed with errno: ${posixErrno.errno}",
+      posixErrno.errno == (EINVAL) || posixErrno.errno == (EPERM)
     )
   }
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -439,7 +439,7 @@ class TimeTest {
     assertEquals(
       s"clock_getres tv_sec ${timespecP.tv_sec} != 0",
       0,
-      timespecP.tv_sec.toInt
+      timespecP.tv_sec.toLong
     )
 
     // Apparently silly test ensures CLOCKS_PER_SEC is exercised.
@@ -489,8 +489,8 @@ class TimeTest {
      * test, not to stress either race conditions or developers.
      */
 
-    val acceptableDiff = 5
-    val secondsDiff = Math.abs(timespecP.tv_sec.toInt - now.toInt)
+    val acceptableDiff = 5L
+    val secondsDiff = Math.abs((timespecP.tv_sec - now).toLong)
 
     assertTrue(
       s"clock_gettime seconds ${secondsDiff} not within ${acceptableDiff}",


### PR DESCRIPTION
This PR adds definitions and does not delete any. There is no strict requirement
for SN 0.5.0.

We implement missing clock_* and timer_* methods and associated definitions.
posixlib time.scala is now almost completely in compliance with POSIX time.h.

There are a few slight differences, especially in the handling of timer_* methods. 
The Library Guide for posixlib has been updated.

##### Implementation Notes
1) macOS does not provide `clock_nanosleep()`.  To simplify operating
    on multiple operating systems that do, a stub is provided for
    macOS which always returns ENOSUP (not supported).

2) The `timer_*` methods are implemented in a separate `timer` object in
    `time.scala`.  This is to simplify the overwhelmingly more common
    usage of the methods in the `time` object.  On most, but not all,
    operating systems one must explicitly include librt, "-lrt" on the 
    link line. macOS does not implement these methods/routines at all.
   Placing them in a separate object means they are available 
   (import foo.timer._) to those who want to use them but do 
   not impose link time complexity or overhead on those who
   who do not want them.  

##### Testing Note
1) New Test cases were written for the `clock_*` routines. It
    is hard to automate checking if `clock_nanosleep()` actually
    slept, especially at microsecond or nanosecond granularity.
    Best one can easily do is to check that the method executes
    without problem.

2) The `timer_*` routines, with their maybe requirement for "-lrt" &
   librtl not existing/needed on some systems makes them hard
   to test in Continuous Integration.  Also, by their nature, 
   they introduce real wall-clock time delays and slow down
   the CI.

    I wrote a personal test to exercise most of the `timer_*` methods
    and `clock_nanosleep()`. `clock_nanosleep` was exercised at
    second, not nanosecond, granularity.   All tests passed.