### PR TITLE
Fix #2921: Commix Heap.c now compiles with Clang 15.0.3

### DIFF
--- a/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
+++ b/nativelib/src/main/resources/scala-native/gc/commix/Heap.c
@@ -236,7 +236,7 @@ void Heap_Collect(Heap *heap) {
                       heap->mark.currentEnd_ns);
     Phase_Nullify(heap, stats);
     Phase_StartSweep(heap);
-    WeakRefGreyList_CallHandlers(heap);
+    WeakRefGreyList_CallHandlers();
 }
 
 bool Heap_shouldGrow(Heap *heap) {


### PR DESCRIPTION
Fix #2921 

Recent PR #2890 changed the prototype for `WeakRefGreyList_CallHandlers()` so that
the prototype match its implementation. That satisfied Clang 15.0.1.

This PR changes the call site to match the prototype and satisfies the more
stringent checking of Clang 15.0.3.
