### PR TITLE
Fix scala-native#2604: Print signal name when test interface exits

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -59,7 +59,7 @@ C Header          Scala Native Module
 `stdint.h`_       N/A
 `stdio.h`_        N/A
 `stdlib.h`_       scala.scalanative.posix.stdlib_
-`string.h`_       N/A
+`string.h`_       scala.scalanative.posix.string_
 `strings.h`_      N/A
 `stropts.h`_      N/A
 `sys/ipc.h`_      N/A
@@ -202,6 +202,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.signal: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
 .. _scala.scalanative.posix.stddef: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/stddef.scala
 .. _scala.scalanative.posix.stdlib: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
+.. _scala.scalanative.posix.string: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/string.scala
 .. _scala.scalanative.posix.sys.resource: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
 .. _scala.scalanative.posix.sys.select: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
 .. _scala.scalanative.posix.sys.socket: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala

--- a/posixlib/src/main/scala/scala/scalanative/posix/string.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/string.scala
@@ -1,0 +1,8 @@
+package scala.scalanative.posix
+
+import scalanative.unsafe.{extern, CInt, CString}
+
+@extern
+object string {
+  def strsignal(signum: CInt): CString = extern
+}

--- a/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
+++ b/test-interface/src/main/scala/scala/scalanative/testinterface/signalhandling/SignalConfig.scala
@@ -59,8 +59,15 @@ private[testinterface] object SignalConfig {
       str(index) = 0.toByte
     }
 
-    val signalNumberStr: Ptr[CChar] = stackalloc[CChar](8.toUInt)
-    signalToCString(signalNumberStr, sig)
+    val signalNumberStr: Ptr[CChar] =
+      if (!isWindows) {
+        import scala.scalanative.posix.string.strsignal
+        strsignal(sig)
+      } else {
+        val str: Ptr[CChar] = stackalloc[CChar](8.toUInt)
+        signalToCString(str, sig)
+        str
+      }
 
     val stackTraceHeader: Ptr[CChar] = stackalloc[CChar](2048.toUInt)
     stackTraceHeader(0.toUInt) = 0.toByte

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/TimeTest.scala
@@ -10,7 +10,8 @@ import org.scalanative.testsuite.utils.Platform
 import scala.scalanative.meta.LinktimeInfo.isWindows
 import scala.scalanative.runtime.PlatformExt
 
-import scala.scalanative.libc.string
+// libc.string is hidden by posix.string
+import scala.scalanative.libc.{string => libcString}
 
 /* Scala 2.11.n & 2.12.n complain about import of posixErrno.errno.
  * To span many Scala versions with same code used as
@@ -157,7 +158,9 @@ class TimeTest {
         val tmPtr = tmBuf.asInstanceOf[Ptr[tm]]
 
         if (localtime_r(ttPtr, tmPtr) == null) {
-          throw new IOException(fromCString(string.strerror(posixErrno.errno)))
+          throw new IOException(
+            fromCString(libcString.strerror(posixErrno.errno))
+          )
         } else {
           val unexpected = "BOGUS"
 


### PR DESCRIPTION
This PR adds `strsignal` to `string.scala` to fix #2604.

I'm not really sure how to test if this works, open to suggestions!