### PR TITLE
Optimize method `AbstractStringBuilder.append0(CharSequence, Int, Int)`

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1793,7 +1793,15 @@ THE SOFTWARE.
 
 # License notice for Android Luni
 
-Implementation of `InflaterOutputStream` is taken based on the [Android Luni](https://android.googlesource.com/platform/libcore/) project.
+Scala Native's `javalib/` contains parts that are derived from either:
+* the latest "Apache 2.0 licensed" [libcore snapshot](https://android.googlesource.com/platform/libcore/+/2e317a02b5a8f9b319488ab9311521e8b4f87a0a/luni/) of the Android Luni project.
+* the "Apache 2.0 licensed" [libcore2 archive](https://android.googlesource.com/platform/libcore2/+/master/luni/) of the Android Luni project.
+
+Those parts are either marked with `// ported from Android Luni` or include the full copyright preamble in the source code file.
+
+For instance, the implementation of `InflaterOutputStream` is based on this source file:
+https://android.googlesource.com/platform/libcore/+/2e317a02b5a8f9b319488ab9311521e8b4f87a0a/luni/src/main/java/java/util/zip/InflaterInputStream.java
+
 The original license notice is included below:
 
 ```

--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -1,3 +1,4 @@
+// Contains parts ported from Android Luni
 package java.lang
 
 import java.io.InvalidObjectException

--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -139,7 +139,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     if (newCount > value.length)
       enlargeBuffer(newCount)
 
-    chars match {
+    chars0 match {
       case str: String => str.getChars(start, end, value, count)
       case asb: AbstractStringBuilder =>
         System.arraycopy(asb.value, start, value, count, length)
@@ -147,7 +147,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
         var i = start
         var j = count // Destination index.
         while (i < end) {
-          value(j) = chars.charAt(i)
+          value(j) = chars0.charAt(i)
           j += 1
           i += 1
         }

--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -121,15 +121,38 @@ abstract class AbstractStringBuilder private (unit: Unit) {
   }
 
   final def append0(
-      chars: CharSequence,
-      start: scala.Int,
-      end: scala.Int
+    chars: CharSequence,
+    start: scala.Int,
+    end: scala.Int
   ): Unit = {
     val chars0 = if (chars != null) chars else "null"
-    if (start < 0 || end < 0 || start > end || end > chars0.length()) {
+
+    val nChars = chars0.length()
+    if (nChars == 0) return
+
+    if (start < 0 || end < 0 || start > end || end > nChars)
       throw new IndexOutOfBoundsException()
+    
+    val length = end - start
+    val newCount = count + length
+    if (newCount > value.length)
+      enlargeBuffer(newCount)
+
+    chars match {
+      case str: String => str.getChars(start, end, value, count)
+      case asb: AbstractStringBuilder =>
+        System.arraycopy(asb.value, start, value, count, length)
+      case _ =>
+        var i = start
+        var j = count // Destination index.
+        while (i < end) {
+          value(j) = chars.charAt(i)
+          j += 1
+          i += 1
+        }
     }
-    append0(chars0.subSequence(start, end).toString)
+    
+    this.count = newCount
   }
 
   def capacity(): scala.Int = value.length

--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -126,33 +126,10 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     end: scala.Int
   ): Unit = {
     val chars0 = if (chars != null) chars else "null"
-
-    val nChars = chars0.length()
-    if (nChars == 0) return
-
-    if (start < 0 || end < 0 || start > end || end > nChars)
+    if (start < 0 || end < 0 || start > end || end > chars0.length()) {
       throw new IndexOutOfBoundsException()
-    
-    val length = end - start
-    val newCount = count + length
-    if (newCount > value.length)
-      enlargeBuffer(newCount)
-
-    chars match {
-      case str: String => str.getChars(start, end, value, count)
-      case asb: AbstractStringBuilder =>
-        System.arraycopy(asb.value, start, value, count, length)
-      case _ =>
-        var i = start
-        var j = count // Destination index.
-        while (i < end) {
-          value(j) = chars.charAt(i)
-          j += 1
-          i += 1
-        }
     }
-    
-    this.count = newCount
+    append0(chars0.subSequence(start, end).toString)
   }
 
   def capacity(): scala.Int = value.length

--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -122,9 +122,9 @@ abstract class AbstractStringBuilder private (unit: Unit) {
   }
 
   final def append0(
-    chars: CharSequence,
-    start: scala.Int,
-    end: scala.Int
+      chars: CharSequence,
+      start: scala.Int,
+      end: scala.Int
   ): Unit = {
     val chars0 = if (chars != null) chars else "null"
 
@@ -133,7 +133,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
 
     if (start < 0 || end < 0 || start > end || end > nChars)
       throw new IndexOutOfBoundsException()
-    
+
     val length = end - start
     val newCount = count + length
     if (newCount > value.length)
@@ -152,7 +152,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
           i += 1
         }
     }
-    
+
     this.count = newCount
   }
 

--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -126,10 +126,33 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     end: scala.Int
   ): Unit = {
     val chars0 = if (chars != null) chars else "null"
-    if (start < 0 || end < 0 || start > end || end > chars0.length()) {
+
+    val nChars = chars0.length()
+    if (nChars == 0) return
+
+    if (start < 0 || end < 0 || start > end || end > nChars)
       throw new IndexOutOfBoundsException()
+    
+    val length = end - start
+    val newCount = count + length
+    if (newCount > value.length)
+      enlargeBuffer(newCount)
+
+    chars match {
+      case str: String => str.getChars(start, end, value, count)
+      case asb: AbstractStringBuilder =>
+        System.arraycopy(asb.value, start, value, count, length)
+      case _ =>
+        var i = start
+        var j = count // Destination index.
+        while (i < end) {
+          value(j) = chars.charAt(i)
+          j += 1
+          i += 1
+        }
     }
-    append0(chars0.subSequence(start, end).toString)
+    
+    this.count = newCount
   }
 
   def capacity(): scala.Int = value.length

--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -5,20 +5,21 @@ import java.io.InvalidObjectException
 import java.util.Arrays
 import scala.util.control.Breaks._
 
-abstract class AbstractStringBuilder private (unit: Unit) {
+protected abstract class AbstractStringBuilder private (unit: Unit) {
   import AbstractStringBuilder._
 
   protected var value: Array[Char] = _
   protected var count: scala.Int = _
   protected var shared: scala.Boolean = _
 
-  final def getValue(): Array[scala.Char] = value
+  private[lang] final def getValue(): Array[scala.Char] = value
+
   final def shareValue(): Array[scala.Char] = {
     shared = true
     value
   }
 
-  final def set(chars: Array[scala.Char], len: scala.Int): Unit = {
+  /*final def set(chars: Array[scala.Char], len: scala.Int): Unit = {
     val chars0 = if (chars != null) chars else new Array[scala.Char](0)
     if (chars0.length < len) {
       throw new InvalidObjectException("")
@@ -27,7 +28,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     shared = false
     value = chars0
     count = len
-  }
+  }*/
 
   def this() = {
     this(())
@@ -55,7 +56,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     shared = false
   }
 
-  final def appendNull(): Unit = {
+  protected final def appendNull(): Unit = {
     val newSize = count + 4
     if (newSize > value.length) {
       enlargeBuffer(newSize)
@@ -70,7 +71,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     count += 1
   }
 
-  final def append0(chars: Array[Char]): Unit = {
+  protected final def append0(chars: Array[Char]): Unit = {
     val newSize = count + chars.length
     if (newSize > value.length) {
       enlargeBuffer(newSize)
@@ -79,7 +80,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     count = newSize
   }
 
-  final def append0(
+  protected final def append0(
       chars: Array[Char],
       offset: scala.Int,
       length: scala.Int
@@ -99,7 +100,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     count = newSize
   }
 
-  final def append0(ch: Char): Unit = {
+  protected final def append0(ch: Char): Unit = {
     if (count == value.length) {
       enlargeBuffer(count + 1)
     }
@@ -107,7 +108,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     count += 1
   }
 
-  final def append0(string: String): Unit = {
+  protected final def append0(string: String): Unit = {
     if (string == null) {
       appendNull()
       return
@@ -121,7 +122,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     count = newSize
   }
 
-  final def append0(
+  protected final def append0(
       chars: CharSequence,
       start: scala.Int,
       end: scala.Int
@@ -165,7 +166,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     return value(index)
   }
 
-  final def delete0(start: scala.Int, _end: scala.Int): Unit = {
+  protected final def delete0(start: scala.Int, _end: scala.Int): Unit = {
     var end = _end
     if (start >= 0) {
       if (end > count) {
@@ -194,7 +195,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     throw new StringIndexOutOfBoundsException()
   }
 
-  final def deleteCharAt0(location: scala.Int): scala.Unit = {
+  protected final def deleteCharAt0(location: scala.Int): scala.Unit = {
     if (0 > location || location >= count) {
       throw new StringIndexOutOfBoundsException(location)
     }
@@ -232,7 +233,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     System.arraycopy(value, start, dest, destStart, end - start)
   }
 
-  final def insert0(index: scala.Int, chars: Array[Char]): Unit = {
+  protected final def insert0(index: scala.Int, chars: Array[Char]): Unit = {
     if (0 > index || index > count) {
       throw new StringIndexOutOfBoundsException(index)
     }
@@ -243,7 +244,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     }
   }
 
-  final def insert0(
+  protected final def insert0(
       index: scala.Int,
       chars: Array[Char],
       start: scala.Int,
@@ -266,7 +267,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     throw new StringIndexOutOfBoundsException(index)
   }
 
-  final def insert0(index: scala.Int, ch: scala.Char): Unit = {
+  protected final def insert0(index: scala.Int, ch: scala.Char): Unit = {
     if (0 > index || index > count) {
       throw new ArrayIndexOutOfBoundsException(index)
     }
@@ -275,7 +276,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     count += 1
   }
 
-  final def insert0(index: scala.Int, string: String): Unit = {
+  protected final def insert0(index: scala.Int, string: String): Unit = {
     if (0 <= index && index <= count) {
       val string0 = if (string != null) string else "null"
       val min = string0.length
@@ -289,7 +290,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     }
   }
 
-  final def insert0(
+  protected final def insert0(
       index: scala.Int,
       chars: CharSequence,
       start: scala.Int,
@@ -325,7 +326,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     shared = false
   }
 
-  final def replace0(
+  protected final def replace0(
       start: scala.Int,
       _end: scala.Int,
       string: String
@@ -376,7 +377,7 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     throw new StringIndexOutOfBoundsException()
   }
 
-  final def reverse0(): Unit = {
+  protected final def reverse0(): Unit = {
     if (count < 2)
       return
     if (!shared) {

--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -122,7 +122,7 @@ final class _String()
     this()
     value = string.value
     offset = string.offset
-    count = string.length()
+    count = string.count
   }
 
   def this(sb: StringBuffer) = {

--- a/unit-tests/shared/src/test/scala/javalib/lang/StringBufferTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/StringBufferTest.scala
@@ -158,4 +158,21 @@ class StringBufferTest {
     buf.appendCodePoint(0x00010ffff)
     assertEquals("a\uD800\uDC00fixture\uDBFF\uDFFF", buf.toString)
   }
+
+  /** Checks that modifying a StringBuffer, converted to a String using a
+   *  `.toString` call, is not breaking String immutability. See:
+   *  https://github.com/scala-native/scala-native/issues/2925
+   */
+  @Test def toStringThenModifyStringBuffer(): Unit = {
+    val buf = new StringBuffer()
+    buf.append("foobar")
+
+    val s = buf.toString
+    buf.setCharAt(0, 'm')
+
+    assertTrue(
+      s"foobar should start with 'f' instead of '${s.charAt(0)}'",
+      'f' == s.charAt(0)
+    )
+  }
 }

--- a/unit-tests/shared/src/test/scala/javalib/lang/StringBuilderTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/StringBuilderTest.scala
@@ -169,4 +169,20 @@ class StringBuilderTest {
     b.appendCodePoint(0x00010ffff)
     assertEquals("a\uD800\uDC00fixture\uDBFF\uDFFF", b.toString)
   }
+
+  /** Checks that modifying a StringBuilder, converted to a String using a
+   *  `.toString` call, is not breaking String immutability.
+   */
+  @Test def toStringThenModifyStringBuilder(): Unit = {
+    val b = newBuilder
+    b.append("foobar")
+
+    val s = b.toString
+    b.setCharAt(0, 'm')
+
+    assertTrue(
+      s"foobar should start with 'f' instead of '${s.charAt(0)}'",
+      'f' == s.charAt(0)
+    )
+  }
 }


### PR DESCRIPTION
This PR changes the implementation of the following method:
https://github.com/scala-native/scala-native/blob/cf6d1a4de1e1a9386fc437119158dc7384b9a58e/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala#L123

This PR also attributes Android Luni in the source code and updates the project attribution in `LICENSE.md`

The code modification is based on the "Android Luni libcore2" implementation (Apache 2.0 license) that can be found at:
https://android.googlesource.com/platform/libcore2/+/master/luni/src/main/java/java/lang/AbstractStringBuilder.java#151

A significant difference compared to the reference code is that value is not cloned if the backing Array is shared.
For this purpose the following code fragment has been removed:
```scala
if (shared) {
    value = value.clone();
    shared = false;
}
```

This may have side effects in combination of the other related PR https://github.com/scala-native/scala-native/pull/2908.