### PR TITLE
Fix #2902: Avoid Array allocation in ieee754tostring implementations

### DIFF
--- a/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/AbstractStringBuilder.scala
@@ -4,6 +4,8 @@ import java.io.InvalidObjectException
 import java.util.Arrays
 import scala.util.control.Breaks._
 
+import scala.scalanative.runtime.ieee754tostring.ryu._
+
 abstract class AbstractStringBuilder private (unit: Unit) {
   import AbstractStringBuilder._
 
@@ -104,6 +106,36 @@ abstract class AbstractStringBuilder private (unit: Unit) {
     }
     value(count) = ch
     count += 1
+  }
+
+  // Optimization: use `RyuFloat.floatToChars()` instead of `floatToString()`
+  final def append0(f: scala.Float): Unit = {
+
+    // We first ensure that we have enough space in the backing Array (`value`)
+    this.ensureCapacity(this.count + RyuFloat.RESULT_STRING_MAX_LENGTH)
+
+    // Then we call `RyuFloat.floatToChars()`, which will append chars to `value`
+    this.count = RyuFloat.floatToChars(
+      f,
+      RyuRoundingMode.Conservative,
+      value,
+      this.count
+    )
+  }
+
+  // Optimization: use `RyuFloat.doubleToChars()` instead of `doubleToString()`
+  def append0(d: scala.Double): Unit = {
+
+    // We first ensure that we have enough space in the backing Array (`value`)
+    this.ensureCapacity(this.count + RyuDouble.RESULT_STRING_MAX_LENGTH)
+
+    // Then we call `RyuFloat.doubleToChars()`, which will append chars to `value`
+    this.count = RyuDouble.doubleToChars(
+      d,
+      RyuRoundingMode.Conservative,
+      value,
+      this.count
+    )
   }
 
   final def append0(string: String): Unit = {

--- a/javalib/src/main/scala/java/lang/StringBuffer.scala
+++ b/javalib/src/main/scala/java/lang/StringBuffer.scala
@@ -43,11 +43,15 @@ final class StringBuffer
       this
     }
 
-  def append(d: scala.Double): StringBuffer =
-    append(Double.toString(d))
+  def append(f: scala.Float): StringBuffer = {
+    append0(f)
+    this
+  }
 
-  def append(f: scala.Float): StringBuffer =
-    append(Float.toString(f))
+  def append(d: scala.Double): StringBuffer = {
+    append0(d)
+    this
+  }
 
   def append(i: scala.Int): StringBuffer =
     append(Integer.toString(i))

--- a/javalib/src/main/scala/java/lang/StringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/StringBuilder.scala
@@ -50,12 +50,12 @@ final class StringBuilder
   }
 
   def append(f: scala.Float): StringBuilder = {
-    append0(Float.toString(f))
+    append0(f)
     this
   }
 
   def append(d: scala.Double): StringBuilder = {
-    append0(Double.toString(d))
+    append0(d)
     this
   }
 

--- a/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu/RyuFloat.scala
@@ -35,9 +35,9 @@ package scala.scalanative
 package runtime
 package ieee754tostring.ryu
 
