### PR TITLE
Enable the use of memcpy in IEEE754Helpers.bytesToCString

### DIFF
--- a/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
+++ b/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
@@ -40,7 +40,7 @@ private[java] object IEEE754Helpers {
     memcpy(cStr, bytesPtr, n.toUSize)
 
     // add NUL-terminator to CString
-    !(cStr + n) = 0.toByte
+    cStr(n) = 0.toByte
 
     cStr
   }

--- a/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
+++ b/javalib/src/main/scala/java/lang/IEEE754Helpers.scala
@@ -3,6 +3,8 @@ package java.lang
 import scalanative.unsafe._
 import scalanative.unsigned._
 import scalanative.libc.errno
+import scalanative.libc.string.memcpy
+import scalanative.runtime.ByteArray
 
 import scalanative.posix.errno.ERANGE
 
@@ -31,14 +33,13 @@ private[java] object IEEE754Helpers {
   private def bytesToCString(bytes: Array[scala.Byte], n: Int)(implicit
       z: Zone
   ): CString = {
-    val cStr = z.alloc((n + 1).toUInt) // z.alloc() does not clear bytes.
+    val cStr = z.alloc((n + 1).toUSize) // z.alloc() does not clear bytes.
 
-    var c = 0
-    while (c < n) {
-      !(cStr + c) = bytes(c)
-      c += 1
-    }
+    // memcpy bytes from Array to CString
+    val bytesPtr = bytes.asInstanceOf[ByteArray].at(0)
+    memcpy(cStr, bytesPtr, n.toUSize)
 
+    // add NUL-terminator to CString
     !(cStr + n) = 0.toByte
 
     cStr
@@ -46,6 +47,9 @@ private[java] object IEEE754Helpers {
 
   def parseIEEE754[T](s: String, f: (CString, Ptr[CString]) => T): T = {
     Zone { implicit z =>
+      if (s.isEmpty)
+        throw new NumberFormatException(exceptionMsg(s))
+
       val bytes = s.getBytes(java.nio.charset.Charset.defaultCharset())
       val bytesLen = bytes.length
 
@@ -54,7 +58,8 @@ private[java] object IEEE754Helpers {
       val end = stackalloc[CString]() // Address one past last parsed cStr byte.
 
       errno.errno = 0
-      var res = f(cStr, end)
+
+      val res = f(cStr, end)
 
       if (errno.errno != 0) {
         if (errno.errno == ERANGE) {


### PR DESCRIPTION
This PR is a continuation of IEEE754Helpers improvements (last change done in PR #2907).

According to discussions with @densh on Discord, `memcpy()` should be favored instead of plain while loops for transferring bytes between ` Ptr[Byte]` instances.

Current changes:
* replace while loop by `memcpy()` call
* throw NumberFormatException when String is empty (otherwise bytesToCString would throw ArrayIndexOutOfBoundsException)
* replace `var res = f(cStr, end)` by `val res = f(cStr, end)` (var not needed there)