### PR TITLE
Fix #2835: Simplify & shorten posixlib time code paths

### DIFF
--- a/posixlib/src/main/resources/scala-native/time.c
+++ b/posixlib/src/main/resources/scala-native/time.c
@@ -118,8 +118,6 @@ _Static_assert(offsetof(struct scalanative_itimerspec, it_value) ==
 #endif
 #endif // __STDC_VERSION__
 
-static struct scalanative_tm scalanative_shared_tm_buf;
-
 static void scalanative_tm_init(struct scalanative_tm *scala_tm,
                                 struct tm *tm) {
     scala_tm->tm_sec = tm->tm_sec;
@@ -133,33 +131,6 @@ static void scalanative_tm_init(struct scalanative_tm *scala_tm,
     scala_tm->tm_isdst = tm->tm_isdst;
 }
 
-static void tm_init(struct tm *tm, struct scalanative_tm *scala_tm) {
-    tm->tm_sec = scala_tm->tm_sec;
-    tm->tm_min = scala_tm->tm_min;
-    tm->tm_hour = scala_tm->tm_hour;
-    tm->tm_mday = scala_tm->tm_mday;
-    tm->tm_mon = scala_tm->tm_mon;
-    tm->tm_year = scala_tm->tm_year;
-    tm->tm_wday = scala_tm->tm_wday;
-    tm->tm_yday = scala_tm->tm_yday;
-    tm->tm_isdst = scala_tm->tm_isdst;
-    // On BSD-like systems or with glibc sizeof(tm) is greater than
-    // sizeof(scalanative_tm), so contents of rest of tm is left undefined.
-    // asctime, asctime_r, mktime, gmtime, & gmtime_r are robust to this.
-    // strftime is _NOT_ and must zero the excess fields itself.
-}
-
-char *scalanative_asctime_r(struct scalanative_tm *scala_tm, char *buf) {
-    struct tm tm;
-    tm_init(&tm, scala_tm);
-    return asctime_r(&tm, buf);
-}
-
-char *scalanative_asctime(struct scalanative_tm *scala_tm) {
-    struct tm tm;
-    tm_init(&tm, scala_tm);
-    return asctime(&tm);
-}
 int scalanative_clock_nanosleep(clockid_t clockid, int flags,
                                 struct timespec *request,
                                 struct timespec *remain) {
@@ -171,97 +142,78 @@ int scalanative_clock_nanosleep(clockid_t clockid, int flags,
 #endif
 }
 
-struct scalanative_tm *scalanative_gmtime_r(const time_t *clock,
-                                            struct scalanative_tm *result) {
-    struct tm tm;
-    gmtime_r(clock, &tm);
-    scalanative_tm_init(result, &tm);
-    return result;
-}
-
-struct scalanative_tm *scalanative_gmtime(const time_t *clock) {
-    return scalanative_gmtime_r(clock, &scalanative_shared_tm_buf);
-}
-
-struct scalanative_tm *scalanative_localtime_r(const time_t *clock,
-                                               struct scalanative_tm *result) {
-    struct tm tm;
-    localtime_r(clock, &tm);
-    scalanative_tm_init(result, &tm);
-    return result;
-}
-
-struct scalanative_tm *scalanative_localtime(const time_t *clock) {
-    // Calling localtime() ensures that tzset() has been called.
-    scalanative_tm_init(&scalanative_shared_tm_buf, localtime(clock));
-    return &scalanative_shared_tm_buf;
-}
-
-time_t scalanative_mktime(struct scalanative_tm *result) {
-    struct tm tm;
-    tm_init(&tm, result);
-    return mktime(&tm);
-}
-
 size_t scalanative_strftime(char *buf, size_t maxsize, const char *format,
                             struct scalanative_tm *scala_tm) {
 
-    // The operating system struct tm can be larger than
-    // the scalanative tm.  On 64 bit GNU or _BSD_SOURCE Linux this
-    // usually is true and beyond easy control.
-    //
-    // Clear any fields not known to scalanative, such as tm_zone,
-    // so they are zero/NULL, not J-Random garbage.
-    // strftime() in Scala Native release mode is particularly sensitive
-    // to garbage beyond the end of the scalanative tm.
+    /* The operating system struct tm can be larger than
+     * the scalanative tm.  On 64 bit GNU or _BSD_SOURCE Linux this
+     * usually is true and beyond easy control.
+     *
+     * The C designated initializer idiom will clear any fields not explicitly
+     * named, such as tm_zone and anything beyond the end of scalanative tm.
+     *
+     * strftime() in Scala Native release mode is particularly sensitive
+     * to garbage beyond the end of the scalanative tm.
+     */
+    struct tm tm = {.tm_sec = scala_tm->tm_sec,
+                    .tm_min = scala_tm->tm_min,
+                    .tm_hour = scala_tm->tm_hour,
+                    .tm_mday = scala_tm->tm_mday,
+                    .tm_mon = scala_tm->tm_mon,
+                    .tm_year = scala_tm->tm_year,
+                    .tm_wday = scala_tm->tm_wday,
+                    .tm_yday = scala_tm->tm_yday,
+                    .tm_isdst = scala_tm->tm_isdst};
 
-    // Initializing all of tm when part of it will be immediately overwritten
-    // is _slightly_ inefficient but short, simple, and easy to get right.
-
-    struct tm tm = {0};
-    tm_init(&tm, scala_tm);
     return strftime(buf, maxsize, format, &tm);
 }
 
 // XSI
 char *scalanative_strptime(const char *s, const char *format,
                            struct scalanative_tm *scala_tm) {
-    // Note Well:
-    //
-    // Reference: "The Open Group Base Specifications Issue 7, 2018 edition".
-    // A long comment for a deceptively complicated standard and implementation
-    // thereof.
-    //
-    // 1) Hazard Alert! Booby trap ahead.
-    //
-    //    Only the fields in the "scalanative_tm" argument with explicit
-    //    conversion specifiers in the format argument are reliably
-    //    and portably set. Other fields may or may not be written.
-    //
-    //    The "APPLICATION USAGE" section of the specification says
-    //    that the contents of a second call to this method with the
-    //    same "struct tm" are unspecified (implementation dependent).
-    //    The "struct tm" may be updated (leaving some fields untouched)
-    //    or completely overwritten. If the structure is overwritten,
-    //    the value used to overwrite fields not in the format is
-    //    also specified.
-    //
-    //    The implies, but does not state, that the value of fields
-    //    not in the format may stay the same or change.
-    //
-    //    There is no specifier for the is_dst field. The non-binding example
-    //    describes that field as not set by strptime(). This supports, but
-    //    does not specify, the idea that fields not in the format are
-    //    untouched. Caveat Utilitor (user beware)!
-    //
-    //
-    // 2) This implementation is slightly nonconforming, but useful,
-    //    in that the format argument is passed directly to the underlying
-    //    libc. This means that conversions specifiers such as "%Z"
-    //    supported by Posix strftime(), glibc, and macOS will will not
-    //    be reported as parse errors at this level.
+    /* Note Well:
+     *
+     * Reference: "The Open Group Base Specifications Issue 7, 2018 edition".
+     * A long comment for a deceptively complicated standard and implementation
+     * thereof.
+     *
+     * 1) Hazard Alert! Booby trap ahead.
+     *
+     *    Only the fields in the "scalanative_tm" argument with explicit
+     *    conversion specifiers in the format argument are reliably
+     *    and portably set. Other fields may or may not be written.
+     *
+     *    The "APPLICATION USAGE" section of the specification says
+     *    that the contents of a second call to this method with the
+     *    same "struct tm" are unspecified (implementation dependent).
+     *    The "struct tm" may be updated (leaving some fields untouched)
+     *    or completely overwritten. If the structure is overwritten,
+     *    the value used to overwrite fields not in the format is
+     *    also specified.
+     *
+     *    The implies, but does not state, that the value of fields
+     *    not in the format may stay the same or change.
+     *
+     *    There is no specifier for the is_dst field. The non-binding example
+     *    describes that field as not set by strptime(). This supports, but
+     *    does not specify, the idea that fields not in the format are
+     *    untouched. Caveat Utilitor (user beware)!
+     *
+     *
+     * 2) This implementation is slightly nonconforming, but useful,
+     *    in that the format argument is passed directly to the underlying
+     *    libc. This means that conversions specifiers such as "%Z"
+     *    supported by Posix strftime(), glibc, and macOS will will not
+     *    be reported as parse errors at this level.
+     */
 
-    struct tm tm;
+    /* tm and the copy back to scala_tm are needed because strptime()
+     * could and does write beyond the end of a scala_tm.
+     * Initialize all of tm to zero. What strptime() does with fields not in
+     * the format may be implementation dependent.
+     */
+
+    struct tm tm = {0};
 
     char *result = strptime(s, format, &tm);
     scalanative_tm_init(scala_tm, &tm);
@@ -367,7 +319,7 @@ int scalanative_timer_abstime() {
 #if !defined(__APPLE__)
     return TIMER_ABSTIME;
 #else
-    return 1; // Fake it, using "know" value on some systems.
+    return 1; // Fake it, using value "known" on some systems.
 #endif
 }
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -65,21 +65,13 @@ object time {
    * _Static_assert code now in time.c checks the match of scalanative
    * structures such as timespec and tm with the operating system definition.
    * "clock_*" & "timer_*" use this assurance to avoid "glue".
-   *
-   * Some methods which now do not strictly need "@name" annotations
-   * retain them for historical reasons.
    */
 
-  @name("scalanative_asctime")
   def asctime(time_ptr: Ptr[tm]): CString = extern
-
-  @name("scalanative_asctime_r")
   def asctime_r(time_ptr: Ptr[tm], buf: Ptr[CChar]): CString = extern
 
   def clock(): clock_t = extern
-
   def clock_getres(clockid: clockid_t, res: Ptr[timespec]): CInt = extern
-
   def clock_gettime(clockid: clockid_t, tp: Ptr[timespec]): CInt = extern
 
   // No clock_nanosleep on macOS. time.c provides a stub always returning -1.
@@ -92,25 +84,17 @@ object time {
   ): CInt = extern
 
   def clock_settime(clockid: clockid_t, tp: Ptr[timespec]): CInt = extern
-
   def ctime(time: Ptr[time_t]): CString = extern
   def ctime_r(time: Ptr[time_t], buf: Ptr[CChar]): CString = extern
 
   def difftime(time_end: CLong, time_beg: CLong): CDouble = extern
 
-  @name("scalanative_gmtime")
   def gmtime(time: Ptr[time_t]): Ptr[tm] = extern
-
-  @name("scalanative_gmtime_r")
   def gmtime_r(time: Ptr[time_t], tm: Ptr[tm]): Ptr[tm] = extern
 
-  @name("scalanative_localtime")
   def localtime(time: Ptr[time_t]): Ptr[tm] = extern
-
-  @name("scalanative_localtime_r")
   def localtime_r(time: Ptr[time_t], tm: Ptr[tm]): Ptr[tm] = extern
 
-  @name("scalanative_mktime")
   def mktime(time: Ptr[tm]): time_t = extern
 
   def nanosleep(requested: Ptr[timespec], remaining: Ptr[timespec]): CInt =
@@ -213,7 +197,7 @@ object timer {
    *    no special linking is needed.  Include this object and link away.
    *
    * 2) Many/most operating systems require that the linker "-lrt" be specified
-   *    so that the real time library, librt, is can be used to resolve the
+   *    so that the real time library, librt, is used to resolve the
    *    timer_* symbols.
    *
    * 3) macOS does not provide librt and has it own, entirely different, way of


### PR DESCRIPTION
Remove unnecessary calls to C "glue".  Should be no functional change to methods.
After a suitable 0.5.0 seasoning period these changes are applicable to 0.4.x.

Among other things, the changes of this PR make it easier to trace & review
the code. Less of a need to ask: Why do these have glue and apparently
equivalent other methods do not?

A few methods remain where the "glue" is essential to correct behavior.

To keep concerns separate & identifiable, this PR _does_not_ contain the 
changes of pending PR #2665.  That PR is still applicable & relevant.

I am hoping the two merge cleanly. Otherwise I will monitor & rebase.

fix #2835