### PR TITLE
Fix #2626, #2623: handle socket fields sin6_len & sin_len, when present on OS

### DIFF
--- a/posixlib/src/main/resources/scala-native/arpa/inet.c
+++ b/posixlib/src/main/resources/scala-native/arpa/inet.c
@@ -8,27 +8,7 @@
 #endif
 #include "../netinet/in.h"
 
-uint32_t scalanative_htonl(uint32_t arg) { return htonl(arg); }
-
-uint16_t scalanative_htons(uint16_t arg) { return htons(arg); }
-
-uint32_t scalanative_ntohl(uint32_t arg) { return ntohl(arg); }
-
-uint16_t scalanative_ntohs(uint16_t arg) { return ntohs(arg); }
-
-int scalanative_inet_pton(int af, const char *src, void *dst) {
-    return inet_pton(af, src, dst);
-}
-
 char *scalanative_inet_ntoa(struct scalanative_in_addr *in) {
-    struct in_addr converted;
-    scalanative_convert_in_addr(in, &converted);
-    return inet_ntoa(converted);
+    // _Static_assert code in netinet/in.c allow this transform to be valid.
+    return inet_ntoa(*((struct in_addr *)in));
 }
-
-const char *scalanative_inet_ntop(int af, const void *src, char *dst,
-                                  socklen_t size) {
-    return inet_ntop(af, src, dst, size);
-}
-
-in_addr_t scalanative_inet_addr(char *in) { return inet_addr(in); }

--- a/posixlib/src/main/resources/scala-native/netinet/in.c
+++ b/posixlib/src/main/resources/scala-native/netinet/in.c
@@ -1,25 +1,72 @@
+#include <stddef.h>
 #include <string.h>
 #include "in.h"
 
-void scalanative_convert_in_addr(struct scalanative_in_addr *in,
-                                 struct in_addr *out) {
-    out->s_addr = in->so_addr;
-}
+#if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
+#ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING
+#warning "Size and order of C structures are not checked when -std < c11."
+#endif
+#else
+// Posix defines the name and type of required fields. Size of fields
+// and any internal or tail padding are left unspecified. This section
+// verifies that the C and Scala Native definitions match in each compilation
+// environment.
 
-void scalanative_convert_in6_addr(struct scalanative_in6_addr *in,
-                                  struct in6_addr *out) {
-    void *ignored = memcpy(out->s6_addr, in->_s6_addr, 16);
-}
+// IPv4
+_Static_assert(sizeof(struct scalanative_sockaddr_in) == 16,
+               "Unexpected size: scalanative_sockaddr_in");
 
-void scalanative_convert_scalanative_in_addr(struct in_addr *in,
-                                             struct scalanative_in_addr *out) {
-    out->so_addr = in->s_addr;
-}
+_Static_assert(sizeof(struct scalanative_sockaddr_in) ==
+                   sizeof(struct sockaddr_in),
+               "Unexpected size: os sockaddr_in");
 
-void scalanative_convert_scalanative_in6_addr(
-    struct in6_addr *in, struct scalanative_in6_addr *out) {
-    void *ignored = memcpy(out->_s6_addr, in->s6_addr, 16);
-}
+// On systems which define/use IETF RFC SIN6_LEN macro, sin_family &
+// sin_len are synthesized fields, managed by Ops access routines in in.scala.
+// C offsetof() sin_family will be 2 for the OS sockaddr_in, but strictly 0 for
+// scalanative_sockaddr_in. Scala access routines will access the
+// expected bytes.
+
+_Static_assert(offsetof(struct scalanative_sockaddr_in, sin_family) == 0,
+               "Unexpected offset: scalanative_sockaddr_in.sin_family");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_in, sin_port) ==
+                   offsetof(struct sockaddr_in, sin_port),
+               "Unexpected offset: sockaddr_in.sin_port");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_in, sin_addr) ==
+                   offsetof(struct sockaddr_in, sin_addr),
+               "Unexpected offset: sockaddr_in.sin_addr");
+// IPv6
+_Static_assert(sizeof(struct scalanative_sockaddr_in6) == 28,
+               "Unexpected size: scalanative_sockaddr_in6");
+
+_Static_assert(sizeof(struct scalanative_sockaddr_in6) ==
+                   sizeof(struct sockaddr_in6),
+               "Unexpected size: os sockaddr_in");
+
+// For systems which define/use IETF RFC SIN6_LEN macro, sin6_family &
+// sin6_len see comment above for corresponding scalanative_sockaddr_in6.
+
+_Static_assert(offsetof(struct scalanative_sockaddr_in6, sin6_family) == 0,
+               "Unexpected offset: scalanative_sockaddr_in6.sin6_family");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_in6, sin6_port) ==
+                   offsetof(struct sockaddr_in6, sin6_port),
+               "Unexpected offset: sockaddr_in6.sin6_port");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_in6, sin6_flowinfo) ==
+                   offsetof(struct sockaddr_in6, sin6_flowinfo),
+               "Unexpected offset: sockaddr_in6.sin6_flowinfo");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_in6, sin6_addr) ==
+                   offsetof(struct sockaddr_in6, sin6_addr),
+               "Unexpected offset: sockaddr_in6.sin6_addr");
+
+_Static_assert(offsetof(struct scalanative_sockaddr_in6, sin6_scope_id) ==
+                   offsetof(struct sockaddr_in6, sin6_scope_id),
+               "Unexpected offset: sockaddr_in6.sin6_scope_id");
+
+#endif // structure checking
 
 int scalanative_ipproto_ip() { return IPPROTO_IP; }
 
