### PR TITLE
Handle null args to `accept`

### DIFF
--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -190,7 +190,7 @@ int scalanative_connect(int socket, struct scalanative_sockaddr *address,
 int scalanative_accept(int socket, struct scalanative_sockaddr *address,
                        socklen_t *address_len) {
     struct sockaddr *converted_address;
-    int convert_result = address != null ? // addr and addr_len can be null
+    int convert_result = address != NULL ? // addr and addr_len can be NULL
                              scalanative_convert_sockaddr(
                                  address, &converted_address, address_len)
                                          : 0;
@@ -199,7 +199,7 @@ int scalanative_accept(int socket, struct scalanative_sockaddr *address,
 
     if (convert_result == 0) {
         result = accept(socket, converted_address, address_len);
-        convert_result = address != null
+        convert_result = address != NULL
                              ? scalanative_convert_scalanative_sockaddr(
                                    converted_address, address, address_len)
                              : 0;
@@ -213,7 +213,7 @@ int scalanative_accept(int socket, struct scalanative_sockaddr *address,
         result = -1;
     }
 
-    if (address != null)
+    if (address != NULL)
         free(converted_address);
     return result;
 }

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -190,15 +190,19 @@ int scalanative_connect(int socket, struct scalanative_sockaddr *address,
 int scalanative_accept(int socket, struct scalanative_sockaddr *address,
                        socklen_t *address_len) {
     struct sockaddr *converted_address;
-    int convert_result =
-        scalanative_convert_sockaddr(address, &converted_address, address_len);
+    int convert_result = address != null ? // addr and addr_len can be null
+                             scalanative_convert_sockaddr(
+                                 address, &converted_address, address_len)
+                                         : 0;
 
     int result;
 
     if (convert_result == 0) {
         result = accept(socket, converted_address, address_len);
-        convert_result = scalanative_convert_scalanative_sockaddr(
-            converted_address, address, address_len);
+        convert_result = address != null
+                             ? scalanative_convert_scalanative_sockaddr(
+                                   converted_address, address, address_len)
+                             : 0;
 
         if (convert_result != 0) {
             errno = convert_result;
@@ -209,6 +213,7 @@ int scalanative_accept(int socket, struct scalanative_sockaddr *address,
         result = -1;
     }
 
-    free(converted_address);
+    if (address != null)
+        free(converted_address);
     return result;
 }


### PR DESCRIPTION
Targeting 0.4.x

> When addr is NULL, nothing is filled in; in this case, addrlen is
       not used, and should also be NULL.

https://man7.org/linux/man-pages/man2/accept.2.html
