### PR TITLE
Remove version scheme

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -219,8 +219,7 @@ object Settings {
       </issueManagement>
     ),
     Compile / publishArtifact := true,
-    Test / publishArtifact := false,
-    versionScheme := Some("early-semver")
+    Test / publishArtifact := false
   ) ++ mimaSettings
 
   lazy val mavenPublishSettings = Def.settings(


### PR DESCRIPTION
At the moment it is creating more harm than use. See:
- https://github.com/portable-scala/sbt-crossproject/pull/148

See also discussion about version schemes in:
- https://github.com/scala-js/scala-js/pull/4517

As a middleground, we can only set `versionScheme` for some projects. Like nativelib, which should be `early-semver` I believe.