### PR TITLE
Fix #2841: SN 0.4.n; 0.5.n - complete POSIX string.h, strings.h

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -60,10 +60,10 @@ C Header          Scala Native Module
 `stdio.h`_        N/A
 `stdlib.h`_       scala.scalanative.posix.stdlib_
 `string.h`_       scala.scalanative.posix.string_
-`strings.h`_      N/A
+`strings.h`_      scala.scalanative.posix.strings_
 `stropts.h`_      N/A
 `sys/ipc.h`_      N/A
-`sys/mman.h`_     N/A
+`sys/mman.h`_     scala.scalanative.posix.sys.mman_
 `sys/msg.h`_      N/A
 `sys/resource.h`_ scala.scalanative.posix.sys.resource_
 `sys/select.h`_   scala.scalanative.posix.sys.select_
@@ -202,6 +202,8 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.signal: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
 .. _scala.scalanative.posix.stdlib: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
 .. _scala.scalanative.posix.string: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/string.scala
+.. _scala.scalanative.posix.strings: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/strings.scala
+.. _scala.scalanative.posix.sys.mman: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/mman.scala
 .. _scala.scalanative.posix.sys.resource: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/resource.scala
 .. _scala.scalanative.posix.sys.select: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/select.scala
 .. _scala.scalanative.posix.sys.socket: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sys/socket.scala

