### PR TITLE
WIP: Fix #2798: Read System Properties from an environment variable

### DIFF
--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -47,7 +47,22 @@ object System {
         s"Error loading properties from environment: '${envVar}=${fileName}'"
 
       try {
-        val inReader = new BufferedReader(new FileReader(fileName));
+        /* There 2 slight variances from Java 8 spec here.
+         * 1) Java 8 reads properties files as ISO-8859-1, a.k.a Latin-1.
+         *    Java 9 and above read them as UTF-8. UTF-8 and ISO-8859-1 have
+         *    the same encoding for ASCII characters. UTF-8 is more useful
+         *    in an international world. You can not put emojis in properties.
+         *
+         * 2) The Java 9 specifies re-reading the file as ISO-8859-1 if
+         *    there an invalid UTF-8 byte sequence is detected. That is
+         *    not done here and left as an exercise for the reader.
+         */
+        val inReader = new BufferedReader(
+          new InputStreamReader(
+            new FileInputStream(fileName),
+            StandardCharsets.UTF_8
+          )
+        )
 
         try {
           val props = new Properties()

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -63,8 +63,6 @@ object System {
           systemProperties.putAll(props)
 
         } catch {
-          case _: IOException =>
-            throw new FileNotFoundException(exceptionMsg)
           case _: IllegalArgumentException =>
             throw new IllegalArgumentException(exceptionMsg)
         } finally {


### PR DESCRIPTION
#####
* I am submitting this as a WIP in order to give folks a chance to comment on  the indicated issue.
  It is High Summer. If I am asking people's opinion, it is common curtsy plenty of time to respond.
 This code allows me to get on with what I was really trying to accomplish.

* I am submitting for the 0.5.0 stream to give the code time to get exercised and lager.
  I believe that it could be backported to the 0.4.x once it has proven itself.

##### PR

Java & ScalaJVM allow setting environment variables on the command line used to 
invoke them: '-Dfoo=bar'. These become System properties in the program.

This model is not suitable for Scala Native programs.  Code ported from Scala
or Java are likely to run into a need to set properties from the execution environment.

This PR introduces that capability. If the environment variable `SCALANATIVE_SYSTEM_PROPERTIES_FILE`
is set, its value will be taken to be the name of a Java line-oriented properties file. The initialization
code for the `System` object will attempt to load that file.

This strengthens Scala Native by giving  a way to specify System properties such as `java.net.preferIPv4Stack' or 
`"networkaddress.cache.ttl`.

##### Notes
1) I pondered ways of adding one or more test cases to `SystemTest.scala`. Each of the test cases
    required manual setup and interpretation, so I was not able to add automatic testing.

2) I manually tested this code extensively, including error messages.

3) Documentation is a TBD because I want to see community acceptance of this WIP before
    I invest more time.  The javalib section needs a paragraph describing this new capability
    and giving an example of setting the environment variable and the fact that local
    variables supersede prior hard coded values.