### PR TITLE
Fix #2717: Complete POSIX errno.scala by providing errno variable

### DIFF
--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -2,9 +2,10 @@ package java.net
 
 import scala.scalanative.unsigned._
 import scala.scalanative.unsafe._
-import scala.scalanative.libc._
 import scala.scalanative.runtime.ByteArray
-import scala.scalanative.posix.errno._
+
+// Import posix name errno as variable, not class or type.
+import scala.scalanative.posix.{errno => posixErrno}, posixErrno._
 import scala.scalanative.posix.unistd
 import scala.scalanative.posix.sys.socket
 import scala.scalanative.posix.sys.socketOps._
@@ -17,6 +18,7 @@ import scala.scalanative.posix.netdb._
 import scala.scalanative.posix.netdbOps._
 import scala.scalanative.posix.sys.time._
 import scala.scalanative.posix.sys.timeOps._
+
 import scala.scalanative.meta.LinktimeInfo.isWindows
 import java.io.{FileDescriptor, IOException, OutputStream, InputStream}
 import scala.scalanative.windows._
@@ -506,7 +508,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     if (isWindows)
       onWindows(WSAGetLastError())
     else
-      onUnix(errno.errno)
+      onUnix(errno)
   }
 }
 

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixFileAttributeViewImpl.scala
@@ -9,15 +9,19 @@ import java.io.IOException
 
 import scalanative.unsigned._
 import scalanative.unsafe._
-import scalanative.libc._
-import scalanative.posix.{errno => e, grp, pwd, unistd, time, utime}, e._
+
+import scalanative.posix._
+
+// Import posix name errno as variable, not class or type.
+import scala.scalanative.posix.{errno => posixErrno}, posixErrno.errno
+
 import scalanative.posix.sys.stat
 
 final class PosixFileAttributeViewImpl(path: Path, options: Array[LinkOption])
     extends PosixFileAttributeView
     with FileOwnerAttributeView {
   private def throwIOException() =
-    throw PosixException(path.toString, errno.errno)
+    throw PosixException(path.toString, errno)
 
   override def name(): String = "posix"
 

--- a/javalib/src/main/scala/java/nio/file/attribute/PosixUserPrincipalLookupService.scala
+++ b/javalib/src/main/scala/java/nio/file/attribute/PosixUserPrincipalLookupService.scala
@@ -2,9 +2,14 @@ package java.nio.file.attribute
 
 import scalanative.unsigned._
 import scalanative.unsafe._
-import scalanative.libc._
-import scalanative.posix.{errno => e, grp, pwd, unistd, time, utime}, e._
+
+import scalanative.posix._
+
+// Import posix name errno as variable, not class or type.
+import scala.scalanative.posix.{errno => posixErrno}, posixErrno.errno
+
 import scalanative.posix.sys.stat
+
 import scala.scalanative.nio.fs.unix.UnixException
 
 final case class PosixUserPrincipal(uid: stat.uid_t)(name: Option[String])
@@ -40,15 +45,15 @@ object PosixUserPrincipalLookupService extends UserPrincipalLookupService {
     implicit z =>
       val buf = alloc[grp.group]()
 
-      errno.errno = 0
+      errno = 0
       val err = grp.getgrgid(gid, buf)
 
       if (err == 0) {
         fromCString(buf._1)
-      } else if (errno.errno == 0) {
+      } else if (errno == 0) {
         gid.toString
       } else {
-        throw UnixException("getgrgid", errno.errno)
+        throw UnixException("getgrgid", errno)
       }
   }
 
@@ -56,15 +61,15 @@ object PosixUserPrincipalLookupService extends UserPrincipalLookupService {
     implicit z =>
       val buf = alloc[pwd.passwd]()
 
-      errno.errno = 0
+      errno = 0
       val err = pwd.getpwuid(uid, buf)
 
       if (err == 0) {
         fromCString(buf._1)
-      } else if (errno.errno == 0) {
+      } else if (errno == 0) {
         uid.toString
       } else {
-        throw UnixException("getpwuid", errno.errno)
+        throw UnixException("getpwuid", errno)
       }
   }
 
@@ -73,15 +78,15 @@ object PosixUserPrincipalLookupService extends UserPrincipalLookupService {
   )(implicit z: Zone): Option[Ptr[grp.group]] = {
     val buf = alloc[grp.group]()
 
-    errno.errno = 0
+    errno = 0
     val err = grp.getgrnam(name, buf)
 
     if (err == 0) {
       Some(buf)
-    } else if (errno.errno == 0) {
+    } else if (errno == 0) {
       None
     } else {
-      throw UnixException("getgrnam", errno.errno)
+      throw UnixException("getgrnam", errno)
     }
   }
 
@@ -104,15 +109,15 @@ object PosixUserPrincipalLookupService extends UserPrincipalLookupService {
   )(implicit z: Zone): Option[Ptr[pwd.passwd]] = {
     val buf = alloc[pwd.passwd]()
 
-    errno.errno = 0
+    errno = 0
     val err = pwd.getpwnam(name, buf)
 
     if (err == 0) {
       Some(buf)
-    } else if (errno.errno == 0) {
+    } else if (errno == 0) {
       None
     } else {
-      throw UnixException("getpwnam", errno.errno)
+      throw UnixException("getpwnam", errno)
     }
   }
 }

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/FileHelpers.scala
@@ -4,7 +4,11 @@ import scalanative.unsafe._
 import scalanative.unsigned._
 import scalanative.libc._
 import scalanative.posix.dirent._
