### PR TITLE
Fix #2738: Shorten posixlib uio codepaths & add UioTest

### DIFF
--- a/posixlib/src/main/resources/scala-native/sys/uio.c
+++ b/posixlib/src/main/resources/scala-native/sys/uio.c
@@ -3,29 +3,22 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 
+#include <stddef.h>
+
 struct scalanative_iovec {
     void *iov_base; /** Base address of a memory region for input or output. */
     size_t iov_len; /** The size of the memory pointed to by iov_base. */
 };
 
-void iovec_to_scalanative_iovec(struct iovec *orig,
-                                struct scalanative_iovec *buf) {
-    buf->iov_base = orig->iov_base;
-    buf->iov_len = orig->iov_len;
-}
+_Static_assert(sizeof(struct scalanative_iovec) == sizeof(struct iovec),
+               "Unexpected size: iovec");
 
-ssize_t scalanative_readv(int d, struct scalanative_iovec *buf, int iovcnt) {
-    struct iovec copy;
-    ssize_t result = readv(d, &copy, iovcnt);
-    iovec_to_scalanative_iovec(&copy, buf);
-    return result;
-}
+_Static_assert(offsetof(struct scalanative_iovec, iov_base) ==
+                   offsetof(struct iovec, iov_base),
+               "Unexpected offset: iov_base");
 
-ssize_t scalanative_writev(int fildes, struct scalanative_iovec *buf,
-                           int iovcnt) {
-    struct iovec copy;
-    ssize_t result = writev(fildes, &copy, iovcnt);
-    iovec_to_scalanative_iovec(&copy, buf);
-    return result;
-}
+_Static_assert(offsetof(struct scalanative_iovec, iov_len) ==
+                   offsetof(struct iovec, iov_len),
+               "Unexpected offset: iov_len");
+
 #endif // Unix or Mac OS

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/uio.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/uio.scala
@@ -11,10 +11,25 @@ object uio {
     CSize // iov_len
   ]
 
-  @name("scalanative_readv")
   def readv(d: CInt, buf: Ptr[iovec], iovcnt: CInt): CSSize = extern
 
-  @name("scalanative_writev")
   def writev(fildes: CInt, iov: Ptr[iovec], iovcnt: CInt): CSSize = extern
+}
 
