### PR TITLE
Partial fix #2765: Remove long deprecated alloc/stackalloc signed argument methods

### DIFF
--- a/docs/changelog/0.5.0.md
+++ b/docs/changelog/0.5.0.md
@@ -97,12 +97,21 @@ Javadoc and JVM output:
 
 ### Removed in this version
 
-* ScalaNativePlugin.scala 'val AutoImport' (deprecated in 0.3.7)
+Ordered by version of Scala Native in which a deprecation was introduced.
 
-* scala.scalanative.libc.signal.kill(pid, sig) (deprecated in 0.4.1)
+* ScalaNativePlugin.scala 'val AutoImport' (deprecated in 0.3.7).
+
+* scala.scalanative.unsafe.alloc with signed type (deprecated in 0.4.0).
+  Suggested replacement: unsafe.alloc with unsigned type
+
+* scala.scalanative.unsafe.stackalloc with signed type (deprecated in 0.4.0).
+  <br>
+  Suggested replacement: unsafe.stackalloc with unsigned type
+
+* scala.scalanative.libc.signal.kill(pid, sig) (deprecated in 0.4.1).
   Suggested replacement: kill(pid, sig) from POSIX signal.
 
-* scala.scalanative.libc.signal.SIGUSR1 (deprecated in 0.4.1)
+* scala.scalanative.libc.signal.SIGUSR1 (deprecated in 0.4.1).
   Suggested replacement: SIGUSR1 from POSIX signal.
 
 ### Introduced in this version

--- a/docs/lib/libc.rst
+++ b/docs/lib/libc.rst
@@ -84,6 +84,7 @@ wctype.h_      N/A
 .. _scala.scalanative.libc.stdlib: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/stdlib.scala
 .. _scala.scalanative.libc.string: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/string.scala
 .. _scala.scalanative.libc.signal: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/signal.scala
+.. _scala.scalanative.libc.time: https://github.com/scala-native/scala-native/blob/main/clib/src/main/scala/scala/scalanative/libc/time.scala
 
 Continue to :ref:`posixlib`.
 

