### PR TITLE
Add links to scaladoc version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,14 @@ Scala Native is an optimizing ahead-of-time compiler and lightweight managed run
 
 [![Discord](https://img.shields.io/discord/632150470000902164.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/scala)
 
-Getting Started and full documentation can be found at [http://www.scala-native.org/](http://www.scala-native.org/)
-
+Getting Started and full documentation can be found at [http://www.scala-native.org/](http://www.scala-native.org/
 
 ## Online Scaladoc
-
-[![Scaladoc nativelib](https://javadoc.io/badge2/org.scala-native/nativelib_native0.4_2.13/javadoc.svg?label=nativelib)](https://javadoc.io/doc/org.scala-native/nativelib_native0.4_2.13)
-[![Scaladoc clib](https://javadoc.io/badge2/org.scala-native/clib_native0.4_2.13/javadoc.svg?label=clib)](https://javadoc.io/doc/org.scala-native/clib_native0.4_2.13)
-[![Scaladoc posixlib](https://javadoc.io/badge2/org.scala-native/posixlib_native0.4_2.13/javadoc.svg?label=posixlib)](https://javadoc.io/doc/org.scala-native/posixlib_native0.4_2.13)
-[![Scaladoc windowslib](https://javadoc.io/badge2/org.scala-native/windowslib_native0.4_2.13/javadoc.svg?label=windowslib)](https://javadoc.io/doc/org.scala-native/windowslib_native0.4_2.13)
-
-## Online Scaladoc 3
 
 [![Scaladoc nativelib](https://javadoc.io/badge2/org.scala-native/nativelib_native0.4_3/javadoc.svg?label=nativelib)](https://javadoc.io/doc/org.scala-native/nativelib_native0.4_3)
 [![Scaladoc clib](https://javadoc.io/badge2/org.scala-native/clib_native0.4_3/javadoc.svg?label=clib)](https://javadoc.io/doc/org.scala-native/clib_native0.4_3)
 [![Scaladoc posixlib](https://javadoc.io/badge2/org.scala-native/posixlib_native0.4_3/javadoc.svg?label=posixlib)](https://javadoc.io/doc/org.scala-native/posixlib_native0.4_3)
 [![Scaladoc windowslib](https://javadoc.io/badge2/org.scala-native/windowslib_native0.4_3/javadoc.svg?label=windowslib)](https://javadoc.io/doc/org.scala-native/windowslib_native0.4_3)
-
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Scala Native is an optimizing ahead-of-time compiler and lightweight managed run
 
 [![Discord](https://img.shields.io/discord/632150470000902164.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/scala)
 
-Getting Started and full documentation can be found at [http://www.scala-native.org/](http://www.scala-native.org/
+Getting Started and full documentation can be found at [http://www.scala-native.org/](http://www.scala-native.org/)
 
 ## Online Scaladoc
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Scala Native is an optimizing ahead-of-time compiler and lightweight managed run
 ## Chat and Documentation
 
 [![Discord](https://img.shields.io/discord/632150470000902164.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/scala)
-[![Join chat https://gitter.im/scala-native/scala-native](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scala-native/scala-native?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Getting Started and full documentation can be found at [http://www.scala-native.org/](http://www.scala-native.org/)
 
@@ -21,6 +20,13 @@ Getting Started and full documentation can be found at [http://www.scala-native.
 [![Scaladoc clib](https://javadoc.io/badge2/org.scala-native/clib_native0.4_2.13/javadoc.svg?label=clib)](https://javadoc.io/doc/org.scala-native/clib_native0.4_2.13)
 [![Scaladoc posixlib](https://javadoc.io/badge2/org.scala-native/posixlib_native0.4_2.13/javadoc.svg?label=posixlib)](https://javadoc.io/doc/org.scala-native/posixlib_native0.4_2.13)
 [![Scaladoc windowslib](https://javadoc.io/badge2/org.scala-native/windowslib_native0.4_2.13/javadoc.svg?label=windowslib)](https://javadoc.io/doc/org.scala-native/windowslib_native0.4_2.13)
+
+## Online Scaladoc 3
+
+[![Scaladoc nativelib](https://javadoc.io/badge2/org.scala-native/nativelib_native0.4_3/javadoc.svg?label=nativelib)](https://javadoc.io/doc/org.scala-native/nativelib_native0.4_3)
+[![Scaladoc clib](https://javadoc.io/badge2/org.scala-native/clib_native0.4_3/javadoc.svg?label=clib)](https://javadoc.io/doc/org.scala-native/clib_native0.4_3)
+[![Scaladoc posixlib](https://javadoc.io/badge2/org.scala-native/posixlib_native0.4_3/javadoc.svg?label=posixlib)](https://javadoc.io/doc/org.scala-native/posixlib_native0.4_3)
+[![Scaladoc windowslib](https://javadoc.io/badge2/org.scala-native/windowslib_native0.4_3/javadoc.svg?label=windowslib)](https://javadoc.io/doc/org.scala-native/windowslib_native0.4_3)
 
 
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -124,8 +124,7 @@ object Settings {
       Compile / doc / sources := {
         val prev = (Compile / doc / sources).value
         if (Platform.isWindows &&
-            sys.env.contains("CI") && // Always present in GitHub Actions
-            scalaVersion.value.startsWith("3.") // Bug in Scala 3 scaladoc
+            sys.env.contains("CI") // Always present in GitHub Actions
         ) Nil
         else prev
       }


### PR DESCRIPTION
Scaladoc 3 is the future and looks nicer too. It has been generated too - I missed the change.

Example: https://javadoc.io/doc/org.scala-native/posixlib_native0.4_3/latest/index.html