### PR TITLE
Fix 2980: javalib j.l.p.UnixProcessGen2 now spawns when it can.

### DIFF
--- a/unit-tests/shared/src/test/resources/process/unix/hello.sh
+++ b/unit-tests/shared/src/test/resources/process/unix/hello.sh
@@ -1,1 +1,6 @@
+# Please, no shebang here. This file used to test Process shell fallback.
+
 echo "hello"
+
+# hello.sh is used in unit-tests to test Process shell fallback.
+# A shebang defeats/prevents that usage.

--- a/unit-tests/shared/src/test/scala/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/ProcessTest.scala
@@ -62,6 +62,15 @@ class ProcessTest {
     checkPathOverride(pb)
   }
 
+  @Test def dirOverride(): Unit = {
+    assumeNotJVMCompliant()
+    assumeFalse("Not tested in Windows", isWindows)
+
+    val pb = new ProcessBuilder("./ls")
+    pb.directory(File(resourceDir))
+    checkPathOverride(pb) // off-label use of checkPathOverride() here.
+  }
+
   @Test def inputAndErrorStream(): Unit = {
     val proc = processForScript(Scripts.err).start()
 

--- a/unit-tests/shared/src/test/scala/javalib/lang/ProcessTest.scala
+++ b/unit-tests/shared/src/test/scala/javalib/lang/ProcessTest.scala
@@ -62,12 +62,13 @@ class ProcessTest {
     checkPathOverride(pb)
   }
 
+  // Exercise the fork() path in UnixProcessGen2
   @Test def dirOverride(): Unit = {
     assumeNotJVMCompliant()
     assumeFalse("Not tested in Windows", isWindows)
 
     val pb = new ProcessBuilder("./ls")
-    pb.directory(File(resourceDir))
+    pb.directory(new File(resourceDir))
     checkPathOverride(pb) // off-label use of checkPathOverride() here.
   }
 


### PR DESCRIPTION
Fix #2980 

Javalib java.lang.process.UnixProcessGen2.apply() now spawns when it can, just like a salmon or trout.

Using `ProcessBuilder.directory(newDirectory)` to specify a new working directory will cause fallback to
the legacy `fork()` code.

Process spawn is recommended by macOS >= 12.0 as the replacement for
the now entirely removed `vfork()` syscall.  On Linux, spawn should be marginally
faster & less system resource hungry than `fork()`.

End users should see no functional change beyond, possibly, an improvement in execution speed.