--- a/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
+++ b/nativelib/src/main/scala-2/scala/scalanative/unsafe/UnsafePackageCompat.scala
@@ -6,16 +6,6 @@ private[scalanative] trait UnsafePackageCompat { self =>
   /** Heap allocate and zero-initialize a value using current implicit
    *  allocator.
    */
-  @deprecated(
-    "In Scala 3 alloc[T](n) can be confused with alloc[T].apply(n) leading to runtime errors, use alloc[T]() instead",
-    since = "0.4.3"
-  )
-  def alloc[T](implicit tag: Tag[T], z: Zone): Ptr[T] =
-    macro MacroImpl.alloc1[T]
-
-  /** Heap allocate and zero-initialize a value using current implicit
-   *  allocator.
-   */
   def alloc[T]()(implicit tag: Tag[T], z: Zone): Ptr[T] =
     macro MacroImpl.allocSingle[T]
 
@@ -25,69 +15,17 @@ private[scalanative] trait UnsafePackageCompat { self =>
   def alloc[T](n: CSize)(implicit tag: Tag[T], z: Zone): Ptr[T] =
     macro MacroImpl.allocN[T]
 
-  /** Heap allocate and zero-initialize n values using current implicit
-   *  allocator. This method takes argument of type `CSSize` for easier interop,
-   *  but it' always converted into `CSize`
-   */
-  @deprecated(
-    "alloc with signed type is deprecated, convert size to unsigned value",
-    "0.4.0"
-  )
-  def alloc[T](n: CSSize)(implicit tag: Tag[T], z: Zone): Ptr[T] =
-    macro MacroImpl.allocN[T]
-
-  /** Stack allocate a value of given type.
-   *
-   *  Note: unlike alloc, the memory is not zero-initialized.
-   */
-  @deprecated(
-    "In Scala 3 alloc[T](n) can be confused with alloc[T].apply(n) leading to runtime errors, use alloc[T]() instead",
-    since = "0.4.3"
-  )
-  def stackalloc[T](implicit tag: Tag[T]): Ptr[T] =
-    macro MacroImpl.stackalloc1[T]
-
-  /** Stack allocate a value of given type.
-   *
-   *  Note: unlike alloc, the memory is not zero-initialized.
-   */
+  /** Stack allocate and zero-initialize 1 value of given type */
   def stackalloc[T]()(implicit tag: Tag[T]): Ptr[T] =
     macro MacroImpl.stackallocSingle[T]
 
-  /** Stack allocate n values of given type.
-   *
-   *  Note: unlike alloc, the memory is not zero-initialized.
-   */
+  /** Stack allocate and zero-initialize n values of given type */
   def stackalloc[T](n: CSize)(implicit tag: Tag[T]): Ptr[T] =
-    macro MacroImpl.stackallocN[T]
-
-  /** Stack allocate n values of given type.
-   *
-   *  Note: unlike alloc, the memory is not zero-initialized. This method takes
-   *  argument of type `CSSize` for easier interop, but it's always converted
-   *  into `CSize`
-   */
-  @deprecated(
-    "alloc with signed type is deprecated, convert size to unsigned value",
-    "0.4.0"
-  )
-  def stackalloc[T](n: CSSize)(implicit tag: Tag[T]): Ptr[T] =
     macro MacroImpl.stackallocN[T]
 }
 
 private object MacroImpl {
   import scala.reflect.macros.blackbox.Context
-
-  def alloc1[T: c.WeakTypeTag](c: Context)(tag: c.Tree, z: c.Tree): c.Tree = {
-    c.warning(
-      c.enclosingPosition,
-      s"Scala Native method `alloc[T]` is deprecated, " +
-        "in Scala 3 `alloc[T](n)` can be interpreted as " +
-        "`alloc[T].apply(n)` leading to runtime errors, " +
-        "use `alloc[T]()` instead "
-    )
-    alloc1Impl(c)(tag, z)
-  }
 
   private def alloc1Impl[T: c.WeakTypeTag](
       c: Context
@@ -135,17 +73,6 @@ private object MacroImpl {
 
   def stackallocSingle[T: c.WeakTypeTag](c: Context)()(tag: c.Tree): c.Tree =
     stackalloc1Impl(c)(tag)
-
-  def stackalloc1[T: c.WeakTypeTag](c: Context)(tag: c.Tree): c.Tree = {
-    c.warning(
-      c.enclosingPosition,
-      s"Scala Native method `stackalloc[T]` is deprecated, " +
-        "in Scala 3 `stackalloc[T](n)` can be interpreted as " +
-        "`stackalloc[T].apply(n)` leading to runtime errors, " +
-        "use `stackalloc[T]()` instead "
-    )
-    stackalloc1Impl(c)(tag)
-  }
 
   private def stackalloc1Impl[T: c.WeakTypeTag](
       c: Context

--- a/nativelib/src/main/scala-3/scala/scalanative/unsafe/UnsafePackageCompat.scala
+++ b/nativelib/src/main/scala-3/scala/scalanative/unsafe/UnsafePackageCompat.scala
@@ -20,18 +20,7 @@ private[scalanative] trait UnsafePackageCompat {
     ptr.asInstanceOf[Ptr[T]]
   }
 
-  /** Heap allocate and zero-initialize n values using current implicit
-   *  allocator. This method takes argument of type `CSSize` for easier interop,
-   *  but it' always converted into `CSize`
-   */
-  @deprecated(
-    "alloc with signed type is deprecated, convert size to unsigned value",
-    since = "0.4.0"
-  )
-  inline def alloc[T](inline n: CSSize)(using Tag[T], Zone): Ptr[T] =
-    alloc[T](n.toUInt)
-
-  /** Stack allocate n values of given type */
+  /** Stack allocate and zero-initialize n values of given type */
   inline def stackalloc[T](
       inline n: CSize = 1.toUSize
   )(using Tag[T]): Ptr[T] = {
@@ -40,17 +29,4 @@ private[scalanative] trait UnsafePackageCompat {
     libc.memset(rawPtr, 0, size)
     fromRawPtr[T](rawPtr)
   }
-
-  /** Stack allocate n values of given type.
-   *
-   *  Note: unlike alloc, the memory is not zero-initialized. This method takes
-   *  argument of type `CSSize` for easier interop, but it's always converted
-   *  into `CSize`
-   */
-  @deprecated(
-    "alloc with signed type is deprecated, convert size to unsigned value",
-    since = "0.4.0"
-  )
-  inline def stackalloc[T](inline n: CSSize)(using Tag[T]): Ptr[T] =
-    stackalloc[T](n.toUSize)
 }


### PR DESCRIPTION
After months as an Issue and 10 days or so announcement in Discourse, long deprecated
alloc & stackalloc methods are removed. The removals and suggested replacements are
documented in  `changelog/0.5.0.md`.

This PR also contains an apparently unrelated change to `libc.rst`. A recently introduced
defect was removed so that I could cleanly build the documentation for this PR.
