### PR TITLE
Update 0.5.0 changelog with deprecation removals from PR #2988

### DIFF
--- a/docs/changelog/0.5.0.md
+++ b/docs/changelog/0.5.0.md
@@ -99,6 +99,10 @@ Javadoc and JVM output:
 
 * ScalaNativePlugin.scala 'val AutoImport' (deprecated in 0.3.7)
 
+* scala.scalanative.libc.signal.kill(pid, sig) (deprecated in 0.4.1)
+
+* scala.scalanative.libc.signal.SIGUSR1 (deprecated in 0.4.1)
+
 ### Introduced in this version
 * All newly deprecated declarations are subject to removal in the future.
 

--- a/docs/changelog/0.5.0.md
+++ b/docs/changelog/0.5.0.md
@@ -100,8 +100,10 @@ Javadoc and JVM output:
 * ScalaNativePlugin.scala 'val AutoImport' (deprecated in 0.3.7)
 
 * scala.scalanative.libc.signal.kill(pid, sig) (deprecated in 0.4.1)
+  Suggested replacement: kill(pid, sig) from POSIX signal.
 
 * scala.scalanative.libc.signal.SIGUSR1 (deprecated in 0.4.1)
+  Suggested replacement: SIGUSR1 from POSIX signal.
 
 ### Introduced in this version
 * All newly deprecated declarations are subject to removal in the future.
@@ -110,7 +112,7 @@ Javadoc and JVM output:
   is not part of the POSIX 2018 standard.
 
 * posixlib unistd.scala 'vfork()' is now deprecated because it was removed
-  in the POSIX.1-2018 standard.
+  in the POSIX.1-2018 standard. Suggested replacement: 'posix_spawn()'.
 
 ### Build integrator features
 


### PR DESCRIPTION
Two declarations in libc.signal dating from SN 0.4.1 were, rightly, removed in PR #2988.
Update the changelog to match.