### PR TITLE
Fix #2832: A step towards posixlib using shared types

### DIFF
--- a/posixlib/src/main/resources/scala-native/sys/stat.c
+++ b/posixlib/src/main/resources/scala-native/sys/stat.c
@@ -81,14 +81,6 @@ int scalanative_lstat(char *path, struct scalanative_stat *buf) {
     }
 }
 
-int scalanative_mkdir(char *path, mode_t mode) { return mkdir(path, mode); }
-
-int scalanative_chmod(char *pathname, mode_t mode) {
-    return chmod(pathname, mode);
-}
-
-int scalanative_fchmod(int fd, mode_t mode) { return fchmod(fd, mode); }
-
 mode_t scalanative_s_isuid() { return S_ISUID; }
 
 mode_t scalanative_s_isgid() { return S_ISGID; }

--- a/posixlib/src/main/scala/scala/scalanative/posix/grp.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/grp.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package posix
 
 import scalanative.unsafe.{CInt, CString, CStruct3, extern, name, Ptr}
-import scalanative.posix.sys.stat.gid_t
+import scalanative.posix.sys.types.gid_t
 
 @extern
 object grp {

--- a/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/pwd.scala
@@ -2,7 +2,7 @@ package scala.scalanative
 package posix
 
 import scalanative.unsafe.{CInt, CString, CStruct5, extern, name, Ptr}
-import scalanative.posix.sys.stat.{uid_t, gid_t}
+import scalanative.posix.sys.types.{uid_t, gid_t}
 
 @extern
 object pwd {

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/stat.scala
@@ -4,18 +4,46 @@ package sys
 
 import scalanative.unsafe._
 import scalanative.posix.time._
+import scalanative.posix.sys.types._
+
+import scalanative.meta.LinktimeInfo.is32BitPlatform
 
 @extern
 object stat {
+
+  /* This file is incomplete and DOES NOT comply with POSIX 2018.
+   * It is useful in the time before it can be brought into compliance.
+   */
+
+  /* POSIX states that these types be declared "as described in <sys/types.h>".
+   *
+   * Although not face evident, that requirement is met here on 64 bit systems.
+   * The various C*Long fields here and in types.h all describe 64 bits.
+   *
+   * 32 bit systems meet the requirement except for 4 types:
+   * dev_t, ino_t, off_t, and blkcnt_t.
+   *
+   * Socket.c uses the variant types on 32 bit systems to adapt to differences
+   * in how operating systems declare the type. That code is hard to follow
+   * but seems to work; do not disturb its tranquility in the search for
+   * purity or yours may be disturbed as a consequence.
+   *
+   * Because this is an "@extern" object, LinktimeInfo can not be used.
+   * expressions, including necessary "if", are not allowed in such objects.
+   */
+
+  // Declare in the order they are used in 'struct stat'
   type dev_t = CUnsignedLong
   type ino_t = CUnsignedLongLong
-  type mode_t = CUnsignedInt
-  type nlink_t = CUnsignedLong
-  type uid_t = CUnsignedInt
-  type gid_t = CUnsignedInt
+  type uid_t = types.uid_t
+  type gid_t = types.gid_t
   type off_t = CLongLong
-  type blksize_t = CLong
+  type blksize_t = types.blksize_t
   type blkcnt_t = CLongLong
+  type nlink_t = types.nlink_t
+  type mode_t = types.mode_t
+
+  // This structure is _not_ a candidate for direct pass-thru to OS.
   type stat = CStruct13[
     dev_t, // st_dev
     dev_t, // st_rdev
@@ -41,13 +69,9 @@ object stat {
   @name("scalanative_lstat")
   def lstat(path: CString, buf: Ptr[stat]): CInt = extern
 
-  @name("scalanative_mkdir")
+  // mkdir(), chmod(), & fchmod() are straight passthrough; "glue" needed.
   def mkdir(path: CString, mode: mode_t): CInt = extern
-
-  @name("scalanative_chmod")
   def chmod(pathname: CString, mode: mode_t): CInt = extern
-
-  @name("scalanative_fchmod")
   def fchmod(fd: CInt, mode: mode_t): CInt = extern
 
   @name("scalanative_s_isdir")


### PR DESCRIPTION
fix #2832

Several posixlib files now use the shared, common types of `sys/types`, as described in the POSIX 2018 
specification.  `stat.scala` now uses `sys/types` but still requires some types declared in that file
in order to deal with 32/64 bit architectural and operating system differences in the structure
it uses.