### PR TITLE
Fix #2660: j.u.UUID#randomUUID now follows Java 8 specification

### DIFF
--- a/javalib/src/main/resources/scala-native/uuid_getentropy.c
+++ b/javalib/src/main/resources/scala-native/uuid_getentropy.c
@@ -1,0 +1,76 @@
+#include <unistd.h>
+#include <errno.h>
+
+#ifdef __APPLE__
+#include <sys/random.h>
+#endif
+
+#ifdef _WIN32
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/
+//     realloc?view=msvc-170
+//     rand-s?view=msvc-170
+#define _CRT_RAND_S
+#include <stdlib.h>
+#include <string.h>
+#endif
+
+/* This file is not a candidate for either 'posixlib' or 'clib'.
+ * 'getentropy()' and 'rand_s1' are not defined in either POSIX, nor IEEE/ISO.
+ */
+
+int scalanative_uuid_getentropy(void *buffer, size_t length, int *error) {
+
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
+    /* Linux:
+     * URL https://man7.org/linux/man-pages/man3/getentropy.3.html
+     * content dated: 2021-03-22
+     * Other BSDs should work but have not been tested.
+     *
+     * On macOS there is no real need for the overhead of "arc4random()"
+     * because only a small number of bytes are being fetched,
+     */
+
+    int status = getentropy(buffer, length);
+
+    if (status == -1) {
+        *error = errno;
+    }
+
+    return status;
+
+#elif defined(_WIN32)
+    int nInts = length / sizeof(int);
+    int nExcessBytes = length % sizeof(int);
+    errno_t status;
+
+    for (int i = 0; i < nInts; i += 1) {
+        status = rand_s(buffer + (i * sizeof(int)));
+        if (status == -1) {
+            *error = status;
+            break;
+        }
+    }
+
+    if ((status == 0) && (nExcessBytes > 0)) {
+        int excessBytes = 0;
+        status = rand_s(&excessBytes);
+        if (status == -1) {
+            *error = status;
+        } else {
+            (void)memcpy(buffer + (length - nExcessBytes), &excessBytes,
+                         nExcessBytes);
+        }
+    }
+
+    return status;
+
+#else
+#warning "Unknown OS, not Linux, FreeBSD, macOS, or Windows"
+    /* If ENOSYS available on OS, code should compile & and link,
+     * but fail unit-test.
+     * Compilation failure will focus attention of person porting new OS here.
+     */
+    *error = ENOSYS;
+    return status;
+#endif
+}

--- a/javalib/src/main/resources/scala-native/uuid_getentropy.c
+++ b/javalib/src/main/resources/scala-native/uuid_getentropy.c
@@ -1,23 +1,31 @@
+/* This file is not a candidate for either 'posixlib' or 'clib'.
+ * 'getentropy()' and 'rand_s' are not defined in either POSIX, nor IEEE/ISO.
+ */
+
 #include <errno.h>
 
-#ifdef __APPLE__
-#include <sys/random.h>
-#endif
-
-#ifndef _WIN32
+#if defined(__linux__) || defined(__FreeBSD__)
 #include <unistd.h>
-#else // _WIN32
+#elif defined(__APPLE__)
+/* getentropy() first appeared in 10.12
+ * The proper include should work with the MacOSX10.15.sdk used in CI,
+ * but it fails, probably because of ancient bugs in that sdk.
+ *
+ * The include works just file on Monteray 12.n.
+ */
+// #include <sys/random.h> // documented include
+#include <stddef.h>
+int getentropy(void *buffer, size_t size);
+#elif defined(_WIN32)
 // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/
 //     realloc?view=msvc-170
 //     rand-s?view=msvc-170
 #define _CRT_RAND_S
 #include <stdlib.h>
 #include <string.h>
