### PR TITLE
Fix #2255: complete socket.h; simplify & shorten code paths

### DIFF
--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -303,11 +303,14 @@ struct cmsghdr *scalanative_cmsg_firsthdr(struct msghdr *mhdr) {
 #endif
 
 // Functions
-long scalanative_recvmsg(int socket, struct msghdr *msg, int flags) {
-#if defined(_WIN32)
+#ifdef _WIN32
+long scalanative_recvmsg(int socket, void *msg, int flags) {
     errno = ENOTSUP;
     return -1;
-#elif !defined(__linux__) || !defined(__LP64__)
+}
+#else // unix
+long scalanative_recvmsg(int socket, struct msghdr *msg, int flags) {
+#if !defined(__linux__) || !defined(__LP64__)
     return recvmsg(socket, (struct msghdr *)msg, flags);
 #else // Linux 64 bits
     /* BEWARE: Embedded control messages are not converted!
@@ -346,12 +349,16 @@ long scalanative_recvmsg(int socket, struct msghdr *msg, int flags) {
     return status;
 #endif
 }
+#endif // unix
 
+#ifdef _WIN32
 long scalanative_sendmsg(int socket, struct msghdr *msg, int flags) {
-#if defined(_WIN32)
     errno = ENOTSUP;
     return -1;
-#elif !defined(__linux__) || !defined(__LP64__)
+}
+#else // unix
+long scalanative_sendmsg(int socket, struct msghdr *msg, int flags) {
+#if !defined(__linux__) || !defined(__LP64__)
     return sendmsg(socket, (struct msghdr *)msg, flags);
 #else // Linux 64 bits
     /* BEWARE: Embedded control messages are not converted!
@@ -379,6 +386,7 @@ long scalanative_sendmsg(int socket, struct msghdr *msg, int flags) {
     return status;
 #endif
 }
+#endif // unix
 
 int scalanative_sockatmark(int socket) {
 #if defined(_WIN32)

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -63,8 +63,106 @@ _Static_assert(offsetof(struct scalanative_sockaddr, sa_data) ==
 
 _Static_assert(sizeof(struct sockaddr_storage) == 128,
                "unexpected size for sockaddr_storage");
+
+// struct msghdr - POSIX 48 byte (padding) on 64 bit machines, 40 on 32 bit.
+struct scalanative_msghdr {
+    void *msg_name;
+    uint32_t msg_namelen;
+    struct iovec *msg_iov;
+    uint32_t msg_iovlen;
+    void *msg_control;
+    uint32_t msg_controllen;
+    int msg_flags;
+};
+
+#if !defined(__LP64__) && !defined(__ILP32__)
+#error "Unknown hardware memory model, not __ILP32__, not __LP64__"
 #endif
-#endif
+
+#if defined(__ILP32__)
+_Static_assert(sizeof(struct msghdr) == 40,
+               "Unexpected size: struct msghdr, expected 40");
+#elif defined(__linux__) // __LP64__
+// Only do a rough check, will use conversion mapping routines in C code.
+_Static_assert(sizeof(struct msghdr) == 56,
+               "Unexpected size: struct msghdr, expected 56");
+#else                    // 64 bit POSIX - macOS, FreeBSD
+
+// Will use direct passthru to C, so check all fields.
+_Static_assert(sizeof(struct msghdr) == 48,
+               "Unexpected size: struct msghdr, expected 48");
+
+_Static_assert(sizeof(struct msghdr) == sizeof(struct scalanative_msghdr),
+               "sizeof mismatch: OS & SN msghdr");
+
+_Static_assert(offsetof(struct msghdr, msg_name) ==
+                   offsetof(struct scalanative_msghdr, msg_name),
+               "offset mismatch: OS & SN msg_name expected 0");
+
+_Static_assert(offsetof(struct msghdr, msg_namelen) ==
+                   offsetof(struct scalanative_msghdr, msg_namelen),
+               "offset mismatch: OS & SN msg_namelen expected 8");
+
+_Static_assert(offsetof(struct msghdr, msg_iov) ==
+                   offsetof(struct scalanative_msghdr, msg_iov),
+               "offset mismatch: OS & SN msg_iov expected 16");
+
+_Static_assert(offsetof(struct msghdr, msg_iovlen) ==
+                   offsetof(struct scalanative_msghdr, msg_iovlen),
+               "offset mismatch: OS & SN msg_iovlen expected 24");
+
+_Static_assert(offsetof(struct msghdr, msg_control) ==
+                   offsetof(struct scalanative_msghdr, msg_control),
+               "offset mismatch: OS & SN msg_control expected 32");
+
+_Static_assert(offsetof(struct msghdr, msg_controllen) ==
+                   offsetof(struct scalanative_msghdr, msg_controllen),
+               "offset mismatch: OS & SN msg_controllen expected 40");
+
+_Static_assert(offsetof(struct msghdr, msg_flags) ==
+                   offsetof(struct scalanative_msghdr, msg_flags),
+               "offset mismatch: OS & SN msg_flags expected 44");
+#endif                   // POSIX msghdr
+
+// POSIX 2018 & prior 12 byte definition, Linux uses 16 bytes.
+struct scalanative_cmsghdr {
+    socklen_t cmsg_len;
+    int cmsg_level;
+    int cmsg_type;
+};
+
+#if defined(__ILP32__)
+_Static_assert(sizeof(struct cmsghdr) == 12,
+               "Unexpected size: struct cmsghdr, expected 12");
+#elif defined(__linux__) // __LP64__
+// Only do a rough check, developer must pass OS cmsghdr in & expect same back.
+_Static_assert(sizeof(struct cmsghdr) == 16,
+               "Unexpected size: struct msghdr, expected 16");
+#else                    // 64 bit POSIX - macOS, FreeBSD
+
+// Will use direct passthru to C, so check all fields.
+_Static_assert(sizeof(struct cmsghdr) == 12,
+               "Unexpected size: struct cmsghdr, expected 12");
+
+_Static_assert(sizeof(struct cmsghdr) == sizeof(struct scalanative_cmsghdr),
+               "sizeof mismatch: OS & SN cmsghdr");
+
+_Static_assert(offsetof(struct cmsghdr, cmsg_len) ==
+                   offsetof(struct scalanative_cmsghdr, cmsg_len),
+               "offset mismatch: OS & SN cmsg_len expected 0");
+
+_Static_assert(offsetof(struct cmsghdr, cmsg_level) ==
+                   offsetof(struct scalanative_cmsghdr, cmsg_level),
+               "offset mismatch: OS & SN cmsg_level expected 4");
+
+_Static_assert(offsetof(struct cmsghdr, cmsg_type) ==
+                   offsetof(struct scalanative_cmsghdr, cmsg_type),
+               "offset mismatch: OS & SN cmsg_type expected 8");
+#endif                   // POSIX cmsghdr
+#endif                   // structure size checking
+#endif                   // !_WIN32
+
+// Symbolic constants
 
 int scalanative_scm_rights() {
 #ifdef SCM_RIGHTS
@@ -153,3 +251,122 @@ int scalanative_af_inet6() { return AF_INET6; }
 int scalanative_af_unix() { return AF_UNIX; }
 
 int scalanative_af_unspec() { return AF_UNSPEC; }
+
+int scalanative_shut_rd() { return SHUT_RD; }
+
+int scalanative_shut_rdwr() { return SHUT_RDWR; }
+
+int scalanative_shut_wr() { return SHUT_WR; }
+
+// Macros
+unsigned char *scalanative_cmsg_data(struct cmsghdr *cmsg) {
+    return CMSG_DATA(cmsg);
+}
+
+struct cmsghdr *scalanative_cmsg_nxthdr(struct msghdr *mhdr,
+                                        struct cmsghdr *cmsg) {
+    return CMSG_NXTHDR(mhdr, cmsg);
+}
+
+struct cmsghdr *scalanative_cmsg_firsthdr(struct msghdr *mhdr) {
+    return CMSG_FIRSTHDR(mhdr);
+}
+
+// Functions
+long scalanative_recvmsg(int socket, struct scalanative_msghdr *msg,
+                         int flags) {
+
+#if defined(_WIN32)
+    errno = ENOTSUP;
+    return -1;
+#elif !defined(__linux__) || !defined(__LP64__)
+    return recvmsg(socket, (struct msghdr *)msg, flags);
+#else // Linux 64 bits
+    /* BEWARE: Embedded control messages are not converted!
+     *	       Caller must send non-POSIX linux64 ctlhdr structures
+     *	       and expect such to be returned by OS.
+     */
+
+    int status = -1;
+
+    if (msg == NULL) {
+        errno = EINVAL;
+    } else {
+
+        struct msghdr cMsg = {.msg_name = msg->msg_name,
+                              .msg_namelen = msg->msg_namelen,
+                              .msg_iov = msg->msg_iov,
+                              .msg_iovlen = msg->msg_iovlen,
+                              .msg_control = msg->msg_control,
+                              .msg_controllen = msg->msg_controllen,
+                              .msg_flags = msg->msg_flags};
+
+        status = recvmsg(socket, &cMsg, flags);
+
+        // recvmsg can alter some of these fields, so copy everything back.
+        if (status > -1) {
+            msg->msg_name = cMsg.msg_name;
+            msg->msg_namelen = cMsg.msg_namelen;
+            msg->msg_iov = cMsg.msg_iov;
+            msg->msg_iovlen = cMsg.msg_iovlen;
+            msg->msg_control = cMsg.msg_control;
+            msg->msg_controllen = cMsg.msg_controllen;
+            msg->msg_flags = cMsg.msg_flags;
+        }
+    }
+
+    return status;
+#endif
+}
+
+long scalanative_sendmsg(int socket, struct scalanative_msghdr *msg,
+                         int flags) {
+#if defined(_WIN32)
+    errno = ENOTSUP;
+    return -1;
+#elif !defined(__linux__) || !defined(__LP64__)
+    return sendmsg(socket, (struct msghdr *)msg, flags);
+#else // Linux 64 bits
+    /* BEWARE: Embedded control messages are not converted!
+     *	       Caller must send non-POSIX linux64 ctlhdr structures
+     *	       and expect such to be returned by OS.
+     */
+
+    int status = -1;
+
+    if (msg == NULL) {
+        errno = EINVAL;
+    } else {
+        struct msghdr cMsg = {.msg_name = msg->msg_name,
+                              .msg_namelen = msg->msg_namelen,
+                              .msg_iov = msg->msg_iov,
+                              .msg_iovlen = msg->msg_iovlen,
+                              .msg_control = msg->msg_control,
+                              .msg_controllen = msg->msg_controllen,
+                              .msg_flags = msg->msg_flags};
+
+        // cMsg is read-only, so no need to copy data back to Scala
+        status = sendmsg(socket, &cMsg, flags);
+    }
+
+    return status;
+#endif
+}
+
+int scalanative_sockatmark(int socket) {
+#if defined(_WIN32)
+    errno = ENOTSUP;
+    return -1;
+#else
+    return sockatmark(socket);
+#endif
+}
+
+int scalanative_socketpair(int domain, int type, int protocol, int *sv) {
+#if defined(_WIN32)
+    errno = ENOTSUP;
+    return -1;
+#else
+    return socketpair(domain, type, protocol, sv);
+#endif
+}

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -285,30 +285,29 @@ unsigned char *scalanative_cmsg_data(struct cmsghdr *cmsg) {
 #endif
 }
 
+#ifdef _WIN32
+void *scalanative_cmsg_nxthdr(void *mhdr, void *cmsg) {
+    return NULL;
+#else
 struct cmsghdr *scalanative_cmsg_nxthdr(struct msghdr *mhdr,
                                         struct cmsghdr *cmsg) {
-#ifdef _WIN32
-    return NULL;
-#else
     return CMSG_NXTHDR(mhdr, cmsg);
-#endif
 }
+#endif
 
-struct cmsghdr *scalanative_cmsg_firsthdr(struct msghdr *mhdr) {
 #ifdef _WIN32
-    return NULL;
+    void *scalanative_cmsg_firsthdr(void *mhdr) { return NULL; }
 #else
+struct cmsghdr *scalanative_cmsg_firsthdr(struct msghdr *mhdr) {
     return CMSG_FIRSTHDR(mhdr);
-#endif
 }
+#endif
 
-// Functions
-long scalanative_recvmsg(int socket, struct scalanative_msghdr *msg,
-                         int flags) {
-
+    // Functions
+    long scalanative_recvmsg(int socket, struct msghdr *msg, int flags) {
 #if defined(_WIN32)
-    errno = ENOTSUP;
-    return -1;
+        errno = ENOTSUP;
+        return -1;
 #elif !defined(__linux__) || !defined(__LP64__)
     return recvmsg(socket, (struct msghdr *)msg, flags);
 #else // Linux 64 bits
@@ -347,13 +346,12 @@ long scalanative_recvmsg(int socket, struct scalanative_msghdr *msg,
 
     return status;
 #endif
-}
+    }
 
-long scalanative_sendmsg(int socket, struct scalanative_msghdr *msg,
-                         int flags) {
+    long scalanative_sendmsg(int socket, struct msghdr *msg, int flags) {
 #if defined(_WIN32)
-    errno = ENOTSUP;
-    return -1;
+        errno = ENOTSUP;
+        return -1;
 #elif !defined(__linux__) || !defined(__LP64__)
     return sendmsg(socket, (struct msghdr *)msg, flags);
 #else // Linux 64 bits
@@ -381,22 +379,22 @@ long scalanative_sendmsg(int socket, struct scalanative_msghdr *msg,
 
     return status;
 #endif
-}
+    }
 
-int scalanative_sockatmark(int socket) {
+    int scalanative_sockatmark(int socket) {
 #if defined(_WIN32)
-    errno = ENOTSUP;
-    return -1;
+        errno = ENOTSUP;
+        return -1;
 #else
     return sockatmark(socket);
 #endif
-}
+    }
 
-int scalanative_socketpair(int domain, int type, int protocol, int *sv) {
+    int scalanative_socketpair(int domain, int type, int protocol, int *sv) {
 #if defined(_WIN32)
-    errno = ENOTSUP;
-    return -1;
+        errno = ENOTSUP;
+        return -1;
 #else
     return socketpair(domain, type, protocol, sv);
 #endif
-}
+    }

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -1,6 +1,6 @@
 #include <string.h>
 #include <stddef.h>
-#include <stdio.h>
+//#include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -252,24 +252,54 @@ int scalanative_af_unix() { return AF_UNIX; }
 
 int scalanative_af_unspec() { return AF_UNSPEC; }
 
-int scalanative_shut_rd() { return SHUT_RD; }
+int scalanative_shut_rd() {
+#ifdef SHUT_RD
+    return SHUT_RD;
+#else // _WIN32
+    return 0;
+#endif
+}
 
-int scalanative_shut_rdwr() { return SHUT_RDWR; }
+int scalanative_shut_rdwr() {
+#ifdef SHUT_RDWR
+    return SHUT_RDWR;
+#else // _WIN32
+    return 0;
+#endif
+}
 
-int scalanative_shut_wr() { return SHUT_WR; }
+int scalanative_shut_wr() {
+#ifdef SHUT_WR
+    return SHUT_WR;
+#else // _WIN32
+    return 0;
+#endif
+}
 
 // Macros
 unsigned char *scalanative_cmsg_data(struct cmsghdr *cmsg) {
+#ifdef _WIN32
+    return NULL;
+#else
     return CMSG_DATA(cmsg);
+#endif
 }
 
 struct cmsghdr *scalanative_cmsg_nxthdr(struct msghdr *mhdr,
                                         struct cmsghdr *cmsg) {
+#ifdef _WIN32
+    return NULL;
+#else
     return CMSG_NXTHDR(mhdr, cmsg);
+#endif
 }
 
 struct cmsghdr *scalanative_cmsg_firsthdr(struct msghdr *mhdr) {
+#ifdef _WIN32
+    return NULL;
+#else
     return CMSG_FIRSTHDR(mhdr);
+#endif
 }
 
 // Functions

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -64,7 +64,7 @@ _Static_assert(offsetof(struct scalanative_sockaddr, sa_data) ==
 _Static_assert(sizeof(struct sockaddr_storage) == 128,
                "unexpected size for sockaddr_storage");
 
-// struct msghdr - POSIX 48 byte (padding) on 64 bit machines, 40 on 32 bit.
+// struct msghdr - POSIX 48 byte (padding) on 64 bit machines, 28 on 32 bit.
 struct scalanative_msghdr {
     void *msg_name;
     uint32_t msg_namelen;
@@ -80,8 +80,10 @@ struct scalanative_msghdr {
 #endif
 
 #if defined(__ILP32__)
-_Static_assert(sizeof(struct msghdr) == 40,
-               "Unexpected size: struct msghdr, expected 40");
+_Static_assert(sizeof(struct msghdr) == 28,
+               "Unexpected size: struct msghdr, expected 28");
+_Static_assert(sizeof(struct msghdr) == sizeof(struct scalanative_msghdr),
+               "sizeof mismatch: OS & SN msghdr");
 #elif defined(__linux__) // __LP64__
 // Only do a rough check, will use conversion mapping routines in C code.
 _Static_assert(sizeof(struct msghdr) == 56,

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -15,7 +15,7 @@ typedef SSIZE_T ssize_t;
 #ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING
 #warning "Size and order of C structures are not checked when -std < c11."
 #endif
-#else
+#else // POSIX
 /* POSIX defines the name and type of required fields. Size of fields
  * and any internal or tail padding are left unspecified. This section
  * verifies that the C and Scala Native definitions match in each compilation

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -277,17 +277,16 @@ int scalanative_shut_wr() {
 }
 
 // Macros
-unsigned char *scalanative_cmsg_data(struct cmsghdr *cmsg) {
 #ifdef _WIN32
-    return NULL;
+void *scalanative_cmsg_data(void *cmsg) { return NULL; }
 #else
+unsigned char *scalanative_cmsg_data(struct cmsghdr *cmsg) {
     return CMSG_DATA(cmsg);
-#endif
 }
+#endif
 
 #ifdef _WIN32
-void *scalanative_cmsg_nxthdr(void *mhdr, void *cmsg) {
-    return NULL;
+void *scalanative_cmsg_nxthdr(void *mhdr, void *cmsg) { return NULL; }
 #else
 struct cmsghdr *scalanative_cmsg_nxthdr(struct msghdr *mhdr,
                                         struct cmsghdr *cmsg) {
@@ -296,18 +295,18 @@ struct cmsghdr *scalanative_cmsg_nxthdr(struct msghdr *mhdr,
 #endif
 
 #ifdef _WIN32
-    void *scalanative_cmsg_firsthdr(void *mhdr) { return NULL; }
+void *scalanative_cmsg_firsthdr(void *mhdr) { return NULL; }
 #else
 struct cmsghdr *scalanative_cmsg_firsthdr(struct msghdr *mhdr) {
     return CMSG_FIRSTHDR(mhdr);
 }
 #endif
 
-    // Functions
-    long scalanative_recvmsg(int socket, struct msghdr *msg, int flags) {
+// Functions
+long scalanative_recvmsg(int socket, struct msghdr *msg, int flags) {
 #if defined(_WIN32)
-        errno = ENOTSUP;
-        return -1;
+    errno = ENOTSUP;
+    return -1;
 #elif !defined(__linux__) || !defined(__LP64__)
     return recvmsg(socket, (struct msghdr *)msg, flags);
 #else // Linux 64 bits
@@ -346,12 +345,12 @@ struct cmsghdr *scalanative_cmsg_firsthdr(struct msghdr *mhdr) {
 
     return status;
 #endif
-    }
+}
 
-    long scalanative_sendmsg(int socket, struct msghdr *msg, int flags) {
+long scalanative_sendmsg(int socket, struct msghdr *msg, int flags) {
 #if defined(_WIN32)
-        errno = ENOTSUP;
-        return -1;
+    errno = ENOTSUP;
+    return -1;
 #elif !defined(__linux__) || !defined(__LP64__)
     return sendmsg(socket, (struct msghdr *)msg, flags);
 #else // Linux 64 bits
@@ -379,22 +378,22 @@ struct cmsghdr *scalanative_cmsg_firsthdr(struct msghdr *mhdr) {
 
     return status;
 #endif
-    }
+}
 
-    int scalanative_sockatmark(int socket) {
+int scalanative_sockatmark(int socket) {
 #if defined(_WIN32)
-        errno = ENOTSUP;
-        return -1;
+    errno = ENOTSUP;
+    return -1;
 #else
     return sockatmark(socket);
 #endif
-    }
+}
 
-    int scalanative_socketpair(int domain, int type, int protocol, int *sv) {
+int scalanative_socketpair(int domain, int type, int protocol, int *sv) {
 #if defined(_WIN32)
-        errno = ENOTSUP;
-        return -1;
+    errno = ENOTSUP;
+    return -1;
 #else
     return socketpair(domain, type, protocol, sv);
 #endif
-    }
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -8,8 +8,6 @@ import scalanative.unsafe._
 import scalanative.unsigned._
 import scalanative.meta.LinktimeInfo.isWindows
 
-import scala.scalanative.posix.sys.types
-
 /** socket.h for Scala
  *  @see
  *    [[https://scala-native.readthedocs.io/en/latest/lib/posixlib.html]]

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala
@@ -64,7 +64,7 @@ object socket {
     sa_family_t, // ss_family, // ss_family, sa_len is synthesized if needed
     CUnsignedShort, // __opaquePadTo32
     CUnsignedInt, // opaque, __opaquePadTo64
-    CArray[CUnsignedLongLong, _15] // __opaqueAlignStructure to 8 bytes
+    CArray[CUnsignedLongLong, _15] // __opaqueAlignStructure to 8 bytes.
   ]
 
   /* This is the POSIX 2018 & prior definition. Because SN 'naturally'

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/MsgIoSocketTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/MsgIoSocketTest.scala
@@ -1,0 +1,402 @@
+package scala.scalanative.posix
+package sys
+
+import scalanative.unsafe._
+import scalanative.unsigned._
+
+import scalanative.libc.string.memcmp
+
+import scalanative.posix.arpa.inet.inet_addr
+import scalanative.posix.errno
+import scalanative.posix.netinet.in._
+import scalanative.posix.netinet.inOps._
+import scalanative.posix.sys.socket._
+import scalanative.posix.sys.socketOps._
+import scalanative.posix.sys.SocketTestHelpers._
+import scalanative.posix.time._
+import scalanative.posix.sys.time.timeval
+import scalanative.posix.sys.timeOps._
+import scalanative.posix.sys.uio._
+import scalanative.posix.sys.uioOps._
+
+import scalanative.meta.LinktimeInfo.isWindows
+
+import org.scalanative.testsuite.utils.Platform
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Before
+
+/** Exercise the POSIX socket.h sendmsg and recvmg routines.
+ *
+ *  Those functions do not exist on Windows.
+ */
+class MsgIoSocketTest {
+
+  @Before
+  def before(): Unit = {
+    val isIPv4Available = hasLoopbackAddress(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+    assumeTrue("IPv4 UDP loopback is not available", isIPv4Available)
+
+    assumeTrue(
+      "POSIX sendmsg & recvmsg are not available on Windows",
+      !isWindows
+    )
+  }
+
+  /* Percy Bysshe Shelly - Ozymandias - 1818
+   * This poem is in the public domain.
+   *
+   * URL: https://en.wikisource.org/wiki/Ozymandias_(Shelley)
+   * Thank you, wikisource.
+   */
+
+  private final val poemHeader =
+    """	  |
+	  |Percy Bysshe Shelley, 1818 -- Public Domain
+	  |
+	  |OZYMANDIAS of EGYPT
+	  |
+	  |""".stripMargin
+
+  private final val chunk1 =
+    """	  |I met a traveller from an antique land
+	  |Who said:—Two vast and trunkless legs of stone
+	  |Stand in the desert. Near them on the sand,
+	  |Half sunk, a shatter'd visage lies, whose frown
+	  |And wrinkled lip and sneer of cold command
+	  |""".stripMargin
+
+  private final val chunk2 =
+    """	  |Tell that its sculptor well those passions read
+	  |Which yet survive, stamp'd on these lifeless things,
+	  |The hand that mock'd them and the heart that fed.
+	  |And on the pedestal these words appear:
+	  |"My name is Ozymandias, king of kings:
+	  |
+	  |""".stripMargin
+
+  private final val chunk3 =
+    """	  |Look on my works, ye mighty, and despair!"
+	  |Nothing beside remains: round the decay
+	  |Of that colossal wreck, boundless and bare,
+	  |The lone and level sands stretch far away.
+	  |
+	  |""".stripMargin
+
+  @Test def msgIoShouldScatterGather(): Unit = if (!isWindows) {
+    // sendmsg() should gather, recvmsg() should scatter, the twain shall meet
+    Zone { implicit z =>
+      val (inSocket, outSocket, dstAddr) = getUdpLoopbackSockets(AF_INET)
+
+      try {
+        val outData0 = poemHeader + chunk1 + chunk2
+        val outData1 = chunk3
+
+        val nOutIovs = 2
+        val outVec = alloc[iovec](nOutIovs.toUSize)
+
+        // outData created with only 1 byte UTF-8 chars, so length method OK.
+
+        outVec(0).iov_base = toCString(outData0)
+        outVec(0).iov_len = outData0.length.toUSize
+
+        outVec(1).iov_base = toCString(outData1)
+        outVec(1).iov_len = outData1.length.toUSize
+
+        val outMsgHdr = alloc[msghdr]()
+        outMsgHdr.msg_name = dstAddr.asInstanceOf[Ptr[Byte]]
+        outMsgHdr.msg_namelen = sizeof[sockaddr_in].toUInt
+        outMsgHdr.msg_iov = outVec
+        outMsgHdr.msg_iovlen = nOutIovs
+
+        val nBytesSent = sendmsg(outSocket, outMsgHdr, 0)
+
+        checkIoResult(nBytesSent, "sendmsg_1")
+
+        // When sending a small UDP datagram, data will be sent in one shot.
+        val expectedBytesSent = outData0.size + outData1.size
+        assertEquals("sendmsg_2", expectedBytesSent, nBytesSent.toInt)
+
+        // If inSocket did not get data by timeout, it probably never will.
+        pollReadyToRecv(inSocket, 30 * 1000) // assert fail on error or timeout
+
+        // Design Notes: Scatter read at least 2 buffers.
+
+        // To mix things up, read data in reverse order of how it was sent.
+
+        val inData0Size = outData1.size
+        val inData0: Ptr[Byte] = alloc[Byte](inData0Size.toInt.toUSize)
+
+        val inData1Size = outData0.size
+        val inData1: Ptr[Byte] = alloc[Byte](inData1Size.toInt.toUSize)
+
+        val nInIovs = 2
+        val inVec = alloc[iovec](nInIovs.toUSize)
+
+        inVec(0).iov_base = inData0
+        inVec(0).iov_len = inData0Size.toUInt
+
+        inVec(1).iov_base = inData1
+        inVec(1).iov_len = inData1Size.toUInt
+
+        val srcAddr = alloc[sockaddr_in]()
+        val srcAddrLen = sizeof[sockaddr_in].toUInt
+        val srcAddrLenBefore = srcAddrLen
+
+        val inMsgHdr = alloc[msghdr]()
+        inMsgHdr.msg_name = srcAddr.asInstanceOf[Ptr[Byte]]
+        inMsgHdr.msg_namelen = srcAddrLen
+        inMsgHdr.msg_iov = inVec
+        inMsgHdr.msg_iovlen = nInIovs.toInt
+
+        val nBytesRead = recvmsg(inSocket, inMsgHdr, 0)
+
+        checkIoResult(nBytesRead, "recvmsg_1")
+
+        assertEquals(
+          "recmsg data was truncated",
+          0,
+          (inMsgHdr.msg_flags & MSG_TRUNC)
+        )
+
+        // When reading small UDP packets, all data should be there together.
+        // Given msg_flags MSG_TRUNC assert above, this should never trigger.
+        assertEquals("recvmsg_2", nBytesRead, nBytesSent)
+
+        /* Did address size change out from underneath us?
+         * sockaddr_in supplied is expected to stay that way, at least
+         * on known continuous integration (CI) systems.
+         *
+         * There is a chance that, in the wild, we could get an IPv4
+         * mapped IPv6 address.
+         *
+         * If a sockaddr_in6 comes back, we want to know about it.
+         * srcAddr is truncated & trash in that case.
+         *
+         * This is why we check corner cases.
+         */
+        assertEquals(
+          "Unexpected change in source address size",
+          srcAddrLenBefore,
+          inMsgHdr.msg_namelen
+        )
+
+        // Did packet came from where we expected, and not from Mars?
+        assertEquals(
+          "unexpected remote address",
+          dstAddr.asInstanceOf[Ptr[sockaddr_in]].sin_addr.s_addr,
+          srcAddr.sin_addr.s_addr
+        )
+
+        /// Check that contents are as expected; nothing got mangled.
+
+        val peck1 = outVec(0).iov_base
+        val peck1Len = inVec(0).iov_len // 171 bytes
+        assertTrue("recvmsg lengths_1", peck1Len <= outVec(0).iov_len)
+
+        val cmp1 = memcmp(peck1, inData0, peck1Len)
+        assertEquals("recvmsg content_1", 0, cmp1)
+
+        val peck2 = outVec(0).iov_base + inVec(0).iov_len
+        val peck2Len = outVec(0).iov_len - inVec(0).iov_len // 519 - 171 == 348
+        assertTrue("recvmsg lengths_2", peck2Len <= inVec(1).iov_len)
+
+        val cmp2 = memcmp(peck2, inData1, peck2Len)
+        assertEquals("recvmsg content_2", 0, cmp2)
+
+        val peck3 = outVec(1).iov_base
+        val peck3Len = inVec(1).iov_len - peck2Len // 519 - 348 == 171
+        assertTrue("recvmsg lengths_3", peck3Len <= outVec(1).iov_len)
+
+        val cmp3 = memcmp(peck3, inData1 + peck2Len, peck3Len)
+        assertEquals("recvmsg content_3", 0, cmp3)
+
+        // Q.E.D.
+      } finally {
+        SocketTestHelpers.closeSocket(inSocket)
+        SocketTestHelpers.closeSocket(outSocket)
+      }
+    }
+  }
+
+  /* Exercise the complex Linux 64 bit case.
+   * Portable code leads to a tangle of "isPlatform" branches. Focusing
+   * on one OS & architecture makes the cmsg unit-under-test logic
+   * stand out.
+   *
+   * A macOs or 32 bit Linux test would look substantially the same
+   * but be a bit easier because cmsg.cmsg_level & cmsg.cmsg_type
+   * would be directly available. Of course, there would be different
+   * constant names & values.
+   *
+   */
+  @Test def linux64ControlMessages(): Unit = if (!isWindows) {
+    // The focus is on control messages, the data sent is only an excuse.
+    if (Platform.isLinux && !Platform.is32BitPlatform) Zone { implicit z =>
+      // Linux bit definition. Useful for cmsg_level & cmsg_type on 64 bit OS.
+      type l64cmsghdr = CStruct3[
+        size_t, // cmsg_len
+        CInt, // cmsg_level
+        CInt // cmsg_type
+      ]
+
+      val (inSocket, outSocket, dstAddr) = getUdpLoopbackSockets(AF_INET)
+
+      try {
+        // Linux values, empirically determined
+        val SO_TIMESTAMP = 0x1d // decimal 29
+        val SCM_TIMESTAMP = 0x1d // decimal 29
+        val SOF_TIMESTAMPING_SOFTWARE = 0x10 // decimal 16
+
+        val sOpt = stackalloc[Int](1.toUSize)
+        !sOpt = SOF_TIMESTAMPING_SOFTWARE
+
+        val ssoStatus = setsockopt(
+          inSocket,
+          SOL_SOCKET,
+          SO_TIMESTAMP,
+          sOpt.asInstanceOf[Ptr[Byte]],
+          sizeof[Int].toUInt
+        )
+
+        assertEquals(s"setsockopt errno: ${errno.errno}", 0, ssoStatus)
+
+        val outData0 = poemHeader + chunk1 + chunk2
+        val outData1 = chunk3
+
+        val nOutIovs = 2
+        val outVec = alloc[iovec](nOutIovs.toUSize)
+
+        // outData created with only 1 byte UTF-8 chars, so length method OK.
+
+        outVec(0).iov_base = toCString(outData0)
+        outVec(0).iov_len = outData0.length.toUSize
+
+        outVec(1).iov_base = toCString(outData1)
+        outVec(1).iov_len = outData1.length.toUSize
+
+        val outMsgHdr = alloc[msghdr]()
+        outMsgHdr.msg_name = dstAddr.asInstanceOf[Ptr[Byte]]
+        outMsgHdr.msg_namelen = sizeof[sockaddr_in].toUInt
+        outMsgHdr.msg_iov = outVec
+        outMsgHdr.msg_iovlen = nOutIovs
+
+        val nBytesSent = sendmsg(outSocket, outMsgHdr, 0)
+
+        checkIoResult(nBytesSent, "sendmsg_1")
+
+        // When sending a small UDP datagram, data will be sent in one shot.
+        val expectedBytesSent = outData0.size + outData1.size
+        assertEquals("sendmsg_2", expectedBytesSent, nBytesSent.toInt)
+
+        // If inSocket did not get data by timeout, it probably never will.
+        pollReadyToRecv(
+          inSocket,
+          30 * 1000
+        ) // assert fail on error or timeout
+
+        // Read all in one gulp. We are only marginally interested in data.
+
+        val inData0Size = nBytesSent
+        val inData0: Ptr[Byte] = alloc[Byte](inData0Size.toInt.toUSize)
+
+        val nInIovs = 1
+        val inVec = alloc[iovec](nInIovs.toUSize)
+
+        inVec(0).iov_base = inData0
+        inVec(0).iov_len = inData0Size.toUInt
+
+        /* Here we get down to the matter at hand: control messages
+         * Pause for a moment and get your true geek on before proceeding.
+         * Do you know Dante's famous quote about the Gates of Hell?
+         */
+
+        /* BEWARE: The obvious
+         *	   'type timestampCtlMsg_t = CStruct2[cmsghdr, timeval]'
+         *	   will pad 4 bytes between the two fields, yielding 32
+         *	   bytes. ptr._2 will not match OS and you will waste time.
+         *
+         * Supply a buffer slightly larger than sizeof[linux cmsghdr].
+         * Make it less than one complete linux cmsghdr so that any
+         * unexpected additional message(s) returned get reported as truncated.
+         */
+
+        val nCtlBuf = 40 // sizeof[linux cmsghdr] + 8 // 8 is a guess
+        val ctlBuf = alloc[Byte](nCtlBuf.toUInt)
+
+        val inMsgHdr = alloc[msghdr]()
+        inMsgHdr.msg_iov = inVec
+        inMsgHdr.msg_iovlen = nInIovs.toInt
+        inMsgHdr.msg_control = ctlBuf
+        inMsgHdr.msg_controllen = nCtlBuf.toUInt
+
+        val nBytesRead = recvmsg(inSocket, inMsgHdr, 0)
+
+        checkIoResult(nBytesRead, "recvmsg_1")
+
+        assertEquals(
+          "recmsg content data was truncated",
+          0,
+          (inMsgHdr.msg_flags & MSG_TRUNC)
+        )
+
+        assertEquals(
+          "recmsg control data was truncated",
+          0,
+          (inMsgHdr.msg_flags & MSG_TRUNC)
+        )
+
+        // When reading small UDP packets, all data should be there together.
+        // Given msg_flags MSG_TRUNC assert above, this should never trigger.
+        assertEquals("recvmsg_2", nBytesRead, nBytesSent)
+
+        /* Open Group 2018 documenataion discourages hand parsing of cmsghdr.
+         * The Scala Native implementation of the CMSG 'macros' work on
+         * Linux, macOS, and others.
+         */
+
+        // A Linux64 OS cmsghdr, cmsg_level & cmsg_type are harder to get.
+        val l64cmsg = CMSG_FIRSTHDR(inMsgHdr).asInstanceOf[Ptr[l64cmsghdr]]
+        assertNotNull("l64cmsg_1", l64cmsg)
+
+        // redundant, but establishes a confidence baseline.
+        assertEquals("l64cmsg should == ctlBuf", l64cmsg, ctlBuf)
+
+        // Received the expected TIMESTAMP?
+        assertEquals(
+          "l64cmsg.cmsg_level is not SOL_SOCKET",
+          SOL_SOCKET,
+          l64cmsg._2
+        )
+        assertEquals(
+          "l64cmsg.cmsg_type is not SCM_TIMESTAMP",
+          SCM_TIMESTAMP,
+          l64cmsg._3
+        )
+
+        val tv = CMSG_DATA(l64cmsg.asInstanceOf[Ptr[cmsghdr]])
+          .asInstanceOf[Ptr[timeval]]
+
+        val now: time_t = scala.scalanative.posix.time.time(null)
+
+        /* Is value received as CMS_DATA roughly correct/as_expected?
+         *
+         * Comparing timestamps is exact, especially when they are
+         * not retrieved atomically.
+         *
+         * Another instance of a classic ROC (receiver operating
+         * characteristic) curve decision.
+         */
+        val tolerance = 3.0f // Allow _some_ slack, but not too much!
+        assertEquals(tv.tv_sec.toLong.toFloat, now.toLong.toFloat, tolerance)
+
+        // Q.E.D.
+      } finally {
+        SocketTestHelpers.closeSocket(inSocket)
+        SocketTestHelpers.closeSocket(outSocket)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR  brings `socket.scala` into nearly complete compliance with POSIX 2018 specification `socket.h`.
 This implies implementing the `sendmsg` and `recvmsg` methods and creating `MsgIoSocketTest.scala`
to exercise them.

In addition, a number of socket code paths were simplified and shortened.

A number of items, including  `sockatmark()`, `socketpair()`, and the  CMSG* & SHUT_* macros have no direct 
correspondents on Windows. A reasonable attempt was made to provide "stub" error values.  A experienced
Windows developer could probably improve those shots-in-the-dark.
