### PR TITLE
Fix #2893: Implement posixlib wait.scala

### DIFF
--- a/posixlib/src/main/resources/scala-native/sys/wait.c
+++ b/posixlib/src/main/resources/scala-native/sys/wait.c
@@ -25,9 +25,7 @@ int scalanative_c_wstopped() { return WSTOPPED; }
 // POSIX "Macros"
 int scalanative_c_wexitstatus(int wstatus) { return WEXITSTATUS(wstatus); }
 
-bool scalanative_c_wifcontinued(int wstatus) {
-    return WIFCONTINUED(wstatus);
-}
+bool scalanative_c_wifcontinued(int wstatus) { return WIFCONTINUED(wstatus); }
 
 bool scalanative_c_wifexited(int wstatus) { return WIFEXITED(wstatus); }
 

--- a/posixlib/src/main/resources/scala-native/sys/wait.c
+++ b/posixlib/src/main/resources/scala-native/sys/wait.c
@@ -6,26 +6,28 @@
 
 // Symbolic constants, roughly in POSIX declaration order
 
-// idtype_t   
-int scalanative_posix_p_all(){ return P_ALL; }   // POSIX enum: idtype_t
-int scalanative_posix_p_pgid(){ return P_PGID; } // POSIX enum: idtype_t
-int scalanative_posix_p_pid(){ return P_PID; }   // POSIX enum: idtype_t
+// idtype_t
+int scalanative_posix_p_all() { return P_ALL; }   // POSIX enum: idtype_t
+int scalanative_posix_p_pgid() { return P_PGID; } // POSIX enum: idtype_t
+int scalanative_posix_p_pid() { return P_PID; }   // POSIX enum: idtype_t
 
-// "constants" for waitpid()   
+// "constants" for waitpid()
 
 int scalanative_posix_wcontinued() { return WCONTINUED; }
 int scalanative_posix_wnohang() { return WNOHANG; }
 int scalanative_posix_wuntraced() { return WUNTRACED; }
 
-// "constants" for waitid() options                                         
-int scalanative_posix_wexited() { return WEXITED;  }
+// "constants" for waitid() options
+int scalanative_posix_wexited() { return WEXITED; }
 int scalanative_posix_wnowait() { return WNOWAIT; }
 int scalanative_posix_wstopped() { return WSTOPPED; }
 
 // POSIX "Macros"
 int scalanative_posix_wexitstatus(int wstatus) { return WEXITSTATUS(wstatus); }
 
-bool scalanative_posix_wifcontinued(int wstatus) { return WIFCONTINUED(wstatus); }
+bool scalanative_posix_wifcontinued(int wstatus) {
+    return WIFCONTINUED(wstatus);
+}
 
 bool scalanative_posix_wifexited(int wstatus) { return WIFEXITED(wstatus); }
 

--- a/posixlib/src/main/resources/scala-native/sys/wait.c
+++ b/posixlib/src/main/resources/scala-native/sys/wait.c
@@ -1,0 +1,40 @@
+#if !defined(_WIN32)
+
+#include <stdbool.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+// Symbolic constants, roughly in POSIX declaration order
+
+// idtype_t   
+int scalanative_posix_p_all(){ return P_ALL; }   // POSIX enum: idtype_t
+int scalanative_posix_p_pgid(){ return P_PGID; } // POSIX enum: idtype_t
+int scalanative_posix_p_pid(){ return P_PID; }   // POSIX enum: idtype_t
+
+// "constants" for waitpid()   
+
+int scalanative_posix_wcontinued() { return WCONTINUED; }
+int scalanative_posix_wnohang() { return WNOHANG; }
+int scalanative_posix_wuntraced() { return WUNTRACED; }
+
+// "constants" for waitid() options                                         
+int scalanative_posix_wexited() { return WEXITED;  }
+int scalanative_posix_wnowait() { return WNOWAIT; }
+int scalanative_posix_wstopped() { return WSTOPPED; }
+
+// POSIX "Macros"
+int scalanative_posix_wexitstatus(int wstatus) { return WEXITSTATUS(wstatus); }
+
+bool scalanative_posix_wifcontinued(int wstatus) { return WIFCONTINUED(wstatus); }
+
+bool scalanative_posix_wifexited(int wstatus) { return WIFEXITED(wstatus); }
+
+bool scalanative_posix_wifsignaled(int wstatus) { return WIFSIGNALED(wstatus); }
+
+bool scalanative_posix_wifstopped(int wstatus) { return WIFSTOPPED(wstatus); }
+
+int scalanative_posix_wstopsig(int wstatus) { return WSTOPSIG(wstatus); }
+
+int scalanative_posix_wtermsig(int wstatus) { return WTERMSIG(wstatus); }
+
+#endif // !_WIN32