-#endif // _WIN32
-
-/* This file is not a candidate for either 'posixlib' or 'clib'.
- * 'getentropy()' and 'rand_s1' are not defined in either POSIX, nor IEEE/ISO.
- */
+#else
+#warning "Unknown OS, not Linux, FreeBSD, macOS, or Windows"
+#endif // OS specific configuration
 
 int scalanative_uuid_getentropy(void *buffer, size_t length, int *error) {
 

--- a/javalib/src/main/resources/scala-native/uuid_getentropy.c
+++ b/javalib/src/main/resources/scala-native/uuid_getentropy.c
@@ -1,18 +1,19 @@
-#include <unistd.h>
 #include <errno.h>
 
 #ifdef __APPLE__
 #include <sys/random.h>
 #endif
 
-#ifdef _WIN32
+#ifndef _WIN32
+#include <unistd.h>
+#else // _WIN32
 // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/
 //     realloc?view=msvc-170
 //     rand-s?view=msvc-170
 #define _CRT_RAND_S
 #include <stdlib.h>
 #include <string.h>
-#endif
+#endif // _WIN32
 
 /* This file is not a candidate for either 'posixlib' or 'clib'.
  * 'getentropy()' and 'rand_s1' are not defined in either POSIX, nor IEEE/ISO.

--- a/javalib/src/main/resources/scala-native/uuid_getentropy.c
+++ b/javalib/src/main/resources/scala-native/uuid_getentropy.c
@@ -36,7 +36,7 @@ int scalanative_uuid_getentropy(void *buffer, size_t length, int *error) {
      * Other BSDs should work but have not been tested.
      *
      * On macOS there is no real need for the overhead of "arc4random()"
-     * because only a small number of bytes are being fetched,
+     * because only a small number of bytes are being fetched.
      */
 
     int status = getentropy(buffer, length);

--- a/javalib/src/main/resources/scala-native/uuid_getentropy.c
+++ b/javalib/src/main/resources/scala-native/uuid_getentropy.c
@@ -1,5 +1,5 @@
 /* This file is not a candidate for either 'posixlib' or 'clib'.
- * 'getentropy()' and 'rand_s' are not defined in either POSIX, nor IEEE/ISO.
+ * 'getentropy()' and 'rand_s' are not defined in either POSIX or IEEE/ISO.
  */
 
 #include <errno.h>
@@ -24,7 +24,7 @@ int getentropy(void *buffer, size_t size);
 #include <stdlib.h>
 #include <string.h>
 #else
-#warning "Unknown OS, not Linux, FreeBSD, macOS, or Windows"
+#warning "Unknown OS: not Linux, FreeBSD, macOS, or Windows"
 #endif // OS specific configuration
 
 int scalanative_uuid_getentropy(void *buffer, size_t length, int *error) {
@@ -75,9 +75,28 @@ int scalanative_uuid_getentropy(void *buffer, size_t length, int *error) {
 
 #else
 #warning "Unknown OS, not Linux, FreeBSD, macOS, or Windows"
-    /* If ENOSYS available on OS, code should compile & and link,
-     * but fail unit-test.
-     * Compilation failure will focus attention of person porting new OS here.
+    /* An application end user using an officially released version
+     * of Scala Native should never enter this section.
+     * unit-tests would have failed during Continuous Integration,
+     * preventing official release.
+     *
+     * This section exists so that people porting Scala Native
+     * to new operating systems are given the opportunity (i.e. forced)
+     * to consider the security implications of this method. This is
+     * explicit opt-in rather than silently providing something
+     * unexamined & untested in that environment.
+     *
+     * There is an attempt to 'soft fail' in local development environments.
+     * so that such developers can skip over the two "#warning"s and
+     * link applications, including unit-tests.
+     *
+     * By intent, if ENOSYS is available, UUIDTest will fail until an
+     * implementation for the new  operating system is provided, if only
+     * by supplying a suitable '#if defined(__NEW_OS)'. Meanwhile,
+     * other tests can run and provide value.
+     *
+     * If ENOSYS is not available on OS, this branch will not compile,
+     * forcing attention to the issue at hand.
      */
     *error = ENOSYS;
     return status;

--- a/unit-tests/native/src/test/scala/java/util/UUIDTest.scala
+++ b/unit-tests/native/src/test/scala/java/util/UUIDTest.scala
@@ -1,0 +1,276 @@
+/* Ported from Scala.js, commit: 9def628 dated: 2022-04-01
+ *
+ * "randomUUID" test:
+ * Ported from Scala.js, commit: dff0db4, dated: 2022-04-01
+ */
+
+package javalib.util
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.UUID
+
+import scalanative.junit.utils.AssertThrows.assertThrows
+
+class UUIDTest {
+  @Test def constructor(): Unit = {
+    val uuid = new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6bf6L)
+    assertEquals(0xf81d4fae7dec11d0L, uuid.getMostSignificantBits())
+    assertEquals(0xa76500a0c91e6bf6L, uuid.getLeastSignificantBits())
+    assertEquals(2, uuid.variant())
+    assertEquals(1, uuid.version())
+    assertEquals(0x1d07decf81d4faeL, uuid.timestamp())
+    assertEquals(0x2765, uuid.clockSequence())
+    assertEquals(0xa0c91e6bf6L, uuid.node())
+  }
+
+  @Test def getLeastSignificantBits(): Unit = {
+    assertEquals(0L, new UUID(0L, 0L).getLeastSignificantBits())
+    assertEquals(
+      Long.MinValue,
+      new UUID(0L, Long.MinValue).getLeastSignificantBits()
+    )
+    assertEquals(
+      Long.MaxValue,
+      new UUID(0L, Long.MaxValue).getLeastSignificantBits()
+    )
+  }
+
+  @Test def getMostSignificantBits(): Unit = {
+    assertEquals(0L, new UUID(0L, 0L).getMostSignificantBits())
+    assertEquals(
+      Long.MinValue,
+      new UUID(Long.MinValue, 0L).getMostSignificantBits()
+    )
+    assertEquals(
+      Long.MaxValue,
+      new UUID(Long.MaxValue, 0L).getMostSignificantBits()
+    )
+  }
+
+  @Test def version(): Unit = {
+    assertEquals(0, new UUID(0L, 0L).version())
+    assertEquals(1, new UUID(0x0000000000001000L, 0L).version())
+    assertEquals(2, new UUID(0x00000000000f2f00L, 0L).version())
+  }
+
+  @Test def variant(): Unit = {
+    assertEquals(0, new UUID(0L, 0L).variant())
+    assertEquals(0, new UUID(0L, 0x7000000000000000L).variant())
+    assertEquals(0, new UUID(0L, 0x3ff0000000000000L).variant())
+    assertEquals(0, new UUID(0L, 0x1ff0000000000000L).variant())
+
+    assertEquals(2, new UUID(0L, 0x8000000000000000L).variant())
+    assertEquals(2, new UUID(0L, 0xb000000000000000L).variant())
+    assertEquals(2, new UUID(0L, 0xaff0000000000000L).variant())
+    assertEquals(2, new UUID(0L, 0x9ff0000000000000L).variant())
+
+    assertEquals(6, new UUID(0L, 0xc000000000000000L).variant())
+    assertEquals(6, new UUID(0L, 0xdf00000000000000L).variant())
+  }
+
+  @Test def timestamp(): Unit = {
+    assertEquals(
+      0L,
+      new UUID(0x0000000000001000L, 0x8000000000000000L).timestamp()
+    )
+    assertEquals(
+      0x333555577777777L,
+      new UUID(0x7777777755551333L, 0x8000000000000000L).timestamp()
+    )
+
+    assertThrows(
+      classOf[Exception],
+      new UUID(0x0000000000000000L, 0x8000000000000000L).timestamp()
+    )
+    assertThrows(
+      classOf[Exception],
+      new UUID(0x0000000000002000L, 0x8000000000000000L).timestamp()
+    )
+  }
+
+  @Test def clockSequence(): Unit = {
+    assertEquals(
+      0,
+      new UUID(0x0000000000001000L, 0x8000000000000000L).clockSequence()
+    )
+    assertEquals(
+      0x0fff,
+      new UUID(0x0000000000001000L, 0x8fff000000000000L).clockSequence()
+    )
+    assertEquals(
+      0x3fff,
+      new UUID(0x0000000000001000L, 0xbfff000000000000L).clockSequence()
+    )
+
+    assertThrows(
+      classOf[Exception],
+      new UUID(0x0000000000000000L, 0x8000000000000000L).clockSequence()
+    )
+    assertThrows(
+      classOf[Exception],
+      new UUID(0x0000000000002000L, 0x8000000000000000L).clockSequence()
+    )
+  }
+
+  @Test def node(): Unit = {
+    assertEquals(0L, new UUID(0x0000000000001000L, 0x8000000000000000L).node())
+    assertEquals(
+      0xffffffffffffL,
+      new UUID(0x0000000000001000L, 0x8000ffffffffffffL).node()
+    )
+
+    assertThrows(
+      classOf[Exception],
+      new UUID(0x0000000000000000L, 0x8000000000000000L).node()
+    )
+    assertThrows(
+      classOf[Exception],
+      new UUID(0x0000000000002000L, 0x8000000000000000L).node()
+    )
+  }
+
+  @Test def compareTo(): Unit = {
+    val uuid0101 = new UUID(1L, 1L)
+    val uuid0111 = new UUID(1L, 0x100000001L)
+    val uuid1000 = new UUID(0x100000000L, 0L)
+
+    assertEquals(0, uuid0101.compareTo(uuid0101))
+    assertEquals(0, uuid0111.compareTo(uuid0111))
+    assertEquals(0, uuid1000.compareTo(uuid1000))
+
+    assertTrue(uuid0101.compareTo(uuid0111) < 0)
+    assertTrue(uuid0101.compareTo(uuid1000) < 0)
+    assertTrue(uuid0111.compareTo(uuid1000) < 0)
+
+    assertTrue(uuid0111.compareTo(uuid0101) > 0)
+    assertTrue(uuid1000.compareTo(uuid0101) > 0)
+    assertTrue(uuid1000.compareTo(uuid0111) > 0)
+  }
+
+  @Test def hashCodeTest(): Unit = {
+    assertEquals(0, new UUID(0L, 0L).hashCode())
+    assertEquals(
+      new UUID(123L, 123L).hashCode(),
+      new UUID(123L, 123L).hashCode()
+    )
+  }
+
+  @Test def equalsTest(): Unit = {
+    val uuid1 = new UUID(0L, 0L)
+    assertTrue(uuid1.equals(uuid1))
+    assertFalse(uuid1.equals(null))
+    assertFalse(uuid1.equals("something else"))
+
+    val uuid2 = new UUID(0L, 0L)
+    assertTrue(uuid1.equals(uuid2))
+
+    val uuid3 = new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6bf6L)
+    val uuid4 = new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6bf6L)
+    assertTrue(uuid3.equals(uuid4))
+    assertFalse(uuid3.equals(uuid1))
+
+    assertFalse(
+      uuid3.equals(new UUID(0x781d4fae7dec11d0L, 0xa76500a0c91e6bf6L))
+    )
+    assertFalse(
+      uuid3.equals(new UUID(0xf81d4fae7dec11d1L, 0xa76500a0c91e6bf6L))
+    )
+    assertFalse(
+      uuid3.equals(new UUID(0xf81d4fae7dec11d0L, 0xa76530a0c91e6bf6L))
+    )
+    assertFalse(
+      uuid3.equals(new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6cf6L))
+    )
+  }
+
+  @Test def toStringTest(): Unit = {
+    assertEquals(
+      "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+      new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6bf6L).toString
+    )
+    assertEquals(
+      "00000000-0000-1000-8000-000000000000",
+      new UUID(0x0000000000001000L, 0x8000000000000000L).toString
+    )
+  }
+
+  @Test def fromString(): Unit = {
+    val uuid1 = UUID.fromString("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+    assertTrue(uuid1.equals(new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6bf6L)))
+    assertEquals(0xf81d4fae7dec11d0L, uuid1.getMostSignificantBits())
+    assertEquals(0xa76500a0c91e6bf6L, uuid1.getLeastSignificantBits())
+    assertEquals(2, uuid1.variant())
+    assertEquals(1, uuid1.version())
+    assertEquals(130742845922168750L, uuid1.timestamp())
+    assertEquals(10085, uuid1.clockSequence())
+    assertEquals(690568981494L, uuid1.node())
+
+    val uuid2 = UUID.fromString("00000000-0000-1000-8000-000000000000")
+    assertEquals(uuid2, new UUID(0x0000000000001000L, 0x8000000000000000L))
+    assertEquals(0x0000000000001000L, uuid2.getMostSignificantBits())
+    assertEquals(0x8000000000000000L, uuid2.getLeastSignificantBits())
+    assertEquals(2, uuid2.variant())
+    assertEquals(1, uuid2.version())
+    assertEquals(0L, uuid2.timestamp())
+    assertEquals(0, uuid2.clockSequence())
+    assertEquals(0L, uuid2.node())
+
+    assertThrows(classOf[Exception], UUID.fromString(null))
+    assertThrows(classOf[Exception], UUID.fromString(""))
+    assertThrows(
+      classOf[Exception],
+      UUID.fromString("f81d4fae_7dec-11d0-a765-00a0c91e6bf6")
+    )
+    assertThrows(
+      classOf[Exception],
+      UUID.fromString("f81d4fae-7dec_11d0-a765-00a0c91e6bf6")
+    )
+    assertThrows(
+      classOf[Exception],
+      UUID.fromString("f81d4fae-7dec-11d0_a765-00a0c91e6bf6")
+    )
+    assertThrows(
+      classOf[Exception],
+      UUID.fromString("f81d4fae-7dec-11d0-a765_00a0c91e6bf6")
+    )
+    assertThrows(
+      classOf[Exception],
+      UUID.fromString("-7dec-11d0-a765-00a0c91e6bf6")
+    )
+    assertThrows(
+      classOf[Exception],
+      UUID.fromString("f81d4fae--11d0-a765-00a0c91e6bf6")
+    )
+    assertThrows(
+      classOf[Exception],
+      UUID.fromString("f81d4fae-7dec--a765-00a0c91e6bf6")
+    )
+    assertThrows(
+      classOf[Exception],
+      UUID.fromString("f81d4fae-7dec-11d0--00a0c91e6bf6")
+    )
+    assertThrows(
+      classOf[Exception],
+      UUID.fromString("f81d4fae-7dec-11d0-a765-")
+    )
+    assertThrows(classOf[Exception], UUID.fromString("f81d4fae-7dec-11d0-a765"))
+    assertThrows(
+      classOf[Exception],
+      UUID.fromString("f81d4fae-7dZc-11d0-a765-00a0c91e6bf6")
+    )
+  }
+
+  @Test def randomUUID(): Unit = {
+    val uuid1 = UUID.randomUUID()
+    assertEquals(2, uuid1.variant())
+    assertEquals(4, uuid1.version())
+
+    val uuid2 = UUID.randomUUID()
+    assertEquals(2, uuid2.variant())
+    assertEquals(4, uuid2.version())
+
+    assertNotEquals(uuid1, uuid2)
+  }
+}


