### PR TITLE
Publish local command for easier local development

### DIFF
--- a/project/Commands.scala
+++ b/project/Commands.scala
@@ -13,7 +13,8 @@ object Commands {
     "test-tools" ::
       "test-mima" ::
       "test-runtime" ::
-      "test-scripted" :: _
+      "test-scripted" ::
+      "publish-local-dev" :: _
   }
 
   lazy val testRuntime = projectVersionCommand("test-runtime") {
@@ -114,6 +115,65 @@ object Commands {
           )
 
         fn(version, state)
+    }
+  }
+
+  private def projectFullVersionCommand(
+      name: String
+  )(fn: (String, State) => State): Command = {
+    Command.args(name, "<args>") {
+      case (state, args) =>
+        val version = args.headOption
+          .getOrElse(
+            "Used command needs explicit full Scala version as an argument"
+          )
+
+        fn(version, state)
+    }
+  }
+
+  lazy val publishLocalDev = {
+    projectFullVersionCommand("publish-local-dev") {
+      case (version, state) =>
+        val binaryVersion = CrossVersion.binaryScalaVersion(version)
+
+        val sbtPluginModules = List(
+          Build.util,
+          nir,
+          tools,
+          testRunner,
+          testInterface,
+          testInterfaceSbtDefs,
+          junitRuntime,
+          nativelib,
+          clib,
+          posixlib,
+          windowslib,
+          auxlib,
+          javalib,
+          scalalib
+        ).map(_.forBinaryVersion("2.12").id).map(id => s"$id/publishLocal")
+
+        val compilerPlugin = nscPlugin.forBinaryVersion(binaryVersion).id
+
+        val runtimeModules = List(
+          nativelib,
+          clib,
+          posixlib,
+          windowslib,
+          auxlib,
+          javalib,
+          scalalib,
+          testInterface,
+          junitRuntime,
+          testInterfaceSbtDefs
+        ).map(_.forBinaryVersion(binaryVersion).id)
+          .map(id => s"$id/publishLocal")
+
+        sbtPluginModules :::
+          List(s"++${version} $compilerPlugin/publishLocal") :::
+          runtimeModules :::
+          state
     }
   }
 


### PR DESCRIPTION
Let's bikeshed on the name!

The purpose of this command is to be able to run

```
sbt> publish-local-dev 3.2.0
```

And get everything published for a project to use a local version of SN with this particular Scala version.
This includes the nscplugin, sbt plugin, and test stuff.

Did I miss any projects?