### PR TITLE
Encode main class name to match outputs of the compiler

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenPhase.scala
@@ -88,7 +88,7 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
           (path, reflectiveInstBuf.toSeq)
       }.toMap
 
-      val allRegularDefns = if (generatedStaticForwarderClasses.isEmpty) {
+      val allRegularDefns = if (generatedMirrorClasses.isEmpty) {
         /* Fast path, applicable under -Xno-forwarders, as well as when all
          * the `object`s of a compilation unit have a companion class.
          */
@@ -121,9 +121,9 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
           }.toSet
 
         val staticForwarderDefns: List[nir.Defn] =
-          generatedStaticForwarderClasses
+          generatedMirrorClasses
             .collect {
-              case (site, StaticForwarderClass(classDef, forwarders)) =>
+              case (site, MirrorClass(classDef, forwarders)) =>
                 val name = caseInsensitiveNameOf(classDef)
                 if (!generatedCaseInsensitiveNames.contains(name)) {
                   classDef +: forwarders
@@ -164,7 +164,7 @@ abstract class NirGenPhase[G <: Global with Singleton](override val global: G)
         .parallel()
         .forEach(generateIRFile)
     } finally {
-      generatedStaticForwarderClasses.clear()
+      generatedMirrorClasses.clear()
     }
   }
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirCodeGen.scala
@@ -57,7 +57,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
       genCompilationUnit(ctx.compilationUnit)
     } finally {
       generatedDefns.clear()
-      generatedStaticForwarderClasses.clear()
+      generatedMirrorClasses.clear()
       reflectiveInstantiationBuffers.clear()
     }
   }
@@ -84,7 +84,7 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
       .groupMapReduce(buf => getFileFor(cunit, buf.name.top))(_.toSeq)(_ ++ _)
       .foreach(genIRFile(_, _))
 
-    if (generatedStaticForwarderClasses.nonEmpty) {
+    if (generatedMirrorClasses.nonEmpty) {
       // Ported from Scala.js
       /* #4148 Add generated static forwarder classes, except those that
        * would collide with regular classes on case insensitive file systems.
@@ -108,8 +108,8 @@ class NirCodeGen(val settings: GenNIR.Settings)(using ctx: Context)
           case cls: Defn.Class => caseInsensitiveNameOf(cls)
         }.toSet
 
-      for ((site, staticCls) <- generatedStaticForwarderClasses) {
-        val StaticForwarderClass(classDef, forwarders) = staticCls
+      for ((site, staticCls) <- generatedMirrorClasses) {
+        val MirrorClass(classDef, forwarders) = staticCls
         val caseInsensitiveName = caseInsensitiveNameOf(classDef)
         if (!generatedCaseInsensitiveNames.contains(caseInsensitiveName)) {
           val file = getFileFor(cunit, classDef.name)

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenStat.scala
@@ -26,10 +26,10 @@ trait NirGenStat(using Context) {
   import positionsConversions.fromSpan
 
   protected val generatedDefns = mutable.UnrolledBuffer.empty[nir.Defn]
-  protected val generatedStaticForwarderClasses =
-    mutable.Map.empty[Symbol, StaticForwarderClass]
+  protected val generatedMirrorClasses =
+    mutable.Map.empty[Symbol, MirrorClass]
 
-  protected case class StaticForwarderClass(
+  protected case class MirrorClass(
       defn: nir.Defn.Class,
       forwarders: Seq[nir.Defn.Define]
   )
@@ -66,6 +66,7 @@ trait NirGenStat(using Context) {
     genClassFields(td)
     genMethods(td)
     genReflectiveInstantiation(td)
+    genMirrorClass(td)
   }
 
   private def genClassAttrs(td: TypeDef): nir.Attrs = {
@@ -583,23 +584,35 @@ trait NirGenStat(using Context) {
   ): Seq[Defn] = {
     val sym = td.symbol
     if !isCandidateForForwarders(sym) then Nil
-    else if sym.isStaticModule then {
-      if !sym.linkedClass.exists then {
-        val forwarders = genStaticForwardersFromModuleClass(Nil, sym)
-        if (forwarders.nonEmpty) {
-          given pos: nir.Position = td.span
-          val classDefn = Defn.Class(
-            attrs = Attrs.None,
-            name = Global.Top(genTypeName(sym).id.stripSuffix("$")),
-            parent = Some(Rt.Object.name),
-            traits = Nil
-          )
-          val forwarderClass = StaticForwarderClass(classDefn, forwarders)
-          generatedStaticForwarderClasses += sym -> forwarderClass
-        }
-      }
-      Nil
-    } else genStaticForwardersForClassOrInterface(existingMethods, sym)
+    else if sym.isStaticModule then Nil
+    else genStaticForwardersForClassOrInterface(existingMethods, sym)
   }
 
+  /** Create a mirror class for top level module that has no defined companion
+   *  class. A mirror class is a class containing only static methods that
+   *  forward to the corresponding method on the MODULE instance of the given
+   *  Scala object. It will only be generated if there is no companion class: if
+   *  there is, an attempt will instead be made to add the forwarder methods to
+   *  the companion class.
+   */
+  private def genMirrorClass(td: TypeDef): Unit = {
+    given pos: nir.Position = td.span
+    val sym = td.symbol
+    val isTopLevelModuleClass = sym.is(ModuleClass) &&
+      atPhase(flattenPhase) {
+        toDenot(sym).owner.is(PackageClass)
+      }
+    if isTopLevelModuleClass && sym.companionClass == NoSymbol then {
+      val classDefn = Defn.Class(
+        attrs = Attrs.None,
+        name = Global.Top(genTypeName(sym).id.stripSuffix("$")),
+        parent = Some(Rt.Object.name),
+        traits = Nil
+      )
+      generatedMirrorClasses += sym -> MirrorClass(
+        classDefn,
+        genStaticForwardersFromModuleClass(Nil, sym)
+      )
+    }
+  }
 }

--- a/tools/src/main/scala/scala/scalanative/build/core/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/core/ScalaNative.scala
@@ -17,8 +17,7 @@ private[scalanative] object ScalaNative {
   /** Compute all globals that must be reachable based on given configuration.
    */
   def entries(config: Config): Seq[Global] = {
-    val mainClass = Global.Top(config.mainClass)
-    val entry = mainClass.member(Rt.ScalaMainSig)
+    val entry = encodedMainClass(config).member(Rt.ScalaMainSig)
     entry +: CodeGen.depends
   }
 
@@ -178,4 +177,35 @@ private[scalanative] object ScalaNative {
       }
     }
   }
