### PR TITLE
Fix incorrect declarations of extern methods defined in `extern trait`

### DIFF
--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenStat.scala
@@ -657,7 +657,13 @@ trait NirGenStat[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
             }
 
           case EmptyTree =>
-            Some(Defn.Declare(attrs, name, sig))
+            Some(
+              Defn.Declare(
+                attrs,
+                name,
+                if (attrs.isExtern) genExternMethodSig(sym) else sig
+              )
+            )
 
           case Apply(TypeApply(Select(retBlock, _), _), _)
               if retBlock.tpe == NoType && isScala211 =>


### PR DESCRIPTION
Extern declarations produced by method declarations in extern traits were producing incorrect type signature containing boxed types. This PR fixes this behavior.
Fixes compilation errors present in #2996 
