### PR TITLE
Add a missing colon to the `NumberFormatException` message

### DIFF
--- a/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
+++ b/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
@@ -26,7 +26,7 @@ private[java] object IEEE754Helpers {
   //     https://github.com/scala/scala/pull/8830
   // The second is yet unmerged for Scala 2.13.x.
 
-  private def exceptionMsg(s: String) = "For input string \"" + s + "\""
+  private def exceptionMsg(s: String) = "For input string: \"" + s + "\""
 
   private def bytesToCString(bytes: Array[scala.Byte], n: Int)(implicit
       z: Zone


### PR DESCRIPTION
That's a pretty minor thing. Was found when adding support for Scala Native in the [mouse](https://github.com/typelevel/mouse/pull/371).