### PR TITLE
Implement `UUID.randomUUID()` using `java.security.SecureRandom`

### DIFF
--- a/javalib-ext-dummies/src/main/scala/java/security/SecureRandom.scala
+++ b/javalib-ext-dummies/src/main/scala/java/security/SecureRandom.scala
@@ -1,0 +1,7 @@
+package java.security
+
+/** Fake implementation of `SecureRandom` that is not actually secure at all.
+ *
+ *  It directly delegates to `java.util.Random`.
+ */
+class SecureRandom extends java.util.Random

--- a/unit-tests-ext/shared/src/test/scala/javalib/util/UUIDTestEx.scala
+++ b/unit-tests-ext/shared/src/test/scala/javalib/util/UUIDTestEx.scala
@@ -1,0 +1,27 @@
+// Ported from Scala.js, commit: dff0db4, dated: 2022-04-01
+
+package javalib.util
+
+import java.util.UUID
+
+import org.junit.Test
+import org.junit.Assert._
+
+/** Additional tests for `java.util.UUID` that require
+ *  `java.security.SecureRandom`.
+ */
+class UUIDTestEx {
+
+  @Test def randomUUID(): Unit = {
+    val uuid1 = UUID.randomUUID()
+    assertEquals(2, uuid1.variant())
+    assertEquals(4, uuid1.version())
+
+    val uuid2 = UUID.randomUUID()
+    assertEquals(2, uuid2.variant())
+    assertEquals(4, uuid2.version())
+
+    assertNotEquals(uuid1, uuid2)
+  }
+
+}


### PR DESCRIPTION
Fixes https://github.com/scala-native/scala-native/issues/2600 by porting the changes in https://github.com/scala-js/scala-js/pull/4659. Targeting 0.4.x.