### PR TITLE
Fix #2831: Towards a more complete posixlib unistd.scala

### DIFF
--- a/clib/src/main/resources/scala-native/stdio.c
+++ b/clib/src/main/resources/scala-native/stdio.c
@@ -25,6 +25,7 @@ int scalanative_iolbf() { return _IOLBF; }
 
 int scalanative_ionbf() { return _IONBF; }
 
+// SEEK_SET, SEEK_CUR, and SEEK_END also used by posixlib/unistd.scala
 int scalanative_seek_set() { return SEEK_SET; }
 
 int scalanative_seek_cur() { return SEEK_CUR; }

--- a/posixlib/src/main/resources/scala-native/unistd.c
+++ b/posixlib/src/main/resources/scala-native/unistd.c
@@ -1,11 +1,29 @@
 #if defined(__unix__) || defined(__unix) || defined(unix) ||                   \
     (defined(__APPLE__) && defined(__MACH__))
+
+// #define _POSIX_C_SOURCE 2 // constr
+// #define _X_OPEN // constr
+
 #include <unistd.h>
-#include "types.h"
+#include "types.h" // scalanative_* types, not <sys/types.h>
 
 extern char **environ;
+extern char *optarg;
+extern int opterr, optind, optopt;
 
 char **scalanative_environ() { return environ; }
+
+char *scalanative_optarg() { return optarg; }
+
+int scalanative_opterr() { return opterr; }
+
+int scalanative_optind() { return optind; }
+
+int scalanative_optopt() { return optopt; }
+
+long scalanative__posix_version() { return _POSIX_VERSION; }
+
+int scalanative__xopen_version() { return _XOPEN_VERSION; }
 
 int scalanative_f_ok() { return F_OK; }
 
@@ -15,8 +33,11 @@ int scalanative_w_ok() { return W_OK; }
 
 int scalanative_x_ok() { return X_OK; }
 
-// SEEK_CUR, SEEK_END, SEEK_SET in clib stdio
+// SEEK_CUR, SEEK_END, SEEK_SET implementations are in clib stdio.c
 
+// lockf
+
+// XSI - Begin
 int scalanative_f_lock() { return F_LOCK; }
 
 int scalanative_f_test() { return F_TEST; }
@@ -24,6 +45,7 @@ int scalanative_f_test() { return F_TEST; }
 int scalanative_f_tlock() { return F_TLOCK; }
 
 int scalanative_f_ulock() { return F_ULOCK; }
+// XSI - End
 
 int scalanative_stdin_fileno() { return STDIN_FILENO; }
 
@@ -31,25 +53,346 @@ int scalanative_stdout_fileno() { return STDOUT_FILENO; }
 
 int scalanative_stderr_fileno() { return STDERR_FILENO; }
 
-int scalanative_symlink(char *path1, char *path2) {
-    return symlink(path1, path2);
-}
+int scalanative__posix_vdisable() { return _POSIX_VDISABLE; }
 
-int scalanative_symlinkat(char *path1, int fd, char *path2) {
-    return symlinkat(path1, fd, path2);
-}
+// confstr
 
-int scalanative_link(char *oldpath, char *newpath) {
-    return link(oldpath, newpath);
-}
+int scalanative__cs_path() { return _CS_PATH; };
 
-int scalanative_linkat(int fd1, char *path1, int fd2, char *path2, int flag) {
-    return linkat(fd1, path1, fd2, path2, flag);
-}
+/* Not implemented, not defined on macOS.
+ *	_CS_POSIX_V7_ILP32_OFF32_CFLAGS
+ *	_CS_POSIX_V7_ILP32_OFF32_LDFLAGS:
+ *	_CS_POSIX_V7_ILP32_OFF32_LIBS
+ *	_CS_POSIX_V7_ILP32_OFFBIG_CFLAGS
+ *	_CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS
+ *	_CS_POSIX_V7_ILP32_OFFBIG_LIBS
+ *	_CS_POSIX_V7_LP64_OFF64_CFLAGS
+ *	_CS_POSIX_V7_LP64_OFF64_LDFLAGS
+ *	_CS_POSIX_V7_LP64_OFF64_LIBS
+ *	_CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS
+ *	_CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS
+ *	_CS_POSIX_V7_LPBIG_OFFBIG_LIBS
+ */
 