### PR DESCRIPTION
##### Scala Native train
This PR is submitted for SN 0.4.x.
 
Because it uses `stackalloc`, I suspect that it will not merge cleanly into 0.5.0.
If the concept of this PR is approved by the community, I can submit
a separate PR for 0.5.0. 

##### PR
 `java.util.UUID#randomUUID' now follows the [Java 8 **specification]](https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html#randomUUID--),
in particular the part about `The UUID is generated using a cryptographically strong pseudo random number generator.`.
The operating system CSPRNG ( cryptographically strong pseudo random number generator) provides the
required entropy.  

`UUIDTest.scala` is ported, with thanks & gratitude, from Scala.js, by way of Arman Bilge, This Scala Native
version  consolidates two Scala.js files, to suit SN environment.

This PR is an alternate implementation of PR #2759 and is presented for consideration by the community.
The current PR provides the `randomUUID` method directly and does not require either 3rd party or locally-implemented
methods.  

##### Reviewers

* The type of Exception, the content of their message, naming of methods can all be changed
  to suit.  It is the underlying concept of using Scala Native's easy access to the operating
  system features which is key.

* There is code in `uuid_getentropy.c` which checks the type of the underlying operating system (OS).
   If the OS is not known to CI or the author of this PR, the code will either not comple or fail the unit-test. 

* There is an entire discussion about "Is the OS CSPRNG strong enough" that can be had. 
   The short story, for the operating systems covered here, is "Either a strong 'YES' or your OS is old
   enough that you have other problems (like not linking)".  Linux since 2018 should link, BSD systems
   back to the beginning of BSD should link but may not be secure".