### PR TITLE
Fix #2769, #2650: SN 0.4.x - remove several defects discovered by ProcessTest

### DIFF
--- a/javalib/src/main/scala/java/lang/process/UnixProcess.scala
+++ b/javalib/src/main/scala/java/lang/process/UnixProcess.scala
@@ -190,7 +190,7 @@ object UnixProcess {
          * give historical context to "that is strange, why did they do
          * that???" invokeChildProcess code. Child code after 'fork()' is
          * usually inline.
-         * 
+         *
          * In the current 'fork()' implementation the inner method is now
          * probably "unnecessary but harmless". Someday a braver soul with
          * time on their hands can try removing it.

--- a/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
+++ b/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
@@ -57,11 +57,14 @@ static void *wait_loop(void *arg) {
         if (pid != -1) {
             pthread_mutex_lock(&shared_mutex);
 
-            const int last_result = WIFEXITED(status) ? WEXITSTATUS(status)
-                                    : WIFSIGNALED(status)
-                                        ? 0x80 + WTERMSIG(status)
-                                        : status; // other cases probably yield
-                                                  // garbage but let it flow.
+            // probably yields garbage if not superseded below. Let it show.
+            int last_result = status;
+
+            if (WIFEXITED(status)) {
+                last_result = WEXITSTATUS(status);
+            } else if (WIFSIGNALED(status)) {
+                last_result = 0x80 + WTERMSIG(status);
+            }
 
             const auto monitor = waiting_procs.find(pid);
             if (monitor != waiting_procs.end()) {

--- a/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
+++ b/nativelib/src/main/resources/scala-native/platform/posix/process_monitor.cpp
@@ -56,8 +56,13 @@ static void *wait_loop(void *arg) {
         const int pid = waitpid(-1, &status, 0);
         if (pid != -1) {
             pthread_mutex_lock(&shared_mutex);
-            const int last_result =
-                WIFSIGNALED(status) ? 0x80 + status : status;
+
+            const int last_result = WIFEXITED(status) ? WEXITSTATUS(status)
+                                    : WIFSIGNALED(status)
+                                        ? 0x80 + WTERMSIG(status)
+                                        : status; // other cases probably yield
+                                                  // garbage but let it flow.
+
             const auto monitor = waiting_procs.find(pid);
             if (monitor != waiting_procs.end()) {
                 auto m = monitor->second;


### PR DESCRIPTION
##### Release trains
This PR is intended for the SN 0.4.x release train. It addresses a set of bugs
which may be experienced by people in the wild attempting to use the Process class
with macOS.

It is also appropriate for 0.5.0.  After its merge into 0.5.0 I can submit
another PR removing a feature introduced in the 0.4.x stream. At that
time, it looked like some signal defects were specific to arm64 (Apple M1).
Turns out, they due to a platform independent change in macOS 12.0.

##### Changes
ProcessTest now runs cleanly on Linux, various macOS versions, and Windows. 
Its failures in CI on macOS 12.n turned out to be real problems.  Good for ProcessTest.

##### Analysis, for Reviewers & the curious
After years of documenting that `vfork()` was going to be deprecated, Apple finally
did it in macOS 12.  They deprecated `vfork()` and made it, basically, an alias
for `fork()`.  This appears to have changed timings so that a parent process can
run earlier than the child.  Always a theoretical possibility, but not the facts
on the ground.  Now they are.

Changing the timing meant that the parent could send SIGTERM to the
child before the child had executed one of the exec family.  There is 
as window in the child between fork() and exec() where a delivered
signal will execute any special signal handler of the parent (
because exec has not yet re-set them).  SN build establishes
a signal handler for SIGTERM (and others). Executing it
causes an unexpected & unwanted traceback. That 
traceback can cause concern to people reading log files.

Lastly, when SIGKILL (which can not be caught) and SIGTERM
were handled, they went through some defective code in `process_monitor.cpp`
which caused the carnage reported in @2769.
