### PR TITLE
Fix `runMain`

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -165,6 +165,11 @@ object ScalaNativePluginInternal {
         else Some("Nonzero exit code: " + exitCode)
 
       message.foreach(sys.error)
+    },
+    runMain := {
+      throw new MessageOnlyException(
+        "`runMain` is not supported in Scala Native"
+      )
     }
   )
 


### PR DESCRIPTION
Following our Scala.js friends.
https://github.com/scala-js/scala-js/blob/a2c4b63a51923c77de09cf91a6965f3a9abe0d19/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala#L627-L629