### PR TITLE
Port `j.u.ArrayDeque` from JSR 166

### DIFF
--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -1320,14 +1320,10 @@ class ArrayDeque[E](
    *    a copy of this deque
    */
   override def clone(): ArrayDeque[E] = {
-    try {
-      val result = super.clone().asInstanceOf[ArrayDeque[E]]
-      result.elements = Arrays.copyOf(elements, elements.length)
-      return result
-    } catch {
-      case e: CloneNotSupportedException =>
-        throw new AssertionError()
-    }
+    val result = new ArrayDeque[E](Arrays.copyOf(elements, elements.length))
+    result.head = this.head
+    result.tail = this.tail
+    result
   }
 
   /** debugging */

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -1127,9 +1127,10 @@ class ArrayDeque[E](
         if (i >= to) {
           if (w == capacity) w = 0 // "corner" case
           continue = false
+        } else {
+          w = 0 // w rejoins i on second leg
         }
       }
-      w = 0 // w rejoins i on second leg
     }
     if (end != tail) throw new ConcurrentModificationException()
     tail = w

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -1092,16 +1092,17 @@ class ArrayDeque[E](
       }
       if (to == end) continue = false
       else {
+        i = 0
         to = end
         k -= capacity
       }
     }
     // a two-finger traversal, with hare i reading, tortoise w writing
     var w = beg
-    continue = true
     i = beg + 1
     to = if (i <= end) end else es.length
     k = beg