-import scalanative.posix.{errno => e, fcntl, unistd}, e._, unistd.access
+
+// Import posix name errno as variable, not class or type.
+import scalanative.posix.{errno => posixErrno}, posixErrno._
+import scalanative.posix.{fcntl, unistd}, unistd.access
+
 import scalanative.unsafe._, stdlib._, stdio._, string._
 import scalanative.meta.LinktimeInfo.isWindows
 import scala.collection.mutable.UnrolledBuffer
@@ -66,7 +70,7 @@ object FileHelpers {
       val dir = opendir(toCString(path))
 
       if (dir == null) {
-        if (!allowEmpty) throw UnixException(path, errno.errno)
+        if (!allowEmpty) throw UnixException(path, posixErrno.errno)
         null
       } else {
         Zone { implicit z =>
@@ -154,7 +158,7 @@ object FileHelpers {
         } else {
           fopen(toCString(path), c"w") match {
             case null =>
-              if (throwOnError) throw UnixException(path, errno.errno)
+              if (throwOnError) throw UnixException(path, posixErrno.errno)
               else false
             case fd => fclose(fd); exists(path)
           }

--- a/posixlib/src/main/scala/scala/scalanative/posix/errno.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/errno.scala
@@ -5,164 +5,257 @@ import scalanative.unsafe.{CInt, extern, name}
 
 @extern
 object errno {
+
+  // errno and errno_= will use common scala.scalanative.libc implementation.
+
+  @name("scalanative_errno")
+  def errno: CInt = extern
+
+  @name("scalanative_set_errno")
+  def errno_=(value: CInt): Unit = extern
+
+  // Macros
+
   @name("scalanative_e2big")
   def E2BIG: CInt = extern
+
   @name("scalanative_eacces")
   def EACCES: CInt = extern
+
   @name("scalanative_eaddrinuse")
   def EADDRINUSE: CInt = extern
+
+  @name("scalanative_eaddrnotavail")
+  def EADDRNOTAVAIL: CInt = extern
+
   @name("scalanative_eafnosupport")
   def EAFNOSUPPORT: CInt = extern
+
   @name("scalanative_eagain")
   def EAGAIN: CInt = extern
+
   @name("scalanative_ealready")
   def EALREADY: CInt = extern
+
   @name("scalanative_ebadf")
   def EBADF: CInt = extern
+
   @name("scalanative_ebadmsg")
   def EBADMSG: CInt = extern
+
   @name("scalanative_ebusy")
   def EBUSY: CInt = extern
+
   @name("scalanative_ecanceled")
   def ECANCELED: CInt = extern
+
   @name("scalanative_echild")
   def ECHILD: CInt = extern
+
   @name("scalanative_econnaborted")
   def ECONNABORTED: CInt = extern
+
   @name("scalanative_econnrefused")
   def ECONNREFUSED: CInt = extern
+
   @name("scalanative_econnreset")
   def ECONNRESET: CInt = extern
+
   @name("scalanative_edeadlk")
   def EDEADLK: CInt = extern
+
   @name("scalanative_edestaddrreq")
   def EDESTADDRREQ: CInt = extern
+
   @name("scalanative_edom")
   def EDOM: CInt = extern
+
   @name("scalanative_edquot")
   def EDQUOT: CInt = extern
+
   @name("scalanative_eexist")
   def EEXIST: CInt = extern
+
   @name("scalanative_efault")
   def EFAULT: CInt = extern
+
   @name("scalanative_efbig")
   def EFBIG: CInt = extern
+
   @name("scalanative_ehostunreach")
   def EHOSTUNREACH: CInt = extern
+
   @name("scalanative_eidrm")
   def EIDRM: CInt = extern
+
   @name("scalanative_eilseq")
   def EILSEQ: CInt = extern
+
   @name("scalanative_einprogress")
   def EINPROGRESS: CInt = extern
+
   @name("scalanative_eintr")
   def EINTR: CInt = extern
+
   @name("scalanative_einval")
   def EINVAL: CInt = extern
+
   @name("scalanative_eio")
   def EIO: CInt = extern
+
   @name("scalanative_eisconn")
   def EISCONN: CInt = extern
+
   @name("scalanative_eisdir")
   def EISDIR: CInt = extern
+
   @name("scalanative_eloop")
   def ELOOP: CInt = extern
+
   @name("scalanative_emfile")
   def EMFILE: CInt = extern
+
   @name("scalanative_emlink")
   def EMLINK: CInt = extern
+
   @name("scalanative_emsgsize")
   def EMSGSIZE: CInt = extern
+
   @name("scalanative_emultihup")
   def EMULTIHOP: CInt = extern
+
   @name("scalanative_enametoolong")
   def ENAMETOOLONG: CInt = extern
+
   @name("scalanative_enetdown")
   def ENETDOWN: CInt = extern
+
   @name("scalanative_enetreset")
   def ENETRESET: CInt = extern
+
   @name("scalanative_enetunreach")
   def ENETUNREACH: CInt = extern
+
   @name("scalanative_enfile")
   def ENFILE: CInt = extern
+
   @name("scalanative_enobufs")
   def ENOBUFS: CInt = extern
+
   @name("scalanative_enodata")
   def ENODATA: CInt = extern
+
   @name("scalanative_enodev")
   def ENODEV: CInt = extern
+
   @name("scalanative_enoent")
   def ENOENT: CInt = extern
+
   @name("scalanative_enoexec")
   def ENOEXEC: CInt = extern
+
   @name("scalanative_enolck")
   def ENOLCK: CInt = extern
+
   @name("scalanative_enolink")
   def ENOLINK: CInt = extern
+
   @name("scalanative_enomem")
   def ENOMEM: CInt = extern
+
   @name("scalanative_enomsg")
   def ENOMSG: CInt = extern
+
   @name("scalanative_enoprotoopt")
   def ENOPROTOOPT: CInt = extern
+
   @name("scalanative_enospc")
   def ENOSPC: CInt = extern
+
   @name("scalanative_enosr")
   def ENOSR: CInt = extern
+
   @name("scalanative_enostr")
   def ENOSTR: CInt = extern
+
   @name("scalanative_enosys")
   def ENOSYS: CInt = extern
+
   @name("scalanative_enotconn")
   def ENOTCONN: CInt = extern
+
   @name("scalanative_enotdir")
   def ENOTDIR: CInt = extern
+
   @name("scalanative_enotempty")
   def ENOTEMPTY: CInt = extern
+
   @name("scalanative_enotrecoverable")
   def ENOTRECOVERABLE: CInt = extern
+
   @name("scalanative_enotsock")
   def ENOTSOCK: CInt = extern
+
   @name("scalanative_enotsup")
   def ENOTSUP: CInt = extern
+
   @name("scalanative_enotty")
   def ENOTTY: CInt = extern
+
   @name("scalanative_enxio")
   def ENXIO: CInt = extern
+
   @name("scalanative_eopnotsupp")
   def EOPNOTSUPP: CInt = extern
+
   @name("scalanative_eoverflow")
   def EOVERFLOW: CInt = extern
+
   @name("scalanative_eownerdead")
   def EOWNERDEAD: CInt = extern
+
   @name("scalanative_eperm")
   def EPERM: CInt = extern
+
   @name("scalanative_epipe")
   def EPIPE: CInt = extern
+
   @name("scalanative_eproto")
   def EPROTO: CInt = extern
+
   @name("scalanative_eprotonosupport")
   def EPROTONOSUPPORT: CInt = extern
+
   @name("scalanative_eprototype")
   def EPROTOTYPE: CInt = extern
+
   @name("scalanative_erange")
   def ERANGE: CInt = extern
+
   @name("scalanative_erofs")
   def EROFS: CInt = extern
+
   @name("scalanative_espipe")
   def ESPIPE: CInt = extern
+
   @name("scalanative_esrch")
   def ESRCH: CInt = extern
+
   @name("scalanative_estale")
   def ESTALE: CInt = extern
+
   @name("scalanative_etime")
   def ETIME: CInt = extern
+
   @name("scalanative_etimedout")
   def ETIMEDOUT: CInt = extern
+
   @name("scalanative_etxtbsy")
   def ETXTBSY: CInt = extern
+
   @name("scalanative_ewouldblock")
   def EWOULDBLOCK: CInt = extern
+
   @name("scalanative_exdev")
   def EXDEV: CInt = extern
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -12,8 +12,11 @@ import scala.scalanative.runtime.PlatformExt
 
 import scala.scalanative.libc.string
 
-// Import posix name errno as variable, not class or type.
-import scala.scalanative.posix.{errno => posixErrno}, posixErrno.errno
+/* Scala 2.11.n & 2.12.n complain about import of posixErrno.errno.
+ * To span many Scala versions with same code used as
+ * qualified posixErrno.errno below.
+ */
+import scala.scalanative.posix.{errno => posixErrno}
 
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
@@ -154,7 +157,7 @@ class TimeTest {
         val tmPtr = tmBuf.asInstanceOf[Ptr[tm]]
 
         if (localtime_r(ttPtr, tmPtr) == null) {
-          throw new IOException(fromCString(string.strerror(errno)))
+          throw new IOException(fromCString(string.strerror(posixErrno.errno)))
         } else {
           val unexpected = "BOGUS"
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -10,7 +10,11 @@ import org.scalanative.testsuite.utils.Platform
 import scala.scalanative.meta.LinktimeInfo.isWindows
 import scala.scalanative.runtime.PlatformExt
 
-import scalanative.libc.{errno => libcErrno, string}
+import scala.scalanative.libc.string
+
+// Import posix name errno as variable, not class or type.
+import scala.scalanative.posix.{errno => posixErrno}, posixErrno.errno
+
 import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 
@@ -150,7 +154,7 @@ class TimeTest {
         val tmPtr = tmBuf.asInstanceOf[Ptr[tm]]
 
         if (localtime_r(ttPtr, tmPtr) == null) {
-          throw new IOException(fromCString(string.strerror(libcErrno.errno)))
+          throw new IOException(fromCString(string.strerror(errno)))
         } else {
           val unexpected = "BOGUS"
 


### PR DESCRIPTION
This PR can trigger the need for source code changes so it should be on the 0.5.0 track.

#### TL; DR

This PR completes POSIX errno.scala by supplying the previously missing errno variable.

#### Discussion

To be supplied. 

Life got complicated when CI revealed Scala 2.11.n & 2.12.n 'features`