### PR TITLE
add onType function on CollectLocalValDeps and Lower.Impl

### DIFF
--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -88,6 +88,8 @@ object Lower {
         super.onDefn(defn)
     }
 
+    override def onType(ty: Type): Type = ty
+
     def genNext(buf: Buffer, next: Next)(implicit pos: Position): Next = {
       next match {
         case Next.Unwind(exc, next) => Next.Unwind(exc, genNext(buf, next))

--- a/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
@@ -51,7 +51,7 @@ object UseDef {
     }
 
     override def onType(ty: Type): Type = ty
-    
+
   }
 
   private def collect(inst: Inst): Seq[Local] = {

--- a/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/UseDef.scala
@@ -49,6 +49,9 @@ object UseDef {
       }
       super.onNext(next)
     }
+
+    override def onType(ty: Type): Type = ty
+    
   }
 
   private def collect(inst: Inst): Seq[Local] = {


### PR DESCRIPTION
`CollectLocalValDeps` and `Lower.Impl` extend `transform`. However, the function `onType` in transform does nothing. Therefore we can add `override def onType(ty: Type): Type = ty` in the two classes to avoid unnecessary calculations. 