### PR TITLE
Fix #2927: Expunge non-JVM j.l.String#getValue()

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -1526,10 +1526,9 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     result.toString()
   }
 
+  // Java 15 and above.
   def transform[R](f: java.util.function.Function[String, R]): R =
     f.apply(thisString)
-
-  def getValue(): Array[Char] = value
 }
 
 object _String {


### PR DESCRIPTION
Fix #2927.

Removed an used,  non-JVM method in `java.lang.String` which had the ability
to violate String immutability. 