@@ -62,73 +109,49 @@ int scalanative_ip_multicast_loop() { return IP_MULTICAST_LOOP; }
 int scalanative_ip_tos() { return IP_TOS; }
 
 int scalanative_in6_is_addr_unspecified(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_UNSPECIFIED(&converted);
+    return IN6_IS_ADDR_UNSPECIFIED((struct in6_addr *)arg);
 }
 
 int scalanative_in6_is_addr_loopback(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_LOOPBACK(&converted);
+    return IN6_IS_ADDR_LOOPBACK((struct in6_addr *)arg);
 }
 
 int scalanative_in6_is_addr_multicast(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_MULTICAST(&converted);
+    return IN6_IS_ADDR_MULTICAST((struct in6_addr *)arg);
 }
 
 int scalanative_in6_is_addr_linklocal(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_LINKLOCAL(&converted);
+    return IN6_IS_ADDR_LINKLOCAL((struct in6_addr *)arg);
 }
 
 int scalanative_in6_is_addr_sitelocal(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_SITELOCAL(&converted);
+    return IN6_IS_ADDR_SITELOCAL((struct in6_addr *)arg);
 }
 
 int scalanative_in6_is_addr_v4mapped(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_V4MAPPED(&converted);
+    return IN6_IS_ADDR_V4MAPPED((struct in6_addr *)arg);
 }
 
 int scalanative_in6_is_addr_v4compat(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_V4COMPAT(&converted);
+    return IN6_IS_ADDR_V4COMPAT((struct in6_addr *)arg);
 }
 
 int scalanative_in6_is_addr_mc_nodelocal(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_MC_NODELOCAL(&converted);
+    return IN6_IS_ADDR_MC_NODELOCAL((struct in6_addr *)arg);
 }
 
 int scalanative_in6_is_addr_mc_linklocal(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_MC_LINKLOCAL(&converted);
+    return IN6_IS_ADDR_MC_LINKLOCAL((struct in6_addr *)arg);
 }
 
 int scalanative_in6_is_addr_mc_sitelocal(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_MC_SITELOCAL(&converted);
+    return IN6_IS_ADDR_MC_SITELOCAL((struct in6_addr *)arg);
 }
 
 int scalanative_in6_is_addr_mc_orglocal(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_MC_ORGLOCAL(&converted);
+    return IN6_IS_ADDR_MC_ORGLOCAL((struct in6_addr *)arg);
 }
 
 int scalanative_in6_is_addr_mc_global(struct scalanative_in6_addr *arg) {
-    struct in6_addr converted;
-    scalanative_convert_in6_addr(arg, &converted);
-    return IN6_IS_ADDR_MC_GLOBAL(&converted);
+    return IN6_IS_ADDR_MC_GLOBAL((struct in6_addr *)arg);
 }

--- a/posixlib/src/main/resources/scala-native/netinet/in.h
+++ b/posixlib/src/main/resources/scala-native/netinet/in.h
@@ -40,13 +40,4 @@ struct scalanative_sockaddr_in6 {
     uint32_t sin6_scope_id;
 };
 
-void scalanative_convert_in_addr(struct scalanative_in_addr *in,
-                                 struct in_addr *out);
-void scalanative_convert_in6_addr(struct scalanative_in6_addr *in,
-                                  struct in6_addr *out);
-void scalanative_convert_scalanative_in_addr(struct in_addr *in,
-                                             struct scalanative_in_addr *out);
-void scalanative_convert_scalanative_in6_addr(struct in6_addr *in,
-                                              struct scalanative_in6_addr *out);
-
 #endif // __NETINET_IN_H

