### PR TITLE
Remove deprecated assert idiom from five regex Tests

### DIFF
--- a/unit-tests/native/src/test/scala/java/util/regex/MatcherTest.scala
+++ b/unit-tests/native/src/test/scala/java/util/regex/MatcherTest.scala
@@ -13,7 +13,6 @@ import org.junit.Test
 import org.junit.Assert._
 
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
-import org.scalanative.testsuite.utils.ThrowsHelper._
 
 class MatcherTest {
 

--- a/unit-tests/native/src/test/scala/java/util/regex/MatcherTest.scala
+++ b/unit-tests/native/src/test/scala/java/util/regex/MatcherTest.scala
@@ -528,8 +528,10 @@ class MatcherTest {
 
     assertEquals(m.groupCount, 2)
 
-    assertThrowsAnd(classOf[IllegalStateException], m.group)(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      m.group
     )
 
     assertTrue(m.find())
@@ -537,8 +539,10 @@ class MatcherTest {
     assertEquals(m.group(0), "a12z")
     assertEquals(m.group(1), "1")
     assertEquals(m.group(2), "2")
-    assertThrowsAnd(classOf[IndexOutOfBoundsException], m.group(42))(
-      _.getMessage == "No group 42"
+    assertThrows(
+      "No group 42",
+      classOf[IndexOutOfBoundsException],
+      m.group(42)
     )
 
     assertTrue(m.find())
@@ -720,8 +724,10 @@ class MatcherTest {
     assertTrue(m.find())
     assertEquals(m.group("S"), "Montreal, Canada")
     assertEquals(m.group("D"), "Lausanne, Switzerland")
-    assertThrowsAnd(classOf[IllegalStateException], m.group("foo"))(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      m.group("foo")
     )
   }
 
@@ -735,8 +741,10 @@ class MatcherTest {
     assertTrue("A1", m.find())
     assertTrue("A2", m.group("S") == "Montreal, Canada")
     assertTrue("A3", m.group("D") == "Lausanne, Switzerland")
-    assertThrowsAnd(classOf[IllegalStateException], m.group("foo"))(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      m.group("foo")
     )
   }
 
@@ -878,12 +886,16 @@ class MatcherTest {
   @Test def startEndIndices(): Unit = {
     val m = matcher("a(\\d)(\\d)z", "012345_a12z_012345")
 
-    assertThrowsAnd(classOf[IllegalStateException], m.start())(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      m.start()
     )
 
-    assertThrowsAnd(classOf[IllegalStateException], m.end())(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      m.end()
     )
 
     assertTrue(m.find())
@@ -900,12 +912,16 @@ class MatcherTest {
     assertEquals(m.start(2), 9)
     assertEquals(m.end(2), 10)
 
-    assertThrowsAnd(classOf[IndexOutOfBoundsException], m.start(42))(
-      _.getMessage == "No group 42"
+    assertThrows(
+      "No group 42",
+      classOf[IndexOutOfBoundsException],
+      m.start(42)
     )
 
-    assertThrowsAnd(classOf[IndexOutOfBoundsException], m.end(42))(
-      _.getMessage == "No group 42"
+    assertThrows(
+      "No group 42",
+      classOf[IndexOutOfBoundsException],
+      m.end(42)
     )
   }
 
@@ -959,12 +975,16 @@ class MatcherTest {
     assertEquals(m.start("D"), 25)
     assertEquals(m.end("D"), 46)
 
-    assertThrowsAnd(classOf[IllegalStateException], m.start("foo"))(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      m.start("foo")
     )
 
-    assertThrowsAnd(classOf[IllegalStateException], m.end("foo"))(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      m.end("foo")
     )
   }
 

--- a/unit-tests/native/src/test/scala/java/util/regex/PatternTest.scala
+++ b/unit-tests/native/src/test/scala/java/util/regex/PatternTest.scala
@@ -13,7 +13,6 @@ import org.junit.Assert._
 
 import scala.scalanative.junit.utils.CollectionConverters._
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
-import org.scalanative.testsuite.utils.ThrowsHelper._
 
 class PatternTest {
 

--- a/unit-tests/native/src/test/scala/java/util/regex/PatternTest.scala
+++ b/unit-tests/native/src/test/scala/java/util/regex/PatternTest.scala
@@ -601,17 +601,25 @@ class PatternTest {
   }
 
   @Test def syntaxExceptions(): Unit = {
-    assertThrowsAnd(classOf[PatternSyntaxException], Pattern.compile("foo\\L"))(
-      e => {
-        e.getDescription == "Illegal/unsupported escape sequence" &&
-        e.getIndex == 4 &&
-        e.getPattern == "foo\\L" &&
-        e.getMessage ==
+    try {
+      Pattern.compile("foo\\L")
+    } catch {
+      case e: PatternSyntaxException =>
+        assertEquals(
+          "Illegal/unsupported escape sequence",
+          e.getDescription
+        )
+
+        assertEquals(4, e.getIndex)
+        assertEquals("foo\\L", e.getPattern)
+
+        assertEquals(
           """|Illegal/unsupported escape sequence near index 4
              |foo\L
-             |    ^""".stripMargin
-      }
-    )
+             |    ^""".stripMargin,
+          e.getMessage
+        )
+    }
 
     /// Ordered alphabetical by description (second arg).
     /// Helps ensuring that each scalanative/regex Parser description
@@ -650,13 +658,14 @@ class PatternTest {
   }
 
   private def syntax(pattern: String, description: String, index: Int): Unit = {
-    assertThrowsAnd(classOf[PatternSyntaxException], Pattern.compile(pattern))(
-      e => {
-        (e.getDescription == description) &&
-        (e.getPattern == pattern) &&
-        (e.getIndex == index)
-      }
-    )
+    try {
+      Pattern.compile(pattern)
+    } catch {
+      case e: PatternSyntaxException =>
+        assertEquals(description, e.getDescription)
+        assertEquals(pattern, e.getPattern)
+        assertEquals(index, e.getIndex)
+    }
   }
 
   private def pass(pattern: String, input: String): Unit =

--- a/unit-tests/native/src/test/scala/scala/scalanative/regex/MatcherTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/regex/MatcherTest.scala
@@ -5,7 +5,8 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalanative.testsuite.utils.ThrowsHelper._
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
 import TestUtils._
 
 // Tests are inspired by those projects under Apache2 License:
@@ -37,8 +38,10 @@ class MatcherTest {
 
     assertTrue(groupCount() == 2)
 
-    assertThrowsAnd(classOf[IllegalStateException], group())(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      group()
     )
 
     assertTrue(find())
@@ -46,8 +49,10 @@ class MatcherTest {
     assertTrue(group(0) == "a12z")
     assertTrue(group(1) == "1")
     assertTrue(group(2) == "2")
-    assertThrowsAnd(classOf[IndexOutOfBoundsException], group(42))(
-      _.getMessage == "No group 42"
+    assertThrows(
+      "No group 42",
+      classOf[IndexOutOfBoundsException],
+      group(42)
     )
 
     assertTrue(find())
@@ -63,12 +68,16 @@ class MatcherTest {
     val m = matcher("a(\\d)(\\d)z", "012345_a12z_012345")
     import m._
 
-    assertThrowsAnd(classOf[IllegalStateException], start())(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      start()
     )
 
-    assertThrowsAnd(classOf[IllegalStateException], end())(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      end()
     )
 
     assertTrue(find())
@@ -85,12 +94,16 @@ class MatcherTest {
     assertTrue(start(2) == 9)
     assertTrue(end(2) == 10)
 
-    assertThrowsAnd(classOf[IndexOutOfBoundsException], start(42))(
-      _.getMessage == "No group 42"
+    assertThrows(
+      "No group 42",
+      classOf[IndexOutOfBoundsException],
+      start(42)
     )
 
-    assertThrowsAnd(classOf[IndexOutOfBoundsException], end(42))(
-      _.getMessage == "No group 42"
+    assertThrows(
+      "No group 42",
+      classOf[IndexOutOfBoundsException],
+      end(42)
     )
 
   }
@@ -223,8 +236,10 @@ class MatcherTest {
     assertEquals(-1, m.start("nomatch"));
     assertEquals(-1, m.end("nomatch"));
 
-    assertThrowsAnd(classOf[IllegalStateException], m.group("nonexistent"))(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      m.group("nonexistent")
     )
 
     // appendReplacement
@@ -233,18 +248,16 @@ class MatcherTest {
       re2jAppendReplacement(m, "what$2ever${bag}")
     )
 
-    assertThrowsAnd(
+    assertThrows(
+      "No match available",
       classOf[IllegalStateException],
       re2jAppendReplacement(m, "what$2ever${no-final-brace ")
-    )(
-      _.getMessage == "No match available"
     )
 
-    assertThrowsAnd(
+    assertThrows(
+      "No match available",
       classOf[IllegalStateException],
       re2jAppendReplacement(m, "what$2ever${NOTbag}")
-    )(
-      _.getMessage == "No match available"
     )
   }
 
@@ -273,8 +286,10 @@ class MatcherTest {
     assertEquals(-1, m.start("nomatch"));
     assertEquals(-1, m.end("nomatch"));
 
-    assertThrowsAnd(classOf[IllegalStateException], m.group("nonexistent"))(
-      _.getMessage == "No match found"
+    assertThrows(
+      "No match found",
+      classOf[IllegalStateException],
+      m.group("nonexistent")
     )
 
     // appendReplacement
@@ -283,18 +298,16 @@ class MatcherTest {
       re2jAppendReplacement(m, "what$2ever${bag}")
     )
 
-    assertThrowsAnd(
+    assertThrows(
+      "No match available",
       classOf[IllegalStateException],
       re2jAppendReplacement(m, "what$2ever${no-final-brace ")
-    )(
-      _.getMessage == "No match available"
     )
 
-    assertThrowsAnd(
+    assertThrows(
+      "No match available",
       classOf[IllegalStateException],
       re2jAppendReplacement(m, "what$2ever${NOTbag}")
-    )(
-      _.getMessage == "No match available"
     )
   }
 

--- a/unit-tests/native/src/test/scala/scala/scalanative/regex/NamedGroupTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/regex/NamedGroupTest.scala
@@ -6,7 +6,8 @@ import scala.util.Random
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalanative.testsuite.utils.ThrowsHelper._
+import org.scalanative.testsuite.utils.AssertThrows.assertThrows
+
 import TestUtils._
 
 import scala.collection.mutable
@@ -81,12 +82,10 @@ class NamedGroupTest {
     )
     import m._
     find()
-    assertThrowsAnd(
+    assertThrows(
+      "No match available",
       classOf[IllegalStateException],
       appendReplacement(buf, "such open ${S such closed ${D}")
-    )(
-      _.getMessage == "No match available"
     )
-
   }
 }


### PR DESCRIPTION
Towards a cleaner build of Scala Native on Scala 3.2.n, Part 2. Remove instances of the now
deprecated AssertThrowsAnd method.
