### PR TITLE
Add `LinktimeInfo.{debugMode,releaseMode}`

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
+++ b/nativelib/src/main/scala/scala/scalanative/meta/LinktimeInfo.scala
@@ -6,6 +6,12 @@ import scala.scalanative.unsafe._
  *  discard some parts of NIR instructions when linking
  */
 object LinktimeInfo {
+  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.debugMode")
+  def debugMode: Boolean = resolved
+
+  @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.releaseMode")
+  def releaseMode: Boolean = resolved
+
   @resolvedAtLinktime("scala.scalanative.meta.linktimeinfo.isWindows")
   def isWindows: Boolean = resolved
 

--- a/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/LinktimeValueResolver.scala
@@ -11,6 +11,8 @@ trait LinktimeValueResolver { self: Reach =>
     val conf = config.compilerConfig
     val linktimeInfo = "scala.scalanative.meta.linktimeinfo"
     val predefined: NativeConfig.LinktimeProperites = Map(
+      s"$linktimeInfo.debugMode" -> (conf.mode == Mode.debug),
+      s"$linktimeInfo.releaseMode" -> (conf.mode == Mode.releaseFast || conf.mode == Mode.releaseFull),
       s"$linktimeInfo.isWindows" -> Platform.isWindows,
       s"$linktimeInfo.isLinux" -> Platform.isLinux,
       s"$linktimeInfo.isMac" -> Platform.isMac,

--- a/unit-tests/native/src/test/scala/scala/scalanative/meta/LinktimeInfoTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/meta/LinktimeInfoTest.scala
@@ -7,6 +7,10 @@ import org.junit.Assert._
 
 class LinktimeInfoTest {
 
+  @Test def testMode(): Unit = {
+    assertEquals(LinktimeInfo.debugMode, !LinktimeInfo.releaseMode)
+  }
+
   @Test def testOS(): Unit = {
     assertEquals(Platform.isFreeBSD(), LinktimeInfo.isFreeBSD)
     assertEquals(Platform.isLinux(), LinktimeInfo.isLinux)


### PR DESCRIPTION
This is analogous to the `developmentMode` and `productionMode` exposed in Scala.js `LinkingInfo`.

https://github.com/scala-js/scala-js/blob/0708917912938714d52be1426364f78a3d1fd269/library/src/main/scala/scala/scalajs/LinkingInfo.scala

In Cats Effect we enable additional diagnostics (tracing, fiber dumps) in development/debug mode, but for performance it is preferable to completely elide those code paths in production/release mode.