### PR TITLE
Implement posixlib net/if.{scala,c}

### DIFF
--- a/docs/lib/posixlib.rst
+++ b/docs/lib/posixlib.rst
@@ -38,7 +38,7 @@ C Header          Scala Native Module
 `monetary.h`_     N/A
 `mqueue.h`_       N/A
 `ndbm.h`_         N/A
-`net/if.h`_       N/A
+`net/if.h`_       scala.scalanative.posix.net.if_
 `netdb.h`_        scala.scalanative.posix.netdb_
 `netinet/in.h`_   scala.scalanative.posix.netinet.in_
 `netinet/tcp.h`_  scala.scalanative.posix.netinet.tcp_
@@ -191,6 +191,7 @@ C Header          Scala Native Module
 .. _scala.scalanative.posix.inttypes: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/inttypes.scala
 .. _scala.scalanative.posix.limits: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/limits.scala
 .. _scala.scalanative.libc.math: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/math.scala
+.. _scala.scalanative.posix.net.if: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/net/if.scala
 .. _scala.scalanative.posix.netdb: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/netdb.scala
 .. _scala.scalanative.posix.netinet.in: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/netinet/in.scala
 .. _scala.scalanative.posix.netinet.tcp: https://github.com/scala-native/scala-native/blob/main/posixlib/src/main/scala/scala/scalanative/posix/netinet/tcp.scala

--- a/posixlib/src/main/resources/scala-native/net/if.c
+++ b/posixlib/src/main/resources/scala-native/net/if.c
@@ -4,7 +4,6 @@
 #include <Iphlpapi.h>
 #else
 #include <net/if.h>
-#endif
 
 #include <stddef.h>
 
@@ -33,6 +32,7 @@ _Static_assert(offsetof(struct scalanative_if_nameindex, if_name) ==
                "Unexpected offset: scalanative_if_nameindex.if_name");
 
 #endif // __STDC_VERSION__
+#endif
 
 // Symbolic constants
 

--- a/posixlib/src/main/resources/scala-native/net/if.c
+++ b/posixlib/src/main/resources/scala-native/net/if.c
@@ -1,6 +1,7 @@
 #ifdef _WIN32
-#include <Iphlpapi.h>
+#include <WinSock2.h>
 #include <Netioapi.h>
+#include <Iphlpapi.h>
 #else
 #include <net/if.h>
 #endif

--- a/posixlib/src/main/resources/scala-native/net/if.c
+++ b/posixlib/src/main/resources/scala-native/net/if.c
@@ -1,4 +1,5 @@
 #ifdef _WIN32
+#include <Iphlpapi.h>
 #include <Netioapi.h>
 #else
 #include <net/if.h>

--- a/posixlib/src/main/resources/scala-native/net/if.c
+++ b/posixlib/src/main/resources/scala-native/net/if.c
@@ -1,0 +1,47 @@
+#ifdef _WIN32
+#include <Netioapi.h>
+#else
+#include <net/if.h>
+#endif
+
+#include <stddef.h>
+
+struct scalanative_if_nameindex {
+    unsigned int if_index;
+    char *if_name;
+};
+
+#if !(defined __STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
+#ifndef SCALANATIVE_SUPPRESS_STRUCT_CHECK_WARNING
+#warning "Size and order of C structures are not checked when -std < c11."
+#endif
+#else
+
+// struct if_nameindex
+_Static_assert(sizeof(struct scalanative_if_nameindex) <=
+                   sizeof(struct if_nameindex),
+               "Unexpected size: struct if_nameindex");
+
+_Static_assert(offsetof(struct scalanative_if_nameindex, if_index) ==
+                   offsetof(struct if_nameindex, if_index),
+               "Unexpected offset: scalanative_if_nameindex.if_index");
+
+_Static_assert(offsetof(struct scalanative_if_nameindex, if_name) ==
+                   offsetof(struct if_nameindex, if_name),
+               "Unexpected offset: scalanative_if_nameindex.if_name");
+
+#endif // __STDC_VERSION__
+
+// Symbolic constants
+
+/* POSIX 2018 says:
+ *   The <net/if.h> header shall define the following symbolic constant for
+ *   the length of a buffer containing an interface name (including the
+ *   terminating NULL character)
+ *
+ * Windows appears to define the constant without space for that NUL.
+ * Be ultra-conservative and allocate one extra location. It is more
+ * economical to do that than to spend time debugging strange Windows-only
+ * buffer overrun defects.
+ */
+int scalanative_if_namesize() { return IF_NAMESIZE + 1; }

--- a/posixlib/src/main/scala/scala/scalanative/posix/net/if.scala
+++ b/posixlib/src/main/scala/scala/scalanative/posix/net/if.scala
@@ -1,0 +1,41 @@
+package scala.scalanative
+package posix
+package net
+
+import scalanative.unsafe._
+
+/** POSIX if.h for Scala
+ *
+ *  The Open Group Base Specifications
+ *  [[https://pubs.opengroup.org/onlinepubs/9699919799 Issue 7, 2018]] edition.
+ */
+@extern object `if` {
+
+  type if_nameindex = CStruct2[
+    CUnsignedInt, // if_index
+    CString // if_name
+  ]
+
+  // Symbolic constants
+
+  @name("scalanative_if_namesize")
+  def IF_NAMESIZE: CInt = extern
+
+  // Methods
+
+  def if_freenameindex(ptr: Ptr[if_nameindex]): Unit = extern
+  def if_indextoname(ifindex: CUnsignedInt, ifname: Ptr[Byte]): CString =
+    extern
+  def if_nameindex(): Ptr[if_nameindex] = extern
+  def if_nametoindex(ifname: CString): CUnsignedInt = extern
+}
+
+object ifOps {
+  import `if`.if_nameindex
+
+  implicit class ifOps(private val ptr: Ptr[if_nameindex]) extends AnyVal {
+    def if_index: CUnsignedInt = ptr._1
+    def if_name: CString = ptr._2
+    // These are used as read-only fields, so no Ops here to set them.
+  }
+}


### PR DESCRIPTION
Implement Open Group 2018 variant of posixlib `net/if.h`.   This is used to enumerate IP network 
interface names and indices.  

No corresponding file defined in ISO C, so no clib entry here.
