### PR TITLE
Fix #2730: Part 2 - Make sandbox and test settings easier

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -386,9 +386,16 @@ object Build {
       )
       .dependsOn(junitAsyncJVM % "test")
 
+  import scala.scalanative.build._
+
   lazy val sandbox =
     MultiScalaProject("sandbox", file("sandbox"))
       .enablePlugins(MyScalaNativePlugin)
+      .settings(nativeConfig ~= {
+        _.withLTO(LTO.default)
+          .withMode(Mode.default)
+          .withGC(GC.default)
+      })
       .withNativeCompilerPlugin
       .withJUnitPlugin
       .dependsOn(scalalib, testInterface % "test")
@@ -542,7 +549,7 @@ object Build {
             s.log.info(s"Fetching Scala source version $ver")
 
             // Make parent dirs and stuff
-            IO.createDirectory(trgDir)
+            sbt.IO.createDirectory(trgDir)
 
             // Clone scala source code
             new CloneCommand()

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,6 +10,7 @@ import sbtbuildinfo.BuildInfoPlugin
 
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
+import scala.scalanative.build._
 import ScriptedPlugin.autoImport._
 
 object Build {
@@ -318,8 +319,8 @@ object Build {
       testsCommonSettings,
       sharedTestSource(withBlacklist = false),
       javaVersionSharedTestSources,
-      nativeConfig ~= {
-        _.withLinkStubs(true)
+      nativeConfig ~= { c =>
+        c.withLinkStubs(true)
           .withEmbedResources(true)
       },
       Test / unmanagedSourceDirectories ++= {
@@ -385,8 +386,6 @@ object Build {
         libraryDependencies ++= Deps.JUnitJvm
       )
       .dependsOn(junitAsyncJVM % "test")
-
-  import scala.scalanative.build._
 
   lazy val sandbox =
     MultiScalaProject("sandbox", file("sandbox"))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -391,8 +391,8 @@ object Build {
   lazy val sandbox =
     MultiScalaProject("sandbox", file("sandbox"))
       .enablePlugins(MyScalaNativePlugin)
-      .settings(nativeConfig ~= {
-        _.withLTO(LTO.default)
+      .settings(nativeConfig ~= { c =>
+        c.withLTO(LTO.default)
           .withMode(Mode.default)
           .withGC(GC.default)
       })


### PR DESCRIPTION
This is a followup to the previous PR, #2744. We make use of `sbt.IO` explicit just to avoid confusion because of the `core.IO` in the build package and we add default options to `sandbox` to make it easy for people to test by just changing the options.