### PR TITLE
Fix encoding of `scala.Nothing` and `scala.Null` in type signatures

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenName.scala
@@ -31,6 +31,8 @@ trait NirGenName[G <: Global with Singleton] {
       if (fullName == "java.lang._String") "java.lang.String"
       else if (fullName == "java.lang._Object") "java.lang.Object"
       else if (fullName == "java.lang._Class") "java.lang.Class"
+      else if (fullName == "scala.Nothing") "scala.runtime.Nothing$"
+      else if (fullName == "scala.Null") "scala.runtime.Null$"
       else fullName
     }
     val name = sym match {

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenName.scala
@@ -163,7 +163,9 @@ object NirGenName {
     "java.lang._Object" -> "java.lang.Object",
     "java.lang._String" -> "java.lang.String",
     "java.lang.annotation._Retention" -> "java.lang.annotation.Retention",
-    "java.io._Serializable" -> "java.io.Serializable"
+    "java.io._Serializable" -> "java.io.Serializable",
+    "scala.Nothing" -> "scala.runtime.Nothing$",
+    "scala.Null" -> "scala.runtime.Null$"
   ).flatMap {
     case classEntry @ (nativeName, javaName) =>
       List(

--- a/sandbox/src/main/scala/Test.scala
+++ b/sandbox/src/main/scala/Test.scala
@@ -1,5 +1,13 @@
-object Test {
+//> using scala "2"
+//> using lib "dev.zio::izumi-reflect::2.2.0"
+//> using option "-Xprint:typer"
+
+import izumi.reflect._
+
+object Main {
+  def foo[T: Tag] = ???
   def main(args: Array[String]): Unit = {
-    println("Hello, World!")
+    println(foo)
   }
+
 }

--- a/sandbox/src/main/scala/Test.scala
+++ b/sandbox/src/main/scala/Test.scala
@@ -1,13 +1,5 @@
-//> using scala "2"
-//> using lib "dev.zio::izumi-reflect::2.2.0"
-//> using option "-Xprint:typer"
-
-import izumi.reflect._
-
-object Main {
-  def foo[T: Tag] = ???
+object Test {
   def main(args: Array[String]): Unit = {
-    println(foo)
+    println("Hello, World!")
   }
-
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/IssuesTest.scala
@@ -549,6 +549,12 @@ class IssuesTest {
     assertEquals("case 2", 0, Bar.bar())
   }
 
+  @Test def test_Issue2858() = {
+    // In the reported issue symbols for scala.Nothing and scala.Null
+    assertEquals("class scala.runtime.Nothing$", classOf[Nothing].toString())
+    assertEquals("class scala.runtime.Null$", classOf[Null].toString())
+  }
+
 }
 
 package issue1090 {


### PR DESCRIPTION
fixes #2858 
fixes #2920 

`scala.Nothing` and `scala.Null` were not encoded as `scala.runtime.Nothing$` and `scala.runtime.Null$` leading to missing definitons when linking.