### PR TITLE
Fix #2280: Add Unix-only IPv6 TCP support to javalib

### DIFF
--- a/docs/lib/javalib.rst
+++ b/docs/lib/javalib.rst
@@ -666,4 +666,35 @@ Native's reimplementation, this remains not implemented for now. The added
 ``getClass().getResourceAsInputStream()`` however is able to be consistent between
 the platforms.
 
+
+Internet Protocol Version 6 (IPv6) Networking
+---------------------------------------------
+
+IPv6 provides network features which are more efficient and gradually
+replacing its worthy, but venerable, predecessor IPv4.
+
+The Scala Native Java library now supports IPv6 as it is described in the
+original `Java Networking IPv6 User Guide  <https://docs.oracle.com/javase/8/docs/technotes/guides/net/ipv6_guide/index.html/>`_. The design center is that
+a Scala Java Virtual Machine (JVM) program using networking 
+will run almost identically using Scala Native.
+
+IPv6 will be used if any network interface on a system/node/host, other
+than the loopback interface, is configured to enable IPv6. Otherwise,
+IPv4 is used as before. Java has been using this approach for decades.
+
+Most people will not be able to determine if IPv6 or IPv4 is in use.
+Networks experts will, by using specialist tools.
+
+Scala Native checks and honors the two System Properties described in
+the ipv6_guide above: ``java.net.preferIPv4Stack`` and
+``java.net.preferIPv6Addresses``. This check is done once, when the
+network is first used.
+
+* If there is ever a reason to use only IPv4, a program can
+  set the ``java.net.preferIPv4Stack``  to ``true`` at runtime
+  before the first use of the network.  There is no way to accomplish
+  this from the command line or environment.::
+
+      System.setProperty("java.net.preferIPv6Addresses", "true") 
+
 Continue to :ref:`libc`.

--- a/javalib/src/main/resources/scala-native/netinet/in6.c
+++ b/javalib/src/main/resources/scala-native/netinet/in6.c
@@ -1,4 +1,6 @@
+#ifndef _WIN32
 #include <netinet/in.h>
+#endif
 
 /* Internet Engineering Task Force (IETF) RFC2553 describes in6.h
  * being accessed via netinet/in.h, which includes it, and not directly.

--- a/javalib/src/main/resources/scala-native/netinet/in6.c
+++ b/javalib/src/main/resources/scala-native/netinet/in6.c
@@ -1,0 +1,23 @@
+#include <netinet/in.h>
+
+/* Internet Engineering Task Force (IETF) RFC2553 describes in6.h
+ * being accessed via netinet/in.h, which includes it, and not directly.
+ */
+
+// This file implements only the sole declaration need by java.net.
+
+int scalanative_ipv6_tclass() {
+#ifndef IPV6_TCLASS
+    /* Force a runtime error, probably errno 92: "Protocol not available"
+     * Do no force link errors for something which is used in the wild
+     * only by experts, and then rarely.
+     */
+    return 0; // 0 is an invalid socket option.
+#else
+    /* Operating system specific.
+     *   Known values: Linus 67, macOS 36, FreeBSD 61.
+     *   Windows seems to not have it at all, although WSL might.
+     */
+    return IPV6_TCLASS;
+#endif
+}

--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -18,6 +18,7 @@ import scala.scalanative.posix.netdb._
 import scala.scalanative.posix.netdbOps._
 import scala.scalanative.posix.sys.time._
 import scala.scalanative.posix.sys.timeOps._
+import scala.scalanative.posix.arpa.inet._
 
 import scala.scalanative.meta.LinktimeInfo.isWindows
 import java.io.{FileDescriptor, IOException, OutputStream, InputStream}
@@ -91,7 +92,52 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     portOpt.map(inet.ntohs(_).toInt)
   }
 