--- a/posixlib/src/main/resources/scala-native/sys/socket_conversions.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket_conversions.c
@@ -1,6 +1,5 @@
 #include "../netinet/in.h"
 #include "socket_conversions.h"
-#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -8,18 +7,14 @@
 #include <sys/socket.h>
 #endif
 
-_Static_assert(sizeof(struct scalanative_sockaddr_storage) ==
-                   sizeof(struct sockaddr_storage),
-               "Unexpected size: scalanative_storage sa_family");
-
 int scalanative_convert_sockaddr_in(struct scalanative_sockaddr_in *in,
                                     struct sockaddr_in **out, socklen_t *size) {
     struct sockaddr_in *s =
         (struct sockaddr_in *)malloc(sizeof(struct sockaddr_in));
     *size = sizeof(struct sockaddr_in);
-    s->sin_family = in->sin_family;
-    s->sin_port = in->sin_port;
-    scalanative_convert_in_addr(&(in->sin_addr), &(s->sin_addr));
+
+    void *ignored = memcpy(s, in, sizeof(struct sockaddr_in));
+
     *out = s;
     return 0;
 }
@@ -30,11 +25,9 @@ int scalanative_convert_sockaddr_in6(struct scalanative_sockaddr_in6 *in,
     struct sockaddr_in6 *s =
         (struct sockaddr_in6 *)malloc(sizeof(struct sockaddr_in6));
     *size = sizeof(struct sockaddr_in6);
-    s->sin6_family = in->sin6_family;
-    s->sin6_port = in->sin6_port;
-    s->sin6_flowinfo = in->sin6_flowinfo;
-    scalanative_convert_in6_addr(&(in->sin6_addr), &(s->sin6_addr));
-    s->sin6_scope_id = in->sin6_scope_id;
+
+    void *ignored = memcpy(s, in, sizeof(struct sockaddr_in6));
+
     *out = s;
     return 0;
 }
