### PR TITLE
Drop empty elements in `Paths.get`

### DIFF
--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
@@ -2,6 +2,7 @@ package scala.scalanative.nio.fs.unix
 
 import java.io.IOException
 import java.lang.Iterable
+import java.lang.StringBuilder
 import java.nio.file.{
   FileStore,
   FileSystem,

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixFileSystem.scala
@@ -45,8 +45,19 @@ class UnixFileSystem(
   override def getUserPrincipalLookupService(): UserPrincipalLookupService =
     PosixUserPrincipalLookupService
 
-  override def getPath(first: String, more: Array[String]): Path =
-    new UnixPath(this, (first +: more).mkString("/"))
+  override def getPath(first: String, more: Array[String]): Path = {
+    if (more.length == 0) new UnixPath(this, first)
+    else {
+      val sb = new StringBuilder(first)
+      more.foreach { element =>
+        if (element.length > 0) {
+          if (sb.length() > 0) sb.append('/')
+          sb.append(element)
+        }
+      }
+      new UnixPath(this, sb.toString())
+    }
+  }
 
   override def getPathMatcher(syntaxAndPattern: String): PathMatcher =
     PathMatcherImpl(syntaxAndPattern)

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
@@ -1,6 +1,7 @@
 package scala.scalanative.nio.fs.windows
 
 import java.lang.Iterable
+import java.lang.StringBuilder
 import java.nio.charset.StandardCharsets
 import java.nio.file.{
   FileStore,

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsFileSystem.scala
@@ -30,8 +30,20 @@ class WindowsFileSystem(fsProvider: WindowsFileSystemProvider)
   @stub
   override def getFileStores(): Iterable[FileStore] = ???
 
-  override def getPath(first: String, more: Array[String]): Path =
-    WindowsPathParser((first +: more).mkString(getSeparator()))(this)
+  override def getPath(first: String, more: Array[String]): Path = {
+    if (more.length == 0) WindowsPathParser(first)(this)
+    else {
+      val sep = getSeparator()
+      val sb = new StringBuilder(first)
+      more.foreach { element =>
+        if (element.length > 0) {
+          if (sb.length() > 0) sb.append(sep)
+          sb.append(element)
+        }
+      }
+      WindowsPathParser(sb.toString())(this)
+    }
+  }
 
   override def getPathMatcher(syntaxAndPattern: String): PathMatcher =
     PathMatcherImpl(syntaxAndPattern)

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/PathsTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/PathsTest.scala
@@ -81,4 +81,8 @@ class PathsTest {
     val path = Paths.get("space dir/space file")
     assertEquals(expected, path.toString)
   }
+
+  @Test def joiningEmptyIsEmpty() = {
+    assertEquals(Paths.get(""), Paths.get("", ""))
+  }
 }


### PR DESCRIPTION
> If `more` specifies one or more elements then each non-empty string, including `first`, is considered to be a sequence of name elements (see [`Path`](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Path.html)) and is joined to form a path string.

https://docs.oracle.com/javase/8/docs/api/java/nio/file/Paths.html#get-java.lang.String-java.lang.String...-

Targeted to 0.4.x.