### PR TITLE
Build: Update sbt to 1.8.0

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.7.2
+sbt.version = 1.8.0


### PR DESCRIPTION
Update the version of sbt which the sbt runner uses to build Scala Native to sbt 1.8.0.

No attempt is made to update the versions of the sbt runner itself. Someday, 
perhaps the day after leap seconds are discontinued.
