### PR TITLE
Get rid of compilation warnings in tests using Scala 3

### DIFF
--- a/javalib/src/main/scala/java/util/Hashtable.scala
+++ b/javalib/src/main/scala/java/util/Hashtable.scala
@@ -91,20 +91,20 @@ class Hashtable[K, V] private (inner: mutable.HashMap[Box[Any], V])
     b
   }
 
-  def entrySet(): ju.Set[ju.Map.Entry[K, V]] = {
-    class UnboxedEntry(
-        private[UnboxedEntry] val boxedEntry: ju.Map.Entry[Box[Any], V]
-    ) extends ju.Map.Entry[K, V] {
-      def getKey(): K = boxedEntry.getKey().inner.asInstanceOf[K]
-      def getValue(): V = boxedEntry.getValue()
-      def setValue(value: V): V = boxedEntry.setValue(value)
-      override def equals(o: Any): Boolean = o match {
-        case o: UnboxedEntry => boxedEntry.equals(o.boxedEntry)
-        case _               => false
-      }
-      override def hashCode(): Int = boxedEntry.hashCode()
+  private class UnboxedEntry(
+      private[UnboxedEntry] val boxedEntry: ju.Map.Entry[Box[Any], V]
+  ) extends ju.Map.Entry[K, V] {
+    def getKey(): K = boxedEntry.getKey().inner.asInstanceOf[K]
+    def getValue(): V = boxedEntry.getValue()
+    def setValue(value: V): V = boxedEntry.setValue(value)
+    override def equals(o: Any): Boolean = o match {
+      case o: UnboxedEntry => boxedEntry.equals(o.boxedEntry)
+      case _               => false
     }
+    override def hashCode(): Int = boxedEntry.hashCode()
+  }
 
+  def entrySet(): ju.Set[ju.Map.Entry[K, V]] = {
     val entries = new LinkedHashSet[ju.Map.Entry[K, V]]
     inner.foreach {
       case (key, value) =>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -317,6 +317,8 @@ object Build {
       buildInfoSettings,
       noPublishSettings,
       testsCommonSettings,
+      // To silence warnings when testing ScalaNative specific features
+      scalacOptions -= "-Xfatal-warnings",
       sharedTestSource(withBlacklist = false),
       javaVersionSharedTestSources,
       nativeConfig ~= { c =>

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -260,7 +260,6 @@ object Settings {
   lazy val testsCommonSettings = Def.settings(
     scalacOptions -= "-deprecation",
     scalacOptions ++= Seq("-deprecation:false"),
-    scalacOptions -= "-Xfatal-warnings",
     Test / testOptions ++= Seq(
       Tests.Argument(TestFrameworks.JUnit, "-a", "-s", "-v")
     ),

--- a/unit-tests/shared/src/test/scala-2.11/scala/annotation/nowarn.scala
+++ b/unit-tests/shared/src/test/scala-2.11/scala/annotation/nowarn.scala
@@ -1,0 +1,4 @@
+package scala.annotation
+
+// Mock of nowarn annotations to allow cross-compilation with Scala 2.11
+class nowarn extends StaticAnnotation

--- a/unit-tests/shared/src/test/scala/javalib/io/DataInputStreamTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/io/DataInputStreamTest.scala
@@ -287,7 +287,7 @@ trait DataInputStreamTest {
     assertEquals(-1, stream.read())
   }
 
-  @Test def readLine(): Unit = {
+  @deprecated @Test def readLine(): Unit = {
     val stream = newStream(
       "Hello World\nUNIX\nWindows\r\nMac (old)\rStuff".map(_.toInt): _*
     )
@@ -300,7 +300,7 @@ trait DataInputStreamTest {
     assertEquals(null, stream.readLine())
   }
 
-  @Test def markReadLinePushBack(): Unit = {
+  @deprecated @Test def markReadLinePushBack(): Unit = {
     assumeNotJVMCompliant()
 
     val stream = newStream(

--- a/unit-tests/shared/src/test/scala/javalib/lang/IterableTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/IterableTest.scala
@@ -54,7 +54,7 @@ class IterableDefaultTest extends IterableTest {
     def fromElements[E: ClassTag](elems: E*): JIterable[E] = {
       new JIterable[E] {
         override def iterator(): ju.Iterator[E] = {
-          val l: Iterator[E] = elems.toIterator
+          val l: Iterator[E] = elems.iterator
           new ju.Iterator[E] {
             override def hasNext(): Boolean = l.hasNext
             override def next(): E = l.next()

--- a/unit-tests/shared/src/test/scala/javalib/lang/ScalaNumberTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/ScalaNumberTest.scala
@@ -7,7 +7,7 @@ import java.lang._
 import org.junit.Test
 import org.junit.Assert._
 
-class ScalaNumberTest {
+@deprecated class ScalaNumberTest {
 
   @Test def bigIntEqualEqualBigInt(): Unit = {
     val token = 2047L

--- a/unit-tests/shared/src/test/scala/javalib/util/ArraysTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/ArraysTest.scala
@@ -988,7 +988,9 @@ class ArraysTest {
     assertFalse(Arrays.equals(a1, Array[Double](1.1, -7.4, 10.0, 20.0)))
   }
 
-  @Test def equals_AnyRefs(): Unit = {
+  // An object with model for `equals_AnyRefs` test.
+  // Extracted due to runtime type-test warnings in Scala 3.2.1+
+  private object EqualsAnyRefs {
     // scalastyle:off equals.hash.code
     class A(private val x: Int) {
       override def equals(that: Any): Boolean = that match {
@@ -997,7 +999,10 @@ class ArraysTest {
       }
     }
     // scalastyle:on equals.hash.code
+  }
 
+  @Test def equals_AnyRefs(): Unit = {
+    import EqualsAnyRefs._
     def A(x: Int): A = new A(x)
 
     val a1 = Array[AnyRef](A(1), A(-7), A(10))

--- a/unit-tests/shared/src/test/scala/javalib/util/PropertiesTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/PropertiesTest.scala
@@ -178,7 +178,7 @@ class PropertiesTest {
     assertThrows(classOf[NullPointerException], properties.put("any", null))
   }
 
-  @Test def nonStringValues(): Unit = {
+  @deprecated @Test def nonStringValues(): Unit = {
     val properties = new Properties
 
     properties.put("age", new Integer(18))

--- a/unit-tests/shared/src/test/scala/javalib/util/jar/AttributesTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/util/jar/AttributesTest.scala
@@ -39,7 +39,7 @@ class AttributesTest {
     assertFalse(a.containsKey("1"))
   }
 
-  @Test def containsKeyObject(): Unit = {
+  @deprecated @Test def containsKeyObject(): Unit = {
     assertFalse(a.containsKey(new Integer(1)))
     assertFalse(a.containsKey("0"))
     assertTrue(a.containsKey(new Attributes.Name("1")))

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/math/BigDecimalArithmeticTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/math/BigDecimalArithmeticTest.scala
@@ -17,7 +17,7 @@ import org.junit.Assert._
 import org.scalanative.testsuite.utils.AssertThrows.assertThrows
 import org.scalanative.testsuite.utils.Platform.executingInJVM
 
-class BigDecimalArithmeticTest {
+@deprecated class BigDecimalArithmeticTest {
 
   @Test def testAddDiffScaleNegPos(): Unit = {
     val a = "1231212478987482988429808779810457634781384756794987"

--- a/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/math/BigDecimalScaleOperationsTest.scala
+++ b/unit-tests/shared/src/test/scala/org/scalanative/testsuite/javalib/math/BigDecimalScaleOperationsTest.scala
@@ -14,7 +14,7 @@ import java.math._
 import org.junit.Test
 import org.junit.Assert._
 
-class BigDecimalScaleOperationsTest {
+@deprecated class BigDecimalScaleOperationsTest {
 
   @Test def testScaleByPowerOfTen(): Unit = {
     val bd = BigDecimal.ONE.scaleByPowerOfTen(1)

--- a/unit-tests/shared/src/test/scala/scala/IsInstanceOfTest.scala
+++ b/unit-tests/shared/src/test/scala/scala/IsInstanceOfTest.scala
@@ -2,6 +2,7 @@ package scala
 
 import org.junit.Test
 import org.junit.Assert._
+import scala.annotation.nowarn
 
 class IsInstanceOfTest {
 
@@ -15,7 +16,7 @@ class IsInstanceOfTest {
   }
 
   @Test def expectsLiteralNullIsInstanceOfStringEqEqFalse(): Unit = {
-    assertFalse(null.isInstanceOf[String])
+    assertFalse(null.isInstanceOf[String]: @nowarn)
   }
 
   @Test def expectsEmptyStringIsInstanceOfStringEqEqTrue(): Unit = {

--- a/unit-tests/shared/src/test/scala/scala/ShiftOverflowTest.scala
+++ b/unit-tests/shared/src/test/scala/scala/ShiftOverflowTest.scala
@@ -3,7 +3,7 @@ package scala
 import org.junit.Test
 import org.junit.Assert._
 
-class ShiftOverflowTest {
+@deprecated class ShiftOverflowTest {
   @noinline def noinlineByte42: Byte = 42.toByte
   @noinline def noinlineShort42: Short = 42.toShort
   @noinline def noinlineChar42: Char = 42.toChar


### PR DESCRIPTION
* Local classes were moved to the outer scope - fixes #2952
* Added `@deprecated` annotations to tests using deprecated syntax
* Reenabled `-Xfatal-warnings` in `testsJVM` projects. Warnings are still accepted in `tests` due to warnings in tests of unsafe features.