-  override def bind(addr: InetAddress, port: Int): Unit = {
+  /* Fill in the given sockaddr_in6 with the given InetAddress, either
+   * Inet4Address or Inet6Address, and the given port.
+   * Set the af_family for IPv6.  On return, the sockaddr_in6 should
+   * be ready to use in bind() or connect().
+   *
+   * By contract, all the bytes in sa6 are zero coming in.
+   */
+  private def prepareSockaddrIn6(
+      inetAddress: InetAddress,
+      port: Int,
+      sa6: Ptr[in.sockaddr_in6]
+  ): Unit = {
+
+    /* BEWARE: This is Unix-only code.
+     *   Currently (2022-08-27) execution on Windows never get here. IPv4Only
+     *   is forced on.  If that ever changes, this method may need
+     *   Windows code.
+     *
+     *   Having the complexity in one place, it should make adding
+     *   Windows support easier.
+     */
+
+    sa6.sin6_family = socket.AF_INET6.toUShort
+    sa6.sin6_port = htons(port.toUShort)
+
+    val src = inetAddress.getAddress()
+
+    if (inetAddress.isInstanceOf[Inet6Address]) {
+      sa6.sin6_addr = src.asInstanceOf[in.in6_addr]
+    } else { // Use IPv4mappedIPv6 address
+      val dst = sa6.sin6_addr.toPtr.s6_addr
+
+      // By contract, the leading bytes are already zero already.
+      val FF = 255.toUByte
+      dst(10) = FF // set the IPv4mappedIPv6 indicator bytes
+      dst(11) = FF
+
+      // add the IPv4 trailing bytes, unrolling small loop
+      dst(12) = src(0).toUByte
+      dst(13) = src(1).toUByte
+      dst(14) = src(2).toUByte
+      dst(15) = src(3).toUByte
+    }
+  }
+
+  private def bind4(addr: InetAddress, port: Int): Unit = {
     val hints = stackalloc[addrinfo]()
     val ret = stackalloc[Ptr[addrinfo]]()
     hints.ai_family = socket.AF_UNSPEC
@@ -121,6 +167,37 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     }
   }
 
