### PR TITLE
Use `-O2` in debug mode for C files

### DIFF
--- a/tools/src/main/scala/scala/scalanative/build/LLVM.scala
+++ b/tools/src/main/scala/scala/scalanative/build/LLVM.scala
@@ -57,7 +57,7 @@ private[scalanative] object LLVM {
         }
         val expectionsHandling =
           List("-fexceptions", "-fcxx-exceptions", "-funwind-tables")
-        val flags = opt(config) +: "-fvisibility=hidden" +:
+        val flags = opt(config, isLl) +: "-fvisibility=hidden" +:
           stdflag ++: platformFlags ++: expectionsHandling ++: config.compileOptions
         val compilec =
           Seq(compiler) ++ flto(config) ++ flags ++
@@ -163,10 +163,10 @@ private[scalanative] object LLVM {
       case None     => Seq("-Wno-override-module")
     }
 
-  private def opt(config: Config): String =
+  private def opt(config: Config, isLl: Boolean): String =
     config.mode match {
-      case Mode.Debug       => "-O0"
-      case Mode.ReleaseFast => "-O2"
-      case Mode.ReleaseFull => "-O3"
+      case Mode.Debug if isLl            => "-O0"
+      case Mode.Debug | Mode.ReleaseFast => "-O2"
+      case Mode.ReleaseFull              => "-O3"
     }
 }


### PR DESCRIPTION
Debug builds don't inline anything in the GC code. Since the C compilation is done only once and then the object files are reused in successive compilations, and since the C compiler is faster than the Scala compiler, we can use the `-O2` compile flag to compile the C files. This makes the GC faster which can improve the runtime speed of debug builds.
This can be particularly useful for tests which are notoriously slow to execute in Scala Native and are almost always executed in debug mode. I profiled some applications in debug mode and found that 9% of the time was spent in `ObjectMeta_SetAllocated` which is a simple assignment of a byte. 5% of stacks were falling in `MathUtils_RoundToNextMultiple` which is a rounding function which is implemented using `mul` and `div` in `-O0` mode but gets inlined to simple bit shifts and `xor`s in `-O2` mode.
I think this is an interesting tradeoff to consider.