--- a/posixlib/src/main/resources/scala-native/sys/wait.c
+++ b/posixlib/src/main/resources/scala-native/sys/wait.c
@@ -7,36 +7,36 @@
 // Symbolic constants, roughly in POSIX declaration order
 
 // idtype_t
-int scalanative_posix_p_all() { return P_ALL; }   // POSIX enum: idtype_t
-int scalanative_posix_p_pgid() { return P_PGID; } // POSIX enum: idtype_t
-int scalanative_posix_p_pid() { return P_PID; }   // POSIX enum: idtype_t
+int scalanative_c_p_all() { return P_ALL; }   // POSIX enum: idtype_t
+int scalanative_c_p_pgid() { return P_PGID; } // POSIX enum: idtype_t
+int scalanative_c_p_pid() { return P_PID; }   // POSIX enum: idtype_t
 
 // "constants" for waitpid()
 
-int scalanative_posix_wcontinued() { return WCONTINUED; }
-int scalanative_posix_wnohang() { return WNOHANG; }
-int scalanative_posix_wuntraced() { return WUNTRACED; }
+int scalanative_c_wcontinued() { return WCONTINUED; }
+int scalanative_c_wnohang() { return WNOHANG; }
+int scalanative_c_wuntraced() { return WUNTRACED; }
 
 // "constants" for waitid() options
-int scalanative_posix_wexited() { return WEXITED; }
-int scalanative_posix_wnowait() { return WNOWAIT; }
-int scalanative_posix_wstopped() { return WSTOPPED; }
+int scalanative_c_wexited() { return WEXITED; }
+int scalanative_c_wnowait() { return WNOWAIT; }
+int scalanative_c_wstopped() { return WSTOPPED; }
 
 // POSIX "Macros"
-int scalanative_posix_wexitstatus(int wstatus) { return WEXITSTATUS(wstatus); }
+int scalanative_c_wexitstatus(int wstatus) { return WEXITSTATUS(wstatus); }
 