+  private def bind6(addr: InetAddress, port: Int): Unit = {
+    val sa6 = stackalloc[in.sockaddr_in6]()
+
+    // By contract, all the bytes in sa6 are zero going in.
+    prepareSockaddrIn6(addr, port, sa6)
+
+    val bindRes = socket.bind(
+      fd.fd,
+      sa6.asInstanceOf[Ptr[socket.sockaddr]],
+      sizeof[in.sockaddr_in6].toUInt
+    )
+
+    if (bindRes < 0)
+      throwCannotBind(addr)
+
+    this.localport = fetchLocalPort(sa6.sin6_family.toInt).getOrElse {
+      throwCannotBind(addr)
+    }
+  }
+
+  override def bind(addr: InetAddress, port: Int): Unit = {
+    throwIfClosed("bind")
+
+    val useIPv4Only = SocketHelpers.getPreferIPv4Stack()
+    val bindFunc =
+      if (useIPv4Only) bind4(_: InetAddress, _: Int)
+      else bind6(_: InetAddress, _: Int)
+
+    bindFunc(addr, port)
+  }
+
   override def listen(backlog: Int): Unit = {
     if (socket.listen(fd.fd, backlog) == -1) {
       throw new SocketException("Listen failed")
@@ -131,9 +208,8 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
   override def accept(s: SocketImpl): Unit = {
     throwIfClosed("accept") // Do not send negative fd.fd to poll()
 
-    if (timeout > 0) {
+    if (timeout > 0)
       tryPollOnAccept()
-    }
 
     val storage: Ptr[Byte] = stackalloc[Byte](sizeof[in.sockaddr_in6])
     val len = stackalloc[socket.socklen_t]()
@@ -168,7 +244,9 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
       s.port = inet.ntohs(sa.sin6_port).toInt
     }
 
-    Zone { implicit z => s.address = InetAddress.getByName(fromCString(ipstr)) }
+    Zone { implicit z =>
+      s.address = InetAddress.getByName(fromCString(ipstr))
+    }
 
     s.fd = new FileDescriptor(newFd)
     s.localport = this.localport
@@ -183,10 +261,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     connect(new InetSocketAddress(address, port), 0)
   }
 
-  override def connect(address: SocketAddress, timeout: Int): Unit = {
-
-    throwIfClosed("connect") // Do not send negative fd.fd to poll()
-
+  private def connect4(address: SocketAddress, timeout: Int): Unit = {
     val inetAddr = address.asInstanceOf[InetSocketAddress]
     val hints = stackalloc[addrinfo]()
     val ret = stackalloc[Ptr[addrinfo]]()
@@ -244,6 +319,63 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
         "Could not resolve a local port when connecting"
       )
     }
+  }
+
+  private def connect6(address: SocketAddress, timeout: Int): Unit = {
+    val insAddr = address.asInstanceOf[InetSocketAddress]
+
+    val sa6 = stackalloc[in.sockaddr_in6]()
+
+    // By contract, all the bytes in sa6 are zero going in.
+    prepareSockaddrIn6(insAddr.getAddress, insAddr.getPort, sa6)
+
+    if (timeout != 0)
+      setSocketFdBlocking(fd, blocking = false)
+
+    val connectRet = socket.connect(
+      fd.fd,
+      sa6.asInstanceOf[Ptr[socket.sockaddr]],
+      sizeof[in.sockaddr_in6].toUInt
+    )
+
+    if (connectRet < 0) {
+      def inProgress = mapLastError(
+        onUnix = _ == EINPROGRESS,
+        onWindows = {
+          case WSAEINPROGRESS | WSAEWOULDBLOCK => true
+          case _                               => false
+        }
+      )
+
+      if (timeout > 0 && inProgress) {
+        tryPollOnConnect(timeout)
+      } else {
+        val ra = insAddr.getAddress.getHostAddress()
+        throw new ConnectException(
+          s"Could not connect to address: ${ra}"
+            + s" on port: ${insAddr.getPort}"
+            + s", errno: ${lastError()}"
+        )
+      }
+    }
+
+    this.address = insAddr.getAddress
+    this.port = insAddr.getPort
+    this.localport = fetchLocalPort(sa6.sin6_family.toInt).getOrElse {
+      throw new ConnectException(
+        "Could not resolve a local port when connecting"
+      )
+    }
+  }
+
+  override def connect(address: SocketAddress, timeout: Int): Unit = {
+    throwIfClosed("connect") // Do not send negative fd.fd to poll()
+
+    val useIPv4Only = SocketHelpers.getPreferIPv4Stack()
+    val connectFunc =
+      if (useIPv4Only) connect4(_: SocketAddress, _: Int)
+      else connect6(_: SocketAddress, _: Int)
+    connectFunc(address, timeout)
   }
 
   override def close(): Unit = {

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -132,7 +132,7 @@ private[net] trait InetAddressBase {
     } else {
       val ip = SocketHelpers.hostToIp(host).getOrElse {
         throw new UnknownHostException(
-          "No IP address could be found for the specified host: " + host
+          host + ": Name or service not known"
         )
       }
       if (isValidIPv4Address(ip))
@@ -158,7 +158,7 @@ private[net] trait InetAddressBase {
     val ips: Array[String] = SocketHelpers.hostToIpArray(host)
     if (ips.isEmpty) {
       throw new UnknownHostException(
-        "No IP address could be found for the specified host: " + host
+        host + ": Name or service not known"
       )
     }
 

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -9,9 +9,6 @@ import java.util.StringTokenizer
 // Ported from Apache Harmony
 private[net] trait InetAddressBase {
 
-  private[net] val wildcard =
-    new Inet4Address(Array[Byte](0, 0, 0, 0), "0.0.0.0")
-
   def getByName(host: String): InetAddress = {
 
     if (host == null || host.length == 0)
@@ -349,9 +346,26 @@ private[net] trait InetAddressBase {
     true
   }
 
-  private val loopback = new Inet4Address(Array[Byte](127, 0, 0, 1))
+  private lazy val loopbackIPv4 = new Inet4Address(Array[Byte](127, 0, 0, 1))
+  private lazy val loopbackIPv6 = new Inet6Address(
+    Array[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
+  )
 
-  def getLoopbackAddress(): InetAddress = loopback
+  def getLoopbackAddress(): InetAddress =
+    if (SocketHelpers.getPreferIPv6Addresses()) loopbackIPv6
+    else loopbackIPv4
+
+  private lazy val wildcardIPv4 =
+    new Inet4Address(Array[Byte](0, 0, 0, 0), "0.0.0.0")
+
+  private lazy val wildcardIPv6 = new Inet6Address(
+    Array[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+    "0:0:0:0:0:0:0:0"
+  )
+
+  private[net] def getWildcardAddress(): InetAddress =
+    if (SocketHelpers.getPreferIPv6Addresses()) wildcardIPv6
+    else wildcardIPv4
 
   private def byteArrayFromIPString(ip: String): Array[Byte] = {
     if (isValidIPv4Address(ip))

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -618,22 +618,26 @@ class InetAddress private[net] (
       // remember the host given to the constructor
       originalHost
     } else {
-      // reverse name lookup with cache
-      val timeNow = time(null)
-      if (cachedHost == null || hostTimeoutExpired(timeNow)) {
-        hostLastUpdated = timeNow
-        val ipString = createIPStringFromByteArray(ipAddress)
-        SocketHelpers.ipToHost(ipString, isValidIPv6Address(ipString)) match {
-          case None =>
-            lastLookupFailed = true
-            cachedHost = ipString
-          case Some(hostName) =>
-            lastLookupFailed = false
-            cachedHost = hostName
-        }
-      }
-      cachedHost
+      getCanonicalHostName()
     }
+  }
+
+  def getCanonicalHostName(): String = {
+    // reverse name lookup with cache
+    val timeNow = time(null)
+    if (cachedHost == null || hostTimeoutExpired(timeNow)) {
+      hostLastUpdated = timeNow
+      val ipString = createIPStringFromByteArray(ipAddress)
+      SocketHelpers.ipToHost(ipString, isValidIPv6Address(ipString)) match {
+        case None =>
+          lastLookupFailed = true
+          cachedHost = ipString
+        case Some(hostName) =>
+          lastLookupFailed = false
+          cachedHost = hostName
+      }
+    }
+    cachedHost
   }
 
   def getAddress() = ipAddress.clone

--- a/javalib/src/main/scala/java/net/InetSocketAddress.scala
+++ b/javalib/src/main/scala/java/net/InetSocketAddress.scala
@@ -6,7 +6,7 @@ import scala.util.Try
 @SerialVersionUID(1L)
 class InetSocketAddress private[net] (
     private var addr: InetAddress,
-    private val port: Int,
+    private val port: Int, // host presentation order
     private var hostName: String,
     needsResolving: Boolean
 ) extends SocketAddress {
@@ -20,7 +20,7 @@ class InetSocketAddress private[net] (
 
   if (needsResolving) {
     if (addr == null) {
-      addr = InetAddress.wildcard
+      addr = InetAddress.getWildcardAddress()
     }
     hostName = addr.getHostAddress()
   }
@@ -33,8 +33,11 @@ class InetSocketAddress private[net] (
 
   private val isResolved = (addr != null)
 
-  def this(port: Int) =
-    this(InetAddress.wildcard, port, InetAddress.wildcard.getHostName(), false)
+  def this(port: Int) = {
+    this(null, port, null, false)
+    addr = InetAddress.getWildcardAddress()
+    hostName = addr.getHostName()
+  }
 
   def this(hostname: String, port: Int) =
     this(

--- a/javalib/src/main/scala/java/net/ServerSocket.scala
+++ b/javalib/src/main/scala/java/net/ServerSocket.scala
@@ -14,20 +14,11 @@ class ServerSocket(
   private var bound = false
   private var closed = false
 
-  if (bindAddr == null) {
-    bindAddr = InetAddress.wildcard
-  }
+  if (bindAddr == null)
+    bindAddr = InetAddress.getWildcardAddress()
 
-  if (port >= 0) {
+  if (port >= 0)
     startup()
-  }
-
-  def startup(): Unit = {
-    impl.create(true)
-    bind(new InetSocketAddress(bindAddr, port), backlog)
-    created = true
-    bound = true
-  }
 
   def this() =
     this(-1, 50, null)
@@ -38,15 +29,24 @@ class ServerSocket(
   def this(port: Int, backlog: Int) =
     this(port, backlog, null)
 
-  private def checkClosedAndCreate: Unit = {
-    if (closed) {
-      throw new SocketException("Socket is closed")
-    }
+  private def create(): Unit = {
+    // Sockets & ServerSockets always stream.
+    impl.create(stream = true)
+    created = true
+  }
 
-    if (!created) {
-      impl.create(true)
-      created = true
-    }
+  private def startup(): Unit = {
+    this.create()
+    bind(new InetSocketAddress(bindAddr, port), backlog)
+    bound = true
+  }
+
+  private def checkClosedAndCreate: Unit = {
+    if (closed)
+      throw new SocketException("Socket is closed")
+
+    if (!created)
+      this.create()
   }
 
   def accept: Socket = {

--- a/javalib/src/main/scala/java/net/UnixPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/UnixPlainSocketImpl.scala
@@ -14,8 +14,22 @@ import java.io.{FileDescriptor, IOException}
 private[net] class UnixPlainSocketImpl extends AbstractPlainSocketImpl {
 
   override def create(streaming: Boolean): Unit = {
-    val sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-    if (sock < 0) throw new IOException("Couldn't create a socket")
+    val af =
+      if (SocketHelpers.getPreferIPv4Stack()) socket.AF_INET
+      else socket.AF_INET6
+
+    val sockType =
+      if (streaming) socket.SOCK_STREAM
+      else socket.SOCK_DGRAM
+
+    val sock = socket.socket(af, sockType, 0)
+
+    if (sock < 0)
+      throw new IOException(
+        s"Could not create a socket in address family: ${af}" +
+          " streaming: ${streaming}"
+      )
+
     fd = new FileDescriptor(sock)
   }
 

--- a/posixlib/src/main/resources/scala-native/sys/socket.c
+++ b/posixlib/src/main/resources/scala-native/sys/socket.c
@@ -354,7 +354,7 @@ long scalanative_recvmsg(int socket, struct msghdr *msg, int flags) {
 #endif // unix
 
 #ifdef _WIN32
-long scalanative_sendmsg(int socket, struct msghdr *msg, int flags) {
+long scalanative_sendmsg(int socket, void *msg, int flags) {
     errno = ENOTSUP;
     return -1;
 }

--- a/unit-tests/shared/src/test/scala/javalib/net/Inet6AddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/Inet6AddressTest.scala
@@ -80,11 +80,13 @@ class Inet6AddressTest {
 
   @Test def getByAddress(): Unit = {
     assertThrows(
+      "123: Name or service not known",
       classOf[UnknownHostException],
       Inet6Address.getByAddress("123", null, 0)
     )
     val addr1 = Array[Byte](127.toByte, 0.toByte, 0.toByte, 1.toByte)
     assertThrows(
+      "123: Name or service not known",
       classOf[UnknownHostException],
       Inet6Address.getByAddress("123", addr1, 0)
     )

--- a/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
@@ -77,6 +77,12 @@ class InetAddressTest {
 
     val i3 = InetAddress.getByName(String.valueOf(0xffffffffL))
     assertEquals("255.255.255.255", i3.getHostAddress())
+
+    assertThrows(
+      "not.example.com: Name or service not known",
+      classOf[UnknownHostException],
+      InetAddress.getByName("not.example.com")
+    )
   }
 
   @Test def getHostAddress(): Unit = {

--- a/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
@@ -9,6 +9,8 @@ import org.junit.Assert._
 
 import scalanative.junit.utils.AssertThrows.assertThrows
 
+import org.scalanative.testsuite.utils.Platform
+
 class InetAddressTest {
 
   @Test def equalsShouldWorkOnLocalhostsFromGetByName(): Unit = {
@@ -39,6 +41,12 @@ class InetAddressTest {
     val all = InetAddress.getAllByName("localhost")
     assertFalse(all == null)
     assertTrue(all.length >= 1)
+
+    if (!Platform.isWindows) {
+      // TODO remove filter on main
+      for (alias <- all; if alias.isInstanceOf[Inet4Address])
+        assertTrue(alias.getCanonicalHostName().startsWith("localhost"))
+    }
 
     for (alias <- all)
       assertTrue(alias.getHostName().startsWith("localhost"))

--- a/unit-tests/shared/src/test/scala/javalib/net/ServerSocketTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/ServerSocketTest.scala
@@ -10,7 +10,7 @@ import scalanative.junit.utils.AssertThrows.assertThrows
 class ServerSocketTest {
 
   @Test def bind(): Unit = {
-    val s1 = new ServerSocket
+    val s1 = new ServerSocket()
     try {
       val addr = new InetSocketAddress(InetAddress.getLoopbackAddress, 0)
 
@@ -23,8 +23,8 @@ class ServerSocketTest {
       )
       assertTrue(s1.isBound)
 
-      val s2 = new ServerSocket
-      val s3 = new ServerSocket // creating new socket unlikely to throw.
+      val s2 = new ServerSocket()
+      val s3 = new ServerSocket() // creating new socket unlikely to throw.
       try {
         s2.bind(addr)
         assertThrows(classOf[BindException], s3.bind(s2.getLocalSocketAddress))
@@ -36,7 +36,7 @@ class ServerSocketTest {
       s1.close()
     }
 
-    val s4 = new ServerSocket
+    val s4 = new ServerSocket()
     try {
       assertThrows(
         classOf[BindException],
@@ -48,7 +48,7 @@ class ServerSocketTest {
 
     class UnsupportedSocketAddress extends SocketAddress {}
 
-    val s5 = new ServerSocket
+    val s5 = new ServerSocket()
     try {
       assertThrows(
         classOf[IllegalArgumentException],
@@ -97,7 +97,7 @@ class ServerSocketTest {
         s1.toString
       )
 
-      val s2 = new ServerSocket
+      val s2 = new ServerSocket()
       try {
         assertEquals("ServerSocket[unbound]", s2.toString)
 

--- a/unit-tests/shared/src/test/scala/javalib/net/SocketTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/SocketTest.scala
@@ -5,6 +5,7 @@ import java.net._
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
+import org.junit.Ignore
 
 import org.scalanative.testsuite.utils.Platform
 import scalanative.junit.utils.AssertThrows.assertThrows
@@ -167,20 +168,21 @@ class SocketTest {
   }
 
   @Test def bind(): Unit = {
-    val s1 = new Socket
+    val s1 = new Socket()
     try {
       val nonLocalAddr =
         new InetSocketAddress(InetAddress.getByName("123.123.123.123"), 0)
-      assertThrows(classOf[BindException], s1.bind(nonLocalAddr))
+      assertThrows("a1", classOf[BindException], s1.bind(nonLocalAddr))
     } finally {
       s1.close()
     }
 
-    val s2 = new Socket
+    val s2 = new Socket()
     try {
       s2.bind(new InetSocketAddress(InetAddress.getLoopbackAddress, 0))
       val port = s2.getLocalPort
       assertEquals(
+        "a2",
         new InetSocketAddress(InetAddress.getLoopbackAddress, port),
         s2.getLocalSocketAddress
       )
@@ -188,20 +190,24 @@ class SocketTest {
       s2.close()
     }
 
-    val s3 = new Socket
+    val s3 = new Socket()
     try {
       s3.bind(null)
-      assertTrue(s3.getLocalSocketAddress != null)
+      assertTrue("a3", s3.getLocalSocketAddress != null)
     } finally {
       s3.close()
     }
 
-    val s4 = new Socket
+    val s4 = new Socket()
     try {
       s4.bind(new InetSocketAddress(InetAddress.getLoopbackAddress, 0))
-      val s5 = new Socket
+      val s5 = new Socket()
       try {
-        assertThrows(classOf[BindException], s5.bind(s4.getLocalSocketAddress))
+        assertThrows(
+          "a4",
+          classOf[BindException],
+          s5.bind(s4.getLocalSocketAddress)
+        )
       } finally {
         s5.close()
       }
@@ -210,9 +216,10 @@ class SocketTest {
     }
 
     class UnsupportedSocketAddress extends SocketAddress
-    val s6 = new Socket
+    val s6 = new Socket()
     try {
       assertThrows(
+        "a5",
         classOf[IllegalArgumentException],
         s6.bind(new UnsupportedSocketAddress)
       )


### PR DESCRIPTION
We add IPv6 TCP, a.k.a streaming, support to javalib net on Unix-like systems.

This allows Scala Native programs using javalib TCP sockets to use a more efficient
network protocol.

This capability will probably be most used by programs ported from JVM or ScalaJVM.
posixlib sockets offer much finer control with less internal overhead.

The "Java Standard Library" section of the ReadTheDocs Scala Native documentation
is updated in the PR and provides the best description of the new IPv6 support.

The TL;DR is that if a Scala Native JVM program is using IPv6 successfully, then
that program should work with this new IPv6 support.

 This work follows the two decade long precedent of the JVM in silently
enabling the use of IPv6 if any network interface, other than the loopback
interface, is configured for IPv6.  Programs can execute code to
disable that default enabling.   

This PR incorporates the changes from two network related PRs that
were merged in the 0.4.x stream.

It has benefited from review and discussion in WIP PR #2484, which
it supersedes.