### PR TITLE
Fix #2757: make non-API FileDescriptor#close private

### DIFF
--- a/javalib/src/main/scala/java/io/FileDescriptor.scala
+++ b/javalib/src/main/scala/java/io/FileDescriptor.scala
@@ -85,7 +85,8 @@ final class FileDescriptor private[java] (
       fcntl.fcntl(fd, fcntl.F_GETFD, 0) != -1
     }
 
-  def close(): Unit = {
+  // Not in the Java API. Called by java.nio.channels.FileChannelImpl.scala
+  private[java] def close(): Unit = {
     if (isWindows) CloseHandle(handle)
     else unistd.close(fd)
   }


### PR DESCRIPTION
The Java 8 & 17 descriptions of FileDescriptor do not list a `close()` method.  This PR
makes the implementation detail of `close()` private so that it now follows the API: i.e. is 
not visible.

Teamwork between Ekrich and myself. 