### PR TITLE
Upgrade to 3.6.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,7 +3,7 @@
 # settings is preferred over adding especially as
 # the Scala language evolves and styles change.
 # Test upgrades: $ scripts/scalafmt --test 2> diff.txt
-version = 3.5.9
+version = 3.6.1
 docstrings.style = AsteriskSpace
 project.git = true
 project.excludePaths = [
@@ -13,6 +13,8 @@ project.excludePaths = [
 ]
 # Default runner.dialect is deprecated now, needs to be explicitly set
 runner.dialect = scala213
+# Added for CI error via --test option
+runner.fatalWarnings = true
 # This creates less of a diff but is not default
 # but is more aligned with Scala.js syntax.
 newlines.beforeCurlyLambdaParams = multilineWithCaseOnly


### PR DESCRIPTION
This addresses the shebang issue in the scala-cli script that was removed. Adds an option to make sure CI errors with format warning/error using the `--test` option to fix that complaint.