### PR TITLE
 A few java.net.Inet*Address fixes

### DIFF
--- a/javalib/src/main/scala/java/net/Inet4Address.scala
+++ b/javalib/src/main/scala/java/net/Inet4Address.scala
@@ -1,10 +1,11 @@
 package java.net
 
 // Ported from Apache Harmony
-final class Inet4Address private[net] (ipAddress: Array[Byte], host: String)
+
+final class Inet4Address(ipAddress: Array[Byte], host: String)
     extends InetAddress(ipAddress, host) {
 
-  private[net] def this(ipAddress: Array[Byte]) = this(ipAddress, null)
+  def this(ipAddress: Array[Byte]) = this(ipAddress, null)
 
   override def isMulticastAddress(): Boolean =
     (ipAddress(0) & 0xf0) == 0xe0
@@ -26,29 +27,23 @@ final class Inet4Address private[net] (ipAddress: Array[Byte], host: String)
 
   override def isMCGlobal(): Boolean = {
     if (!isMulticastAddress()) return false
-
-    val address = InetAddress.bytesToInt(ipAddress, 0)
-
+    val address = bytesToInt(ipAddress, 0)
     if (address >>> 8 < 0xe00001) return false
-
     if (address >>> 24 > 0xee) return false
-
     true
   }
 
   override def isMCNodeLocal(): Boolean = false
 
   override def isMCLinkLocal(): Boolean =
-    InetAddress.bytesToInt(ipAddress, 0) >>> 8 == 0xe00000
+    bytesToInt(ipAddress, 0) >>> 8 == 0xe00000
 
   override def isMCSiteLocal(): Boolean =
-    (InetAddress.bytesToInt(ipAddress, 0) >>> 16) == 0xefff
+    bytesToInt(ipAddress, 0) >>> 16 == 0xefff
 
   override def isMCOrgLocal(): Boolean = {
-    val prefix = InetAddress.bytesToInt(ipAddress, 0) >>> 16
+    val prefix = bytesToInt(ipAddress, 0) >>> 16
     prefix >= 0xefc0 && prefix <= 0xefc3
   }
 
 }
-
-object Inet4Address extends InetAddressBase {}

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -145,7 +145,7 @@ class InetAddress protected (ipAddress: Array[Byte], originalHost: String)
 
   def isMulticastAddress(): Boolean = false
 
-  /* Editorial comment: isReachable() is in the Java 8 specification and
+  /* Editorial Comment: isReachable() is in the Java 8 specification and
    * must be implemented for completeness. It has severely limited utility
    * in the 21st century.  Many, if not most, systems now block the
    * echo port (7). ICMP is not used here because it requires elevated

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -503,7 +503,7 @@ object InetAddress {
         v4addr.sin_family = AF_INET.toUShort
         v4addr.sin_addr = !(from.asInstanceOf[Ptr[in_addr]]) // Structure copy
       } else {
-        throw new IOException(s"Invalid ipAddress length: ${ipBa.length}")
+        throw new IOException(s"Invalid ipAddress length: ${ipBA.length}")
       }
     }
 

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -216,7 +216,7 @@ object InetAddress {
      * The Scastie JVM and those used for Linux/macOS manual testing seem
      * to leave the host field blank/empty.
      */
