### PR TITLE
Fix #2730: Package private at the top level of build breaks easy import

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -3,6 +3,9 @@ package build
 
 import java.nio.file.{Path, Paths}
 import scala.scalanative.util.Scope
+import scala.scalanative.build.core.Filter
+import scala.scalanative.build.core.NativeLib
+import scala.scalanative.build.core.ScalaNative
 
 /** Utility methods for building code using Scala Native. */
 object Build {

--- a/tools/src/main/scala/scala/scalanative/build/Discover.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Discover.scala
@@ -5,7 +5,7 @@ import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import scala.util.Try
 import scala.sys.process._
-import scalanative.build.IO.RichPath
+import scalanative.build.core.IO.RichPath
 
 /** Utilities for discovery of command-line tools and settings required to build
  *  Scala Native applications.

--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -3,7 +3,7 @@ package build
 
 import java.nio.file.{Files, Path, Paths}
 import scala.sys.process._
-import scalanative.build.IO.RichPath
+import scalanative.build.core.IO.RichPath
 import scalanative.compat.CompatParColls.Converters._
 import scalanative.nir.Attr.Link
 

--- a/tools/src/main/scala/scala/scalanative/build/LTO.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LTO.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.build
+package scala.scalanative
+package build
 
 /** Link Time Optimization (LTO) mode to be used when during a release build.
  */

--- a/tools/src/main/scala/scala/scalanative/build/Mode.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Mode.scala
@@ -1,4 +1,5 @@
-package scala.scalanative.build
+package scala.scalanative
+package build
 
 /** Compilation mode. Either of the two:
  *

--- a/tools/src/main/scala/scala/scalanative/build/core/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/core/Filter.scala
@@ -1,10 +1,11 @@
 package scala.scalanative
 package build
+package core
 
 import java.nio.file.{Files, Path, Paths}
 
-import scalanative.build.IO.RichPath
-import scalanative.build.NativeLib._
+import scalanative.build.core.IO.RichPath
+import scalanative.build.core.NativeLib._
 import scalanative.build.LLVM._
 
 private[scalanative] object Filter {

--- a/tools/src/main/scala/scala/scalanative/build/core/IO.scala
+++ b/tools/src/main/scala/scala/scalanative/build/core/IO.scala
@@ -1,4 +1,6 @@
-package scala.scalanative.build
+package scala.scalanative
+package build
+package core
 
 import java.io.IOException
 import java.nio.file.{

--- a/tools/src/main/scala/scala/scalanative/build/core/NativeLib.scala
+++ b/tools/src/main/scala/scala/scalanative/build/core/NativeLib.scala
@@ -1,5 +1,6 @@
 package scala.scalanative
 package build
+package core
 
 import java.io.File
 import java.nio.file.{Files, Path}

--- a/tools/src/main/scala/scala/scalanative/build/core/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/core/ScalaNative.scala
@@ -1,5 +1,6 @@
 package scala.scalanative
 package build
+package core
 
 import java.nio.file.{Path, Files}
 import scala.collection.mutable

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -4,7 +4,7 @@ package codegen
 import java.nio.file.Path
 import scala.collection.mutable
 import scala.scalanative.build.Config
-import scala.scalanative.build.ScalaNative.dumpDefns
+import scala.scalanative.build.core.ScalaNative.dumpDefns
 
 import scala.scalanative.io.VirtualDirectory
 import scala.scalanative.nir._

--- a/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/LinkerSpec.scala
@@ -3,7 +3,8 @@ package scala.scalanative
 import scala.language.implicitConversions
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
-import scalanative.build.{Config, NativeConfig, ScalaNative}
+import scalanative.build.{Config, NativeConfig}
+import scalanative.build.core.ScalaNative
 import scalanative.util.Scope
 import org.scalatest.flatspec.AnyFlatSpec
 

--- a/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/OptimizerSpec.scala
@@ -1,6 +1,7 @@
 package scala.scalanative
 
-import build.{ScalaNative, Config, NativeConfig, Mode}
+import scala.scalanative.build.{Config, NativeConfig, Mode}
+import scala.scalanative.build.core.ScalaNative
 
 /** Base class to test the optimizer */
 abstract class OptimizerSpec extends LinkerSpec {

--- a/tools/src/test/scala/scala/scalanative/codegen/CodeGenSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/codegen/CodeGenSpec.scala
@@ -3,7 +3,8 @@ package codegen
 
 import java.nio.file.{Path, Paths}
 import scalanative.io.VirtualDirectory
-import scalanative.build.{Config, ScalaNative}
+import scalanative.build.Config
+import scalanative.build.core.ScalaNative
 import scalanative.util.Scope
 
 /** Base class to test code generation */

--- a/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/ReachabilitySuite.scala
@@ -7,7 +7,7 @@ import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import scalanative.util.Scope
 import scalanative.nir.{Sig, Global}
-import scalanative.build.ScalaNative
+import scalanative.build.core.ScalaNative
 
 trait ReachabilitySuite extends AnyFunSuite {
 


### PR DESCRIPTION
Move package private objects in `core` package.