### PR TITLE
WIP: Fix #2765, Part 1: Begin removing expired deprecated definitions

### DIFF
--- a/docs/changelog/0.5.0-SNAPSHOT.md
+++ b/docs/changelog/0.5.0-SNAPSHOT.md
@@ -1,0 +1,89 @@
+
+[comment]: # (BEWARE: this file is rough scaffolding, not for final release)
+
+
+# 0.5.0-SNAPSHOT (TBS)
+
+We're happy to announce the release of Scala Native 0.5.0-SNAPSHOT. 
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis suscipit 
+iaculis odio, in porta nibh ornare id. Ut in sodales diam. Sed lacinia eget
+metus sed ullamcorper. Suspendisse potenti. Donec imperdiet sem ac sapien
+ultricies hendrerit. Vestibulum magna lacus, tristique quis nulla a,
+fringilla varius augue. Curabitur aliquet massa quis erat elementum ultrices.
+
+Sed interdum est non facilisis sagittis. Donec faucibus massa sit amet
+vulputate posuere. Pellentesque enim nisi, ornare id pharetra eu, volutpat
+scelerisque neque. Aliquam ut odio eget risus vulputate vulputate eu luctus
+turpis. Nulla facilisi. Morbi non feugiat dui, sed varius mi. Fusce id 
+consequat urna. Maecenas sed diam erat. 
+
+
+Scala standard library used by this release is based on the following versions:
+<table>
+<tbody>
+  <tr>
+    <td>Scala binary version</td>
+    <td>Scala release</td>
+  </tr>
+  <tr>
+    <td align="center">2.11</td>
+    <td align="center">2.11.12</td>
+  </tr>
+  <tr>
+    <td align="center">2.12</td>
+    <td align="center">2.12.16</td>
+  </tr>
+  <tr>
+    <td align="center">2.13</td>
+    <td align="center">2.13.8</td>
+  </tr>
+  <tr>
+    <td align="center">3</td>
+    <td align="center">3.1.3</td>
+  </tr>
+</tbody>
+</table>
+
+
+<table>
+<tbody>
+  <tr>
+    <td>Commits since last release</td>
+    <td align="center">TBS</td>
+  </tr>
+  <tr>
+    <td>Merged PRs</td>
+    <td align="center">TBS</td>
+  <tr>
+    <td>Deprecated definitions removed</td>
+    <td align="center">TBS</td>
+  </tr>
+    <tr>
+    <td>Contributors</td>
+    <td align="center">TBS</td>
+  </tr>
+</tbody>
+</table>
+
+## Contributors
+
+Big thanks to everybody who contributed to this release or reported an issue!
+
+```
+$ git shortlog -sn --no-merges v0.4.5..v0.5.0
+TBS
+```
+
+## Deprecated definitions removed in this version
+
+- ScalaNativePlugin.scala 'val AutoImport' (deprecated in 0.3.7)
+
+
+## Merged PRs
+
+
+## C/POSIX standard library bindings
+
+
+## Scala Native runtime library

--- a/docs/changelog/0.5.0-SNAPSHOT.md
+++ b/docs/changelog/0.5.0-SNAPSHOT.md
@@ -6,6 +6,9 @@
 
 We're happy to announce the release of Scala Native 0.5.0-SNAPSHOT. 
 
+## TL;DR
+* **Not backward compatible with previous releases**,
+
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis suscipit 
 iaculis odio, in porta nibh ornare id. Ut in sodales diam. Sed lacinia eget
 metus sed ullamcorper. Suspendisse potenti. Donec imperdiet sem ac sapien

--- a/docs/changelog/0.5.0-SNAPSHOT.md
+++ b/docs/changelog/0.5.0-SNAPSHOT.md
@@ -9,7 +9,7 @@ We're happy to announce the release of Scala Native 0.5.0-SNAPSHOT.
 ## TL;DR
 * **Not backward compatible with previous releases**,
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis suscipit 
+Dolorem ipsum dolor sit amet, consectetur adipiscing elit. Duis suscipit 
 iaculis odio, in porta nibh ornare id. Ut in sodales diam. Sed lacinia eget
 metus sed ullamcorper. Suspendisse potenti. Donec imperdiet sem ac sapien
 ultricies hendrerit. Vestibulum magna lacus, tristique quis nulla a,

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -6,6 +6,7 @@ Changelog
 .. toctree::
   :maxdepth: 1
 
+  0.5.0-SNAPSHOT
   0.4.5
   0.4.4
   0.4.3

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -63,9 +63,6 @@ object ScalaNativePlugin extends AutoPlugin {
       )
   }
 
-  @deprecated("use autoImport instead", "0.3.7")
-  val AutoImport = autoImport
-
   override def globalSettings: Seq[Setting[_]] =
     ScalaNativePluginInternal.scalaNativeGlobalSettings
 


### PR DESCRIPTION
2022-08-17  PR #2788 should probably be merged first, so I marked this Work In Progress (WIP)
                     I will re-base and change back to mainline after Eric's PR is merged. 

This PR begins the process of removing Scala Native definitions which
have been deprecated for longer than "a decent interval". 

Anything before SN 0.5.0  and older than a year is fair game.

The intent is to be fair to developers using Scala Native and
at the same time reduce the amount of technical cruft in
Scala Native being carried forward, to no good use.

This PR creates a very rough "0.5.0-SNAPSHOT.md" changelog
to help keep track of the removals.  That placeholder file needs MAJOR
work before even an "RC" release.

The "removed deprecations" section is rough but serves its
purpose. As more removals  happen we can begin to 
tell what an improvement, such as a markdown table, would need to look like
(column spacing etc.)   Early days yet.

