### PR TITLE
Make sure `clean` command is applied to all projects

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -30,6 +30,7 @@ object Build {
           val allProjects: Seq[Project] = Seq(
               sbtScalaNative
             ) ++ Seq(
+                nir, util, tools,
                 nscPlugin, junitPlugin,
                 nativelib, clib, posixlib, windowslib,
                 auxlib, javalib, javalibExtDummies, scalalib,


### PR DESCRIPTION
Fixes #2733
Projects `nir`, `util`, and `tools` were not included in aggregations of the `clean` command. This lead to preserving some of the files when releasing new version