### PR TITLE
Remove deprecated assert idiom from three java.lang Tests

### DIFF
--- a/unit-tests/shared/src/test/scala/javalib/lang/IntegerTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/IntegerTest.scala
@@ -24,8 +24,7 @@ class IntegerTest {
       expectedThrowable: Class[T],
       code: => U
   )(expectedMsg: String): Unit = {
-    val exception = assertThrows(expectedThrowable, code)
-    assertEquals(expectedMsg, exception.toString)
+    assertThrows(expectedMsg, expectedThrowable, code)
   }
 
   @Test def decodeTest(): Unit = {

--- a/unit-tests/shared/src/test/scala/javalib/lang/LongTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/LongTest.scala
@@ -24,8 +24,7 @@ class LongTest {
       expectedThrowable: Class[T],
       code: => U
   )(expectedMsg: String): Unit = {
-    val exception = assertThrows(expectedThrowable, code)
-    assertEquals(expectedMsg, exception.toString)
+    assertThrows(expectedMsg, expectedThrowable, code)
   }
 
   @Test def decodeTest(): Unit = {

--- a/unit-tests/shared/src/test/scala/javalib/lang/ShortTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/ShortTest.scala
@@ -6,7 +6,6 @@ import org.junit.Test
 import org.junit.Assert._
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
-import org.scalanative.testsuite.utils.ThrowsHelper._
 
 class ShortTest {
   val signedMaxValue = Short.MAX_VALUE

--- a/unit-tests/shared/src/test/scala/javalib/lang/ShortTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/ShortTest.scala
@@ -21,8 +21,7 @@ class ShortTest {
       expectedThrowable: Class[T],
       code: => U
   )(expectedMsg: String): Unit = {
-    val exception = assertThrows(expectedThrowable, code)
-    assertEquals(expectedMsg, exception.toString)
+    assertThrows(expectedMsg, expectedThrowable, code)
   }
 
   @Test def decodeTest(): Unit = {


### PR DESCRIPTION
Towards a cleaner build of Scala Native on Scala 3.2.n.  Remove instances of the now
deprecated `AssertThrowsAnd` method.