-    val effectiveHost = if (isNumeric) "" else host
+    val effectiveHost = if (isNumeric) null else host
 
     if (addrinfoP.ai_family == AF_INET) {
       new Inet4Address(addrinfoToByteArray(addrinfoP), effectiveHost)

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -145,7 +145,7 @@ class InetAddress protected (ipAddress: Array[Byte], originalHost: String)
 
   def isMulticastAddress(): Boolean = false
 
-  /* Editorial Comment: isReachable() is in the Java 8 specification and
+  /* Editorial comment: isReachable() is in the Java 8 specification and
    * must be implemented for completeness. It has severely limited utility
    * in the 21st century.  Many, if not most, systems now block the
    * echo port (7). ICMP is not used here because it requires elevated

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -503,7 +503,7 @@ object InetAddress {
         v4addr.sin_family = AF_INET.toUShort
         v4addr.sin_addr = !(from.asInstanceOf[Ptr[in_addr]]) // Structure copy
       } else {
-        throw new IOException("Invalid ipAddress length: ${ipBa.length}")
+        throw new IOException(s"Invalid ipAddress length: ${ipBa.length}")
       }
     }
 

--- a/javalib/src/main/scala/java/net/InetAddress.scala
+++ b/javalib/src/main/scala/java/net/InetAddress.scala
@@ -1,616 +1,102 @@
 package java.net
 
+/* Originally ported from Apache Harmony.
+ * Extensively re-written for Scala Native.
+ * Some code ported under license from or influenced by Arman Bilge. See:
+ *   https://github.com/armanbilge/epollcat (and other repositories).
+ */
+
 import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+import scala.annotation.tailrec
+
+import java.io.IOException
+import java.{util => ju}
+
+import scala.scalanative.annotation.alwaysinline
+
+import scala.scalanative.libc.string.memcpy
+
+import scala.scalanative.posix.arpa.inet._
+import scala.scalanative.posix.errno.errno
+import scala.scalanative.posix.netinet.in._
+import scala.scalanative.posix.netinet.inOps._
+import scala.scalanative.posix.netdb._
+import scala.scalanative.posix.netdbOps._
+import scala.scalanative.posix.sys.socket._
 import scala.scalanative.posix.time.{time_t, time, difftime}
-import scala.collection.mutable.ArrayBuffer
+import scala.scalanative.posix.unistd
 
-import java.util.StringTokenizer
+/* Design note:
+ *    Much of java.net, both in JVM and Scala Native defines or assumes
+ *    the ipAddress field to have either 4 or 16 bytes.
+ *
+ *    One might guess from the output of 'toString() that the
+ *    the IPv6 scope_id/zone_id/interface_id (e.g. "%en0") is handled
+ *    by extending this ipAddress field beyond 16. That is not the case.
+ *    That information is handled separately.
+ */
 
-// Ported from Apache Harmony
-private[net] trait InetAddressBase {
-
-  def getByName(host: String): InetAddress = {
-
-    if (host == null || host.length == 0)
-      return getLoopbackAddress()
-
-    var address: InetAddress = null
-    if (isValidIPv4Address(host)) {
-      val byteAddress: Array[Byte] = Array.ofDim[Byte](4)
-      val parts: Array[String] = host.split("\\.")
-      val length: Int = parts.length
-      if (length == 1) {
-        val value: Long = java.lang.Long.parseLong(parts(0))
-        for (i <- 0.until(4)) {
-          byteAddress(i) = (value >> ((3 - i) * 8)).toByte
-        }
-      } else {
-        for (i <- 0 until length) {
-          byteAddress(i) = java.lang.Integer.parseInt(parts(i)).toByte
-        }
-      }
-      if (length == 2) {
-        byteAddress(3) = byteAddress(1)
-        byteAddress(1) = 0
-      }
-      if (length == 3) {
-        byteAddress(3) = byteAddress(2)
-        byteAddress(2) = 0
-      }
-      address = new Inet4Address(byteAddress)
-    } else if (isValidIPv6Address(host)) {
-      var ipAddressString = host
-      if (ipAddressString.charAt(0) == '[') {
-        ipAddressString =
-          ipAddressString.substring(1, ipAddressString.length - 1)
-      }
-      val tokenizer: StringTokenizer =
-        new StringTokenizer(ipAddressString, ":.%", true)
-      val hexStrings = new ArrayBuffer[String]()
-      val decStrings = new ArrayBuffer[String]()
-      var scopeString: String = null
-      var token: String = ""
-      var prevToken: String = ""
-      var prevPrevToken: String = ""
-      var doubleColonIndex: Int = -1
-      while (tokenizer.hasMoreTokens()) {
-        prevPrevToken = prevToken
-        prevToken = token
-        token = tokenizer.nextToken()
-        if (token == ":") {
-          if (prevToken == ":") {
-            doubleColonIndex = hexStrings.size
-          } else if (prevToken != "") {
-            hexStrings.append(prevToken)
-          }
-        } else if (token == ".") {
-          decStrings.append(prevToken)
-        } else if (token == "%") {
-          if (prevToken != ":" && prevToken != ".") {
-            if (prevPrevToken == ":") {
-              hexStrings.append(prevToken)
-            } else if (prevPrevToken == ".") {
-              decStrings.append(prevToken)
-            }
-          }
-          val buf: StringBuilder = new StringBuilder()
-          while (tokenizer.hasMoreTokens()) buf.append(tokenizer.nextToken())
-          scopeString = buf.toString
-        }
-      }
-      if (prevToken == ":") {
-        if (token == ":") {
-          doubleColonIndex = hexStrings.size
-        } else {
-          hexStrings.append(token)
-        }
-      } else if (prevToken == ".") {
-        decStrings.append(token)
-      }
-      var hexStringsLength: Int = 8
-      if (decStrings.size > 0) {
-        hexStringsLength -= 2
-      }
-      if (doubleColonIndex != -1) {
-        val numberToInsert: Int = hexStringsLength - hexStrings.size
-        for (i <- 0 until numberToInsert) {
-          hexStrings.insert(doubleColonIndex, "0")
-        }
-      }
-      val ipByteArray: Array[Byte] = Array.ofDim[Byte](16)
-      for (i <- 0 until hexStrings.size) {
-        convertToBytes(hexStrings(i), ipByteArray, i * 2)
-      }
-      for (i <- 0 until decStrings.size) {
-        ipByteArray(i + 12) =
-          (java.lang.Integer.parseInt(decStrings(i)) & 255).toByte
-      }
-      var ipV4 = true
-      if (ipByteArray.take(10).exists(_ != 0)) {
-        ipV4 = false
-      }
-      if (ipByteArray(10) != -1 || ipByteArray(11) != -1) {
-        ipV4 = false
-      }
-      if (ipV4) {
-        val ipv4ByteArray = new Array[Byte](4)
-        for (i <- 0.until(4)) {
-          ipv4ByteArray(i) = ipByteArray(i + 12)
-        }
-        address = InetAddress.getByAddress(ipv4ByteArray)
-      } else {
-        var scopeId: Int = 0
-        if (scopeString != null) {
-          try {
-            scopeId = java.lang.Integer.parseInt(scopeString)
-          } catch {
-            case e: Exception => {}
-          }
-        }
-        address = Inet6Address.getByAddress(null, ipByteArray, scopeId)
-      }
-    } else {
-      val ip = SocketHelpers.hostToIp(host).getOrElse {
-        throw new UnknownHostException(
-          host + ": Name or service not known"
-        )
-      }
-      if (isValidIPv4Address(ip))
-        address = new Inet4Address(byteArrayFromIPString(ip), host)
-      else if (isValidIPv6Address(ip))
-        address = new Inet6Address(byteArrayFromIPString(ip), host)
-      else
-        throw new UnknownHostException("Malformed IP: " + ip)
-    }
-    address
-  }
-
-  def getAllByName(host: String): Array[InetAddress] = {
-    if (host == null || host.length == 0)
-      return Array[InetAddress](getLoopbackAddress())
-
-    if (isValidIPv4Address(host))
-      return Array[InetAddress](new Inet4Address(byteArrayFromIPString(host)))
-
-    if (isValidIPv6Address(host))
-      return Array[InetAddress](new Inet6Address(byteArrayFromIPString(host)))
-
-    val ips: Array[String] = SocketHelpers.hostToIpArray(host)
-    if (ips.isEmpty) {
-      throw new UnknownHostException(
-        host + ": Name or service not known"
-      )
-    }
-
-    ips.map(ip => {
-      if (isValidIPv4Address(ip)) {
-        new Inet4Address(byteArrayFromIPString(ip), host)
-      } else {
-        new Inet6Address(byteArrayFromIPString(ip), host)
-      }
-    })
-  }
-
-  def getByAddress(addr: Array[Byte]): InetAddress =
-    getByAddress(null, addr)
-
-  def getByAddress(host: String, addr: Array[Byte]): InetAddress = {
-    if (addr.length == 4)
-      return new Inet4Address(addr.clone, host)
-    else if (addr.length == 16)
-      return new Inet6Address(addr.clone, host)
-    else
-      throw new UnknownHostException(
-        "IP address is of illegal length: " + addr.length
-      )
-  }
-
-  private def isValidIPv4Address(addr: String): Boolean = {
-    if (!addr.matches("[0-9\\.]*")) {
-      return false
-    }
-
-    val parts = addr.split("\\.")
-    if (parts.length > 4) return false
-
-    if (parts.length == 1) {
-      val longValue = parts(0).toLong
-      longValue >= 0 && longValue <= 0xffffffffL
-    } else {
-      parts.forall(part => {
-        part.length <= 3 || Integer.parseInt(part) <= 255
-      })
-    }
-  }
-
-  private[net] def isValidIPv6Address(ipAddress: String): Boolean = {
-    val length: Int = ipAddress.length
-    var doubleColon: Boolean = false
-    var numberOfColons: Int = 0
-    var numberOfPeriods: Int = 0
-    var numberOfPercent: Int = 0
-    var word: String = ""
-    var c: Char = 0
-    var prevChar: Char = 0
-    // offset for [] IP addresses
-    var offset: Int = 0
-    if (length < 2) {
-      return false
-    }
-    for (i <- 0 until length) {
-      prevChar = c
-      c = ipAddress.charAt(i)
-      c match {
-        // case for an open bracket [x:x:x:...x]
-        case '[' =>
-          if (i != 0) {
-            // must be first character
-            return false
-          }
-          if (ipAddress.charAt(length - 1) != ']') {
-            // must have a close ]
-            return false
-          }
-          offset = 1
-          if (length < 4) {
-            return false
-          }
-        // case for a closed bracket at end of IP [x:x:x:...x]
-        case ']' =>
-          if (i != (length - 1)) {
-            // must be last character
-            return false
-          }
-          if (ipAddress.charAt(0) != '[') {
-            // must have a open [
-            return false
-          }
-        // case for the last 32-bits represented as IPv4 x:x:x:x:x:x:d.d.d.d
-        case '.' =>
-          numberOfPeriods += 1
-          if (numberOfPeriods > 3) {
-            return false
-          }
-          if (!isValidIP4Word(word)) {
-            return false
-          }
-          if (numberOfColons != 6 && !doubleColon) {
-            return false
-          }
-          // IPv4 ending, otherwise 7 :'s is bad
-          if (numberOfColons == 7 && ipAddress.charAt(0 + offset) != ':' &&
-              ipAddress.charAt(1 + offset) != ':') {
-            return false
-          }
-          word = ""
-        // a special case ::1:2:3:4:5:d.d.d.d allows 7 colons with an
-        case ':' =>
-          numberOfColons += 1
-          if (numberOfColons > 7) {
-            return false
-          }
-          if (numberOfPeriods > 0) {
-            return false
-          }
-          if (prevChar == ':') {
-            if (doubleColon) {
-              return false
-            }
-            doubleColon = true
-          }
-          word = ""
-        case '%' =>
-          if (numberOfColons == 0) {
-            return false
-          }
-          numberOfPercent += 1
-          // validate that the stuff after the % is valid
-          if ((i + 1) >= length) {
-            // in this case the percent is there but no number is available
-            return false
-          }
-          try Integer.parseInt(ipAddress.substring(i + 1))
-          catch {
-            case e: NumberFormatException => return false
-          }
-        case _ =>
-          if (numberOfPercent == 0) {
-            if (word.length > 3) {
-              return false
-            }
-            if (!isValidHexChar(c)) {
-              return false
-            }
-          }
-          word += c
-
-      }
-    }
-    // Check if we have an IPv4 ending
-    if (numberOfPeriods > 0) {
-      if (numberOfPeriods != 3 || !isValidIP4Word(word)) {
-        return false
-      }
-    } else {
-      if (numberOfColons != 7 && !doubleColon) {
-        return false
-      }
-      if (numberOfPercent == 0) {
-        if (word == "" && ipAddress.charAt(length - 1 - offset) == ':' &&
-            ipAddress.charAt(length - 2 - offset) != ':') {
-          return false
-        }
-      }
-    }
-    true
-  }
-
-  private def isValidHexChar(c: Char): Boolean =
-    (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f')
-
-  private def isValidIP4Word(word: String): Boolean = {
-    if (word.length < 1 || word.length > 3) {
-      return false
-    }
-
-    for (c <- word) {
-      if (!(c >= '0' && c <= '9')) {
-        return false
-      }
-    }
-
-    if (Integer.parseInt(word) > 255) {
-      return false
-    }
-
-    true
-  }
-
-  private lazy val loopbackIPv4 = new Inet4Address(Array[Byte](127, 0, 0, 1))
-  private lazy val loopbackIPv6 = new Inet6Address(
-    Array[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
-  )
-
-  def getLoopbackAddress(): InetAddress =
-    if (SocketHelpers.getPreferIPv6Addresses()) loopbackIPv6
-    else loopbackIPv4
-
-  private lazy val wildcardIPv4 =
-    new Inet4Address(Array[Byte](0, 0, 0, 0), "0.0.0.0")
-
-  private lazy val wildcardIPv6 = new Inet6Address(
-    Array[Byte](0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
-    "0:0:0:0:0:0:0:0"
-  )
-
-  private[net] def getWildcardAddress(): InetAddress =
-    if (SocketHelpers.getPreferIPv6Addresses()) wildcardIPv6
-    else wildcardIPv4
-
-  private def byteArrayFromIPString(ip: String): Array[Byte] = {
-    if (isValidIPv4Address(ip))
-      return ip.split("\\.").map(Integer.parseInt(_).toByte)
-
-    var ipAddr = ip
-    if (ipAddr.charAt(0) == '[')
-      ipAddr = ipAddr.substring(1, ipAddr.length - 1)
-
-    val tokenizer = new StringTokenizer(ipAddr, ":.", true)
-    val hexStrings = new ArrayBuffer[String]()
-    val decStrings = new ArrayBuffer[String]()
-    var token = ""
-    var prevToken = ""
-    var doubleColonIndex = -1
-
-    /*
-     * Go through the tokens, including the separators ':' and '.' When we
-     * hit a : or . the previous token will be added to either the hex list
-     * or decimal list. In the case where we hit a :: we will save the index
-     * of the hexStrings so we can add zeros in to fill out the string
-     */
-    while (tokenizer.hasMoreTokens()) {
-      prevToken = token
-      token = tokenizer.nextToken()
-
-      if (token == ":") {
-        if (prevToken == ":")
-          doubleColonIndex = hexStrings.size
-        else if (prevToken != "")
-          hexStrings += prevToken
-      } else if (token == ".")
-        decStrings += prevToken
-    }
-
-    if (prevToken == ":") {
-      if (token == ":")
-        doubleColonIndex = hexStrings.size
-      else
-        hexStrings += token
-    } else if (prevToken == ".")
-      decStrings += token
-
-    // figure out how many hexStrings we should have
-    // also check if it is a IPv4 address
-    var hexStringLength = 8
-    // If we have an IPv4 address tagged on at the end, subtract
-    // 4 bytes, or 2 hex words from the total
-    if (decStrings.size > 0)
-      hexStringLength -= 2
-
-    if (doubleColonIndex != -1) {
-      val numberToInsert = hexStringLength - hexStrings.size
-      for (i <- 0 until numberToInsert)
-        hexStrings.insert(doubleColonIndex, "0")
-    }
-
-    val ipByteArray = new Array[Byte](16)
-
-    for (i <- 0 until hexStrings.size)
-      convertToBytes(hexStrings(i), ipByteArray, i * 2)
-
-    for (i <- 0 until decStrings.size)
-      ipByteArray(i + 12) =
-        (java.lang.Byte.parseByte(decStrings(i)) & 255).toByte
-
-    // now check to see if this guy is actually and IPv4 address
-    // an ipV4 address is ::FFFF:d.d.d.d
-    var ipV4 = true
-    for (i <- 0 until 10) {
-      if (ipByteArray(i) != 0)
-        ipV4 = false
-    }
-
-    if (ipByteArray(10) != -1 || ipByteArray(11) != -1)
-      ipV4 = false
-
-    if (ipV4) {
-      val ipv4ByteArray = new Array[Byte](4)
-      for (i <- 0 until 4)
-        ipv4ByteArray(i) = ipByteArray(i + 12)
-      return ipv4ByteArray
-    }
-
-    return ipByteArray
-  }
-
-  private def convertToBytes(
-      hexWord: String,
-      ipByteArray: Array[Byte],
-      byteIndex: Int
-  ): Unit = {
-    val hexWordLength = hexWord.length
-    var hexWordIndex = 0
-    ipByteArray(byteIndex) = 0
-    ipByteArray(byteIndex + 1) = 0
-
-    var charValue = 0
-    if (hexWordLength > 3) {
-      charValue = getIntValue(hexWord.charAt(hexWordIndex))
-      hexWordIndex += 1
-      ipByteArray(byteIndex) =
-        (ipByteArray(byteIndex) | (charValue << 4)).toByte
-    }
-    if (hexWordLength > 2) {
-      charValue = getIntValue(hexWord.charAt(hexWordIndex))
-      hexWordIndex += 1
-      ipByteArray(byteIndex) = (ipByteArray(byteIndex) | charValue).toByte
-    }
-    if (hexWordLength > 1) {
-      charValue = getIntValue(hexWord.charAt(hexWordIndex))
-      hexWordIndex += 1
-      ipByteArray(byteIndex + 1) =
-        (ipByteArray(byteIndex + 1) | (charValue << 4)).toByte
-    }
-
-    charValue = getIntValue(hexWord.charAt(hexWordIndex))
-    ipByteArray(byteIndex + 1) =
-      (ipByteArray(byteIndex + 1) | charValue & 15).toByte
-  }
-
-  private def getIntValue(c: Char): Int = {
-    if (c <= '9' && c >= '0')
-      return c - '0'
-    val cLower = Character.toLowerCase(c)
-    if (cLower <= 'f' && cLower >= 'a') {
-      return cLower - 'a' + 10
-    }
-    return 0
-  }
-
-  private val hexCharacters = "0123456789ABCDEF"
-
-  private[net] def createIPStringFromByteArray(
-      ipByteArray: Array[Byte]
-  ): String = {
-    if (ipByteArray.length == 4)
-      return addressToString(bytesToInt(ipByteArray, 0))
-
-    if (ipByteArray.length == 16) {
-      if (isIPv4MappedAddress(ipByteArray)) {
-        val ipv4ByteArray = new Array[Byte](4)
-        for (i <- 0 until 4)
-          ipv4ByteArray(i) = ipByteArray(i + 12)
-
-        return addressToString(bytesToInt(ipv4ByteArray, 0))
-      }
-      val buffer = new StringBuilder()
-      var isFirst = true
-      for (i <- 0 until ipByteArray.length) {
-        if ((i & 1) == 0)
-          isFirst = true
-
-        var j = (ipByteArray(i) & 0xf0) >>> 4
-        if (j != 0 || !isFirst) {
-          buffer.append(hexCharacters.charAt(j))
-          isFirst = false
-        }
-        j = ipByteArray(i) & 0x0f
-        if (j != 0 || !isFirst) {
-          buffer.append(hexCharacters.charAt(j))
-          isFirst = false
-        }
-        if ((i & 1) != 0 && (i + 1) < ipByteArray.length) {
-          if (isFirst)
-            buffer.append('0')
-          buffer.append(':')
-        }
-        if ((i & 1) != 0 && (i + 1) == ipByteArray.length && isFirst) {
-          buffer.append('0')
-        }
-      }
-      return buffer.toString
-    }
-    null
-  }
-
-  private def isIPv4MappedAddress(ipAddress: Array[Byte]): Boolean = {
-    // Check if the address matches ::FFFF:d.d.d.d
-    // The first 10 bytes are 0. The next to are -1 (FF).
-    // The last 4 bytes are varied.
-    for (i <- 0 until 10)
-      if (ipAddress(i) != 0)
-        return false
-
-    if (ipAddress(10) != -1 || ipAddress(11) != -1)
-      return false
-
-    return true
-  }
-
-  private[net] def bytesToInt(bytes: Array[Byte], start: Int): Int = {
-    // First mask the byte with 255, as when a negative
-    // signed byte converts to an integer, it has bits
-    // on in the first 3 bytes, we are only concerned
-    // about the right-most 8 bits.
-    // Then shift the rightmost byte to align with its
-    // position in the integer.
-    return (((bytes(start + 3) & 255)) | ((bytes(start + 2) & 255) << 8)
-      | ((bytes(start + 1) & 255) << 16)
-      | ((bytes(start) & 255) << 24))
-  }
-
-  private def addressToString(value: Int): String = {
-    val p1 = (value >> 24) & 0xff
-    val p2 = (value >> 16) & 0xff
-    val p3 = (value >> 8) & 0xff
-    val p4 = value & 0xff
-    s"$p1.$p2.$p3.$p4"
-  }
-}
-
-object InetAddress extends InetAddressBase {
-  // cached host values are discarded after this amount of time (seconds)
-  private val HostTimeout: Int =
-    sys.props
-      .get("networkaddress.cache.ttl")
-      .map(_.toInt)
-      .getOrElse(30)
-
-  // failed lookups are retried after this amount of time (seconds)
-  private val NegativeHostTimeout: Int =
-    sys.props
-      .get("networkaddress.cache.negative.ttl")
-      .map(_.toInt)
-      .getOrElse(10)
-}
-
-class InetAddress private[net] (
-    ipAddress: Array[Byte],
-    private val originalHost: String
-) extends Serializable {
+class InetAddress protected (ipAddress: Array[Byte], originalHost: String)
+    extends Serializable {
   import InetAddress._
+
+  private def this(ipAddress: Array[Byte]) = this(ipAddress, null)
 
   private var hostLastUpdated: time_t = 0
   private var cachedHost: String = null
   private var lastLookupFailed = true
 
-  private[net] def this(ipAddress: Array[Byte]) = this(ipAddress, null)
+  override def equals(obj: Any): Boolean = {
+    if (obj == null || obj.getClass != this.getClass) {
+      false
+    } else {
+      val objIPAddress = obj.asInstanceOf[InetAddress].getAddress()
+      objIPAddress.indices.forall(i => objIPAddress(i) == ipAddress(i))
+    }
+  }
 
-  def getHostAddress(): String = createIPStringFromByteArray(ipAddress)
+  def getAddress() = ipAddress.clone
 
-  private def hostTimeoutExpired(timeNow: time_t): Boolean = {
-    val timeout = if (lastLookupFailed) NegativeHostTimeout else HostTimeout
-    difftime(timeNow, hostLastUpdated) > timeout
+  def getCanonicalHostName(): String = {
+    // reverse name lookup with cache
+
+    def hostTimeoutExpired(timeNow: time_t): Boolean = {
+      val timeout = if (lastLookupFailed) NegativeHostTimeout else HostTimeout
+      difftime(timeNow, hostLastUpdated) > timeout
+    }
+
+    val timeNow = time(null)
+    if (cachedHost == null || hostTimeoutExpired(timeNow)) {
+      hostLastUpdated = timeNow
+
+      getFullyQualifiedDomainName(ipAddress) match {
+        case None =>
+          lastLookupFailed = true
+          cachedHost = getHostAddress()
+        case Some(hostName) =>
+          lastLookupFailed = false
+          cachedHost = hostName
+      }
+    }
+    cachedHost
+  }
+
+  def getHostAddress(): String = {
+    if (ipAddress.length == 4) {
+      formatIn4Addr(arrayByteToPtrByte(ipAddress))
+    } else if (ipAddress.length == 16) {
+      if (isIPv4MappedAddress(arrayByteToPtrByte(ipAddress))) {
+        formatIn4Addr(
+          arrayByteToPtrByte(extractIP4Bytes(arrayByteToPtrByte(ipAddress)))
+        )
+      } else {
+        Inet6Address.formatInet6Address(this.asInstanceOf[Inet6Address])
+      }
+    } else {
+      "<unknown>"
+    }
   }
 
   def getHostName(): String = {
@@ -622,56 +108,24 @@ class InetAddress private[net] (
     }
   }
 
-  def getCanonicalHostName(): String = {
-    // reverse name lookup with cache
-    val timeNow = time(null)
-    if (cachedHost == null || hostTimeoutExpired(timeNow)) {
-      hostLastUpdated = timeNow
-      val ipString = createIPStringFromByteArray(ipAddress)
-      SocketHelpers.ipToHost(ipString, isValidIPv6Address(ipString)) match {
-        case None =>
-          lastLookupFailed = true
-          cachedHost = ipString
-        case Some(hostName) =>
-          lastLookupFailed = false
-          cachedHost = hostName
-      }
-    }
-    cachedHost
+  // Method used historically by Scala Native for IPv4 addresses.
+  protected def bytesToInt(bytes: Array[Byte], start: Int): Int = {
+    // First mask the byte with 255, as when a negative
+    // signed byte converts to an integer, it has bits
+    // on in the first 3 bytes, we are only concerned
+    // about the right-most 8 bits.
+    // Then shift the rightmost byte to align with its
+    // position in the integer.
+    return (((bytes(start + 3) & 255)) | ((bytes(start + 2) & 255) << 8)
+      | ((bytes(start + 1) & 255) << 16)
+      | ((bytes(start) & 255) << 24))
   }
 
-  def getAddress() = ipAddress.clone
+  protected def getZoneIdent(): String = "" // Ease Inet6Address declaration
 
-  override def equals(obj: Any): Boolean = {
-    if (obj == null || obj.getClass != this.getClass) {
-      false
-    } else {
-      val objIPAddress = obj.asInstanceOf[InetAddress].getAddress()
-      objIPAddress.indices.forall(i => objIPAddress(i) == ipAddress(i))
-    }
-  }
-
-  override def hashCode(): Int = InetAddress.bytesToInt(ipAddress, 0)
-
-  override def toString(): String = {
-    val hostName =
-      if (originalHost != null) originalHost
-      else if (!lastLookupFailed) cachedHost
-      else ""
-
-    hostName + "/" + getHostAddress()
-  }
-
-  def isReachable(timeout: Int): Boolean = {
-    if (timeout < 0) {
-      throw new IllegalArgumentException(
-        "Argument 'timeout' in method 'isReachable' is negative"
-      )
-    } else {
-      val ipString = createIPStringFromByteArray(ipAddress)
-      SocketHelpers.isReachableByEcho(ipString, timeout, 7)
-    }
-  }
+  override def hashCode(): Int =
+    if (ipAddress.length == 4) bytesToInt(ipAddress, 0) // too scared to change
+    else ju.Arrays.hashCode(ipAddress)
 
   def isLinkLocalAddress(): Boolean = false
 
@@ -691,6 +145,605 @@ class InetAddress private[net] (
 
   def isMulticastAddress(): Boolean = false
 
+  /* Editorial comment: isReachable() is in the Java 8 specification and
+   * must be implemented for completeness. It has severely limited utility
+   * in the 21st century.  Many, if not most, systems now block the
+   * echo port (7). ICMP is not used here because it requires elevated
+   * privileges and is also often blocked.
+   */
+
+  def isReachable(timeout: Int): Boolean = {
+    if (timeout < 0) {
+      throw new IllegalArgumentException(
+        "Argument 'timeout' in method 'isReachable' is negative"
+      )
+    } else {
+      val s = new Socket()
+      val echoPort = 7 // Port from Java spec, almost _always_ disbled.
+      val isReachable =
+        try {
+          s.connect(new InetSocketAddress(this, echoPort), timeout)
+          /* Most likely outcome: java.net.ConnectException: Connection refused
+           * Could also be a TimeoutException. Let them bubble up.
+           */
+          true
+        } finally {
+          s.close()
+        }
+      isReachable
+    }
+  }
+
+  // Not implemented: isReachable(NetworkInterface netif, int ttl, int timeout)
+
   def isSiteLocalAddress(): Boolean = false
+
+  override def toString(): String = {
+    val hostName =
+      if (originalHost != null) originalHost
+      else if (!lastLookupFailed) cachedHost
+      else ""
+
+    hostName + "/" + getHostAddress()
+  }
+
+}
+
+object InetAddress {
+
+  // cached host values are discarded after this amount of time (seconds)
+  private val HostTimeout: Int =
+    sys.props
+      .get("networkaddress.cache.ttl")
+      .map(_.toInt)
+      .getOrElse(30)
+
+  // failed lookups are retried after this amount of time (seconds)
+  private val NegativeHostTimeout: Int =
+    sys.props
+      .get("networkaddress.cache.negative.ttl")
+      .map(_.toInt)
+      .getOrElse(10)
+
+  private def apply(
+      addrinfoP: Ptr[addrinfo],
+      host: String,
+      isNumeric: Boolean
+  ): InetAddress = {
+    /* if an address parses as numeric, some JVM implementations are said
+     * to fill the host field in the resultant InetAddress with the
+     * numeric representation.
+     * The Scastie JVM and those used for Linux/macOS manual testing seem
+     * to leave the host field blank/empty.
+     */
+    val effectiveHost = if (isNumeric) "" else host
+
+    if (addrinfoP.ai_family == AF_INET) {
+      new Inet4Address(addrinfoToByteArray(addrinfoP), effectiveHost)
+    } else if (addrinfoP.ai_family == AF_INET6) {
+      val addr = addrinfoP.ai_addr.asInstanceOf[Ptr[sockaddr_in6]]
+      val addrBytes = addr.sin6_addr.at1.asInstanceOf[Ptr[Byte]]
+
+      // Scala JVM down-converts even when preferIPv6Addresses is "true"
+      if (isIPv4MappedAddress(addrBytes)) {
+        new Inet4Address(extractIP4Bytes(addrBytes), effectiveHost)
+      } else {
+        /* Yes, Java specifies Int for scope_id in a way which disallows
+         * some values POSIX/IEEE/IETF allows.
+         */
+
+        val scope_id = addr.sin6_scope_id.toInt
+
+        val zoneIdent = {
+          val ifIndex = host.indexOf('%')
+          val ifNameStart = ifIndex + 1
+          if ((ifIndex < 0) || (ifNameStart >= host.length)) ""
+          else host.substring(ifNameStart)
+        }
+
+        Inet6Address(
+          addrinfoToByteArray(addrinfoP),
+          effectiveHost,
+          scope_id,
+          zoneIdent
+        )
+      }
+    } else {
+      val af = addrinfoP.ai_family
+      throw new IOException(
+        s"The requested address family is not supported: ${af}."
+      )
+    }
+  }
+
+  /* This is for littleEndian machines. It may need to detect BigEndian
+   * machines and do something different, at worst a byte-by-byte copy.
+   */
+  private def addrinfoToByteArray(
+      addrinfoP: Ptr[addrinfo]
+  ): Array[Byte] = {
+
+    if (addrinfoP.ai_family == AF_INET6) {
+      val bufSize = 16
+      val buf = new Array[Byte](bufSize)
+
+      val addr = addrinfoP.ai_addr.asInstanceOf[Ptr[sockaddr_in6]]
+      val addrBytes = addr.sin6_addr.at1.asInstanceOf[Ptr[Byte]]
+
+      memcpy(arrayByteToPtrByte(buf), addrBytes, bufSize.toUInt)
+
+      buf
+    } else if (addrinfoP.ai_family == AF_INET) {
+      val buf = new Array[Byte](4)
+
+      val v4addr = addrinfoP.ai_addr.asInstanceOf[Ptr[sockaddr_in]]
+      val sinAddr = v4addr.sin_addr
+
+      val dst = arrayByteToPtrByte(buf).asInstanceOf[Ptr[in_addr]]
+      !dst = sinAddr // Structure copy
+
+      buf
+    } else {
+      // caller should have detected & thrown before getting this far.
+      Array.empty[Byte]
+    }
+  }
+
+  @alwaysinline private def arrayByteToPtrByte(ab: Array[Byte]): Ptr[Byte] =
+    ab.asInstanceOf[scala.scalanative.runtime.ByteArray].at(0)
+
+  private def extractIP4Bytes(pb: Ptr[Byte]): Array[Byte] = {
+    val buf = new Array[Byte](4)
+    buf(0) = pb(12)
+    buf(1) = pb(13)
+    buf(2) = pb(14)
+    buf(3) = pb(15)
+    buf
+  }
+
+  private def formatIn4Addr(pb: Ptr[Byte]): String = {
+    val addr = pb.asInstanceOf[Ptr[in_addr]]
+    val dstSize = INET_ADDRSTRLEN
+    val dst = stackalloc[Byte](dstSize.toUSize)
+
+    val result = inet_ntop(
+      AF_INET,
+      addr.at1.asInstanceOf[Ptr[Byte]],
+      dst,
+      dstSize.toUInt
+    )
+
+    if (result == null)
+      throw new IOException(s"inet_ntop IPv4 failed, errno: ${errno}")
+
+    fromCString(dst)
+  }
+
+  private def getByNumericName(host: String): Option[InetAddress] = Zone {
+    implicit z =>
+      val hints = stackalloc[addrinfo]() // stackalloc clears its memory
+      val addrinfo = stackalloc[Ptr[addrinfo]]()
+
+      hints.ai_family = AF_UNSPEC
+      hints.ai_socktype = SOCK_STREAM
+      hints.ai_protocol = IPPROTO_TCP
+      hints.ai_flags = AI_NUMERICHOST
+
+      val gaiStatus = getaddrinfo(toCString(host), null, hints, addrinfo)
+
+      if (gaiStatus != 0) {
+        if (gaiStatus == EAI_NONAME) {
+          val ifIndex = host.indexOf('%')
+          val hasInterface = (ifIndex >= 0)
+          if (!hasInterface) {
+            None
+          } else {
+            /* If execution gets here, we know that we are dealing with one
+             * of a large number of corner cases where interface/scope
+             * id suppplied us not valid for host supplied.
+             * ScalaJVM reports some cases early, such as an unknown
+             * non-numeric interface name, and some later, probably at the
+             * point of use, such as an invalid numeric interface id.
+             *
+             * It is simply not economic to try to match the timing and
+             * mesage of all those cases. They all boil down to the
+             * interface being invalid.
+             */
+            throw new UnknownHostException(
+              s"something rotten with host and/or interface: '${host}'"
+            )
+          }
+        } else {
+          val gaiMsg = SocketHelpers.getGaiErrorMessage(gaiStatus)
+          throw new IOException(gaiMsg)
+        }
+      } else
+        try {
+          // should never happen, but check anyways
+          java.util.Objects.requireNonNull(!addrinfo)
+
+          /* At this point, there is at least one addrinfo. Use the first
+           * one unconditionally because here is a vanishingly small chance
+           * it will have an af_family other than AF_INET or AF_INET6. Other
+           * protocols should caused getaddrinfo() to return EAI_NONAME.
+           *
+           * InetAddress() will catch the case of an af_family which is
+           * neither IPv4 nor IPv6.
+           */
+
+          Some(InetAddress(!addrinfo, host, isNumeric = true))
+        } finally {
+          freeaddrinfo(!addrinfo)
+        }
+  }
+
+  private def getByNonNumericName(host: String): InetAddress = Zone {
+    implicit z =>
+      /* To prevent circular dependencies, javalib is not supposed to use
+       * the quite powerful Scala Collections library.
+       *
+       * Use tail recursion to avoid an even nastier while loop. Let
+       * the Scala compiler do the work.
+       */
+
+      @tailrec
+      def findPreferrredAddrinfo(
+          preference: Option[Boolean],
+          ai: Ptr[addrinfo]
+      ): Option[Ptr[addrinfo]] = {
+
+        if (ai == null) {
+          None
+        } else {
+          val result =
+            if (ai.ai_family == AF_INET) {
+              if ((preference == None) || (preference.get == false)) {
+                Some(ai)
+              } else {
+                None
+              }
+            } else if (ai.ai_family == AF_INET6) {
+              if ((preference == None) || (preference.get == true)) {
+                Some(ai)
+              } else {
+                None
+              }
+            } else { // skip AF_UNSPEC & other unknown families
+              None
+            }
+
+          if (result != None) {
+            result
+          } else {
+            val aiNext = ai.ai_next.asInstanceOf[Ptr[addrinfo]]
+            findPreferrredAddrinfo(preference, aiNext)
+          }
+        }
+      }
+
+      val hints = stackalloc[addrinfo]() // stackalloc clears its memory
+      val addrinfo = stackalloc[Ptr[addrinfo]]()
+
+      hints.ai_family = SocketHelpers.getGaiHintsAddressFamily()
+      hints.ai_socktype = SOCK_STREAM
+      hints.ai_protocol = IPPROTO_TCP
+      if (hints.ai_family == AF_INET6) {
+        hints.ai_flags |= (AI_V4MAPPED | AI_ADDRCONFIG)
+      }
+
+      val gaiStatus = getaddrinfo(toCString(host), null, hints, addrinfo)
+
+      if (gaiStatus != 0) {
+        val gaiMsg = SocketHelpers.getGaiErrorMessage(gaiStatus)
+        val ex =
+          if (gaiStatus == EAI_NONAME)
+            new UnknownHostException(gaiMsg)
+          else
+            new IOException(gaiMsg)
+        throw ex
+      } else
+        try {
+          val preferIPv6 = SocketHelpers.getPreferIPv6Addresses()
+          findPreferrredAddrinfo(preferIPv6, !addrinfo) match {
+            case None =>
+              throw new UnknownHostException(s"${host}: Name does not resolve")
+            case Some(ai) => InetAddress(ai, host, isNumeric = false)
+          }
+        } finally {
+          freeaddrinfo(!addrinfo)
+        }
+  }
+
+  /* Fully Qualified Domain Name which may or may not be the same as the
+   * canonical name.
+   */
+  private def getFullyQualifiedDomainName(
+      ipByteArray: Array[Byte]
+  ): Option[String] = {
+    /* MAXDNAME is the largest size of a Fully Qualified Domain Name.
+     * It is defined in:
+     *   https://github.com/openbsd/src/blob/master/include/arpa/nameser.h
+     *
+     * That URL says: "Define constants based on rfc883".
+     * These are direct name (bind) server definitions.
+     *
+     * This is larger than the length of individual segments because there
+     * can be multiple segments of 256. Two56.Two56.Two56.com
+     *
+     * On many BSD derived systems, this value is defined as (non-POSIX)
+     * NI_MAXHOST.
+     *   https://man7.org/linux/man-pages/man3/getnameinfo.3.html
+     *
+     * RFC 2181, section "Name syntax" states:
+     *   The length of any one label is limited to between 1 and 63 octets.
+     *   A full domain name is limited to 255 octets (including the
+     *   separators).
+     *
+     * A CString needs one more space for its terminal NUL.
+     *
+     * Use the larger MAXDNAME here, the extra space is not _all_ that
+     * expensive, and it is not used for long.
+     */
+
+    val MAXDNAME = 1025.toUInt /* maximum presentation domain name */
+
+    def tailorSockaddr(ipBA: Array[Byte], addr: Ptr[sockaddr]): Unit = {
+      val from =
+        ipBA.asInstanceOf[scala.scalanative.runtime.Array[Byte]].at(0)
+
+      // By contract the 'sockaddr' argument passed in is cleared/all_zeros.
+      if (ipBA.length == 16) {
+        val v6addr = addr.asInstanceOf[Ptr[sockaddr_in6]]
+        v6addr.sin6_family = AF_INET6.toUShort
+        // because the FQDN scope is Global, no need to set sin6_scope_id
+        val dst = v6addr.sin6_addr.at1.at(0).asInstanceOf[Ptr[Byte]]
+        memcpy(dst, from, 16.toUInt)
+      } else {
+        val v4addr = addr.asInstanceOf[Ptr[sockaddr_in]]
+        v4addr.sin_family = AF_INET.toUShort
+        v4addr.sin_addr = !(from.asInstanceOf[Ptr[in_addr]]) // Structure copy
+      }
+    }
+
+    def ipToHost(ipBA: Array[Byte]): Option[String] =
+      Zone { implicit z =>
+        // Reserve extra space for NUL terminator.
+        val hostSize = MAXDNAME + 1.toUInt
+        val host: Ptr[CChar] = alloc[CChar](hostSize)
+        val addr = stackalloc[sockaddr]() // will clear/zero all memory returned
+
+        // By contract 'sockaddr' passed into tailor method is all zeros.
+        tailorSockaddr(ipBA, addr)
+        val status =
+          getnameinfo(
+            addr,
+            if (ipBA.length == 16) sizeof[sockaddr_in6].toUInt
+            else sizeof[sockaddr_in].toUInt,
+            host,
+            hostSize,
+            null, // 'service' is not used; do not retrieve
+            0.toUInt,
+            0
+          )
+
+        if (status != 0) None else Some(fromCString(host))
+      }
+
+    ipToHost(ipByteArray: Array[Byte])
+  }
+
+  private def hostToInetAddressArray(host: String): Array[InetAddress] =
+    Zone { implicit z =>
+      /* The JVM implementations in both the manual testing &
+       * Continuous Integration environments have the "feature" of
+       * not filling in the host field of an InetAddress if the name
+       * is strictly numeric.
+       *
+       * See the getByName() method and those it calls for a discussion
+       * about difficulties determining if a given string is a numeric
+       * hostname or not.
+       *
+       * Use a heuristic (a.k.a "weasel") to avoid the complexity of
+       * "double getadderfo" handling here. Not much bad happens when
+       * the heuristic fails.
+       */
+
+      val hostIsNumeric = {
+        val leadingCh = host(0)
+        Character.isDigit(leadingCh) || (leadingCh == ':')
+      }
+
+      @tailrec
+      def addAddresses(
+          addIPv4: Boolean,
+          addIPv6: Boolean,
+          ai: Ptr[addrinfo],
+          host: String,
+          iaBuf: scala.collection.mutable.ArrayBuffer[InetAddress]
+      ): Unit = {
+        if (ai != null) {
+          if ((ai.ai_family == AF_INET) && addIPv4) {
+            iaBuf += InetAddress(ai, host, hostIsNumeric)
+          } else if ((ai.ai_family == AF_INET6) && addIPv6) {
+            iaBuf += InetAddress(ai, host, hostIsNumeric)
+          }
+          // else skip AF_UNSPEC & other unknown families
+
+          val aiNext = ai.ai_next.asInstanceOf[Ptr[addrinfo]]
+          addAddresses(addIPv4, addIPv6, aiNext, host, iaBuf)
+        }
+      }
+
+      def fillAddressBuffer(
+          preference: Option[Boolean],
+          ai: Ptr[addrinfo],
+          host: String,
+          iaBuf: scala.collection.mutable.ArrayBuffer[InetAddress]
+      ): Unit = {
+
+        preference match {
+          case None =>
+            addAddresses(addIPv4 = true, addIPv6 = true, ai, host, iaBuf)
+
+          case Some(preferIPv6) if (preferIPv6) => // AddIPv6 first, then IPv4
+            addAddresses(addIPv4 = false, addIPv6 = true, ai, host, iaBuf)
+            addAddresses(addIPv4 = true, addIPv6 = false, ai, host, iaBuf)
+
+          case Some(_) => // AddIPv4 first, then IPv6
+            addAddresses(addIPv4 = true, addIPv6 = false, ai, host, iaBuf)
+            addAddresses(addIPv4 = false, addIPv6 = true, ai, host, iaBuf)
+        }
+      } // def fillAddressBuffer
+
+      val retArray = scala.collection.mutable.ArrayBuffer[InetAddress]()
+
+      val hints = stackalloc[addrinfo]()
+      val ret = stackalloc[Ptr[addrinfo]]()
+
+      hints.ai_family = AF_UNSPEC
+      hints.ai_socktype = SOCK_STREAM // ignore SOCK_DGRAM only
+      hints.ai_protocol = IPPROTO_TCP
+
+      val gaiStatus = getaddrinfo(toCString(host), null, hints, ret)
+
+      if (gaiStatus != 0) {
+        if (gaiStatus != EAI_NONAME) {
+          val gaiMsg = SocketHelpers.getGaiErrorMessage(gaiStatus)
+          throw new IOException(gaiMsg)
+        }
+      } else
+        try {
+          val preferIPv6 = SocketHelpers.getPreferIPv6Addresses()
+          fillAddressBuffer(preferIPv6, !ret, host, retArray)
+        } finally {
+          freeaddrinfo(!ret)
+        }
+
+      retArray.toArray
+    }
+
+  private def isIPv4MappedAddress(pb: Ptr[Byte]): Boolean = {
+    val ptrInt = pb.asInstanceOf[Ptr[Int]]
+    val ptrLong = pb.asInstanceOf[Ptr[Long]]
+    (ptrInt(2) == 0xffff0000) && (ptrLong(0) == 0x0L)
+  }
+
+  private def unknownHostExceptionMsg(name: String): String = {
+    /* This is the text used by 'Temurin Java 1.8.0_345'.
+     * Please consult frequent Scala Native contributor Arman Bilge
+     * before changing it. Changes may break versions of project ip4s.
+     * Having that project run unchanged on JVM, Scala.js, & Scala Native
+     * is influential.
+     *
+     * Yes, tests for exact messages is fraught with hazard, especially
+     * if they can be internationalized. On the other hand, having
+     * a user base is a Good Thing.
+     *
+     * Scastie (online Scala JVM) and macOS Monterrey 12.6 Zulu JVM
+     * have text which differ from this and each other.
+     */
+
+    name + ": Name or service not known"
+  }
+
+  def getAllByName(host: String): Array[InetAddress] = {
+    if ((host == null) || (host.length == 0)) {
+      /* The obvious recursive call to getAllByName("localhost") does not
+       * work here.
+       *
+       * ScalaJVM, on both Linux & macOS, returns a 1 element array
+       * with the host field filled in. The InetAddress type and address
+       * field are controlled by the System property
+       * "java.net.preferIPv6Addresses"
+       */
+
+      val lbBytes = SocketHelpers.getLoopbackAddress().getAddress()
+
+      // use a subclass so that isLoopback method is effective & truthful.
+      val ia = if (lbBytes.length == 4) {
+        new Inet4Address(lbBytes, "localhost")
+      } else {
+        new Inet6Address(lbBytes, "localhost")
+      }
+      Array[InetAddress](ia)
+    } else {
+      val ips = InetAddress.hostToInetAddressArray(host)
+      if (ips.isEmpty) {
+        throw new UnknownHostException(host + ": Name or service not known")
+      }
+      ips
+    }
+  }
+
+  def getByAddress(addr: Array[Byte]): InetAddress =
+    getByAddress(null, addr)
+
+  def getByAddress(host: String, addr: Array[Byte]): InetAddress = {
+    /* Java 8 spec say adddress must be 4 or 16 bytes long, so no IPv6
+     * scope_id complexity required here.
+     */
+    if (addr.length == 4) {
+      new Inet4Address(addr.clone, host)
+    } else if (addr.length == 16) {
+      new Inet6Address(addr.clone, host)
+    } else {
+      throw new UnknownHostException(
+        s"addr is of illegal length: ${addr.length}"
+      )
+    }
+  }
+
+  def getByName(host: String): InetAddress = {
+    /* Design Note:
+     *     A long comment because someone is going to have to maintain this
+     * and will appreciate the clues. 18 lines of comments for 3 lines of code.
+     *
+     * The double lookup below, first to check if the host is a numeric
+     * IPv4 or IPv6 address and then to look the host up as a non-numeric
+     * name, may look somewhere between passing strange and straight out
+     * dumb.
+     *
+     * It is because ScalaJVM creates the InetAddress with a null host name
+     * if the host resolves as numeric.  If the host resolves to non-numeric
+     * then the InetAddress is created using that String.
+     *
+     * There is not good way to test after a single omnibus lookup to tell
+     * if the host resolved as numeric or non-numeric.  inet_pton() for
+     * IPv4 addresses requires full dotted decimal: ddd.ddd.ddd.ddd.
+     * ScalaJVM parses and passes some more obscure but valid IPv4 addresses.
+     * There have long been test cases in InetAddressTest.scala for such.
+     *
+     * The less preferred inet_aton() handles these obscure cases but
+     * misses more modern usages. inet_aton() is not POSIX, so it's portability
+     * is an issue.
+     *
+     * Hence, the double lookup. Better solutions are welcome.
+     */
+
+    if (host == null || host.length == 0) {
+      getLoopbackAddress()
+    } else {
+      InetAddress
+        .getByNumericName(host)
+        .getOrElse(InetAddress.getByNonNumericName(host))
+    }
+  }
+
+  def getLocalHost(): InetAddress = {
+    val MAXHOSTNAMELEN = 256.toUInt // SUSv2 255 + 1 for terminal NUL
+    val hostName = stackalloc[Byte](MAXHOSTNAMELEN)
+
+    val ghnStatus = unistd.gethostname(hostName, MAXHOSTNAMELEN);
+    if (ghnStatus != 0) {
+      throw new UnknownHostException(unknownHostExceptionMsg(""))
+    } else {
+      /* OS library routine should have NUL terminated 'hostName'.
+       * If not, hostName(MAXHOSTNAMELEN) should be NUL from stackalloc.
+       */
+      InetAddress.getByName(fromCString(hostName))
+    }
+  }
+
+  def getLoopbackAddress(): InetAddress = SocketHelpers.getLoopbackAddress()
 
 }

--- a/javalib/src/main/scala/java/net/InetSocketAddress.scala
+++ b/javalib/src/main/scala/java/net/InetSocketAddress.scala
@@ -20,7 +20,7 @@ class InetSocketAddress private[net] (
 
   if (needsResolving) {
     if (addr == null) {
-      addr = InetAddress.getWildcardAddress()
+      addr = SocketHelpers.getWildcardAddress()
     }
     hostName = addr.getHostAddress()
   }
@@ -35,7 +35,7 @@ class InetSocketAddress private[net] (
 
   def this(port: Int) = {
     this(null, port, null, false)
-    addr = InetAddress.getWildcardAddress()
+    addr = SocketHelpers.getWildcardAddress()
     hostName = addr.getHostName()
   }
 

--- a/javalib/src/main/scala/java/net/ServerSocket.scala
+++ b/javalib/src/main/scala/java/net/ServerSocket.scala
@@ -15,7 +15,7 @@ class ServerSocket(
   private var closed = false
 
   if (bindAddr == null)
-    bindAddr = InetAddress.getWildcardAddress()
+    bindAddr = SocketHelpers.getWildcardAddress()
 
   if (port >= 0)
     startup()

--- a/javalib/src/main/scala/java/net/SocketHelpers.scala
+++ b/javalib/src/main/scala/java/net/SocketHelpers.scala
@@ -123,7 +123,11 @@ object SocketHelpers {
 
   // Return text translation of getaddrinfo (gai) error code.
   private[net] def getGaiErrorMessage(gaiErrorCode: CInt): String = {
-    fromCString(gai_strerror(gaiErrorCode))
+    if (isWindows) {
+      "getAddrInfo error code: ${gaiErrorCode}"
+    } else {
+      fromCString(gai_strerror(gaiErrorCode))
+    }
   }
 
   // Create copies of loopback & wildcard, so that originals never get changed

--- a/javalib/src/main/scala/java/net/UnixPlainSocketImpl.scala
+++ b/javalib/src/main/scala/java/net/UnixPlainSocketImpl.scala
@@ -15,7 +15,7 @@ private[net] class UnixPlainSocketImpl extends AbstractPlainSocketImpl {
 
   override def create(streaming: Boolean): Unit = {
     val af =
-      if (SocketHelpers.getPreferIPv4Stack()) socket.AF_INET
+      if (SocketHelpers.getUseIPv4Stack()) socket.AF_INET
       else socket.AF_INET6
 
     val sockType =

--- a/unit-tests/shared/src/test/scala/javalib/net/Inet6AddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/Inet6AddressTest.scala
@@ -7,88 +7,120 @@ import java.net._
 import org.junit.Test
 import org.junit.Assert._
 
+import org.scalanative.testsuite.utils.Platform
 import scalanative.junit.utils.AssertThrows.assertThrows
 
 class Inet6AddressTest {
 
+  @Test def getByNameIPv6ScopedZoneId(): Unit = {
+
+    // Establish baseline: valid address does not throw
+    val ia1 = InetAddress.getByName("::1")
+    assertEquals("/0:0:0:0:0:0:0:1", ia1.toString())
+
+    // Numeric address with numeric scope id does not throw.
+    val ia2 = InetAddress.getByName("::1%99")
+    assertEquals("/0:0:0:0:0:0:0:1%99", ia2.toString()) // shows proper zoneId
+
+    /* Scala JVM has a large number of corner cases where it throws an
+     * Exception when an interface (a.k.a scope) id is not valid.
+     * It is simply not economic to try to match the early/late timing
+     * and message of those conditions.
+     *
+     * Test here that an Exception _is_ thrown in a known case where
+     * ScalaJVM on some operating systems throws one.
+     */
+
+    if (!Platform.isMacOs) {
+      // Invalid interface name does throw.
+      assertThrows(
+        "getByName(\"::1%bogus\")",
+        classOf[UnknownHostException],
+        InetAddress.getByName("::1%bogus")
+      )
+    }
+  }
+
   @Test def isMulticastAddress(): Unit = {
     val addr = InetAddress.getByName("FFFF::42:42")
-    assertTrue(addr.isMulticastAddress())
+    assertTrue("a1", addr.isMulticastAddress())
 
     val addr2 = InetAddress.getByName("42::42:42")
-    assertFalse(addr2.isMulticastAddress())
+    assertFalse("a2", addr2.isMulticastAddress())
 
     val addr3 = InetAddress.getByName("::224.42.42.42")
-    assertFalse(addr3.isMulticastAddress())
+    assertFalse("a3", addr3.isMulticastAddress())
 
     val addr4 = InetAddress.getByName("::42.42.42.42")
-    assertFalse(addr4.isMulticastAddress())
+    assertFalse("a4", addr4.isMulticastAddress())
 
     val addr5 = InetAddress.getByName("::FFFF:224.42.42.42")
-    assert(addr5.isMulticastAddress())
+    assertTrue("a5", addr5.isMulticastAddress())
 
     val addr6 = InetAddress.getByName("::FFFF:42.42.42.42")
-    assertFalse(addr6.isMulticastAddress())
+    assertFalse("a6", addr6.isMulticastAddress())
   }
 
   @Test def isAnyLocalAddress(): Unit = {
     val addr = InetAddress.getByName("::0")
-    assert(addr.isAnyLocalAddress)
+    assertTrue("a1", addr.isAnyLocalAddress)
 
     val addr2 = InetAddress.getByName("::")
-    assert(addr2.isAnyLocalAddress)
+    assertTrue("a2", addr2.isAnyLocalAddress)
 
     val addr3 = InetAddress.getByName("::1")
-    assertFalse(addr3.isAnyLocalAddress)
+    assertFalse("a3", addr3.isAnyLocalAddress)
   }
 
   @Test def isLoopbackAddress(): Unit = {
     val addr = InetAddress.getByName("::1")
-    assert(addr.isLoopbackAddress)
+    assertTrue("a1", addr.isLoopbackAddress)
 
     val addr2 = InetAddress.getByName("::2")
-    assertFalse(addr2.isLoopbackAddress)
+    assertFalse("a2", addr2.isLoopbackAddress)
 
     val addr3 = InetAddress.getByName("::FFFF:127.0.0.0")
-    assert(addr3.isLoopbackAddress)
+    assertTrue("a3", addr3.isLoopbackAddress)
   }
 
   @Test def isLinkLocalAddress(): Unit = {
     val addr = InetAddress.getByName("FE80::0")
-    assert(addr.isLinkLocalAddress)
+    assertTrue("a1", addr.isLinkLocalAddress)
 
     val addr2 = InetAddress.getByName("FEBF::FFFF:FFFF:FFFF:FFFF")
-    assert(addr2.isLinkLocalAddress)
+    assertTrue("a2", addr2.isLinkLocalAddress)
 
     val addr3 = InetAddress.getByName("FEC0::1")
-    assertFalse(addr3.isLinkLocalAddress)
+    assertFalse("a3", addr3.isLinkLocalAddress)
   }
 
   @Test def isSiteLocalAddress(): Unit = {
     val addr = InetAddress.getByName("FEC0::0")
-    assert(addr.isSiteLocalAddress)
+    assertTrue("a1", addr.isSiteLocalAddress)
 
     val addr2 = InetAddress.getByName("FEBF::FFFF:FFFF:FFFF:FFFF:FFFF")
-    assertFalse(addr2.isSiteLocalAddress)
+    assertFalse("a2", addr2.isSiteLocalAddress)
   }
 
   @Test def isIPv4CompatibleAddress(): Unit = {
     val addr2 =
       InetAddress.getByName("::255.255.255.255").asInstanceOf[Inet6Address]
-    assert(addr2.isIPv4CompatibleAddress)
+    assertTrue(addr2.isIPv4CompatibleAddress)
   }
 
   @Test def getByAddress(): Unit = {
     assertThrows(
-      "123: Name or service not known",
+      "getByAddress(\"123\" , null, 0)",
       classOf[UnknownHostException],
       Inet6Address.getByAddress("123", null, 0)
     )
+
+    // Lookup IPv4 as an non-mapped IPv6, should fail
     val addr1 = Array[Byte](127.toByte, 0.toByte, 0.toByte, 1.toByte)
     assertThrows(
-      "123: Name or service not known",
+      "getByAddress(null, Array[Byte](127, 0, 0, 1), 0)",
       classOf[UnknownHostException],
-      Inet6Address.getByAddress("123", addr1, 0)
+      Inet6Address.getByAddress(null, addr1, 0)
     )
 
     val addr2 = Array[Byte](
@@ -110,9 +142,19 @@ class Inet6AddressTest {
       0xb2.toByte
     )
 
-    Inet6Address.getByAddress("123", addr2, 3)
-    Inet6Address.getByAddress("123", addr2, 0)
-    Inet6Address.getByAddress("123", addr2, -1)
+    // Test specifying IPv6 scope_id. Is scope_id durable?
+
+    val scope_0 = 0
+    val addr3 = Inet6Address.getByAddress("125", addr2, scope_0)
+    assertEquals(scope_0, addr3.getScopeId())
+
+    val scope_minus1 = -1
+    val addr4 = Inet6Address.getByAddress("126", addr2, scope_minus1)
+    assertEquals(scope_0, addr4.getScopeId()) // yes, scope_0
+
+    val scope_3 = 3
+    val addr5 = Inet6Address.getByAddress("124", addr2, scope_3)
+    assertEquals(scope_3, addr5.getScopeId())
   }
 
   // Issue 2313

--- a/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
@@ -2,7 +2,9 @@ package javalib.net
 
 import java.net._
 
-// Ported from Apache Harmony
+/* Originally ported from Apache Harmony.
+ * Extensively modified for Scala Native. Additional test cases added.
+ */
 
 import org.junit.Test
 import org.junit.Assert._
@@ -25,7 +27,7 @@ class InetAddressTest {
       val caddr = Array[Byte](127.toByte, 0.toByte, 0.toByte, 1.toByte)
       val addr = ia.getAddress()
       for (i <- addr.indices)
-        assertEquals(caddr(i), addr(i))
+        assertEquals("a1", caddr(i), addr(i))
     } catch {
       case e: UnknownHostException => {}
     }
@@ -34,144 +36,229 @@ class InetAddressTest {
     val address = InetAddress.getByAddress(origBytes)
     origBytes(0) = -1
     val newBytes = address.getAddress()
-    assertEquals(newBytes(0), 0.toByte)
+    assertEquals("a2", newBytes(0), 0.toByte)
   }
 
   @Test def getAllByName(): Unit = {
     val all = InetAddress.getAllByName("localhost")
-    assertFalse(all == null)
-    assertTrue(all.length >= 1)
+    assertNotNull("a1", all)
+    assertTrue("a1.1", all.length >= 1)
 
     if (!Platform.isWindows) {
-      for (alias <- all)
-        assertTrue(alias.getCanonicalHostName().startsWith("localhost"))
+      for (alias <- all) {
+        assertTrue("a2", alias.getCanonicalHostName().startsWith("localhost"))
+      }
     }
 
     for (alias <- all)
-      assertTrue(alias.getHostName().startsWith("localhost"))
+      assertTrue("a3", alias.getHostName().startsWith("localhost"))
 
     val ias = InetAddress.getAllByName(null)
     for (ia <- ias)
-      assertTrue(ia.isLoopbackAddress())
+      assertTrue("a4", ia.isLoopbackAddress())
+
+    // match JVM behavior, not getAllByName("localhost"), which can give size 2
+    assertEquals("a4.1", 1, ias.length)
 
     val ias2 = InetAddress.getAllByName("")
     for (ia <- ias2)
-      assertTrue(ia.isLoopbackAddress())
+      assertTrue("a5", ia.isLoopbackAddress())
 
-    // Check that getting addresses by dotted string distingush IPv4 and IPv6 subtypes
+    // match JVM behavior, not getAllByName("localhost"), which can give size 2
+    assertEquals("a5.1", 1, ias2.length)
+
+    /* Check that getting addresses by dotted string distinguishes
+     * IPv4 and IPv6 subtypes
+     */
     val list = InetAddress.getAllByName("192.168.0.1")
     for (addr <- list)
-      assertFalse(addr.getClass == classOf[InetAddress])
-
+      assertFalse("a6", addr.getClass == classOf[InetAddress])
+    assertEquals("a6.1", 1, list.length)
   }
 
   @Test def getByName(): Unit = {
-    val ia = InetAddress.getByName("127.0.0.1")
+    val ia = InetAddress.getByName("127.0.0.1") // numeric lookup path
 
+    val ia2 = InetAddress.getByName("localhost") // non-numeric lookup path
+    assertEquals("a1", ia, ia2)
+
+    // Test IPv4 archaic variant addresses.
     val i1 = InetAddress.getByName("1.2.3")
-    assertEquals("1.2.0.3", i1.getHostAddress())
+    assertEquals("a2", "1.2.0.3", i1.getHostAddress())
 
     val i2 = InetAddress.getByName("1.2")
-    assertEquals("1.0.0.2", i2.getHostAddress())
+    assertEquals("a3", "1.0.0.2", i2.getHostAddress())
 
     val i3 = InetAddress.getByName(String.valueOf(0xffffffffL))
-    assertEquals("255.255.255.255", i3.getHostAddress())
+    assertEquals("a4", "255.255.255.255", i3.getHostAddress())
 
+    // case from 'Comcast/ip4s' project, lookup non-existing host.
     assertThrows(
-      "not.example.com: Name or service not known",
+      "getByName(not.example.com)",
       classOf[UnknownHostException],
       InetAddress.getByName("not.example.com")
     )
   }
 
+  @Test def getByNameInvalidIPv4Addresses(): Unit = {
+
+    assertThrows(
+      "getByName(\"240.0.0.\" )",
+      classOf[UnknownHostException],
+      InetAddress.getByName("240.0.0.")
+    )
+
+    // Establish baseline: variant IPv4 address does not throw
+    val ia1 = InetAddress.getByName("10")
+
+    /* same address with scope_id is detected as invalid.
+     * It is taken as a non-numeric host, which is never found because
+     * '%' is not valid in a hostname.
+     */
+    assertThrows(
+      "getByName(\"10%en0\")",
+      classOf[UnknownHostException],
+      InetAddress.getByName("10%en0")
+    )
+
+  }
+
   @Test def getHostAddress(): Unit = {
-    assertEquals("1.3.0.4", InetAddress.getByName("1.3.4").getHostAddress())
     assertEquals(
+      "a1",
+      "1.3.0.4",
+      InetAddress.getByName("1.3.4").getHostAddress()
+    )
+    assertEquals(
+      "a2",
       "0:0:0:0:0:0:0:1",
       InetAddress.getByName("::1").getHostAddress()
     )
   }
 
-  @Test def isReachable(): Unit = {
-    // Linux disables ICMP requests by default and most of the addresses
-    // don't have echo servers running on port 7, so it's quite difficult
-    // to test this method
+  @Test def getLocalHost(): Unit = {
+    /* If compiler does not optimize away, check that no Exception is thrown
+     * and something other than null is returned.
+     * This code will be run on many machines, with varied names.
+     * It is hard to check the actual InetAddress returned.
+     */
+    assertNotNull(InetAddress.getLocalHost())
+  }
 
-    val addr = InetAddress.getByName("127.0.0.1")
-    assertThrows(classOf[IllegalArgumentException], addr.isReachable(-1))
+  @Test def getLoopbackAddress(): Unit = {
+    // Skip testing the "system" case. Save that for some future evolution.
+    val useIPv6Addrs =
+      System.getProperty("java.net.preferIPv6Addresses", "false")
+    val lba = InetAddress.getLoopbackAddress().getHostAddress()
+
+    if (useIPv6Addrs == "true") {
+      assertEquals("0:0:0:0:0:0:0:1", lba)
+    } else {
+      assertEquals("127.0.0.1", lba)
+    }
   }
 
   @Test def isMulticastAddress(): Unit = {
     val ia1 = InetAddress.getByName("239.255.255.255")
-    assertTrue(ia1.isMulticastAddress())
+    assertTrue("ia1", ia1.isMulticastAddress())
     val ia2 = InetAddress.getByName("localhost")
-    assertFalse(ia2.isMulticastAddress())
+    assertFalse("ia2", ia2.isMulticastAddress())
   }
 
   @Test def isAnyLocalAddress(): Unit = {
     val ia1 = InetAddress.getByName("239.255.255.255")
-    assertFalse(ia1.isAnyLocalAddress())
+    assertFalse("ia1", ia1.isAnyLocalAddress())
     val ia2 = InetAddress.getByName("localhost")
-    assertFalse(ia2.isAnyLocalAddress())
+    assertFalse("ia2", ia2.isAnyLocalAddress())
   }
 
   @Test def isLinkLocalAddress(): Unit = {
     val ia1 = InetAddress.getByName("239.255.255.255")
-    assertFalse(ia1.isLinkLocalAddress())
+    assertFalse("ia1", ia1.isLinkLocalAddress())
     val ia2 = InetAddress.getByName("localhost")
-    assertFalse(ia2.isLinkLocalAddress())
+    assertFalse("ia2", ia2.isLinkLocalAddress())
   }
 
   @Test def isLoopbackAddress(): Unit = {
     val ia1 = InetAddress.getByName("239.255.255.255")
-    assertFalse(ia1.isLoopbackAddress())
+    assertFalse("ia1", ia1.isLoopbackAddress())
     val ia2 = InetAddress.getByName("localhost")
-    assertTrue(ia2.isLoopbackAddress())
+    assertTrue("ia2", ia2.isLoopbackAddress())
     val ia3 = InetAddress.getByName("127.0.0.2")
-    assertTrue(ia3.isLoopbackAddress())
+    assertTrue("ia3", ia3.isLoopbackAddress())
+  }
+
+  @Test def isReachableIllegalArgument(): Unit = {
+    val addr = InetAddress.getByName("127.0.0.1")
+    assertThrows(
+      "isReachable(-1)",
+      classOf[IllegalArgumentException],
+      addr.isReachable(-1)
+    )
+  }
+
+  @Test def isReachable(): Unit = {
+    /* Linux disables ICMP requests by default and most addresses do not
+     * have echo servers running on port 7, so it's quite difficult
+     * to test this method
+     *
+     * This test exercises the parts of the code path that it can.
+     */
+
+    val addr = InetAddress.getByName("127.0.0.1")
+    try {
+      addr.isReachable(20) // Unexpected success is OK.
+    } catch {
+      /* A better test would try to distinguish the varieties of
+       * ConnectionException. Local setup, on the network, etc.
+       * That would help with supporting users who report problems.
+       */
+      case ex: ConnectException => // expected, do nothing
+      // Timeout is not expected,even on Windows & CI. Do not catch.
+    }
   }
 
   @Test def isSiteLocalAddress(): Unit = {
     val ia1 = InetAddress.getByName("239.255.255.255")
-    assertFalse(ia1.isSiteLocalAddress())
+    assertFalse("ia1", ia1.isSiteLocalAddress())
     val ia2 = InetAddress.getByName("localhost")
-    assertFalse(ia2.isSiteLocalAddress())
+    assertFalse("ia2", ia2.isSiteLocalAddress())
     val ia3 = InetAddress.getByName("127.0.0.2")
-    assertFalse(ia3.isSiteLocalAddress())
+    assertFalse("ia3", ia3.isSiteLocalAddress())
     val ia4 = InetAddress.getByName("243.243.45.3")
-    assertFalse(ia4.isSiteLocalAddress())
+    assertFalse("ia4", ia4.isSiteLocalAddress())
     val ia5 = InetAddress.getByName("10.0.0.2")
-    assertTrue(ia5.isSiteLocalAddress())
+    assertTrue("ia5", ia5.isSiteLocalAddress())
   }
 
   @Test def mcMethods(): Unit = {
     val ia1 = InetAddress.getByName("239.255.255.255")
-    assertFalse(ia1.isMCGlobal())
-    assertFalse(ia1.isMCLinkLocal())
-    assertFalse(ia1.isMCNodeLocal())
-    assertFalse(ia1.isMCOrgLocal())
-    assertTrue(ia1.isMCSiteLocal())
+    assertFalse("ia1.1", ia1.isMCGlobal())
+    assertFalse("ia1.2", ia1.isMCLinkLocal())
+    assertFalse("ia1.3", ia1.isMCNodeLocal())
+    assertFalse("ia1.4", ia1.isMCOrgLocal())
+    assertTrue("ia1.5", ia1.isMCSiteLocal())
 
     val ia2 = InetAddress.getByName("243.243.45.3")
-    assertFalse(ia2.isMCGlobal())
-    assertFalse(ia2.isMCLinkLocal())
-    assertFalse(ia2.isMCNodeLocal())
-    assertFalse(ia2.isMCOrgLocal())
-    assertFalse(ia2.isMCSiteLocal())
+    assertFalse("ia2.1", ia2.isMCGlobal())
+    assertFalse("ia2.2", ia2.isMCLinkLocal())
+    assertFalse("ia2.3", ia2.isMCNodeLocal())
+    assertFalse("ia2.4", ia2.isMCOrgLocal())
+    assertFalse("ia2.5", ia2.isMCSiteLocal())
 
     val ia3 = InetAddress.getByName("250.255.255.254")
-    assertFalse(ia3.isMCGlobal())
-    assertFalse(ia3.isMCLinkLocal())
-    assertFalse(ia3.isMCNodeLocal())
-    assertFalse(ia3.isMCOrgLocal())
-    assertFalse(ia3.isMCSiteLocal())
+    assertFalse("ia3.1", ia3.isMCGlobal())
+    assertFalse("ia3.2", ia3.isMCLinkLocal())
+    assertFalse("ia3.3", ia3.isMCNodeLocal())
+    assertFalse("ia3.4", ia3.isMCOrgLocal())
+    assertFalse("ia3.5", ia3.isMCSiteLocal())
 
     val ia4 = InetAddress.getByName("10.0.0.2")
-    assertFalse(ia4.isMCGlobal())
-    assertFalse(ia4.isMCLinkLocal())
-    assertFalse(ia4.isMCNodeLocal())
-    assertFalse(ia4.isMCOrgLocal())
-    assertFalse(ia4.isMCSiteLocal())
+    assertFalse("ia4.1", ia4.isMCGlobal())
+    assertFalse("ia4.2", ia4.isMCLinkLocal())
+    assertFalse("ia4.3", ia4.isMCNodeLocal())
+    assertFalse("ia4.4", ia4.isMCOrgLocal())
+    assertFalse("ia4.5", ia4.isMCSiteLocal())
   }
 
   @Test def testToString(): Unit = {

--- a/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
@@ -29,7 +29,7 @@ class InetAddressTest {
       for (i <- addr.indices)
         assertEquals("a1", caddr(i), addr(i))
     } catch {
-      case e: UnknownHostException => {}
+      case e: UnknownHostException => // OK
     }
 
     val origBytes = Array[Byte](0.toByte, 1.toByte, 2.toByte, 3.toByte)
@@ -74,11 +74,6 @@ class InetAddressTest {
     for (addr <- list)
       assertFalse("a6", addr.getClass == classOf[InetAddress])
     assertEquals("a6.1", 1, list.length)
-
-    // getAllByName does not fill in host field for numeric addresses.
-    val wwwGoogleCom = InetAddress.getAllByName("108.177.11.104")
-    assertTrue("a7", wwwGoogleCom.length >= 1)
-    assertEquals("a7.1", "", wwwGoogleCom(0).getHostName())
   }
 
   @Test def getByName(): Unit = {
@@ -103,11 +98,6 @@ class InetAddressTest {
       classOf[UnknownHostException],
       InetAddress.getByName("not.example.com")
     )
-
-    // getByName does not fill in host field for numeric addresses.
-    val scalaLangOrg = InetAddress.getByName("128.178.218.78")
-    assertEquals("a5.1", "", scalaLangOrg.getHostName())
-
   }
 
   @Test def getByNameInvalidIPv4Addresses(): Unit = {
@@ -144,6 +134,23 @@ class InetAddressTest {
       "0:0:0:0:0:0:0:1",
       InetAddress.getByName("::1").getHostAddress()
     )
+  }
+
+  @Test def getHostName(): Unit = {
+    /* This test only yields useful information if a capable nameserver
+     * is active.
+     */
+
+    // he.net - Hurricane Electric, CNAME: www.he.net
+    val heNet = "216.218.236.2" // "$dig he.net ANY"
+    val hostName = InetAddress.getByName(heNet).getHostName()
+
+    if (Character.isDigit(hostName(0))) {
+      // Nothing learned, name server could not resolve name, as can happen.
+      assertEquals("a1", heNet, hostName)
+    } else {
+      assertEquals("a1", "he.net", hostName)
+    }
   }
 
   @Test def getLocalHost(): Unit = {

--- a/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
@@ -200,21 +200,24 @@ class InetAddressTest {
   @Test def isReachable(): Unit = {
     /* Linux disables ICMP requests by default and most addresses do not
      * have echo servers running on port 7, so it's quite difficult
-     * to test this method
+     * to test this method.
      *
      * This test exercises the parts of the code path that it can.
      */
 
     val addr = InetAddress.getByName("127.0.0.1")
     try {
-      addr.isReachable(20) // Unexpected success is OK.
+      addr.isReachable(10) // Unexpected success is OK.
     } catch {
       /* A better test would try to distinguish the varieties of
        * ConnectionException. Local setup, on the network, etc.
        * That would help with supporting users who report problems.
        */
       case ex: ConnectException => // expected, do nothing
-      // Timeout is not expected,even on Windows & CI. Do not catch.
+      // SocketTimeoutException is thrown only on Windows. OK to do nothing
+      case ex: SocketTimeoutException => // do nothing
+      // We want to see other timeouts and exception, let them bubble up.
+
     }
   }
 

--- a/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/InetAddressTest.scala
@@ -74,6 +74,11 @@ class InetAddressTest {
     for (addr <- list)
       assertFalse("a6", addr.getClass == classOf[InetAddress])
     assertEquals("a6.1", 1, list.length)
+
+    // getAllByName does not fill in host field for numeric addresses.
+    val wwwGoogleCom = InetAddress.getAllByName("108.177.11.104")
+    assertTrue("a7", wwwGoogleCom.length >= 1)
+    assertEquals("a7.1", "", wwwGoogleCom(0).getHostName())
   }
 
   @Test def getByName(): Unit = {
@@ -98,6 +103,11 @@ class InetAddressTest {
       classOf[UnknownHostException],
       InetAddress.getByName("not.example.com")
     )
+
+    // getByName does not fill in host field for numeric addresses.
+    val scalaLangOrg = InetAddress.getByName("128.178.218.78")
+    assertEquals("a5.1", "", scalaLangOrg.getHostName())
+
   }
 
   @Test def getByNameInvalidIPv4Addresses(): Unit = {

--- a/unit-tests/shared/src/test/scala/javalib/net/InetSocketAddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/InetSocketAddressTest.scala
@@ -14,9 +14,30 @@ class InetSocketAddressTest {
   @Test def thisStringInt(): Unit = {
     val address = new InetSocketAddress("127.0.0.1", 0)
     assertEquals("/127.0.0.1:0", address.toString)
-    val localhostName = address.getHostName
-    assertFalse(localhostName == null)
-    assertEquals(localhostName + "/127.0.0.1:0", address.toString)
+
+    /* This section explains deleted lines, so that somebody does not restore
+     * them.
+     *
+     * InetSocketAddress calls InetAddress with a numeric argument to
+     * create an underlying InetAddress. The InetAddress so created will have
+     * a null host. There is no attempt to resolve the hostname.
+     * The address.toString test is correct in expecting a empty_string
+     * hostname (left of the slash).
+     *
+     * 'address.getHostName'will attempt to resolve the hostname if it has not
+     * been resolved before. Recall that at creation the hostname was not
+     * resolved.
+     *
+     * Almost all systems the IPv4 loopback address will resolve to
+     * "localhost". Only a tiny minority of systems are configured otherwise.
+     * This makes the test below chancy at best and better called invalid.
+     *
+     *   val localhostName = address.getHostName
+     *   assertFalse(localhostName == null)
+     *   assertEquals(localhostName + "/127.0.0.1:0", address.toString)
+     *
+     * The bug is that this test ever passed in the wild.
+     */
   }
 
   @Test def createUnresolved(): Unit = {


### PR DESCRIPTION
This PR is intended for the Scala Native 0.5.0 branch.   I know of no limitations
which preclude it from the 0.4.n branch. Because of the large number of changes,
I would like to see this code prove itself in 0.5.0 before being backported to 0.4.n.

###### Authorship
This PR has been influenced by Arman Blige. This is not to imply that Arman
has seen, reviewed, or approved this code.  Thank you, Arman.

Snippets have been copied, under license, from [epollcat] (https://github.com/armanbilge/epollcat). 

All merit to Arman, all bugs to me.

##### Fixes:

* Fix #2849 

* Fix #2847

* Fix #2842
 
* Fix #2767 

* Fix #2311

##### Partial Fixes:

* Partial fix: #2808
  
  Added code in several places to try to detect incorrect conditions.
  This Issue becomes: "WWW - Watchful Waiting on Windows"

* Partial fix: #2863 

  The InetAddress & Inet6Address classes now handle entering (getByName())
  and displaying (toString(), getHostName(), etc.) IPv6 addresses which
  have scope_id/zone_id/interface_id (RFCs conflate the three) identifiers,
  Per the RFCs, the address part must be numeric. Both numeric (FE80::1%99)
  and non-numeric (FF80::1%en0) work.

  The success cases work as expected. No attempt was made to match the
  timing or message of a vast number of failure cases. Java detects some
  errors (invalid non-numeric interface_id) early and some late (attempting
  to use an invalid numeric interface_id). This code attempts to detect
  and report all invalid cases early.

  The change of this PR are a necessary but not sufficient condition to
  fixing issue #2863.

##### Concern

This work was done on a Little Endian machine. I believe all the CI machines are
also Little Endian.  I believe the code also works for Big Endian machines but
have not exercised it on such.  