### PR TITLE
Fix codegen when accessing Scala 3 enum in Scala 2.13 codebase

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirCompat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirCompat.scala
@@ -8,26 +8,33 @@ trait NirCompat[G <: Global with Singleton] { self: NirPhase[G] =>
   import NirCompat.{infiniteLoop, noImplClasses}
   import global._
 
-  // SAMFunction was introduced in 2.12 for LMF-capable SAM type
-
-  object SAMFunctionAttachCompatDef {
+  /* SAMFunction was introduced in 2.12 for LMF-capable SAM types.
+   * DottyEnumSingleton was introduced in 2.13.6 to identify Scala 3 `enum` singleton cases.
+   */
+  object AttachmentsCompatDef {
     case class SAMFunction(samTp: Type, sam: Symbol, synthCls: Symbol)
         extends PlainAttachment
+    object DottyEnumSingleton extends PlainAttachment
   }
 
-  object SAMFunctionAttachCompat {
-    import SAMFunctionAttachCompatDef._
+  object AttachmentsCompat {
+    import AttachmentsCompatDef._
 
     object Inner {
       import global._
 
       type SAMFunctionAlias = SAMFunction
       val SAMFunctionAlias = SAMFunction
+
+      val DottyEnumSingletonAlias = DottyEnumSingleton
     }
   }
 
-  type SAMFunctionCompat = SAMFunctionAttachCompat.Inner.SAMFunctionAlias
-  lazy val SAMFunctionCompat = SAMFunctionAttachCompat.Inner.SAMFunctionAlias
+  type SAMFunctionCompat = AttachmentsCompat.Inner.SAMFunctionAlias
+  lazy val SAMFunctionCompat = AttachmentsCompat.Inner.SAMFunctionAlias
+
+  lazy val DottyEnumSingletonCompat =
+    AttachmentsCompat.Inner.DottyEnumSingletonAlias
 
   implicit final class SAMFunctionCompatOps(self: SAMFunctionCompat) {
     // Introduced in 2.12.5 to synthesize bridges in LMF classes
@@ -52,6 +59,8 @@ trait NirCompat[G <: Global with Singleton] { self: NirPhase[G] =>
     def implClass: Symbol = NoSymbol
 
     def isTraitOrInterface: Boolean = self.isTrait || self.isInterface
+
+    def isScala3Defined: Boolean = false
   }
 
   implicit final class GlobalCompat(self: NirCompat.this.global.type) {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -495,7 +495,6 @@ object Settings {
       scriptedLaunchOpts.value ++
         Seq(
           "-Xmx1024M",
-          "-XX:MaxMetaspaceSize=256M",
           "-Dplugin.version=" + version.value,
           // Default scala.version, can be overriden in test-scrippted command
           "-Dscala.version=" + ScalaVersions.scala212,

--- a/scripted-tests/scala3/cross-version-compat/base/src/main/scala-2.13/ADT.scala
+++ b/scripted-tests/scala3/cross-version-compat/base/src/main/scala-2.13/ADT.scala
@@ -1,0 +1,7 @@
+package testlib
+
+sealed trait ADT
+object ADT {
+  case object SingletonCase extends ADT
+  case class ClassCase(x: String)
+}

--- a/scripted-tests/scala3/cross-version-compat/base/src/main/scala-3/ADT.scala
+++ b/scripted-tests/scala3/cross-version-compat/base/src/main/scala-3/ADT.scala
@@ -1,0 +1,5 @@
+package testlib
+
+enum ADT:
+  case SingletonCase
+  case ClassCase(x: String)

--- a/scripted-tests/scala3/cross-version-compat/project-C/src/main/scala/Main.scala
+++ b/scripted-tests/scala3/cross-version-compat/project-C/src/main/scala/Main.scala
@@ -1,0 +1,8 @@
+package app
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    println(testlib.ADT.SingletonCase) // #2983
+    println(testlib.ADT.ClassCase("foo"))
+  }
+}

--- a/scripted-tests/scala3/cross-version-compat/test
+++ b/scripted-tests/scala3/cross-version-compat/test
@@ -12,6 +12,7 @@
 ## Use CrossVersion.for2_13use3
 > +projectC/publishLocal
 > +projectC/test
+> +projectC/run
 
 # Use published projects
 ## No CrossVersion


### PR DESCRIPTION
Fixes #2983
Based on the fix in Scala.js https://github.com/scala-js/scala-js/pull/4740 
