### PR TITLE
Fix deep resource embedding on Windows

### DIFF
--- a/scripted-tests/run/resource-embedding/D/src/main/resources/dir/d-res
+++ b/scripted-tests/run/resource-embedding/D/src/main/resources/dir/d-res
@@ -1,0 +1,1 @@
+d-resource

--- a/scripted-tests/run/resource-embedding/D/src/main/scala/Main.scala
+++ b/scripted-tests/run/resource-embedding/D/src/main/scala/Main.scala
@@ -4,5 +4,10 @@ object Main {
       getClass().getResourceAsStream("dir/d-res") != null,
       "d-res should be embedded"
     )
+
+    assert(
+      getClass().getResourceAsStream("dir\\d-res") != null,
+      "d-res should be embedded"
+    )
   }
 }

--- a/scripted-tests/run/resource-embedding/D/src/main/scala/Main.scala
+++ b/scripted-tests/run/resource-embedding/D/src/main/scala/Main.scala
@@ -1,0 +1,8 @@
+object Main {
+  def main(args: Array[String]): Unit = {
+    assert(
+      getClass().getResourceAsStream("dir/d-res") != null,
+      "d-res should be embedded"
+    )
+  }
+}

--- a/scripted-tests/run/resource-embedding/build.sbt
+++ b/scripted-tests/run/resource-embedding/build.sbt
@@ -39,3 +39,13 @@ lazy val projectC = (project in file("C"))
     scalaVersion := commonScalaVersion
   )
   .dependsOn(projectA)
+
+// Embedded in a directory
+lazy val projectD = (project in file("D"))
+  .enablePlugins(ScalaNativePlugin)
+  .settings(
+    nativeConfig ~= {
+      _.withEmbedResources(true)
+    },
+    scalaVersion := commonScalaVersion
+  )

--- a/scripted-tests/run/resource-embedding/test
+++ b/scripted-tests/run/resource-embedding/test
@@ -15,3 +15,9 @@
 > projectC/nativeLink
 # includes simple tests
 > projectC/run
+
+# -- links and runs tests without conflicts
+> projectD/compile
+> projectD/nativeLink
+# includes simple tests
+> projectD/run

--- a/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/ResourceEmbedder.scala
@@ -1,24 +1,25 @@
 package scala.scalanative.codegen
 
-import java.nio.file.Files._
-import java.nio.file.SimpleFileVisitor
-import java.nio.file.attribute.BasicFileAttributes
-import java.util.EnumSet
-import java.nio.file.Files
-import java.nio.file.Path
+import java.io.File
 import java.io.IOException
+import java.nio.ByteBuffer
 import java.nio.file.FileVisitResult
 import java.nio.file.FileVisitResult._
-import scala.collection.mutable.ArrayBuffer
-import scala.scalanative.nir._
+import java.nio.file.Files
+import java.nio.file.Files._
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 import java.util.Base64
-import java.nio.ByteBuffer
+import java.util.EnumSet
+import scala.annotation.tailrec
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 import scala.scalanative.build.Config
 import scala.scalanative.io.VirtualDirectory
+import scala.scalanative.nir._
 import scala.scalanative.util.Scope
-import java.nio.file.Paths
-import scala.collection.mutable
-import scala.annotation.tailrec
 
 private[scalanative] object ResourceEmbedder {
 
@@ -40,11 +41,13 @@ private[scalanative] object ResourceEmbedder {
 
           virtualDir.files
             .flatMap { path =>
+              // Use the same path separator on all OSs
+              val pathString = path.toString().replace(File.separator, "/")
               val (pathName, correctedPath) =
-                if (!path.toString().startsWith("/")) { // local file
-                  ("/" + path.toString(), classpath.resolve(path))
+                if (!pathString.startsWith("/")) { // local file
+                  ("/" + pathString, classpath.resolve(path))
                 } else { // other file (f.e in jar)
-                  (path.toString(), path)
+                  (pathString, path)
                 }
 
               if (isInIgnoredDirectory(path)) {


### PR DESCRIPTION
Normalizes all embedded files to use "/" as a path separator when they are embedded.

Fixes #2603