### PR TITLE
`Path` extends `Watchable`

### DIFF
--- a/javalib/src/main/scala/java/nio/file/Path.scala
+++ b/javalib/src/main/scala/java/nio/file/Path.scala
@@ -5,7 +5,7 @@ import java.util.Iterator
 import java.io.File
 import java.net.URI
 
-trait Path extends Comparable[Path] with Iterable[Path] /*with Watchable*/ {
+trait Path extends Comparable[Path] with Iterable[Path] with Watchable {
 
   def compareTo(other: Path): Int
   def endsWith(other: Path): Boolean

--- a/javalib/src/main/scala/java/nio/file/ProviderMismatchException.scala
+++ b/javalib/src/main/scala/java/nio/file/ProviderMismatchException.scala
@@ -1,0 +1,8 @@
+package java.nio.file
+
+class ProviderMismatchException(msg: String)
+    extends IllegalArgumentException(msg) {
+
+  def this() = this(null)
+
+}

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/unix/UnixPath.scala
@@ -193,6 +193,19 @@ class UnixPath(private val fs: UnixFileSystem, rawPath: String) extends Path {
     }
   }
 
+  def register(
+      watcher: WatchService,
+      events: Array[WatchEvent.Kind[_]]
+  ): WatchKey =
+    register(watcher, events, Array.empty)
+
+  def register(
+      watcher: WatchService,
+      events: Array[WatchEvent.Kind[_]],
+      modifiers: Array[WatchEvent.Modifier]
+  ): WatchKey =
+    throw new ProviderMismatchException
+
   override def toFile(): File = file
 
   override def toUri(): URI = uri

--- a/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
+++ b/javalib/src/main/scala/scala/scalanative/nio/fs/windows/WindowsPath.scala
@@ -8,8 +8,10 @@ import java.nio.file.{
   LinkOption,
   NoSuchFileException,
   Path,
+  ProviderMismatchException,
   WatchEvent,
-  WatchKey
+  WatchKey,
+  WatchService
 }
 import java.util.Iterator
 import scala.scalanative.nio.fs.unix._
@@ -195,6 +197,19 @@ class WindowsPath private[windows] (
       }
     }
   }
+
+  def register(
+      watcher: WatchService,
+      events: Array[WatchEvent.Kind[_]]
+  ): WatchKey =
+    register(watcher, events, Array.empty)
+
+  def register(
+      watcher: WatchService,
+      events: Array[WatchEvent.Kind[_]],
+      modifiers: Array[WatchEvent.Modifier]
+  ): WatchKey =
+    throw new ProviderMismatchException
 
   override def toFile(): File = new File(path)
 


### PR DESCRIPTION
Targeting 0.4.x.

The implementations of `register()` for `UnixPath` and `WindowsPath` are "cheating" because they throw a `ProviderMismatchException` instead of doing something useful.

However, this is arguably correct: the JVM will throw a `ProviderMismatchException` if the `WatchService` provider does not match the `Path`'s provider.

Since Scala Native does not provide any concrete implementations of `WatchService` at this time, any `WatchService` passed to these methods would not be matching, and therefore it makes sense to throw this exception.

Meanwhile, by letting `Path` extend `Watchable` opens the door for implementations in user-land.