### PR TITLE
Fix #2814: 0.4.x: Port and extend StandardSocketOptions

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1812,3 +1812,30 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+# License notice for armanbilge/epollcat
+
+Implementation of `StandardSocketOptions` is based on the
+[armanbilge/epollcat](https://github.com/armanbilge/epollcat) project.
+The original license notice is included below:
+```
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+```
+
+Additions by this project to the original `epollcat` implementation carry
+the Scala Native license.

--- a/javalib/src/main/scala/java/net/StandardSocketOptions.scala
+++ b/javalib/src/main/scala/java/net/StandardSocketOptions.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Original code is from the armanbilge/epollcat project at
+ * https://github.com/armanbilge/epollcat/
+ *
+ * For full original license notice , see:
+ *     https://github.com/scala-native/scala-native/blob/main/LICENSE.md
+ *
+ * Additional code provided by the Scala Native project carries the
+ * Scala Native license, described in the same LICENSE.md.
+ */
+
+package java.net
+
+object StandardSocketOptions {
+
+  val IP_MULTICAST_IF: SocketOption[java.net.NetworkInterface] =
+    new StdSocketOption("IP_MULTICAST_IF", classOf)
+
+  val IP_MULTICAST_LOOP: SocketOption[java.lang.Boolean] =
+    new StdSocketOption("IP_MULTICAST_LOOP", classOf)
+
+  val IP_MULTICAST_TTL: SocketOption[java.lang.Integer] =
+    new StdSocketOption("IP_MULTICAST_TTL", classOf)
+
+  val IP_TOS: SocketOption[java.lang.Integer] =
+    new StdSocketOption("IP_TOS", classOf)
+
+  val SO_BROADCAST: SocketOption[java.lang.Boolean] =
+    new StdSocketOption("SO_BROADCAST", classOf)
+
+  val SO_KEEPALIVE: SocketOption[java.lang.Boolean] =
+    new StdSocketOption("SO_KEEPALIVE", classOf)
+
+  val SO_LINGER: SocketOption[java.lang.Integer] =
+    new StdSocketOption("SO_LINGER", classOf)
+
+  val SO_RCVBUF: SocketOption[java.lang.Integer] =
+    new StdSocketOption("SO_RCVBUF", classOf)
+
+  val SO_REUSEADDR: SocketOption[java.lang.Boolean] =
+    new StdSocketOption("SO_REUSEADDR", classOf)
+
+  val SO_REUSEPORT: SocketOption[java.lang.Boolean] =
+    new StdSocketOption("SO_REUSEPORT", classOf)
+
+  val SO_SNDBUF: SocketOption[java.lang.Integer] =
+    new StdSocketOption("SO_SNDBUF", classOf)
+
+  val TCP_NODELAY: SocketOption[java.lang.Boolean] =
+    new StdSocketOption("TCP_NODELAY", classOf)
+
+  private final class StdSocketOption[T](val name: String, val `type`: Class[T])
+      extends SocketOption[T] {
+    override def toString = name
+  }
+}

--- a/javalib/src/main/scala/java/net/StandardSocketOptions.scala
+++ b/javalib/src/main/scala/java/net/StandardSocketOptions.scala
@@ -15,7 +15,12 @@ package java.net
 
 object StandardSocketOptions {
 
-  val IP_MULTICAST_IF: SocketOption[java.net.NetworkInterface] =
+  /* NetworkInterface is not-yet-implemented.
+   * IP_MULTICAST_IF is defined for completeness.
+   * Any code using it before NetworkInterface is implemented will
+   * encounter a 'symbol not found' error at link time.
+   */
+  val IP_MULTICAST_IF: SocketOption[java.net.NetworkInterface] = // BEWARE!
     new StdSocketOption("IP_MULTICAST_IF", classOf)
 
   val IP_MULTICAST_LOOP: SocketOption[java.lang.Boolean] =

--- a/javalib/src/main/scala/java/net/StandardSocketOptions.scala
+++ b/javalib/src/main/scala/java/net/StandardSocketOptions.scala
@@ -29,6 +29,10 @@ object StandardSocketOptions {
   val IP_MULTICAST_TTL: SocketOption[java.lang.Integer] =
     new StdSocketOption("IP_MULTICAST_TTL", classOf)
 
+  /* Quoting from both the Java 8 & 17 documentation:
+   *   The behavior of this socket option on a stream-oriented socket,
+   *   or an IPv6 socket, is not defined in this release.
+   */
   val IP_TOS: SocketOption[java.lang.Integer] =
     new StdSocketOption("IP_TOS", classOf)
 


### PR DESCRIPTION
Submitted for 0.4.x. I understand entirely that 0.4.6 has left the station already.  
This is a candidate for merging into 0.5.x.


Given Arman's kind consent and original hard work,  we port the javalib class `java.net.StandardSocketOptions` from 
the [armanbilge/epollcat](https://github.com/armanbilge/epollcat) project and extended it to match the Java 
specification.

All bugs come to me, all good karma goes to Arman.

Thank you, Arman.