### PR TITLE
Fix #2750: 0.4.x two javalib entities now throw expected Exceptions

### DIFF
--- a/javalib/src/main/scala/java/nio/channels/FileChannel.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannel.scala
@@ -1,14 +1,13 @@
 package java.nio.channels
 
+import java.io.{RandomAccessFile, FileNotFoundException}
+
 import java.nio.{ByteBuffer, MappedByteBuffer}
-import java.nio.file.{OpenOption, Path}
+import java.nio.channels.spi.AbstractInterruptibleChannel
+import java.nio.file._
 import java.nio.file.attribute.FileAttribute
-import spi.AbstractInterruptibleChannel
 
 import java.util.{HashSet, Set}
-import java.io.RandomAccessFile
-
-import java.nio.file._
 
 abstract class FileChannel protected ()
     extends AbstractInterruptibleChannel
@@ -72,6 +71,18 @@ object FileChannel {
     final val READ_WRITE = new MapMode {}
   }
 
+  private def tryRandomAccessFile(
+      fileName: String,
+      mode: String
+  ): RandomAccessFile = {
+    try {
+      new RandomAccessFile(fileName, mode)
+    } catch {
+      case fnf: FileNotFoundException =>
+        throw new AccessDeniedException(fileName)
+    }
+  }
+
   def open(
       path: Path,
       options: Set[_ <: OpenOption],
@@ -113,24 +124,30 @@ object FileChannel {
       mode.append("s")
     }
 
-    val file = path.toFile()
-    val raf = new RandomAccessFile(file, mode.toString)
+    val raf = tryRandomAccessFile(path.toString, mode.toString)
 
-    if (writing && options.contains(TRUNCATE_EXISTING)) {
-      raf.setLength(0L)
+    try {
+      if (writing && options.contains(TRUNCATE_EXISTING)) {
+        raf.setLength(0L)
+      }
+
+      if (writing && options.contains(APPEND)) {
+        raf.seek(raf.length())
+      }
+
+      new FileChannelImpl(
+        raf.getFD(),
+        Some(path.toFile()),
+        deleteFileOnClose =
+          options.contains(StandardOpenOption.DELETE_ON_CLOSE),
+        openForReading = true,
+        openForWriting = writing
+      )
+    } catch {
+      case e: Throwable =>
+        raf.close()
+        throw e
     }
-
-    if (writing && options.contains(APPEND)) {
-      raf.seek(raf.length())
-    }
-
-    new FileChannelImpl(
-      raf.getFD(),
-      Some(file),
-      deleteFileOnClose = options.contains(StandardOpenOption.DELETE_ON_CLOSE),
-      openForReading = true,
-      openForWriting = writing
-    )
   }
 
   def open(path: Path, options: Array[OpenOption]): FileChannel = {

--- a/javalib/src/main/scala/java/nio/channels/FileChannel.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannel.scala
@@ -145,7 +145,11 @@ object FileChannel {
       )
     } catch {
       case e: Throwable =>
-        raf.close()
+        try {
+          raf.close()
+        } catch {
+          case _: Throwable => // caller interested in original e not this one.
+        }
         throw e
     }
   }

--- a/unit-tests/shared/src/test/scala/javalib/io/RandomAccessFileTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/RandomAccessFileTest.scala
@@ -140,4 +140,19 @@ class RandomAccessFileTest {
     raf.seek(0)
     assertTrue(raf.readUTF() == value)
   }
+
+  @Test def canNotOpenReadOnlyFileForWrite(): Unit = {
+    val roFile = File.createTempFile("tmp", "")
+
+    try {
+      assertTrue("Could not set file read-only", roFile.setReadOnly())
+
+      assertThrows(
+        classOf[FileNotFoundException],
+        new RandomAccessFile(roFile, "rw")
+      )
+    } finally {
+      assertTrue("Could not delete read-only temporary file", roFile.delete())
+    }
+  }
 }

--- a/unit-tests/shared/src/test/scala/javalib/nio/channels/FileChannelTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/channels/FileChannelTest.scala
@@ -4,6 +4,7 @@ import java.nio.channels._
 
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Path, StandardOpenOption}
+import java.nio.file.AccessDeniedException
 import java.io.File
 
 import org.junit.Test
@@ -225,6 +226,22 @@ class FileChannelTest {
       channel.close()
       val readb = Files.readAllBytes(f)
       assertTrue(bytes sameElements readb)
+    }
+  }
+
+  @Test def fileChannelThrowsAccessDeniedForReadOnly(): Unit = {
+    withTemporaryDirectory { dir =>
+      val f = dir.resolve("file")
+      Files.write(f, "hello, world".getBytes("UTF-8"))
+
+      val sroStatus = f.toFile().setReadOnly()
+      assertTrue("setReadOnly failed", sroStatus)
+
+      assertThrows(
+        f.toString(),
+        classOf[AccessDeniedException],
+        FileChannel.open(f, StandardOpenOption.WRITE)
+      )
     }
   }
 


### PR DESCRIPTION
##### Administration
This PR is submitted for the 0.4.x train.  

It is applicable to 0.5.0. Do I need to do a separate PR for 0.5.0, or will
0.4.x get merged into 0.5.0 administratively?  Please advise.
##### Description
Two entities in javalib now throw Exceptions comparable to Scala JVM & Java itself.
Both were previously silent when attempting, and failing, to open a read-only file
for writing.

The constructors for `RandomAccessFile` now throw `FileNotFound` .
`FileChannel#open` now throws `AccessDeniedException`.

##### Authors
This work is the joint effort of  Arman Bilge and Lee Tibbert.  Arman reported
the original issue and provided a small reproducer.  With his permission,
that reproducer was folded into `FileChannelTest.scala`. 

##### Due diligence

Where there are two bugs, there may be more.  I searched `java.io` and `java.nio`
for places where files were opened.  Something could be hiding in the weeds,
but there appear to be no more cases of opening read-only files for write.

* `java.io.FileOutputStream#fileDescriptor` reports `FileNotFoundException`.
 On the unix path it gives the exceedingly helpful but unconventional errno string.
 The convention is to give the file name (and abandon the useful error details to the bit bucket).
 The Windows path uses the convention.

* `java.nio.file.Files#readAllBytes` opens a file without checking the error return.
  The file is opened `fcntl.O_RDONLY` so it does not have this bug, but it is
   still a bug.  See Issue #2755.

