### PR TITLE
Make a small build optimization

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/core/Filter.scala
+++ b/tools/src/main/scala/scala/scalanative/build/core/Filter.scala
@@ -59,15 +59,10 @@ private[scalanative] object Filter {
         }
       }
 
-      val (includePaths, excludePaths) = allPaths.map(_.abs).partition(include)
+      // All the .o files are kept but we pass on the
+      // included files to the link phase
+      val includePaths = allPaths.map(_.abs).filter(include)
 
-      // delete .o files for all excluded source files
-      // avoids deleting .o files except when changing
-      // optional or garbage collectors
-      excludePaths.foreach { path =>
-        val opath = Paths.get(path + oExt)
-        Files.deleteIfExists(opath)
-      }
       val projectConfig = config.withCompilerConfig(
         _.withCompileOptions(
           config.compileOptions ++ gcIncludePaths.map("-I" + _)


### PR DESCRIPTION
We shouldn't need to remove `.o` files. We just need to avoid passing the ones we don't need to the link phase.