### PR TITLE
Fix #2873, #2865: posix netdb is missing symbols

### DIFF
--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -118,8 +118,8 @@ int scalanative_ni_numericserv() { return NI_NUMERICSERV; }
 int scalanative_ni_numericscope() {
 #if !defined(NI_NUMERICSCOPE)
     /* Silently return a no-op flag.
-     * Do not disturb the tranquility of the vast majority of projects
-     * which have absolutely no interest in NI_NUMERICSCOPE by issuing the
+     * Do not disturb the tranquility of the vast majority of projects,
+     * which have absolutely no interest in NI_NUMERICSCOPE, by issuing the
      * #warning one might expect.
      *
      * NI_NUMERICSCOPE is undefined on Linux and possibly Windows.

--- a/posixlib/src/main/resources/scala-native/netdb.c
+++ b/posixlib/src/main/resources/scala-native/netdb.c
@@ -22,8 +22,8 @@ struct scalanative_addrinfo {
     int ai_family;        /* Protocol family for socket.  */
     int ai_socktype;      /* Socket type.  */
     int ai_protocol;      /* Protocol for socket.  */
-    socklen_t ai_addrlen; /* Length of socket address.  */
-    void *ai_addr;        /* Socket address for socket.  */
+    socklen_t ai_addrlen; /* Length of socket address.	*/
+    void *ai_addr;        /* Socket address for socket.	 */
     char *ai_canonname;   /* Canonical name for service location.  */
     void *ai_next;        /* Pointer to next in list.  */
 };
@@ -89,17 +89,48 @@ int scalanative_getaddrinfo(char *name, char *service,
     return getaddrinfo(name, service, vettedHints, (struct addrinfo **)res);
 }
 
-int scalanative_ai_numerichost() { return AI_NUMERICHOST; }
+// AI_* items are declared in the order of Posix specification
 
 int scalanative_ai_passive() { return AI_PASSIVE; }
 
-int scalanative_ai_numericserv() { return AI_NUMERICSERV; }
+int scalanative_ai_canonname() { return AI_CANONNAME; }
 
-int scalanative_ai_addrconfig() { return AI_ADDRCONFIG; }
+int scalanative_ai_numerichost() { return AI_NUMERICHOST; }
+
+int scalanative_ai_numericserv() { return AI_NUMERICSERV; }
 
 int scalanative_ai_v4mapped() { return AI_V4MAPPED; }
 
-int scalanative_ai_canonname() { return AI_CANONNAME; }
+int scalanative_ai_all() { return AI_ALL; }
+
+int scalanative_ai_addrconfig() { return AI_ADDRCONFIG; }
+
+// NI_* items are declared in the order of Posix specification
+
+int scalanative_ni_nofqdn() { return NI_NOFQDN; }
+
+int scalanative_ni_numerichost() { return NI_NUMERICHOST; }
+
+int scalanative_ni_namereqd() { return NI_NAMEREQD; }
+
+int scalanative_ni_numericserv() { return NI_NUMERICSERV; }
+
+int scalanative_ni_numericscope() {
+#if !defined(NI_NUMERICSCOPE)
+    /* Silently return a no-op flag.
+     * Do not disturb the tranquility of the vast majority of projects
+     * which have absolutely no interest in NI_NUMERICSCOPE by issuing the
+     * #warning one might expect.
+     *
+     * NI_NUMERICSCOPE is undefined on Linux and possibly Windows.
+     */
+    return 0;
+#else
+    return NI_NUMERICSCOPE;
+#endif
+}
+
+int scalanative_ni_dgram() { return NI_DGRAM; }
 
 // EAI_* items are declared in the order of Posix specification
 
@@ -126,7 +157,7 @@ int scalanative_eai_overflow() { return EAI_OVERFLOW; }
 
 #else // _Win32
 /* Reference:  https://docs.microsoft.com/en-us/windows/win32/api
- *                 /ws2tcpip/nf-ws2tcpip-getaddrinfo
+ *		   /ws2tcpip/nf-ws2tcpip-getaddrinfo
  */
 
 int scalanative_eai_again() { return WSATRY_AGAIN; }