+object uioOps {
+  import uio.iovec
+
+  implicit class iovecOps(val ptr: Ptr[iovec]) extends AnyVal {
+    def iov_base: Ptr[Byte] = ptr._1
+    def iov_len: CSize = ptr._2
+    def iov_base_=(v: Ptr[Byte]): Unit = ptr._1 = v
+    def iov_len_=(v: CSize): Unit = ptr._2 = v
+  }
+
+  implicit class iovecValOps(val vec: iovec) extends AnyVal {
+    def iov_base: Ptr[Byte] = vec._1
+    def iov_len: CSize = vec._2
+    def iov_base_=(v: Ptr[Byte]): Unit = vec._1 = v
+    def iov_len_=(v: CSize): Unit = vec._2 = v
+  }
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/SocketTestHelpers.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/SocketTestHelpers.scala
@@ -4,13 +4,15 @@ package sys
 import scalanative.unsafe._
 import scalanative.unsigned._
 
-import scalanative.libc.errno
 import scalanative.libc.string.strerror
 
+import scalanative.posix.arpa.inet.{inet_addr, inet_pton}
+import scalanative.posix.errno
+import scalanative.posix.fcntl.{F_SETFL, O_NONBLOCK}
+import scalanative.posix.netinet.inOps._
 import scalanative.posix.netdb._
 import scalanative.posix.netdbOps._
 import scalanative.posix.netinet.in._
-import scalanative.posix.netinet.inOps._
 import scalanative.posix.poll._
 import scalanative.posix.pollOps._
 import scalanative.posix.sys.socket._
@@ -27,6 +29,193 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 object SocketTestHelpers {
+
+  def checkIoResult(v: CSSize, label: String): Unit = {
+    if (v.toInt < 0) {
+      val reason =
+        if (isWindows) ErrorHandlingApiOps.errorMessage(GetLastError())
+        else fromCString(strerror(errno.errno))
+      fail(s"$label failed - $reason")
+    }
+  }
+
+  def closeSocket(socket: CInt): Unit = {
+    if (isWindows) WinSocketApi.closeSocket(socket.toPtr[Byte])
+    else unistd.close(socket)
+  }
+
+  def createAndCheckUdpSocket(domain: CInt): CInt = {
+    if (isWindows) {
+      val socket = WSASocketW(
+        addressFamily = domain,
+        socketType = SOCK_DGRAM,
+        protocol = IPPROTO_UDP,
+        protocolInfo = null,
+        group = 0.toUInt,
+        flags = WSA_FLAG_OVERLAPPED
+      )
+      assertNotEquals("socket create", InvalidSocket, socket)
+      socket.toInt
+    } else {
+      val sock = sys.socket.socket(domain, SOCK_DGRAM, IPPROTO_UDP)
+      assertNotEquals("socket create", -1, sock)
+      sock
+    }
+  }
+
+  /* Setting up IPv6 and IPv6 sockets is just different enough that
+   * separate, near duplicate, code is easier to get write.
+   * Consolidating the two without lots of hairy "if (ipv6)" and such
+   * is left for the next generation.
+   */
+
+  def getUdp4LoopbackSockets()(implicit
+      z: Zone
+  ): Tuple3[CInt, CInt, Ptr[sockaddr]] = {
+    val localhost = c"127.0.0.1"
+    val localhostInetAddr = inet_addr(localhost)
+
+    val sin: CInt = createAndCheckUdpSocket(AF_INET)
+
+    try {
+      val inAddr = alloc[sockaddr]()
+      val inAddrInPtr = inAddr.asInstanceOf[Ptr[sockaddr_in]]
+
+      inAddrInPtr.sin_family = AF_INET.toUShort
+      inAddrInPtr.sin_addr.s_addr = localhostInetAddr
+      // inAddrInPtr.sin_port is already the desired 0; "find a free port".
+
+      setSocketBlocking(sin)
+
+      // Get port for write() to use.
+      val bindInStatus = bind(sin, inAddr, sizeof[sockaddr].toUInt)
+      assertNotEquals(
+        s"bind input socket failed,  errno: ${errno.errno}",
+        -1,
+        bindInStatus
+      )
+
+      val inAddrInfo = alloc[sockaddr]()
+      val gsnAddrLen = alloc[socklen_t]()
+      !gsnAddrLen = sizeof[sockaddr].toUInt
+
+      val gsnStatus = getsockname(sin, inAddrInfo, gsnAddrLen)
+      assertNotEquals("getsockname", -1, gsnStatus)
+
+      // Now use port in output socket
+      val sout = createAndCheckUdpSocket(AF_INET)
+
+      try {
+        val outAddr = alloc[sockaddr]() // must be alloc, NO stackalloc
+        val outAddrInPtr = outAddr.asInstanceOf[Ptr[sockaddr_in]]
+        outAddrInPtr.sin_family = AF_INET.toUShort
+        outAddrInPtr.sin_addr.s_addr = localhostInetAddr
+        outAddrInPtr.sin_port =
+          inAddrInfo.asInstanceOf[Ptr[sockaddr_in]].sin_port
+
+        (sin, sout, outAddr)
+      } catch {
+        case e: Throwable =>
+          SocketTestHelpers.closeSocket(sout)
+          throw e
+      }
+    } catch {
+      case e: Throwable =>
+        SocketTestHelpers.closeSocket(sin)
+        throw e
+        (-1, -1, null) // should never get here.
+    }
+  }
+
+  def getUdp6LoopbackSockets()(implicit
+      z: Zone
+  ): Tuple3[CInt, CInt, Ptr[sockaddr]] = {
+    val localhost = c"::1"
+
+    val in6SockAddr = alloc[sockaddr_in6]()
+    in6SockAddr.sin6_family = AF_INET6.toUShort
+
+    /* Scala Native currently implements neither inaddr_loopback
+     * nor IN6ADDR_LOOPBACK_INIT. When they become available,
+     * this code can be simplified by using the former instead
+     * of the inet_pton(code below). All things in due time.
+     *
+     * in6SockAddr.sin6_addr = in6addr_loopback
+     */
+
+    // sin6_port is already the desired 0; "find a free port".
+    // all other fields already 0.
+
+    val ptonStatus = inet_pton(
+      AF_INET6,
+      localhost,
+      in6SockAddr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]]
+    )
+
+    assertEquals(s"inet_pton failed errno: ${errno.errno}", ptonStatus, 1)
+
+    val sin: CInt = createAndCheckUdpSocket(AF_INET6)
+
+    try {
+      setSocketBlocking(sin)
+
+      // Get port for sendto() to use.
+      val bindStatus = bind(
+        sin,
+        in6SockAddr
+          .asInstanceOf[Ptr[sockaddr]],
+        sizeof[sockaddr_in6].toUInt
+      )
+
+      assertNotEquals(s"bind failed,  errno: ${errno.errno}", -1, bindStatus)
+
+      val in6AddrInfo = alloc[sockaddr_in6]()
+      val gsnAddrLen = alloc[socklen_t]()
+      !gsnAddrLen = sizeof[sockaddr_in6].toUInt
+
+      val gsnStatus = getsockname(
+        sin,
+        in6AddrInfo.asInstanceOf[Ptr[sockaddr]],
+        gsnAddrLen
+      )
+
+      assertNotEquals("getsockname failed errno: ${errno.errno}", -1, gsnStatus)
+
+      // Now use port in output socket
+      val sout = createAndCheckUdpSocket(AF_INET6)
+
+      try {
+        val out6Addr = alloc[sockaddr_in6]()
+        out6Addr.sin6_family = AF_INET6.toUShort
+        out6Addr.sin6_port = in6AddrInfo.sin6_port
+        out6Addr.sin6_addr = in6SockAddr.sin6_addr
+
+        (sin, sout, out6Addr.asInstanceOf[Ptr[sockaddr]])
+      } catch {
+        case e: Throwable =>
+          SocketTestHelpers.closeSocket(sout)
+          throw e
+      }
+    } catch {
+      case e: Throwable =>
+        SocketTestHelpers.closeSocket(sin)
+        throw e
+        (-1, -1, null) // should never get here.
+    }
+  }
+
+  def getUdpLoopbackSockets(domain: CInt)(implicit
+      z: Zone
+  ): Tuple3[CInt, CInt, Ptr[sockaddr]] = {
+    if (domain == AF_INET) {
+      getUdp4LoopbackSockets()
+    } else if (domain == AF_INET6) {
+      getUdp6LoopbackSockets()
+    } else {
+      fail(s"getUdpLoopbackSockets: unsupported domain ${domain}")
+      (-1, -1, null)
+    }
+  }
 
   def hasLoopbackAddress(
       family: CInt,
@@ -46,60 +235,59 @@ object SocketTestHelpers {
        */
 
       true
-    } else
-      Zone { implicit z =>
-        /* Test where a working IPv6 or IPv4 network is available.
-         * The Scala Native GitHub CI environment is known to have a
-         * working IPv6 network. Arbitrary local systems may not.
-         *
-         * The JVM sets a system property "java.net.preferIPv4Stack=false"
-         * when an IPv6 interface is active. Scala Native does not
-         * set this property. One has to see if an IPv6 loopback address
-         * can be found.
-         */
+    } else {
+      /* Test where a working IPv6 or IPv4 network is available.
+       * The Scala Native GitHub CI environment is known to have a
+       * working IPv6 network. Arbitrary local systems may not.
+       *
+       * The JVM sets a system property "java.net.preferIPv4Stack=false"
+       * when an IPv6 interface is active. Scala Native does not
+       * set this property. One has to see if an IPv6 loopback address
+       * can be found.
+       */
 
-        assumeTrue(
-          s"Address family ${family} is not supported",
-          (family == AF_INET6) || (family == AF_INET)
-        )
-        assumeTrue(
-          s"Socket type ${socktype} is not supported",
-          (socktype == SOCK_DGRAM) || (socktype == SOCK_STREAM)
-        )
-        assumeTrue(
-          s"IP protocol ${protocol} is not supported",
-          (protocol == IPPROTO_UDP) || (protocol == IPPROTO_TCP)
-        )
+      assumeTrue(
+        s"Address family ${family} is not supported",
+        (family == AF_INET6) || (family == AF_INET)
+      )
+      assumeTrue(
+        s"Socket type ${socktype} is not supported",
+        (socktype == SOCK_DGRAM) || (socktype == SOCK_STREAM)
+      )
+      assumeTrue(
+        s"IP protocol ${protocol} is not supported",
+        (protocol == IPPROTO_UDP) || (protocol == IPPROTO_TCP)
+      )
 
-        val localhost =
-          if (family == AF_INET) c"127.0.0.1"
-          else c"::1"
+      val localhost =
+        if (family == AF_INET) c"127.0.0.1"
+        else c"::1"
 
-        val hints = stackalloc[addrinfo]()
-        hints.ai_family = family
-        hints.ai_socktype = socktype
-        hints.ai_protocol = protocol
-        hints.ai_flags = AI_NUMERICHOST
+      val hints = stackalloc[addrinfo]()
+      hints.ai_family = family
+      hints.ai_socktype = socktype
+      hints.ai_protocol = protocol
+      hints.ai_flags = AI_NUMERICHOST
 
-        val resultPtr = stackalloc[Ptr[addrinfo]]()
+      val resultPtr = stackalloc[Ptr[addrinfo]]()
 
-        val status = getaddrinfo(localhost, null, hints, resultPtr);
+      val status = getaddrinfo(localhost, null, hints, resultPtr);
 
-        if (status == 0) {
-          freeaddrinfo(!resultPtr) // leak not, want not!
-        } else if ((status != EAI_FAMILY) && (status != EAI_SOCKTYPE)) {
-          val msg = s"getaddrinfo failed: ${fromCString(gai_strerror(status))}"
-          assertEquals(msg, 0, status)
-        }
-
-        /* status 0 means 'found'
-         * status EAI_FAMILY means 'not found'.
-         * status EAI_SOCKTYPE means not only 'not found' but not even
-         *          supported. i.e. Looking for IPv6 with IPv4 single stack.
-         */
-
-        status == 0
+      if (status == 0) {
+        freeaddrinfo(!resultPtr) // leak not, want not!
+      } else if ((status != EAI_FAMILY) && (status != EAI_SOCKTYPE)) {
+        val msg = s"getaddrinfo failed: ${fromCString(gai_strerror(status))}"
+        assertEquals(msg, 0, status)
       }
+
+      /* status 0 means 'found'
+       * status EAI_FAMILY means 'not found'.
+       * status EAI_SOCKTYPE means not only 'not found' but not even
+       *          supported. i.e. Looking for IPv6 with IPv4 single stack.
+       */
+
+      status == 0
+    }
   }
 
   def pollReadyToRecv(fd: CInt, timeout: CInt): Unit = {
@@ -138,6 +326,26 @@ object SocketTestHelpers {
         fail(s"poll for input failed - $reason")
       }
       // else good to go
+    }
+  }
+
+  // For some unknown reason inlining content of this method leads to failures
+  // on Unix, probably due to bug in linktime conditions.
+  def setSocketBlocking(socket: CInt): Unit = {
+    if (isWindows) {
+      val mode = stackalloc[CInt]()
+      !mode = 1
+      assertNotEquals(
+        "iotctl setBLocking",
+        -1,
+        ioctlSocket(socket.toPtr[Byte], FIONBIO, mode)
+      )
+    } else {
+      assertNotEquals(
+        s"fcntl set blocking",
+        -1,
+        fcntl.fcntl(socket, F_SETFL, O_NONBLOCK)
+      )
     }
   }
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/Udp6SocketTest.scala
@@ -4,12 +4,10 @@ package sys
 import scalanative.unsafe._
 import scalanative.unsigned._
 