-int scalanative_chown(char *path, scalanative_uid_t owner,
-                      scalanative_gid_t group) {
-    return chown(path, owner, group);
-}
+/* Not implemented, not defined on Linux & probably macOS
+ *   _CS_POSIX_V7_THREADS_CFLAGS
+ *   _CS_POSIX_V7_THREADS_LDFLAGS
+ */
+
+/* Not implemented, not defined on macOS.
+ *	_CS_POSIX_V7_WIDTH_RESTRICTED_ENVS
+ *	_CS_V7_ENV
+ */
+
+// pathconf
+
+int scalanative__pc_2_symlinks() { return _PC_2_SYMLINKS; };
+
+int scalanative__pc_alloc_size_min() { return _PC_ALLOC_SIZE_MIN; };
+
+int scalanative__pc_async_io() { return _PC_ASYNC_IO; };
+
+int scalanative__pc_chown_restricted() { return _PC_CHOWN_RESTRICTED; };
+
+int scalanative__pc_filesizebits() { return _PC_FILESIZEBITS; };
+
+int scalanative__pc_link_max() { return _PC_LINK_MAX; };
+
+int scalanative__pc_max_canon() { return _PC_MAX_CANON; };
+
+int scalanative__pc_max_input() { return _PC_MAX_INPUT; };
+
+int scalanative__pc_name_max() { return _PC_NAME_MAX; };
+
+int scalanative__pc_no_trunc() { return _PC_NO_TRUNC; };
+
+int scalanative__pc_path_max() { return _PC_PATH_MAX; };
+
+int scalanative__pc_pipe_buf() { return _PC_PIPE_BUF; };
+
+int scalanative__pc_prio_io() { return _PC_PRIO_IO; };
+
+int scalanative__pc_rec_incr_xfer_size() { return _PC_REC_INCR_XFER_SIZE; };
+
+int scalanative__pc_rec_max_xfer_size() { return _PC_REC_MAX_XFER_SIZE; };
+
+int scalanative__pc_rec_min_xfer_size() { return _PC_REC_MIN_XFER_SIZE; };
+
+int scalanative__pc_rec_xfer_align() { return _PC_REC_XFER_ALIGN; };
+
+int scalanative__pc_symlink_max() { return _PC_SYMLINK_MAX; };
+
+int scalanative__pc_sync_io() { return _PC_SYNC_IO; };
+
+/* Not implemented, not defined on Linux.
+ *   _PC_TIMESTAMP_RESOLUTION
+ */
+
+int scalanative__pc_vdisable() { return _PC_VDISABLE; };
+
+// sysconf
+
+int scalanative__sc_2_c_bind() { return _SC_2_C_BIND; };
+
+int scalanative__sc_2_c_dev() { return _SC_2_C_DEV; };
+
+int scalanative__sc_2_char_term() { return _SC_2_CHAR_TERM; };
+
+int scalanative__sc_2_fort_dev() { return _SC_2_FORT_DEV; };
+
+int scalanative__sc_2_fort_run() { return _SC_2_FORT_RUN; };
+
+int scalanative__sc_2_localedef() { return _SC_2_LOCALEDEF; };
+
+int scalanative__sc_2_pbs() { return _SC_2_PBS; };
+
+int scalanative__sc_2_pbs_accounting() { return _SC_2_PBS_ACCOUNTING; };
+
+int scalanative__sc_2_pbs_checkpoint() { return _SC_2_PBS_CHECKPOINT; };
+
+int scalanative__sc_2_pbs_locate() { return _SC_2_PBS_LOCATE; };
+
+int scalanative__sc_2_pbs_message() { return _SC_2_PBS_MESSAGE; };
+
+int scalanative__sc_2_pbs_track() { return _SC_2_PBS_TRACK; };
+
+int scalanative__sc_2_sw_dev() { return _SC_2_SW_DEV; };
+
+int scalanative__sc_2_upe() { return _SC_2_UPE; };
+
+int scalanative__sc_2_version() { return _SC_2_VERSION; };
+
+int scalanative__sc_advisory_info() { return _SC_ADVISORY_INFO; };
+
+int scalanative__sc_aio_listio_max() { return _SC_AIO_LISTIO_MAX; };
+
+int scalanative__sc_aio_max() { return _SC_AIO_MAX; };
+
+int scalanative__sc_aio_prio_delta_max() { return _SC_AIO_PRIO_DELTA_MAX; };
+
+int scalanative__sc_arg_max() { return _SC_ARG_MAX; };
+
+int scalanative__sc_asynchronous_io() { return _SC_ASYNCHRONOUS_IO; };
+
+int scalanative__sc_atexit_max() { return _SC_ATEXIT_MAX; };
+
+int scalanative__sc_barriers() { return _SC_BARRIERS; };
+
+int scalanative__sc_bc_base_max() { return _SC_BC_BASE_MAX; };
+
+int scalanative__sc_bc_dim_max() { return _SC_BC_DIM_MAX; };
+
+int scalanative__sc_bc_scale_max() { return _SC_BC_SCALE_MAX; };
+
+int scalanative__sc_bc_string_max() { return _SC_BC_STRING_MAX; };
+
+int scalanative__sc_child_max() { return _SC_CHILD_MAX; };
+
+int scalanative__sc_clk_tck() { return _SC_CLK_TCK; };
+
+int scalanative__sc_clock_selection() { return _SC_CLOCK_SELECTION; };
+
+int scalanative__sc_coll_weights_max() { return _SC_COLL_WEIGHTS_MAX; };
+
+int scalanative__sc_cputime() { return _SC_CPUTIME; };
+
+int scalanative__sc_delaytimer_max() { return _SC_DELAYTIMER_MAX; };
+
+int scalanative__sc_expr_nest_max() { return _SC_EXPR_NEST_MAX; };
+
+int scalanative__sc_fsync() { return _SC_FSYNC; };
+
+int scalanative__sc_getgr_r_size_max() { return _SC_GETGR_R_SIZE_MAX; };
+
+int scalanative__sc_getpw_r_size_max() { return _SC_GETPW_R_SIZE_MAX; };
+
+int scalanative__sc_host_name_max() { return _SC_HOST_NAME_MAX; };
+
+int scalanative__sc_iov_max() { return _SC_IOV_MAX; };
+
+int scalanative__sc_ipv6() { return _SC_IPV6; };
+
+int scalanative__sc_job_control() { return _SC_JOB_CONTROL; };
+
+int scalanative__sc_line_max() { return _SC_LINE_MAX; };
+
+int scalanative__sc_login_name_max() { return _SC_LOGIN_NAME_MAX; };
+
+int scalanative__sc_mapped_files() { return _SC_MAPPED_FILES; };
+
+int scalanative__sc_memlock() { return _SC_MEMLOCK; };
+
+int scalanative__sc_memlock_range() { return _SC_MEMLOCK_RANGE; };
+
+int scalanative__sc_memory_protection() { return _SC_MEMORY_PROTECTION; };
+
+int scalanative__sc_message_passing() { return _SC_MESSAGE_PASSING; };
+
+int scalanative__sc_monotonic_clock() { return _SC_MONOTONIC_CLOCK; };
+
+int scalanative__sc_mq_open_max() { return _SC_MQ_OPEN_MAX; };
+
+int scalanative__sc_mq_prio_max() { return _SC_MQ_PRIO_MAX; };
+
+int scalanative__sc_ngroups_max() { return _SC_NGROUPS_MAX; };
+
+int scalanative__sc_open_max() { return _SC_OPEN_MAX; };
+
+int scalanative__sc_page_size() { return _SC_PAGE_SIZE; };
+
+int scalanative__sc_pagesize() { return _SC_PAGESIZE; };
+
+int scalanative__sc_prioritized_io() { return _SC_PRIORITIZED_IO; };
+
+int scalanative__sc_priority_scheduling() { return _SC_PRIORITY_SCHEDULING; };
+
+int scalanative__sc_raw_sockets() { return _SC_RAW_SOCKETS; };
+
+int scalanative__sc_re_dup_max() { return _SC_RE_DUP_MAX; };
+
+int scalanative__sc_reader_writer_locks() { return _SC_READER_WRITER_LOCKS; };
+
+int scalanative__sc_realtime_signals() { return _SC_REALTIME_SIGNALS; };
+
+int scalanative__sc_regexp() { return _SC_REGEXP; };
+
+int scalanative__sc_rtsig_max() { return _SC_RTSIG_MAX; };
+
+int scalanative__sc_saved_ids() { return _SC_SAVED_IDS; };
+
+int scalanative__sc_sem_nsems_max() { return _SC_SEM_NSEMS_MAX; };
+
+int scalanative__sc_sem_value_max() { return _SC_SEM_VALUE_MAX; };
+
+int scalanative__sc_semaphores() { return _SC_SEMAPHORES; };
+
+int scalanative__sc_shared_memory_objects() {
+    return _SC_SHARED_MEMORY_OBJECTS;
+};
+
+int scalanative__sc_shell() { return _SC_SHELL; };
+
+int scalanative__sc_sigqueue_max() { return _SC_SIGQUEUE_MAX; };
+
+int scalanative__sc_spawn() { return _SC_SPAWN; };
+
+int scalanative__sc_spin_locks() { return _SC_SPIN_LOCKS; };
+
+int scalanative__sc_sporadic_server() { return _SC_SPORADIC_SERVER; };
+
+int scalanative__sc_ss_repl_max() { return _SC_SS_REPL_MAX; };
+
+int scalanative__sc_stream_max() { return _SC_STREAM_MAX; };
+
+int scalanative__sc_symloop_max() { return _SC_SYMLOOP_MAX; };
+
+int scalanative__sc_synchronized_io() { return _SC_SYNCHRONIZED_IO; };
+
+int scalanative__sc_thread_attr_stackaddr() {
+    return _SC_THREAD_ATTR_STACKADDR;
+};
+
+int scalanative__sc_thread_attr_stacksize() {
+    return _SC_THREAD_ATTR_STACKSIZE;
+};
+
+int scalanative__sc_thread_cputime() { return _SC_THREAD_CPUTIME; };
+
+int scalanative__sc_thread_destructor_iterations() {
+    return _SC_THREAD_DESTRUCTOR_ITERATIONS;
+};
+
+int scalanative__sc_thread_keys_max() { return _SC_THREAD_KEYS_MAX; };
+
+/* Not implemented, not defined on macOS.
+ *	_SC_THREAD_PRIO_INHERIT
+ *	_SC_THREAD_PRIO_PROTECT
+ */
+
+int scalanative__sc_thread_priority_scheduling() {
+    return _SC_THREAD_PRIORITY_SCHEDULING;
+};
+
+int scalanative__sc_thread_process_shared() {
+    return _SC_THREAD_PROCESS_SHARED;
+};
+
+/* Not implemented, not defined on macOS.
+ *	_SC_THREAD_ROBUST_PRIO_INHERIT
+ *	_SC_THREAD_ROBUST_PRIO_PROTECT
+ */
+
+int scalanative__sc_thread_safe_functions() {
+    return _SC_THREAD_SAFE_FUNCTIONS;
+};
+
+int scalanative__sc_thread_sporadic_server() {
+    return _SC_THREAD_SPORADIC_SERVER;
+};
+
+int scalanative__sc_thread_stack_min() { return _SC_THREAD_STACK_MIN; };
+
+int scalanative__sc_thread_threads_max() { return _SC_THREAD_THREADS_MAX; };
+
+int scalanative__sc_threads() { return _SC_THREADS; };
+
+int scalanative__sc_timeouts() { return _SC_TIMEOUTS; };
+
+int scalanative__sc_timer_max() { return _SC_TIMER_MAX; };
+
+int scalanative__sc_timers() { return _SC_TIMERS; };
+
+int scalanative__sc_trace() { return _SC_TRACE; };
+
+int scalanative__sc_trace_event_filter() { return _SC_TRACE_EVENT_FILTER; };
+
+int scalanative__sc_trace_event_name_max() { return _SC_TRACE_EVENT_NAME_MAX; };
+
+int scalanative__sc_trace_inherit() { return _SC_TRACE_INHERIT; };
+
+int scalanative__sc_trace_log() { return _SC_TRACE_LOG; };
+
+int scalanative__sc_trace_name_max() { return _SC_TRACE_NAME_MAX; };
+
+int scalanative__sc_trace_sys_max() { return _SC_TRACE_SYS_MAX; };
+
+int scalanative__sc_trace_user_event_max() { return _SC_TRACE_USER_EVENT_MAX; };
+
+int scalanative__sc_tty_name_max() { return _SC_TTY_NAME_MAX; };
+
+int scalanative__sc_typed_memory_objects() { return _SC_TYPED_MEMORY_OBJECTS; };
+
+int scalanative__sc_tzname_max() { return _SC_TZNAME_MAX; };
+
+/* Not implemented, not defined on macOS.
+ *	_SC_V7_ILP32_OFF32
+ *	_SC_V7_ILP32_OFFBIG
+ *	_SC_V7_LP64_OFF64
+ *	_SC_V7_LPBIG_OFFBIG
+ */
+
+int scalanative__sc_version() { return _SC_VERSION; };
+
+int scalanative__sc_xopen_crypt() { return _SC_XOPEN_CRYPT; };
+
+int scalanative__sc_xopen_enh_i18n() { return _SC_XOPEN_ENH_I18N; };
+
+int scalanative__sc_xopen_realtime() { return _SC_XOPEN_REALTIME; };
+
+int scalanative__sc_xopen_realtime_threads() {
+    return _SC_XOPEN_REALTIME_THREADS;
+};
+
+int scalanative__sc_xopen_shm() { return _SC_XOPEN_SHM; };
+
+int scalanative__sc_xopen_streams() { return _SC_XOPEN_STREAMS; };
+
+int scalanative__sc_xopen_unix() { return _SC_XOPEN_UNIX; };
+
+/* Not implemented, not defined on Linux.
+ *	_SC_XOPEN_UUCP
+ */
+
+int scalanative__sc_xopen_version() { return _SC_XOPEN_VERSION; };
 
 #endif // Unix or Mac OS

