### PR TITLE
Fix #2987: j.n.Inet6Address#toString now handles interface names

### DIFF
--- a/posixlib/src/main/resources/scala-native/net/if.c
+++ b/posixlib/src/main/resources/scala-native/net/if.c
@@ -1,7 +1,9 @@
 #ifdef _WIN32
 #include <WinSock2.h>
+#pragma comment(lib, "Ws2_32.lib")
 #include <Netioapi.h>
 #include <Iphlpapi.h>
+#pragma comment(lib, "Iphlpapi.lib")
 #else
 #include <net/if.h>
 


### PR DESCRIPTION
Fix #2987

A Javalib `java.net.Inet6Address` can be created with an IPv6 address containing a numeric
interface index or alphanumeric interface name, if properly specified for the executing system.
For example: "fe80::b0e5:59d7:2501:3a58%2" or  "fe80::b0e5:59d7:2501:3a58%en".

Assume for discussion that interface name "en" has interface index 2.

Previously,  the `toString` method of that class would print out a suffix "%2" for an
Inet6Address created with "%2".  This is consistent with the JVM practice of "just
stash numeric IP addresses when creating".  It is inconsistent if the address has
been created any other way.

Now, `Inet6Address#toString` will attempt to convert the interface index to the
corresponding interface name, if such exists.   The suffix changes from "%2" to
the more useful "%en".  This is consistent with more general useage. I think
if one tried hard enough, one would find that it is also consistent with JVM
outside the creation context.

For example, try using an IPv6 link-local address to ssh twice to a macOS system.  Examine
the "last login" message and it should show the last login address using a interface name.


This PR was tested manually.  Testing requires a knowledge of the network environment
in which the test will be run.  Tests are likely to be run in a variety of  such environments and are
difficult to robustly automate.
 