+
+  private[scalanative] def encodedMainClass(config: build.Config): Global.Top =
+    Global.Top(encodeClassName(config.mainClass))
+
+  private def encodeClassName(className: String): String = {
+    // Based on https://github.com/scala/scala/blob/b8b6c05efce99611b4a8e558260c7f74e6196b97/src/library/scala/reflect/NameTransformer.scala#L44-L97
+    className.flatMap {
+      case '~'  => "$tilde"
+      case '='  => "$eq"
+      case '<'  => "$less"
+      case '>'  => "$greater"
+      case '!'  => "$bang"
+      case '#'  => "$hash"
+      case '%'  => "$percent"
+      case '^'  => "$up"
+      case '&'  => "$amp"
+      case '|'  => "$bar"
+      case '*'  => "$times"
+      case '/'  => "$div"
+      case '+'  => "$plus"
+      case '-'  => "$minus"
+      case ':'  => "$colon"
+      case '\\' => "$bslash"
+      case '?'  => "$qmark"
+      case '@'  => "$at"
+      case c =>
+        if (!Character.isJavaIdentifierPart(c)) "$u%04X".format(c.toInt)
+        else c.toString
+    }
+  }
+
 }

--- a/tools/src/main/scala/scala/scalanative/build/core/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/core/ScalaNative.scala
@@ -178,34 +178,9 @@ private[scalanative] object ScalaNative {
     }
   }
 
-  private[scalanative] def encodedMainClass(config: build.Config): Global.Top =
-    Global.Top(encodeClassName(config.mainClass))
-
-  private def encodeClassName(className: String): String = {
-    // Based on https://github.com/scala/scala/blob/b8b6c05efce99611b4a8e558260c7f74e6196b97/src/library/scala/reflect/NameTransformer.scala#L44-L97
-    className.flatMap {
-      case '~'  => "$tilde"
-      case '='  => "$eq"
-      case '<'  => "$less"
-      case '>'  => "$greater"
-      case '!'  => "$bang"
-      case '#'  => "$hash"
-      case '%'  => "$percent"
-      case '^'  => "$up"
-      case '&'  => "$amp"
-      case '|'  => "$bar"
-      case '*'  => "$times"
-      case '/'  => "$div"
-      case '+'  => "$plus"
-      case '-'  => "$minus"
-      case ':'  => "$colon"
-      case '\\' => "$bslash"
-      case '?'  => "$qmark"
-      case '@'  => "$at"
-      case c =>
-        if (!Character.isJavaIdentifierPart(c)) "$u%04X".format(c.toInt)
-        else c.toString
-    }
+  private[scalanative] def encodedMainClass(config: Config): Global.Top = {
+    import scala.reflect.NameTransformer.encode
+    Global.Top(encode(config.mainClass))
   }
 
 }

--- a/tools/src/main/scala/scala/scalanative/build/core/ScalaNative.scala
+++ b/tools/src/main/scala/scala/scalanative/build/core/ScalaNative.scala
@@ -180,7 +180,8 @@ private[scalanative] object ScalaNative {
 
   private[scalanative] def encodedMainClass(config: Config): Global.Top = {
     import scala.reflect.NameTransformer.encode
-    Global.Top(encode(config.mainClass))
+    val encoded = config.mainClass.split('.').map(encode).mkString(".")
+    Global.Top(encoded)
   }
 
 }

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -5,7 +5,7 @@ import java.io.File
 import java.nio.file.{Path, Paths}
 import scala.collection.mutable
 import scala.scalanative.build.{Config, IncCompilationContext}