-import RyuRoundingMode._
-
 object RyuFloat {
+
+  final val RESULT_STRING_MAX_LENGTH = 15
 
   final val FLOAT_MANTISSA_BITS = 23
 
@@ -177,27 +177,88 @@ object RyuFloat {
       roundingMode: RyuRoundingMode
   ): String = {
 
-    // Step 1: Decode the floating point number, and unify normalized and
-    // subnormal cases.
-    // First, handle all the trivial cases.
+    // Handle all the trivial cases.
     if (value.isNaN) return "NaN"
     if (value == Float.PositiveInfinity) return "Infinity"
     if (value == Float.NegativeInfinity) return "-Infinity"
     val bits = java.lang.Float.floatToIntBits(value)
     if (bits == 0) return "0.0"
     if (bits == 0x80000000) return "-0.0"
-    // Otherwise extract the mantissa and exponent bits and run the full
-    // algorithm.
+
+    val result = new scala.Array[Char](RyuFloat.RESULT_STRING_MAX_LENGTH)
+    val strLen = floatToChars(value, roundingMode, result, 0)
+
+    new String(result, 0, strLen)
+  }
+
+  @inline
+  private def copyLitteralToCharArray(
+      litteral: String,
+      litteralLength: Int,
+      result: scala.Array[scala.Char],
+      offset: Int
+  ): Int = {
+    litteral.getChars(0, litteralLength, result, offset)
+    offset + litteralLength
+  }
+
+  // See: https://github.com/scala-native/scala-native/issues/2902
+  /** Low-level function executing the Ryu algorithm on `Float`` value. Compared
+   *  to [[floatToString]] this function allows destination passing style. This
+   *  means that the result destination (`Array[Char]`) has to be passed as an
+   *  argument. The goal is to avoid additional allocations when possible.
+   *  Warning: this function makes no verification of destination bounds (offset
+   *  and length are assumed to be valid).
+   *
+   *  @param value
+   *    the value to be converted
+   *  @param roundingMode
+   *    customization of Ryu rounding mode
+   *  @param result
+   *    the `Array[Char]` destination of the conversion result
+   *  @param offset
+   *    index in `Array[Char]` destination where new chars will start to be
+   *    written
+   *  @return
+   *    new offset as: old offset + number of created chars (i.e. last modified
+   *    index + 1)
+   */
+  @noinline
+  def floatToChars(
+      value: Float,
+      roundingMode: RyuRoundingMode,
+      result: scala.Array[scala.Char],
+      offset: Int
+  ): Int = {
+
+    // First, handle all the trivial cases.
+    if (value.isNaN)
+      return copyLitteralToCharArray("NaN", 3, result, offset)
+    if (value == Float.PositiveInfinity)
+      return copyLitteralToCharArray("Infinity", 8, result, offset)
+    if (value == Float.NegativeInfinity)
+      return copyLitteralToCharArray("-Infinity", 9, result, offset)
+
+    val bits = java.lang.Float.floatToIntBits(value)
+    if (bits == 0)
+      return copyLitteralToCharArray("0.0", 3, result, offset)
+    if (bits == 0x80000000)
+      return copyLitteralToCharArray("-0.0", 4, result, offset)
+
+    // Otherwise extract the mantissa and exponent bits and run the full algorithm.
+    // Step 1: Decode the floating point number, and unify normalized and subnormal cases.
     val ieeeExponent = (bits >> FLOAT_MANTISSA_BITS) & FLOAT_EXPONENT_MASK
     val ieeeMantissa = bits & FLOAT_MANTISSA_MASK
-    // By default, the correct mantissa starts with a 1, except for
-    // denormal numbers.
+
+    // By default, the correct mantissa starts with a 1, except for denormal numbers.
     var e2 = 0
     var m2 = 0
     if (ieeeExponent == 0) {
+      // Denormal number - no implicit leading 1, and the exponent is 1, not 0.
       e2 = 1 - FLOAT_EXPONENT_BIAS - FLOAT_MANTISSA_BITS
       m2 = ieeeMantissa
     } else {
+      // Add implicit leading 1.
       e2 = ieeeExponent - FLOAT_EXPONENT_BIAS - FLOAT_MANTISSA_BITS
       m2 = ieeeMantissa | (1 << FLOAT_MANTISSA_BITS)
     }
@@ -225,6 +286,7 @@ object RyuFloat {
     if (e2 >= 0) {
       // Compute m * 2^e_2 / 10^q = m * 2^(e_2 - q) / 5^q
       val q = (e2 * LOG10_2_NUMERATOR / LOG10_2_DENOMINATOR).toInt
+      // k = constant + floor(log_2(5^q))
       val k = POW5_INV_BITCOUNT + pow5bits(q) - 1
       val i = -e2 + q + k
       dv = mulPow5InvDivPow2(mv, q, i).toInt
@@ -265,21 +327,18 @@ object RyuFloat {
       dmIsTrailingZeros = (if (mm % 2 == 1) 0 else 1) >= q
     }
 
-    // Step 4: Find the shortest decimal representation in the interval of
-    // legal representations.
+    // Step 4: Find the shortest decimal representation in the interval of legal representations.
     //
     // We do some extra work here in order to follow Float/Double.toString
     // semantics. In particular, that requires printing in scientific format
     // if and only if the exponent is between -3 and 7, and it requires
     // printing at least two decimal digits.
     //
-    // Above, we moved the decimal dot all the way to the right, so now we
-    // need to count digits to
-    // figure out the correct exponent for scientific notation.
+    // Above, we moved the decimal dot all the way to the right, so now we need to count digits
+    // to figure out the correct exponent for scientific notation.
     val dplength = decimalLength(dp)
     var exp = e10 + dplength - 1
-    // Float.toString semantics requires using scientific notation if and
-    // only if outside this range.
+    // Float.toString semantics requires using scientific notation if and only if outside this range.
     val scientificNotation = !((exp >= -3) && (exp < 7))
     var removed = 0
     if (dpIsTrailingZeros && !roundingMode.acceptUpperBound(even)) {
@@ -329,12 +388,13 @@ object RyuFloat {
 
     // Step 5: Print the decimal representation.
     // We follow Float.toString semantics here.
-    val result = new scala.Array[Char](15)
-    var index = 0
+    var index = offset
     if (sign) {
       result(index) = '-'
       index += 1
     }
+
+    // Values in the interval [1E-3, 1E7) are special.
     if (scientificNotation) {
       for (i <- 0 until olength - 1) {
         val c = output % 10
@@ -348,8 +408,7 @@ object RyuFloat {
         result(index) = '0'
         index += 1
       }
-      // Print 'E', the exponent sign, and the exponent, which has at most
-      // two digits.
+      // Print 'E', the exponent sign, and the exponent, which has at most two digits.
       result(index) = 'E'
       index += 1
       if (exp < 0) {
@@ -411,7 +470,8 @@ object RyuFloat {
         index += olength + 1
       }
     }
-    new String(result, 0, index)
+
+    index
   }
 
   private def pow5bits(e: Int): Int =

--- a/unit-tests/shared/src/test/scala/javalib/lang/StringBufferTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/StringBufferTest.scala
@@ -35,6 +35,11 @@ class StringBufferTest {
     assertEquals("2.5", newBuf.append(2.5f).toString)
     assertEquals("3.5", newBuf.append(3.5).toString)
   }
+  
+  @Test def appendFloats(): Unit = {
+    assertEquals("2.5 3.5", newBuf.append(2.5f).append(' ').append(3.5).toString)
+    assertEquals("3.5 2.5", newBuf.append(3.5).append(' ').append(2.5f).toString)
+  }
 
   @Test def insert(): Unit = {
     assertEquals("asdf", newBuf.insert(0, "asdf").toString)


### PR DESCRIPTION
This PR is an attempt to fix #2902

The issue ticket explain the rationale of the modifications.

This PR also adds a Unit test to verify if consecutive addition of Float/Double in a `StringBuilder`, is still leading to consistent results.
It is performed as follows:

```scala
  @Test def appendFloats(): Unit = {
    assertEquals("2.5 3.5", newBuf.append(2.5f).append(' ').append(3.5).toString)
    assertEquals("3.5 2.5", newBuf.append(3.5).append(' ').append(2.5f).toString)
  }
```
