### PR TITLE
Fixes to usage of structural types in Scala 3

### DIFF
--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2446,11 +2446,22 @@ trait NirGenExpr(using Context) {
                   .zip(formalParamTypes)
                   .map { (actualArgAny, formalParamType) =>
                     val genActualArgAny = genExpr(actualArgAny)
-                    buf.as(
-                      formalParamType,
-                      genActualArgAny,
-                      unwind
-                    )
+                    (genActualArgAny.ty, formalParamType) match {
+                      case (ty: Type.Ref, formal: Type.Ref) =>
+                        if ty.name == formal.name then genActualArgAny
+                        else
+                          buf.as(
+                            formalParamType,
+                            genActualArgAny,
+                            unwind
+                          )
+
+                      case (ty: Type.Ref, formal: Type.PrimitiveKind) =>
+                        assert(Type.Ref(ty.name) == Type.box(formal))
+                        genActualArgAny
+
+                      case _ => scalanative.util.unreachable
+                    }
                   }
 
               (formalParamTypes, actualArgs)
@@ -2469,8 +2480,15 @@ trait NirGenExpr(using Context) {
         Sig.Proxy(methodNameStr, formalParamTypeRefs),
         unwind
       )
+      // Proxies operate only on boxed types, however formal param types and name of the method
+      // might contain primitive types. With current imlementation of proxies we workaround it
+      // by always using boxed types in function calls
+      val boxedFormalParamTypeRefs = formalParamTypeRefs.map {
+        case ty: Type.PrimitiveKind => Type.box(ty)
+        case ty                     => ty
+      }
       buf.call(
-        Type.Function(selectedValue.ty :: formalParamTypeRefs, Rt.Object),
+        Type.Function(selectedValue.ty :: boxedFormalParamTypeRefs, Rt.Object),
         dynMethod,
         selectedValue :: actualArgs,
         unwind

--- a/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
+++ b/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
@@ -60,6 +60,22 @@ class Scala3IssuesTest:
     assertEquals("List", collectionClassName(List(1, 2, 3)))
   }
 
+  @Test def issue2715(): Unit = {
+    import reflect.Selectable.reflectiveSelectable
+    class Foo {
+      def bar(i: Int): String = (2 * i).toString
+      def baz(i: Integer): String = (2 * i.intValue()).toString()
+    }
+    type Qux = { 
+      def bar(i: Int): String 
+      def baz(i: Integer): String
+    }
+    val z: Any = if true then new Foo else new AnyRef
+    val z: Any = if true then new Foo else new AnyRef
+    assertEquals("42", z.asInstanceOf[Qux].bar(21))
+    assertEquals("42", z.asInstanceOf[Qux].baz(21))
+  }
+
 end Scala3IssuesTest
 
 private object issue2484 {

--- a/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
+++ b/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
@@ -66,8 +66,8 @@ class Scala3IssuesTest:
       def bar(i: Int): String = (2 * i).toString
       def baz(i: Integer): String = (2 * i.intValue()).toString()
     }
-    type Qux = { 
-      def bar(i: Int): String 
+    type Qux = {
+      def bar(i: Int): String
       def baz(i: Integer): String
     }
     val z: Any = if true then new Foo else new AnyRef

--- a/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
+++ b/unit-tests/shared/src/test/scala-3/scala/issues/Scala3IssuesTest.scala
@@ -71,9 +71,9 @@ class Scala3IssuesTest:
       def baz(i: Integer): String
     }
     val z: Any = if true then new Foo else new AnyRef
-    val z: Any = if true then new Foo else new AnyRef
-    assertEquals("42", z.asInstanceOf[Qux].bar(21))
-    assertEquals("42", z.asInstanceOf[Qux].baz(21))
+    val q: Qux = z.asInstanceOf[Qux]
+    assertEquals("42", q.bar(21))
+    assertEquals("42", q.baz(21))
   }
 
 end Scala3IssuesTest


### PR DESCRIPTION
Fixes #2715 
The fix involves skipping the casting of the arguments when it's not needed.
On top of fixes according to correct handling of primitive types, additional fixes to handling proxies using boxed types were added.  It is needed to handle Scala 3 reflective access using selectable fully. Previously proxy types assumed target arguments should always be unboxed, this is however incorrect in Scala 3. 