### PR TITLE
Fix two sets of quality preception diminishing typos

### DIFF
--- a/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
+++ b/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
@@ -7,7 +7,7 @@ private[scalanative] trait UnsafePackageCompat { self =>
    *  allocator.
    */
   @deprecated(
-    "In Scala 3 alloc[T](n) can be confused with alloc[T].apply(n) leading to runtime erros, use alloc[T]() instead",
+    "In Scala 3 alloc[T](n) can be confused with alloc[T].apply(n) leading to runtime errors, use alloc[T]() instead",
     since = "0.4.3"
   )
   def alloc[T](implicit tag: Tag[T], z: Zone): Ptr[T] =
@@ -41,7 +41,7 @@ private[scalanative] trait UnsafePackageCompat { self =>
    *  Note: unlike alloc, the memory is not zero-initialized.
    */
   @deprecated(
-    "In Scala 3 alloc[T](n) can be confused with alloc[T].apply(n) leading to runtime erros, use alloc[T]() instead",
+    "In Scala 3 alloc[T](n) can be confused with alloc[T].apply(n) leading to runtime errors, use alloc[T]() instead",
     since = "0.4.3"
   )
   def stackalloc[T](implicit tag: Tag[T]): Ptr[T] =
@@ -83,7 +83,7 @@ private object MacroImpl {
       c.enclosingPosition,
       s"Scala Native method `alloc[T]` is deprecated, " +
         "in Scala 3 `alloc[T](n)` can be interpreted as " +
-        "`alloc[T].apply(n)` leading to runtime erros, " +
+        "`alloc[T].apply(n)` leading to runtime errors, " +
         "use `alloc[T]()` instead "
     )
     alloc1Impl(c)(tag, z)
@@ -141,7 +141,7 @@ private object MacroImpl {
       c.enclosingPosition,
       s"Scala Native method `stackalloc[T]` is deprecated, " +
         "in Scala 3 `stackalloc[T](n)` can be interpreted as " +
-        "`stackalloc[T].apply(n)` leading to runtime erros, " +
+        "`stackalloc[T].apply(n)` leading to runtime errors, " +
         "use `stackalloc[T]()` instead "
     )
     stackalloc1Impl(c)(tag)

--- a/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
@@ -19,7 +19,7 @@ object in {
   type in_addr = CStruct1[in_addr_t] // s_addr
 
   type sockaddr_in = CStruct4[
-    socket.sa_family_t, // sin_family, sin_len is synthisized if needed
+    socket.sa_family_t, // sin_family, sin_len is synthesized if needed
     in_port_t, // sin_port
     in_addr, // sin_addr
     CArray[Byte, _8] // sin_zero, Posix allowed
@@ -28,7 +28,7 @@ object in {
   type in6_addr = CStruct1[CArray[uint8_t, _16]] // s6_addr
 
   type sockaddr_in6 = CStruct5[
-    socket.sa_family_t, // sin6_family, sin6_len is synthisized if needed
+    socket.sa_family_t, // sin6_family, sin6_len is synthesized if needed
     in_port_t, // sin6_port
     uint32_t, // sin6_flowinfo
     in6_addr, // sin6_addr

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -105,7 +105,7 @@ object CodeGen {
         Impl(config, env, sorted).gen(id = "out", workdir) :: Nil
       }
 
-      // For some reason in the CI matching for `case _: build.Mode.Release` throws compile time erros
+      // For some reason in the CI matching for `case _: build.Mode.Release` throws compile time errors
       import build.Mode._
       (
         config.mode,


### PR DESCRIPTION
"erros" change will fix #2883. 

In each of my most recent one thousand readings of `in.scala` I have been brought up
short by "synthisized" but have always had more pressing things to accomplish than
create an issue. 

To a first approximation, these are internal use only, so do not need a Release Note.
Technically, the Exception "erros" message text can be seen by a user, which is how I saw it,
but only by a user who has gone astray. It was recently introduced into 0.5.0 and,
I think, not backported.  The "synthisized" typos were also introduced in 0.5.0.

Normally,  fixing typographical errors does not warrant the overhead of a PR.
They are like character marks on leather: breaks up uniformity.

These typos stand out as ones which reduce a readers perception of the quality of
the SN review process: if this got thru review what other bogosity did also?
Especially the Exception messages, which has the potential of being seen
by users of Scala Native.

This PR is a small one that I could knock of whilst waiting for another to clear
CI.  Small improvements where and as when we can.

Now if only I did not typo the tpyo corrections.


