### PR TITLE
Fix #2891: posixlib spawn is now implemented.

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -52,7 +52,7 @@ C Header          Scala Native Module
 `semaphore.h`_    N/A
 `setjmp.h`_       N/A
 `signal.h`_       scala.scalanative.posix.signal_
-`spawn.h`_        N/A
+`spawn.h`_        scala.scalanative.posix.spawn_
 `stdarg.h`_       N/A
 `stdbool.h`_      N/A
 `stddef.h`_       scala.scalanative.posix.stddef_
@@ -200,6 +200,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.regex: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/regex.scala
 .. _scala.scalanative.posix.sched: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/sched.scala
 .. _scala.scalanative.posix.signal: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/signal.scala
+.. _scala.scalanative.posix.spawn: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/spawn.scala
 .. _scala.scalanative.posix.stddef: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/stddef.scala
 .. _scala.scalanative.posix.stdlib: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/stdlib.scala
 .. _scala.scalanative.posix.string: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/string.scala

--- a/posixlib/src/main/resources/scala-native/spawn.c
+++ b/posixlib/src/main/resources/scala-native/spawn.c
@@ -1,0 +1,53 @@
+#if !defined(_WIN32)
+
+#include <spawn.h>
+
+#if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
+#ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING
+#warning "Size and order of C structures are not checked when -std < c11."
+#endif
+#else
+
+// posix_spawnattr_t
+_Static_assert(sizeof(posix_spawnattr_t) <= 336,
+               "Scala Native posix_spawnattr_t is too small");
+
+// posix_spawn_file_actions_t
+_Static_assert(sizeof(posix_spawn_file_actions_t) <= 80,
+               "Scala Native posix_spawn_file_actions_t is too small");
+
+#endif // __STDC_VERSION__
+
+// Symbolic constants
+
+int scalanative_posix_spawn_posix_spawn_resetids() {
+    return POSIX_SPAWN_RESETIDS;
+}
+
+int scalanative_posix_spawn_posix_spawn_setpgroup() {
+    return POSIX_SPAWN_SETPGROUP;
+}
+
+/** PS */
+int scalanative_posix_spawn_setschedparam() {
+#if defined(__APPLE__)
+    return 0; // Unsupported - zero bits set is the "no-op/do-nothing" flag
+#else
+    return POSIX_SPAWN_SETSCHEDPARAM;
+#endif // !__APPLE__
+}
+
+/** PS */
+int scalanative_posix_spawn_setscheduler() {
+#if defined(__APPLE__)
+    return 0; // Unsupported - zero bits set is the "no-op/do-nothing" flag
+#else
+    return POSIX_SPAWN_SETSCHEDULER;
+#endif // !__APPLE__
+}
+
+int scalanative_posix_spawn_setsigdef() { return POSIX_SPAWN_SETSIGDEF; }
+
+int scalanative_posix_spawn_setsigmask() { return POSIX_SPAWN_SETSIGMASK; }
+
+#endif // Unix or Mac OS

--- a/posixlib/src/main/scala/scala/scalanative/posix/spawn.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/spawn.scala
@@ -3,7 +3,6 @@ package scala.scalanative.posix
 import scalanative.unsafe._
 import scalanative.unsafe.Nat._
 