+    continue = true
     while (continue) {
       // In this loop, i and w are on the same leg, with i > w
       while (i < to) {

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -1089,9 +1089,11 @@ class ArrayDeque[E](
           setBit(doRemove, i - k)
         i += 1
       }
-      to = end
-      k -= capacity
       if (to == end) continue = false
+      else {
+        to = end
+        k -= capacity
+      }
     }
     // a two-finger traversal, with hare i reading, tortoise w writing
     var w = beg

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -1184,7 +1184,7 @@ class ArrayDeque[E](
    *  @return
    *    {@code true} if this deque contained the specified element
    */
-  def remove(o: Object): Boolean = {
+  override def remove(o: Any): Boolean = {
     return removeFirstOccurrence(o)
   }
 

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -1,232 +1,1359 @@
-// Ported from Scala.js.
-// Also contains original work for Scala Native.
+/*
+ * Written by Josh Bloch of Google Inc. and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/.
+ */
 
-package java.util
+/*
+ * Ported from jsr166 revision 1.138
+ * https://gee.cs.oswego.edu/dl/concurrency-interest/index.html
+ */
 
-/// ScalaNative Porting Note:
-///
-///     * Ported, with thanks & gratitude, from Scala.js ArrayDeque.scala
-///       commit 9DC4D5b, dated 2018-10-12.
-///       Also contains original work for Scala Native.
-///
-///     * Changes in Scala.js original commit E07F99D, dated 2019-07-30
-///       were considered on 2020-05-19. The Scala.js changes to
-///       ArrayDeque.scala were to use Objects.equals() in 3 places:
-///       contains(), removeFirstOccurrence(), & removeLastOccurrence().
-///       No corresponding change is needed here because the above
-///       methods of this class are defined in terms of
-///       inner.{contains,indexOf,lastIndexOf}. inner is a
-///       java.util.ArrayList, whose methods already use the semantics of
-///       Object.equals().
-///
-///     * ArrayList is the inner type, rather than js.Array.
-///
-///     * The order of method declarations is not alphabetical to reduce
-///       churn versus Scala.js original.
+package java.util;
 
-class ArrayDeque[E] private (private val inner: ArrayList[E])
-    extends AbstractCollection[E]
+import java.io.Serializable
+import java.util.function.Consumer
+import java.util.function.Predicate
+import java.util.function.UnaryOperator
+
+import ArrayDeque._
+
+/** Resizable-array implementation of the {@link Deque} interface. Array deques
+ *  have no capacity restrictions; they grow as necessary to support usage. They
+ *  are not thread-safe; in the absence of external synchronization, they do not
+ *  support concurrent access by multiple threads. Null elements are prohibited.
+ *  This class is likely to be faster than {@link Stack} when used as a stack,
+ *  and faster than {@link LinkedList} when used as a queue.
+ *
+ *  <p>Most {@code ArrayDeque} operations run in amortized constant time.
+ *  Exceptions include {@link #remove(Object) remove}, {@link
+ *  #removeFirstOccurrence removeFirstOccurrence}, {@link #removeLastOccurrence
+ *  removeLastOccurrence}, {@link #contains contains}, {@link #iterator
+ *  iterator.remove()}, and the bulk operations, all of which run in linear
+ *  time.
+ *
+ *  <p>The iterators returned by this class's {@link #iterator() iterator}
+ *  method are <em>fail-fast</em>: If the deque is modified at any time after
+ *  the iterator is created, in any way except through the iterator's own {@code
+ *  remove} method, the iterator will generally throw a {@link
+ *  ConcurrentModificationException}. Thus, in the face of concurrent
+ *  modification, the iterator fails quickly and cleanly, rather than risking
+ *  arbitrary, non-deterministic behavior at an undetermined time in the future.
+ *
+ *  <p>Note that the fail-fast behavior of an iterator cannot be guaranteed as
+ *  it is, generally speaking, impossible to make any hard guarantees in the
+ *  presence of unsynchronized concurrent modification. Fail-fast iterators
+ *  throw {@code ConcurrentModificationException} on a best-effort basis.
+ *  Therefore, it would be wrong to write a program that depended on this
+ *  exception for its correctness: <i>the fail-fast behavior of iterators should
+ *  be used only to detect bugs.</i>
+ *
+ *  <p>This class and its iterator implement all of the <em>optional</em>
+ *  methods of the {@link Collection} and {@link Iterator} interfaces.
+ *
+ *  <p>This class is a member of the <a
+ *  href="{@docRoot}/java.base/java/util/package-summary.html#CollectionsFramework">
+ *  Java Collections Framework</a>.
+ *
+ *  @author
+ *    Josh Bloch and Doug Lea
+ *  @param <E>
+ *    the type of elements held in this deque
+ *  @since 1.6
+ */
+object ArrayDeque {
+
+  /** The maximum size of array to allocate. Some VMs reserve some header words
+   *  in an array. Attempts to allocate larger arrays may result in
+   *  OutOfMemoryError: Requested array size exceeds VM limit
+   */
+  private val MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8
+
+}
+
+class ArrayDeque[E](
+    /** The array in which the elements of the deque are stored. All array cells
+     *  not holding deque elements are always null. The array always has at
+     *  least one null slot (at tail).
+     */
+    var elements: Array[Object]
+) extends AbstractCollection[E]
     with Deque[E]
     with Cloneable
     with Serializable {
-  self =>
+  /*
+   * VMs excel at optimizing simple array loops where indices are
+   * incrementing or decrementing over a valid slice, e.g.
+   *
+   * for (int i = start; i < end; i++) ... elements[i]
+   *
+   * Because in a circular array, elements are in general stored in
+   * two disjoint such slices, we help the VM by writing unusual
+   * nested loops for all traversals over the elements.  Having only
+   * one hot inner loop body instead of two or three eases human
+   * maintenance and encourages VM loop inlining into the caller.
+   */
 
-  private var status = 0
+  /** The index of the element at the head of the deque (which is the element
+   *  that would be removed by remove() or pop()); or an arbitrary number 0 <=
+   *  head < elements.length equal to tail if the deque is empty.
+   */
+  var head: Int = _
 
-  def this() =
-    this(new ArrayList[E](16))
+  /** The index at which the next element would be added to the tail of the
+   *  deque (via addLast(E), add(E), or push(E)); elements[tail] is always null.
+   */
+  var tail: Int = _
 
-  def this(initialCapacity: Int) = {
-    // This is the JVM behavior for negative initialCapacity.
-    this(new ArrayList[E](Math.max(0, initialCapacity)))
+  /** Increases the capacity of this deque by at least the given amount.
+   *
+   *  @param needed
+   *    the required minimum extra capacity; must be positive
+   */
+  private def grow(needed: Int): Unit = {
+    // overflow-conscious code
+    val oldCapacity = elements.length
+    var newCapacity = 0
+    // Double capacity if small; else grow by 50%
+    val jump = if (oldCapacity < 64) (oldCapacity + 2) else (oldCapacity >> 1)
+    if (jump < needed
+        || {
+          newCapacity = (oldCapacity + jump); newCapacity
+        } - MAX_ARRAY_SIZE > 0)
+      newCapacity = this.newCapacity(needed, jump)
+    elements = Arrays.copyOf(elements, newCapacity)
+    val es = elements
+    // Exceptionally, here tail == head needs to be disambiguated
+    if (tail < head || (tail == head && es(head) != null)) {
+      // wrap around; slide first leg forward to end of array
+      val newSpace = newCapacity - oldCapacity
+      System.arraycopy(es, head, es, head + newSpace, oldCapacity - head)
+      var i = head
+      head += newSpace
+      val to = head
+      while (i < to) {
+        es(i) = null
+        i += 1
+      }
+    }
+    // checkInvariants();
   }
 
+  /** Capacity calculation for edge conditions, especially overflow. */
+  private def newCapacity(needed: Int, jump: Int): Int = {
+    val oldCapacity = elements.length
+    val minCapacity = oldCapacity + needed
+    if (minCapacity - MAX_ARRAY_SIZE > 0) {
+      if (minCapacity < 0)
+        throw new IllegalStateException("Sorry, deque too big")
+      return Integer.MAX_VALUE
+    }
+    if (needed > jump)
+      return minCapacity
+    return if (oldCapacity + jump - MAX_ARRAY_SIZE < 0)
+      oldCapacity + jump
+    else MAX_ARRAY_SIZE
+  }
+
+  /** Increases the internal storage of this collection, if necessary, to ensure
+   *  that it can hold at least the given number of elements.
+   *
+   *  @param minCapacity
+   *    the desired minimum capacity
+   *  @since TBD
+   */
+  /* public */
+  def ensureCapacity(minCapacity: Int): Unit = {
+    val needed = minCapacity + 1 - elements.length
+    if (needed > 0)
+      grow(needed)
+    // checkInvariants();
+  }
+
+  /** Minimizes the internal storage of this collection.
+   *
+   *  @since TBD
+   */
+  /* public */
+  def trimToSize(): Unit = {
+    val size = this.size()
+    if (size + 1 < elements.length) {
+      elements = toArray(new Array[Object](size + 1))
+      head = 0
+      tail = size
+    }
+    // checkInvariants();
+  }
+
+  /** Constructs an empty array deque with an initial capacity sufficient to
+   *  hold 16 elements.
+   */
+  def this() = {
+    this(new Array[Object](16 + 1))
+  }
+
+  /** Constructs an empty array deque with an initial capacity sufficient to
+   *  hold the specified number of elements.
+   *
+   *  @param numElements
+   *    lower bound on initial capacity of the deque
+   */
+  def this(numElements: Int) = {
+    this(
+      new Array[Object](
+        if (numElements < 1) 1
+        else if (numElements == Integer.MAX_VALUE) Integer.MAX_VALUE
+        else
+          numElements + 1
+      )
+    )
+  }
+
+  /** Constructs a deque containing the elements of the specified collection, in
+   *  the order they are returned by the collection's iterator. (The first
+   *  element returned by the collection's iterator becomes the first element,
+   *  or <i>front</i> of the deque.)
+   *
+   *  @param c
+   *    the collection whose elements are to be placed into the deque
+   *  @throws NullPointerException
+   *    if the specified collection is null
+   */
   def this(c: Collection[_ <: E]) = {
     this(c.size())
-    addAll(c)
+    copyElements(c)
   }
 
-  override def add(e: E): Boolean = {
-    offerLast(e)
-    true
+  /** Circularly increments i, mod modulus. Precondition and postcondition: 0 <=
+   *  i < modulus.
+   */
+  private def inc(_i: Int, modulus: Int): Int = {
+    var i = _i + 1
+    if (i >= modulus) i = 0
+    return i
   }
 
-  def addFirst(e: E): Unit =
-    offerFirst(e)
+  /** Circularly decrements i, mod modulus. Precondition and postcondition: 0 <=
+   *  i < modulus.
+   */
+  private def dec(_i: Int, modulus: Int): Int = {
+    var i = _i - 1
+    if (i < 0) i = modulus - 1
+    return i
+  }
 
-  def addLast(e: E): Unit =
-    offerLast(e)
+  /** Circularly adds the given distance to index i, mod modulus. Precondition:
+   *  0 <= i < modulus, 0 <= distance <= modulus.
+   *  @return
+   *    index 0 <= i < modulus
+   */
+  private def inc(_i: Int, distance: Int, modulus: Int): Int = {
+    var i = _i + distance
+    if (i - modulus >= 0) i -= modulus
+    return i
+  }
 
-  // shallow-copy
-  override def clone(): ArrayDeque[E] =
-    new ArrayDeque[E](inner.clone.asInstanceOf[ArrayList[E]])
+  /** Subtracts j from i, mod modulus. Index i must be logically ahead of index
+   *  j. Precondition: 0 <= i < modulus, 0 <= j < modulus.
+   *  @return
+   *    the "circular distance" from j to i; corner case i == j is disambiguated
+   *    to "empty", returning 0.
+   */
+  private def sub(_i: Int, j: Int, modulus: Int): Int = {
+    var i = _i - j
+    if (i < 0) i += modulus
+    return i
+  }
 
+  /** Returns element at array index i. This is a slight abuse of generics,
+   *  accepted by javac.
+   */
+  private def elementAt(es: Array[Object], i: Int): E = {
+    return es(i).asInstanceOf[E]
+  }
+
+  /** A version of elementAt that checks for null elements. This check doesn't
+   *  catch all possible comodifications, but does catch ones that corrupt
+   *  traversal.
+   */
+  private def nonNullElementAt(es: Array[Object], i: Int): E = {
+    val e = es(i).asInstanceOf[E]
+    if (e == null)
+      throw new ConcurrentModificationException()
+    return e
+  }
+
+  // The main insertion and extraction methods are addFirst,
+  // addLast, pollFirst, pollLast. The other methods are defined in
+  // terms of these.
+
+  /** Inserts the specified element at the front of this deque.
+   *
+   *  @param e
+   *    the element to add
+   *  @throws NullPointerException
+   *    if the specified element is null
+   */
+  def addFirst(e: E): Unit = {
+    if (e == null)
+      throw new NullPointerException()
+    val es = elements
+    head = dec(head, es.length)
+    es(head) = e.asInstanceOf[Object]
+    if (head == tail)
+      grow(1)
+    // checkInvariants();
+  }
+
+  /** Inserts the specified element at the end of this deque.
+   *
+   *  <p>This method is equivalent to {@link #add}.
+   *
+   *  @param e
+   *    the element to add
+   *  @throws NullPointerException
+   *    if the specified element is null
+   */
+  def addLast(e: E): Unit = {
+    if (e == null)
+      throw new NullPointerException()
+    val es = elements
+    es(tail) = e.asInstanceOf[Object]
+    tail = inc(tail, es.length)
+    if (head == tail)
+      grow(1)
+    // checkInvariants();
+  }
+
+  /** Adds all of the elements in the specified collection at the end of this
+   *  deque, as if by calling {@link #addLast} on each one, in the order that
+   *  they are returned by the collection's iterator.
+   *
+   *  @param c
+   *    the elements to be inserted into this deque
+   *  @return
+   *    {@code true} if this deque changed as a result of the call
+   *  @throws NullPointerException
+   *    if the specified collection or any of its elements are null
+   */
+  override def addAll(c: Collection[_ <: E]): Boolean = {
+    val s = size()
+    val needed = s + c.size() + 1 - elements.length
+    if (needed > 0)
+      grow(needed)
+    copyElements(c)
+    // checkInvariants();
+    return size() > s
+  }
+
+  private def copyElements(c: Collection[_ <: E]): Unit = {
+    c.forEach(addLast(_))
+  }
+
+  /** Inserts the specified element at the front of this deque.
+   *
+   *  @param e
+   *    the element to add
+   *  @return
+   *    {@code true} (as specified by {@link Deque#offerFirst})
+   *  @throws NullPointerException
+   *    if the specified element is null
+   */
   def offerFirst(e: E): Boolean = {
-    if (e == null) {
-      throw new NullPointerException()
-    } else {
-      inner.add(0, e)
-      status += 1
-      true
-    }
+    addFirst(e)
+    return true
   }
 
+  /** Inserts the specified element at the end of this deque.
+   *
+   *  @param e
+   *    the element to add
+   *  @return
+   *    {@code true} (as specified by {@link Deque#offerLast})
+   *  @throws NullPointerException
+   *    if the specified element is null
+   */
   def offerLast(e: E): Boolean = {
-    if (e == null) {
-      throw new NullPointerException()
-    } else {
-      inner.add(e)
-      status += 1
-      true
-    }
+    addLast(e)
+    return true
   }
 
+  /** @throws NoSuchElementException
+   *    {@inheritDoc}
+   */
   def removeFirst(): E = {
-    if (inner.isEmpty())
+    val e = pollFirst()
+    if (e == null)
       throw new NoSuchElementException()
-    else
-      pollFirst()
+    // checkInvariants();
+    return e
   }
 
+  /** @throws NoSuchElementException
+   *    {@inheritDoc}
+   */
   def removeLast(): E = {
-    if (inner.isEmpty())
+    val e = pollLast()
+    if (e == null)
       throw new NoSuchElementException()
-    else
-      pollLast()
+    // checkInvariants();
+    return e
   }
 
   def pollFirst(): E = {
-    if (inner.isEmpty()) null.asInstanceOf[E]
-    else {
-      val res = inner.remove(0)
-      status += 1
-      res
+    val es = elements
+    val h = head
+    val e = elementAt(es, h)
+    if (e != null) {
+      es(h) = null
+      head = inc(h, es.length)
     }
+    // checkInvariants();
+    return e
   }
 
   def pollLast(): E = {
-    if (inner.isEmpty()) null.asInstanceOf[E]
-    else {
-      val res = inner.remove(inner.size() - 1)
-      status += 1
-      res
+    val es = elements
+    val t = dec(tail, es.length)
+    val e = elementAt(es, t)
+    if (e != null) {
+      tail = t
+      es(t) = null
     }
+    // checkInvariants();
+    return e
   }
 
+  /** @throws NoSuchElementException
+   *    {@inheritDoc}
+   */
   def getFirst(): E = {
-    if (inner.isEmpty())
+    val e = elementAt(elements, head)
+    if (e == null)
       throw new NoSuchElementException()
-    else
-      peekFirst()
+    // checkInvariants();
+    return e
   }
 
+  /** @throws NoSuchElementException
+   *    {@inheritDoc}
+   */
   def getLast(): E = {
-    if (inner.isEmpty())
+    val es = elements
+    val e = elementAt(es, dec(tail, es.length))
+    if (e == null)
       throw new NoSuchElementException()
-    else
-      peekLast()
+    // checkInvariants();
+    return e
   }
 
   def peekFirst(): E = {
-    if (inner.isEmpty()) null.asInstanceOf[E]
-    else inner.get(0)
+    // checkInvariants();
+    return elementAt(elements, head)
   }
 
   def peekLast(): E = {
-    if (inner.isEmpty()) null.asInstanceOf[E]
-    else inner.get(inner.size() - 1)
+    // checkInvariants();
+    val es = elements
+    return elementAt(es, dec(tail, es.length))
   }
 
+  /** Removes the first occurrence of the specified element in this deque (when
+   *  traversing the deque from head to tail). If the deque does not contain the
+   *  element, it is unchanged. More formally, removes the first element {@code
+   *  e} such that {@code o.equals(e)} (if such an element exists). Returns
+   *  {@code true} if this deque contained the specified element (or
+   *  equivalently, if this deque changed as a result of the call).
+   *
+   *  @param o
+   *    element to be removed from this deque, if present
+   *  @return
+   *    {@code true} if the deque contained the specified element
+   */
   def removeFirstOccurrence(o: Any): Boolean = {
-    val index = inner.indexOf(o)
-    if (index >= 0) {
-      inner.remove(index)
-      status += 1
-      true
-    } else
-      false
-  }
-
-  def removeLastOccurrence(o: Any): Boolean = {
-    val index = inner.lastIndexOf(o)
-    if (index >= 0) {
-      inner.remove(index)
-      status += 1
-      true
-    } else
-      false
-  }
-
-  def offer(e: E): Boolean = offerLast(e)
-
-  override def remove(): E = removeFirst()
-
-  def poll(): E = pollFirst()
-
-  def element(): E = getFirst()
-
-  def peek(): E = peekFirst()
-
-  def push(e: E): Unit = addFirst(e)
-
-  def pop(): E = removeFirst()
-
-  def size(): Int = inner.size()
-
-  private def failFastIterator(startIndex: Int, nex: (Int) => Int) = {
-    new Iterator[E] {
-      private def checkStatus() = {
-        if (self.status != actualStatus)
-          throw new ConcurrentModificationException()
-      }
-
-      private val actualStatus = self.status
-
-      private var index: Int = startIndex
-
-      def hasNext(): Boolean = {
-        checkStatus()
-        val n = nex(index)
-        (n >= 0) && (n < inner.size())
-      }
-
-      def next(): E = {
-        checkStatus()
-        index = nex(index)
-        inner.get(index)
-      }
-
-      override def remove(): Unit = {
-        checkStatus()
-        if (index < 0 || index >= inner.size()) {
-          throw new IllegalStateException()
-        } else {
-          inner.remove(index)
+    if (o != null) {
+      val es = elements
+      var i = head
+      val end = tail
+      var to = if (i <= end) end else es.length
+      while (true) {
+        while (i < to) {
+          if (o.equals(es(i))) {
+            delete(i)
+            return true
+          }
+          i += 1
         }
+        if (to == end) return false
+        i = 0
+        to = end
+      }
+    }
+    return false
+  }
+
+  /** Removes the last occurrence of the specified element in this deque (when
+   *  traversing the deque from head to tail). If the deque does not contain the
+   *  element, it is unchanged. More formally, removes the last element {@code
+   *  e} such that {@code o.equals(e)} (if such an element exists). Returns
+   *  {@code true} if this deque contained the specified element (or
+   *  equivalently, if this deque changed as a result of the call).
+   *
+   *  @param o
+   *    element to be removed from this deque, if present
+   *  @return
+   *    {@code true} if the deque contained the specified element
+   */
+  def removeLastOccurrence(o: Any): Boolean = {
+    if (o != null) {
+      val es = elements
+      var i = tail
+      val end = head
+      var to = if (i >= end) end else 0
+      while (true) {
+        while (i > to - 1) {
+          if (o.equals(es(i))) {
+            delete(i)
+            return true
+          }
+          i -= 1
+        }
+        if (to == end) return false
+        i = es.length
+        to = end
+      }
+    }
+    return false;
+  }
+
+  // *** Queue methods ***
+
+  /** Inserts the specified element at the end of this deque.
+   *
+   *  <p>This method is equivalent to {@link #addLast}.
+   *
+   *  @param e
+   *    the element to add
+   *  @return
+   *    {@code true} (as specified by {@link Collection#add})
+   *  @throws NullPointerException
+   *    if the specified element is null
+   */
+  override def add(e: E): Boolean = {
+    addLast(e)
+    return true
+  }
+
+  /** Inserts the specified element at the end of this deque.
+   *
+   *  <p>This method is equivalent to {@link #offerLast}.
+   *
+   *  @param e
+   *    the element to add
+   *  @return
+   *    {@code true} (as specified by {@link Queue#offer})
+   *  @throws NullPointerException
+   *    if the specified element is null
+   */
+  def offer(e: E): Boolean = {
+    return offerLast(e)
+  }
+
+  /** Retrieves and removes the head of the queue represented by this deque.
+   *
+   *  This method differs from {@link #poll() poll()} only in that it throws an
+   *  exception if this deque is empty.
+   *
+   *  <p>This method is equivalent to {@link #removeFirst}.
+   *
+   *  @return
+   *    the head of the queue represented by this deque
+   *  @throws NoSuchElementException
+   *    {@inheritDoc}
+   */
+  def remove(): E = {
+    return removeFirst()
+  }
+
+  /** Retrieves and removes the head of the queue represented by this deque (in
+   *  other words, the first element of this deque), or returns {@code null} if
+   *  this deque is empty.
+   *
+   *  <p>This method is equivalent to {@link #pollFirst}.
+   *
+   *  @return
+   *    the head of the queue represented by this deque, or {@code null} if this
+   *    deque is empty
+   */
+  def poll(): E = {
+    return pollFirst()
+  }
+
+  /** Retrieves, but does not remove, the head of the queue represented by this
+   *  deque. This method differs from {@link #peek peek} only in that it throws
+   *  an exception if this deque is empty.
+   *
+   *  <p>This method is equivalent to {@link #getFirst}.
+   *
+   *  @return
+   *    the head of the queue represented by this deque
+   *  @throws NoSuchElementException
+   *    {@inheritDoc}
+   */
+  def element(): E = {
+    return getFirst()
+  }
+
+  /** Retrieves, but does not remove, the head of the queue represented by this
+   *  deque, or returns {@code null} if this deque is empty.
+   *
+   *  <p>This method is equivalent to {@link #peekFirst}.
+   *
+   *  @return
+   *    the head of the queue represented by this deque, or {@code null} if this
+   *    deque is empty
+   */
+  def peek(): E = {
+    return peekFirst()
+  }
+
+  // *** Stack methods ***
+
+  /** Pushes an element onto the stack represented by this deque. In other
+   *  words, inserts the element at the front of this deque.
+   *
+   *  <p>This method is equivalent to {@link #addFirst}.
+   *
+   *  @param e
+   *    the element to push
+   *  @throws NullPointerException
+   *    if the specified element is null
+   */
+  def push(e: E): Unit = {
+    addFirst(e)
+  }
+
+  /** Pops an element from the stack represented by this deque. In other words,
+   *  removes and returns the first element of this deque.
+   *
+   *  <p>This method is equivalent to {@link #removeFirst()}.
+   *
+   *  @return
+   *    the element at the front of this deque (which is the top of the stack
+   *    represented by this deque)
+   *  @throws NoSuchElementException
+   *    {@inheritDoc}
+   */
+  def pop(): E = {
+    return removeFirst()
+  }
+
+  /** Removes the element at the specified position in the elements array. This
+   *  can result in forward or backwards motion of array elements. We optimize
+   *  for least element motion.
+   *
+   *  <p>This method is called delete rather than remove to emphasize that its
+   *  semantics differ from those of {@link List#remove(int)}.
+   *
+   *  @return
+   *    true if elements near tail moved backwards
+   */
+  private def delete(i: Int): Boolean = {
+    // checkInvariants();
+    val es = elements
+    val capacity = es.length
+    val h = head
+    val t = tail
+    // number of elements before to-be-deleted elt
+    val front = sub(i, h, capacity)
+    // number of elements after to-be-deleted elt
+    val back = sub(t, i, capacity) - 1
+    if (front < back) {
+      // move front elements forwards
+      if (h <= i) {
+        System.arraycopy(es, h, es, h + 1, front)
+      } else { // Wrap around
+        System.arraycopy(es, 0, es, 1, i)
+        es(0) = es(capacity - 1)
+        System.arraycopy(es, h, es, h + 1, front - (i + 1))
+      }
+      es(h) = null
+      head = inc(h, capacity)
+      // checkInvariants();
+      return false
+    } else {
+      // move back elements backwards
+      tail = dec(t, capacity)
+      if (i <= tail) {
+        System.arraycopy(es, i + 1, es, i, back)
+      } else { // Wrap around
+        System.arraycopy(es, i + 1, es, i, capacity - (i + 1))
+        es(capacity - 1) = es(0)
+        System.arraycopy(es, 1, es, 0, t - 1)
+      }
+      es(tail) = null
+      // checkInvariants();
+      return true
+    }
+  }
+
+  // *** Collection Methods ***
+
+  /** Returns the number of elements in this deque.
+   *
+   *  @return
+   *    the number of elements in this deque
+   */
+  def size(): Int = {
+    return sub(tail, head, elements.length)
+  }
+
+  /** Returns {@code true} if this deque contains no elements.
+   *
+   *  @return
+   *    {@code true} if this deque contains no elements
+   */
+  override def isEmpty(): Boolean = {
+    return head == tail;
+  }
+
+  /** Returns an iterator over the elements in this deque. The elements will be
+   *  ordered from first (head) to last (tail). This is the same order that
+   *  elements would be dequeued (via successive calls to {@link #remove} or
+   *  popped (via successive calls to {@link #pop}).
+   *
+   *  @return
+   *    an iterator over the elements in this deque
+   */
+  def iterator(): Iterator[E] = {
+    return new DeqIterator()
+  }
+
+  def descendingIterator(): Iterator[E] = {
+    return new DescendingIterator();
+  }
+
+  private class DeqIterator(
+      /** Index of element to be returned by subsequent call to next. */
+      var cursor: Int = head
+  ) extends Iterator[E] {
+
+    /** Number of elements yet to be returned. */
+    var remaining = size()
+
+    /** Index of element returned by most recent call to next. Reset to -1 if
+     *  element is deleted by a call to remove.
+     */
+    var lastRet = -1;
+
+    def hasNext(): Boolean = {
+      return remaining > 0
+    }
+
+    def next(): E = {
+      if (remaining <= 0)
+        throw new NoSuchElementException()
+      val es = elements
+      val e = nonNullElementAt(es, cursor)
+      lastRet = cursor
+      cursor = inc(cursor, es.length)
+      remaining -= 1
+      return e
+    }
+
+    private def postDelete(leftShifted: Boolean): Unit = {
+      if (leftShifted)
+        cursor = dec(cursor, elements.length)
+    }
+
+    override def remove(): Unit = {
+      if (lastRet < 0)
+        throw new IllegalStateException()
+      postDelete(delete(lastRet))
+      lastRet = -1
+    }
+
+    override def forEachRemaining(action: Consumer[_ >: E]): Unit = {
+      Objects.requireNonNull(action)
+      val r = remaining
+      if (r <= 0)
+        return ()
+      remaining = 0
+      val es = elements;
+      if (es(cursor) == null || sub(tail, cursor, es.length) != r)
+        throw new ConcurrentModificationException()
+      var i = cursor
+      val end = tail
+      var to = if (i <= end) end else es.length
+      while (true) {
+        while (i < to) {
+          action.accept(elementAt(es, i))
+          i += 1
+        }
+        if (to == end) {
+          if (end != tail)
+            throw new ConcurrentModificationException();
+          lastRet = dec(end, es.length)
+          return ()
+        }
+        i = 0
+        to = end
       }
     }
   }
 
-  def iterator(): Iterator[E] =
-    failFastIterator(-1, x => (x + 1))
+  private class DescendingIterator
+      extends DeqIterator(dec(tail, elements.length)) {
 
-  def descendingIterator(): Iterator[E] =
-    failFastIterator(inner.size(), x => (x - 1))
+    final override def next(): E = {
+      if (remaining <= 0)
+        throw new NoSuchElementException()
+      val es = elements
+      val e = nonNullElementAt(es, cursor)
+      lastRet = cursor
+      cursor = dec(cursor, es.length)
+      remaining -= 1
+      return e
+    }
 
-  override def contains(o: Any): Boolean = inner.contains(o)
+    private def postDelete(leftShifted: Boolean): Unit = {
+      if (!leftShifted)
+        cursor = inc(cursor, elements.length)
+    }
 
-  override def remove(o: Any): Boolean = removeFirstOccurrence(o)
+    final override def forEachRemaining(action: Consumer[_ >: E]): Unit = {
+      Objects.requireNonNull(action)
+      val r = remaining
+      if (r <= 0)
+        return ()
+      remaining = 0
+      val es = elements
+      if (es(cursor) == null || sub(cursor, head, es.length) + 1 != r)
+        throw new ConcurrentModificationException()
+      var i = cursor
+      val end = head
+      var to = if (i >= end) end else 0
+      while (true) {
+        while (i > to - 1) {
+          action.accept(elementAt(es, i))
+          i -= 1
+        }
+        if (to == end) {
+          if (end != head)
+            throw new ConcurrentModificationException()
+          lastRet = end
+          return ()
+        }
+        i = es.length - 1
+        to = end
+      }
+    }
+  }
 
+  /** Creates a <em><a href="Spliterator.html#binding">late-binding</a></em> and
+   *  <em>fail-fast</em> {@link Spliterator} over the elements in this deque.
+   *
+   *  <p>The {@code Spliterator} reports {@link Spliterator#SIZED}, {@link
+   *  Spliterator#SUBSIZED}, {@link Spliterator#ORDERED}, and {@link
+   *  Spliterator#NONNULL}. Overriding implementations should document the
+   *  reporting of additional characteristic values.
+   *
+   *  @return
+   *    a {@code Spliterator} over the elements in this deque
+   *  @since 1.8
+   */
+  def spliterator(): Spliterator[E] = {
+    return new DeqSpliterator()
+  }
+
+  final class DeqSpliterator extends Spliterator[E] {
+
+    /** Constructs late-binding spliterator over all elements. */
+    private var fence: Int = -1 // -1 until first use
+    private var cursor: Int = _ // current index, modified on traverse/split
+
+    /** Constructs spliterator over the given range. */
+    def this(origin: Int, fence: Int) = {
+      this()
+      // assert 0 <= origin && origin < elements.length;
+      // assert 0 <= fence && fence < elements.length;
+      this.cursor = origin
+      this.fence = fence
+    }
+
+    /** Ensures late-binding initialization; then returns fence. */
+    private def getFence(): Int = { // force initialization
+      var t = fence
+      if (t < 0) {
+        fence = tail
+        t = fence
+        cursor = head
+      }
+      return t
+    }
+
+    def trySplit(): DeqSpliterator = {
+      val es = elements
+      val i = cursor
+      val n = sub(getFence(), i, es.length) >> 1
+      return if (n <= 0)
+        null
+      else {
+        cursor = inc(i, n, es.length)
+        new DeqSpliterator(i, cursor)
+      }
+    }
+
+    override def forEachRemaining(action: Consumer[_ >: E]): Unit = {
+      if (action == null)
+        throw new NullPointerException()
+      val end = getFence()
+      val cursor = this.cursor
+      val es = elements
+      if (cursor != end) {
+        this.cursor = end
+        // null check at both ends of range is sufficient
+        if (es(cursor) == null || es(dec(end, es.length)) == null)
+          throw new ConcurrentModificationException()
+        var i = cursor
+        var to = if (i <= end) end else es.length
+        while (true) {
+          while (i < to) {
+            action.accept(elementAt(es, i))
+            i += 1
+          }
+          if (to == end) return ()
+          i = 0
+          to = end
+        }
+      }
+    }
+
+    def tryAdvance(action: Consumer[_ >: E]): Boolean = {
+      Objects.requireNonNull(action)
+      val es = elements
+      if (fence < 0) { fence = tail; cursor = head; } // late-binding
+      var i = cursor
+      if (i == fence)
+        return false
+      val e = nonNullElementAt(es, i)
+      cursor = inc(i, es.length)
+      action.accept(e)
+      return true
+    }
+
+    def estimateSize(): Long = {
+      return sub(getFence(), cursor, elements.length)
+    }
+
+    def characteristics(): Int = {
+      return Spliterator.NONNULL | Spliterator.ORDERED | Spliterator.SIZED | Spliterator.SUBSIZED
+    }
+  }
+
+  /** @throws NullPointerException
+   *    {@inheritDoc}
+   */
+  override def forEach(action: Consumer[_ >: E]): Unit = {
+    Objects.requireNonNull(action)
+    val es = elements
+    var i = head
+    val end = tail
+    var to = if (i <= end) end else es.length
+    while (true) {
+      while (i < to) {
+        action.accept(elementAt(es, i))
+        i += 1
+      }
+      if (to == end) {
+        if (end != tail) throw new ConcurrentModificationException()
+        return ()
+      }
+      i = 0
+      to = end
+    }
+    // checkInvariants();
+  }
+
+  /** Replaces each element of this deque with the result of applying the
+   *  operator to that element, as specified by {@link List#replaceAll}.
+   *
+   *  @param operator
+   *    the operator to apply to each element
+   *  @since TBD
+   */
+  def replaceAll(operator: UnaryOperator[E]): Unit = {
+    Objects.requireNonNull(operator)
+    val es = elements
+    var i = head
+    val end = tail
+    var to = if (i <= end) end else es.length
+    while (true) {
+      while (i < to) {
+        es(i) = operator.apply(elementAt(es, i)).asInstanceOf[Object]
+        i += 1
+      }
+      if (to == end) {
+        if (end != tail) throw new ConcurrentModificationException()
+        return ()
+      }
+      i = 0
+      to = end
+    }
+    // checkInvariants();
+  }
+
+  /** @throws NullPointerException
+   *    {@inheritDoc}
+   */
+  override def removeIf(filter: Predicate[_ >: E]): Boolean = {
+    Objects.requireNonNull(filter)
+    return bulkRemove(filter)
+  }
+
+  /** @throws NullPointerException
+   *    {@inheritDoc}
+   */
+  override def removeAll(c: Collection[_]): Boolean = {
+    Objects.requireNonNull(c)
+    return bulkRemove(c.contains(_))
+  }
+
+  /** @throws NullPointerException
+   *    {@inheritDoc}
+   */
+  override def retainAll(c: Collection[_]): Boolean = {
+    Objects.requireNonNull(c)
+    return bulkRemove(!c.contains(_))
+  }
+
+  /** Implementation of bulk remove methods. */
+  def bulkRemove(filter: Predicate[_ >: E]): Boolean = {
+    // checkInvariants();
+    val es = elements
+    // Optimize for initial run of survivors
+    var i = head
+    val end = tail
+    var to = if (i <= end) end else es.length
+    while (true) {
+      while (i < to) {
+        if (filter.test(elementAt(es, i)))
+          return bulkRemoveModified(filter, i);
+        i += 1
+      }
+      if (to == end) {
+        if (end != tail) throw new ConcurrentModificationException()
+        return false
+      }
+      i = 0
+      to = end
+    }
+    return false
+  }
+
+  // A tiny bit set implementation
+
+  private def nBits(n: Int): Array[Long] = {
+    return new Array[Long](((n - 1) >> 6) + 1)
+  }
+  private def setBit(bits: Array[Long], i: Int): Unit = {
+    bits(i >> 6) |= 1L << i
+  }
+  private def isClear(bits: Array[Long], i: Int): Boolean = {
+    return (bits(i >> 6) & (1L << i)) == 0
+  }
+
+  /** Helper for bulkRemove, in case of at least one deletion. Tolerate
+   *  predicates that reentrantly access the collection for read (but writers
+   *  still get CME), so traverse once to find elements to delete, a second pass
+   *  to physically expunge.
+   *
+   *  @param beg
+   *    valid index of first element to be deleted
+   */
+  private def bulkRemoveModified(
+      filter: Predicate[_ >: E],
+      beg: Int
+  ): Boolean = {
+    val es = elements
+    val capacity = es.length
+    val end = tail
+    val doRemove = nBits(sub(end, beg, capacity))
+    doRemove(0) = 1L // set bit 0
+    var i = beg + 1
+    var to = if (i <= end) end else es.length
+    var k = beg
+    var continue = true
+    while (continue) {
+      while (i < to) {
+        if (filter.test(elementAt(es, i)))
+          setBit(doRemove, i - k)
+        i += 1
+      }
+      to = end
+      k -= capacity
+      if (to == end) continue = false
+    }
+    // a two-finger traversal, with hare i reading, tortoise w writing
+    var w = beg
+    continue = true
+    i = beg + 1
+    to = if (i <= end) end else es.length
+    k = beg
+    while (continue) {
+      // In this loop, i and w are on the same leg, with i > w
+      while (i < to) {
+        if (isClear(doRemove, i - k)) {
+          es(w) = es(i)
+          w += 1
+        }
+        i += 1
+      }
+      if (to == end) {
+        continue = false
+      } else {
+        // In this loop, w is on the first leg, i on the second
+        i = 0
+        to = end
+        k -= capacity
+        while (i < to && w < capacity) {
+          if (isClear(doRemove, i - k)) {
+            es(w) = es(i)
+            w += 1
+          }
+          i += 1
+        }
+        if (i >= to) {
+          if (w == capacity) w = 0 // "corner" case
+          continue = false
+        }
+      }
+      w = 0 // w rejoins i on second leg
+    }
+    if (end != tail) throw new ConcurrentModificationException()
+    tail = w
+    circularClear(es, tail, end)
+    // checkInvariants();
+    return true;
+  }
+
+  /** Returns {@code true} if this deque contains the specified element. More
+   *  formally, returns {@code true} if and only if this deque contains at least
+   *  one element {@code e} such that {@code o.equals(e)}.
+   *
+   *  @param o
+   *    object to be checked for containment in this deque
+   *  @return
+   *    {@code true} if this deque contains the specified element
+   */
+  override def contains(o: Any): Boolean = {
+    if (o != null) {
+      val es = elements
+      var i = head
+      val end = tail
+      var to = if (i <= end) end else es.length
+      while (true) {
+        while (i < to) {
+          if (o.equals(es(i)))
+            return true
+          i += 1
+        }
+        if (to == end) return false
+        i = 0
+        to = end
+      }
+    }
+    return false
+  }
+
+  /** Removes a single instance of the specified element from this deque. If the
+   *  deque does not contain the element, it is unchanged. More formally,
+   *  removes the first element {@code e} such that {@code o.equals(e)} (if such
+   *  an element exists). Returns {@code true} if this deque contained the
+   *  specified element (or equivalently, if this deque changed as a result of
+   *  the call).
+   *
+   *  <p>This method is equivalent to {@link #removeFirstOccurrence(Object)}.
+   *
+   *  @param o
+   *    element to be removed from this deque, if present
+   *  @return
+   *    {@code true} if this deque contained the specified element
+   */
+  def remove(o: Object): Boolean = {
+    return removeFirstOccurrence(o)
+  }
+
+  /** Removes all of the elements from this deque. The deque will be empty after
+   *  this call returns.
+   */
   override def clear(): Unit = {
-    if (!inner.isEmpty()) status += 1
-    inner.clear()
+    circularClear(elements, head, tail)
+    head = 0
+    tail = 0
+    // checkInvariants();
   }
 
-  override def toArray(): Array[AnyRef] = {
-    inner.toArray()
+  /** Nulls out slots starting at array index i, upto index end. Condition i ==
+   *  end means "empty" - nothing to do.
+   */
+  private def circularClear(es: Array[Object], _i: Int, end: Int): Unit = {
+    var i = _i
+    var to = if (i <= end) end else es.length
+    // assert 0 <= i && i < es.length;
+    // assert 0 <= end && end < es.length;
+    while (true) {
+      while (i < to) {
+        es(i) = null
+        i += 1
+      }
+      if (to == end) return ()
+      i = 0
+      to = end
+    }
   }
 
+  /** Returns an array containing all of the elements in this deque in proper
+   *  sequence (from first to last element).
+   *
+   *  <p>The returned array will be "safe" in that no references to it are
+   *  maintained by this deque. (In other words, this method must allocate a new
+   *  array). The caller is thus free to modify the returned array.
+   *
+   *  <p>This method acts as bridge between array-based and collection-based
+   *  APIs.
+   *
+   *  @return
+   *    an array containing all of the elements in this deque
+   */
+  override def toArray(): Array[Object] = {
+    return toArrayImpl(classOf[Array[Object]])
+  }
+
+  private def toArrayImpl[T <: AnyRef](klazz: Class[Array[T]]): Array[T] = {
+    val es = elements;
+    var a: Array[T] = null
+    val head = this.head
+    val tail = this.tail
+    val end = tail + (if ((head <= tail)) 0 else es.length)
+    if (end >= 0) {
+      // Uses null extension feature of copyOfRange
+      a = Arrays.copyOfRange(es, head, end, klazz)
+    } else {
+      // integer overflow!
+      a = Arrays.copyOfRange[T, Object](es, 0, end - head, klazz)
+      System.arraycopy(es, head, a, 0, es.length - head)
+    }
+    if (end != tail)
+      System.arraycopy(es, 0, a, es.length - head, tail)
+    return a
+  }
+
+  /** Returns an array containing all of the elements in this deque in proper
+   *  sequence (from first to last element); the runtime type of the returned
+   *  array is that of the specified array. If the deque fits in the specified
+   *  array, it is returned therein. Otherwise, a new array is allocated with
+   *  the runtime type of the specified array and the size of this deque.
+   *
+   *  <p>If this deque fits in the specified array with room to spare (i.e., the
+   *  array has more elements than this deque), the element in the array
+   *  immediately following the end of the deque is set to {@code null}.
+   *
+   *  <p>Like the {@link #toArray()} method, this method acts as bridge between
+   *  array-based and collection-based APIs. Further, this method allows precise
+   *  control over the runtime type of the output array, and may, under certain
+   *  circumstances, be used to save allocation costs.
+   *
+   *  <p>Suppose {@code x} is a deque known to contain only strings. The
+   *  following code can be used to dump the deque into a newly allocated array
+   *  of {@code String}:
+   *
+   *  <pre> {@code String[] y = x.toArray(new String[0]);}</pre>
+   *
+   *  Note that {@code toArray(new Object[0])} is identical in function to
+   *  {@code toArray()}.
+   *
+   *  @param a
+   *    the array into which the elements of the deque are to be stored, if it
+   *    is big enough; otherwise, a new array of the same runtime type is
+   *    allocated for this purpose
+   *  @return
+   *    an array containing all of the elements in this deque
+   *  @throws ArrayStoreException
+   *    if the runtime type of the specified array is not a supertype of the
+   *    runtime type of every element in this deque
+   *  @throws NullPointerException
+   *    if the specified array is null
+   */
   override def toArray[T <: AnyRef](a: Array[T]): Array[T] = {
-    inner.toArray(a)
+    val size = this.size()
+    if (size > a.length)
+      return toArrayImpl(a.getClass().asInstanceOf[Class[Array[T]]])
+    val es = elements
+    var i = head
+    var j = 0
+    var len = Math.min(size, es.length - i)
+    var continue = true
+    while (continue) {
+      System.arraycopy(es, i, a, j, len)
+      j += len
+      if (j == size) continue = false
+      else {
+        i = 0
+        len = tail
+      }
+    }
+    if (size < a.length)
+      a(size) = null.asInstanceOf[T]
+    return a
   }
+
+  // *** Object methods ***
+
+  /** Returns a copy of this deque.
+   *
+   *  @return
+   *    a copy of this deque
+   */
+  override def clone(): ArrayDeque[E] = {
+    try {
+      val result = super.clone().asInstanceOf[ArrayDeque[E]]
+      result.elements = Arrays.copyOf(elements, elements.length)
+      return result
+    } catch {
+      case e: CloneNotSupportedException =>
+        throw new AssertionError()
+    }
+  }
+
+  /** debugging */
+  private def checkInvariants(): Unit = {
+    // Use head and tail fields with empty slot at tail strategy.
+    // head == tail disambiguates to "empty".
+    try {
+      val capacity = elements.length
+      // assert 0 <= head && head < capacity;
+      // assert 0 <= tail && tail < capacity;
+      // assert capacity > 0;
+      // assert size() < capacity;
+      // assert head == tail || elements[head] != null;
+      // assert elements[tail] == null;
+      // assert head == tail || elements[dec(tail, capacity)] != null;
+    } catch {
+      case t: Throwable =>
+        System.err.printf(
+          "head=%d tail=%d capacity=%d%n",
+          Array[Object](
+            Integer.valueOf(head),
+            Integer.valueOf(tail),
+            Integer.valueOf(elements.length)
+          )
+        )
+        System.err.printf(
+          "elements=%s%n",
+          Array[Object](Arrays.toString(elements))
+        )
+        throw t
+    }
+  }
+
 }

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -760,7 +760,7 @@ class ArrayDeque[E](
       return e
     }
 
-    private def postDelete(leftShifted: Boolean): Unit = {
+    def postDelete(leftShifted: Boolean): Unit = {
       if (leftShifted)
         cursor = dec(cursor, elements.length)
     }
@@ -815,7 +815,7 @@ class ArrayDeque[E](
       return e
     }
 
-    private def postDelete(leftShifted: Boolean): Unit = {
+    override def postDelete(leftShifted: Boolean): Unit = {
       if (!leftShifted)
         cursor = inc(cursor, elements.length)
     }

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -4,7 +4,7 @@
  */
 
 /*
- * Ported from jsr166 revision 1.138
+ * Ported from JSR 166 revision 1.138
  * https://gee.cs.oswego.edu/dl/concurrency-interest/index.html
  */
 

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -510,6 +510,7 @@ class ArrayDeque[E](
       val end = head
       var to = if (i >= end) end else 0
       while (true) {
+        i -= 1
         while (i > to - 1) {
           if (o.equals(es(i))) {
             delete(i)

--- a/javalib/src/main/scala/java/util/Spliterator.scala
+++ b/javalib/src/main/scala/java/util/Spliterator.scala
@@ -1,0 +1,44 @@
+package java.util
+
+import java.util.function.Consumer
+import scala.scalanative.annotation.JavaDefaultMethod
+
+import Spliterator._
+
+object Spliterator {
+  final val DISTINCT = 0x00000001
+  final val SORTED = 0x00000004
+  final val ORDERED = 0x00000010
+  final val SIZED = 0x00000040
+  final val NONNULL = 0x00000100
+  final val IMMUTABLE = 0x00000400
+  final val CONCURRENT = 0x00001000
+  final val SUBSIZED = 0x00004000
+}
+
+trait Spliterator[T] {
+
+  def characteristics(): Int
+
+  def estimateSize(): Long
+
+  @JavaDefaultMethod
+  def forEachRemaining(action: Consumer[_ >: T]): Unit =
+    while (tryAdvance(action)) {}
+
+  @JavaDefaultMethod
+  def getComparator(): Comparator[_ >: T] = throw new IllegalStateException()
+
+  @JavaDefaultMethod
+  def getExactSizeIfKnown(): Long =
+    if (hasCharacteristics(SIZED)) estimateSize() else -1L
+
+  @JavaDefaultMethod
+  def hasCharacteristics(chars: Int): Boolean =
+    (characteristics() & chars) == chars
+
+  def tryAdvance(action: Consumer[_ >: T]): Boolean
+
+  def trySplit(): Spliterator[T]
+
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/ArrayDequeTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/ArrayDequeTest.scala
@@ -1016,3 +1016,911 @@ class ArrayDequeTest {
     }
   }
 }
+
+import java.util.concurrent.ThreadLocalRandom
+
+/*
+ * Written by Doug Lea and Martin Buchholz with assistance from
+ * members of JCP JSR-166 Expert Group and released to the public
+ * domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * Ported from JSR 166 revision 1.138
+ * https://gee.cs.oswego.edu/dl/concurrency-interest/index.html
+ *
+ */
+class ArrayDequeJSR166Test {
+
+  final val SIZE = 32
+  def mustEqual(x: Int, y: Int) = assertEquals(x, y)
+  def mustAdd(d: ArrayDeque[Integer], t: Int) = assertTrue(d.add(t))
+  def mustRemove(d: ArrayDeque[Integer], t: Int) = assertTrue(d.remove(t))
+  def mustNotRemove(d: ArrayDeque[Integer], t: Int) = assertFalse(d.remove(t))
+  def mustContain(d: ArrayDeque[Integer], t: Int) = assertTrue(d.contains(t))
+  def mustNotContain(d: ArrayDeque[Integer], t: Int) =
+    assertFalse(d.contains(t))
+  def itemFor(x: Int): Int = x
+  def assertIteratorExhausted[T](it: Iterator[T]) =
+    assertThrows(classOf[NoSuchElementException], it.next())
+  val defaultItems = Array.tabulate(SIZE)(i => i)
+
+  /** Returns a new deque of given size containing consecutive Items 0 ... n -
+   *  \1.
+   */
+  private def populatedDeque(n: Int): ArrayDeque[Integer] = {
+    // Randomize various aspects of memory layout, including
+    // capacity slop and wraparound.
+    val rnd = ThreadLocalRandom.current();
+    val q = rnd.nextInt(6) match {
+      case 0 => new ArrayDeque[Integer]()
+      case 1 => new ArrayDeque[Integer](0)
+      case 2 => new ArrayDeque[Integer](1)
+      case 3 => new ArrayDeque[Integer](Math.max(0, n - 1))
+      case 4 => new ArrayDeque[Integer](n)
+      case 5 => new ArrayDeque[Integer](n + 1)
+      case _ => throw new AssertionError()
+    }
+    (rnd.nextInt(3)) match {
+      case 0 =>
+        q.addFirst(42)
+        mustEqual(42, q.removeLast())
+      case 1 =>
+        q.addLast(42)
+        mustEqual(42, q.removeFirst())
+      case 2 => /* do nothing */
+      case _ => throw new AssertionError()
+    }
+    assertTrue(q.isEmpty())
+    if (rnd.nextBoolean())
+      for (i <- 0 until n)
+        assertTrue(q.offerLast(itemFor(i)))
+    else
+      for (i <- (n - 1) to 0 by -1)
+        q.addFirst(itemFor(i))
+    mustEqual(n, q.size())
+    if (n > 0) {
+      assertFalse(q.isEmpty())
+      mustEqual(0, q.peekFirst())
+      mustEqual((n - 1), q.peekLast())
+    }
+    return q
+  }
+
+  /** new deque is empty
+   */
+  @Test def testConstructor1(): Unit = {
+    mustEqual(0, new ArrayDeque[Int]().size())
+  }
+
+  /** Initializing from null Collection throws NPE
+   */
+  @Test def testConstructor3(): Unit = {
+    assertThrows(
+      classOf[NullPointerException],
+      new ArrayDeque[Object](null: Collection[Object])
+    )
+  }
+
+  /** Initializing from Collection of null elements throws NPE
+   */
+  @Test def testConstructor4(): Unit = {
+    assertThrows(
+      classOf[NullPointerException],
+      new ArrayDeque[Integer](Arrays.asList(new Array[Integer](SIZE): _*))
+    )
+  }
+
+  /** Initializing from Collection with some null elements throws NPE
+   */
+  @Test def testConstructor5(): Unit = {
+    val items = new Array[Integer](2)
+    items(0) = 0
+    assertThrows(
+      classOf[NullPointerException],
+      new ArrayDeque(Arrays.asList(items: _*))
+    )
+  }
+
+  /** Deque contains all elements of collection used to initialize
+   */
+  @Test def testConstructor6(): Unit = {
+    val items = defaultItems
+    val q = new ArrayDeque(Arrays.asList(items: _*))
+    for (i <- 0 until SIZE)
+      mustEqual(items(i), q.pollFirst())
+  }
+
+  /** isEmpty is true before add, false after
+   */
+  @Test def testEmpty(): Unit = {
+    val q = new ArrayDeque[Int]()
+    assertTrue(q.isEmpty());
+    q.add(1);
+    assertFalse(q.isEmpty());
+    q.add(2);
+    q.removeFirst();
+    q.removeFirst();
+    assertTrue(q.isEmpty());
+  }
+
+  /** size changes when elements added and removed
+   */
+  @Test def testSize(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(SIZE - i, q.size())
+      q.removeFirst()
+    }
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.size())
+      mustAdd(q, i)
+    }
+  }
+
+  /** push(null) throws NPE
+   */
+  @Test def testPushNull(): Unit = {
+    val q = new ArrayDeque[Integer](1)
+    assertThrows(classOf[NullPointerException], q.push(null))
+  }
+
+  /** peekFirst() returns element inserted with push
+   */
+  @Test def testPush(): Unit = {
+    val q = populatedDeque(3)
+    q.pollLast()
+    q.push(4)
+    assertSame(4, q.peekFirst())
+  }
+
+  /** pop() removes next element, or throws NSEE if empty
+   */
+  @Test def testPop(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.pop())
+    }
+    assertThrows(
+      classOf[NoSuchElementException],
+      q.pop()
+    )
+  }
+
+  /** offer(null) throws NPE
+   */
+  @Test def testOfferNull(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    assertThrows(
+      classOf[NullPointerException],
+      q.offer(null)
+    )
+  }
+
+  /** offerFirst(null) throws NPE
+   */
+  @Test def testOfferFirstNull(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    assertThrows(
+      classOf[NullPointerException],
+      q.offerFirst(null)
+    )
+  }
+
+  /** offerLast(null) throws NPE
+   */
+  @Test def testOfferLastNull(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    assertThrows(
+      classOf[NullPointerException],
+      q.offerLast(null)
+    )
+  }
+
+  /** offer(x) succeeds
+   */
+  @Test def testOffer(): Unit = {
+    val q = new ArrayDeque[Int]()
+    assertTrue(q.offer(0))
+    assertTrue(q.offer(1))
+    assertSame(0, q.peekFirst())
+    assertSame(1, q.peekLast())
+  }
+
+  /** offerFirst(x) succeeds
+   */
+  @Test def testOfferFirst(): Unit = {
+    val q = new ArrayDeque[Int]()
+    assertTrue(q.offerFirst(0))
+    assertTrue(q.offerFirst(1))
+    assertSame(1, q.peekFirst())
+    assertSame(0, q.peekLast())
+  }
+
+  /** offerLast(x) succeeds
+   */
+  @Test def testOfferLast(): Unit = {
+    val q = new ArrayDeque[Int]()
+    assertTrue(q.offerLast(0))
+    assertTrue(q.offerLast(1))
+    assertSame(0, q.peekFirst())
+    assertSame(1, q.peekLast())
+  }
+
+  /** add(null) throws NPE
+   */
+  @Test def testAddNull(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    assertThrows(
+      classOf[NullPointerException],
+      q.add(null)
+    )
+  }
+
+  /** addFirst(null) throws NPE
+   */
+  @Test def testAddFirstNull(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    assertThrows(
+      classOf[NullPointerException],
+      q.addFirst(null)
+    )
+  }
+
+  /** addLast(null) throws NPE
+   */
+  @Test def testAddLastNull(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    assertThrows(
+      classOf[NullPointerException],
+      q.addLast(null)
+    )
+  }
+
+  /** add(x) succeeds
+   */
+  @Test def testAdd(): Unit = {
+    val q = new ArrayDeque[Int]()
+    assertTrue(q.add(0))
+    assertTrue(q.add(1))
+    assertSame(0, q.peekFirst())
+    assertSame(1, q.peekLast())
+  }
+
+  /** addFirst(x) succeeds
+   */
+  @Test def testAddFirst(): Unit = {
+    val q = new ArrayDeque[Int]()
+    q.addFirst(0)
+    q.addFirst(1)
+    assertSame(1, q.peekFirst())
+    assertSame(0, q.peekLast())
+  }
+
+  /** addLast(x) succeeds
+   */
+  @Test def testAddLast(): Unit = {
+    val q = new ArrayDeque[Int]()
+    q.addLast(0)
+    q.addLast(1)
+    assertSame(0, q.peekFirst())
+    assertSame(1, q.peekLast())
+  }
+
+  /** addAll(null) throws NPE
+   */
+  @Test def testAddAll1(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    assertThrows(
+      classOf[NullPointerException],
+      q.addAll(null)
+    )
+  }
+
+  /** addAll of a collection with null elements throws NPE
+   */
+  @Test def testAddAll2(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    assertThrows(
+      classOf[NullPointerException],
+      q.addAll(Arrays.asList(new Array[Integer](SIZE): _*))
+    )
+  }
+
+  /** addAll of a collection with any null elements throws NPE after possibly
+   *  adding some elements
+   */
+  @Test def testAddAll3(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    val items = new Array[Integer](2)
+    items(0) = 0
+    assertThrows(
+      classOf[NullPointerException],
+      q.addAll(Arrays.asList(new Array[Integer](SIZE): _*))
+    )
+  }
+
+  /** Deque contains all elements, in traversal order, of successful addAll
+   */
+  @Test def testAddAll5(): Unit = {
+    val empty = new Array[Int](0)
+    val items = defaultItems
+    val q = new ArrayDeque[Int]()
+    assertFalse(q.addAll(Arrays.asList(empty: _*)))
+    assertTrue(q.addAll(Arrays.asList(items: _*)))
+    for (i <- 0 until SIZE)
+      mustEqual(items(i), q.pollFirst())
+  }
+
+  /** pollFirst() succeeds unless empty
+   */
+  @Test def testPollFirst(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.pollFirst())
+    }
+    assertNull(q.pollFirst())
+  }
+
+  /** pollLast() succeeds unless empty
+   */
+  @Test def testPollLast(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- (SIZE - 1) to 0 by -1) {
+      mustEqual(i, q.pollLast())
+    }
+    assertNull(q.pollLast())
+  }
+
+  /** poll() succeeds unless empty
+   */
+  @Test def testPoll(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.poll())
+    }
+    assertNull(q.poll())
+  }
+
+  /** remove() removes next element, or throws NSEE if empty
+   */
+  @Test def testRemove(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.remove())
+    }
+    assertThrows(
+      classOf[NoSuchElementException],
+      q.remove()
+    )
+  }
+
+  /** remove(x) removes x and returns true if present
+   */
+  @Test def testRemoveElement(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 1 until SIZE by 2) {
+      mustContain(q, i)
+      mustRemove(q, i)
+      mustNotContain(q, i)
+      mustContain(q, i - 1)
+    }
+    for (i <- 0 until SIZE by 2) {
+      mustContain(q, i)
+      mustRemove(q, i)
+      mustNotContain(q, i)
+      mustNotRemove(q, i + 1)
+      mustNotContain(q, i + 1)
+    }
+    assertTrue(q.isEmpty())
+  }
+
+  /** peekFirst() returns next element, or null if empty
+   */
+  @Test def testPeekFirst(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.peekFirst())
+      mustEqual(i, q.pollFirst())
+      assertTrue(
+        q.peekFirst() == null ||
+        q.peekFirst() != i
+      )
+    }
+    assertNull(q.peekFirst())
+  }
+
+  /** peek() returns next element, or null if empty
+   */
+  @Test def testPeek(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.peek())
+      mustEqual(i, q.poll())
+      assertTrue(
+        q.peek() == null ||
+        q.peek() != i
+      )
+    }
+    assertNull(q.peek())
+  }
+
+  /** peekLast() returns next element, or null if empty
+   */
+  @Test def testPeekLast(): Unit = {
+    val q = populatedDeque(SIZE);
+    for (i <- (SIZE - 1) to 0 by -1) {
+      mustEqual(i, q.peekLast())
+      mustEqual(i, q.pollLast())
+      assertTrue(
+        q.peekLast() == null ||
+        q.peekLast() != i
+      )
+    }
+    assertNull(q.peekLast())
+  }
+
+  /** element() returns first element, or throws NSEE if empty
+   */
+  @Test def testElement(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.element())
+      mustEqual(i, q.poll())
+    }
+    assertThrows(
+      classOf[NoSuchElementException],
+      q.element()
+    )
+  }
+
+  /** getFirst() returns first element, or throws NSEE if empty
+   */
+  @Test def testFirstElement(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.getFirst())
+      mustEqual(i, q.pollFirst())
+    }
+    assertThrows(
+      classOf[NoSuchElementException],
+      q.getFirst()
+    )
+  }
+
+  /** getLast() returns last element, or throws NSEE if empty
+   */
+  @Test def testLastElement(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- (SIZE - 1) to 0 by -1) {
+      mustEqual(i, q.getLast())
+      mustEqual(i, q.pollLast())
+    }
+    assertThrows(
+      classOf[NoSuchElementException],
+      q.getLast()
+    )
+    assertNull(q.peekLast())
+  }
+
+  /** removeFirst() removes first element, or throws NSEE if empty
+   */
+  @Test def testRemoveFirst(): Unit = {
+    val q = populatedDeque(SIZE);
+    for (i <- 0 until SIZE) {
+      mustEqual(i, q.removeFirst())
+    }
+    assertThrows(
+      classOf[NoSuchElementException],
+      q.removeFirst()
+    )
+    assertNull(q.peekFirst())
+  }
+
+  /** removeLast() removes last element, or throws NSEE if empty
+   */
+  @Test def testRemoveLast(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- (SIZE - 1) to 0 by -1) {
+      mustEqual(i, q.removeLast())
+    }
+    assertThrows(
+      classOf[NoSuchElementException],
+      q.removeLast()
+    )
+    assertNull(q.peekLast())
+  }
+
+  /** removeFirstOccurrence(x) removes x and returns true if present
+   */
+  @Test def testRemoveFirstOccurrence(): Unit = {
+    var q = populatedDeque(SIZE)
+    assertFalse(q.removeFirstOccurrence(null))
+    for (i <- 1 until SIZE by 2) {
+      assertTrue(q.removeFirstOccurrence(itemFor(i)))
+      mustNotContain(q, i)
+    }
+    for (i <- 0 until SIZE by 2) {
+      assertTrue(q.removeFirstOccurrence(itemFor(i)))
+      assertFalse(q.removeFirstOccurrence(itemFor(i + 1)))
+      mustNotContain(q, i)
+      mustNotContain(q, i + 1)
+    }
+    assertTrue(q.isEmpty())
+    assertFalse(q.removeFirstOccurrence(null))
+    assertFalse(q.removeFirstOccurrence(42))
+    q = new ArrayDeque[Integer]();
+    assertFalse(q.removeFirstOccurrence(null))
+    assertFalse(q.removeFirstOccurrence(42))
+  }
+
+  /** removeLastOccurrence(x) removes x and returns true if present
+   */
+  @Test def testRemoveLastOccurrence(): Unit = {
+    var q = populatedDeque(SIZE);
+    assertFalse(q.removeLastOccurrence(null));
+    for (i <- 1 until SIZE by 2) {
+      assertTrue(q.removeLastOccurrence(itemFor(i)))
+      mustNotContain(q, i)
+    }
+    for (i <- 0 until SIZE by 2) {
+      assertTrue(q.removeLastOccurrence(itemFor(i)))
+      assertFalse(q.removeLastOccurrence(itemFor(i + 1)))
+      mustNotContain(q, i)
+      mustNotContain(q, i + 1)
+    }
+    assertTrue(q.isEmpty())
+    assertFalse(q.removeLastOccurrence(null))
+    assertFalse(q.removeLastOccurrence(42))
+    q = new ArrayDeque[Integer]()
+    assertFalse(q.removeLastOccurrence(null))
+    assertFalse(q.removeLastOccurrence(42))
+  }
+
+  /** contains(x) reports true when elements added but not yet removed
+   */
+  @Test def testContains(): Unit = {
+    val q = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      mustContain(q, i)
+      mustEqual(i, q.pollFirst())
+      mustNotContain(q, i)
+    }
+  }
+
+  /** clear removes all elements
+   */
+  @Test def testClear(): Unit = {
+    val q = populatedDeque(SIZE)
+    q.clear()
+    assertTrue(q.isEmpty())
+    mustEqual(0, q.size())
+    mustAdd(q, 1)
+    assertFalse(q.isEmpty())
+    q.clear()
+    assertTrue(q.isEmpty())
+  }
+
+  /** containsAll(c) is true when c contains a subset of elements
+   */
+  @Test def testContainsAll(): Unit = {
+    val q = populatedDeque(SIZE)
+    val p = new ArrayDeque[Integer]()
+    for (i <- 0 until SIZE) {
+      assertTrue(q.containsAll(p))
+      assertFalse(p.containsAll(q))
+      mustAdd(p, i)
+    }
+    assertTrue(p.containsAll(q))
+  }
+
+  /** retainAll(c) retains only those elements of c and reports true if changed
+   */
+  @Test def testRetainAll(): Unit = {
+    val q = populatedDeque(SIZE)
+    val p = populatedDeque(SIZE)
+    for (i <- 0 until SIZE) {
+      val changed = q.retainAll(p)
+      assertEquals(changed, (i > 0))
+      assertTrue(q.containsAll(p))
+      mustEqual(SIZE - i, q.size())
+      p.removeFirst()
+    }
+  }
+
+  /** removeAll(c) removes only those elements of c and reports true if changed
+   */
+  @Test def testRemoveAll(): Unit = {
+    for (i <- 1 until SIZE) {
+      val q = populatedDeque(SIZE)
+      val p = populatedDeque(i)
+      assertTrue(q.removeAll(p))
+      mustEqual(SIZE - i, q.size())
+      for (j <- 0 until i) {
+        mustNotContain(q, p.removeFirst());
+      }
+    }
+  }
+
+  def checkToArray(q: ArrayDeque[Integer]): Unit = {
+    val size = q.size()
+    val a1 = q.toArray()
+    mustEqual(size, a1.length)
+    val a2 = q.toArray(new Array[Integer](0))
+    mustEqual(size, a2.length)
+    val a3 = q.toArray(new Array[Integer](Math.max(0, size - 1)))
+    mustEqual(size, a3.length)
+    val a4 = new Array[Integer](size)
+    assertSame(a4, q.toArray(a4))
+    val a5 = Array.fill(size + 1)(Integer.valueOf(42))
+    assertSame(a5, q.toArray(a5))
+    val a6 = Array.fill(size + 2)(Integer.valueOf(42))
+    assertSame(a6, q.toArray(a6))
+    val as = Array(a1, a2, a3, a4, a5, a6)
+    as.foreach { a =>
+      if (a.length > size) assertNull(a(size))
+      if (a.length > size + 1) assertEquals(42, a(size + 1))
+    }
+    val it = q.iterator()
+    val s = q.peekFirst()
+    for (i <- 0 until size) {
+      val x = it.next()
+      mustEqual(s + i, x)
+      as.foreach { a =>
+        assertSame(a(i), x)
+      }
+    }
+  }
+
+  /** toArray() and toArray(a) contain all elements in FIFO order
+   */
+  @Test def testToArray(): Unit = {
+    val size = ThreadLocalRandom.current().nextInt(10)
+    val q = new ArrayDeque[Integer](size)
+    for (i <- 0 until size) {
+      checkToArray(q)
+      q.addLast(itemFor(i))
+    }
+    // Provoke wraparound
+    val added = size * 2
+    for (i <- 0 until added) {
+      checkToArray(q)
+      mustEqual(i, q.poll())
+      q.addLast(itemFor(size + i))
+    }
+    for (i <- 0 until size) {
+      checkToArray(q)
+      mustEqual((added + i), q.poll())
+    }
+  }
+
+  /** toArray(null) throws NullPointerException
+   */
+  @Test def testToArray_NullArg(): Unit = {
+    val l = new ArrayDeque[Integer]()
+    l.add(0)
+    assertThrows(
+      classOf[NullPointerException],
+      l.toArray(null: Array[Object])
+    )
+  }
+
+  /** toArray(incompatible array type) throws ArrayStoreException
+   */
+  @Test def testToArray_incompatibleArrayType(): Unit = {
+    val l = new ArrayDeque[Integer]()
+    l.add(5)
+    assertThrows(
+      classOf[ArrayStoreException],
+      l.toArray(new Array[String](10))
+    )
+    assertThrows(
+      classOf[ArrayStoreException],
+      l.toArray(new Array[String](0))
+    )
+  }
+
+  /** Iterator iterates through all elements
+   */
+  @Test def testIterator(): Unit = {
+    val q = populatedDeque(SIZE)
+    val it = q.iterator()
+    var i = 0
+    while (it.hasNext()) {
+      mustContain(q, it.next())
+      i += 1
+    }
+    mustEqual(i, SIZE)
+    assertIteratorExhausted(it)
+  }
+
+  /** iterator of empty collection has no elements
+   */
+  @Test def testEmptyIterator(): Unit = {
+    val c = new ArrayDeque[Integer]()
+    assertIteratorExhausted(c.iterator())
+    assertIteratorExhausted(c.descendingIterator())
+  }
+
+  /** Iterator ordering is FIFO
+   */
+  @Test def testIteratorOrdering(): Unit = {
+    val q = new ArrayDeque[Integer]();
+    q.add(1);
+    q.add(2);
+    q.add(3);
+    var k = 0;
+    val it = q.iterator()
+    while (it.hasNext()) {
+      k += 1
+      mustEqual(k, it.next())
+    }
+    mustEqual(3, k)
+  }
+
+  /** iterator.remove() removes current element
+   */
+  @Test def testIteratorRemove(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    val rng = new Random()
+    for (iters <- 0 until 100) {
+      val max = rng.nextInt(5) + 2
+      val split = rng.nextInt(max - 1) + 1
+      for (j <- 1 to max)
+        mustAdd(q, j)
+      var it = q.iterator()
+      for (j <- 1 to split)
+        mustEqual(it.next(), j)
+      it.remove()
+      mustEqual(it.next(), split + 1)
+      for (j <- 1 to split)
+        q.remove(itemFor(j))
+      it = q.iterator();
+      for (j <- (split + 1) to max) {
+        mustEqual(it.next(), j)
+        it.remove()
+      }
+      assertFalse(it.hasNext())
+      assertTrue(q.isEmpty())
+    }
+  }
+
+  /** Descending iterator iterates through all elements
+   */
+  @Test def testDescendingIterator(): Unit = {
+    val q = populatedDeque(SIZE)
+    var i = 0
+    val it = q.descendingIterator()
+    while (it.hasNext()) {
+      mustContain(q, it.next())
+      i += 1
+    }
+    mustEqual(i, SIZE)
+    assertFalse(it.hasNext())
+    assertThrows(
+      classOf[NoSuchElementException],
+      it.next()
+    )
+  }
+
+  /** Descending iterator ordering is reverse FIFO
+   */
+  @Test def testDescendingIteratorOrdering(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    for (iters <- 0 until 100) {
+      q.add(3);
+      q.add(2);
+      q.add(1);
+      var k = 0;
+      val it = q.descendingIterator()
+      while (it.hasNext()) {
+        k += 1
+        mustEqual(k, it.next())
+      }
+
+      mustEqual(3, k)
+      q.remove()
+      q.remove()
+      q.remove()
+    }
+  }
+
+  /** descendingIterator.remove() removes current element
+   */
+  @Test def testDescendingIteratorRemove(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    val rng = new Random()
+    for (iter <- 0 until 100) {
+      val max = rng.nextInt(5) + 2
+      val split = rng.nextInt(max - 1) + 1
+      for (j <- max to 1 by -1)
+        q.add(itemFor(j))
+      var it = q.descendingIterator()
+      for (j <- 1 to split)
+        mustEqual(it.next(), itemFor(j))
+      it.remove()
+      mustEqual(it.next(), itemFor(split + 1))
+      for (j <- 1 to split)
+        q.remove(itemFor(j))
+      it = q.descendingIterator()
+      for (j <- (split + 1) to max) {
+        mustEqual(it.next(), j)
+        it.remove()
+      }
+      assertFalse(it.hasNext())
+      assertTrue(q.isEmpty())
+    }
+  }
+
+  /** toString() contains toStrings of elements
+   */
+  @Test def testToString(): Unit = {
+    val q = populatedDeque(SIZE)
+    val s = q.toString()
+    for (i <- 0 until SIZE) {
+      assertTrue(s.contains(String.valueOf(i)))
+    }
+  }
+
+  /** A cloned deque has same elements in same order
+   */
+  @Test def testClone(): Unit = {
+    val x = populatedDeque(SIZE)
+    val y = x.clone()
+
+    assertNotSame(y, x)
+    mustEqual(x.size(), y.size())
+    assertEquals(x.toString(), y.toString())
+    assertTrue(Arrays.equals(x.toArray(), y.toArray()))
+    while (!x.isEmpty()) {
+      assertFalse(y.isEmpty())
+      mustEqual(x.remove(), y.remove())
+    }
+    assertTrue(y.isEmpty())
+  }
+
+  /** remove(null), contains(null) always return false
+   */
+  @Test def testNeverContainsNull(): Unit = {
+    val qs = Array(
+      new ArrayDeque[Integer](),
+      populatedDeque(2)
+    )
+
+    for (q <- qs) {
+      assertFalse(q.contains(null))
+      assertFalse(q.remove(null))
+      assertFalse(q.removeFirstOccurrence(null))
+      assertFalse(q.removeLastOccurrence(null))
+    }
+  }
+
+  /** Spliterator.getComparator always throws IllegalStateException
+   */
+  @Test def testSpliterator_getComparator(): Unit = {
+    assertThrows(
+      classOf[IllegalStateException],
+      new ArrayDeque[Integer]().spliterator().getComparator()
+    )
+  }
+
+  /** Spliterator characteristics are as advertised
+   */
+  @Test def testSpliterator_characteristics(): Unit = {
+    val q = new ArrayDeque[Integer]()
+    val s = q.spliterator()
+    val characteristics = s.characteristics()
+    val required =
+      Spliterator.NONNULL | Spliterator.ORDERED | Spliterator.SIZED | Spliterator.SUBSIZED
+    mustEqual(required, characteristics & required)
+    assertTrue(s.hasCharacteristics(required))
+    mustEqual(
+      0,
+      characteristics
+        & (Spliterator.CONCURRENT
+          | Spliterator.DISTINCT
+          | Spliterator.IMMUTABLE
+          | Spliterator.SORTED)
+    );
+  }
+
+}