--- a/posixlib/src/main/scala/scala/scalanative/posix/locale.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/locale.scala
@@ -1,0 +1,17 @@
+package scala.scalanative
+package posix
+
+import scala.scalanative.unsafe._
+
+@extern
+object locale {
+
+  /* This file/object is a less-than-minimal implementation.
+   * It provides only the type local_t. This allows a common
+   * definition of the type to be used by the several files
+   * required by POSIX to define that type.
+   */
+
+  type locale_t = Ptr[Byte]
+
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/locale.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/locale.scala
@@ -6,10 +6,9 @@ import scala.scalanative.unsafe._
 @extern
 object locale {
 
-  /* This file/object is a less-than-minimal implementation.
-   * It provides only the type local_t. This allows a common
-   * definition of the type to be used by the several files
-   * required by POSIX to define that type.
+  /** This file/object is a less-than-minimal implementation. It provides only
+   *  the type local_t. This allows a common definition of the type to be used
+   *  by the several files required by POSIX to define that type.
    */
 
   type locale_t = Ptr[Byte]

--- a/posixlib/src/main/scala/scala/scalanative/posix/string.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/string.scala
@@ -3,12 +3,14 @@ package scala.scalanative.posix
 import scala.scalanative.unsafe._
 import scala.scalanative.posix.sys.types
 
-// The Open Group Base Specifications Issue 7, 2018 edition
-
-/* A CX comment before a method indicates a POSIX extension to
+/** POSIX string.h for Scala
+ *
+ * The Open Group Base Specifications Issue 7, 2018 edition
+ *
+ * A CX comment before a method indicates a POSIX extension to
  * the ISO/IEEE C standard.
  *
- * An XSI comment before method indicates it is defined in
+ * An XSI comment before a method indicates it is defined in
  * extended POSIX X/Open System Interfaces, not base POSIX.
  */
 
@@ -20,14 +22,12 @@ object string {
 
   type size_t = types.size_t
 
-// CX - Begin
+/** CX */
   type locale_t = locale.locale_t
-// CX - End
 
-// XSI - Begin
+/** XSI */
   def memccpy(dest: Ptr[Byte], src: Ptr[Byte], c: CInt, n: size_t): Ptr[Byte] =
     extern
-// XSI - End
 
   def memchr(s: Ptr[Byte], c: CInt, n: size_t): Ptr[Byte] = extern
   def memcmp(s1: Ptr[Byte], s2: Ptr[Byte], n: size_t): CInt = extern
@@ -35,71 +35,68 @@ object string {
   def memmove(dest: Ptr[Byte], src: Ptr[Byte], n: size_t): Ptr[Byte] = extern
   def memset(s: Ptr[Byte], c: CInt, n: size_t): Ptr[Byte] = extern
 
-// CX - Begin
+/** CX */
   def stpcpy(dest: Ptr[Byte], src: String): Ptr[Byte] = extern
+
+/** CX */
   def stpncpy(dest: Ptr[Byte], src: String, n: size_t): Ptr[Byte] = extern
-// CX - End
 
   def strcat(dest: CString, src: CString): CString = extern
   def strchr(s: CString, c: CInt): CString = extern
   def strcmp(s1: CString, s2: CString): CInt = extern
   def stroll(s1: CString, s2: CString): CInt = extern
 
-// CX - Begin
+/** CX */
   def stroll_l(s1: CString, s2: CString, locale: locale_t): CInt = extern
-// CX - End
 
   def strcpy(dest: CString, src: CString): CString = extern
   def strcspn(s: CString, reject: CString): size_t = extern
 
-// CX - Begin
+/** CX */
   def strdup(s: CString): CString = extern
-// CX - End
 
   def strerror(errnum: CInt): CString = extern
 
-// CX - Begin
+/** CX */
   def strerror_l(errnum: CInt, locale: locale_t): CString = extern
+
+/** CX */
   def strerror_r(errnum: CInt, buf: CString, buflen: size_t): CInt = extern
-// CX - End
 
   def strlen(s: CString): size_t = extern
   def strncat(dest: CString, src: CString, n: size_t): CString = extern
   def strncmp(s1: CString, s2: CString, n: size_t): CInt = extern
   def strcpy(dest: CString, src: CString, n: size_t): CString = extern
 
-// CX - Begin
+/** CX */
   def strndup(s: CString, n: size_t): CString = extern
+
+/** CX */
   def strnlen(s: CString, n: size_t): size_t = extern
-// CX - End
 
   def strpbrk(s: CString, accept: CString): CString = extern
   def strrchr(s: CString, c: CInt): CString = extern
 
-// CX - Begin
+/** CX */
   def strsignal(signum: CInt): CString = extern
-// CX - End
 
   def strspn(s: CString, accept: CString): size_t = extern
   def strstr(haystack: CString, needle: CString): CString = extern
 
-// char    *strtok(char *restrict, const char *restrict);
   def strtok(str: CString, delim: CString): CString = extern
 
-// CX - Begin
+/** CX */
   def strtok_r(str: CString, delim: CString, saveptr: Ptr[Ptr[Byte]]): CString =
     extern
-// CX - End
 
   def strxfrm(dest: Ptr[Byte], src: Ptr[Byte], n: size_t): size_t = extern
 
-// CX - Begin
+/** CX */
   def strxfrm_l(
       dest: Ptr[Byte],
       src: Ptr[Byte],
       n: size_t,
       locale: locale_t
   ): size_t = extern
-// CX - End
 
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/string.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/string.scala
@@ -1,8 +1,105 @@
 package scala.scalanative.posix
 
-import scalanative.unsafe.{extern, CInt, CString}
+import scala.scalanative.unsafe._
+import scala.scalanative.posix.sys.types
+
+// The Open Group Base Specifications Issue 7, 2018 edition
+
+/* A CX comment before a method indicates a POSIX extension to
+ * the ISO/IEEE C standard.
+ *
+ * An XSI comment before method indicates it is defined in
+ * extended POSIX X/Open System Interfaces, not base POSIX.
+ */
 
 @extern
 object string {
+  /* NULL is required by the POSIX standard but is not directly implemented
+   * here. It is implemented in posix/stddef.scala.
+   */
+
+  type size_t = types.size_t
+
+// CX - Begin
+  type locale_t = locale.locale_t
+// CX - End
+
+// XSI - Begin
+  def memccpy(dest: Ptr[Byte], src: Ptr[Byte], c: CInt, n: size_t): Ptr[Byte] =
+    extern
+// XSI - End
+
+  def memchr(s: Ptr[Byte], c: CInt, n: size_t): Ptr[Byte] = extern
+  def memcmp(s1: Ptr[Byte], s2: Ptr[Byte], n: size_t): CInt = extern
+  def memcpy(dest: Ptr[Byte], src: Ptr[Byte], n: size_t): Ptr[Byte] = extern
+  def memmove(dest: Ptr[Byte], src: Ptr[Byte], n: size_t): Ptr[Byte] = extern
+  def memset(s: Ptr[Byte], c: CInt, n: size_t): Ptr[Byte] = extern
+
+// CX - Begin
+  def stpcpy(dest: Ptr[Byte], src: String): Ptr[Byte] = extern
+  def stpncpy(dest: Ptr[Byte], src: String, n: size_t): Ptr[Byte] = extern
+// CX - End
+
+  def strcat(dest: CString, src: CString): CString = extern
+  def strchr(s: CString, c: CInt): CString = extern
+  def strcmp(s1: CString, s2: CString): CInt = extern
+  def stroll(s1: CString, s2: CString): CInt = extern
+
+// CX - Begin
+  def stroll_l(s1: CString, s2: CString, locale: locale_t): CInt = extern
+// CX - End
+
+  def strcpy(dest: CString, src: CString): CString = extern
+  def strcspn(s: CString, reject: CString): size_t = extern
+
+// CX - Begin
+  def strdup(s: CString): CString = extern
+// CX - End
+
+  def strerror(errnum: CInt): CString = extern
+
+// CX - Begin
+  def strerror_l(errnum: CInt, locale: locale_t): CString = extern
+  def strerror_r(errnum: CInt, buf: CString, buflen: size_t): CInt = extern
+// CX - End
+
+  def strlen(s: CString): size_t = extern
+  def strncat(dest: CString, src: CString, n: size_t): CString = extern
+  def strncmp(s1: CString, s2: CString, n: size_t): CInt = extern
+  def strcpy(dest: CString, src: CString, n: size_t): CString = extern
+
+// CX - Begin
+  def strndup(s: CString, n: size_t): CString = extern
+  def strnlen(s: CString, n: size_t): size_t = extern
+// CX - End
+
+  def strpbrk(s: CString, accept: CString): CString = extern
+  def strrchr(s: CString, c: CInt): CString = extern
+
+// CX - Begin
   def strsignal(signum: CInt): CString = extern
+// CX - End
+
+  def strspn(s: CString, accept: CString): size_t = extern
+  def strstr(haystack: CString, needle: CString): CString = extern
+
+// char    *strtok(char *restrict, const char *restrict);
+  def strtok(str: CString, delim: CString): CString = extern
+
+// CX - Begin
+  def strtok_r(str: CString, delim: CString, saveptr: Ptr[Ptr[Byte]]): CString =
+    extern
+// CX - End
+
+  def strxfrm(dest: Ptr[Byte], src: Ptr[Byte], n: size_t): size_t = extern
+
+// CX - Begin
+  def strxfrm_l(
+      dest: Ptr[Byte],
+      src: Ptr[Byte],
+      n: size_t,
+      locale: locale_t
+  ): size_t = extern
+// CX - End
+
 }

--- a/posixlib/src/main/scala/scala/scalanative/posix/string.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/string.scala
@@ -5,12 +5,13 @@ import scala.scalanative.posix.sys.types
 
 /** POSIX string.h for Scala
  *
- *  The Open Group Base Specifications Issue 7, 2018 edition
+ *  The Open Group Base Specifications
+ *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
  *
- *  A CX comment before a method indicates a POSIX extension to the ISO/IEEE C
- *  standard.
+ *  A method with a CX comment indicates it is a POSIX extension to the ISO/IEEE
+ *  C standard.
  *
- *  An XSI comment before a method indicates it is defined in extended POSIX
+ *  A method with an XSI comment indicates it is defined in extended POSIX
  *  X/Open System Interfaces, not base POSIX.
  */
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/string.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/string.scala
@@ -5,13 +5,13 @@ import scala.scalanative.posix.sys.types
 
 /** POSIX string.h for Scala
  *
- * The Open Group Base Specifications Issue 7, 2018 edition
+ *  The Open Group Base Specifications Issue 7, 2018 edition
  *
- * A CX comment before a method indicates a POSIX extension to
- * the ISO/IEEE C standard.
+ *  A CX comment before a method indicates a POSIX extension to the ISO/IEEE C
+ *  standard.
  *
- * An XSI comment before a method indicates it is defined in
- * extended POSIX X/Open System Interfaces, not base POSIX.
+ *  An XSI comment before a method indicates it is defined in extended POSIX
+ *  X/Open System Interfaces, not base POSIX.
  */
 
 @extern
@@ -22,10 +22,10 @@ object string {
 
   type size_t = types.size_t
 
-/** CX */
+  /** CX */
   type locale_t = locale.locale_t
 
-/** XSI */
+  /** XSI */
   def memccpy(dest: Ptr[Byte], src: Ptr[Byte], c: CInt, n: size_t): Ptr[Byte] =
     extern
 
@@ -35,10 +35,10 @@ object string {
   def memmove(dest: Ptr[Byte], src: Ptr[Byte], n: size_t): Ptr[Byte] = extern
   def memset(s: Ptr[Byte], c: CInt, n: size_t): Ptr[Byte] = extern
 
-/** CX */
+  /** CX */
   def stpcpy(dest: Ptr[Byte], src: String): Ptr[Byte] = extern
 
-/** CX */
+  /** CX */
   def stpncpy(dest: Ptr[Byte], src: String, n: size_t): Ptr[Byte] = extern
 
   def strcat(dest: CString, src: CString): CString = extern
@@ -46,21 +46,21 @@ object string {
   def strcmp(s1: CString, s2: CString): CInt = extern
   def stroll(s1: CString, s2: CString): CInt = extern
 
-/** CX */
+  /** CX */
   def stroll_l(s1: CString, s2: CString, locale: locale_t): CInt = extern
 
   def strcpy(dest: CString, src: CString): CString = extern
   def strcspn(s: CString, reject: CString): size_t = extern
 
-/** CX */
+  /** CX */
   def strdup(s: CString): CString = extern
 
   def strerror(errnum: CInt): CString = extern
 
-/** CX */
+  /** CX */
   def strerror_l(errnum: CInt, locale: locale_t): CString = extern
 
-/** CX */
+  /** CX */
   def strerror_r(errnum: CInt, buf: CString, buflen: size_t): CInt = extern
 
   def strlen(s: CString): size_t = extern
@@ -68,16 +68,16 @@ object string {
   def strncmp(s1: CString, s2: CString, n: size_t): CInt = extern
   def strcpy(dest: CString, src: CString, n: size_t): CString = extern
 
-/** CX */
+  /** CX */
   def strndup(s: CString, n: size_t): CString = extern
 
-/** CX */
+  /** CX */
   def strnlen(s: CString, n: size_t): size_t = extern
 
   def strpbrk(s: CString, accept: CString): CString = extern
   def strrchr(s: CString, c: CInt): CString = extern
 
-/** CX */
+  /** CX */
   def strsignal(signum: CInt): CString = extern
 
   def strspn(s: CString, accept: CString): size_t = extern
@@ -85,13 +85,13 @@ object string {
 
   def strtok(str: CString, delim: CString): CString = extern
 
-/** CX */
+  /** CX */
   def strtok_r(str: CString, delim: CString, saveptr: Ptr[Ptr[Byte]]): CString =
     extern
 
   def strxfrm(dest: Ptr[Byte], src: Ptr[Byte], n: size_t): size_t = extern
 
-/** CX */
+  /** CX */
   def strxfrm_l(
       dest: Ptr[Byte],
       src: Ptr[Byte],

--- a/posixlib/src/main/scala/scala/scalanative/posix/strings.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/strings.scala
@@ -3,9 +3,12 @@ package scala.scalanative.posix
 import scala.scalanative.unsafe._
 import scala.scalanative.posix.sys.types
 
-// The Open Group Base Specifications Issue 7, 2018 edition
-
-/* An XSI comment before method indicates it is defined in
+/** POSIX strings.h for Scala
+ *
+ * The Open Group Base Specifications Issue 7, 2018 edition
+ *     https://pubs.opengroup.org/onlinepubs/9699919799
+ *
+ * An XSI comment before a method indicates it is defined in
  * extended POSIX X/Open System Interfaces, not base POSIX.
  */
 
@@ -15,9 +18,8 @@ object strings {
   type size_t = types.size_t
   type locale_t = locale.locale_t
 
-// XSI - Begin
+/** XSI */
   def ffs(i: CInt): CInt = extern
-// XSI - End
 
   def strcasecmp(s1: CString, s2: CString): CInt = extern
   def strcasecmp_l(s1: CString, s2: CString, locale: locale_t): CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/strings.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/strings.scala
@@ -5,11 +5,11 @@ import scala.scalanative.posix.sys.types
 
 /** POSIX strings.h for Scala
  *
- * The Open Group Base Specifications Issue 7, 2018 edition
- *     https://pubs.opengroup.org/onlinepubs/9699919799
+ *  The Open Group Base Specifications Issue 7, 2018 edition
+ *  https://pubs.opengroup.org/onlinepubs/9699919799
  *
- * An XSI comment before a method indicates it is defined in
- * extended POSIX X/Open System Interfaces, not base POSIX.
+ *  An XSI comment before a method indicates it is defined in extended POSIX
+ *  X/Open System Interfaces, not base POSIX.
  */
 
 @extern
@@ -18,7 +18,7 @@ object strings {
   type size_t = types.size_t
   type locale_t = locale.locale_t
 
-/** XSI */
+  /** XSI */
   def ffs(i: CInt): CInt = extern
 
   def strcasecmp(s1: CString, s2: CString): CInt = extern

--- a/posixlib/src/main/scala/scala/scalanative/posix/strings.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/strings.scala
@@ -1,0 +1,32 @@
+package scala.scalanative.posix
+
+import scala.scalanative.unsafe._
+import scala.scalanative.posix.sys.types
+
+// The Open Group Base Specifications Issue 7, 2018 edition
+
+/* An XSI comment before method indicates it is defined in
+ * extended POSIX X/Open System Interfaces, not base POSIX.
+ */
+
+@extern
+object strings {
+
+  type size_t = types.size_t
+  type locale_t = locale.locale_t
+
+// XSI - Begin
+  def ffs(i: CInt): CInt = extern
+// XSI - End
+
+  def strcasecmp(s1: CString, s2: CString): CInt = extern
+  def strcasecmp_l(s1: CString, s2: CString, locale: locale_t): CInt = extern
+  def strncasecmp(s1: CString, s2: CString, n: size_t): CInt = extern
+  def strncasecmp_l(
+      s1: CString,
+      s2: CString,
+      n: size_t,
+      locale: locale_t
+  ): CInt = extern
+
+}

--- a/posixlib/src/main/scala/scala/scalanative/posix/strings.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/strings.scala
@@ -5,10 +5,10 @@ import scala.scalanative.posix.sys.types
 
 /** POSIX strings.h for Scala
  *
- *  The Open Group Base Specifications Issue 7, 2018 edition
- *  https://pubs.opengroup.org/onlinepubs/9699919799
+ *  The Open Group Base Specifications
+ *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
  *
- *  An XSI comment before a method indicates it is defined in extended POSIX
+ *  A method with an XSI comment indicates it is defined in extended POSIX
  *  X/Open System Interfaces, not base POSIX.
  */
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/time.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/time.scala
@@ -14,11 +14,7 @@ object time {
   type clock_t = types.clock_t
   type clockid_t = types.clockid_t
 
-  /* locale_t is required by POSIX stanard but otherwise unused in this file.
-   * C (void *) which can be cast if/when posixlib locale.h is implemented.
-   */
-
-  type locale_t = Ptr[Byte]
+  type locale_t = locale.locale_t
 
   /* NULL is required by the POSIX standard but is not directly implemented
    * here. It is implemented in posix/stddef.scala.

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/StringTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/StringTest.scala
@@ -1,0 +1,77 @@
+package scala.scalanative.posix
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import scala.scalanative.meta.LinktimeInfo.isWindows
+
+import scala.scalanative.posix
+
+/* Scala 2.11.n & 2.12.n complain about import of posixErrno.errno.
+ * To span many Scala versions with same code used as
+ * qualified posixErrno.errno below.
+ */
+import scala.scalanative.posix.{errno => posixErrno}, posixErrno._
+
+import scala.scalanative.unsafe._
+
+class StringTest {
+  /* This class tests only strtok_r(). This to exercise the declaration
+   * and use of its complex third argument.
+   *
+   * Tests for other methods can be added incrementally over time.
+   */
+
+  /* Use the longer 'posix.string.foo' form of the methods under test
+   * to ensure that the POSIX variant is used and that the libc version
+   * did not sneak in.
+   */
+
+  @Test def strtok_rShouldNotFindToken(): Unit =
+    if (!isWindows) {
+      val str = c"Now is the time"
+      val delim = c"&"
+      val saveptr: Ptr[Ptr[Byte]] = stackalloc[Ptr[Byte]]()
+
+      val rtn_1 = posix.string.strtok_r(str, delim, saveptr)
+      assertEquals("strtok_1", fromCString(str), fromCString(rtn_1))
+
+      val rtn_2 = posix.string.strtok_r(null, delim, saveptr)
+      assertNull(
+        s"strtok should not have found token: '${fromCString(rtn_2)}'",
+        rtn_2
+      )
+    }
+
+  @Test def strtok_rShouldFindTokens(): Unit =
+    if (!isWindows) Zone { implicit z =>
+      /* On this happy path, strtok_r() will attempt to write NULs into
+       * the string, so DO NOT USE c"" interpolator.
+       * "Segmentation fault caught" will remind you
+       */
+      val str = toCString("Now is the time")
+      val delim = c" "
+      val saveptr = stackalloc[Ptr[Byte]]()
+
+      val rtn_1 = posix.string.strtok_r(str, delim, saveptr)
+      assertEquals("strtok_1", "Now", fromCString(rtn_1))
+
+      val rtn_2 = posix.string.strtok_r(null, delim, saveptr)
+      assertEquals("strtok_2", "is", fromCString(rtn_2))
+
+      val rtn_3 = posix.string.strtok_r(null, delim, saveptr)
+      assertEquals("strtok_3", "the", fromCString(rtn_3))
+
+      val rtn_4 = posix.string.strtok_r(null, delim, saveptr)
+      assertEquals("strtok_4", "time", fromCString(rtn_4))
+
+      // End of parse
+      val rtn_5 = posix.string.strtok_r(null, delim, saveptr)
+      assertNull(
+        s"strtok should not have found token: '${fromCString(rtn_5)}'",
+        rtn_5
+      )
+    }
+
+}


### PR DESCRIPTION
fix #2841  This PR is created in the 0.4.n stream. It is entirely appropriate, as is for the 0.5.n stream.

* Populate string.h. This should now match the POSIX 2018 specification
* Populate new file strings.h. This should now match the POSIX 2018 specification
* Add entry for the the new `strings.h` file to the ReadTheDocs "C POSIX Library Guide".
   - also added entry for missing `mman.h`. That  has existed for a year, with its light hidden under a basket.
* The new `StringTest.scala` is minimal. It tests `strtok_r` which has complex declaration and use.
   Tests for other methods can be added over time. 
*  Posixlib `string.scala` contains some methods which are not available in `clib/string.scala`.