-import scalanative.libc.errno
-import scalanative.libc.string.{memcmp, strerror}
+import scalanative.libc.string.memcmp
 
 import scalanative.posix.arpa.inet._
-import scalanative.posix.fcntl
-import scalanative.posix.fcntl.{F_SETFL, O_NONBLOCK}
+import scalanative.posix.errno
 import scalanative.posix.netinet.in._
 import scalanative.posix.netinet.inOps._
 import scalanative.posix.sys.socket._
@@ -65,59 +63,6 @@ class Udp6SocketTest {
     }
   }
 
-  // For some unknown reason inlining content of this method leads to failures
-  // on Unix, probably due to bug in linktime conditions.
-  private def setSocketBlocking(socket: CInt): Unit = {
-    if (isWindows) {
-      val mode = stackalloc[CInt]()
-      !mode = 1
-      assertNotEquals(
-        "iotctl setBLocking",
-        -1,
-        ioctlSocket(socket.toPtr[Byte], FIONBIO, mode)
-      )
-    } else {
-      assertNotEquals(
-        s"fcntl set blocking",
-        -1,
-        fcntl.fcntl(socket, F_SETFL, O_NONBLOCK)
-      )
-    }
-  }
-
-  private def createAndCheckUdpSocket(): CInt = {
-    if (isWindows) {
-      val socket = WSASocketW(
-        addressFamily = AF_INET6,
-        socketType = SOCK_DGRAM,
-        protocol = IPPROTO_UDP,
-        protocolInfo = null,
-        group = 0.toUInt,
-        flags = WSA_FLAG_OVERLAPPED
-      )
-      assertNotEquals("socket create", InvalidSocket, socket)
-      socket.toInt
-    } else {
-      val sock = sys.socket.socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)
-      assertNotEquals("socket create", -1, sock)
-      sock
-    }
-  }
-
-  private def closeSocket(socket: CInt): Unit = {
-    if (isWindows) WinSocketApi.closeSocket(socket.toPtr[Byte])
-    else unistd.close(socket)
-  }
-
-  private def checkRecvfromResult(v: CSSize, label: String): Unit = {
-    if (v.toInt < 0) {
-      val reason =
-        if (isWindows) ErrorHandlingApiOps.errorMessage(GetLastError())
-        else fromCString(strerror(errno.errno))
-      fail(s"$label failed - $reason")
-    }
-  }
-
   private def formatIn6addr(addr: in6_addr): String = Zone { implicit z =>
     val dstSize = INET6_ADDRSTRLEN + 1
     val dst = alloc[Byte](dstSize.toUSize)
@@ -139,69 +84,11 @@ class Udp6SocketTest {
       WinSocketApiOps.init()
     }
 
-    val in6SockAddr = alloc[sockaddr_in6]()
-    in6SockAddr.sin6_family = AF_INET6.toUShort
-
-    /* Scala Native currently implements neither inaddr_loopback
-     * nor IN6ADDR_LOOPBACK_INIT. When they become available,
-     * this code can be simplified by using the former instead
-     * of the inet_pton(code below). All things in due time.
-     *
-     * in6SockAddr.sin6_addr = in6addr_loopback
-     */
-
-    // sin6_port is already the desired 0; "find a free port".
-    // all other fields already 0.
-
-    val localhost = c"::1"
-    val ptonStatus = inet_pton(
-      AF_INET6,
-      localhost,
-      in6SockAddr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]]
-    )
-
-    assertEquals(s"inet_pton failed errno: ${errno.errno}", ptonStatus, 1)
-
-    val inSocket: CInt = createAndCheckUdpSocket()
+    val (inSocket, outSocket, out6Addr) = getUdpLoopbackSockets(AF_INET6)
 
     try {
-      setSocketBlocking(inSocket)
-
-      // Get port for sendto() to use.
-      val bindStatus = bind(
-        inSocket,
-        in6SockAddr
-          .asInstanceOf[Ptr[sockaddr]],
-        sizeof[sockaddr_in6].toUInt
-      )
-
-      assertNotEquals(s"bind failed,  errno: ${errno.errno}", -1, bindStatus)
-
-      val inAddrInfo = alloc[sockaddr_in6]()
-      val gsnAddrLen = alloc[socklen_t]()
-      !gsnAddrLen = sizeof[sockaddr_in6].toUInt
-
-      val gsnStatus = getsockname(
-        inSocket,
-        inAddrInfo.asInstanceOf[Ptr[sockaddr]],
-        gsnAddrLen
-      )
-
-      assertNotEquals("getsockname failed errno: ${errno.errno}", -1, gsnStatus)
-
-      // Now use port.
-      val outSocket = createAndCheckUdpSocket()
-
-      try {
-        val out6Addr = alloc[sockaddr_in6]()
-        out6Addr.sin6_family = AF_INET6.toUShort
-        out6Addr.sin6_port = inAddrInfo.sin6_port
-        out6Addr.sin6_addr = in6SockAddr.sin6_addr
-
-        // all other fields in out6Addr have been cleared by alloc[].
-
-        val outData =
-          """
+      val outData =
+        """
           |"She moved through the fair" lyrics, Traditional, no copyright
           |   I dreamed it last night
           |   That my true love came in
@@ -213,94 +100,89 @@ class Udp6SocketTest {
           |   Till our wedding day."
           """.stripMargin
 
-        val nBytesSent = sendto(
-          outSocket,
-          toCString(outData),
-          outData.length.toUSize,
-          0,
-          out6Addr.asInstanceOf[Ptr[sockaddr]],
-          sizeof[sockaddr_in6].toUInt
+      val nBytesSent = sendto(
+        outSocket,
+        toCString(outData),
+        outData.length.toUSize,
+        0,
+        out6Addr.asInstanceOf[Ptr[sockaddr]],
+        sizeof[sockaddr_in6].toUInt
+      )
+
+      assertTrue(s"sendto failed errno: ${errno.errno}\n", (nBytesSent >= 0))
+      assertEquals("sendto length", outData.size, nBytesSent.toInt)
+
+      // If inSocket did not get data by timeout, it probably never will.
+      pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout
+
+      /// Two tests using one inbound packet, save test duplication.
+
+      // Provide extra room to allow detecting extra junk being sent.
+      val maxInData = 2 * outData.length
+      val inData: Ptr[Byte] = alloc[Byte](maxInData.toUSize)
+
+      // Test not fetching remote address. Exercise last two arguments.
+      val nBytesPeekedAt =
+        recvfrom(
+          inSocket,
+          inData,
+          maxInData.toUInt,
+          MSG_PEEK,
+          null.asInstanceOf[Ptr[sockaddr]],
+          null.asInstanceOf[Ptr[socklen_t]]
         )
 
-        assertTrue(s"sendto failed errno: ${errno.errno}\n", (nBytesSent >= 0))
-        assertEquals("sendto length", outData.size, nBytesSent.toInt)
+      checkIoResult(nBytesPeekedAt, "recvfrom_1")
 
-        // If inSocket did not get data by timeout, it probably never will.
-        pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout
+      // When sending a small UDP datagram, data will be sent in one shot.
+      assertEquals("recvfrom_1 length", nBytesSent, nBytesPeekedAt)
 
-        /// Two tests using one inbound packet, save test duplication.
+      // Test retrieving remote address.
+      val srcAddr = alloc[sockaddr_in6]()
+      val srcAddrLen = alloc[socklen_t]()
+      !srcAddrLen = sizeof[sockaddr_in6].toUInt
 
-        // Provide extra room to allow detecting extra junk being sent.
-        val maxInData = 2 * outData.length
-        val inData: Ptr[Byte] = alloc[Byte](maxInData.toUSize)
+      val nBytesRecvd =
+        recvfrom(
+          inSocket,
+          inData,
+          maxInData.toUInt,
+          0,
+          srcAddr.asInstanceOf[Ptr[sockaddr]],
+          srcAddrLen
+        )
 
-        // Test not fetching remote address. Exercise last two arguments.
-        val nBytesPeekedAt =
-          recvfrom(
-            inSocket,
-            inData,
-            maxInData.toUInt,
-            MSG_PEEK,
-            null.asInstanceOf[Ptr[sockaddr]],
-            null.asInstanceOf[Ptr[socklen_t]]
-          )
+      checkIoResult(nBytesRecvd, "recvfrom_2")
+      assertEquals("recvfrom_2 length", nBytesSent, nBytesRecvd)
 
-        checkRecvfromResult(nBytesPeekedAt, "recvfrom_1")
+      // Did packet came from where we expected, and not from Mars?
 
-        /* Friendlier code here and after the next recvfrom() would loop
-         *  on partial reads rather than fail.
-         *  Punt to a future generation. Since this is loopback and
-         *  writes are small, if any bytes are ready, all should be.
-         */
-        assertEquals("recvfrom_1 length", nBytesSent, nBytesPeekedAt)
+      val expectedAddr = out6Addr.asInstanceOf[Ptr[sockaddr_in6]]
 
-        // Test retrieving remote address.
-        val srcAddr = alloc[sockaddr_in6]()
-        val srcAddrLen = alloc[socklen_t]()
-        !srcAddrLen = sizeof[sockaddr_in6].toUInt
-
-        val nBytesRecvd =
-          recvfrom(
-            inSocket,
-            inData,
-            maxInData.toUInt,
-            0,
-            srcAddr.asInstanceOf[Ptr[sockaddr]],
-            srcAddrLen
-          )
-
-        checkRecvfromResult(nBytesRecvd, "recvfrom_2")
-        assertEquals("recvfrom_2 length", nBytesSent, nBytesRecvd)
-
-        // Did packet came from where we expected, and not from Mars?
-
-        val addrsMatch = {
-          0 == memcmp(
-            in6SockAddr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]],
-            srcAddr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]],
-            sizeof[in6_addr]
-          )
-        }
-
-        if (!addrsMatch) {
-          val expectedNtop = formatIn6addr(in6SockAddr.sin6_addr)
-          val gotNtop = formatIn6addr(srcAddr.sin6_addr)
-
-          val msg =
-            s"expected remote address: '${expectedNtop}' got: '${gotNtop}'"
-          fail(msg)
-        }
-
-        assertEquals("inData is not NUL terminated", 0, inData(nBytesRecvd))
-
-        // Are received contents good?
-        assertEquals("recvfrom content", outData, fromCString(inData))
-
-      } finally {
-        closeSocket(outSocket)
+      val addrsMatch = {
+        0 == memcmp(
+          expectedAddr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]],
+          srcAddr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]],
+          sizeof[in6_addr]
+        )
       }
+
+      if (!addrsMatch) {
+        val expectedNtop = formatIn6addr(expectedAddr.sin6_addr)
+        val gotNtop = formatIn6addr(srcAddr.sin6_addr)
+
+        val msg =
+          s"expected remote address: '${expectedNtop}' got: '${gotNtop}'"
+        fail(msg)
+      }
+
+      assertEquals("inData is not NUL terminated", 0, inData(nBytesRecvd))
+
+      // Are received contents good?
+      assertEquals("recvfrom content", outData, fromCString(inData))
     } finally {
-      closeSocket(inSocket)
+      SocketTestHelpers.closeSocket(inSocket)
+      SocketTestHelpers.closeSocket(outSocket)
     }
   }
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UdpSocketTest.scala
@@ -4,18 +4,11 @@ package sys
 import scalanative.unsafe._
 import scalanative.unsigned._
 
-import scalanative.libc.errno
-import scalanative.libc.string.strerror
-
-import scalanative.posix.arpa.inet.inet_addr
-import scalanative.posix.fcntl.{F_SETFL, O_NONBLOCK}
+import scalanative.posix.errno
 import scalanative.posix.netinet.in._
 import scalanative.posix.netinet.inOps._
-import scalanative.posix.poll._
-import scalanative.posix.pollOps._
 import scalanative.posix.sys.socket._
 import scalanative.posix.sys.SocketTestHelpers._
-import scalanative.posix.unistd
 
 import scalanative.meta.LinktimeInfo.isWindows
 
@@ -31,147 +24,22 @@ import org.junit.Assume._
 import org.junit.Before
 
 class UdpSocketTest {
-
-  val isIPv4Available = hasLoopbackAddress(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
-
   @Before
   def before(): Unit = {
+    val isIPv4Available = hasLoopbackAddress(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
     assumeTrue("IPv4 UDP loopback is not available", isIPv4Available)
-  }
-
-  // For some unknown reason inlining content of this method leads to failures
-  // on Unix, probably due to bug in linktime conditions.
-  private def setSocketBlocking(socket: CInt): Unit = {
-    if (isWindows) {
-      val mode = stackalloc[CInt]()
-      !mode = 1
-      assertNotEquals(
-        "iotctl setBLocking",
-        -1,
-        ioctlSocket(socket.toPtr[Byte], FIONBIO, mode)
-      )
-    } else {
-      assertNotEquals(
-        s"fcntl set blocking",
-        -1,
-        fcntl.fcntl(socket, F_SETFL, O_NONBLOCK)
-      )
-    }
-  }
-
-  private def createAndCheckUdpSocket(): CInt = {
-    if (isWindows) {
-      val socket = WSASocketW(
-        addressFamily = AF_INET,
-        socketType = SOCK_DGRAM,
-        protocol = IPPROTO_UDP,
-        protocolInfo = null,
-        group = 0.toUInt,
-        flags = WSA_FLAG_OVERLAPPED
-      )
-      assertNotEquals("socket create", InvalidSocket, socket)
-      socket.toInt
-    } else {
-      val sock = sys.socket.socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
-      assertNotEquals("socket create", -1, sock)
-      sock
-    }
-  }
-
-  private def closeSocket(socket: CInt): Unit = {
-    if (isWindows) WinSocketApi.closeSocket(socket.toPtr[Byte])
-    else unistd.close(socket)
-  }
-
-  private def checkRecvfromResult(v: CSSize, label: String): Unit = {
-    if (v.toInt < 0) {
-      val reason =
-        if (isWindows) ErrorHandlingApiOps.errorMessage(GetLastError())
-        else fromCString(strerror(errno.errno))
-      fail(s"$label failed - $reason")
-    }
-  }
-
-  // Make available to Udp6SocketTest.scala
-  private[sys] def pollReadyToRecv(fd: CInt, timeout: CInt) = {
-    // timeout is in milliseconds
-
-    if (isWindows) {
-      val fds = stackalloc[WSAPollFd](1.toUSize)
-      fds.socket = fd.toPtr[Byte]
-      fds.events = WinSocketApiExt.POLLIN
-
-      val ret = WSAPoll(fds, 1.toUInt, timeout)
-
-      if (ret == 0) {
-        fail(s"poll timed out after ${timeout} milliseconds")
-      } else if (ret < 0) {
-        val reason = ErrorHandlingApiOps.errorMessage(GetLastError())
-        fail(s"poll for input failed - $reason")
-      }
-    } else {
-      val fds = stackalloc[struct_pollfd](1.toUSize)
-      (fds + 0).fd = fd
-      (fds + 0).events = pollEvents.POLLIN | pollEvents.POLLRDNORM
-
-      errno.errno = 0
-      // poll() sounds like a nasty busy wait loop, but is event driven in kernel
-
-      val ret = poll(fds, 1.toUInt, timeout)
-
-      if (ret == 0) {
-        fail(s"poll timed out after ${timeout} milliseconds")
-      } else if (ret < 0) {
-        val reason = fromCString(strerror(errno.errno))
-        fail(s"poll for input failed - $reason")
-      }
-      // else good to go
-    }
   }
 
   @Test def sendtoRecvfrom(): Unit = Zone { implicit z =>
     if (isWindows) {
       WinSocketApiOps.init()
     }
-    val localhost = c"127.0.0.1"
-    val localhostInetAddr = inet_addr(localhost)
 
-    val inSocket: CInt = createAndCheckUdpSocket()
+    val (inSocket, outSocket, outAddr) = getUdpLoopbackSockets(AF_INET)
 
     try {
-      val inAddr = alloc[sockaddr]()
-      val inAddrInPtr = inAddr.asInstanceOf[Ptr[sockaddr_in]]
-
-      inAddrInPtr.sin_family = AF_INET.toUShort
-      inAddrInPtr.sin_addr.s_addr = localhostInetAddr
-      // inAddrInPtr.sin_port is already the desired 0; "find a free port".
-
-      setSocketBlocking(inSocket)
-
-      // Get port for sendto() to use.
-      val bindStatus = bind(inSocket, inAddr, sizeof[sockaddr].toUInt)
-      assertNotEquals(s"bind failed,  errno: ${errno.errno}", -1, bindStatus)
-
-      val inAddrInfo = alloc[sockaddr]()
-      val gsnAddrLen = alloc[socklen_t]()
-      !gsnAddrLen = sizeof[sockaddr].toUInt
-
-      val gsnStatus = getsockname(inSocket, inAddrInfo, gsnAddrLen)
-      assertNotEquals("getsockname", -1, gsnStatus)
-
-      // Now use port.
-      val outSocket = createAndCheckUdpSocket()
-
-      try {
-        val outAddr = alloc[sockaddr]()
-        val outAddrInPtr = outAddr.asInstanceOf[Ptr[sockaddr_in]]
-        outAddrInPtr.sin_family = AF_INET.toUShort
-        outAddrInPtr.sin_addr.s_addr = localhostInetAddr
-        outAddrInPtr.sin_port =
-          inAddrInfo.asInstanceOf[Ptr[sockaddr_in]].sin_port
-
-        val outData =
-          """
+      val outData =
+        """
           |Four Freedoms -
           |   Freedom of speech
           |   Freedom of worship
@@ -179,72 +47,68 @@ class UdpSocketTest {
           |   Freedom from fear
           """.stripMargin
 
-        val nBytesSent = sendto(
-          outSocket,
-          toCString(outData),
-          outData.length.toUSize,
-          0,
-          outAddr,
-          sizeof[sockaddr].toUInt
+      val nBytesSent = sendto(
+        outSocket,
+        toCString(outData),
+        outData.length.toUSize,
+        0,
+        outAddr,
+        sizeof[sockaddr].toUInt
+      )
+
+      assertTrue(s"sendto failed errno: ${errno.errno}\n", (nBytesSent >= 0))
+      assertEquals("sendto", outData.size, nBytesSent.toInt)
+
+      // If inSocket did not get data by timeout, it probably never will.
+      pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout
+
+      /// Two tests using one inbound packet, save test duplication.
+
+      // Provide extra room to allow detecting extra junk being sent.
+      val maxInData = 2 * outData.length
+      val inData: Ptr[Byte] = alloc[Byte](maxInData.toUSize)
+
+      // Test not fetching remote address. Exercise last two args as nulls.
+      val nBytesPeekedAt =
+        recvfrom(
+          inSocket,
+          inData,
+          maxInData.toUInt,
+          MSG_PEEK,
+          null.asInstanceOf[Ptr[sockaddr]],
+          null.asInstanceOf[Ptr[socklen_t]]
         )
 
-        assertTrue(s"sendto failed errno: ${errno.errno}\n", (nBytesSent >= 0))
-        assertEquals("sendto", outData.size, nBytesSent.toInt)
+      checkIoResult(nBytesPeekedAt, "recvfrom_1")
 
-        // If inSocket did not get data by timeout, it probably never will.
-        pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout
+      // When sending a small UDP datagram, data will be sent in one shot.
+      assertEquals("recvfrom_1 length", nBytesSent, nBytesPeekedAt)
 
-        /// Two tests using one inbound packet, save test duplication.
+      // Test retrieving remote address.
+      val srcAddr = alloc[sockaddr]()
+      val srcAddrLen = alloc[socklen_t]()
+      !srcAddrLen = sizeof[sockaddr].toUInt
+      val nBytesRecvd =
+        recvfrom(inSocket, inData, maxInData.toUInt, 0, srcAddr, srcAddrLen)
 
-        // Provide extra room to allow detecting extra junk being sent.
-        val maxInData = 2 * outData.length
-        val inData: Ptr[Byte] = alloc[Byte](maxInData.toUSize)
+      checkIoResult(nBytesRecvd, "recvfrom_2")
+      assertEquals("recvfrom_2 length", nBytesSent, nBytesRecvd)
 
-        // Test not fetching remote address. Exercise last two args as nulls.
-        val nBytesPeekedAt =
-          recvfrom(
-            inSocket,
-            inData,
-            maxInData.toUInt,
-            MSG_PEEK,
-            null.asInstanceOf[Ptr[sockaddr]],
-            null.asInstanceOf[Ptr[socklen_t]]
-          )
-        checkRecvfromResult(nBytesPeekedAt, "recvfrom_1")
+      // Packet came from where we expected, and not Mars.
+      assertEquals(
+        "unexpected remote address",
+        outAddr.asInstanceOf[Ptr[sockaddr_in]].sin_addr.s_addr,
+        srcAddr.asInstanceOf[Ptr[sockaddr_in]].sin_addr.s_addr
+      )
 
-        // Friendlier code here and after the next recvfrom() would loop
-        // on partial reads rather than fail.
-        // Punt to a future generation. Since this is loopback and
-        // writes are small, if any bytes are ready, all should be.
-        assertEquals("recvfrom_1 length", nBytesSent, nBytesPeekedAt)
+      assertEquals("inData NUL termination", 0, inData(nBytesRecvd.toUSize))
 
-        // Test retrieving remote address.
-        val srcAddr = alloc[sockaddr]()
-        val srcAddrLen = alloc[socklen_t]()
-        !srcAddrLen = sizeof[sockaddr].toUInt
-        val nBytesRecvd =
-          recvfrom(inSocket, inData, maxInData.toUInt, 0, srcAddr, srcAddrLen)
-
-        checkRecvfromResult(nBytesRecvd, "recvfrom_2")
-        assertEquals("recvfrom_2 length", nBytesSent, nBytesRecvd)
-
-        // Packet came from where we expected, and not Mars.
-        assertEquals(
-          "unexpected remote address",
-          localhostInetAddr,
-          srcAddr.asInstanceOf[Ptr[sockaddr_in]].sin_addr.s_addr
-        )
-
-        assertEquals("inData NUL termination", 0, inData(nBytesRecvd.toUSize))
-
-        // Contents are good.
-        assertEquals("recvfrom content", outData, fromCString(inData))
-      } finally {
-        closeSocket(outSocket)
-      }
+      assertEquals("recvfrom content", outData, fromCString(inData))
+      // Contents are good.
 
     } finally {
-      closeSocket(inSocket)
+      SocketTestHelpers.closeSocket(inSocket)
+      SocketTestHelpers.closeSocket(outSocket)
     }
   }
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UioTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UioTest.scala
@@ -122,128 +122,129 @@ class UioTest {
 
   @Test def writevReadvShouldPlayNicely(): Unit = Zone { implicit z =>
     // writev() should gather, readv() should scatter, the 2 should pass data.
+    if (!isWindows) {
+      val (inSocket, outSocket) = getConnectedUdp4LoopbackSockets()
 
-    val (inSocket, outSocket) = getConnectedUdp4LoopbackSockets()
+      try {
+        val outData0 = poemHeader + verse1 + verse2
+        val outData1 = verse3
+        val outData2 = verse4 + verse5
 
-    try {
-      val outData0 = poemHeader + verse1 + verse2
-      val outData1 = verse3
-      val outData2 = verse4 + verse5
+        // Design Note: Gather write more than 2 buffers
+        val nOutIovs = 3
+        val outVec = alloc[iovec](nOutIovs.toUSize)
 
-      // Design Note: Gather write more than 2 buffers
-      val nOutIovs = 3
-      val outVec = alloc[iovec](nOutIovs.toUSize)
+        outVec(0).iov_base = toCString(outData0)
+        outVec(0).iov_len = outData0.length.toUSize
 
-      outVec(0).iov_base = toCString(outData0)
-      outVec(0).iov_len = outData0.length.toUSize
+        outVec(1).iov_base = toCString(outData1)
+        outVec(1).iov_len = outData1.length.toUSize
 
-      outVec(1).iov_base = toCString(outData1)
-      outVec(1).iov_len = outData1.length.toUSize
+        outVec(2).iov_base = toCString(outData2)
+        outVec(2).iov_len = outData2.length.toUSize
 
-      outVec(2).iov_base = toCString(outData2)
-      outVec(2).iov_len = outData2.length.toUSize
+        val nBytesSent = writev(outSocket, outVec, nOutIovs)
 
-      val nBytesSent = writev(outSocket, outVec, nOutIovs)
+        checkIoResult(nBytesSent, "writev_1")
 
-      checkIoResult(nBytesSent, "writev_1")
+        // When sending a small UDP datagram, data will be sent in one shot.
+        val expectedBytesSent = outData0.size + outData1.size + outData2.size
+        assertEquals("writev_2", expectedBytesSent, nBytesSent.toInt)
 
-      // When sending a small UDP datagram, data will be sent in one shot.
-      val expectedBytesSent = outData0.size + outData1.size + outData2.size
-      assertEquals("writev_2", expectedBytesSent, nBytesSent.toInt)
+        // If inSocket did not get data by timeout, it probably never will.
+        pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout
 
-      // If inSocket did not get data by timeout, it probably never will.
-      pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout
+        /* Design Notes: Scatter read at least 2 buffers.
+         *   - Be playful here. Mix things up, users will do the unexpected.
+         *
+         *   - Allocate one byte more than the number of bytes to be
+         *     read into that buffer.  This is not needed for straight
+         *     execution.
+         *
+         *     It greatly eases debugging by allowing a C NUL to
+         *     be placed in the buffer without clobbering good data.
+         *     'fromCString()' can then be called for printing and easier
+         *     String comparisons. You will understand & appreciate the
+         *     slight extra complexity if you ever have to debug this code.
+         *         !(inData2 + inData2Size) = 0 // NUL terminate CString
+         *         val msg: String = fromCString(inData2)
+         *
+         * Cumbersome type manipulation ((inData0Size.toInt + 1).toUSize)
+         * is to accomodate both Scala 2 & 3 with same code.
+         */
 
-      /* Design Notes: Scatter read at least 2 buffers.
-       *   - Be playful here. Mix things up, users will do the unexpected.
-       *
-       *   - Allocate one byte more than the number of bytes to be
-       *     read into that buffer.  This is not needed for straight
-       *     execution.
-       *
-       *     It greatly eases debugging by allowing a C NUL to
-       *     be placed in the buffer without clobbering good data.
-       *     'fromCString()' can then be called for printing and easier
-       *     String comparisons. You will understand & appreciate the
-       *     slight extra complexity if you ever have to debug this code.
-       *         !(inData2 + inData2Size) = 0 // NUL terminate CString
-       *         val msg: String = fromCString(inData2)
-       *
-       * Cumbersome type manipulation ((inData0Size.toInt + 1).toUSize)
-       * is to accomodate both Scala 2 & 3 with same code.
-       */
+        val inData0Size = outData0.size + outData1.size
+        val inData0: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
 
-      val inData0Size = outData0.size + outData1.size
-      val inData0: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+        val inData1Size = 1.toSize // odd read, just to throw things off.
+        val inData1: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
 
-      val inData1Size = 1.toSize // odd read, just to throw things off.
-      val inData1: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+        val inData2Size = (verse4.length - 1).toSize
+        val inData2: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
 
-      val inData2Size = (verse4.length - 1).toSize
-      val inData2: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+        val inData3Size = verse5.length.toSize
+        val inData3: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
 
-      val inData3Size = verse5.length.toSize
-      val inData3: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+        val nInIovs = 4
+        val inVec = alloc[iovec](nInIovs.toUSize)
 
-      val nInIovs = 4
-      val inVec = alloc[iovec](nInIovs.toUSize)
+        inVec(0).iov_base = inData0
+        inVec(0).iov_len = inData0Size.toUInt
 
-      inVec(0).iov_base = inData0
-      inVec(0).iov_len = inData0Size.toUInt
+        inVec(1).iov_base = inData1
+        inVec(1).iov_len = inData1Size.toUInt
 
-      inVec(1).iov_base = inData1
-      inVec(1).iov_len = inData1Size.toUInt
+        inVec(2).iov_base = inData2
+        inVec(2).iov_len = inData2Size.toUInt
 
-      inVec(2).iov_base = inData2
-      inVec(2).iov_len = inData2Size.toUInt
+        inVec(3).iov_base = inData3
+        inVec(3).iov_len = inData3Size.toUInt
 
-      inVec(3).iov_base = inData3
-      inVec(3).iov_len = inData3Size.toUInt
+        val nBytesRead = readv(inSocket, inVec, nInIovs)
 
-      val nBytesRead = readv(inSocket, inVec, nInIovs)
+        checkIoResult(nBytesRead, "readv_1")
 
-      checkIoResult(nBytesRead, "readv_1")
+        // When reading small UDP packets, all data should be there together.
+        assertEquals("readv_2", nBytesRead, nBytesSent)
 
-      // When reading small UDP packets, all data should be there together.
-      assertEquals("readv_2", nBytesRead, nBytesSent)
+        /// Check that contents are as expected; nothing got mangled.
 
-      /// Check that contents are as expected; nothing got mangled.
+        // outData(0) & (1) were gathered then scattered to inData(0).
+        val cmp1 = memcmp(outVec(0).iov_base, inData0, outVec(0).iov_len)
+        assertEquals("readv content_1", 0, cmp1)
 
-      // outData(0) & (1) were gathered then scattered to inData(0).
-      val cmp1 = memcmp(outVec(0).iov_base, inData0, outVec(0).iov_len)
-      assertEquals("readv content_1", 0, cmp1)
+        val cmp2 = memcmp(
+          outVec(1).iov_base,
+          inData0 + outVec(0).iov_len,
+          outVec(1).iov_len
+        )
+        assertEquals("readv content_2", 0, cmp2)
 
-      val cmp2 = memcmp(
-        outVec(1).iov_base,
-        inData0 + outVec(0).iov_len,
-        outVec(1).iov_len
-      )
-      assertEquals("readv content_2", 0, cmp2)
+        // One byte of outData(2) was scattered to inData(1).
+        val cmp3 = memcmp(outVec(2).iov_base, inData1, inData1Size.toUInt)
+        assertEquals("readv content_3", 0, cmp3)
 
-      // One byte of outData(2) was scattered to inData(1).
-      val cmp3 = memcmp(outVec(2).iov_base, inData1, inData1Size.toUInt)
-      assertEquals("readv content_3", 0, cmp3)
+        // Some of outData(2) was scattered to inData(2).
+        val cmp4 = memcmp(outVec(2).iov_base + 1, inData2, inData2Size.toUInt)
+        assertEquals("readv content_4", 0, cmp4)
 
-      // Some of outData(2) was scattered to inData(2).
-      val cmp4 = memcmp(outVec(2).iov_base + 1, inData2, inData2Size.toUInt)
-      assertEquals("readv content_4", 0, cmp4)
+        // The rest of outData(2) was scattered to inData(3).
+        val cmp5 = memcmp(
+          outVec(2).iov_base + 1 + inData2Size,
+          inData3,
+          inData3Size.toUInt
+        )
+        assertEquals("readv content_5", 0, cmp5)
 
-      // The rest of outData(2) was scattered to inData(3).
-      val cmp5 = memcmp(
-        outVec(2).iov_base + 1 + inData2Size,
-        inData3,
-        inData3Size.toUInt
-      )
-      assertEquals("readv content_5", 0, cmp5)
+        // Verse 5 now stands existentially alone in inData3.
+        val cmp6 = memcmp(toCString(verse5), inData3, inData3Size.toUInt)
+        assertEquals("readv content_6", 0, cmp6)
 
-      // Verse 5 now stands existentially alone in inData3.
-      val cmp6 = memcmp(toCString(verse5), inData3, inData3Size.toUInt)
-      assertEquals("readv content_6", 0, cmp6)
-
-      // Q.E.D.
-    } finally {
-      SocketTestHelpers.closeSocket(inSocket)
-      SocketTestHelpers.closeSocket(outSocket)
+        // Q.E.D.
+      } finally {
+        SocketTestHelpers.closeSocket(inSocket)
+        SocketTestHelpers.closeSocket(outSocket)
+      }
     }
   }
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UioTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/UioTest.scala
@@ -1,0 +1,254 @@
+package scala.scalanative.posix
+package sys
+
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+import scalanative.libc.string.memcmp
+
+import scalanative.posix.arpa.inet.inet_addr
+import scalanative.posix.errno
+import scalanative.posix.netinet.in._
+import scalanative.posix.netinet.inOps._
+import scalanative.posix.sys.socket._
+import scalanative.posix.sys.SocketTestHelpers._
+import scalanative.posix.sys.uio._
+import scalanative.posix.sys.uioOps._
+
+import scalanative.meta.LinktimeInfo.isWindows
+
+import scala.scalanative.windows._
+import scala.scalanative.windows.WinSocketApi._
+import scala.scalanative.windows.WinSocketApiExt._
+import scala.scalanative.windows.WinSocketApiOps._
+import scala.scalanative.windows.ErrorHandlingApi._
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Before
+
+class UioTest {
+  /* writev() & readv() also work with files. Using sockets here makes
+   * it easier to eventually create a unit-test for socket-only methods
+   * sendmsg() & recvmsg() and to highlight the parallels.
+   * Avoiding having to learn Windows file I/O is an additional benefit.
+   */
+
+  @Before
+  def before(): Unit = {
+    val isIPv4Available = hasLoopbackAddress(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+    assumeTrue("IPv4 UDP loopback is not available", isIPv4Available)
+  }
+
+  private def getConnectedUdp4LoopbackSockets()(implicit
+      z: Zone
+  ): Tuple2[CInt, CInt] = {
+
+    val (sin, sout, outAddr) =
+      getUdpLoopbackSockets(AF_INET)
+
+    try {
+      val connectOutStatus =
+        connect(sout, outAddr, sizeof[sockaddr].toUInt)
+      assertNotEquals(
+        s"connect output socket failed,  errno: ${errno.errno}",
+        -1,
+        connectOutStatus
+      )
+
+      (sin, sout)
+    } catch {
+      case e: Throwable =>
+        SocketTestHelpers.closeSocket(sout)
+        SocketTestHelpers.closeSocket(sin)
+        throw e
+        (-1, -1) // should never get here.
+    }
+  }
+
+  /* Emily Dickinson - The Chariot
+   * This version is in the public domain.
+   * URL: https://www.gutenberg.org/files/12242/12242-h/
+   *           12242-h.htm#Because_I_could_not_stop_for_Death
+   */
+
+  private final val poemHeader =
+    """   | 
+          |Emily Dickinson, 1890 -- Public Domain
+          |XXVII.
+          |
+          |THE CHARIOT.
+          |
+          |""".stripMargin
+
+  private final val verse1 =
+    """   |Because I could not stop for Death,
+          |He kindly stopped for me;
+          |The carriage held but just ourselves
+          |And Immortality.
+          | 
+          |""".stripMargin
+
+  private final val verse2 =
+    """   |We slowly drove, he knew no haste,
+          |And I had put away
+          |My labor, and my leisure too,
+          |For his civility.
+          |
+          |""".stripMargin
+
+  private final val verse3 =
+    """   |We passed the school where children played,
+          |Their lessons scarcely done;
+          |We passed the fields of gazing grain,
+          |We passed the setting sun.
+          |
+          |""".stripMargin
+
+  private final val verse4 =
+    """   |We paused before a house that seemed
+          |A swelling of the ground;
+          |The roof was scarcely visible,
+          |The cornice but a mound.
+          |
+          |""".stripMargin
+
+  private final val verse5 =
+    """   |Since then 't is centuries; but each
+          |Feels shorter than the day
+          |I first surmised the horses' heads
+          |Were toward eternity.
+          |
+          |""".stripMargin
+
+  @Test def writevReadvShouldPlayNicely(): Unit = Zone { implicit z =>
+    // writev() should gather, readv() should scatter, & the 2 should connect.
+    if (isWindows) {
+      WinSocketApiOps.init()
+    }
+
+    val (inSocket, outSocket) = getConnectedUdp4LoopbackSockets()
+
+    try {
+      val outData0 = poemHeader + verse1 + verse2
+      val outData1 = verse3
+      val outData2 = verse4 + verse5
+
+      // Design Note: Gather write more than 2 buffers
+      val nOutIovs = 3
+      val outVec = alloc[iovec](nOutIovs.toUSize)
+
+      outVec(0).iov_base = toCString(outData0)
+      outVec(0).iov_len = outData0.length.toUSize
+
+      outVec(1).iov_base = toCString(outData1)
+      outVec(1).iov_len = outData1.length.toUSize
+
+      outVec(2).iov_base = toCString(outData2)
+      outVec(2).iov_len = outData2.length.toUSize
+
+      val nBytesSent = writev(outSocket, outVec, nOutIovs)
+
+      checkIoResult(nBytesSent, "writev_1")
+
+      // When sending a small UDP datagram, data will be sent in one shot.
+      val expectedBytesSent = outData0.size + outData1.size + outData2.size
+      assertEquals("writev_2", expectedBytesSent, nBytesSent.toInt)
+
+      // If inSocket did not get data by timeout, it probably never will.
+      pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout
+
+      /* Design Notes: Scatter read at least 2 buffers.
+       *   - Be playful here. Mix things up, users will do the unexpected.
+       *
+       *   - Allocate one byte more than the number of bytes to be
+       *     read into that buffer.  This is not needed for straight
+       *     execution.
+       *
+       *     It greatly eases debugging by allowing a C NUL to
+       *     be placed in the buffer without clobbering good data.
+       *     'fromCString()' can then be called for printing and easier
+       *     String comparisons. You will understand & appreciate the
+       *     slight extra complexity if you ever have to debug this code.
+       *         !(inData2 + inData2Size) = 0 // NUL terminate CString
+       *         val msg: String = fromCString(inData2)
+       *
+       * Cumbersome type manipulation ((inData0Size.toInt + 1).toUSize)
+       * is to accomodate both Scala 2 & 3 with same code.
+       */
+
+      val inData0Size = outData0.size + outData1.size
+      val inData0: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+
+      val inData1Size = 1.toSize // odd read, just to throw things off.
+      val inData1: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+
+      val inData2Size = (verse4.length - 1).toSize
+      val inData2: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+
+      val inData3Size = verse5.length.toSize
+      val inData3: Ptr[Byte] = alloc[Byte]((inData0Size.toInt + 1).toUSize)
+
+      val nInIovs = 4
+      val inVec = alloc[iovec](nInIovs.toUSize)
+
+      inVec(0).iov_base = inData0
+      inVec(0).iov_len = inData0Size.toUInt
+
+      inVec(1).iov_base = inData1
+      inVec(1).iov_len = inData1Size.toUInt
+
+      inVec(2).iov_base = inData2
+      inVec(2).iov_len = inData2Size.toUInt
+
+      inVec(3).iov_base = inData3
+      inVec(3).iov_len = inData3Size.toUInt
+
+      val nBytesRead = readv(inSocket, inVec, nInIovs)
+
+      checkIoResult(nBytesRead, "readv_1")
+
+      // When reading small UDP packets, all data should be there together.
+      assertEquals("readv_2", nBytesRead, nBytesSent)
+
+      /// Check that contents are as expected; nothing got mangled.
+
+      // outData(0) & (1) were gathered then scattered to inData(0).
+      val cmp1 = memcmp(outVec(0).iov_base, inData0, outVec(0).iov_len)
+      assertEquals("readv content_1", 0, cmp1)
+
+      val cmp2 = memcmp(
+        outVec(1).iov_base,
+        inData0 + outVec(0).iov_len,
+        outVec(1).iov_len
+      )
+      assertEquals("readv content_2", 0, cmp2)
+
+      // One byte of outData(2) was scattered to inData(1).
+      val cmp3 = memcmp(outVec(2).iov_base, inData1, inData1Size.toUInt)
+      assertEquals("readv content_3", 0, cmp3)
+
+      // Some of outData(2) was scattered to inData(2).
+      val cmp4 = memcmp(outVec(2).iov_base + 1, inData2, inData2Size.toUInt)
+      assertEquals("readv content_4", 0, cmp4)
+
+      // The rest of outData(2) was scattered to inData(3).
+      val cmp5 = memcmp(
+        outVec(2).iov_base + 1 + inData2Size,
+        inData3,
+        inData3Size.toUInt
+      )
+      assertEquals("readv content_5", 0, cmp5)
+
+      // Verse 5 now stands existentially alone in inData3.
+      val cmp6 = memcmp(toCString(verse5), inData3, inData3Size.toUInt)
+      assertEquals("readv content_6", 0, cmp6)
+
+      // Q.E.D.
+    } finally {
+      SocketTestHelpers.closeSocket(inSocket)
+      SocketTestHelpers.closeSocket(outSocket)
+    }
+  }
+}


### PR DESCRIPTION
This PR shortens the code paths for posixlib `uio.scala` scatter/gather methods `readv` & `writev`.
It implements `UioTest.scala` to verify that the shorter paths work as specified.

The creation of `UioTest.scala` provided the occasion to reorganize & consolidate `SocketTestHelpers.scala`,
`UdpSocketTest.scala`, and `Udp6SocketTest.scala`.  This allows one implementation to be used
in a number of places.  An upcoming `socket.scala` PR will be another user of this now common/shared
code.