### PR TITLE
Re-implement `PrintStream.print(obj: AnyRef)` to avoid a CharSequence -> String conversion

### DIFF
--- a/javalib/src/main/scala/java/io/PrintStream.scala
+++ b/javalib/src/main/scala/java/io/PrintStream.scala
@@ -165,7 +165,18 @@ class PrintStream private (
   def print(f: Float): Unit = printString(String.valueOf(f))
   def print(d: Double): Unit = printString(String.valueOf(d))
   def print(s: String): Unit = printString(if (s == null) "null" else s)
-  def print(obj: AnyRef): Unit = printString(String.valueOf(obj))
+  def print(obj: AnyRef): Unit = {
+    obj match {
+      case csq: CharSequence => printCharSequence(csq)
+      case _                 => printString(String.valueOf(obj))
+    }
+  }
+
+  private def printCharSequence(csq: CharSequence): Unit =
+    ensureOpenAndTrapIOExceptions {
+      encoder.append(csq)
+      encoder.flushBuffer()
+    }
 
   private def printString(s: String): Unit = ensureOpenAndTrapIOExceptions {
     encoder.write(s)

--- a/unit-tests/shared/src/test/scala/javalib/io/PrintWriterTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/PrintWriterTest.scala
@@ -1,0 +1,30 @@
+package javalib.io
+
+import java.io._
+
+import org.junit.Test
+import org.junit.Assert._
+
+class PrintWriterTest {
+
+  @Test def writerTest(): Unit = {
+
+    val out = new StringWriter()
+    val writer = new PrintWriter(out)
+
+    // Use writer with as String casted as a CharSequence
+    val stringAsCharSeq: CharSequence = "ABC"
+    writer.print(stringAsCharSeq)
+
+    // Use writer with as StringBuilder casted as a CharSequence
+    val stingBuilderAsCharSeq = new StringBuilder("DEF")
+    writer.print(stingBuilderAsCharSeq)
+
+    // flush is optional here, as Writer calls the no-op StringWriter.flush()
+    writer.flush()
+
+    val result = out.toString
+
+    assertEquals("ABCDEF", result)
+  }
+}


### PR DESCRIPTION
This PR is WIP to fix #2906
This issue is focusing on the PrintStream use case, but there are maybe other places in the code where using `CharSequence` instead of `String` could be beneficial.

This PR reimplements the method `PrintStream.print(obj: AnyRef)` in order to call `encoder.append(csq)` instead of `encoder.write(s)`, encoder being an `OutputStreamWriter`.
This allows to avoid the current conversion of `CharSequence` to `String`, and should thus save both CPU and memory consumption.

This PR is a nice workaround to PR #2908, which is proposing a reimplementation of `AbstractStringBuilder.toString`, `AbstractStringBuilder` being one possible `CharSequence`  of javalib. But it only works for StringBuilder/StringBuffer used in this context. The PR #2908 tries to solve the allocation issue in more generic way (through a carefully tuned sharing strategy).

The present PR has however the advantage of fewer consequences in terms of logic (no side effect).