### PR TITLE
Fix #2751: javalib Files#delete now throws informative DirectoryNotEmptyException

### DIFF
--- a/javalib/src/main/scala/java/nio/file/PosixException.scala
+++ b/javalib/src/main/scala/java/nio/file/PosixException.scala
@@ -8,10 +8,11 @@ import scalanative.unsafe.{CInt, fromCString}
 
 object PosixException {
   def apply(file: String, errno: CInt): IOException = errno match {
-    case e if e == ENOTDIR => new NotDirectoryException(file)
-    case e if e == EACCES  => new AccessDeniedException(file)
-    case e if e == ENOENT  => new NoSuchFileException(file)
-    case e if e == EEXIST  => new FileAlreadyExistsException(file)
-    case e                 => new IOException(fromCString(string.strerror(e)))
+    case e if e == EACCES    => new AccessDeniedException(file)
+    case e if e == EEXIST    => new FileAlreadyExistsException(file)
+    case e if e == ENOENT    => new NoSuchFileException(file)
+    case e if e == ENOTDIR   => new NotDirectoryException(file)
+    case e if e == ENOTEMPTY => new DirectoryNotEmptyException(file)
+    case e                   => new IOException(fromCString(string.strerror(e)))
   }
 }

--- a/unit-tests/shared/src/test/scala/javalib/nio/file/FilesTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/file/FilesTest.scala
@@ -666,7 +666,8 @@ class FilesTest {
       Files.createFile(file)
       assertTrue("a1", Files.exists(subdir))
       assertTrue("a2", Files.isDirectory(subdir))
-      assertThrows(classOf[IOException], Files.delete(subdir))
+
+      assertThrows(classOf[DirectoryNotEmptyException], Files.delete(subdir))
     }
   }
 


### PR DESCRIPTION
For the 0.5.0 train This is the 0.5.0  version of PR #2754

The javalib Files#delete method now throws the `DirectoryNotEmptyException` when attempting
to delete a directory which is not empty.  This Exception is a subclass of IOException. 

The Java 8 documentation describes it as an "optional" specialization of IOException.
A more detailed Exception gives the end user a better clue.

This PR is the result of teamwork:  I supplied the bugs & armanbilge supplied the
motivation and collaboration.