-import scala.scalanative.posix.sched
 import scala.scalanative.posix.sys.types
 
 /** POSIX spawn.h for Scala

--- a/posixlib/src/main/scala/scala/scalanative/posix/spawn.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/spawn.scala
@@ -1,0 +1,178 @@
+package scala.scalanative.posix
+
+import scalanative.unsafe._
+import scalanative.unsafe.Nat._
+
+import scala.scalanative.posix.sched
+import scala.scalanative.posix.sys.types
+
+/** POSIX spawn.h for Scala
+ *
+ *  The Open Group Base Specifications
+ *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
+ *
+ *  A method with a PS comment indicates it is defined in POSIX extension
+ *  "Process Scheduling", not base POSIX.
+ */
+@extern
+object spawn {
+
+  /* posix_spawnattr_t & posix_spawn_file_actions_t are opaque bulk storage
+   * types. They have no user accessible fields, not even the component Bytes.
+   * Users of these types should leave them opaque: i.e. no read, no write.
+   *
+   * The sizes here are from Linux 6.0.  Code in spawn.c checks at compile-time
+   * that these sizes are greater than or equal to the equivalent OS types.
+   * Maintainers:  If you change sizes, either here or in spawn.c, change
+   *               the other file also.
+   */
+
+  type posix_spawnattr_t = CArray[CUnsignedLong, Nat.Digit3[_3, _3, _6]]
+
+  type posix_spawn_file_actions_t = CArray[CUnsignedLong, Nat.Digit2[_8, _0]]
+
+  type mode_t = types.mode_t
+  type pid_t = types.pid_t
+  type sigset_t = signal.sigset_t
+  type sched_param = sched.sched_param
+
+  def posix_spawn(
+      pid: Ptr[pid_t],
+      path: CString,
+      file_actions: Ptr[posix_spawn_file_actions_t],
+      attrp: Ptr[posix_spawnattr_t],
+      argv: Ptr[CString],
+      envp: Ptr[CString]
+  ): CInt = extern
+
+  def posix_spawn_file_actions_addclose(
+      file_actions: Ptr[posix_spawn_file_actions_t],
+      filedes: CInt
+  ): CInt = extern
+
+  def posix_spawn_file_actions_adddup2(
+      file_actions: Ptr[posix_spawn_file_actions_t],
+      filedes: CInt,
+      newfiledes: CInt
+  ): CInt = extern
+
+  def posix_spawn_file_actions_open(
+      file_actions: Ptr[posix_spawn_file_actions_t],
+      filedes: CInt,
+      path: CString,
+      oflag: CInt,
+      mode: mode_t
+  ): CInt = extern
+
+  def posix_spawn_file_actions_destroy(
+      file_actions: Ptr[posix_spawn_file_actions_t]
+  ): CInt = extern
+
+  def posix_spawn_file_actions_init(
+      file_actions: Ptr[posix_spawn_file_actions_t]
+  ): CInt = extern
+
+  def posix_spawnattr_destroy(
+      attr: Ptr[posix_spawnattr_t]
+  ): CInt = extern
+
+  def posix_spawnattr_getflags(
+      attr: Ptr[posix_spawnattr_t],
+      flags: Ptr[CShort]
+  ): CInt = extern
+
+  def posix_spawnattr_getpgroup(
+      attr: Ptr[posix_spawnattr_t],
+      pgroup: Ptr[pid_t]
+  ): CInt = extern
+
+  /** PS */
+  def posix_spawnattr_getschedparam(
+      attr: Ptr[posix_spawnattr_t],
+      schedparam: Ptr[sched_param]
+  ): CInt = extern
+
+  /** PS */
+  def posix_spawnattr_getschedpolicy(
+      attr: Ptr[posix_spawnattr_t],
+      schedpolicy: Ptr[CInt]
+  ): CInt = extern
+
+  def posix_spawnattr_getsigdefault(
+      attr: Ptr[posix_spawnattr_t],
+      sigdefault: Ptr[sigset_t]
+  ): CInt = extern
+
+  def posix_spawnattr_getsigmask(
+      attr: Ptr[posix_spawnattr_t],
+      sigmask: Ptr[sigset_t]
+  ): CInt = extern
+
+  def posix_spawnattr_init(
+      attr: Ptr[posix_spawnattr_t]
+  ): CInt = extern
+
+  def posix_spawnattr_setflags(
+      attr: Ptr[posix_spawnattr_t],
+      flags: CShort
+  ): CInt = extern
+
+  def posix_spawnattr_setpgroup(
+      attr: Ptr[posix_spawnattr_t],
+      pgroup: pid_t
+  ): CInt = extern
+
+  /** PS */
+  def posix_spawnattr_setschedparam(
+      attr: Ptr[posix_spawnattr_t],
+      schedparam: Ptr[sched_param]
+  ): CInt = extern
+
+  /** PS */
+  def posix_spawnattr_getschedpolicy(
+      attr: Ptr[posix_spawnattr_t],
+      schedpolicy: CInt
+  ): CInt = extern
+
+  def posix_spawnattr_setsigdefault(
+      attr: Ptr[posix_spawnattr_t],
+      sigdefault: Ptr[sigset_t]
+  ): CInt = extern
+
+  def posix_spawnattr_setsigmask(
+      attr: Ptr[posix_spawnattr_t],
+      sigmask: Ptr[sigset_t]
+  ): CInt = extern
+
+  def posix_spawnp(
+      pid: Ptr[pid_t],
+      file: CString,
+      file_actions: Ptr[posix_spawn_file_actions_t],
+      attrp: Ptr[posix_spawnattr_t],
+      argv: Ptr[CString],
+      envp: Ptr[CString]
+  ): CInt = extern
+
+// Symbolic constants
+
+  @name("scalanative_posix_spawn_posix_spawn_resetids")
+  def POSIX_SPAWN_RESETIDS: CInt = extern
+
+  @name("scalanative_posix_spawn_posix_spawn_setpgroup")
+  def POSIX_SPAWN_SETPGROUP: CInt = extern
+
+  /** PS - Unsupported (zero) on Apple */
+  @name("scalanative_posix_spawn_setschedparam")
+  def POSIX_SPAWN_SETSCHEDPARAM: CInt = extern
+
+  /** PS - Unsupported (zero) on Apple */
+  @name("scalanative_posix_spawn_setscheduler")
+  def POSIX_SPAWN_SETSCHEDULER: CInt = extern
+
+  @name("scalanative_posix_spawn_setsigdef")
+  def POSIX_SPAWN_SETSIGDEF: CInt = extern
+
+  @name("scalanative_posix_spawn_setsigmask")
+  def POSIX_SPAWN_SETSIGMASK: CInt = extern
+
+}


### PR DESCRIPTION
Fix #2891: posixlib spawn.scala & supporting spawn.c are now implemented.

Normally, one would expect a corresponding `spawnTest.scala`.

TL;DR; It is not good for tests to hang forever and `pselect()` and `waitid()` are not 
currently implemented in Scala Native.