### PR TITLE
Fix #2911: javalib IPv6 addresses now display using only lowercase hexadecimal digits

### DIFF
--- a/javalib/src/main/scala/java/net/Inet6Address.scala
+++ b/javalib/src/main/scala/java/net/Inet6Address.scala
@@ -77,12 +77,9 @@ object Inet6Address {
     new Inet6Address(ipAddress, host, scopeId, zone)
   }
 
-  private val hexCharacters = "0123456789ABCDEF"
+  private val hexCharacters = "0123456789abcdef"
 
   private[net] def formatInet6Address(in6Addr: Inet6Address): String = {
-
-//  private[net] def formatIp6Address(ip6ByteArray: Array[Byte],
-//  zoneId: String): String = {
     /* ScalaJVM expects the long form of, say "0:0:0:0:0:0:0:1"
      * inet_pton() and getnameinfo() both return the short form "::1".
      *

--- a/unit-tests/shared/src/test/scala/javalib/net/Inet6AddressTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/net/Inet6AddressTest.scala
@@ -163,4 +163,21 @@ class Inet6AddressTest {
     assertTrue(addr.getHostAddress().endsWith("0"))
   }
 
+  // Issue 2911
+  @Test def shouldUseOnlyLowercaseHexDigits(): Unit = {
+    val addr = InetAddress.getByName("FEBF::ABCD:EF01:2345:67AB:CDEF")
+    assertNotNull("InetAddress.getByName() failed to find name", addr)
+
+    val addrString = addr.getHostAddress()
+
+    // All JVM non-numeric hexadecimal digits are lowercase. Require the same.
+    val hexDigitsAreAllLowerCase = addrString
+      .forall(ch => (Character.isDigit(ch) || "abcdef:".contains(ch)))
+
+    assertTrue(
+      s"Not all hex characters in ${addrString} are lower case",
+      hexDigitsAreAllLowerCase
+    )
+  }
+
 }


### PR DESCRIPTION
Fix #2911 

When javalib displays an IPv6 address it now matches the JVM output, e.g. "fe80::mumble". 
 
The content of this PR is a candidate for porting to the 0.4.x stream. Because of the
restructuring in merged 0.5.0 PR #2877, backporting this PR should probably happen
after #2877 is backported.