-bool scalanative_posix_wifcontinued(int wstatus) {
+bool scalanative_c_wifcontinued(int wstatus) {
     return WIFCONTINUED(wstatus);
 }
 
-bool scalanative_posix_wifexited(int wstatus) { return WIFEXITED(wstatus); }
+bool scalanative_c_wifexited(int wstatus) { return WIFEXITED(wstatus); }
 
-bool scalanative_posix_wifsignaled(int wstatus) { return WIFSIGNALED(wstatus); }
+bool scalanative_c_wifsignaled(int wstatus) { return WIFSIGNALED(wstatus); }
 
-bool scalanative_posix_wifstopped(int wstatus) { return WIFSTOPPED(wstatus); }
+bool scalanative_c_wifstopped(int wstatus) { return WIFSTOPPED(wstatus); }
 
-int scalanative_posix_wstopsig(int wstatus) { return WSTOPSIG(wstatus); }
+int scalanative_c_wstopsig(int wstatus) { return WSTOPSIG(wstatus); }
 
-int scalanative_posix_wtermsig(int wstatus) { return WTERMSIG(wstatus); }
+int scalanative_c_wtermsig(int wstatus) { return WTERMSIG(wstatus); }
 
 #endif // !_WIN32

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
@@ -13,6 +13,20 @@ import scalanative.posix.signal
  *
  *  A method with an XSI comment indicates it is defined in extended POSIX
  *  X/Open System Interfaces, not base POSIX.
+ *
+ *  Note well: It is neither expect nor obvious from the declaration that the
+ *  wait() method of this class can conflict with Object.wait(Long). This makes
+ *  declaration and usage more difficult.
+ *
+ *  The simplest approach is to avoid "wait(Ptr[CInt])" and use the directly
+ *  equivalent idiom: // import scala.scalanative.posix.sys.wait.waitpid // or
+ *  sys.wait._ // Replace Ptr[CInt] with your variable. val status = waitpid(-1,
+ *  Ptr[CInt], 0)
+ *
+ *  If that approach is not available, one can try the following idiom: //
+ *  import scalanative.posix.sys.{wait => Wait} // import
+ *  scalanative.posix.sys.wait._ // for WIFEXITED etc. // Replace Ptr[CInt] with
+ *  your variable. val status = Wait.wait(Ptr[CInt])
  */
 @extern
 object wait {
@@ -86,6 +100,8 @@ object wait {
 
 // Methods
 
+  /** See declaration & usage note in class description.
+   */
   def wait(status: Ptr[CInt]): pid_t = extern
 
   def waitid(

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
@@ -39,14 +39,14 @@ object wait {
   /* The type idtype_t shall be defined as an enumeration type whose possible
    * values shall include at least the following: P_ALL P_PGID P_PID
    */
-  type idtype_t = Int // POSIX enumeration in simple Scala common to 2.n & 3.n
-  @name("scalanative_posix_p_all")
+  type idtype_t = CInt // POSIX enumeration in simple Scala common to 2.n & 3.n
+  @name("scalanative_c_p_all")
   def P_ALL: CInt = extern
 
-  @name("scalanative_posix_p_pgid")
+  @name("scalanative_c_p_pgid")
   def P_PGID: CInt = extern
 
-  @name("scalanative_posix_p_pid")
+  @name("scalanative_c_p_pid")
   def P_PID: CInt = extern
 
 // Symbolic constants, roughly in POSIX declaration order
@@ -55,47 +55,47 @@ object wait {
 
   /** XSI
    */
-  @name("scalanative_posix_wcontinued")
+  @name("scalanative_c_wcontinued")
   def WCONTINUED: CInt = extern
 
-  @name("scalanative_posix_wnohang")
+  @name("scalanative_c_wnohang")
   def WNOHANG: CInt = extern
 
-  @name("scalanative_posix_wuntraced")
+  @name("scalanative_c_wuntraced")
   def WUNTRACED: CInt = extern
 
   // "constants" for waitid()
-  @name("scalanative_posix_wexited")
+  @name("scalanative_c_wexited")
   def WEXITED: CInt = extern
 
-  @name("scalanative_posix_wnowait")
+  @name("scalanative_c_wnowait")
   def WNOWAIT: CInt = extern
 
-  @name("scalanative_posix_wstopped")
+  @name("scalanative_c_wstopped")
   def WSTOPPED: CInt = extern
 
 // POSIX "Macros"
-  @name("scalanative_posix_wexitstatus")
+  @name("scalanative_c_wexitstatus")
   def WEXITSTATUS(wstatus: CInt): CInt = extern
 
   /** XSI
    */
-  @name("scalanative_posix_wifcontinued")
+  @name("scalanative_c_wifcontinued")
   def WIFCONTINUED(wstatus: CInt): CInt = extern
 
-  @name("scalanative_posix_wifexited")
+  @name("scalanative_c_wifexited")
   def WIFEXITED(wstatus: CInt): Boolean = extern
 
-  @name("scalanative_posix_wifsignaled")
+  @name("scalanative_c_wifsignaled")
   def WIFSIGNALED(wstatus: CInt): Boolean = extern
 
-  @name("scalanative_posix_wifstopped")
+  @name("scalanative_c_wifstopped")
   def WIFSTOPPED(wstatus: CInt): Boolean = extern
 
-  @name("scalanative_posix_wstopsig")
+  @name("scalanative_c_wstopsig")
   def WSTOPSIG(wstatus: CInt): Boolean = extern
 
-  @name("scalanative_posix_wtermsig")
+  @name("scalanative_c_wtermsig")
   def WTERMSIG(wstatus: CInt): CInt = extern
 
 // Methods

--- a/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/sys/wait.scala
@@ -1,0 +1,100 @@
+package scala.scalanative
+package posix
+package sys
+
+import scalanative.unsafe._
+
+import scalanative.posix.signal
+
+/** POSIX wait.h for Scala
+ *
+ *  The Open Group Base Specifications
+ *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
+ *
+ *  A method with an XSI comment indicates it is defined in extended POSIX
+ *  X/Open System Interfaces, not base POSIX.
+ */
+@extern
+object wait {
+  type id_t = types.id_t
+  type pid_t = types.pid_t
+
+  type sigval = signal.sigval
+  type siginfo_t = signal.siginfo_t
+
+  /* The type idtype_t shall be defined as an enumeration type whose possible
+   * values shall include at least the following: P_ALL P_PGID P_PID
+   */
+  type idtype_t = Int // POSIX enumeration in simple Scala common to 2.n & 3.n
+  @name("scalanative_posix_p_all")
+  def P_ALL: CInt = extern
+
+  @name("scalanative_posix_p_pgid")
+  def P_PGID: CInt = extern
+
+  @name("scalanative_posix_p_pid")
+  def P_PID: CInt = extern
+
+// Symbolic constants, roughly in POSIX declaration order
+
+  // "constants" for waitpid() options
+
+  /** XSI
+   */
+  @name("scalanative_posix_wcontinued")
+  def WCONTINUED: CInt = extern
+
+  @name("scalanative_posix_wnohang")
+  def WNOHANG: CInt = extern
+
+  @name("scalanative_posix_wuntraced")
+  def WUNTRACED: CInt = extern
+
+  // "constants" for waitid()
+  @name("scalanative_posix_wexited")
+  def WEXITED: CInt = extern
+
+  @name("scalanative_posix_wnowait")
+  def WNOWAIT: CInt = extern
+
+  @name("scalanative_posix_wstopped")
+  def WSTOPPED: CInt = extern
+
+// POSIX "Macros"
+  @name("scalanative_posix_wexitstatus")
+  def WEXITSTATUS(wstatus: CInt): CInt = extern
+
+  /** XSI
+   */
+  @name("scalanative_posix_wifcontinued")
+  def WIFCONTINUED(wstatus: CInt): CInt = extern
+
+  @name("scalanative_posix_wifexited")
+  def WIFEXITED(wstatus: CInt): Boolean = extern
+
+  @name("scalanative_posix_wifsignaled")
+  def WIFSIGNALED(wstatus: CInt): Boolean = extern
+
+  @name("scalanative_posix_wifstopped")
+  def WIFSTOPPED(wstatus: CInt): Boolean = extern
+
+  @name("scalanative_posix_wstopsig")
+  def WSTOPSIG(wstatus: CInt): Boolean = extern
+
+  @name("scalanative_posix_wtermsig")
+  def WTERMSIG(wstatus: CInt): CInt = extern
+
+// Methods
+
+  def wait(status: Ptr[CInt]): pid_t = extern
+
+  def waitid(
+      idtype: idtype_t,
+      id: id_t,
+      status: Ptr[CInt],
+      options: CInt
+  ): CInt = extern
+
+  def waitpid(pid: pid_t, status: Ptr[CInt], options: CInt): pid_t = extern
+
+}

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/WaitTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/WaitTest.scala
@@ -2,9 +2,11 @@ package scala.scalanative.posix
 package sys
 
 import scala.scalanative.unsafe._
-import scalanative.unsigned.UnsignedRichInt
+import scala.scalanative.unsigned.UnsignedRichInt
 
 import scala.scalanative.posix.sys.wait._
+
+import scala.scalanative.meta.LinktimeInfo.isWindows
 
 import org.junit.Test
 import org.junit.Assert._
@@ -40,35 +42,36 @@ class WaitTest {
   def blackHole(a: Any): Unit = ()
 
   @Test def waitBindingsShouldCompileAndLink(): Unit = {
-    // zero initialized placeholder
-    val wstatus = stackalloc[CInt](1.toUSize)
+    if (!isWindows) {
+      // zero initialized placeholder
+      val wstatus = stackalloc[CInt](1.toUSize)
 
-    // idtype_t
-    blackHole(P_ALL)
-    blackHole(P_PGID)
-    blackHole(P_PID)
+      // idtype_t
+      blackHole(P_ALL)
+      blackHole(P_PGID)
+      blackHole(P_PID)
 
 // Symbolic constants, roughly in POSIX declaration order
 
-    // "constants" for waitpid()
+      // "constants" for waitpid()
 
-    blackHole(WCONTINUED) // XSI
-    blackHole(WNOHANG)
-    blackHole(WUNTRACED)
+      blackHole(WCONTINUED) // XSI
+      blackHole(WNOHANG)
+      blackHole(WUNTRACED)
 
-    // "constants" for waitid() options
-    blackHole(WEXITED)
-    blackHole(WNOWAIT)
-    blackHole(WSTOPPED)
+      // "constants" for waitid() options
+      blackHole(WEXITED)
+      blackHole(WNOWAIT)
+      blackHole(WSTOPPED)
 
 // POSIX "Macros"
-    WEXITSTATUS(!wstatus)
-    WIFCONTINUED(!wstatus) // XSI
-    WIFEXITED(!wstatus)
-    WIFSIGNALED(!wstatus)
-    WIFSTOPPED(!wstatus)
-    WSTOPSIG(!wstatus)
-    WTERMSIG(!wstatus)
+      WEXITSTATUS(!wstatus)
+      WIFCONTINUED(!wstatus) // XSI
+      WIFEXITED(!wstatus)
+      WIFSIGNALED(!wstatus)
+      WIFSTOPPED(!wstatus)
+      WSTOPSIG(!wstatus)
+      WTERMSIG(!wstatus)
+    }
   }
-
 }

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/WaitTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/WaitTest.scala
@@ -10,10 +10,33 @@ import org.junit.Test
 import org.junit.Assert._
 
 /* Design Note:
+ *     By their definition, these "wait" methods block the current thread.
+ *     They are also defined without a timeout value.
  *
+ *     The ppoll/epoll/kevent methods needed for the classical
+ *     "block in ppoll/epoll/kevent until either child exits or
+ *     a specified timeout expires, call wait/waitpid/waitid" approach
+ *     is not available. ppoll, epoll, and kevent are not defined in POSIX
+ *     and are operating system specific. They are not implemented in
+ *     Scala Native.
+ *
+ *     These conditions make proper unit-testing difficult.
+ *
+ *     "waitpid()" is/will be well exercise in javalib ProcessTest.
+ *     To keep concerns separate, ProcessTest can not exercise both
+ *     "waitpid()" & "waitid()".
+ *
+ *     Tests for "wait()" & "waitid()" are left as an exercise for the
+ *     reader. Beware that one does not hang the entire Continuous Integration
+ *     build.
  */
 
 class WaitTest {
+
+  /* The major purpose of this file is the above Design Note.
+   * As long as we are here, might as well do some work.
+   */
+
   def blackHole(a: Any): Unit = ()
 
   @Test def waitBindingsShouldCompileAndLink(): Unit = {
@@ -29,7 +52,7 @@ class WaitTest {
 
     // "constants" for waitpid()
 
-    blackHole(WCONTINUED)    // XSI
+    blackHole(WCONTINUED) // XSI
     blackHole(WNOHANG)
     blackHole(WUNTRACED)
 
@@ -40,7 +63,7 @@ class WaitTest {
 
 // POSIX "Macros"
     WEXITSTATUS(!wstatus)
-    WIFCONTINUED(!wstatus)    // XSI
+    WIFCONTINUED(!wstatus) // XSI
     WIFEXITED(!wstatus)
     WIFSIGNALED(!wstatus)
     WIFSTOPPED(!wstatus)

--- a/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/WaitTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/posix/sys/WaitTest.scala
@@ -1,0 +1,51 @@
+package scala.scalanative.posix
+package sys
+
+import scala.scalanative.unsafe._
+import scalanative.unsigned.UnsignedRichInt
+
+import scala.scalanative.posix.sys.wait._
+
+import org.junit.Test
+import org.junit.Assert._
+
+/* Design Note:
+ *
+ */
+
+class WaitTest {
+  def blackHole(a: Any): Unit = ()
+
+  @Test def waitBindingsShouldCompileAndLink(): Unit = {
+    // zero initialized placeholder
+    val wstatus = stackalloc[CInt](1.toUSize)
+
+    // idtype_t
+    blackHole(P_ALL)
+    blackHole(P_PGID)
+    blackHole(P_PID)
+
+// Symbolic constants, roughly in POSIX declaration order
+
+    // "constants" for waitpid()
+
+    blackHole(WCONTINUED)    // XSI
+    blackHole(WNOHANG)
+    blackHole(WUNTRACED)
+
+    // "constants" for waitid() options
+    blackHole(WEXITED)
+    blackHole(WNOWAIT)
+    blackHole(WSTOPPED)
+
+// POSIX "Macros"
+    WEXITSTATUS(!wstatus)
+    WIFCONTINUED(!wstatus)    // XSI
+    WIFEXITED(!wstatus)
+    WIFSIGNALED(!wstatus)
+    WIFSTOPPED(!wstatus)
+    WSTOPSIG(!wstatus)
+    WTERMSIG(!wstatus)
+  }
+
+}


### PR DESCRIPTION
Fix #2893.
Supersede PR #2157 

Posixlib wait.scala is now implemented.

This PR supersedes PR #2157.
  
My thanks to markehammons for allowing me to use snippets of the 
work in that PR. 

markehammons & ekrich deserve co-authored-by credits
for the extensive discussions in PR #2157 and its influence
on this PR.