### PR TITLE
Adding missing `java.lang.Character` functionality

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -842,7 +842,7 @@ object Character {
   // These both allow for the logic in toSurrogate to not change, the codepoint must be normalised first with -0x10000
   @inline private[this] def highSurrogateFromNormalised(cp: Int): Char =
     (0xd800 | ((cp >> 10) & 0x3ff)).toChar
-    
+
   @inline private[this] def lowSurrogateFromNormalised(cp: Int): Char =
     (0xdc00 | (cp & 0x3ff)).toChar
 

--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -835,11 +835,22 @@ object Character {
       dstIndex: Int
   ): Unit = {
     val cpPrime = codePoint - 0x10000
-    val high = 0xd800 | ((cpPrime >> 10) & 0x3ff)
-    val low = 0xdc00 | (cpPrime & 0x3ff)
-    dst(dstIndex) = high.toChar
-    dst(dstIndex + 1) = low.toChar
+    dst(dstIndex) = highSurrogateFromNormalised(cpPrime)
+    dst(dstIndex + 1) = lowSurrogateFromNormalised(cpPrime)
   }
+
+  // These both allow for the logic in toSurrogate to not change, the codepoint must be normalised first with -0x10000
+  @inline private[this] def highSurrogateFromNormalised(cp: Int): Char =
+    (0xd800 | ((cp >> 10) & 0x3ff)).toChar
+    
+  @inline private[this] def lowSurrogateFromNormalised(cp: Int): Char =
+    (0xdc00 | (cp & 0x3ff)).toChar
+
+  @inline def highSurrogate(codePoint: Int): Char =
+    highSurrogateFromNormalised(codePoint - 0x10000)
+
+  @inline def lowSurrogate(codePoint: Int): Char =
+    lowSurrogateFromNormalised(codePoint - 0x10000)
 
   @inline def toString(c: scala.Char): String =
     String.valueOf(c)
@@ -1237,7 +1248,7 @@ object Character {
   private[lang] final val CombiningClassIsNone = 0
   private[lang] final val CombiningClassIsAbove = 1
   private[lang] final val CombiningClassIsOther = 2
-  
+
   /* Ported from Scala.js, commit: ac38a148, dated: 2020-09-25
    * Indices representing the start of ranges of codePoint that have the same
    * `combiningClassNoneOrAboveOrOther` result. The results cycle modulo 3 at

--- a/unit-tests/shared/src/test/scala/javalib/lang/CharacterTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/CharacterTest.scala
@@ -588,4 +588,22 @@ class CharacterTest {
     assertTrue(UnicodeBlock.of('a') equals UnicodeBlock.BASIC_LATIN)
     assertTrue(UnicodeBlock.of('א') equals UnicodeBlock.HEBREW)
   }
+
+  // from scala-js tests
+  @Test def highSurrogate(): Unit = {
+    assertEquals(0xd800, Character.highSurrogate(0x10000))
+    assertEquals(0xd808, Character.highSurrogate(0x12345))
+    assertEquals(0xdbff, Character.highSurrogate(0x10ffff))
+
+    // unspecified for non-supplementary code points
+  }
+
+  @Test def lowSurrogate(): Unit = {
+    assertEquals(0xdc00, Character.lowSurrogate(0x10000))
+    assertEquals(0xdf45, Character.lowSurrogate(0x12345))
+    assertEquals(0xdfff, Character.lowSurrogate(0x10ffff))
+
+    // unspecified for non-supplementary code points
+  }
+
 }


### PR DESCRIPTION
Added `highSurrogate` and `lowSurrogate` to `java.lang.Character` extracted from `toSurrogate`