### PR TITLE
Remove last two Scala 3.2 build warnings

### DIFF
--- a/unit-tests/native/src/test/scala/java/lang/ref/WeakReferenceTest.scala
+++ b/unit-tests/native/src/test/scala/java/lang/ref/WeakReferenceTest.scala
@@ -34,7 +34,7 @@ class WeakReferenceTest {
     weakRef
   }
 
-  @nooptimize @Test def addsToReferenceQueueAfterGC(): Unit = {
+  @deprecated @nooptimize @Test def addsToReferenceQueueAfterGC(): Unit = {
     assumeFalse(
       "In the CI Scala 3 sometimes SN fails to clean weak references in some of Windows build configurations",
       ScalaNativeBuildInfo.scalaVersion.startsWith("3.") &&
@@ -48,7 +48,7 @@ class WeakReferenceTest {
     ): Unit = {
       ref.get() match {
         case null =>
-          assertTrue("collected but not enqueded", ref.isEnqueued())
+          assertTrue("collected but not enqueued", ref.isEnqueued())
         case v =>
           if (System.currentTimeMillis() < deadline) {
             // Give GC something to collect

--- a/unit-tests/shared/src/test/scala/scala/IsInstanceOfTest.scala
+++ b/unit-tests/shared/src/test/scala/scala/IsInstanceOfTest.scala
@@ -2,7 +2,6 @@ package scala
 
 import org.junit.Test
 import org.junit.Assert._
-import scala.annotation.nowarn
 
 class IsInstanceOfTest {
 
@@ -13,10 +12,6 @@ class IsInstanceOfTest {
   @Test def expectsAnyRefIsInstanceOfStringEqEqFalse(): Unit = {
     val anyRef = new AnyRef
     assertFalse(anyRef.isInstanceOf[String])
-  }
-
-  @Test def expectsLiteralNullIsInstanceOfStringEqEqFalse(): Unit = {
-    assertFalse(null.isInstanceOf[String])
   }
 
   @Test def expectsEmptyStringIsInstanceOfStringEqEqTrue(): Unit = {


### PR DESCRIPTION
Scala Native now builds cleanly using Scala 3.2.n.