### PR TITLE
Fix `FileChannel#write` for read-only buffers

### DIFF
--- a/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
+++ b/javalib/src/main/scala/java/nio/channels/FileChannelImpl.scala
@@ -338,7 +338,14 @@ private[java] final class FileChannelImpl(
     val srcPos: Int = buffer.position()
     val srcLim: Int = buffer.limit()
     val lim = math.abs(srcLim - srcPos)
-    write(buffer.array(), 0, lim)
+    val bytes = if (buffer.hasArray()) {
+      buffer.array()
+    } else {
+      val bytes = new Array[Byte](lim)
+      buffer.get(bytes)
+      bytes
+    }
+    write(bytes, 0, lim)
     buffer.position(srcPos + lim)
     lim
   }

--- a/unit-tests/shared/src/test/scala/javalib/nio/channels/FileChannelTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/nio/channels/FileChannelTest.scala
@@ -85,6 +85,25 @@ class FileChannelTest {
     }
   }
 
+  @Test def fileChannelCanWriteReadOnlyByteBufferToFile(): Unit = {
+    withTemporaryDirectory { dir =>
+      val f = dir.resolve("f")
+      val bytes = Array.apply[Byte](1, 2, 3, 4, 5)
+      val src = ByteBuffer.wrap(bytes).asReadOnlyBuffer()
+      val channel =
+        FileChannel.open(f, StandardOpenOption.WRITE, StandardOpenOption.CREATE)
+      while (src.remaining() > 0) channel.write(src)
+
+      val in = Files.newInputStream(f)
+      var i = 0
+      while (i < bytes.length) {
+        assertTrue(in.read() == bytes(i))
+        i += 1
+      }
+
+    }
+  }
+
   @Test def fileChannelCanOverwriteFile(): Unit = {
     withTemporaryDirectory { dir =>
       val f = dir.resolve("file")


### PR DESCRIPTION
Fixes a bug discovered in https://github.com/typelevel/fs2/pull/3008.