### PR TITLE
More j.l.String constructor mutation tests

### DIFF
--- a/javalib/src/main/scala/java/lang/String.scala
+++ b/javalib/src/main/scala/java/lang/String.scala
@@ -136,9 +136,9 @@ final class _String()
 
   def this(sb: StringBuffer) = {
     this()
-    offset = 0
-    value = sb.getValue()
     count = sb.length()
+    value = new Array[Char](count)
+    sb.getChars(0, count, value, 0)
   }
 
   def this(codePoints: Array[Int], offset: Int, count: Int) = {
@@ -162,7 +162,6 @@ final class _String()
 
   def this(sb: java.lang.StringBuilder) = {
     this()
-    offset = 0
     count = sb.length()
     value = new Array[Char](count)
     sb.getChars(0, count, value, 0)

--- a/unit-tests/shared/src/test/scala/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/StringTest.scala
@@ -624,17 +624,135 @@ class StringTest {
 
   }
 
-  // Issue #2925
-  @Test def createStringThenModifyStringBuffer(): Unit = {
-    val buf = new StringBuffer()
-    buf.append("foobar")
+  /* --- UNIT TESTS VERIFYING STRING CONSTRUCTORS IMMUTABILITY INTEGRITY ---
+   * Issue #2925
+   *
+   * These tests are in the order of declaration in the Java 8 specification.
+   *   - The "String()" constructor has no bytes to modify and is not tested.
+   *   - The "String(byte[] ascii, int hibyte, int offset, int count)"
+   *     has been deprecated since Java 1.1 and is not tested.
+   */
 
-    val s = new String(buf)
-    buf.setCharAt(0, 'm')
+  /** Checks that creating a String with an `Array[Char]`, then replacing the
+   *  its first character, is not breaking String immutability.
+   */
+  @Test def checkImmutabilityNewStringFromCharArray(): Unit = {
+    val chars = Array('f', 'o', 'o', 'b', 'a', 'r')
+
+    // Create str from chars
+    val str = new String(chars)
+    // Modify chars
+    chars(0) = 'm'
 
     assertTrue(
-      s"foobar should start with 'f' instead of '${s.charAt(0)}''",
-      'f' == s.charAt(0)
+      s"chars should start with 'm' instead of '${chars(0)}'",
+      'm' == chars(0)
+    )
+
+    assertTrue(
+      s"str should start with 'f' instead of '${str.charAt(0)}'",
+      'f' == str.charAt(0)
     )
   }
+
+  /** Checks that creating a String with an `Array[Char]`, then replacing the
+   *  its first character, is not breaking String immutability.
+   */
+  @Test def checkImmutabilityNewStringFromCharArrayRange(): Unit = {
+    val chars = Array('f', 'o', 'o', 'b', 'a', 'r')
+
+    // Create str from a "range" of chars
+    val str = new String(chars, 0, 1)
+
+    // Modify chars
+    chars(0) = 'm'
+
+    assertTrue(
+      s"chars should start with 'm' instead of '${chars(0)}'",
+      'm' == chars(0)
+    )
+
+    assertTrue(
+      s"str should start with 'f' instead of '${str.charAt(0)}'",
+      'f' == str.charAt(0)
+    )
+  }
+
+  /** Checks that creating a String with an `Array[Char]`, then replacing the
+   *  its first character, is not breaking String immutability.
+   */
+  @Test def checkImmutabilityNewStringFromString(): Unit = {
+    val s1 = "foobar"
+
+    // Create String s2 from a String s1
+    val s2 = new String(s1)
+
+    // Modify String s1
+    val s3 = s1.replace('f', 'm')
+
+    assertTrue(
+      s"s1 should start with 'f' instead of '${s1.charAt(0)}'",
+      'f' == s1.charAt(0)
+    )
+
+    assertTrue(
+      s"s2 should start with 'f' instead of '${s2.charAt(0)}'",
+      'f' == s2.charAt(0)
+    )
+
+    assertTrue(
+      s"s3 should start with 'm' instead of '${s3.charAt(0)}'",
+      'm' == s3.charAt(0)
+    )
+  }
+
+  /** Checks that creating a String with a a StringBuffer, whose backing Array
+   *  is shared with the created String, is not breaking String immutability.
+   *  See: https://github.com/scala-native/scala-native/issues/2925
+   */
+  @Test def checkImmutabilityNewStringFromStringBuffer(): Unit = {
+    val strBuffer = new StringBuffer()
+    strBuffer.append("foobar")
+
+    // Create str from a StringBuffer
+    val str = new String(strBuffer)
+
+    // Modify the StringBuffer
+    strBuffer.setCharAt(0, 'm')
+
+    assertTrue(
+      s"strBuffer should start with 'm' instead of '${strBuffer.charAt(0)}'",
+      'm' == strBuffer.charAt(0)
+    )
+
+    assertTrue(
+      s"str should start with 'f' instead of '${str.charAt(0)}'",
+      'f' == str.charAt(0)
+    )
+  }
+
+  /** Checks that creating a String with a a StringBuilder, whose backing Array
+   *  is shared with the created String, is not breaking String immutability.
+   */
+  @Test def checkImmutabilityNewStringFromStringBuilder(): Unit = {
+    val strBuilder = new StringBuilder()
+    strBuilder.append("foobar")
+
+    // Create str from a StringBuilder
+    val str = new String(strBuilder)
+
+    // Modify the StringBuilder
+    strBuilder.setCharAt(0, 'm')
+
+    assertTrue(
+      s"strBuilder should start with 'm' instead of '${strBuilder.charAt(0)}'",
+      'm' == strBuilder.charAt(0)
+    )
+
+    assertTrue(
+      s"str should start with 'f' instead of '${str.charAt(0)}'",
+      'f' == str.charAt(0)
+    )
+  }
+
 }

--- a/unit-tests/shared/src/test/scala/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/StringTest.scala
@@ -40,12 +40,6 @@ class StringTest {
     )
   }
 
-  @Test def stringArrayByteHighByte(): Unit = {
-    val str = "this constrcutor is deprecated"
-    assertEquals(str, new String(str.getBytes(), 0))
-    assertEquals(str, new String(str.getBytes(), 0, 0, str.length()))
-  }
-
   @Test def stringArrayByteStartLengthWithInvalidStartOrLength(): Unit = {
     val chars: Array[Char] = Array('a', 'b', 'c')
 
@@ -211,7 +205,7 @@ class StringTest {
     )
   }
 
-  @Test def replaceAllLiterallyWithDollarSignInReplacementIssue1070(): Unit = {
+  @Test def replaceWithDollarSignInReplacementIssue1070(): Unit = {
     val literal = "{.0}"
     val replacement = "\\$ipsum"
     val prefix = "Lorem "
@@ -219,7 +213,7 @@ class StringTest {
     val text = prefix + literal + suffix
     val expected = prefix + replacement + suffix
 
-    assertTrue(text.replaceAllLiterally(literal, replacement) == expected)
+    assertTrue(text.replace(literal, replacement) == expected)
   }
 
   private def splitVec(s: String, sep: String, limit: Int = 0) =
@@ -294,13 +288,6 @@ class StringTest {
     splitTest(".", splitExpr = Some("\\."))
     splitTest("ab", splitExpr = Some("ab"))
     splitTest("ab", splitExpr = Some("(ab)"))
-  }
-
-  @Test def getBytes(): Unit = {
-    val b = new Array[scala.Byte](4)
-    // This form of getBytes() has been depricated since JDK 1.1
-    "This is a test".getBytes(10, 14, b, 0)
-    assertTrue(new String(b) equals "test")
   }
 
   def testEncoding(charset: String, expectedInts: Seq[Int]): Unit = {
@@ -626,12 +613,29 @@ class StringTest {
 
   /* --- UNIT TESTS VERIFYING STRING CONSTRUCTORS IMMUTABILITY INTEGRITY ---
    * Issue #2925
-   *
    * These tests are in the order of declaration in the Java 8 specification.
-   *   - The "String()" constructor has no bytes to modify and is not tested.
-   *   - The "String(byte[] ascii, int hibyte, int offset, int count)"
-   *     has been deprecated since Java 1.1 and is not tested.
    */
+
+  /** String() - No Test, no characters to modify.
+   */
+
+  // String(byte[] bytes)
+
+  // String(byte[] bytes, Charset charset)
+
+  /** String(byte[], int) - No test, Deprecated since Java 1.1.
+   */
+
+  // String(byte[] bytes, int offset, int length)
+
+  // String(byte[] bytes, int offset, int length, Charset charset)
+
+  /** String(byte[], int, int, int) - No test, Deprecated since Java 1.1.
+   */
+
+  // String(byte[] bytes, int offset, int length, String charsetName)
+
+  // String(byte[] bytes, String charsetName)
 
   /** Checks that creating a String with an `Array[Char]`, then replacing the
    *  its first character, is not breaking String immutability.
@@ -662,7 +666,7 @@ class StringTest {
     val chars = Array('f', 'o', 'o', 'b', 'a', 'r')
 
     // Create str from a "range" of chars
-    val str = new String(chars, 0, 1)
+    val str = new String(chars, 0, 4)
 
     // Modify chars
     chars(0) = 'm'
@@ -670,6 +674,33 @@ class StringTest {
     assertTrue(
       s"chars should start with 'm' instead of '${chars(0)}'",
       'm' == chars(0)
+    )
+
+    assertTrue(
+      s"str should start with 'f' instead of '${str.charAt(0)}'",
+      'f' == str.charAt(0)
+    )
+  }
+
+  /** Checks that creating a String with an `Array[codePoints]`, then replacing
+   *  the its first character, is not breaking String immutability.
+   */
+  @Test def checkImmutabilityNewStringFromCodepointArrayRange(): Unit = {
+    // Unicode code points are Integers.
+    val chars = Array('f', 'o', 'o', 'b', 'a', 'r')
+    val codepoints = chars.map(c => c.toInt)
+
+    // Create str from a "range" of codepoints
+    val str = new String(codepoints, 0, 5)
+
+    val changedCp = 'm'.toInt
+    // Modify codepoints
+    codepoints(0) = changedCp
+
+    assertTrue(
+      s"codepoints should start with ${changedCp} " +
+        s"instead of '${codepoints(0)}'",
+      changedCp == codepoints(0)
     )
 
     assertTrue(

--- a/unit-tests/shared/src/test/scala/javalib/lang/StringTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/StringTest.scala
@@ -623,4 +623,18 @@ class StringTest {
     )
 
   }
+
+  // Issue #2925
+  @Test def createStringThenModifyStringBuffer(): Unit = {
+    val buf = new StringBuffer()
+    buf.append("foobar")
+
+    val s = new String(buf)
+    buf.setCharAt(0, 'm')
+
+    assertTrue(
+      s"foobar should start with 'f' instead of '${s.charAt(0)}''",
+      'f' == s.charAt(0)
+    )
+  }
 }


### PR DESCRIPTION
Ref: now closed issue I2925

Add additional  tests for `java.lang.String` constructors to detect immutability.
These tests are in support of concurrent work to make String implementations
more efficient.

* Delete two tests of long deprecated constructors. Scala 3.2.0 is getting more vocal about deprecated items.

* Update the ` replaceAllLiterallyWithDollarSignInReplacementIssue1070()` test and change its name to
  `replaceWithDollarSignInReplacementIssue1070` because the `replaceAll` method became deprecated
  in Scala 2.1mumble. Again, Scala 3.2.0 is becoming more insistent.

* I expect additional test to be added as each logical group passes CI.