### PR TITLE
Partial fix #2765: Remove long deprecated declaration in ScalaNativePlugin

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -65,9 +65,6 @@ object ScalaNativePlugin extends AutoPlugin {
       )
   }
 
-  @deprecated("use autoImport instead", "0.3.7")
-  val AutoImport = autoImport
-
   override def globalSettings: Seq[Setting[_]] =
     ScalaNativePluginInternal.scalaNativeGlobalSettings
 


### PR DESCRIPTION
PR #2783 removed a long deprecated declaration in ScalaNativePlugin.scala.  For reasons
at the time, it was never merged.  However `changelog/0.5.0.md` was changed to note
the deprecation.

This PR removes that deprecated declaration. There  is no need to update the documentation.