--- a/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/unistd.scala
@@ -2,55 +2,129 @@ package scala.scalanative
 package posix
 
 import scalanative.unsafe._
-import scalanative.posix.sys.stat.{uid_t, gid_t}
+import scalanative.posix.sys.types
 
+/** unistd.h for Scala
+ *  @see
+ *    [[https://scala-native.readthedocs.io/en/latest/lib/posixlib.html]]
+ */
 @extern
 object unistd {
 
-  type off_t = CLong
+  type gid_t = types.gid_t
+  type off_t = types.off_t
+  type pid_t = types.pid_t
+  type size_t = types.size_t
+  type ssize_t = types.ssize_t
+  type uid_t = types.uid_t
 
-  def _exit(status: CInt): Unit = extern
+  /* The <unistd.h> header shall define the intptr_t type as
+   * described in <stdint.h>.
+   */
+  type intptr_t = Ptr[CInt] // no stdint.scala yet, declare directly
+
+// POSIX external variables (vals, not vars)
+
+  @name("scalanative__posix_version")
+  def _POSIX_VERSION: CLong = extern
+
+  //  _POSIX2_VERSION, not implemented
+
+  @name("scalanative__xopen_version")
+  def _XOPEN_VERSION: CInt = extern
+
+  @name("scalanative_environ")
+  def environ: Ptr[CString] = extern
+
+  // optarg, opterr, optopt, and optopt are used by getopt().
+
+  @name("scalanative_optarg")
+  def optarg: CString = extern
+
+  @name("scalanative_opterr")
+  def opterr: CInt = extern
+
+  @name("scalanative_optind")
+  def optind: CInt = extern
+
+  @name("scalanative_optopt")
+  def optopt: CInt = extern
+
+// Methods/functions
   def access(pathname: CString, mode: CInt): CInt = extern
+  def alarm(seconds: CUnsignedInt): CUnsignedInt = extern
+
   def chdir(path: CString): CInt = extern
+  def chown(path: CString, owner: uid_t, group: gid_t): CInt = extern
   def close(fildes: CInt): CInt = extern
+  def confstr(name: CInt, buf: Ptr[CChar], len: size_t): size_t = extern
+
+  // XSI
+  def crypt(phrase: CString, setting: CString): CString = extern
+
   def dup(fildes: CInt): CInt = extern
   def dup2(fildes: CInt, fildesnew: CInt): CInt = extern
-  def execve(path: CString, argv: Ptr[CString], envp: Ptr[CString]): CInt =
+
+  def _exit(status: CInt): Unit = extern
+
+  // XSI
+  def encrypt(block: Ptr[Byte], edflag: Int): Unit = extern
+
+// Check _very_ carefully, may be issues with ... (and not varargs?)
+// Read & re-read that section in ReadTheDocs.
+// int		execl(const char *, const char *, ...);
+// int		execle(const char *, const char *, ...);
+// int		execlp(const char *, const char *, ...);
+
+  def execv(pathname: CString, argv: Ptr[CString]): CInt = extern
+  def execve(pathname: CString, argv: Ptr[CString], envp: Ptr[CString]): CInt =
     extern
-  def fork(): CInt = extern
+  def execvp(file: CString, argv: Ptr[CString]): CInt = extern
+
+  def faccessat(fd: CInt, path: CString, amode: CInt, flag: CInt): CInt = extern
+  def fchdir(fildes: CInt): CInt = extern
+  def fchown(filedes: CInt, owner: uid_t, group: gid_t): CInt = extern
+  def fchownat(
+      fd: CInt,
+      path: CString,
+      owner: uid_t,
+      group: gid_t,
+      flag: CInt
+  ): CInt = extern
+
+  // POSIX SIO
+  def fdatasync(filedes: CInt): CInt = extern
+
+  def fexecve(fd: CInt, argv: Ptr[CString], envp: Ptr[CString]): CInt = extern
+  def fork(): pid_t = extern
+  def fpathconf(fd: CInt, name: CInt): CLong = extern
   def fsync(fildes: CInt): CInt = extern
   def ftruncate(fildes: CInt, length: off_t): CInt = extern
+
   def getcwd(buf: CString, size: CSize): CString = extern
+  def getegid(): gid_t = extern
+  def geteuid(): uid_t = extern
+  def getgid(): gid_t = extern
+  def getgroups(size: CInt, list: Ptr[gid_t]): CInt = extern
+
+  // XSI
+  def gethostid(): CLong = extern
+
   def gethostname(name: CString, len: CSize): CInt = extern
-  def getpid(): CInt = extern
-  def getppid(): CInt = extern
+  def getlogin(): CString = extern
+  def getlogin_r(buf: Ptr[CChar], bufsize: CSize): CInt = extern
+  def getopt(argc: CInt, argv: Ptr[CString], optstring: CString): CInt = extern
+  def getpgid(pid: pid_t): pid_t = extern
+  def getpgrp(): pid_t = extern
+  def getpid(): pid_t = extern
+  def getppid(): pid_t = extern
+  def getsid(pid: pid_t): pid_t = extern;
   def getuid(): uid_t = extern
-  def lseek(fildes: CInt, offset: off_t, whence: CInt): off_t = extern
-  def pipe(fildes: Ptr[CInt]): CInt = extern
-  def read(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
-  def readlink(path: CString, buf: CString, bufsize: CSize): CInt = extern
-  def sethostname(name: CString, len: CSize): CInt = extern
-  def sleep(seconds: CUnsignedInt): CUnsignedInt = extern
-  def truncate(path: CString, length: off_t): CInt = extern
-  def unlink(path: CString): CInt = extern
 
-  // Maintainer: See 'Developer Note' in Issue #2395 about complete removal.
-  @deprecated(
-    "Removed in POSIX.1-2008. Use POSIX time.h nanosleep().",
-    "posixlib 0.4.5"
-  )
-  def usleep(usecs: CUnsignedInt): CInt = extern
+  def isatty(fd: CInt): CInt = extern
 
-  def vfork(): CInt = extern
-  def write(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
-
-  @name("scalanative_chown")
-  def chown(path: CString, owner: uid_t, group: gid_t): CInt = extern
-
-  @name("scalanative_link")
+  def lchown(path: CString, owner: uid_t, group: gid_t): CInt = extern
   def link(path1: CString, path2: CString): CInt = extern
-
-  @name("scalanative_linkat")
   def linkat(
       fd1: CInt,
       path1: CString,
@@ -58,6 +132,90 @@ object unistd {
       path2: CString,
       flag: CInt
   ): CInt = extern
+
+  // XSI
+  def lockf(fd: CInt, cmd: CInt, len: off_t): CInt = extern
+
+  def lseek(fildes: CInt, offset: off_t, whence: CInt): off_t = extern
+
+  // XSI
+  def nice(inc: CInt): CInt = extern
+
+  def pathconf(path: CString, name: CInt): CLong = extern
+  def pause(): CInt = extern
+  def pipe(fildes: Ptr[CInt]): CInt = extern
+  def pread(fd: CInt, buf: Ptr[Byte], count: size_t, offset: off_t): ssize_t =
+    extern
+  def pwrite(fd: CInt, buf: Ptr[Byte], count: size_t, offset: off_t): ssize_t =
+    extern
+
+  def read(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
+  def readlink(path: CString, buf: CString, bufsize: CSize): CInt = extern
+  def readlinkat(
+      dirfd: CInt,
+      pathname: CString,
+      buf: Ptr[CChar],
+      bufsize: size_t
+  ): ssize_t = extern
+  def rmdir(pathname: CString): CInt = extern
+
+  def setegid(egid: gid_t): CInt = extern
+  def seteuid(euid: uid_t): CInt = extern
+  def setgid(gid: gid_t): CInt = extern
+  def setpgid(pid: pid_t, pgid: pid_t): CInt = extern
+
+  // pid_t setpgrp(void); // [OB XSI], not implemented
+
+// XSI
+  def setregid(rgid: gid_t, egid: gid_t): CInt = extern
+  def setreuid(ruid: gid_t, euid: gid_t): CInt = extern
+
+  def setsid(): pid_t = extern
+  def setuid(uid: uid_t): CInt = extern
+  def sleep(seconds: CUnsignedInt): CUnsignedInt = extern
+
+// XSI
+  def swab(from: Ptr[Byte], to: Ptr[Byte], n: ssize_t): Unit = extern
+
+  def symlink(path1: CString, path2: CString): CInt = extern
+  def symlinkat(path1: CString, fd: CInt, path2: CString): CInt = extern
+
+// XSI
+  def sync(): Unit = extern
+
+  def sysconf(name: CInt): CLong = extern
+
+  @deprecated(
+    "Not POSIX, subject to complete removal in the future.",
+    since = "posixlib 0.5.0"
+  )
+  def sethostname(name: CString, len: CSize): CInt = extern
+
+  def tcgetpgrp(fd: CInt): pid_t = extern
+  def tcsetpgrp(fc: CInt, pgrp: pid_t): CInt = extern
+  def truncate(path: CString, length: off_t): CInt = extern
+  def ttyname(fd: CInt): CString = extern
+  def ttyname_r(fd: CInt, buf: Ptr[CChar], buflen: size_t): CInt = extern
+
+  def unlink(path: CString): CInt = extern
+  def unlinkat(dirfd: CInt, pathname: CString, flags: CInt): CInt = extern
+
+  // Maintainer: See 'Developer Note' in Issue #2395 about complete removal.
+  @deprecated(
+    "Removed in POSIX.1-2008. Use POSIX time.h nanosleep().",
+    since = "posixlib 0.4.5"
+  )
+  def usleep(usecs: CUnsignedInt): CInt = extern
+
+  @deprecated(
+    "Removed in POSIX.1-2008. Consider posix_spawn().",
+    "posixlib 0.5.0"
+  )
+  def vfork(): CInt = extern
+
+  def write(fildes: CInt, buf: Ptr[_], nbyte: CSize): CInt = extern
+
+// Symbolic constants
 
   // NULL, see POSIX stddef
 
@@ -73,8 +231,17 @@ object unistd {
   @name("scalanative_x_ok")
   def X_OK: CInt = extern
 
-  // SEEK_CUR, SEEK_END, SEEK_SET, see clib stdio
+  // SEEK_CUR, SEEK_END, SEEK_SET, use clib stdio c implementation.
+  @name("scalanative_seek_cur")
+  def SEEK_CUR: CInt = extern
 
+  @name("scalanative_seek_end")
+  def SEEK_END: CInt = extern
+
+  @name("scalanative_seek_set")
+  def SEEK_SET: CInt = extern
+
+// lockf								       // XSI - Begin
   @name("scalanative_f_lock")
   def F_LOCK: CInt = extern
 
@@ -86,7 +253,12 @@ object unistd {
 
   @name("scalanative_f_ulock")
   def F_ULOCK: CInt = extern
+// XSI - End
 
+  /* stdin, stdout, stderr are runtime calls rather than 'final val'
+   * inline constants because, at the time of writing, one could not mix
+   * extern and 'normal' declarations in an extern object.
+   */
   @name("scalanative_stderr_fileno")
   def STDERR_FILENO: CInt = extern
 
@@ -96,15 +268,462 @@ object unistd {
   @name("scalanative_stdout_fileno")
   def STDOUT_FILENO: CInt = extern
 
-  @name("scalanative_symlink")
-  def symlink(path1: CString, path2: CString): CInt = extern
+  @name("scalanative__posix_vdisable")
+  def _POSIX_VDISABLE: CInt = extern
 
-  @name("scalanative_symlinkat")
-  def symlinkat(path1: CString, fd: CInt, path2: CString): CInt = extern
+  // confstr
 
-  // Macros
+  @name("scalanative__cs_path")
+  def _CS_PATH: CInt = extern
 
-  @name("scalanative_environ")
-  def environ: Ptr[CString] = extern
+  /* Not implemented, not defined on macOS.
+   *    _CS_POSIX_V7_ILP32_OFF32_CFLAGS
+   *    _CS_POSIX_V7_ILP32_OFF32_LDFLAGS:
+   *    _CS_POSIX_V7_ILP32_OFF32_LIBS
+   *    _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS
+   *    _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS
+   *    _CS_POSIX_V7_ILP32_OFFBIG_LIBS
+   *    _CS_POSIX_V7_LP64_OFF64_CFLAGS
+   *    _CS_POSIX_V7_LP64_OFF64_LDFLAGS
+   *    _CS_POSIX_V7_LP64_OFF64_LIBS
+   *    _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS
+   *    _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS
+   *    _CS_POSIX_V7_LPBIG_OFFBIG_LIBS
+   */
+
+  /* Not implemented, not defined on Linux & probably macOS
+   *   _CS_POSIX_V7_THREADS_CFLAGS
+   *   _CS_POSIX_V7_THREADS_LDFLAGS
+   */
+
+  /* Not implemented, not defined on macOS.
+   *    _CS_POSIX_V7_WIDTH_RESTRICTED_ENVS
+   *    _CS_V7_ENV
+   */
+
+  // pathconf
+
+  @name("scalanative__pc_2_symlinks")
+  def _PC_2_SYMLINKS: CInt = extern
+
+  @name("scalanative__pc_alloc_size_min")
+  def _PC_ALLOC_SIZE_MIN: CInt = extern
+
+  @name("scalanative__pc_async_io")
+  def _PC_ASYNC_IO: CInt = extern
+
+  @name("scalanative__pc_chown_restricted")
+  def _PC_CHOWN_RESTRICTED: CInt = extern
+
+  @name("scalanative__pc_filesizebits")
+  def _PC_FILESIZEBITS: CInt = extern
+
+  @name("scalanative__pc_link_max")
+  def _PC_LINK_MAX: CInt = extern
+
+  @name("scalanative__pc_max_canon")
+  def _PC_MAX_CANON: CInt = extern
+
+  @name("scalanative__pc_max_input")
+  def _PC_MAX_INPUT: CInt = extern
+
+  @name("scalanative__pc_name_max")
+  def _PC_NAME_MAX: CInt = extern
+
+  @name("scalanative__pc_no_trunc")
+  def _PC_NO_TRUNC: CInt = extern
+
+  @name("scalanative__pc_path_max")
+  def _PC_PATH_MAX: CInt = extern
+
+  @name("scalanative__pc_pipe_buf")
+  def _PC_PIPE_BUF: CInt = extern
+
+  @name("scalanative__pc_prio_io")
+  def _PC_PRIO_IO: CInt = extern
+
+  @name("scalanative__pc_rec_incr_xfer_size")
+  def _PC_REC_INCR_XFER_SIZE: CInt = extern
+
+  @name("scalanative__pc_rec_max_xfer_size")
+  def _PC_REC_MAX_XFER_SIZE: CInt = extern
+
+  @name("scalanative__pc_rec_min_xfer_size")
+  def _PC_REC_MIN_XFER_SIZE: CInt = extern
+
+  @name("scalanative__pc_rec_xfer_align")
+  def _PC_REC_XFER_ALIGN: CInt = extern
+
+  @name("scalanative__pc_symlink_max")
+  def _PC_SYMLINK_MAX: CInt = extern
+
+  @name("scalanative__pc_sync_io")
+  def _PC_SYNC_IO: CInt = extern
+
+  /* Not implemented, not defined on Linux.
+   *    _PC_TIMESTAMP_RESOLUTION
+   */
+
+  @name("scalanative__pc_vdisable")
+  def _PC_VDISABLE: CInt = extern
+
+// sysconf
+
+  @name("scalanative__sc_2_c_bind")
+  def _SC_2_C_BIND: CInt = extern
+
+  @name("scalanative__sc_2_c_dev")
+  def _SC_2_C_DEV: CInt = extern
+
+  @name("scalanative__sc_2_char_term")
+  def _SC_2_CHAR_TERM: CInt = extern
+
+  @name("scalanative__sc_2_fort_dev")
+  def _SC_2_FORT_DEV: CInt = extern
+
+  @name("scalanative__sc_2_fort_run")
+  def _SC_2_FORT_RUN: CInt = extern
+
+  @name("scalanative__sc_2_localedef")
+  def _SC_2_LOCALEDEF: CInt = extern
+
+  @name("scalanative__sc_2_pbs")
+  def _SC_2_PBS: CInt = extern
+
+  @name("scalanative__sc_2_pbs_accounting")
+  def _SC_2_PBS_ACCOUNTING: CInt = extern
+
+  @name("scalanative__sc_2_pbs_checkpoint")
+  def _SC_2_PBS_CHECKPOINT: CInt = extern
+
+  @name("scalanative__sc_2_pbs_locate")
+  def _SC_2_PBS_LOCATE: CInt = extern
+
+  @name("scalanative__sc_2_pbs_message")
+  def _SC_2_PBS_MESSAGE: CInt = extern
+
+  @name("scalanative__sc_2_pbs_track")
+  def _SC_2_PBS_TRACK: CInt = extern
+
+  @name("scalanative__sc_2_sw_dev")
+  def _SC_2_SW_DEV: CInt = extern
+
+  @name("scalanative__sc_2_upe")
+  def _SC_2_UPE: CInt = extern
+
+  @name("scalanative__sc_2_version")
+  def _SC_2_VERSION: CInt = extern
+
+  @name("scalanative__sc_advisory_info")
+  def _SC_ADVISORY_INFO: CInt = extern
+
+  @name("scalanative__sc_aio_listio_max")
+  def _SC_AIO_LISTIO_MAX: CInt = extern
+
+  @name("scalanative__sc_aio_max")
+  def _SC_AIO_MAX: CInt = extern
+
+  @name("scalanative__sc_aio_prio_delta_max")
+  def _SC_AIO_PRIO_DELTA_MAX: CInt = extern
+
+  @name("scalanative__sc_arg_max")
+  def _SC_ARG_MAX: CInt = extern
+
+  @name("scalanative__sc_asynchronous_io")
+  def _SC_ASYNCHRONOUS_IO: CInt = extern
+
+  @name("scalanative__sc_atexit_max")
+  def _SC_ATEXIT_MAX: CInt = extern
+
+  @name("scalanative__sc_barriers")
+  def _SC_BARRIERS: CInt = extern
+
+  @name("scalanative__sc_bc_base_max")
+  def _SC_BC_BASE_MAX: CInt = extern
+
+  @name("scalanative__sc_bc_dim_max")
+  def _SC_BC_DIM_MAX: CInt = extern
+
+  @name("scalanative__sc_bc_scale_max")
+  def _SC_BC_SCALE_MAX: CInt = extern
+
+  @name("scalanative__sc_bc_string_max")
+  def _SC_BC_STRING_MAX: CInt = extern
+
+  @name("scalanative__sc_child_max")
+  def _SC_CHILD_MAX: CInt = extern
+
+  @name("scalanative__sc_clk_tck")
+  def _SC_CLK_TCK: CInt = extern
+
+  @name("scalanative__sc_clock_selection")
+  def _SC_CLOCK_SELECTION: CInt = extern
+
+  @name("scalanative__sc_coll_weights_max")
+  def _SC_COLL_WEIGHTS_MAX: CInt = extern
+
+  @name("scalanative__sc_cputime")
+  def _SC_CPUTIME: CInt = extern
+
+  @name("scalanative__sc_delaytimer_max")
+  def _SC_DELAYTIMER_MAX: CInt = extern
+
+  @name("scalanative__sc_expr_nest_max")
+  def _SC_EXPR_NEST_MAX: CInt = extern
+
+  @name("scalanative__sc_fsync")
+  def _SC_FSYNC: CInt = extern
+
+  @name("scalanative__sc_getgr_r_size_max")
+  def _SC_GETGR_R_SIZE_MAX: CInt = extern
+
+  @name("scalanative__sc_getpw_r_size_max")
+  def _SC_GETPW_R_SIZE_MAX: CInt = extern
+
+  @name("scalanative__sc_host_name_max")
+  def _SC_HOST_NAME_MAX: CInt = extern
+
+  @name("scalanative__sc_iov_max")
+  def _SC_IOV_MAX: CInt = extern
+
+  @name("scalanative__sc_ipv6")
+  def _SC_IPV6: CInt = extern
+
+  @name("scalanative__sc_job_control")
+  def _SC_JOB_CONTROL: CInt = extern
+
+  @name("scalanative__sc_line_max")
+  def _SC_LINE_MAX: CInt = extern
+
+  @name("scalanative__sc_login_name_max")
+  def _SC_LOGIN_NAME_MAX: CInt = extern
+
+  @name("scalanative__sc_mapped_files")
+  def _SC_MAPPED_FILES: CInt = extern
+
+  @name("scalanative__sc_memlock")
+  def _SC_MEMLOCK: CInt = extern
+
+  @name("scalanative__sc_memlock_range")
+  def _SC_MEMLOCK_RANGE: CInt = extern
+
+  @name("scalanative__sc_memory_protection")
+  def _SC_MEMORY_PROTECTION: CInt = extern
+
+  @name("scalanative__sc_message_passing")
+  def _SC_MESSAGE_PASSING: CInt = extern
+
+  @name("scalanative__sc_monotonic_clock")
+  def _SC_MONOTONIC_CLOCK: CInt = extern
+
+  @name("scalanative__sc_mq_open_max")
+  def _SC_MQ_OPEN_MAX: CInt = extern
+
+  @name("scalanative__sc_mq_prio_max")
+  def _SC_MQ_PRIO_MAX: CInt = extern
+
+  @name("scalanative__sc_ngroups_max")
+  def _SC_NGROUPS_MAX: CInt = extern
+
+  @name("scalanative__sc_open_max")
+  def _SC_OPEN_MAX: CInt = extern
+
+  @name("scalanative__sc_page_size")
+  def _SC_PAGE_SIZE: CInt = extern
+
+  @name("scalanative__sc_pagesize")
+  def _SC_PAGESIZE: CInt = extern
+
+  @name("scalanative__sc_prioritized_io")
+  def _SC_PRIORITIZED_IO: CInt = extern
+
+  @name("scalanative__sc_priority_scheduling")
+  def _SC_PRIORITY_SCHEDULING: CInt = extern
+
+  @name("scalanative__sc_raw_sockets")
+  def _SC_RAW_SOCKETS: CInt = extern
+
+  @name("scalanative__sc_re_dup_max")
+  def _SC_RE_DUP_MAX: CInt = extern
+
+  @name("scalanative__sc_reader_writer_locks")
+  def _SC_READER_WRITER_LOCKS: CInt = extern
+
+  @name("scalanative__sc_realtime_signals")
+  def _SC_REALTIME_SIGNALS: CInt = extern
+
+  @name("scalanative__sc_regexp")
+  def _SC_REGEXP: CInt = extern
+
+  @name("scalanative__sc_rtsig_max")
+  def _SC_RTSIG_MAX: CInt = extern
+
+  @name("scalanative__sc_saved_ids")
+  def _SC_SAVED_IDS: CInt = extern
+
+  @name("scalanative__sc_sem_nsems_max")
+  def _SC_SEM_NSEMS_MAX: CInt = extern
+
+  @name("scalanative__sc_sem_value_max")
+  def _SC_SEM_VALUE_MAX: CInt = extern
+
+  @name("scalanative__sc_semaphores")
+  def _SC_SEMAPHORES: CInt = extern
+
+  @name("scalanative__sc_shared_memory_objects")
+  def _SC_SHARED_MEMORY_OBJECTS: CInt = extern
+
+  @name("scalanative__sc_shell")
+  def _SC_SHELL: CInt = extern
+
+  @name("scalanative__sc_sigqueue_max")
+  def _SC_SIGQUEUE_MAX: CInt = extern
+
+  @name("scalanative__sc_spawn")
+  def _SC_SPAWN: CInt = extern
+
+  @name("scalanative__sc_spin_locks")
+  def _SC_SPIN_LOCKS: CInt = extern
+
+  @name("scalanative__sc_sporadic_server")
+  def _SC_SPORADIC_SERVER: CInt = extern
+
+  @name("scalanative__sc_ss_repl_max")
+  def _SC_SS_REPL_MAX: CInt = extern
+
+  @name("scalanative__sc_stream_max")
+  def _SC_STREAM_MAX: CInt = extern
+
+  @name("scalanative__sc_symloop_max")
+  def _SC_SYMLOOP_MAX: CInt = extern
+
+  @name("scalanative__sc_synchronized_io")
+  def _SC_SYNCHRONIZED_IO: CInt = extern
+
+  @name("scalanative__sc_thread_attr_stackaddr")
+  def _SC_THREAD_ATTR_STACKADDR: CInt = extern
+
+  @name("scalanative__sc_thread_attr_stacksize")
+  def _SC_THREAD_ATTR_STACKSIZE: CInt = extern
+
+  @name("scalanative__sc_thread_cputime")
+  def _SC_THREAD_CPUTIME: CInt = extern
+
+  @name("scalanative__sc_thread_destructor_iterations")
+  def _SC_THREAD_DESTRUCTOR_ITERATIONS: CInt = extern
+
+  @name("scalanative__sc_thread_keys_max")
+  def _SC_THREAD_KEYS_MAX: CInt = extern
+
+  /* Not implemented, not defined on macOS.
+   *    _SC_THREAD_PRIO_INHERIT
+   *    _SC_THREAD_PRIO_PROTECT
+   */
+
+  @name("scalanative__sc_thread_priority_scheduling")
+  def _SC_THREAD_PRIORITY_SCHEDULING: CInt = extern
+
+  @name("scalanative__sc_thread_process_shared")
+  def _SC_THREAD_PROCESS_SHARED: CInt = extern
+
+  /* Not implemented, not defined on macOS.
+   *    _SC_THREAD_ROBUST_PRIO_INHERIT
+   *    _SC_THREAD_ROBUST_PRIO_PROTECT
+   */
+
+  @name("scalanative__sc_thread_safe_functions")
+  def _SC_THREAD_SAFE_FUNCTIONS: CInt = extern
+
+  @name("scalanative__sc_thread_sporadic_server")
+  def _SC_THREAD_SPORADIC_SERVER: CInt = extern
+
+  @name("scalanative__sc_thread_stack_min")
+  def _SC_THREAD_STACK_MIN: CInt = extern
+
+  @name("scalanative__sc_thread_threads_max")
+  def _SC_THREAD_THREADS_MAX: CInt = extern
+
+  @name("scalanative__sc_threads")
+  def _SC_THREADS: CInt = extern
+
+  @name("scalanative__sc_timeouts")
+  def _SC_TIMEOUTS: CInt = extern
+
+  @name("scalanative__sc_timer_max")
+  def _SC_TIMER_MAX: CInt = extern
+
+  @name("scalanative__sc_timers")
+  def _SC_TIMERS: CInt = extern
+
+  @name("scalanative__sc_trace")
+  def _SC_TRACE: CInt = extern
+
+  @name("scalanative__sc_trace_event_filter")
+  def _SC_TRACE_EVENT_FILTER: CInt = extern
+
+  @name("scalanative__sc_trace_event_name_max")
+  def _SC_TRACE_EVENT_NAME_MAX: CInt = extern
+
+  @name("scalanative__sc_trace_inherit")
+  def _SC_TRACE_INHERIT: CInt = extern
+
+  @name("scalanative__sc_trace_log")
+  def _SC_TRACE_LOG: CInt = extern
+
+  @name("scalanative__sc_trace_name_max")
+  def _SC_TRACE_NAME_MAX: CInt = extern
+
+  @name("scalanative__sc_trace_sys_max")
+  def _SC_TRACE_SYS_MAX: CInt = extern
+
+  @name("scalanative__sc_trace_user_event_max")
+  def _SC_TRACE_USER_EVENT_MAX: CInt = extern
+
+  @name("scalanative__sc_tty_name_max")
+  def _SC_TTY_NAME_MAX: CInt = extern
+
+  @name("scalanative__sc_typed_memory_objects")
+  def _SC_TYPED_MEMORY_OBJECTS: CInt = extern
+
+  @name("scalanative__sc_tzname_max")
+  def _SC_TZNAME_MAX: CInt = extern
+
+  /* Not implemented, not defined on macOS.
+   *    _SC_V7_ILP32_OFF32
+   *    _SC_V7_ILP32_OFFBIG
+   *    _SC_V7_LP64_OFF64
+   *    _SC_V7_LPBIG_OFFBIG
+   */
+
+  @name("scalanative__sc_version")
+  def _SC_VERSION: CInt = extern
+
+  @name("scalanative__sc_xopen_crypt")
+  def _SC_XOPEN_CRYPT: CInt = extern
+
+  @name("scalanative__sc_xopen_enh_i18n")
+  def _SC_XOPEN_ENH_I18N: CInt = extern
+
+  @name("scalanative__sc_xopen_realtime")
+  def _SC_XOPEN_REALTIME: CInt = extern
+
+  @name("scalanative__sc_xopen_realtime_threads")
+  def _SC_XOPEN_REALTIME_THREADS: CInt = extern
+
+  @name("scalanative__sc_xopen_shm")
+  def _SC_XOPEN_SHM: CInt = extern
+
+  @name("scalanative__sc_xopen_streams")
+  def _SC_XOPEN_STREAMS: CInt = extern
+
+  @name("scalanative__sc_xopen_unix")
+  def _SC_XOPEN_UNIX: CInt = extern
+
+  /* Not implemented, not defined on Linux.
+   *    _SC_XOPEN_UUCP
+   */
+
+  @name("scalanative__sc_xopen_version")
+  def _SC_XOPEN_VERSION: CInt = extern
 
 }


### PR DESCRIPTION
Fix #2831. posixlib unistd.scala is more capable and useful now. It is almost complete. 

* A number of A number of _CS, _PC, _SC symbolic constants were not implemented
  because they are not defined on Linux, macOS, or both. Windows
  appears to support this subset. 

   A few other constants or methods were not implemented. 
   ```
    // _POSIX2_VERSION was not implemented

    // pid_t setpgrp(void); // [OB XSI], not implemented
   ```

  See the file for the complete list.

* Two methods were deprecated in order to match the POSIX spec.
   These need a release note but the 0.5.0 release file is awaiting merge, hence locked.
   I will create an Issue so that these deprecations do not get lost.

   ``` 
     @deprecated(
       "Not POSIX, subject to complete removal in the future.", 
       since = "posixlib 0.5.0"
    )
    def sethostname(name: CString, len: CSize): CInt = extern

    @deprecated(
      "Removed in POSIX.1-2008. Consider posix_spawn().",
      "posixlib 0.5.0"
    )
    def vfork(): CInt = extern
    ```  
* An method deprecated in Scala Native 0.4.5 was not removed because, IMO, 
   a sufficient interval has not yet passed.

2022-10-19  For the enquiring mind, the deprecated items are now recorded in the
                    0.5.0 Changelog (PR #2924)