@@ -42,24 +35,20 @@ int scalanative_convert_sockaddr_in6(struct scalanative_sockaddr_in6 *in,
 int scalanative_convert_sockaddr_storage(
     struct scalanative_sockaddr_storage *in, struct sockaddr_storage **out,
     socklen_t *size) {
-
-    assert(*size <= sizeof(struct sockaddr_storage));
-
-    void *s = calloc(1, sizeof(struct sockaddr_storage));
-
-    assert(s != NULL);
-
-    memcpy(s, in, *size);
-
-    *out = s;
+    struct sockaddr_storage *s =
+        (struct sockaddr_storage *)malloc(sizeof(struct sockaddr_storage));
     *size = sizeof(struct sockaddr_storage);
 
+    void *ignored = memcpy(s, in, sizeof(struct sockaddr_storage));
+
+    *out = s;
     return 0;
 }
 
 int scalanative_convert_sockaddr(struct scalanative_sockaddr *raw_in,
                                  struct sockaddr **out, socklen_t *size) {
     int result;
+
     switch (*size) {
     case sizeof(struct scalanative_sockaddr_in):
         result = scalanative_convert_sockaddr_in(
@@ -91,9 +80,9 @@ int scalanative_convert_scalanative_sockaddr_in(
     struct sockaddr_in *in, struct scalanative_sockaddr_in *out,
     socklen_t *size) {
     *size = sizeof(struct scalanative_sockaddr_in);
-    out->sin_family = in->sin_family;
-    out->sin_port = in->sin_port;
-    scalanative_convert_scalanative_in_addr(&(in->sin_addr), &(out->sin_addr));
+
+    void *ignored = memcpy(out, in, sizeof(struct sockaddr_in));
+
     return 0;
 }
 
@@ -101,21 +90,20 @@ int scalanative_convert_scalanative_sockaddr_in6(
     struct sockaddr_in6 *in, struct scalanative_sockaddr_in6 *out,
     socklen_t *size) {
     *size = sizeof(struct scalanative_sockaddr_in6);
-    out->sin6_family = in->sin6_family;
-    out->sin6_port = in->sin6_port;
-    out->sin6_flowinfo = in->sin6_flowinfo;
-    scalanative_convert_scalanative_in6_addr(&(in->sin6_addr),
-                                             &(out->sin6_addr));
-    out->sin6_scope_id = in->sin6_scope_id;
+
+    void *ignored = memcpy(out, in, sizeof(struct sockaddr_in6));
+
     return 0;
 }
 
 int scalanative_convert_scalanative_sockaddr_storage(
     struct sockaddr_storage *in, struct scalanative_sockaddr_storage *out,
     socklen_t *size) {
-
+    struct sockaddr_storage *s =
+        (struct sockaddr_storage *)malloc(sizeof(struct sockaddr_storage));
     *size = sizeof(struct scalanative_sockaddr_storage);
-    memcpy(out, in, *size);
+
+    void *ignored = memcpy(s, in, sizeof(struct sockaddr_storage));
 
     return 0;
 }
@@ -124,6 +112,7 @@ int scalanative_convert_scalanative_sockaddr(struct sockaddr *raw_in,
                                              struct scalanative_sockaddr *out,
                                              socklen_t *size) {
     int result;
+
     switch (*size) {
     case sizeof(struct sockaddr_in):
         result = scalanative_convert_scalanative_sockaddr_in(

--- a/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/arpa/inet.scala
@@ -9,17 +9,18 @@ import scalanative.posix.netinet.in.{in_addr, in_addr_t}
 
 @extern
 object inet {
+  /* Declarations where the arguments are passed to and from the
+   * implementing extern code do not need "@name" intermediate code.
+   * "inet_ntoa()" below transforms its argument before passing it down,
+   * so it requires the annotation and "glue" code.
+   */
 
-  @name("scalanative_htonl")
   def htonl(arg: uint32_t): uint32_t = extern
 
-  @name("scalanative_htons")
   def htons(arg: uint16_t): uint16_t = extern
 
-  @name("scalanative_ntohl")
   def ntohl(arg: uint32_t): uint32_t = extern
 
-  @name("scalanative_ntohs")
   def ntohs(arg: uint16_t): uint16_t = extern
 
   /* The argument for inet_ntoa() differs from the POSIX specification
@@ -38,7 +39,6 @@ object inet {
   @name("scalanative_inet_ntoa")
   def inet_ntoa(in: Ptr[in_addr]): CString = extern
 
-  @name("scalanative_inet_ntop")
   def inet_ntop(
       af: CInt,
       src: Ptr[Byte],
@@ -46,10 +46,7 @@ object inet {
       size: socklen_t
   ): CString = extern
 
-  @name("scalanative_inet_pton")
   def inet_pton(af: CInt, src: CString, dst: Ptr[Byte]): CInt = extern
 
-  @name("scalanative_inet_addr")
   def inet_addr(in: CString): in_addr_t = extern
-
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/netinet/In6Test.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/netinet/In6Test.scala
@@ -8,7 +8,7 @@ import scalanative.posix.inttypes._
 import scalanative.posix.sys.socket._
 import scalanative.posix.sys.socketOps._
 
-import scalanative.unsafe.{alloc, sizeof, Zone}
+import scalanative.unsafe._
 import scalanative.unsigned._
 
 import org.junit.Test

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/netinet/In6Test.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/netinet/In6Test.scala
@@ -1,0 +1,73 @@
+package scala.scalanative.posix
+package netinet
+
+import scalanative.posix.netinet.in._
+import scalanative.posix.netinet.inOps._
+
+import scalanative.posix.inttypes._
+import scalanative.posix.sys.socket._
+import scalanative.posix.sys.socketOps._
+
+import scalanative.unsafe.{alloc, sizeof, Zone}
+import scalanative.unsigned._
+
+import org.junit.Test
+import org.junit.Assert._
+
+class In6Test {
+
+  @Test def testSetSin6Family(): Unit = Zone { implicit z =>
+    /* Setting the sin6_family field should work and should not clobber the
+     * sin6_len field, if such exists on executing OS.
+     */
+    val in6SockAddr = alloc[sockaddr_in6]()
+
+    val expectedSin6Len = in6SockAddr.sin6_len
+
+    val expectedSin6Family = AF_INET6.toUShort
+    in6SockAddr.sin6_family = expectedSin6Family
+
+    assertEquals(
+      "unexpected sin6_len",
+      in6SockAddr.sin6_len,
+      expectedSin6Len
+    )
+
+    assertEquals(
+      "unexpected sin6_family",
+      in6SockAddr.sin6_family,
+      expectedSin6Family
+    )
+  }
+
+  @Test def testSetSin6Len(): Unit = Zone { implicit z =>
+    /* Setting the sin6_len field should work and should not clobber the
+     * sin6_family field.
+     */
+    val in6SockAddr = alloc[sockaddr_in6]()
+
+    val expectedSin6Family = AF_INET6.toUShort
+
+    val suppliedSin6Len = 77.toUByte
+    val expectedSin6Len: uint8_t = if (useSinXLen) {
+      suppliedSin6Len
+    } else {
+      sizeof[sockaddr_in6].toUByte // field is synthesized on non-BSD
+    }
+
+    in6SockAddr.sin6_family = expectedSin6Family
+    in6SockAddr.sin6_len = suppliedSin6Len
+
+    assertEquals(
+      "unexpected sin6_len",
+      in6SockAddr.sin6_len,
+      expectedSin6Len
+    )
+
+    assertEquals(
+      "unexpected sin6_family",
+      in6SockAddr.sin6_family,
+      expectedSin6Family
+    )
+  }
+}

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/netinet/InTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/netinet/InTest.scala
@@ -8,7 +8,7 @@ import scalanative.posix.inttypes._
 import scalanative.posix.sys.socket._
 import scalanative.posix.sys.socketOps._
 
-import scalanative.unsafe.{alloc, sizeof, Zone}
+import scalanative.unsafe._
 import scalanative.unsigned._
 
 import org.junit.Test

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/netinet/InTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/netinet/InTest.scala
@@ -1,0 +1,73 @@
+package scala.scalanative.posix
+package netinet
+
+import scalanative.posix.netinet.in._
+import scalanative.posix.netinet.inOps._
+
+import scalanative.posix.inttypes._
+import scalanative.posix.sys.socket._
+import scalanative.posix.sys.socketOps._
+
+import scalanative.unsafe.{alloc, sizeof, Zone}
+import scalanative.unsigned._
+
+import org.junit.Test
+import org.junit.Assert._
+
+class InTest {
+
+  @Test def testSetSinFamily(): Unit = Zone { implicit z =>
+    /* Setting the sin_family field should work and should not clobber the
+     * sin_len field, if such exists on executing OS.
+     */
+    val in4SockAddr = alloc[sockaddr_in]()
+
+    val expectedSinLen = in4SockAddr.sin_len
+
+    val expectedSinFamily = AF_INET.toUShort
+    in4SockAddr.sin_family = expectedSinFamily
+
+    assertEquals(
+      "unexpected sin_len",
+      in4SockAddr.sin_len,
+      expectedSinLen
+    )
+
+    assertEquals(
+      "unexpected sin_family",
+      in4SockAddr.sin_family,
+      expectedSinFamily
+    )
+  }
+
+  @Test def testSetSinLen(): Unit = Zone { implicit z =>
+    /* Setting the sin_len field should work and should not clobber the
+     * sin_family field.
+     */
+    val in4SockAddr = alloc[sockaddr_in]()
+
+    val expectedSinFamily = AF_INET.toUShort
+
+    val suppliedSinLen = 66.toUByte
+    val expectedSinLen: uint8_t = if (useSinXLen) {
+      suppliedSinLen
+    } else {
+      sizeof[sockaddr_in].toUByte // field is synthesized on non-BSD
+    }
+
+    in4SockAddr.sin_family = expectedSinFamily
+    in4SockAddr.sin_len = suppliedSinLen
+
+    assertEquals(
+      "unexpected sin_len",
+      in4SockAddr.sin_len,
+      expectedSinLen
+    )
+
+    assertEquals(
+      "unexpected sin_family",
+      in4SockAddr.sin_family,
+      expectedSinFamily
+    )
+  }
+}

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
@@ -31,19 +31,12 @@ import org.junit.Assume._
 import org.junit.Before
 
 class Udp6SocketTest {
-
-  /* Tests are failing on GitHub CI BSD based systems.
-   * (errno 47: Address family not supported by protocol).
-   * This is caused by SN not properly handling sin6_len on BSD.
-   * See SN Issue #2626. Disable testing on IPv6 until that Issue is fixed.
-   */
-
-  val isIPv6Available = !(Platform.isMacOs || Platform.isFreeBSD) &&
-    hasLoopbackAddress(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)
-
   @Before
   def before(): Unit = {
-    assumeTrue("IPv6 UDP loopback is not available", isIPv6Available)
+    assumeTrue(
+      "IPv6 UDP loopback is not available",
+      hasLoopbackAddress(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)
+    )
 
     /* Scala Native Continuous Integration linux-arm64 multiarch runs
      * fail, where they succeed on other test configurations.


### PR DESCRIPTION
Two socket fields, sin6_len & sin_len which are commonly available on BSD-derived
systems, such as macOS & FreeBSD, are now handled correctly. 

Two new tests `InTest.scala` and `In6Test.scala` are introduced to verify the changes.

A benefit of this now proper handling is that socket methods `sendto()` and `recvfrom()` work correctly
on those two operating systems (Issue #2623, fixed on Linux & Windows in a prior PR.)