--- a/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
@@ -2,7 +2,6 @@ package scala.scalanative.posix
 
 import scalanative.unsafe._
 
-import scalanative.posix.inttypes
 import scalanative.posix.sys.socket
 import scalanative.posix.netinet.in
 

--- a/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
@@ -2,6 +2,7 @@ package scala.scalanative.posix
 
 import scalanative.unsafe._
 
+import scalanative.posix.inttypes
 import scalanative.posix.sys.socket
 import scalanative.posix.netinet.in
 
@@ -20,6 +21,9 @@ object netdb {
    *
    * Access to the proper field for the OS is handled in netdbOps below.
    */
+
+  type socklen_t = socket.socklen_t
+  type uint32_t = inttypes.uint32_t
 
   /* _Static_assert code in netdb.c checks that Scala Native and operating
    * system structure definitions match "close enough". If you change
@@ -62,23 +66,48 @@ object netdb {
       flags: CInt
   ): CInt = extern
 
-  @name("scalanative_ai_numerichost")
-  def AI_NUMERICHOST: CInt = extern
+  // AI_* items are declared in the order of Posix specification
 
   @name("scalanative_ai_passive")
   def AI_PASSIVE: CInt = extern
 
+  @name("scalanative_ai_canonname")
+  def AI_CANONNAME: CInt = extern
+
+  @name("scalanative_ai_numerichost")
+  def AI_NUMERICHOST: CInt = extern
+
   @name("scalanative_ai_numericserv")
   def AI_NUMERICSERV: CInt = extern
-
-  @name("scalanative_ai_addrconfig")
-  def AI_ADDRCONFIG: CInt = extern
 
   @name("scalanative_ai_v4mapped")
   def AI_V4MAPPED: CInt = extern
 
-  @name("scalanative_ai_canonname")
-  def AI_CANONNAME: CInt = extern
+  @name("scalanative_ai_all")
+  def AI_ALL: CInt = extern
+
+  @name("scalanative_ai_addrconfig")
+  def AI_ADDRCONFIG: CInt = extern
+
+  // NI_* items are declared in the order of Posix specification
+
+  @name("scalanative_ni_nofqdn")
+  def NI_NOFQDN: CInt = extern
+
+  @name("scalanative_ni_numerichost")
+  def NI_NUMERICHOST: CInt = extern
+
+  @name("scalanative_ni_namereqd")
+  def NI_NAMEREQD: CInt = extern
+
+  @name("scalanative_ni_numericserv")
+  def NI_NUMERICSERV: CInt = extern
+
+  @name("scalanative_ni_NI_numericscope")
+  def NI_NUMERICSCOPE: CInt = extern
+
+  @name("scalanative_ni_dgram")
+  def NI_DGRAM: CInt = extern
 
   // EAI_* items are declared in the order of Posix specification
 
@@ -111,6 +140,9 @@ object netdb {
 
   @name("scalanative_eai_overflow")
   def EAI_OVERFLOW: CInt = extern
+
+  @name("scalanative_ipport_reserved")
+  def IPPORT_RESERVED: CInt = extern
 }
 
 /** Allow using C names to access 'addrinfo' structure fields.


### PR DESCRIPTION
Bring posixlib `netdb.scala` closer to complying with the corresponding POSIX 2018 specification by supplying
some missing symbolic constants & types.
* Fix #2873
* Fix #2865 
 
`netdb.scala` remains incomplete because it continues to lack definitions for the `hostent`, `netint`, & `protoent`
structures and the methods which use them.  Cases must be added to `NetdbTest.scala` to validate any
such additions.

##### Discussion

The handling of the constant `NI_NUMERICSCOPE` is a bit tricky because that constant
is not defined on Linux (and possibly Windows) but it _is_ defined on macOS and probably
FreeBSD & kin.  Current handling is probably the best of a bad lot of alternatives, faint praise.