--- a/unit-tests/shared/src/test/scala/javalib/util/ArrayDequeTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/ArrayDequeTest.scala
@@ -1655,7 +1655,14 @@ class ArrayDequeJSR166Test {
     assertSame(a5, q.toArray(a5))
     val a6 = Array.fill(size + 2)(Integer.valueOf(42))
     assertSame(a6, q.toArray(a6))
-    val as = Array(a1, a2, a3, a4, a5, a6)
+    val as = Array(
+      a1,
+      a2.asInstanceOf[Array[Object]],
+      a3.asInstanceOf[Array[Object]],
+      a4.asInstanceOf[Array[Object]],
+      a5.asInstanceOf[Array[Object]],
+      a6.asInstanceOf[Array[Object]]
+    )
     as.foreach { a =>
       if (a.length > size) assertNull(a(size))
       if (a.length > size + 1) assertEquals(42, a(size + 1))

--- a/unit-tests/shared/src/test/scala/javalib/util/ArrayDequeTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/ArrayDequeTest.scala
@@ -1704,21 +1704,6 @@ class ArrayDequeJSR166Test {
     )
   }
 
-  /** toArray(incompatible array type) throws ArrayStoreException
-   */
-  @Test def testToArray_incompatibleArrayType(): Unit = {
-    val l = new ArrayDeque[Integer]()
-    l.add(5)
-    assertThrows(
-      classOf[ArrayStoreException],
-      l.toArray(new Array[String](10))
-    )
-    assertThrows(
-      classOf[ArrayStoreException],
-      l.toArray(new Array[String](0))
-    )
-  }
-
   /** Iterator iterates through all elements
    */
   @Test def testIterator(): Unit = {


### PR DESCRIPTION
This PR replaces the `java.util.ArrayDeque` implementation originally ported from Scala.js with a manual, line-by-line port of the public domain Java implementation distributed in [JSR 166](https://gee.cs.oswego.edu/dl/concurrency-interest/index.html). The new implementation passes all the existing tests, in addition to 60 new tests ported from the JSR 166 test suite.

This fixes problems inherited from the Scala.js implementation such as https://github.com/scala-js/scala-js/issues/4734 and hopefully generally improves the `ArrayDeque`'s performance and robustness.

This PR should be backported to 0.4.x.