### PR TITLE
Allow to calculate real sizeOf class based on `MemoryLayout`

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
+++ b/nativelib/src/main/scala/scala/scalanative/runtime/Intrinsics.scala
@@ -168,4 +168,10 @@ object Intrinsics {
   /** Intrinsified resolving of class field as a raw pointer */
   def classFieldRawPtr[T <: AnyRef](obj: T, fieldName: String): RawPtr =
     intrinsic
+
+  /** Intrinsified resolving of memory layout size of given type */
+  def sizeOf[T]: RawSize = intrinsic
+
+  /** Intrinsified resolving of memory layout size of given type */
+  def sizeOf(cls: Class[_]): RawSize = intrinsic
 }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -243,6 +243,12 @@ trait NirDefinitions {
       getMember(IntrinsicsModule, TermName("stackalloc"))
     lazy val ClassFieldRawPtrMethod =
       getMember(IntrinsicsModule, TermName("classFieldRawPtr"))
+    lazy val SizeOfMethods =
+      getMember(IntrinsicsModule, TermName("sizeOf")).alternatives
+    lazy val SizeOfMethod =
+      SizeOfMethods.find(_.paramss.flatten.nonEmpty).get
+    lazy val SizeOfTypeMethod =
+      SizeOfMethods.find(_.paramss.flatten.isEmpty).get
 
     lazy val CFuncPtrApplyMethods = CFuncPtrNClass.map(
       getMember(_, TermName("apply"))

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -2117,9 +2117,6 @@ trait NirGenExpr[G <: nsc.Global with Singleton] { self: NirGenPhase[G] =>
         reporter.error(app.pos, msg)
         Val.Zero(Type.Size)
       }
-      println(show(app))
-      // println(showRaw(app))
-
       app.args match {
         case Seq(clsType: Literal) =>
           val tpe = clsType.value.typeValue

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirPrimitives.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/NirPrimitives.scala
@@ -73,6 +73,7 @@ object NirPrimitives {
   final val CFUNCPTR_FROM_FUNCTION = 1 + CAST_LONG_TO_RAWSIZE
   final val CFUNCPTR_APPLY = 1 + CFUNCPTR_FROM_FUNCTION
   final val CLASS_FIELD_RAWPTR = 1 + CFUNCPTR_APPLY
+  final val SIZE_OF = 1 + CLASS_FIELD_RAWPTR
 }
 
 abstract class NirPrimitives {
@@ -197,5 +198,6 @@ abstract class NirPrimitives {
     CFuncPtrApplyMethods.foreach(addPrimitive(_, CFUNCPTR_APPLY))
     CFuncPtrFromFunctionMethods.foreach(addPrimitive(_, CFUNCPTR_FROM_FUNCTION))
     addPrimitive(ClassFieldRawPtrMethod, CLASS_FIELD_RAWPTR)
+    SizeOfMethods.foreach(addPrimitive(_, SIZE_OF))
   }
 }

--- a/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-2/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -105,6 +105,14 @@ abstract class PrepNativeInterop[G <: Global with Singleton](
             EmptyTree
           }
 
+        // sizeOf[T] -> sizeOf(classOf[T])
+        case TypeApply(sizeOfTree, List(tpeArg))
+            if sizeOfTree.symbol == SizeOfTypeMethod =>
+          val widenedTpe = tpeArg.tpe.dealias.widen
+          typer.typed {
+            Apply(SizeOfMethod, Literal(Constant(widenedTpe)))
+          }
+
         // Catch the definition of scala.Enumeration itself
         case cldef: ClassDef if cldef.symbol == EnumerationClass =>
           enterOwner(OwnerKind.EnumImpl) { super.transform(cldef) }

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -222,6 +222,9 @@ final class NirDefinitions()(using ctx: Context) {
   @tu lazy val Intrinsics_castLongToRawSizeR = IntrinsicsModule.requiredMethodRef("castLongToRawSize")
   @tu lazy val Intrinsics_stackallocR = IntrinsicsModule.requiredMethodRef("stackalloc")
   @tu lazy val Intrinsics_classFieldRawPtrR = IntrinsicsModule.requiredMethodRef("classFieldRawPtr")
+  @tu lazy val Intrinsics_sizeOfAlts = IntrinsicsModule.info.member(termName("sizeOf")).alternatives
+  @tu lazy val Intrinsics_sizeOfR = Intrinsics_sizeOfAlts.find(_.info.paramInfoss.flatten.nonEmpty).get
+  @tu lazy val Intrinsics_sizeOfTypeR = Intrinsics_sizeOfAlts.find(_.info.paramInfoss.flatten.isEmpty).get
 
   def Intrinsics_divUInt(using Context) = Intrinsics_divUIntR.symbol
   def Intrinsics_divULong(using Context) = Intrinsics_divULongR.symbol
@@ -277,6 +280,9 @@ final class NirDefinitions()(using ctx: Context) {
   def Intrinsics_castLongToRawSize(using Context) = Intrinsics_castLongToRawSizeR.symbol
   def Intrinsics_stackalloc(using Context) = Intrinsics_stackallocR.symbol
   def Intrinsics_classFieldRawPtr(using Context) = Intrinsics_classFieldRawPtrR.symbol
+  def Intrinsics_sizeOf(using Context) = Intrinsics_sizeOfR.symbol
+  def Intrinsics_sizeOfType(using Context) = Intrinsics_sizeOfTypeR.symbol
+
 
   // Runtime types
   @tu lazy val RuntimePrimitive: Map[Char, Symbol] = Map(

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -283,7 +283,6 @@ final class NirDefinitions()(using ctx: Context) {
   def Intrinsics_sizeOf(using Context) = Intrinsics_sizeOfR.symbol
   def Intrinsics_sizeOfType(using Context) = Intrinsics_sizeOfTypeR.symbol
 
-
   // Runtime types
   @tu lazy val RuntimePrimitive: Map[Char, Symbol] = Map(
     'B' -> requiredClass("scala.scalanative.runtime.PrimitiveBoolean"),

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -895,7 +895,6 @@ trait NirGenExpr(using Context) {
     }
 
     def genTypeApply(tree: TypeApply): Val = {
-      println(tree.show)
       given nir.Position = tree.span
       val TypeApply(fun @ Select(receiverp, _), targs) = tree: @unchecked
 

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirGenExpr.scala
@@ -895,6 +895,7 @@ trait NirGenExpr(using Context) {
     }
 
     def genTypeApply(tree: TypeApply): Val = {
+      println(tree.show)
       given nir.Position = tree.span
       val TypeApply(fun @ Select(receiverp, _), targs) = tree: @unchecked
 
@@ -1027,6 +1028,7 @@ trait NirGenExpr(using Context) {
       else if (code == STACKALLOC) genStackalloc(app)
       else if (code == CQUOTE) genCQuoteOp(app)
       else if (code == CLASS_FIELD_RAWPTR) genClassFieldRawPtr(app)
+      else if (code == SIZE_OF) genSizeOf(app)
       else if (code == REFLECT_SELECTABLE_SELECTDYN)
         // scala.reflect.Selectable.selectDynamic
         genReflectiveCall(app, isSelectDynamic = true)
@@ -2157,6 +2159,24 @@ trait NirGenExpr(using Context) {
           )
           Val.Int(-1)
         }
+    }
+
+    def genSizeOf(app: Apply): Val = {
+      given nir.Position = app.span
+      def unsupported(msg: String) =
+        report.error(msg, app.srcPos)
+        Val.Zero(Type.Size)
+      app.args match
+        case Seq(clsType: Literal) =>
+          val tpe = clsType.const.typeValue
+          if !tpe.typeSymbol.isTraitOrInterface
+          then buf.sizeof(genType(tpe), unwind)
+          else
+            unsupported(
+              s"Type ${tpe.show} is a trait or interface, its size cannot be calculated"
+            )
+        case _ =>
+          unsupported("Argument of sizeOf needs to be a class literal")
     }
 
     def genLoadExtern(ty: nir.Type, externTy: nir.Type, sym: Symbol)(using

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPrimitives.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/NirPrimitives.scala
@@ -86,8 +86,9 @@ object NirPrimitives {
   final val CFUNCPTR_APPLY = 1 + CFUNCPTR_FROM_FUNCTION
 
   final val CLASS_FIELD_RAWPTR = 1 + CFUNCPTR_APPLY
+  final val SIZE_OF = CLASS_FIELD_RAWPTR + 1
 
-  final val REFLECT_SELECTABLE_SELECTDYN = CLASS_FIELD_RAWPTR + 1
+  final val REFLECT_SELECTABLE_SELECTDYN = SIZE_OF + 1
   final val REFLECT_SELECTABLE_APPLYDYN = REFLECT_SELECTABLE_SELECTDYN + 1
 
   final val LastNirPrimitiveCode = REFLECT_SELECTABLE_APPLYDYN
@@ -202,6 +203,7 @@ class NirPrimitives(using ctx: Context) extends DottyPrimitives(ctx) {
     defnNir.CFuncPtr_apply.foreach(addPrimitive(_, CFUNCPTR_APPLY))
     defnNir.CFuncPtr_fromScalaFunction.foreach(addPrimitive(_, CFUNCPTR_FROM_FUNCTION))
     addPrimitive(defnNir.Intrinsics_classFieldRawPtr, CLASS_FIELD_RAWPTR)
+    addPrimitive(defnNir.Intrinsics_sizeOf, SIZE_OF)
     addPrimitive(
       defnNir.ReflectSelectable_selectDynamic,
       REFLECT_SELECTABLE_SELECTDYN

--- a/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
+++ b/nscplugin/src/main/scala-3/scala/scalanative/nscplugin/PrepNativeInterop.scala
@@ -36,6 +36,17 @@ class PrepNativeInterop extends PluginPhase {
     dd.symbol.isWrappedToplevelDef
   }
 
+  override def transformTypeApply(tree: TypeApply)(using Context): Tree = {
+    val TypeApply(fun, tArgs) = tree
+    if fun.symbol == defnNir.Intrinsics_sizeOfType then
+      // sizeOf[T] -> sizeOf(classOf[T])
+      cpy.Apply(tree)(
+        ref(defnNir.Intrinsics_sizeOf),
+        tArgs.map(tpe => Literal(Constant(tpe.tpe.finalResultType)))
+      )
+    else tree
+  }
+
   override def transformDefDef(dd: DefDef)(using Context): Tree = {
     // Set `@extern` annotation for top-level extern functions
     if (isTopLevelExtern(dd) && !dd.symbol.hasAnnotation(defnNir.ExternClass)) {

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -8,7 +8,7 @@ object ScalaVersions {
   val crossScala3 = List(
     Seq(scala3Experimental),
     (0 to 3).map(v => s"3.1.$v"),
-    (0 to 1).map(v => s"3.2.$v"),
+    (0 to 1).map(v => s"3.2.$v")
   ).flatten
 
   // Version of Scala 3 standard library sources used for publishing

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -447,7 +447,7 @@ object Settings {
         val sourcesDir = (scope / sourceDirectory).value
         val experimentalSources = allScalaFromDir(sourcesDir / baseDir).toMap
 
-        previous.map { f =>
+        val updatedSources = previous.map { f =>
           val replacement = for {
             relPath <- f.relativeTo(sourcesDir)
             sourceDir = relPath.toPath().getName(0).toString()
@@ -461,7 +461,8 @@ object Settings {
           } yield experimentalSource
           replacement.getOrElse(f)
         }
-
+        val newSources = experimentalSources.values.toList.diff(updatedSources)
+        updatedSources ++ newSources
       }
     )
 

--- a/scripted-tests/scala3/cross-version-compat/build.sbt
+++ b/scripted-tests/scala3/cross-version-compat/build.sbt
@@ -1,10 +1,21 @@
-val scala3Version = sys.props.getOrElse(
-  "scala.version",
-  throw new RuntimeException(
-    """The system property 'scala.version' is not defined.
+val scala3Version = sys.props
+  .get("scala.version")
+  .map { version =>
+    if (!version.contains("NIGHTLY")) version
+    else {
+      println(
+        "Publish test is incompatible with Nightly Scala versions! Using default version."
+      )
+      "3.1.3"
+    }
+  }
+  .getOrElse(
+    throw new RuntimeException(
+      """The system property 'scala.version' is not defined.
       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
   )
-)
+
 val scala213Version = sys.props.getOrElse(
   "scala213.version",
   throw new RuntimeException(

--- a/scripted-tests/scala3/cross-version-compat/build.sbt
+++ b/scripted-tests/scala3/cross-version-compat/build.sbt
@@ -1,21 +1,10 @@
-val scala3Version = sys.props
-  .get("scala.version")
-  .map { version =>
-    if (!version.contains("NIGHTLY")) version
-    else {
-      println(
-        "Publish test is incompatible with Nightly Scala versions! Using default version."
-      )
-      "3.1.3"
-    }
-  }
-  .getOrElse(
-    throw new RuntimeException(
-      """The system property 'scala.version' is not defined.
+val scala3Version = sys.props.getOrElse(
+  "scala.version",
+  throw new RuntimeException(
+    """The system property 'scala.version' is not defined.
       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
-    )
   )
-
+)
 val scala213Version = sys.props.getOrElse(
   "scala213.version",
   throw new RuntimeException(
@@ -23,6 +12,8 @@ val scala213Version = sys.props.getOrElse(
       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
   )
 )
+
+val usesUnstableScala3 = scala3Version.contains("NIGHTLY")
 
 inThisBuild(
   Seq(
@@ -33,6 +24,19 @@ inThisBuild(
     publishMavenStyle := true
   )
 )
+
+// Fix to allow skipping execution of this scripted test in Nightly versions of Scala
+// Tasty produced by nightly versions cannot be consumed by Scala 2.13
+def NoOpInUnstableScala = if (usesUnstableScala3)
+  Def.settings(
+    run := {},
+    Test / test := {},
+    publishLocal := {},
+    Compile / sources := Nil,
+    Test / sources := Nil,
+    libraryDependencies := Nil
+  )
+else Def.settings()
 
 def commonScala213Settigns = Def.settings(
   scalacOptions ++= {
@@ -48,6 +52,7 @@ def commonScala213Settigns = Def.settings(
 lazy val base = project
   .in(file("base"))
   .enablePlugins(ScalaNativePlugin)
+  .settings(NoOpInUnstableScala)
 
 lazy val projectA = project
   .in(file("project-A"))
@@ -55,6 +60,7 @@ lazy val projectA = project
   .settings(
     libraryDependencies += organization.value %%% (base / normalizedName).value % version.value
   )
+  .settings(NoOpInUnstableScala)
 
 lazy val projectB = project
   .in(file("project-B"))
@@ -64,6 +70,7 @@ lazy val projectB = project
     libraryDependencies += (organization.value %%% (base / normalizedName).value % version.value)
       .cross(CrossVersion.for3Use2_13)
   )
+  .settings(NoOpInUnstableScala)
 
 lazy val projectC = project
   .in(file("project-C"))
@@ -73,6 +80,7 @@ lazy val projectC = project
     libraryDependencies += (organization.value %%% (base / normalizedName).value % version.value)
       .cross(CrossVersion.for2_13Use3)
   )
+  .settings(NoOpInUnstableScala)
 
 lazy val projectD = project
   .in(file("project-D"))
@@ -89,6 +97,7 @@ lazy val projectD = project
       s"${(base / normalizedName).value}_native${ScalaNativeCrossVersion.currentBinaryVersion}_2.13"
     )
   )
+  .settings(NoOpInUnstableScala)
 
 lazy val projectE = project
   .in(file("project-E"))
@@ -105,6 +114,7 @@ lazy val projectE = project
       s"${(base / normalizedName).value}_native${ScalaNativeCrossVersion.currentBinaryVersion}_3"
     )
   )
+  .settings(NoOpInUnstableScala)
 
 lazy val projectF = project
   .in(file("project-F"))
@@ -121,3 +131,4 @@ lazy val projectF = project
       s"${(base / normalizedName).value}_native${ScalaNativeCrossVersion.currentBinaryVersion}_2.13"
     )
   )
+  .settings(NoOpInUnstableScala)

--- a/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/CodeGen.scala
@@ -20,8 +20,8 @@ object CodeGen {
     val defns = linked.defns
     val proxies = GenerateReflectiveProxies(linked.dynimpls, defns)
 
-    implicit val meta: Metadata =
-      new Metadata(linked, proxies, config.compilerConfig.is32BitPlatform)
+    implicit val platform: PlatformInfo = PlatformInfo(config)
+    implicit val meta: Metadata = new Metadata(linked, proxies)
 
     val generated = Generate(encodedMainClass(config), defns ++ proxies)
     val embedded = ResourceEmbedder(config)

--- a/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/FieldLayout.scala
@@ -18,7 +18,7 @@ class FieldLayout(meta: Metadata, cls: Class) {
     val body = Type.Ptr +: data
     Type.StructValue(body)
   }
-  val layout = MemoryLayout(struct.tys, meta.is32BitPlatform)
+  val layout = MemoryLayout(struct.tys)(meta.platform)
   val size = layout.size
   val referenceOffsetsTy =
     Type.StructValue(Seq(Type.Ptr))

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -26,7 +26,6 @@ object Lower {
     import meta._
 
     implicit val linked: Result = meta.linked
-    val is32BitPlatform = meta.is32BitPlatform
 
     val Object = linked.infos(Rt.Object.name).asInstanceOf[Class]
 
@@ -758,8 +757,8 @@ object Lower {
         pos: Position
     ): Unit = {
       val Op.Sizeof(ty) = op
-
-      val memorySize = MemoryLayout.sizeOf(ty, is32BitPlatform)
+      val memorySize = MemoryLayout.sizeOf(ty, Some(meta))
+      println(s"genSizeOf: $ty=${memorySize}")
       buf.let(n, Op.Copy(Val.Size(memorySize)), unwind)
     }
 
@@ -768,7 +767,7 @@ object Lower {
     ): Unit = {
       val Op.Classalloc(ClassRef(cls)) = op: @unchecked
 
-      val size = MemoryLayout.sizeOf(layout(cls).struct, is32BitPlatform)
+      val size = MemoryLayout.sizeOf(layout(cls).struct)
       val allocMethod =
         if (size < LARGE_OBJECT_MIN_SIZE) alloc else largeAlloc
 
@@ -935,7 +934,8 @@ object Lower {
           case Type.Int  => Val.Int(java.lang.Integer.MIN_VALUE)
           case Type.Long => Val.Long(java.lang.Long.MIN_VALUE)
           case Type.Size =>
-            if (is32BitPlatform) Val.Size(java.lang.Integer.MIN_VALUE)
+            if (meta.platform.is32BitPlatform)
+              Val.Size(java.lang.Integer.MIN_VALUE)
             else Val.Size(java.lang.Long.MIN_VALUE)
           case _ => util.unreachable
         }

--- a/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Lower.scala
@@ -758,7 +758,6 @@ object Lower {
     ): Unit = {
       val Op.Sizeof(ty) = op
       val memorySize = MemoryLayout.sizeOf(ty, Some(meta))
-      println(s"genSizeOf: $ty=${memorySize}")
       buf.let(n, Op.Copy(Val.Size(memorySize)), unwind)
     }
 

--- a/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/Metadata.scala
@@ -7,9 +7,8 @@ import scalanative.linker.{Trait, Class}
 
 class Metadata(
     val linked: linker.Result,
-    proxies: Seq[Defn],
-    val is32BitPlatform: Boolean
-) {
+    proxies: Seq[Defn]
+)(implicit val platform: PlatformInfo) {
   val rtti = mutable.Map.empty[linker.Info, RuntimeTypeInformation]
   val vtable = mutable.Map.empty[linker.Class, VirtualTable]
   val layout = mutable.Map.empty[linker.Class, FieldLayout]

--- a/tools/src/main/scala/scala/scalanative/codegen/PlatformInfo.scala
+++ b/tools/src/main/scala/scala/scalanative/codegen/PlatformInfo.scala
@@ -1,0 +1,16 @@
+package scala.scalanative.codegen
+
+import scala.scalanative.build.Config
+
+private[scalanative] case class PlatformInfo(
+    targetTriple: Option[String],
+    is32BitPlatform: Boolean
+) {
+  val sizeOfPtr = if (is32BitPlatform) 4 else 8
+}
+object PlatformInfo {
+  def apply(config: Config): PlatformInfo = PlatformInfo(
+    targetTriple = config.compilerConfig.targetTriple,
+    is32BitPlatform = config.compilerConfig.is32BitPlatform
+  )
+}

--- a/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Eval.scala
@@ -368,7 +368,15 @@ trait Eval { self: Interflow =>
       case Op.Copy(v) =>
         eval(v)
       case Op.Sizeof(ty) =>
-        Val.Size(MemoryLayout.sizeOf(ty, is32BitPlatform))
+        def canEval(ty: Type): Boolean = ty match {
+          case Type.ArrayValue(ty, _)  => canEval(ty)
+          case Type.StructValue(types) => types.forall(canEval)
+          case Type.Null               => true
+          case _: Type.ValueKind       => true
+          case _                       => false
+        }
+        if (canEval(ty)) Val.Size(MemoryLayout.sizeOf(ty))
+        else emit(op)
       case Op.Box(boxty @ Type.Ref(boxname, _, _), value) =>
         // Pointer boxes are special because null boxes to null,
         // which breaks the invariant that all virtual allocations

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -20,7 +20,7 @@ class Interflow(val config: build.Config)(implicit
     with Intrinsics
     with Log {
   implicit val platform: PlatformInfo = PlatformInfo(config)
-  
+
   private val originals = {
     val out = mutable.Map.empty[Global, Defn]
     linked.defns.foreach { defn => out(defn.name) = defn }

--- a/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
+++ b/tools/src/main/scala/scala/scalanative/interflow/Interflow.scala
@@ -2,9 +2,10 @@ package scala.scalanative
 package interflow
 
 import scala.collection.mutable
-import scalanative.nir._
-import scalanative.linker._
-import scalanative.util.ScopedVar
+import scala.scalanative.codegen.PlatformInfo
+import scala.scalanative.nir._
+import scala.scalanative.linker._
+import scala.scalanative.util.ScopedVar
 import java.util.function.Supplier
 
 class Interflow(val config: build.Config)(implicit
@@ -18,6 +19,8 @@ class Interflow(val config: build.Config)(implicit
     with PolyInline
     with Intrinsics
     with Log {
+  implicit val platform: PlatformInfo = PlatformInfo(config)
+  
   private val originals = {
     val out = mutable.Map.empty[Global, Defn]
     linked.defns.foreach { defn => out(defn.name) = defn }

--- a/unit-tests/native/src/test/scala/scala/scalanative/runtime/IntrinsicsTest.scala
+++ b/unit-tests/native/src/test/scala/scala/scalanative/runtime/IntrinsicsTest.scala
@@ -2,6 +2,8 @@ package scala.scalanative.runtime
 
 import org.junit.Test
 import org.junit.Assert._
+import scala.scalanative.meta.LinktimeInfo.is32BitPlatform
+import scala.language.implicitConversions
 
 class IntrinsicsTest {
 
@@ -71,6 +73,57 @@ class IntrinsicsTest {
     assertEquals(2.toShort, foo.shortField)
     assertEquals(3, foo.intField)
     assertEquals(4.toByte, foo.byteField)
+  }
+
+  @Test def allowsToCalculateMemoryLayoutSize(): Unit = {
+    case class Entry(actualSize: Int, fieldsSize64: Int, fieldsSize32: Int)
+    class A()
+    class B(a: Int = 0) { override def toString(): String = s"{$a}" }
+    class C(a: Long = 0L) { override def toString(): String = s"{$a}" }
+    class C2(a: Int = 0, b: Int = 0) {
+      override def toString(): String = s"{$a,$b}"
+    }
+    class D(a: Int = 0, b: Long = 0L) {
+      override def toString(): String = s"{$a,$b}"
+    }
+    class E(a: Int = 0, b: Long = 0, c: String = "") {
+      override def toString(): String = s"{$a,$b,$c}"
+    }
+    object E extends E(0, 0, "")
+    class F(a: String = "") {
+      override def toString(): String = s"{$a}"
+    }
+    // Make sure each type and it's fields are reachable to prevent elimination of unused fields
+    Seq(new A(), new B(), new C(), new C2(), new D(), new E(), E, new F())
+      .map(_.toString())
+
+    import scala.scalanative.runtime.Intrinsics._
+    implicit def rawSizeToInt(size: RawSize): Int = castRawSizeToInt(size)
+
+    assertEquals(4, sizeOf[Int]: Int)
+    assertEquals(8, sizeOf[Long]: Int)
+    assertNotEquals(
+      scala.scalanative.unsafe.sizeof[String].toInt, // sizeOf[Ptr]
+      scala.scalanative.runtime.Intrinsics
+        .sizeOf[String]: Int // based on fields
+    )
+
+    val ClassHeaderSize = if (is32BitPlatform) 4 else 8
+    for {
+      Entry(actual, fieldsSize64, fieldsSize32) <- Seq(
+        Entry(sizeOf[A], 0, 0),
+        Entry(sizeOf[B], 8, 4),
+        Entry(sizeOf[C], 8, 8),
+        Entry(sizeOf[C2], 8, 8),
+        Entry(sizeOf[D], 16, 12),
+        Entry(sizeOf[E], 24, 16),
+        Entry(sizeOf[E.type], 32, 20), // Fields of E + reference to outer
+        // Size of each reference field should to sizeOf[Ptr]
+        Entry(sizeOf[F], 8, 4)
+      )
+      fieldsSize = if (is32BitPlatform) fieldsSize32 else fieldsSize64
+      expected = ClassHeaderSize + fieldsSize
+    } assertEquals(expected, actual)
   }
 
 }


### PR DESCRIPTION
* Adds `runtime.Intrinsic.sizeOf[T]` methods evaluated to NIR `Ops.SizeOf(global)`
* Compile time against `sizeOf[T]` where T is a trait  - there is no memory layout for traits
* Adapts MemoryLayout to use FieldLayout of class as a reference to class size
* Make `is32BitPlatform` information an implicit context stored in `PlatformInfo` object

`class Foo()` would yield size of 8 - HeaderSize 8bytes, no fields
`class Foo(x: Int)` would yield size of 16 = HeaderSize + 4 bytes field x + 4 bytes padding
`class Foo(x: Int, y: Int)` would yield size of 16 = HeaderSize + 2 fields 4 bytes each
```
class Foo(x: Int, y: Int)  -> sizeOf = 16
class Bar(x: Foo) -> sizeOf = 16 (inner fields of reference types are still just a pointer, they always count as sizeOf[Ptr] 
```

Current solution might be used to replace `unsafe.sizeOf[T: Tag]`, however it has a different semantics in terms to reference kinds

It's worth mentioning that size of class might change between compilations - any unused field can be removed and though reduce the final size of class. This assumption was presented in the added `IntrinsicsTest` forcing usage of all class fields.