### PR TITLE
Partial fix #2822: 0.4.x, 0.5.x: remove non-local returns from j.u.StringTokenizer

### DIFF
--- a/javalib/src/main/scala/java/util/StringTokenizer.scala
+++ b/javalib/src/main/scala/java/util/StringTokenizer.scala
@@ -1,5 +1,7 @@
 package java.util
 
+import scala.annotation.tailrec
+
 class StringTokenizer(
     string: String,
     private var delimiters: String,
@@ -40,23 +42,28 @@ class StringTokenizer(
   def hasMoreElements(): Boolean = hasMoreTokens()
 
   def hasMoreTokens(): Boolean = {
-    if (delimiters == null) {
+    if (delimiters == null)
       throw new NullPointerException()
-    }
 
-    var found = false
-    val length = string.length
-    if (position < length) {
-      if (returnDelimiters) {
-        found = true
+    @tailrec
+    def hasNonDelim(pos: Int, len: Int): Boolean = {
+      if (pos == len) {
+        false
+      } else if (delimiters.indexOf(string.charAt(pos), 0) == -1) {
+        true
       } else {
-        for (i <- position until length if !found) {
-          if (delimiters.indexOf(string.charAt(i), 0) == -1)
-            found = true
-        }
+        hasNonDelim(pos + 1, len)
       }
     }
-    found
+
+    val length = string.length
+    if (position >= length) {
+      false
+    } else if (returnDelimiters) {
+      true
+    } else {
+      hasNonDelim(position, length)
+    }
   }
 
   def nextElement(): Object = nextToken()
@@ -100,6 +107,9 @@ class StringTokenizer(
   }
 
   def nextToken(delims: String): String = {
+    if (delims == null)
+      throw new NullPointerException()
+
     delimiters = delims
     nextToken()
   }

--- a/javalib/src/main/scala/java/util/StringTokenizer.scala
+++ b/javalib/src/main/scala/java/util/StringTokenizer.scala
@@ -47,23 +47,15 @@ class StringTokenizer(
 
     @tailrec
     def hasNonDelim(pos: Int, len: Int): Boolean = {
-      if (pos == len) {
-        false
-      } else if (delimiters.indexOf(string.charAt(pos), 0) == -1) {
-        true
-      } else {
-        hasNonDelim(pos + 1, len)
-      }
+      if (pos == len) false
+      else if (delimiters.indexOf(string.charAt(pos), 0) == -1) true
+      else hasNonDelim(pos + 1, len)
     }
 
     val length = string.length
-    if (position >= length) {
-      false
-    } else if (returnDelimiters) {
-      true
-    } else {
-      hasNonDelim(position, length)
-    }
+    if (position >= length) false
+    else if (returnDelimiters) true
+    else hasNonDelim(position, length)
   }
 
   def nextElement(): Object = nextToken()

--- a/javalib/src/main/scala/java/util/StringTokenizer.scala
+++ b/javalib/src/main/scala/java/util/StringTokenizer.scala
@@ -43,17 +43,20 @@ class StringTokenizer(
     if (delimiters == null) {
       throw new NullPointerException()
     }
+
+    var found = false
     val length = string.length
     if (position < length) {
-      if (returnDelimiters)
-        return true
-
-      for (i <- position until length) {
-        if (delimiters.indexOf(string.charAt(i), 0) == -1)
-          return true
+      if (returnDelimiters) {
+        found = true
+      } else {
+        for (i <- position until length if !found) {
+          if (delimiters.indexOf(string.charAt(i), 0) == -1)
+            found = true
+        }
       }
     }
-    false
+    found
   }
 
   def nextElement(): Object = nextToken()


### PR DESCRIPTION
This PR is submitted for the 0.4.x stream.  It is also appropriate for the 0.5.0 stream.

javalib `java.util.StringTokenizer` no longer has Scala 3.2 "non-local return" deprecation warnings.