### PR TITLE
Align error messages for `UnknownHost` with JVM

### DIFF
--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -135,7 +135,7 @@ private[net] trait InetAddressBase {
     } else {
       val ip = SocketHelpers.hostToIp(host).getOrElse {
         throw new UnknownHostException(
-          "No IP address could be found for the specified host: " + host
+          host + ": Name or service not known"
         )
       }
       if (isValidIPv4Address(ip))
@@ -161,7 +161,7 @@ private[net] trait InetAddressBase {
     val ips: Array[String] = SocketHelpers.hostToIpArray(host)
     if (ips.isEmpty) {
       throw new UnknownHostException(
-        "No IP address could be found for the specified host: " + host
+        host + ": Name or service not known"
       )
     }
 

--- a/unit-tests/shared/src/test/scala/javalib/net/Inet6AddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/Inet6AddressTest.scala
@@ -80,11 +80,13 @@ class Inet6AddressTest {
 
   @Test def getByAddress(): Unit = {
     assertThrows(
+      "123: Name or service not known",
       classOf[UnknownHostException],
       Inet6Address.getByAddress("123", null, 0)
     )
     val addr1 = Array[Byte](127.toByte, 0.toByte, 0.toByte, 1.toByte)
     assertThrows(
+      "123: Name or service not known",
       classOf[UnknownHostException],
       Inet6Address.getByAddress("123", addr1, 0)
     )

--- a/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
@@ -77,6 +77,12 @@ class InetAddressTest {
 
     val i3 = InetAddress.getByName(String.valueOf(0xffffffffL))
     assertEquals("255.255.255.255", i3.getHostAddress())
+
+    assertThrows(
+      "not.example.com: Name or service not known",
+      classOf[UnknownHostException],
+      InetAddress.getByName("not.example.com")
+    )
   }
 
   @Test def getHostAddress(): Unit = {


### PR DESCRIPTION
Targeting 0.4.x