### PR TITLE
Use correct parameters lists when generating extern methods in Scala 3

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -1456,10 +1456,10 @@ trait NirGenExpr(using Context) {
       if (!sym.isExtern) genSimpleArgs(argsp)
       else {
         val res = Seq.newBuilder[Val]
-        argsp.zip(sym.denot.paramSymss.flatten).foreach {
-          case (argp, paramSym) =>
+        argsp.zip(sym.paramInfo.paramInfoss.flatten).foreach {
+          case (argp, paramTpe) =>
             given nir.Position = argp.span
-            val externType = genExternType(paramSym.info.resultType)
+            val externType = genExternType(paramTpe.finalResultType)
             res += toExtern(externType, genExpr(argp))
         }
         res.result()

--- a/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -146,4 +146,19 @@ class NIRCompilerTest extends AnyFlatSpec with Matchers with Inspectors {
     )
   }
 
+  it should "handle extern methods with generic types" in {
+    // issue #2727
+    NIRCompiler(_.compile("""
+      |import scala.scalanative.unsafe._
+      |@extern
+      |object foo {
+      |  def baz[A](a: Ptr[A]): Unit = extern
+      |}
+      |
+      |object Test {
+      |  def main() = foo.baz(???)
+      |}
+      |""".stripMargin))
+  }
+
 }


### PR DESCRIPTION
Fixes #2727 

Fixes usage of incorrect, and allocation-heavy `SymDenotation.paramSymss` resulting in returning generic parameter types, with the correct Symbol parameter infos list.