### PR TITLE
Fix #2843: 0.4.x: javalib now never returns IPv6 addresses

### DIFF
--- a/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/AbstractPlainSocketImpl.scala
@@ -92,7 +92,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
   override def bind(addr: InetAddress, port: Int): Unit = {
     val hints = stackalloc[addrinfo]()
     val ret = stackalloc[Ptr[addrinfo]]()
-    hints.ai_family = socket.AF_UNSPEC
+    hints.ai_family = socket.AF_INET
     hints.ai_flags = AI_NUMERICHOST
     hints.ai_socktype = socket.SOCK_STREAM
 
@@ -188,7 +188,7 @@ private[net] abstract class AbstractPlainSocketImpl extends SocketImpl {
     val inetAddr = address.asInstanceOf[InetSocketAddress]
     val hints = stackalloc[addrinfo]()
     val ret = stackalloc[Ptr[addrinfo]]()
-    hints.ai_family = socket.AF_UNSPEC
+    hints.ai_family = socket.AF_INET
     hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV
     hints.ai_socktype = socket.SOCK_STREAM
     val remoteAddress = inetAddr.getAddress.getHostAddress()

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -46,7 +46,7 @@ object SocketHelpers {
       val hints = stackalloc[addrinfo]()
       val ret = stackalloc[Ptr[addrinfo]]()
 
-      hints.ai_family = AF_UNSPEC
+      hints.ai_family = AF_INET
       hints.ai_protocol = 0
       hints.ai_addr = null
       hints.ai_flags = 4 // AI_NUMERICHOST
@@ -130,7 +130,7 @@ object SocketHelpers {
       val ret = stackalloc[Ptr[addrinfo]]()
 
       val ipstr: Ptr[CChar] = stackalloc[CChar]((INET6_ADDRSTRLEN + 1).toUInt)
-      hints.ai_family = AF_UNSPEC
+      hints.ai_family = AF_INET
       hints.ai_socktype = 0
       hints.ai_next = null
 
@@ -163,7 +163,7 @@ object SocketHelpers {
       val hints = stackalloc[addrinfo]()
       val ret = stackalloc[Ptr[addrinfo]]()
 
-      hints.ai_family = AF_UNSPEC
+      hints.ai_family = AF_INET
       hints.ai_socktype = SOCK_STREAM
       hints.ai_protocol = 0
       hints.ai_next = null


### PR DESCRIPTION
 fix #2843  for the SN 0.4.x stream.

This PR does not need to be merged into the 0.5.0 stream. We want and handle IPv6 addresses there.

Scala Native 0.4.x posixlib contains functioning IPv6 support. The corresponding javalib does not.
This PR ensures that javalib methods which can not properly handle IPv6 addresses never see them,
for most values of never. 
