### PR TITLE
Add `java.net.ProtocolException`

### DIFF
--- a/javalib/src/main/scala/java/net/Throwables.scala
+++ b/javalib/src/main/scala/java/net/Throwables.scala
@@ -23,6 +23,10 @@ class MalformedURLException(msg: String) extends IOException(msg) {
   def this() = this(null)
 }
 
+class ProtocolException(host: String) extends IOException(host) {
+  def this() = this(null)
+}
+
 class UnknownHostException(private val host: String) extends IOException(host) {
   def this() = this(null)
 }


### PR DESCRIPTION
Targeted to 0.4.x.

https://docs.oracle.com/javase/8/docs/api/java/net/ProtocolException.html#ProtocolException(java.lang.String)