### PR TITLE
Add `LinktimeInfo.is{FreeBSD,Mac,Linux}`

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -9,6 +9,15 @@ object LinktimeInfo {
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.isWindows")
   def isWindows: Boolean = resolved
 
+  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.isLinux")
+  def isLinux: Boolean = resolved
+
+  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.isMac")
+  def isMac: Boolean = resolved
+
+  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.isFreeBSD")
+  def isFreeBSD: Boolean = resolved
+
   @resolvedAtLinktime(
     "scala.scalanative.meta.linktimeinfo.isWeakReferenceSupported"
   )

--- a/tools/src/main/scala/scala/scalanative/build/Platform.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Platform.scala
@@ -7,6 +7,8 @@ object Platform {
     System.getProperty("os.name", "unknown").toLowerCase(Locale.ROOT)
 
   lazy val isWindows: Boolean = osUsed.startsWith("windows")
-  lazy val isUnix: Boolean = osUsed.contains("linux") || osUsed.contains("unix")
+  lazy val isLinux: Boolean = osUsed.contains("linux")
+  lazy val isUnix: Boolean = isLinux || osUsed.contains("unix")
   lazy val isMac: Boolean = osUsed.contains("mac")
+  lazy val isFreeBSD: Boolean = osUsed.contains("freebsd")
 }

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -12,6 +12,9 @@ trait LinktimeValueResolver { self: Reach =>
     val linktimeInfo = "scala.scalanative.meta.linktimeinfo"
     val predefined: NativeConfig.LinktimeProperites = Map(
       s"$linktimeInfo.isWindows" -> Platform.isWindows,
+      s"$linktimeInfo.isLinux" -> Platform.isLinux,
+      s"$linktimeInfo.isMac" -> Platform.isMac,
+      s"$linktimeInfo.isFreeBSD" -> Platform.isFreeBSD,
       s"$linktimeInfo.isWeakReferenceSupported" -> {
         conf.gc == GC.Immix ||
         conf.gc == GC.Commix

--- a/unit-tests/native/src/test/scala/scala/scalanative/meta/LinktimeInfoTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/meta/LinktimeInfoTest.scala
@@ -8,10 +8,10 @@ import org.junit.Assert._
 class LinktimeInfoTest {
 
   @Test def testOS(): Unit = {
-    assertEquals(Platform.isFreeBSD, LinktimeInfo.isFreeBSD)
-    assertEquals(Platform.isLinux, LinktimeInfo.isLinux)
-    assertEquals(Platform.isMac, LinktimeInfo.isMac)
-    assertEquals(Platform.isWindows, LinktimeInfo.isWindows)
+    assertEquals(Platform.isFreeBSD(), LinktimeInfo.isFreeBSD)
+    assertEquals(Platform.isLinux(), LinktimeInfo.isLinux)
+    assertEquals(Platform.isMac(), LinktimeInfo.isMac)
+    assertEquals(Platform.isWindows(), LinktimeInfo.isWindows)
   }
 
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/meta/LinktimeInfoTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/meta/LinktimeInfoTest.scala
@@ -1,0 +1,17 @@
+package scala.scalanative.meta
+
+import scala.scalanative.runtime.Platform
+
+import org.junit.Test
+import org.junit.Assert._
+
+class LinktimeInfoTest {
+
+  @Test def testOS(): Unit = {
+    assertEquals(Platform.isFreeBSD, LinktimeInfo.isFreeBSD)
+    assertEquals(Platform.isLinux, LinktimeInfo.isLinux)
+    assertEquals(Platform.isMac, LinktimeInfo.isMac)
+    assertEquals(Platform.isWindows, LinktimeInfo.isWindows)
+  }
+
+}


### PR DESCRIPTION
Targeted to 0.4.x.

Closes https://github.com/scala-native/scala-native/issues/2802. This aligns `LinktimeInfo` with the OS flags in `scalanative.runtime.Platform`.
https://github.com/scala-native/scala-native/blob/61e01b6222b7d90fbc9fbd3261de618f0d8df6ad/nativelib/src/main/scala/scala/scalanative/runtime/Platform.scala#L7-L22