### PR TITLE
Append in loop instead of creating indented string

### DIFF
--- a/util/src/main/scala/scala/scalanative/util/ShowBuilder.scala
+++ b/util/src/main/scala/scala/scalanative/util/ShowBuilder.scala
@@ -32,7 +32,9 @@ sealed trait ShowBuilder {
 
   def newline(): Unit = {
     out.append("\n")
-    out.append("  " * indentation)
+    for (_ <- 0.until(indentation)) {
+      out.append("  ")
+    }
   }
 
 }


### PR DESCRIPTION
Manually tested to be 1.56x faster on indentation 2 and 2.06x faster on
indentation 10