### PR TITLE
WIP: Update sbt to version 1.7.1

### DIFF
--- a/ci-docker/Dockerfile
+++ b/ci-docker/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /home/scala-native/scala-native
 
 RUN curl -s "https://get.sdkman.io" | bash  \
   && . "$HOME/.sdkman/bin/sdkman-init.sh" \
-  && sdk install sbt 1.6.2 \ 
+  && sdk install sbt 1.7.1 \ 
   && sdk install java 8.0.332-tem
 
 ENV LC_ALL "C.UTF-8"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.2
+sbt.version = 1.7.1


### PR DESCRIPTION
Update sbt to version [1.7.1](https://github.com/sbt/sbt/releases) in two places.

That version has been released for 3 weeks. I have been using
it for 10 to 14 days, on Linux & macOS (m1) without problems.

##### Caveat
On macOS there is a possible issue with how the sbt
used to run scala is downloaded and installed.  

Full [description](https://www.scala-sbt.org/download.html) of sbt macOS install issue.

Short description -- if  `sdkman` is used, sbt 1.71. works fine.
If "brew" is used, the JDK version is forced to not-Java8

I would like to ensure that sdkman is used to download the
'outer' sbt runner before promoting this work to a PR.

##### Work in Progress
I am submitting this as a Work In Progress (WIP) because, 
mea culpa, I could not find how to change the version used
by GitHub Actions.  I studied the various .github & *-setup-env
files.  Does it require action from the person/people behind
the curtain?

Since there appears to be on Single Point of Truth, it would
be nice to document, at least in this PR, all the places
which need to change in order to update the sbt version.

I am aware, and hope that the current CI proves out,
that there is no requirement for the version of sbt  used
to launch the testing environment is the same as the
one used _in_ that environment (build.properties).
However, maintaining parity makes the build easier to trace 
and reduces both the cognitive barrier  and the need for 
hard-to-transmit-and-keep-alive lore.

Is the trick something in or below the login directory
`~` of the account used to run CI?  `~/.sbt` and/or
`~/.coursier`?   Keeps weenies like me out ;-)