-import scala.scalanative.build.core.ScalaNative.dumpDefns
+import scala.scalanative.build.core.ScalaNative.{dumpDefns, encodedMainClass}
 import scala.scalanative.io.VirtualDirectory
 import scala.scalanative.nir._
 import scala.scalanative.util.{Scope, partitionBy, procs}
@@ -23,7 +23,7 @@ object CodeGen {
     implicit val meta: Metadata =
       new Metadata(linked, proxies, config.compilerConfig.is32BitPlatform)
 
-    val generated = Generate(Global.Top(config.mainClass), defns ++ proxies)
+    val generated = Generate(encodedMainClass(config), defns ++ proxies)
     val embedded = ResourceEmbedder(config)
     val lowered = lower(generated ++ embedded)
     dumpDefns(config, "lowered", lowered)

--- a/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
+++ b/tools/src/test/scala/scala/scalanative/NIRCompilerTest.scala
@@ -33,20 +33,8 @@ class NIRCompilerTest extends AnyFlatSpec with Matchers with Inspectors {
         val nirFiles =
           compiler.compile(sourcesDir) filter (Files
             .isRegularFile(_)) map (_.getFileName.toString)
-        val expectedNames =
-          Seq(
-            "A.class",
-            "A.nir",
-            "B.class",
-            "B.nir",
-            "C.class",
-            "C.nir",
-            "D.class",
-            "D.nir",
-            "E$.class",
-            "E$.nir",
-            "E.class"
-          )
+        val expectedNames = Seq("A", "B", "C", "D", "E", "E$")
+          .flatMap(name => Seq(s"$name.class", s"$name.nir"))
         nirFiles should contain theSameElementsAs expectedNames
     }
   }

--- a/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
@@ -6,19 +6,33 @@ import scala.scalanative.LinkerSpec
 import org.scalatest.matchers.should._
 
 class IssuesSpec extends LinkerSpec with Matchers {
-  private val mainClass = "Test$"
+  private val mainClass = "Test"
   private val sourceFile = "Test.scala"
 
-  private def testLinked(source: String)(fn: Result => Unit): Unit =
-    link("Test", sources = Map("Test.scala" -> source)) {
+  private def testLinked(source: String, mainClass: String = mainClass)(
+      fn: Result => Unit
+  ): Unit =
+    link(mainClass, sources = Map("Test.scala" -> source)) {
       case (_, result) => fn(result)
     }
 
-  private def checkNoLinkageErrors(source: String) =
-    testLinked(source.stripMargin) { result =>
+  private def checkNoLinkageErrors(
+      source: String,
+      mainClass: String = mainClass
+  ) =
+    testLinked(source.stripMargin, mainClass) { result =>
       val erros = Check(result)
       erros shouldBe empty
     }
+
+  "Issue #2790" should "link main classes using encoded characters" in {
+    // All encoded character and an example of unciode encode character '.'
+    val mainClass = raw"Test-native~=<>!#%^&|*/+-:'?@.sc"
+    checkNoLinkageErrors(
+      mainClass = mainClass,
+      source = s"object `$mainClass`{ def main(args: Array[String]) = () }"
+    )
+  }
 
   "Issue #2880" should "handle lambas correctly" in checkNoLinkageErrors {
     """

--- a/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
+++ b/tools/src/test/scala/scala/scalanative/linker/IssuesSpec.scala
@@ -26,11 +26,17 @@ class IssuesSpec extends LinkerSpec with Matchers {
     }
 
   "Issue #2790" should "link main classes using encoded characters" in {
-    // All encoded character and an example of unciode encode character '.'
-    val mainClass = raw"Test-native~=<>!#%^&|*/+-:'?@.sc"
+    // All encoded character and an example of unciode encode character ';'
+    val packageName = "foo.`b~a-r`.`b;a;z`"
+    val mainClass = raw"Test-native~=<>!#%^&|*/+-:'?@;sc"
+    val fqcn = s"$packageName.$mainClass".replace("`", "")
     checkNoLinkageErrors(
-      mainClass = mainClass,
-      source = s"object `$mainClass`{ def main(args: Array[String]) = () }"
+      mainClass = fqcn,
+      source = s"""package $packageName
+      |object `$mainClass`{ 
+      |  def main(args: Array[String]) = () 
+      |}
+      |""".stripMargin
     )
   }
 


### PR DESCRIPTION
Fixes #2790 

A special character like `-` can be encoded by the compiler to `$minus`. Main class name returned by sbt mainClass task was containing a row, not encoding the name of the class. This PR applies the same encoding algorithm as compiler for the main class to fix issues with missing definitions.